### PR TITLE
changes welcome screen to stress verification and demote view proposals

### DIFF
--- a/app/views/welcome/welcome.html.erb
+++ b/app/views/welcome/welcome.html.erb
@@ -16,11 +16,14 @@
   </p>
 
   <p>
-    <%= t("welcome.welcome.user_permission_verify",
-    verify: link_to(t("welcome.welcome.user_permission_verify_url"), verification_path)).html_safe %>
+    <%= t("welcome.welcome.user_permission_verify") %>
   </p>
 
   <p class="text-center">
-    <%= link_to t("welcome.welcome.go_to_index"), proposals_path , class: "button success radius" %>
+    <%= link_to(t("welcome.welcome.user_permission_verify_my_account"), verification_path, class: "button success radius") %>
+  </p>
+
+  <p class="text-center">
+    <%= link_to t("welcome.welcome.go_to_index"), proposals_path %>
   </p>
 </div>

--- a/app/views/welcome/welcome.html.erb
+++ b/app/views/welcome/welcome.html.erb
@@ -19,9 +19,7 @@
     <%= t("welcome.welcome.user_permission_verify") %>
   </p>
 
-  <p class="text-center">
-    <%= link_to(t("welcome.welcome.user_permission_verify_my_account"), verification_path, class: "button success radius") %>
-  </p>
+  <%= link_to(t("welcome.welcome.user_permission_verify_my_account"), verification_path, class: "button success radius expand") %>
 
   <p class="text-center">
     <%= link_to t("welcome.welcome.go_to_index"), proposals_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -496,9 +496,9 @@ en:
       user_permission_info: With your account you can...
       user_permission_proposal: Create new proposals
       user_permission_support_proposal: Support proposals*
-      user_permission_verify: To perform all the actions %{verify}.
+      user_permission_verify: To perform all the actions verify your account.
       user_permission_verify_info: "* Only for users on Madrid Census."
-      user_permission_verify_url: verify your account
+      user_permission_verify_my_account: Verify my account
       user_permission_votes: Participate on final voting
   omniauth:
     finish_signup:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -491,15 +491,15 @@ es:
       title: Propones
     signed_in_home_title: Actividad reciente
     welcome:
-      go_to_index: Ver propuestas
+      go_to_index: Ahora no, ver propuestas
       title: Empieza a participar
       user_permission_debates: Participar en debates
       user_permission_info: Con tu cuenta ya puedes...
       user_permission_proposal: Crear nuevas propuestas
       user_permission_support_proposal: Apoyar propuestas*
-      user_permission_verify: Para poder realizar todas las acciones %{verify}.
+      user_permission_verify: Para poder realizar todas las acciones, verifica tu cuenta.
       user_permission_verify_info: "* Sólo usuarios empadronados en el municipio de Madrid."
-      user_permission_verify_url: verifica tu cuenta
+      user_permission_verify_my_account: Verificar mi cuenta
       user_permission_votes: Participar en las votaciones finales*
   omniauth:
     finish_signup:


### PR DESCRIPTION
Related with #905 (welcome screen)

This is the welcome screen after the modifications:

![screen shot 2016-02-22 at 11 01 31](https://cloud.githubusercontent.com/assets/63131/13215212/1e531258-d954-11e5-806e-7c4a6f257451.png)

The previous (current) screen has the link and the button at the end "switched".