### PR TITLE
Participatory budget urls

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :spending_proposals, only: [:index, :new, :create, :show]
+  scope '/participatory_budget' do
+    resources :spending_proposals, only: [:index, :new, :create, :show]
+  end
 
   resources :stats, only: [:index]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
   end
 
   scope '/participatory_budget' do
-    resources :spending_proposals, only: [:index, :new, :create, :show]
+    resources :spending_proposals, only: [:index, :new, :create, :show], path: 'investment_projects'
   end
 
   resources :stats, only: [:index]
@@ -131,7 +131,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :spending_proposals, only: [:index, :show] do
+    resources :spending_proposals, only: [:index, :show], path: 'investment_projects' do
       member do
         put :accept
         put :reject


### PR DESCRIPTION
- Uses 'participatory_budget' as a scope for all related urls
- Uses 'investment_projects' instead of 'spending_proposals' urls