### PR TITLE
refactors proposals search

### DIFF
--- a/app/models/concerns/search_cache.rb
+++ b/app/models/concerns/search_cache.rb
@@ -13,11 +13,14 @@ module SearchCache
   private
 
   def searchable_values_sql
-    searchable_values.collect { |value, weight| set_tsvector(value, weight) }.join(" || ")
+    searchable_values
+      .select{ |k,_| k.present? }
+      .collect{ |value, weight| set_tsvector(value, weight) }
+      .join(" || ")
   end
 
   def set_tsvector(value, weight)
-    "setweight(to_tsvector('spanish', coalesce(#{quote(value)}, '')), #{quote(weight)})"
+    "setweight(to_tsvector('spanish', unaccent(coalesce(#{quote(value)}, ''))), #{quote(weight)})"
   end
 
   def quote(value)

--- a/app/models/concerns/search_cache.rb
+++ b/app/models/concerns/search_cache.rb
@@ -20,11 +20,16 @@ module SearchCache
   end
 
   def set_tsvector(value, weight)
-    "setweight(to_tsvector('spanish', unaccent(coalesce(#{quote(value)}, ''))), #{quote(weight)})"
+    "setweight(to_tsvector('spanish', unaccent(coalesce(#{quote(strip_html(value))}, ''))), #{quote(weight)})"
   end
 
   def quote(value)
     ActiveRecord::Base.connection.quote(value)
   end
+
+  def strip_html(value)
+    ActionController::Base.helpers.sanitize(value, tags: [])
+  end
+
 
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -61,16 +61,12 @@ class Proposal < ActiveRecord::Base
       tag_list.join(' ') => 'B',
       geozone.try(:name) => 'B',
       summary            => 'C',
-      description_text   => 'D'
+      description        => 'D'
     }
   end
 
   def self.search(terms)
     self.pg_search(terms)
-  end
-
-  def description_text
-    ActionController::Base.helpers.sanitize(description, tags: [])
   end
 
   def description

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -45,17 +45,9 @@ class Proposal < ActiveRecord::Base
   scope :last_week,            -> { where("created_at >= ?", 7.days.ago)}
 
   pg_search_scope :pg_search, {
-    against: {
-      title:       'A',
-      question:    'B',
-      summary:     'C',
-      description: 'D'
-    },
-    associated_against: {
-      tags: :name
-    },
+    against: :ignored, # not used since the using: option has a tsvector_column
     using: {
-      tsearch: { dictionary: "spanish", tsvector_column: 'tsv' }
+      tsearch: { dictionary: "spanish", tsvector_column: 'tsv', prefix: true }
     },
     ignoring: :accents,
     ranked_by: '(:tsearch)',
@@ -63,20 +55,22 @@ class Proposal < ActiveRecord::Base
   }
 
   def searchable_values
-    values = {
-      title       => 'A',
-      question    => 'B',
-      summary     => 'C',
-      description => 'D'
+    { title              => 'A',
+      question           => 'B',
+      author.username    => 'B',
+      tag_list.join(' ') => 'B',
+      geozone.try(:name) => 'B',
+      summary            => 'C',
+      description_text   => 'D'
     }
-    tag_list.each{ |tag| values[tag] = 'D' }
-    values[author.username] = 'D'
-    values[geozone.name] = 'D' if geozone.present?
-    values
   end
 
   def self.search(terms)
     self.pg_search(terms)
+  end
+
+  def description_text
+    ActionController::Base.helpers.sanitize(description, tags: [])
   end
 
   def description

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -414,22 +414,21 @@ describe Proposal do
     context "stemming" do
 
       it "searches word stems" do
-        proposal = create(:proposal, summary: 'biblioteca')
+        proposal = create(:proposal, summary: 'Economía')
 
-        results = Proposal.search('bibliotecas')
+        results = Proposal.search('economía')
         expect(results).to eq([proposal])
 
-        results = Proposal.search('bibliotec')
+        results = Proposal.search('econo')
         expect(results).to eq([proposal])
 
-        results = Proposal.search('biblioteco')
+        results = Proposal.search('eco')
         expect(results).to eq([proposal])
       end
 
     end
 
     context "accents" do
-
       it "searches with accents" do
         proposal = create(:proposal, summary: 'difusión')
 
@@ -439,12 +438,14 @@ describe Proposal do
         proposal2 = create(:proposal, summary: 'estadisticas')
         results = Proposal.search('estadísticas')
         expect(results).to eq([proposal2])
-      end
 
+        proposal3 = create(:proposal, summary: 'público')
+        results = Proposal.search('publico')
+        expect(results).to eq([proposal3])
+      end
     end
 
     context "case" do
-
       it "searches case insensite" do
         proposal = create(:proposal, title: 'SHOUT')
 
@@ -455,24 +456,24 @@ describe Proposal do
         results = Proposal.search("SCREAM")
         expect(results).to eq([proposal2])
       end
-
     end
 
     context "tags" do
-
       it "searches by tags" do
         proposal = create(:proposal, tag_list: 'Latina')
 
         results = Proposal.search('Latina')
         expect(results.first).to eq(proposal)
-      end
 
+        results = Proposal.search('Latin')
+        expect(results.first).to eq(proposal)
+      end
     end
 
     context "order" do
 
       it "orders by weight" do
-        proposal_question    = create(:proposal, question:    'stop corruption')
+        proposal_question    = create(:proposal,  question:    'stop corruption')
         proposal_title       = create(:proposal,  title:       'stop corruption')
         proposal_description = create(:proposal,  description: 'stop corruption')
         proposal_summary     = create(:proposal,  summary:     'stop corruption')


### PR DESCRIPTION
This refactors the way searches are done in Proposals.

* `SearchCache` was not applying unaccent when calculating the tsvector, but the search was applying it to the search terms. It is applied everywhere now.
* `SearchCache` automatically discards any blank strings (this was done on each model before)
* `SearchCache` automatically cleans up html before calculating the tsvector
* The option `against:` is ignored in `pg_search_scope` when using a tsvector - so it is removed from `Proposal`'s scope.
* Similarly, the `associated_against:` can be removed because the tsvector already contains the tags inside of it. Removing this option simplifies the generated search sql
* The `prefix: true` option allows looking for `dolor`, but typing `dolo` and `dol` will also bring you results