### PR TITLE
Store locale in a user's field and switch locale on mailers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,14 @@ class ApplicationController < ActionController::Base
 
       session[:locale] ||= I18n.default_locale
 
-      I18n.locale = session[:locale]
+      locale = session[:locale]
+
+      if current_user
+        current_user.locale = locale
+        current_user.save
+      end
+
+      I18n.locale = locale
     end
 
     def set_layout

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,9 +54,8 @@ class ApplicationController < ActionController::Base
 
       locale = session[:locale]
 
-      if current_user
-        current_user.locale = locale
-        current_user.save
+      if current_user && current_user.locale != locale.to_s
+        current_user.update(locale: locale)
       end
 
       I18n.locale = locale

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -47,7 +47,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   private
 
     def sign_up_params
-      params.require(:user).permit(:username, :email, :password, :password_confirmation, :captcha, :captcha_key, :terms_of_service)
+      params.require(:user).permit(:username, :email, :password,
+                                   :password_confirmation, :captcha,
+                                   :captcha_key, :terms_of_service, :locale)
     end
 
     def erase_params

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,0 +1,13 @@
+class DeviseMailer < Devise::Mailer
+  helper :application
+  include Devise::Controllers::UrlHelpers
+  default template_path: 'devise/mailer'
+
+  protected
+
+  def devise_mail(record, action, opts={})
+    I18n.with_locale record.locale do
+      super(record, action, opts)
+    end
+  end
+end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -6,7 +6,9 @@ class Mailer < ApplicationMailer
   def comment(comment)
     @comment = comment
     @commentable = comment.commentable
-    mail(to: @commentable.author.email, subject: t('mailers.comment.subject', commentable: t("activerecord.models.#{@commentable.class.name.downcase}", count: 1).downcase)) if @commentable.present? && @commentable.author.present?
+    with_user(@commentable.author) do
+      mail(to: @commentable.author.email, subject: t('mailers.comment.subject', commentable: t("activerecord.models.#{@commentable.class.name.downcase}", count: 1).downcase)) if @commentable.present? && @commentable.author.present?
+    end
   end
 
   def reply(reply)
@@ -14,7 +16,9 @@ class Mailer < ApplicationMailer
     @commentable = @reply.commentable
     parent = Comment.find(@reply.parent_id)
     @recipient = parent.author
-    mail(to: @recipient.email, subject: t('mailers.reply.subject')) if @commentable.present? && @recipient.present?
+    with_user(@recipient) do
+      mail(to: @recipient.email, subject: t('mailers.reply.subject')) if @commentable.present? && @recipient.present?
+    end
   end
 
   def email_verification(user, recipient, token, document_type, document_number)
@@ -23,7 +27,17 @@ class Mailer < ApplicationMailer
     @token = token
     @document_type = document_type
     @document_number = document_number
-    mail(to: @recipient, subject: t('mailers.email_verification.subject'))
+
+    with_user(user) do
+      mail(to: @recipient, subject: t('mailers.email_verification.subject'))
+    end
   end
 
+  private
+
+  def with_user(user, &block)
+    I18n.with_locale(user.locale) do
+      block.call
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,9 @@ class User < ActiveRecord::Base
   validates_format_of :email, without: OMNIAUTH_EMAIL_REGEX, on: :update
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
 
+  validates :locale, inclusion: {in: I18n.available_locales.map(&:to_s),
+                                 allow_nil: true}
+
   validates_associated :organization, message: false
 
   accepts_nested_attributes_for :organization, update_only: true
@@ -204,6 +207,10 @@ class User < ActiveRecord::Base
   def has_official_email?
     domain = Setting['email_domain_for_officials']
     !email.blank? && ( (email.end_with? "@#{domain}") || (email.end_with? ".#{domain}") )
+  end
+
+  def locale
+    self[:locale] ||= I18n.default_locale.to_s
   end
 
   private

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -27,6 +27,8 @@
                            label: t("devise_views.users.registrations.new.password_confirmation_label"),
                            placeholder: t("devise_views.users.registrations.new.password_confirmation_label") %>
 
+      <%= f.hidden_field :locale, value: I18n.locale %>
+
       <%= f.simple_captcha input_html: {required: false} %>
 
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -15,7 +15,7 @@ Devise.setup do |config|
   config.mailer_sender = 'noreply@madrid.es'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'DeviseMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/db/migrate/20160122153329_add_locale_to_users.rb
+++ b/db/migrate/20160122153329_add_locale_to_users.rb
@@ -1,0 +1,5 @@
+class AddLocaleToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :locale, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160114110933) do
+ActiveRecord::Schema.define(version: 20160122153329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -391,6 +391,7 @@ ActiveRecord::Schema.define(version: 20160114110933) do
     t.boolean  "public_activity",                      default: true
     t.boolean  "newsletter",                           default: false
     t.integer  "notifications_count",                  default: 0
+    t.string   "locale"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -112,4 +112,13 @@ feature 'Emails' do
     end
   end
 
+  scenario "Email depending on user's locale" do
+    sign_up
+
+    email = open_last_email
+    expect(email).to have_subject('Confirmation instructions')
+    expect(email).to deliver_to('manuela@madrid.es')
+    expect(email).to have_body_text(user_confirmation_path)
+  end
+
 end

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -1,0 +1,16 @@
+# coding: utf-8
+require 'rails_helper'
+
+describe DeviseMailer do
+  describe "#confirmation_instructions" do
+    it "sends emails in the user's locale" do
+      user = create(:user, locale: "es")
+
+      email = I18n.with_locale :en do
+        DeviseMailer.confirmation_instructions(user, "ABC")
+      end
+
+      expect(email.subject).to include("confirmación")
+    end
+  end
+end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Mailer do
+  describe "#comment" do
+    it "sends emails in the user's locale" do
+      user = create(:user, locale: "es")
+      proposal = create(:proposal, author: user)
+      comment = create(:comment, commentable: proposal)
+
+      email = I18n.with_locale :en do
+        Mailer.comment(comment)
+      end
+
+      expect(email.subject).to include("comentado")
+    end
+  end
+end


### PR DESCRIPTION
This will ensure all emails will be sent in the user's locale (the last one she used in in the application).

Tests were behaving as this was already happening, as jobs were executed synchronously. In production though, they were asynchronous and thus were getting the default locale (spanish).