### PR TITLE
Fix double-submission prevention not working.

### DIFF
--- a/app/assets/javascripts/prevent_double_submission.js.coffee
+++ b/app/assets/javascripts/prevent_double_submission.js.coffee
@@ -21,7 +21,7 @@ App.PreventDoubleSubmission =
           button.data('text', null)
 
   initialize: ->
-    $('form').on('submit', event, ->
+    $('form').on('submit', (event) ->
       buttons = $(this).find(':button, :submit')
       App.PreventDoubleSubmission.disable_buttons(buttons)
     ).on('ajax:success', ->

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -248,6 +248,18 @@ feature 'Commenting debates' do
     end
   end
 
+  scenario 'Submit button is disabled after clicking', :js do
+    login_as(user)
+    visit debate_path(debate)
+
+    fill_in "comment-body-debate_#{debate.id}", with: 'Testing submit button!'
+    click_button 'Publish comment'
+    
+    # The button's text should now be "..."
+    # This should be checked before the Ajax request is finished
+    expect(page).to_not have_button 'Publish comment'
+  end
+
   feature "Moderators" do
     scenario "can create comment as a moderator", :js do
       moderator = create(:moderator)


### PR DESCRIPTION
Since the submit buttons are asynchronous, the website should disable the submit button once clicked. However, this does not work due to an error in the code, so an user can accidentally submit a the same comment multiple times in a debate. This pull request fixes this error.