### PR TITLE
Use `en` as default locale on tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ RSpec.configure do |config|
   config.before(:each) do |example|
     DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
+    I18n.locale = :en
     load "#{Rails.root}/db/seeds.rb"
   end
 


### PR DESCRIPTION
This ensures the language in which the tests will run is the english language, even if a previous test changes it (it's a global setting!).

Running the tests locally, I've detected sometimes `spec/features/emails_spec.rb` would fail depending on the order of execution (tests are executed in random order).