### PR TITLE
Normalize page paths

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,52 +1,7 @@
 class PagesController < ApplicationController
   skip_authorization_check
 
-  def accessibility
-  end
-
-  def census_terms
-  end
-
-  def conditions
-  end
-
-  def general_terms
-  end
-
-  def privacy
-  end
-
-  def coming_soon
-  end
-
-  def how_it_works
-  end
-
-  def how_to_use
-  end
-
-  def more_information
-  end
-
-  def opendata
-  end
-
-  def participation
-  end
-
-  def proposals_info
-  end
-
-  def participation_facts
-  end
-
-  def participation_world
-  end
-
-  def verify
-  end
-
-  def blog
-    redirect_to "http://diario.madrid.es/participa/"
+  def show
+    render action: params[:id]
   end
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -13,7 +13,7 @@
             consul:  link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), target: "blank")).html_safe
           %>
           <%= t("layouts.footer.contact_us") %>
-          <%= link_to t("layouts.footer.faq"), faq_path %>
+          <%= link_to t("layouts.footer.faq"), page_path('faq') %>
         </p>
       </div>
 
@@ -45,10 +45,10 @@
       <div class="small-12 medium-9 column">
         <p>
           <%= t("layouts.footer.copyright", year: Time.now.year) %>&nbsp;|&nbsp;
-          <%= link_to t("layouts.footer.more_info"), "/more_information" %>&nbsp;|&nbsp;
-          <%= link_to t("layouts.footer.privacy"), "/privacy" %>&nbsp;|&nbsp;
-          <%= link_to t("layouts.footer.conditions"), "/conditions" %>&nbsp;|&nbsp;
-          <%= link_to t("layouts.footer.accessibility"), "/accessibility" %>
+          <%= link_to t("layouts.footer.more_info"), page_path('/more_information') %>&nbsp;|&nbsp;
+          <%= link_to t("layouts.footer.privacy"), page_path('privacy') %>&nbsp;|&nbsp;
+          <%= link_to t("layouts.footer.conditions"), page_path('conditions') %>&nbsp;|&nbsp;
+          <%= link_to t("layouts.footer.accessibility"), page_path('/accessibility') %>
         </p>
       </div>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -57,7 +57,7 @@
       <div class="small-12 medium-8 column">
       <%= link_to t("layouts.header.debates"), debates_path, class: ("active" if current_page?(controller: "/debates")) %>
       <%= link_to t("layouts.header.proposals"), proposals_path, class: ("active" if current_page?(controller: "/proposals")) %>
-      <%= link_to t("layouts.header.more_information"), "/more_information", class: ("active" if current_page?("/more_information"))  %>
+      <%= link_to t("layouts.header.more_information"), page_path('more_information'), class: ("active" if current_page?("/more_information"))  %>
       <%= link_to t("layouts.header.external_link_blog_url"), target: "_blank" do %>
         <%= t("layouts.header.external_link_blog") %>
         <i class="icon-external"></i>

--- a/app/views/pages/more_information.html.erb
+++ b/app/views/pages/more_information.html.erb
@@ -5,49 +5,49 @@
       <h1><%= t('pages.titles.more_information') %></h1>
       <ul>
         <li>
-          <%= link_to how_it_works_path do %>
+          <%= link_to page_path('how_it_works') do %>
             <%= t('pages.more_information.titles.how_it_works') %>
             <span><%= t('pages.more_information.description.how_it_works') %></span>
           <% end %>
         </li>
         <li>
-        <%= link_to how_to_use_path do %>
+        <%= link_to page_path('how_to_use') do %>
             <%= t('pages.more_information.titles.how_to_use') %>
             <span><%= t('pages.more_information.description.how_to_use') %></span>
         <% end %>
         </li>
         <li>
-        <%= link_to participation_path do %>
+        <%= link_to page_path('participation') do %>
             <%= t('pages.more_information.titles.participation') %>
             <span><%= t('pages.more_information.description.participation') %></span>
         <% end %>
         </li>
         <li>
-        <%= link_to proposals_info_path do %>
+        <%= link_to page_path('proposals_info') do %>
             <%= t('pages.more_information.titles.proposals_info') %>
             <span><%= t('pages.more_information.description.proposals_info') %></span>
         <% end %>
         </li>
         <li>
-        <%= link_to participation_world_path do %>
+        <%= link_to page_path('participation_world') do %>
             <%= t('pages.more_information.titles.participation_world') %>
             <span><%= t('pages.more_information.description.participation_world') %></span>
         <% end %>
         </li>
         <li>
-        <%= link_to participation_facts_path do %>
+        <%= link_to page_path('participation_facts') do %>
             <%= t('pages.more_information.titles.participation_facts') %>
             <span><%= t('pages.more_information.description.participation_facts') %></span>
         <% end %>
         </li>
         <li>
-        <%= link_to faq_path do %>
+        <%= link_to page_path('faq') do %>
             <%= t('pages.more_information.titles.faq') %>
             <span><%= t('pages.more_information.description.faq') %></span>
         <% end %>
         </li>
         <li>
-        <%= link_to proposals_info_path(:anchor => "iii") do %>
+        <%= link_to page_path('proposals_info', :anchor => "iii") do %>
             <%= t('pages.more_information.titles.signature_sheet') %>
             <span><%= t('pages.more_information.description.signature_sheet') %></span>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,21 +259,7 @@ Rails.application.routes.draw do
   end
 
   # static pages
-  get "/census_terms", to: "pages#census_terms"
-  get "/conditions", to: "pages#conditions"
-  get "/general_terms", to: "pages#general_terms"
-  get "/privacy", to: "pages#privacy"
-  get "/coming_soon", to: "pages#coming_soon"
-  get "/how_it_works", to: "pages#how_it_works"
-  get "/how_to_use", to: "pages#how_to_use"
-  get "/more_information", to: "pages#more_information"
-  get "/opendata", to: "pages#opendata"
-  get "/participation", to: "pages#participation"
-  get "/proposals_info", to: "pages#proposals_info"
-  get "/participation_facts", to: "pages#participation_facts"
-  get "/participation_world", to: "pages#participation_world"
-  get "/faq", to: "pages#faq"
-  get "/blog", to: "pages#blog"
-  get "/accessibility", to: "pages#accessibility"
-  get "/verifica", to: "verification/letter#edit"
+
+  get '/blog' => redirect("http://diario.madrid.es/participa/")
+  resources :pages, path: '/', only: [:show]
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -4,66 +4,61 @@ describe PagesController do
 
   describe 'Static pages' do
     it 'should include a privacy page' do
-      get :privacy
+      get :show, id: :privacy
       expect(response).to be_ok
     end
 
     it 'should include a conditions page' do
-      get :conditions
+      get :show, id: :conditions
       expect(response).to be_ok
     end
 
     it 'should include a general terms page' do
-      get :general_terms
+      get :show, id: :general_terms
       expect(response).to be_ok
     end
 
     it 'should include a terms page' do
-      get :census_terms
+      get :show, id: :census_terms
       expect(response).to be_ok
     end
   end
 
   describe 'Provisional pages' do
     it 'should include a opendata page' do
-      get :opendata
+      get :show, id: :opendata
       expect(response).to be_ok
     end
   end
 
   describe 'Info pages' do
     it 'should include a coming_soon page' do
-      get :coming_soon
+      get :show, id: :coming_soon
       expect(response).to be_ok
     end
 
     it 'should include a how_it_works page' do
-      get :how_it_works
+      get :show, id: :how_it_works
       expect(response).to be_ok
     end
 
     it 'should include a how_to_use page' do
-      get :how_to_use
+      get :show, id: :how_to_use
       expect(response).to be_ok
     end
 
     it 'should include a more_information page' do
-      get :more_information
+      get :show, id: :more_information
       expect(response).to be_ok
     end
 
     it 'should include a participation page' do
-      get :participation
+      get :show, id: :participation
       expect(response).to be_ok
     end
 
-    it 'should include a blog page' do
-      get :blog
-      expect(response).to be_redirect
-    end
-
     it 'should include a accessibility page' do
-      get :accessibility
+      get :show, id: :accessibility
       expect(response).to be_ok
     end
   end


### PR DESCRIPTION
Normalize page paths so they can be accessed by `page_path(:id)`.

The benefit of this is that forks can add any arbitrary amount of pages without affecting the routing layer.

It also results in a nicer API, IMO.