### PR TITLE
returns empty 404 

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,6 @@ class PagesController < ApplicationController
   def show
     render action: params[:id]
   rescue ActionView::MissingTemplate
-    raise ActionController::RoutingError.new('Not Found')
+    head 404
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -60,7 +60,8 @@ describe PagesController do
 
   describe 'Not found pages' do
     it 'should return a 404 message' do
-      expect { get :show, id: "nonExistentPage" }.to raise_error(ActionController::RoutingError)
+      get :show, id: "nonExistentPage"
+      expect(response).to be_missing
     end
   end
 


### PR DESCRIPTION
instead of raising an exception for the catch-all route