### PR TITLE
Search order

### DIFF
--- a/app/controllers/concerns/commentable_actions.rb
+++ b/app/controllers/concerns/commentable_actions.rb
@@ -81,6 +81,12 @@ module CommentableActions
       @search_terms = params[:search] if params[:search].present?
     end
 
+    def set_search_order
+      if params[:search].present? && params[:order].blank?
+        params[:order] = 'relevance'
+      end
+    end
+
     def set_resource_votes(instance)
       send("set_#{resource_name}_votes", instance)
     end

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -4,9 +4,10 @@ class DebatesController < ApplicationController
 
   before_action :parse_search_terms, only: :index
   before_action :parse_tag_filter, only: :index
+  before_action :set_search_order, only: :index
   before_action :authenticate_user!, except: [:index, :show]
 
-  has_orders %w{hot_score confidence_score created_at most_commented random}, only: :index
+  has_orders %w{hot_score confidence_score created_at most_commented random relevance}, only: :index
   has_orders %w{most_voted newest oldest}, only: :show
 
   load_and_authorize_resource

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -4,9 +4,10 @@ class ProposalsController < ApplicationController
 
   before_action :parse_search_terms, only: :index
   before_action :parse_tag_filter, only: :index
+  before_action :set_search_order, only: :index
   before_action :authenticate_user!, except: [:index, :show]
 
-  has_orders %w{hot_score confidence_score created_at most_commented random}, only: :index
+  has_orders %w{hot_score confidence_score created_at most_commented random relevance}, only: :index
   has_orders %w{most_voted newest oldest}, only: :show
 
   load_and_authorize_resource

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,7 @@
+module OrdersHelper
+
+  def valid_orders
+    @valid_orders.reject { |order| order =='relevance' && params[:search].blank? }
+  end
+
+end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -26,13 +26,14 @@ class Debate < ActiveRecord::Base
 
   before_save :calculate_hot_score, :calculate_confidence_score
 
-  scope :for_render, -> { includes(:tags) }
-  scope :sort_by_hot_score , -> { order(hot_score: :desc) }
-  scope :sort_by_confidence_score , -> { order(confidence_score: :desc) }
-  scope :sort_by_created_at, -> { order(created_at: :desc) }
-  scope :sort_by_most_commented, -> { order(comments_count: :desc) }
-  scope :sort_by_random, -> { order("RANDOM()") }
-  scope :sort_by_flags, -> { order(flags_count: :desc, updated_at: :desc) }
+  scope :for_render,               -> { includes(:tags) }
+  scope :sort_by_hot_score ,       -> { reorder(hot_score: :desc) }
+  scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc) }
+  scope :sort_by_created_at,       -> { reorder(created_at: :desc) }
+  scope :sort_by_most_commented,   -> { reorder(comments_count: :desc) }
+  scope :sort_by_random,           -> { reorder("RANDOM()") }
+  scope :sort_by_relevance,        -> { all }
+  scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
 
   # Ahoy setup
   visitable # Ahoy will automatically assign visit_id on create

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -48,10 +48,10 @@ class Debate < ActiveRecord::Base
     },
     using: {
       tsearch: { dictionary: "spanish" },
-      trigram: { threshold: 0.1 },
     },
-    ranked_by: '(:tsearch + debates.cached_votes_up)',
-    order_within_rank: "debates.created_at DESC"
+    ignoring: :accents,
+    ranked_by: '(:tsearch)',
+    order_within_rank: "debates.cached_votes_up DESC"
   }
 
   def description

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -32,13 +32,14 @@ class Proposal < ActiveRecord::Base
 
   before_save :calculate_hot_score, :calculate_confidence_score
 
-  scope :for_render, -> { includes(:tags) }
-  scope :sort_by_hot_score , -> { order(hot_score: :desc) }
-  scope :sort_by_confidence_score , -> { order(confidence_score: :desc) }
-  scope :sort_by_created_at, -> { order(created_at: :desc) }
-  scope :sort_by_most_commented, -> { order(comments_count: :desc) }
-  scope :sort_by_random, -> { order("RANDOM()") }
-  scope :sort_by_flags, -> { order(flags_count: :desc, updated_at: :desc) }
+  scope :for_render,               -> { includes(:tags) }
+  scope :sort_by_hot_score ,       -> { reorder(hot_score: :desc) }
+  scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc) }
+  scope :sort_by_created_at,       -> { reorder(created_at: :desc) }
+  scope :sort_by_most_commented,   -> { reorder(comments_count: :desc) }
+  scope :sort_by_random,           -> { reorder("RANDOM()") }
+  scope :sort_by_relevance ,       -> { all }
+  scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
 
   pg_search_scope :pg_search, {
     against: {

--- a/app/views/shared/_order_selector.html.erb
+++ b/app/views/shared/_order_selector.html.erb
@@ -1,14 +1,12 @@
-<% # Params:
-   #
-   #   i18n_namespace: for example "moderation.debates.index"
-%>
-
 <form class="inline-block">
   <label for="order-selector-participation" class="sr-only"><%= t("debates.index.select_order") %></label>
-  <select class="js-location-changer js-order-selector select-order" data-order="<%= @current_order %>" name="order-selector" id="order-selector-participation">
-     <% @valid_orders.each do |order| %>
+  <select class="js-location-changer js-order-selector select-order"
+          data-order="<%= @current_order %>"
+          name="order-selector"
+          id="order-selector-participation">
+     <% valid_orders.each do |order| %>
        <option <%= 'selected' if order == @current_order %>
-               value='<%= current_path_with_query_params(order: order, page: 1) %>'>
+          value='<%= current_path_with_query_params(order: order, page: 1) %>'>
          <%= t("#{i18n_namespace}.orders.#{order}") %>
        </option>
      <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,7 @@ en:
         created_at: "newest"
         most_commented: "most commented"
         random: "random"
+        relevance: "relevance"
       filter_topic:
         one: " with topic '%{topic}'"
         other: " with topic '%{topic}'"
@@ -166,6 +167,7 @@ en:
         created_at: "newest"
         most_commented: "most commented"
         random: "random"
+        relevance: "relevance"
       filter_topic:
         one: " with topic '%{topic}'"
         other: " with topic '%{topic}'"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -90,6 +90,7 @@ es:
         created_at: "más nuevos"
         most_commented: "más comentados"
         random: "aleatorio"
+        relevance: "relevancia"
       filter_topic:
         one: " con el tema '%{topic}'"
         other: " con el tema '%{topic}'"
@@ -166,6 +167,7 @@ es:
         created_at: "más nuevas"
         most_commented: "más comentadas"
         random: "aleatorias"
+        relevance: "relevancia"
       filter_topic:
         one: " con el tema '%{topic}'"
         other: " con el tema '%{topic}'"

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -515,6 +515,67 @@ feature 'Debates' do
     end
   end
 
+  pending "Order by relevance by default", :js do
+    debate1 = create(:debate, title: "Show you got",      cached_votes_up: 10)
+    debate2 = create(:debate, title: "Show what you got", cached_votes_up: 1)
+    debate3 = create(:debate, title: "Show you got",      cached_votes_up: 100)
+
+    visit debates_path
+    fill_in "search", with: "Show what you got"
+    click_button "Search"
+
+    expect(page).to have_selector('.js-order-selector[data-order="relevance"]')
+
+    within("#debates") do
+      expect(all(".debate")[0].text).to match "Show what you got"
+      expect(all(".debate")[1].text).to match "Show you got"
+      expect(all(".debate")[2].text).to match "Show you got"
+    end
+  end
+
+  pending "Reorder results maintaing search", :js do
+    debate1 = create(:debate, title: "Show you got",      cached_votes_up: 10,  created_at: 1.week.ago)
+    debate2 = create(:debate, title: "Show what you got", cached_votes_up: 1,   created_at: 1.month.ago)
+    debate3 = create(:debate, title: "Show you got",      cached_votes_up: 100, created_at: Time.now)
+    debate4 = create(:debate, title: "Do not display",    cached_votes_up: 1,   created_at: 1.week.ago)
+
+    visit debates_path
+    fill_in "search", with: "Show what you got"
+    click_button "Search"
+
+    select 'newest', from: 'order-selector'
+    expect(page).to have_selector('.js-order-selector[data-order="created_at"]')
+
+    within("#debates") do
+      expect(all(".debate")[0].text).to match "Show you got"
+      expect(all(".debate")[1].text).to match "Show you got"
+      expect(all(".debate")[2].text).to match "Show what you got"
+      expect(page).to_not have_content "Do not display"
+    end
+  end
+
+  scenario 'Index search does not show featured debates' do
+    featured_debates = create_featured_debates
+    debate = create(:debate, title: "Abcdefghi")
+
+    visit debates_path
+    fill_in "search", with: debate.title
+    click_button "Search"
+
+    expect(page).to_not have_selector('#debates .debate-featured')
+    expect(page).to_not have_selector('#featured-debates')
+  end
+
+  scenario 'Index tag does not show featured debates' do
+    featured_debates = create_featured_debates
+    debates = create(:debate, tag_list: "123")
+
+    visit debates_path(tag: "123")
+
+    expect(page).to_not have_selector('#debates .debate-featured')
+    expect(page).to_not have_selector('#featured-debates')
+  end
+
   scenario 'Conflictive' do
     good_debate = create(:debate)
     conflictive_debate = create(:debate, :conflictive)

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -606,6 +606,35 @@ feature 'Proposals' do
     expect(page).to_not have_selector('#featured-proposals')
   end
 
+  scenario "Reorder search results", :focus do
+    proposal1 = create(:proposal, title: "Show me what you got", cached_votes_up: 1)
+    proposal2 = create(:proposal, title: "Show what you got", cached_votes_up: 100)
+    proposal3 = create(:proposal, title: "Show a what you got", cached_votes_up: 10)
+
+    visit proposals_path
+    fill_in "search", with: "Show me what you got"
+    click_button "Search"
+
+    within("#proposals") do
+      expect(page).to have_css('.proposal', count: 3)
+
+      expect(page).to have_content(proposal1.title)
+      expect(page).to have_content(proposal2.title)
+      expect(page).to have_content(proposal3.title)
+    end
+
+    select 'highest rated', from: 'order-selector'
+    expect(page).to have_selector('.js-order-selector[data-order="confidence_score"]')
+
+    within("#proposals") do
+      expect(page).to have_css('.proposal', count: 3)
+
+      expect(page).to have_content(proposal2.title)
+      expect(page).to have_content(proposal3.title)
+      expect(page).to have_content(proposal1.title)
+    end
+  end
+
   scenario 'Conflictive' do
     good_proposal = create(:proposal)
     conflictive_proposal = create(:proposal, :conflictive)

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe OrdersHelper do
+
+  describe '#valid_orders' do
+    it 'displays relevance when searching' do
+      params[:search] = 'ipsum'
+      assign(:valid_orders, %w(created_at random relevance))
+      expect(helper.valid_orders).to eq %w(created_at random relevance)
+    end
+
+    it 'does not display relevance when not searching' do
+      assign(:valid_orders, %w(created_at random relevance))
+      expect(helper.valid_orders).to eq %w(created_at random)
+    end
+  end
+
+end

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -548,6 +548,90 @@ describe Debate do
 
     end
 
+    context "reorder" do
+
+      xit "should be able to reorder by hot_score after searching" do
+        lowest_score  = create(:debate,  title: 'stop corruption', cached_votes_up: 1)
+        highest_score = create(:debate,  title: 'stop corruption', cached_votes_up: 2)
+        average_score = create(:debate,  title: 'stop corruption', cached_votes_up: 3)
+
+        lowest_score.update_column(:hot_score, 1)
+        highest_score.update_column(:hot_score, 100)
+        average_score.update_column(:hot_score, 10)
+
+        results = Debate.search('stop corruption')
+
+        expect(results.first).to eq(average_score)
+        expect(results.second).to eq(highest_score)
+        expect(results.third).to eq(lowest_score)
+
+        results = results.sort_by_hot_score
+
+        expect(results.first).to eq(highest_score)
+        expect(results.second).to eq(average_score)
+        expect(results.third).to eq(lowest_score)
+      end
+
+      xit "should be able to reorder by confidence_score after searching" do
+        lowest_score  = create(:debate,  title: 'stop corruption', cached_votes_up: 1)
+        highest_score = create(:debate,  title: 'stop corruption', cached_votes_up: 2)
+        average_score = create(:debate,  title: 'stop corruption', cached_votes_up: 3)
+
+        lowest_score.update_column(:confidence_score, 1)
+        highest_score.update_column(:confidence_score, 100)
+        average_score.update_column(:confidence_score, 10)
+
+        results = Debate.search('stop corruption')
+
+        expect(results.first).to eq(average_score)
+        expect(results.second).to eq(highest_score)
+        expect(results.third).to eq(lowest_score)
+
+        results = results.sort_by_confidence_score
+
+        expect(results.first).to eq(highest_score)
+        expect(results.second).to eq(average_score)
+        expect(results.third).to eq(lowest_score)
+      end
+
+      xit "should be able to reorder by created_at after searching" do
+        recent  = create(:debate,  title: 'stop corruption', cached_votes_up: 1, created_at: 1.week.ago)
+        newest  = create(:debate,  title: 'stop corruption', cached_votes_up: 2, created_at: Time.now)
+        oldest  = create(:debate,  title: 'stop corruption', cached_votes_up: 3, created_at: 1.month.ago)
+
+        results = Debate.search('stop corruption')
+
+        expect(results.first).to eq(oldest)
+        expect(results.second).to eq(newest)
+        expect(results.third).to eq(recent)
+
+        results = results.sort_by_created_at
+
+        expect(results.first).to eq(newest)
+        expect(results.second).to eq(recent)
+        expect(results.third).to eq(oldest)
+      end
+
+      xit "should be able to reorder by most commented after searching" do
+        least_commented = create(:debate,  title: 'stop corruption',  cached_votes_up: 1, comments_count: 1)
+        most_commented  = create(:debate,  title: 'stop corruption',  cached_votes_up: 2, comments_count: 100)
+        some_comments   = create(:debate,  title: 'stop corruption',  cached_votes_up: 3, comments_count: 10)
+
+        results = Debate.search('stop corruption')
+
+        expect(results.first).to eq(some_comments)
+        expect(results.second).to eq(most_commented)
+        expect(results.third).to eq(least_commented)
+
+        results = results.sort_by_most_commented
+
+        expect(results.first).to eq(most_commented)
+        expect(results.second).to eq(some_comments)
+        expect(results.third).to eq(least_commented)
+      end
+
+    end
+
     context "tags" do
 
       xit "searches by tags" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -432,6 +432,17 @@ describe Proposal do
 
     end
 
+    context "tags" do
+
+      it "searches by tags" do
+        proposal = create(:proposal, tag_list: 'Latina')
+
+        results = Proposal.search('Latina')
+        expect(results.first).to eq(proposal)
+      end
+
+    end
+
     context "order" do
 
       it "orders by weight" do
@@ -471,17 +482,6 @@ describe Proposal do
 
         expect(results.first).to eq(exact_title_few_votes)
         expect(results.second).to eq(similar_title_many_votes)
-      end
-
-    end
-
-    context "tags" do
-
-      it "searches by tags" do
-        proposal = create(:proposal, tag_list: 'Latina')
-
-        results = Proposal.search('Latina')
-        expect(results.first).to eq(proposal)
       end
 
     end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -486,6 +486,90 @@ describe Proposal do
 
     end
 
+    context "reorder" do
+
+      it "should be able to reorder by hot_score after searching" do
+        lowest_score  = create(:proposal,  title: 'stop corruption', cached_votes_up: 1)
+        highest_score = create(:proposal,  title: 'stop corruption', cached_votes_up: 2)
+        average_score = create(:proposal,  title: 'stop corruption', cached_votes_up: 3)
+
+        lowest_score.update_column(:hot_score, 1)
+        highest_score.update_column(:hot_score, 100)
+        average_score.update_column(:hot_score, 10)
+
+        results = Proposal.search('stop corruption')
+
+        expect(results.first).to eq(average_score)
+        expect(results.second).to eq(highest_score)
+        expect(results.third).to eq(lowest_score)
+
+        results = results.sort_by_hot_score
+
+        expect(results.first).to eq(highest_score)
+        expect(results.second).to eq(average_score)
+        expect(results.third).to eq(lowest_score)
+      end
+
+      it "should be able to reorder by confidence_score after searching" do
+        lowest_score  = create(:proposal,  title: 'stop corruption', cached_votes_up: 1)
+        highest_score = create(:proposal,  title: 'stop corruption', cached_votes_up: 2)
+        average_score = create(:proposal,  title: 'stop corruption', cached_votes_up: 3)
+
+        lowest_score.update_column(:confidence_score, 1)
+        highest_score.update_column(:confidence_score, 100)
+        average_score.update_column(:confidence_score, 10)
+
+        results = Proposal.search('stop corruption')
+
+        expect(results.first).to eq(average_score)
+        expect(results.second).to eq(highest_score)
+        expect(results.third).to eq(lowest_score)
+
+        results = results.sort_by_confidence_score
+
+        expect(results.first).to eq(highest_score)
+        expect(results.second).to eq(average_score)
+        expect(results.third).to eq(lowest_score)
+      end
+
+      it "should be able to reorder by created_at after searching" do
+        recent  = create(:proposal,  title: 'stop corruption', cached_votes_up: 1, created_at: 1.week.ago)
+        newest  = create(:proposal,  title: 'stop corruption', cached_votes_up: 2, created_at: Time.now)
+        oldest  = create(:proposal,  title: 'stop corruption', cached_votes_up: 3, created_at: 1.month.ago)
+
+        results = Proposal.search('stop corruption')
+
+        expect(results.first).to eq(oldest)
+        expect(results.second).to eq(newest)
+        expect(results.third).to eq(recent)
+
+        results = results.sort_by_created_at
+
+        expect(results.first).to eq(newest)
+        expect(results.second).to eq(recent)
+        expect(results.third).to eq(oldest)
+      end
+
+      it "should be able to reorder by most commented after searching" do
+        least_commented = create(:proposal,  title: 'stop corruption',  cached_votes_up: 1, comments_count: 1)
+        most_commented  = create(:proposal,  title: 'stop corruption',  cached_votes_up: 2, comments_count: 100)
+        some_comments   = create(:proposal,  title: 'stop corruption',  cached_votes_up: 3, comments_count: 10)
+
+        results = Proposal.search('stop corruption')
+
+        expect(results.first).to eq(some_comments)
+        expect(results.second).to eq(most_commented)
+        expect(results.third).to eq(least_commented)
+
+        results = results.sort_by_most_commented
+
+        expect(results.first).to eq(most_commented)
+        expect(results.second).to eq(some_comments)
+        expect(results.third).to eq(least_commented)
+      end
+
+    end
+
     context "no results" do
 
       it "no words match" do

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -168,4 +168,10 @@ module CommonActions
      create(:proposal, :with_confidence_score, cached_votes_up: 80)]
   end
 
+  def create_featured_debates
+    [create(:debate, :with_confidence_score, cached_votes_up: 100),
+     create(:debate, :with_confidence_score, cached_votes_up: 90),
+     create(:debate, :with_confidence_score, cached_votes_up: 80)]
+  end
+
 end

--- a/spec/support/matchers/appear_before.rb
+++ b/spec/support/matchers/appear_before.rb
@@ -4,4 +4,3 @@ RSpec::Matchers.define :appear_before do |later_content|
     text.index(earlier_content) < text.index(later_content)
   end
 end
-


### PR DESCRIPTION
Allows users to order by all ordering criteria after a search.
After a search, the default order is relevance.

Closes #715 