### PR TITLE
returns 404 for not found pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,5 +3,7 @@ class PagesController < ApplicationController
 
   def show
     render action: params[:id]
+  rescue ActionView::MissingTemplate
+    raise ActionController::RoutingError.new('Not Found')
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -58,4 +58,10 @@ describe PagesController do
     end
   end
 
+  describe 'Not found pages' do
+    it 'should return a 404 message' do
+      expect { get :show, id: "nonExistentPage" }.to raise_error(ActionController::RoutingError)
+    end
+  end
+
 end


### PR DESCRIPTION
When PagesController#show does not find a page a 404 is returned instead of 500 by MissingTemplate

Fixes #792