### PR TITLE
Simplify Settings API so it better resembles a key-value store

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -53,7 +53,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   private
 
     def set_official_position
-      resource.add_official_position! (Setting.value_for 'official_level_1_name'), 1
+      resource.add_official_position! (Setting['official_level_1_name']), 1
     end
 
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -7,7 +7,7 @@ module AdminHelper
   def official_level_options
     options = [["",0]]
     (1..5).each do |i|
-      options << [[t("admin.officials.level_#{i}"), Setting.value_for("official_level_#{i}_name")].compact.join(': '), i]
+      options << [[t("admin.officials.level_#{i}"), Setting["official_level_#{i}_name"]].compact.join(': '), i]
     end
     options
   end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -75,7 +75,7 @@ class Debate < ActiveRecord::Base
   end
 
   def editable?
-    total_votes <= Setting.value_for('max_votes_for_debate_edit').to_i
+    total_votes <= Setting['max_votes_for_debate_edit'].to_i
   end
 
   def editable_by?(user)
@@ -93,8 +93,8 @@ class Debate < ActiveRecord::Base
     return false unless user
     total_votes <= 100 ||
       !user.unverified? ||
-      Setting.value_for('max_ratio_anon_votes_on_debates').to_i == 100 ||
-      anonymous_votes_ratio < Setting.value_for('max_ratio_anon_votes_on_debates').to_i ||
+      Setting['max_ratio_anon_votes_on_debates'].to_i == 100 ||
+      anonymous_votes_ratio < Setting['max_ratio_anon_votes_on_debates'].to_i ||
       user.voted_for?(self)
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -79,7 +79,7 @@ class Proposal < ActiveRecord::Base
   end
 
   def editable?
-    total_votes <= Setting.value_for("max_votes_for_proposal_edit").to_i
+    total_votes <= Setting["max_votes_for_proposal_edit"].to_i
   end
 
   def editable_by?(user)
@@ -97,7 +97,7 @@ class Proposal < ActiveRecord::Base
   end
 
   def code
-    "#{Setting.value_for("proposal_code_prefix")}-#{created_at.strftime('%Y-%m')}-#{id}"
+    "#{Setting["proposal_code_prefix"]}-#{created_at.strftime('%Y-%m')}-#{id}"
   end
 
   def after_commented
@@ -128,7 +128,7 @@ class Proposal < ActiveRecord::Base
   end
 
   def self.votes_needed_for_success
-    Setting.value_for('votes_for_proposal_success').to_i
+    Setting['votes_for_proposal_success'].to_i
   end
 
   protected

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -3,7 +3,27 @@ class Setting < ActiveRecord::Base
 
   default_scope { order(id: :asc) }
 
-  def self.value_for(key)
-    where(key: key).pluck(:value).first
+  class << self
+    # Public: Gets a setting given a key.
+    #
+    # key - The setting's key.
+    #
+    # Returns a Value with the setting.
+    def [](key)
+      where(key: key).pluck(:value).first
+    end
+
+    # Sets a setting value given a key.
+    #
+    # key   - The setting's key to override.
+    # value - The setting's value.
+    #
+    # Returns the setting's Value.
+    def []=(key, value)
+      setting = where(key: key).first || new(key: key)
+      setting.value = value
+      setting.save!
+      value
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,7 +201,7 @@ class User < ActiveRecord::Base
   end
   
   def has_official_email?
-    domain = Setting.value_for 'email_domain_for_officials'
+    domain = Setting['email_domain_for_officials']
     !email.blank? && ( (email.end_with? "@#{domain}") || (email.end_with? ".#{domain}") )
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Default admin user (change password after first deploy to a server!)
 if Administrator.count == 0 && !Rails.env.test?
   admin = User.create!(username: 'admin', email: 'admin@madrid.es', password: '12345678', password_confirmation: '12345678', confirmed_at: Time.now, terms_of_service: "1")
@@ -6,27 +7,27 @@ end
 
 # Names for the moderation console, as a hint for moderators
 # to know better how to assign users with official positions
-Setting.create(key: 'official_level_1_name', value: 'Empleados públicos')
-Setting.create(key: 'official_level_2_name', value: 'Organización Municipal')
-Setting.create(key: 'official_level_3_name', value: 'Directores generales')
-Setting.create(key: 'official_level_4_name', value: 'Concejales')
-Setting.create(key: 'official_level_5_name', value: 'Alcaldesa')
+Setting["official_level_1_name"] = "Empleados públicos"
+Setting["official_level_2_name"] = "Organización Municipal"
+Setting["official_level_3_name"] = "Directores generales"
+Setting["official_level_4_name"] = "Concejales"
+Setting["official_level_5_name"] = "Alcaldesa"
 
 # Max percentage of allowed anonymous votes on a debate
-Setting.create(key: 'max_ratio_anon_votes_on_debates', value: '50')
+Setting["max_ratio_anon_votes_on_debates"] = 50
 
 # Max votes where a debate is still editable
-Setting.create(key: 'max_votes_for_debate_edit', value: '1000')
+Setting["max_votes_for_debate_edit"] = 1000
 
 # Max votes where a proposal is still editable
-Setting.create(key: 'max_votes_for_proposal_edit', value: '1000')
+Setting["max_votes_for_proposal_edit"] = 1000
 
 # Prefix for the Proposal codes
-Setting.create(key: 'proposal_code_prefix', value: 'MAD')
+Setting["proposal_code_prefix"] = 'MAD'
 
 # Number of votes needed for proposal success
-Setting.create(key: 'votes_for_proposal_success', value: '53726')
+Setting["votes_for_proposal_success"] = 53726
 
 # Users with this email domain will automatically be marked as level 1 officials
 # Emails under the domain's subdomains will also be included
-Setting.create(key: 'email_domain_for_officials', value: '')
+Setting["email_domain_for_officials"] = ''

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -7,7 +7,7 @@ namespace :users do
   
   desc "Assigns official level to users with the officials' email domain"
   task check_for_official_emails: :environment do
-    domain = Setting.value_for 'email_domain_for_officials'
+    domain = Setting['email_domain_for_officials']
 
     # We end the task if there is no email domain configured
     if !domain.blank?
@@ -15,7 +15,7 @@ namespace :users do
       # The real check will be done by check_if_official_email, however.
       User.where('official_level = 0 and email like ?', "%#{domain}").find_each do |user|
         if user.has_official_email?
-          user.add_official_position! (Setting.value_for 'official_level_1_name'), 1
+          user.add_official_position! (Setting['official_level_1_name']), 1
           puts "#{user.username} (#{user.email}) is now a level-1 official."
         end
       end

--- a/spec/controllers/debates_controller_spec.rb
+++ b/spec/controllers/debates_controller_spec.rb
@@ -24,7 +24,7 @@ describe DebatesController do
 
   describe "Vote with too many anonymous votes" do
     it 'should allow vote if user is allowed' do
-      Setting.find_by(key: "max_ratio_anon_votes_on_debates").update(value: 100)
+      Setting["max_ratio_anon_votes_on_debates"] = 100
       debate = create(:debate)
       sign_in create(:user)
 
@@ -34,7 +34,7 @@ describe DebatesController do
     end
 
     it 'should not allow vote if user is not allowed' do
-      Setting.find_by(key: "max_ratio_anon_votes_on_debates").update(value: 0)
+      Setting["max_ratio_anon_votes_on_debates"] = 0
       debate = create(:debate, cached_votes_total: 1000)
       sign_in create(:user)
 

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 feature 'Debates' do
@@ -255,7 +256,7 @@ feature 'Debates' do
 
   scenario 'Update should not be posible if debate is not editable' do
     debate = create(:debate)
-    Setting.find_by(key: "max_votes_for_debate_edit").update(value: 2)
+    Setting["max_votes_for_debate_edit"] = 2
     3.times { create(:vote, votable: debate) }
 
     expect(debate).to_not be_editable

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 feature 'Proposals' do
@@ -342,7 +343,7 @@ feature 'Proposals' do
 
   scenario 'Update should not be posible if proposal is not editable' do
     proposal = create(:proposal)
-    Setting.find_by(key: "max_votes_for_proposal_edit").update(value: 10)
+    Setting["max_votes_for_proposal_edit"] = 10
     11.times { create(:vote, votable: proposal) }
 
     expect(proposal).to_not be_editable

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -304,7 +304,7 @@ feature 'Votes' do
     user = create(:user)
     debate = create(:debate)
 
-    Setting.find_by(key: "max_ratio_anon_votes_on_debates").update(value: 50)
+    Setting["max_ratio_anon_votes_on_debates"] = 50
     debate.update(cached_anonymous_votes_total: 520, cached_votes_total: 1000)
 
     login_as(user)

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 describe Debate do
@@ -82,7 +83,7 @@ describe Debate do
 
   describe "#editable?" do
     let(:debate) { create(:debate) }
-    before(:each) { Setting.find_by(key: "max_votes_for_debate_edit").update(value: 3) }
+    before(:each) { Setting["max_votes_for_debate_edit"] = 3 }
 
     it "should be true if debate has no votes yet" do
       expect(debate.total_votes).to eq(0)
@@ -104,7 +105,7 @@ describe Debate do
 
   describe "#editable_by?" do
     let(:debate) { create(:debate) }
-    before(:each) { Setting.find_by(key: "max_votes_for_debate_edit").update(value: 1) }
+    before(:each) { Setting["max_votes_for_debate_edit"] = 1 }
 
     it "should be true if user is the author and debate is editable" do
       expect(debate.editable_by?(debate.author)).to be true
@@ -124,7 +125,7 @@ describe Debate do
     let(:debate) { create(:debate) }
 
     before(:each) do
-      Setting.find_by(key: "max_ratio_anon_votes_on_debates").update(value: 50)
+      Setting["max_ratio_anon_votes_on_debates"] = 50
     end
 
     it "should be true for level two verified users" do
@@ -160,7 +161,7 @@ describe Debate do
     let(:debate) { create(:debate) }
 
     before(:each) do
-      Setting.find_by(key: "max_ratio_anon_votes_on_debates").update(value: 50)
+      Setting["max_ratio_anon_votes_on_debates"] = 50
     end
 
     describe "from level two verified users" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 describe Proposal do
@@ -134,14 +135,14 @@ describe Proposal do
   end
 
   it "should have a code" do
-    Setting.find_by(key: "proposal_code_prefix").update(value: "TEST")
+    Setting["proposal_code_prefix"] = "TEST"
     proposal = create(:proposal)
     expect(proposal.code).to eq "TEST-#{proposal.created_at.strftime('%Y-%m')}-#{proposal.id}"
   end
 
   describe "#editable?" do
     let(:proposal) { create(:proposal) }
-    before(:each) {Setting.find_by(key: "max_votes_for_proposal_edit").update(value: 5)}
+    before(:each) {Setting["max_votes_for_proposal_edit"] = 5}
 
     it "should be true if proposal has no votes yet" do
       expect(proposal.total_votes).to eq(0)

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,15 +1,19 @@
 require 'rails_helper'
 
 describe Setting do
-
-  it "should be accesible by key" do
-    create(:setting, key: "Important Setting", value: "42")
-
-    expect(Setting.value_for("Important Setting")).to eq("42")
+  before do
+    Setting["official_level_1_name"] = 'Stormtrooper'
   end
 
-  it "should be nil if key does not exist" do
-    expect(Setting.value_for("Undefined key")).to be_nil
+  it "should return the overriden setting" do
+    expect(Setting['official_level_1_name']).to eq('Stormtrooper')
   end
 
+  it "should should return nil" do
+    expect(Setting['undefined_key']).to eq(nil)
+  end
+
+  it "should persist a setting on the db" do
+    expect(Setting.where(key: 'official_level_1_name', value: 'Stormtrooper')).to exist
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -244,7 +244,7 @@ describe User do
     it "checks if the mail address has the officials domain" do
       # We will use empleados.madrid.es as the officials' domain
       # Subdomains are also accepted
-      Setting.find_by(key: 'email_domain_for_officials').update(value: 'officials.madrid.es')
+      Setting['email_domain_for_officials'] = 'officials.madrid.es'
       
       user1 = create(:user, email: "john@officials.madrid.es", confirmed_at: Time.now)
       user2 = create(:user, email: "john@yes.officials.madrid.es", confirmed_at: Time.now)


### PR DESCRIPTION
This simplifies the settings interface in a way that makes it friendlier to read and write, and is also compatible with a key-value store.

The goal is to improve its usability as feature flags and reducing the boilerplate when setting values (decouple it from the `ActiveRecord` interface).