### PR TITLE
Check if spending_proposals is enabled to show 'valuation' link

### DIFF
--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -11,7 +11,7 @@
     </li>
   <% end %>
 
-  <% if current_user.valuator? || current_user.administrator?  %>
+  <% if feature?(:spending_proposals) && (current_user.valuator? || current_user.administrator?) %>
     <li>
       <%= link_to t("layouts.header.valuation"), valuation_root_path %>
     </li>


### PR DESCRIPTION
The link was broken when Spending Proposals is disabled from administration.

The /valuation link points to `Valuation::SpendingProposalsController` which has a `feature_flag :spending_proposals` flag so clicking the link lead to an error page.