### PR TITLE
Make search cache reusable

### DIFF
--- a/app/models/concerns/search_cache.rb
+++ b/app/models/concerns/search_cache.rb
@@ -7,7 +7,7 @@ module SearchCache
 
   def calculate_tsvector
     ActiveRecord::Base.connection.execute("
-      UPDATE proposals SET tsv = (#{searchable_values_sql}) WHERE id = #{self.id}")
+      UPDATE #{self.class.table_name} SET tsv = (#{searchable_values_sql}) WHERE id = #{self.id}")
   end
 
   private


### PR DESCRIPTION
I wanted to use the `SearchCache` concern in a new model but I detected it was hardcoded to `proposals` table.
I included a reference to the model `table_name` making it reusable.