### PR TITLE
Add consul slack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Citizen Participation and Open Government Application
 [![Code Climate](https://codeclimate.com/github/consul/consul/badges/gpa.svg)](https://codeclimate.com/github/consul/consul)
 [![Dependency Status](https://gemnasium.com/consul/consul.svg)](https://gemnasium.com/consul/consul)
 [![Coverage Status](https://coveralls.io/repos/consul/consul/badge.svg?branch=master&service=github)](https://coveralls.io/github/consul/consul?branch=master)
+[![Slack Status](https://consul-slack.herokuapp.com/badge.svg)](https://consul-slack.herokuapp.com)
 
 This is the opensource code repository of the eParticipation website originally developed for the Madrid City government eParticipation website
 


### PR DESCRIPTION
This adds a badge showing the amount of users online in consul's slack channel, and links to the invite app.