### PR TITLE
uses tag ids instead of tag names

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -42,7 +42,7 @@ class Proposal < ActiveRecord::Base
   scope :sort_by_relevance ,       -> { all }
   scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
   scope :last_week,                -> { where("proposals.created_at >= ?", 7.days.ago)}
-  scope :in_categories,            -> { where("tags.name IN (?)", ActsAsTaggableOn::Tag.category_names) }
+  scope :in_categories,            -> { where("tags.id IN (?)", ActsAsTaggableOn::Tag.category_ids) }
 
   def searchable_values
     { title              => 'A',

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -38,6 +38,10 @@ module ActsAsTaggableOn
       Tag.where("kind = 'category'").map {|tag| tag.name.downcase }
     end
 
+    def self.category_ids
+      Tag.where("kind = 'category'").map {|tag| tag.id }
+    end
+
     private
       def custom_counter_field_name_for(taggable_type)
         "#{taggable_type.underscore.pluralize}_count"


### PR DESCRIPTION
To avoid category duplications due to capital letters, accents, etc. Instead of grouping proposals by category name we are now grouping them by category id.