### PR TITLE
Feature flags

### DIFF
--- a/app/controllers/admin/debates_controller.rb
+++ b/app/controllers/admin/debates_controller.rb
@@ -1,4 +1,8 @@
 class Admin::DebatesController < Admin::BaseController
+  include FeatureFlags
+
+  feature_flag :debates
+
   has_filters %w{without_confirmed_hide all with_confirmed_hide}, only: :index
 
   before_action :load_debate, only: [:confirm_hide, :restore]

--- a/app/controllers/admin/spending_proposals_controller.rb
+++ b/app/controllers/admin/spending_proposals_controller.rb
@@ -1,7 +1,11 @@
 class Admin::SpendingProposalsController < Admin::BaseController
+  include FeatureFlags
+
   has_filters %w{unresolved accepted rejected}, only: :index
 
   load_and_authorize_resource
+
+  feature_flag :spending_proposals
 
   def index
     @spending_proposals = @spending_proposals.includes([:geozone]).send(@current_filter).order(created_at: :desc).page(params[:page])

--- a/app/controllers/concerns/feature_flags.rb
+++ b/app/controllers/concerns/feature_flags.rb
@@ -1,0 +1,25 @@
+module FeatureFlags
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def feature_flag(name, *options)
+      before_filter(*options) do
+        check_feature_flag(name)
+      end
+    end
+  end
+
+  def check_feature_flag(name)
+    raise FeatureDisabled, name unless Setting["feature.#{name}"]
+  end
+
+  class FeatureDisabled < Exception
+    def initialize(name)
+      @name = name
+    end
+
+    def message
+      "Feature disabled: #{@name}"
+    end
+  end
+end

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -1,4 +1,5 @@
 class DebatesController < ApplicationController
+  include FeatureFlags
   include CommentableActions
   include FlagActions
 
@@ -6,6 +7,8 @@ class DebatesController < ApplicationController
   before_action :parse_tag_filter, only: :index
   before_action :set_search_order, only: :index
   before_action :authenticate_user!, except: [:index, :show]
+
+  feature_flag :debates
 
   has_orders %w{hot_score confidence_score created_at relevance}, only: :index
   has_orders %w{most_voted newest oldest}, only: :show

--- a/app/controllers/moderation/debates_controller.rb
+++ b/app/controllers/moderation/debates_controller.rb
@@ -1,8 +1,11 @@
 class Moderation::DebatesController < Moderation::BaseController
   include ModerateActions
+  include FeatureFlags
 
   has_filters %w{pending_flag_review all with_ignored_flag}, only: :index
   has_orders %w{flags created_at}, only: :index
+
+  feature_flag :debates
 
   before_action :load_resources, only: [:index, :moderate]
 

--- a/app/controllers/spending_proposals_controller.rb
+++ b/app/controllers/spending_proposals_controller.rb
@@ -1,7 +1,11 @@
 class SpendingProposalsController < ApplicationController
+  include FeatureFlags
+
   before_action :authenticate_user!, except: [:index]
 
   load_and_authorize_resource
+
+  feature_flag :spending_proposals
 
   def index
   end

--- a/app/helpers/feature_flags_helper.rb
+++ b/app/helpers/feature_flags_helper.rb
@@ -1,0 +1,5 @@
+module FeatureFlagsHelper
+  def feature?(name)
+    !!Setting["feature.#{name}"]
+  end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -11,6 +11,7 @@ class Setting < ActiveRecord::Base
     def []=(key, value)
       setting = where(key: key).first || new(key: key)
       setting.value = value
+      setting.value = nil if setting.value == false
       setting.save!
       value
     end

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -18,12 +18,14 @@
       <% end %>
     </li>
 
-    <li <%= "class=active" if controller_name == "debates" %>>
-      <%= link_to admin_debates_path do %>
-        <i class="icon-debates"></i>
-        <%= t("admin.menu.hidden_debates") %>
-      <% end %>
-    </li>
+    <% if feature?(:debates) %>
+      <li <%= "class=active" if controller_name == "debates" %>>
+        <%= link_to admin_debates_path do %>
+          <i class="icon-debates"></i>
+          <%= t("admin.menu.hidden_debates") %>
+        <% end %>
+      </li>
+    <% end %>
 
     <li <%= "class=active" if controller_name == "comments" %>>
       <%= link_to admin_comments_path do %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -39,7 +39,9 @@
             <%= link_to t("layouts.header.debates"), debates_path, class: ("active" if controller_name == "debates") %>
           <% end %>
           <%= link_to t("layouts.header.proposals"), proposals_path, class: ("active" if  controller_name == "proposals") %>
-          <%= link_to t("layouts.header.spending_proposals"), spending_proposals_path, class: ("active" if controller_name == "spending_proposals") %>
+          <% if feature?(:spending_proposals) %>
+            <%= link_to t("layouts.header.spending_proposals"), spending_proposals_path, class: ("active" if controller_name == "spending_proposals") %>
+          <% end %>
           <%= link_to t("layouts.header.more_information"), page_path('more_information'), class: ("active" if current_page?("/more_information"))  %>
           <% if Setting['blog_url'] %>
             <%= link_to Setting['blog_url'], target: "_blank" do %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,7 +35,9 @@
       <section class="subnavigation row">
 
         <div class="small-12 medium-9 column">
-          <%= link_to t("layouts.header.debates"), debates_path, class: ("active" if controller_name == "debates") %>
+          <% if feature?(:debates) %>
+            <%= link_to t("layouts.header.debates"), debates_path, class: ("active" if controller_name == "debates") %>
+          <% end %>
           <%= link_to t("layouts.header.proposals"), proposals_path, class: ("active" if  controller_name == "proposals") %>
           <%= link_to t("layouts.header.spending_proposals"), spending_proposals_path, class: ("active" if controller_name == "spending_proposals") %>
           <%= link_to t("layouts.header.more_information"), page_path('more_information'), class: ("active" if current_page?("/more_information"))  %>

--- a/app/views/moderation/_menu.html.erb
+++ b/app/views/moderation/_menu.html.erb
@@ -11,12 +11,14 @@
       <% end %>
     </li>
 
-    <li <%= "class=active" if controller_name == "debates" %>>
-      <%= link_to moderation_debates_path do %>
-        <i class="icon-debates"></i>
-        <%= t('moderation.menu.flagged_debates') %>
-      <% end %>
-    </li>
+    <% if feature?(:debates) %>
+      <li <%= "class=active" if controller_name == "debates" %>>
+        <%= link_to moderation_debates_path do %>
+          <i class="icon-debates"></i>
+          <%= t('moderation.menu.flagged_debates') %>
+        <% end %>
+      </li>
+    <% end %>
 
     <li <%= "class=active" if controller_name == "comments" %>>
       <%= link_to moderation_comments_path do %>

--- a/app/views/users/_activity_page.html.erb
+++ b/app/views/users/_activity_page.html.erb
@@ -1,3 +1,3 @@
 <%= render "proposals" if @proposals.present? %>
-<%= render "debates" if @debates.present? %>
+<%= render "debates" if @debates.present? && feature?(:debates) %>
 <%= render "comments" if @comments.present? %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,3 +49,6 @@ Setting["org_name"] = "Consul"
 
 # Consul installation place name (City, Country...)
 Setting["place_name"] = "Consul-land"
+
+# Feature flags
+Setting['feature.debates'] = true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,3 +52,4 @@ Setting["place_name"] = "Consul-land"
 
 # Feature flags
 Setting['feature.debates'] = true
+Setting['feature.spending_proposals'] = true

--- a/spec/features/admin/debates_spec.rb
+++ b/spec/features/admin/debates_spec.rb
@@ -2,6 +2,14 @@ require 'rails_helper'
 
 feature 'Admin debates' do
 
+  scenario 'Disabled with a feature flag' do
+    Setting['feature.debates'] = nil
+    admin = create(:administrator)
+    login_as(admin.user)
+
+    expect{ visit admin_debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+  end
+
   background do
     admin = create(:administrator)
     login_as(admin.user)

--- a/spec/features/admin/spending_proposals_spec.rb
+++ b/spec/features/admin/spending_proposals_spec.rb
@@ -7,6 +7,11 @@ feature 'Admin spending proposals' do
     login_as(admin.user)
   end
 
+  scenario 'Disabled with a feature flag' do
+    Setting['feature.spending_proposals'] = nil
+    expect{ visit admin_spending_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+  end
+
   scenario 'Index shows spending proposals' do
     spending_proposal = create(:spending_proposal)
     visit admin_spending_proposals_path

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 
 feature 'Debates' do
 
+  scenario 'Disabled with a feature flag' do
+    Setting['feature.debates'] = nil
+    expect{ visit debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+  end
+
   scenario 'Index' do
     debates = [create(:debate), create(:debate), create(:debate)]
 

--- a/spec/features/moderation/debates_spec.rb
+++ b/spec/features/moderation/debates_spec.rb
@@ -2,6 +2,14 @@ require 'rails_helper'
 
 feature 'Moderate debates' do
 
+  scenario 'Disabled with a feature flag' do
+    Setting['feature.debates'] = nil
+    moderator = create(:moderator)
+    login_as(moderator.user)
+
+    expect{ visit moderation_debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+  end
+
   scenario 'Hide', :js do
     citizen = create(:user)
     moderator = create(:moderator)


### PR DESCRIPTION
This adds support for flagging features as enabled or disabled, leveraging the `Settings` API.

It adds security at the view layer via a `FeatureFlagsHelper`, and as a concern via `FeatureFlags`. The combination of both allows views to hide a particular feature whilst rejecting actions to controllers to disabled features.

It build on top of https://github.com/consul/consul/pull/763, which simplifies the Settings API (merge it first!).