### PR TITLE
Añadir buscador en admin/users #307

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -4,7 +4,10 @@ class Admin::CommentsController < Admin::BaseController
   before_action :load_comment, only: [:confirm_hide, :restore]
 
   def index
-    @comments = Comment.only_hidden.with_visible_author.send(@current_filter).order(hidden_at: :desc).page(params[:page])
+    @comments = Comment.only_hidden.with_visible_author
+                       .send(@current_filter)
+                       .order(hidden_at: :desc)
+                       .page(params[:page])
   end
 
   def confirm_hide
@@ -18,8 +21,19 @@ class Admin::CommentsController < Admin::BaseController
     Activity.log(current_user, :restore, @comment)
     redirect_to request.query_parameters.merge(action: :index)
   end
+  
+  def search
+    if (params[:term]).strip == ""
+      redirect_to request.query_parameters.merge(action: :index)
+    else
+      @comments = Comment.only_hidden.where("body ILIKE?" ,  
+                                             "%#{params[:term]}%")
+                                     .page(params[:page])
+    end
+  end
 
   private
+    
     def load_comment
       @comment = Comment.with_hidden.find(params[:id])
     end

--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -18,6 +18,21 @@ class Admin::ProposalsController < Admin::BaseController
     Activity.log(current_user, :restore, @proposal)
     redirect_to request.query_parameters.merge(action: :index)
   end
+ 
+  def search
+    if (params[:term]).strip == ""
+
+      redirect_to request.query_parameters.merge(action: :index)
+    else
+      @proposals = Proposal.only_hidden.where("title ILIKE ? OR 
+                                               summary ILIKE ? OR 
+                                               description ILIKE ?", 
+                                               "%#{params[:term]}%" , 
+                                               "%#{params[:term]}%" , 
+                                               "%#{params[:term]}%")
+                           .page(params[:page])
+    end
+  end
 
   private
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -24,6 +24,13 @@ class Admin::UsersController < Admin::BaseController
     redirect_to request.query_parameters.merge(action: :index)
   end
 
+  def search
+    if (params[:term]).strip == ""
+      redirect_to request.query_parameters.merge(action: :index)
+    else
+      @users = User.only_hidden.where("username ILIKE?", "%#{params[:term]}%").page(params[:page])
+    end
+  end
   private
 
     def load_user

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -78,6 +78,10 @@ class Comment < ActiveRecord::Base
     moderator_id.present?
   end
 
+  def self.search(term)
+    term.present? ? where("body ILIKE ?", "%#{term}%") : none
+  end
+
   def after_hide
     commentable_type.constantize.with_hidden.reset_counters(commentable_id, :comments)
   end

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -1,5 +1,18 @@
 <h2><%= t("admin.comments.index.title") %></h2>
 
+<!-- Search comments -->
+<%= form_for(Comment.new, url: search_admin_comments_path, method: :get) do |f| %>
+  <div class="row">
+    <div class="small-12 medium-6 column">
+      <%= text_field_tag :term, params[:term], placeholder: t("admin.comments.index.search_placeholder") %>
+    </div>
+    <div class="form-inline small-12 medium-6 column">
+      <%= f.submit t("admin.comments.index.search"), class: "button radius success" %>
+    </div>
+  </div>
+<% end %>
+<!-- /. Search comments -->
+
 <%= render 'shared/filter_subnav', i18n_namespace: "admin.comments.index" %>
 
 <h3><%= page_entries_info @comments %></h3>

--- a/app/views/admin/comments/search.html.erb
+++ b/app/views/admin/comments/search.html.erb
@@ -1,0 +1,46 @@
+<h2><%= t("admin.comments.search.title") %></h2>
+
+<!-- Search comments -->
+<%= form_for(Comment.new, url: search_admin_comments_path, method: :get) do |f| %>
+  <div class="row">
+    <div class="small-12 medium-6 column">
+      <%= text_field_tag :term, "", placeholder: t("admin.comments.index.search_placeholder") %>
+    </div>
+    <div class="form-inline small-12 medium-6 column">
+      <%= f.submit t("admin.comments.index.search"), class: "button radius success" %>
+    </div>
+  </div>
+<% end %>
+<!-- /. Search comments -->
+
+<h3><%= page_entries_info @comments %></h3>
+
+<table id="search-results">
+  <% @comments.each do |comment| %>
+  <tr>
+    <td>
+      <%= text_with_links comment.body %><br>
+        <% if comment.commentable.hidden? %>
+            (<%= t("admin.comments.index.hidden_#{comment.commentable_type.downcase}") %>: <%= comment.commentable.title %>)
+        <% else %>
+            <%= link_to comment.commentable.title, comment.commentable %>
+        <% end %>
+    </td>
+    <td>
+      <%= link_to t("admin.actions.restore"),
+        restore_admin_comment_path(comment, request.query_parameters),
+        method: :put,
+        data: { confirm: t("admin.actions.confirm") },
+        class: "button radius tiny success right" %>
+      <% unless comment.confirmed_hide? %>
+        <%= link_to t("admin.actions.confirm_hide"),
+        confirm_hide_admin_comment_path(comment, request.query_parameters),
+        method: :put,
+        class: "button radius tiny warning right" %>
+      <% end %>
+    </td> 
+  </tr>
+<% end %>
+</table>
+
+<%= paginate @comments %>

--- a/app/views/admin/proposals/search.html.erb
+++ b/app/views/admin/proposals/search.html.erb
@@ -1,10 +1,10 @@
-<h2><%= t("admin.proposals.index.title") %></h2>
+<h2><%= t("admin.proposals.search.title") %></h2>
 
 <!-- Search proposals -->
-<%= form_for(Proposal.new, url: search_admin_proposals_path, method: :get) do |f| %>
+<%= form_for(Comment.new, url: search_admin_proposals_path, method: :get) do |f| %>
   <div class="row">
     <div class="small-12 medium-6 column">
-      <%= text_field_tag :term, params[:term], placeholder: t("admin.proposals.index.search_placeholder") %>
+      <%= text_field_tag :term, "", placeholder: t("admin.proposals.index.search_placeholder") %>
     </div>
     <div class="form-inline small-12 medium-6 column">
       <%= f.submit t("admin.proposals.index.search"), class: "button radius success" %>
@@ -12,8 +12,6 @@
   </div>
 <% end %>
 <!-- /. Search proposals -->
-
-<%= render 'shared/filter_subnav', i18n_namespace: "admin.proposals.index" %>
 
 <h3><%= page_entries_info @proposals %></h3>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,17 @@
+
 <h2><%= t("admin.users.index.title") %></h2>
+<!-- Search users -->
+<%= form_for(User.new, url: search_admin_users_path, method: :get) do |f| %>
+  <div class="row">
+    <div class="small-12 medium-6 column">
+      <%= text_field_tag :term, params[:term], placeholder: t("admin.users.index.search_placeholder") %>
+    </div>
+    <div class="form-inline small-12 medium-6 column">
+      <%= f.submit t("admin.users.index.search"), class: "button radius success" %>
+    </div>
+  </div>
+<% end %>
+<!-- /. Search users -->
 
 <%= render 'shared/filter_subnav', i18n_namespace: "admin.users.index" %>
 
@@ -25,5 +38,3 @@
 </ul>
 
 <%= paginate @users %>
-
-

--- a/app/views/admin/users/search.html.erb
+++ b/app/views/admin/users/search.html.erb
@@ -1,0 +1,39 @@
+<h2><%= t("admin.users.search.title") %></h2>
+
+<!-- Search users -->
+<%= form_for(User.new, url: search_admin_users_path, method: :get) do |f| %>
+  <div class="row">
+    <div class="small-12 medium-6 column">
+      <%= text_field_tag :term, "", placeholder: t("admin.users.index.search_placeholder") %>
+    </div>
+    <div class="form-inline small-12 medium-6 column">
+      <%= f.submit t("admin.users.index.search"), class: "button radius success" %>
+    </div>
+  </div>
+<% end %>
+<!-- /. Search users -->
+
+<h3><%= page_entries_info @users %></h3>
+
+<table id="search-results">
+  <% @users.each do |user| %>
+  <tr>
+    <td><%= link_to user.username, admin_user_path(user) %></td>
+    <td>
+      <%= link_to t("admin.actions.restore"),
+            restore_admin_user_path(user, request.query_parameters),
+            method: :put,
+            data: { confirm: t("admin.actions.confirm") },
+            class: "button radius tiny success right" %>
+      <% unless user.confirmed_hide? %>
+        <%= link_to t("admin.actions.confirm_hide"),
+            confirm_hide_admin_user_path(user, request.query_parameters),
+            method: :put,
+            class: "button radius tiny warning right" %>
+      <% end %>
+    </td> 
+  </tr>
+<% end %>
+</table>
+
+<%= paginate @users %>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -26,14 +26,18 @@ en:
         type: Type
     comments:
       index:
+        search_placeholder: Search comments
+        search: Search
         filter: Filter
         filters:
           all: All
           with_confirmed_hide: Confirmed
           without_confirmed_hide: Pending
-        hidden_debate: Hidden debate
+        hidden_debate: Hidden debates
         hidden_proposal: Hidden proposal
         title: Hidden comments
+      search:
+        title: Search hidden comments
     dashboard:
       index:
         title: Administration
@@ -55,7 +59,7 @@ en:
       incomplete_verifications: Incomplete verifications
       moderators: Moderators
       officials: Officials
-      organizations: Organisations
+      organizations: Organizations
       settings: General settings
       spending_proposals: Spending proposals
       stats: Statistics
@@ -98,17 +102,17 @@ en:
           rejected: Rejected
           verified: Verified
         hidden_count:
-          one: There is also one organisation with no users or with a hidden user
-          other: There are %{count} organisations with no users or with a hidden user
+          one: There is also one organizations with no users or with a hidden user
+          other: There are %{count} organizations with no users or with a hidden user
         reject: Reject
         rejected: Rejected
         search: Search
         search_placeholder: Name, email or phone number
-        title: Organisations
+        title: Organizations
         verified: Verified
         verify: Verify
       search:
-        title: Search Organisations
+        title: Search Organizations
     proposals:
       index:
         filter: Filter
@@ -117,6 +121,10 @@ en:
           with_confirmed_hide: Confirmed
           without_confirmed_hide: Pending
         title: Hidden proposals
+        search: Search
+        search_placeholder: Search proposals
+      search:
+        title: Search Hidden proposals
     settings:
       flash:
         updated: Value updated
@@ -175,6 +183,8 @@ en:
       update: Update Topic
     users:
       index:
+        search_placeholder: Search for Name
+        search: Search
         filter: Filter
         filters:
           all: All
@@ -187,6 +197,8 @@ en:
         hidden_at: 'Hidden at:'
         registered_at: 'Registered at:'
         title: Activity of user %{user}
+      search:
+        title: Search hidden users
     verifications:
       index:
         phone_not_given: Phone not given

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -26,14 +26,18 @@ es:
         type: Tipo
     comments:
       index:
+        search_placeholder: Buscar por comentarios
+        search: Buscar
         filter: Filtro
         filters:
           all: Todos
           with_confirmed_hide: Confirmados
           without_confirmed_hide: Pendientes
-        hidden_debate: Debate oculto
-        hidden_proposal: Propuesta oculta
+        hidden_debate: Debates ocultos
+        hidden_proposal: Propuestas ocultas
         title: Comentarios ocultos
+      search:
+        title: Buscar comentarios ocultos
     dashboard:
       index:
         title: Administración
@@ -116,7 +120,11 @@ es:
           all: Todas
           with_confirmed_hide: Confirmadas
           without_confirmed_hide: Pendientes
-        title: Propuestas ocultos
+        search: Buscar
+        search_placeholder: Buscar propuestas
+        title: Propuestas ocultas
+      search:
+        title: Buscar propuestas ocultas
     settings:
       flash:
         updated: Valor actualizado
@@ -175,7 +183,9 @@ es:
       update: Actualizar Tema
     users:
       index:
-        filter: Filtro
+        search_placeholder: Buscar por Nombre
+        search: Buscar
+        filter: Filtro   
         filters:
           all: Todos
           with_confirmed_hide: Confirmados
@@ -186,7 +196,9 @@ es:
         email: 'Email:'
         hidden_at: 'Bloqueado:'
         registered_at: 'Fecha de alta:'
-        title: Actividad del usuario %{user}
+        title: Actividad del usuario %{user}      
+      search:
+        title: Buscar Usuarios bloqueados
     verifications:
       index:
         phone_not_given: No ha dado su teléfono

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,7 +84,7 @@ en:
     form:
       debate_text: Initial debate text
       debate_title: Debate title
-      tags_instructions: Tag this debate. You can choose from our suggestions or enter your own.
+      tags_instructions: Tag this debate.
       tags_label: Topics
       tags_placeholder: Enter the tags you would like to use, separated by commas (',')
     index:
@@ -225,6 +225,11 @@ en:
         one: Someone replied to your comment on
         other: There are %{count} new replies to your comment on
       title: Notifications
+  map:
+    title: "Districts"
+    proposal_for_district: "Start a proposal for your district"
+    select_district: Scope of operation
+    start_proposal: Create a proposal
   omniauth:
     facebook:
       sign_in: Sign in with Facebook
@@ -259,7 +264,8 @@ en:
       proposal_title: Proposal title
       proposal_video_url: Link to external video
       proposal_video_url_note: You may add a link to YouTube or Vimeo
-      tags_instructions: Tag this proposal. You can choose from our tags or add your own.
+      tag_category_label: "Categories"
+      tags_instructions: "Tag this proposal. You can choose from proposed categories or add your own"
       tags_label: Tags
       tags_placeholder: Enter the tags you would like to use, separated by commas (',')
     index:
@@ -358,8 +364,23 @@ en:
     flag: Flag as inappropriate
     print:
       print_button: Print this info
+    suggest:
+      debate:
+        found:
+          one: "There is a debate with the term '%{query}', you can participate in it instead of opening a new one."
+          other: "There are debates with the term '%{query}', you can participate in them instead of opening a new one."
+        message: "You are seeing %{limit} of %{count} debates containing the term '%{query}'"
+        see_all: "Ver todos"
+      proposal:
+        found:
+          one: "There is a proposal with the term '%{query}', you can contribute to it instead of creating a new"
+          other: "There are proposals with the term '%{query}', you can contribute to them instead of creating a new"
+        message: "You are seeing %{limit} of %{count} proposals containing the term '%{query}'"
+        see_all: "See all"
     tags_cloud:
       tags: Trending
+      districts: "Districts"
+      categories: "Categories"
     unflag: Unflag
   simple_captcha:
     label: Enter the text from the image in the box below
@@ -460,3 +481,22 @@ en:
       user_permission_verify_info: "* Only for users on Madrid Census."
       user_permission_verify_url: verify your account
       user_permission_votes: Participate on final voting
+  omniauth:
+    finish_signup:
+      title: "Additional details"
+    twitter:
+      sign_in: "Sign in with Twitter"
+      sign_up: "Sign up with Twitter"
+    facebook:
+      sign_in: "Sign in with Facebook"
+      sign_up: "Sign up with Facebook"
+    google_oauth2:
+      sign_in: "Sign in with Google"
+      sign_up: "Sign up with Google"
+  legislation:
+    help:
+      title: "How I can comment this document?"
+      text: "To comment this document you must %{sign_in} or %{sign_up}. Then select the text you want to comment and press the button with the pencil."
+      text_sign_in: "login"
+      text_sign_up: "sign up"
+      alt: "Select the text you want to comment and press the button with the pencil."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
     end
 
     resources :users, only: [:index, :show] do
+      collection { get :search }
       member do
         put :restore
         put :confirm_hide
@@ -116,6 +117,7 @@ Rails.application.routes.draw do
     end
 
     resources :proposals, only: :index do
+      collection { get :search }
       member do
         put :restore
         put :confirm_hide
@@ -130,6 +132,7 @@ Rails.application.routes.draw do
     end
 
     resources :comments, only: :index do
+      collection { get :search }
       member do
         put :restore
         put :confirm_hide

--- a/spec/features/admin/comments_spec.rb
+++ b/spec/features/admin/comments_spec.rb
@@ -98,4 +98,42 @@ feature 'Admin comments' do
     expect(current_url).to include('page=2')
   end
 
+  context "Search" do
+    background do
+
+      comment = create(:comment, 
+                       :hidden, 
+                       body: "SPAM from SPAMMER", 
+                       hidden_at: '016-01-25 13:04:01.021165')
+      proposal = create(:proposal, 
+                         author: comment.author)
+    end
+
+    scenario "The search is not running if search term is empty" do
+      visit admin_comments_path
+      fill_in "term", with: "      "
+      click_button "Search"
+      expect(current_path).to eq(admin_comments_path)
+      expect(page).to have_content("SPAM from SPAMMER")
+    end
+
+    scenario "returns no results if search term does not exist" do
+      visit admin_comments_path
+
+      fill_in "term", with: "Prueba"
+      click_button "Search"
+      expect(current_path).to eq(search_admin_comments_path)
+      expect(page).to_not have_content("Prueba")
+      expect(page).to have_content("comments cannot be found")
+    end
+    
+    scenario "finds by comment" do
+      visit admin_comments_path
+
+      fill_in "term", with: "SPAM from SPAMMER"
+      click_button "Search"
+      expect(current_path).to eq(search_admin_comments_path)
+      expect(page).to have_content("SPAM from SPAMMER")
+    end
+  end
 end

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -94,5 +94,39 @@ feature 'Admin proposals' do
     expect(current_url).to include('filter=with_confirmed_hide')
     expect(current_url).to include('page=2')
   end
+  context "Search" do
+    background do
+      proposal = create(:proposal, 
+                        :hidden,
+                         title: "Testing proposal",
+                         hidden_at: '016-01-25 13:04:01.021165')
+    end
 
+    scenario "The search is not running if search term is empty" do
+      visit admin_proposals_path
+      fill_in "term", with: "      "
+      click_button "Search"
+      expect(current_path).to eq(admin_proposals_path)
+      expect(page).to have_content("Testing proposal")
+    end
+
+    scenario "returns no results if search term does not exist" do
+      visit admin_proposals_path
+
+      fill_in "term", with: "Prueba"
+      click_button "Search"
+      expect(current_path).to eq(search_admin_proposals_path)
+      expect(page).to_not have_content("Prueba")
+      expect(page).to have_content("proposals cannot be found")
+    end
+    
+    scenario "finds by proposal" do
+      visit admin_proposals_path
+
+      fill_in "term", with: "Testing proposal"
+      click_button "Search"
+      expect(current_path).to eq(search_admin_proposals_path)
+      expect(page).to have_content("Testing proposal")
+    end
+  end
 end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -94,4 +94,42 @@ feature 'Admin users' do
     expect(current_url).to include('page=2')
   end
 
+context "Search" do
+
+    background do
+      @usu1 = create(:user, email: 'enrique@madrid.es', 
+                    password: '915885635', 
+                    username: 'Enrique Ruiz Roldán', 
+                    hidden_at: '016-01-25 13:04:01.021165',
+                    phone_number: '915885635')
+    end
+
+    scenario "The search is not running if search term is empty" do
+      visit admin_users_path
+      fill_in "term", with: "      "
+      click_button "Search"
+      expect(current_path).to eq(admin_users_path)
+      expect(page).to have_content("Enrique Ruiz Roldán")
+    end
+
+    scenario "returns no results if search term does not exist" do
+      visit admin_users_path
+
+      fill_in "term", with: "Raul"
+      click_button "Search"
+      expect(current_path).to eq(search_admin_users_path)
+      expect(page).to_not have_content("Raul")
+      expect(page).to have_content("users cannot be found")
+    end
+    
+    scenario "finds by name" do
+      visit admin_users_path
+
+      fill_in "term", with: "Enrique"
+      click_button "Search"
+
+      expect(current_path).to eq(search_admin_users_path)
+      expect(page).to have_content("Enrique Ruiz Roldán")
+    end
+  end
 end


### PR DESCRIPTION
Se aprovecha para añadir la misma funcionalidad a admin/comments, admin/debates y admin/proposal 

Resolviendo conflictos