### PR TITLE
shows all pagination links in mobile

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -416,7 +416,7 @@ $pagination-item-background-current: $primary-color;
 $pagination-item-color-current: foreground($pagination-item-background-current);
 $pagination-item-color-disabled: $medium-gray;
 $pagination-ellipsis-color: $black;
-$pagination-mobile-items: false;
+$pagination-mobile-items: true;
 $pagination-arrows: true;
 
 // 26. Progress Bar


### PR DESCRIPTION
Before:

![screen shot 2016-03-08 at 11 28 23](https://cloud.githubusercontent.com/assets/63131/13598963/0b3dc388-e521-11e5-8d3a-e0a473c1a1d4.png)

After:
![screen shot 2016-03-08 at 11 23 24](https://cloud.githubusercontent.com/assets/63131/13598964/0b3db910-e521-11e5-99e1-7c0ae095a743.png)
