### PR TITLE
Destroy spending proposals

### DIFF
--- a/app/controllers/spending_proposals_controller.rb
+++ b/app/controllers/spending_proposals_controller.rb
@@ -28,6 +28,12 @@ class SpendingProposalsController < ApplicationController
     end
   end
 
+  def destroy
+    spending_proposal = current_user.spending_proposals.find(params[:id])
+    spending_proposal.destroy
+    redirect_to user_path(current_user, filter: 'spending_proposals'), notice: t('flash.actions.destroy.spending_proposal')
+  end
+
   private
 
     def spending_proposal_params

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -25,7 +25,7 @@ module Abilities
 
       can :suggest, Debate
       can :suggest, Proposal
-      
+
       can [:flag, :unflag], Comment
       cannot [:flag, :unflag], Comment, user_id: user.id
 
@@ -44,6 +44,7 @@ module Abilities
         can :vote, Proposal
         can :vote_featured, Proposal
         can :create, SpendingProposal
+        can :destroy, SpendingProposal, author_id: user.id
       end
 
       can :create, Annotation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ActiveRecord::Base
   has_many :debates, -> { with_hidden }, foreign_key: :author_id
   has_many :proposals, -> { with_hidden }, foreign_key: :author_id
   has_many :comments, -> { with_hidden }
+  has_many :spending_proposals, foreign_key: :author_id
   has_many :failed_census_calls
   has_many :notifications
   belongs_to :geozone

--- a/app/views/users/_spending_proposals.html.erb
+++ b/app/views/users/_spending_proposals.html.erb
@@ -1,10 +1,16 @@
-<table class="clear activity-proposals">
+<table id="spending_proposals_list" class="clear activity-proposals">
   <% @spending_proposals.each do |spending_proposal| %>
     <tr id="spending_proposal_<%= spending_proposal.id %>">
       <td>
         <%= link_to spending_proposal.title, spending_proposal %>
-        <br>
-        <%= spending_proposal.description %>
+
+        <% if current_user && current_user.id == spending_proposal.author_id %>
+          <%= link_to t("users.show.delete_spending_proposal"),
+                      spending_proposal,
+                      method: :delete,
+                      data: { confirm: t("users.show.confirm_deletion_spending_proposal") },
+                      class: 'button small warning' %>
+        <% end %>
       </td>
     </tr>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -445,6 +445,8 @@ en:
       deleted: Deleted
       deleted_debate: This debate has been deleted
       deleted_proposal: This proposal has been deleted
+      delete_spending_proposal: Delete
+      confirm_deletion_spending_proposal: Are you sure? This action can not be undone
       filters:
         comments:
           one: 1 Comment

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -445,6 +445,8 @@ es:
       deleted: Eliminado
       deleted_debate: Este debate ha sido eliminado
       deleted_proposal: Este propuesta ha sido eliminada
+      delete_spending_proposal: Eliminar
+      confirm_deletion_spending_proposal: "¿Seguro que desea eliminar esta propuesta?"
       filters:
         comments:
           one: 1 Comentario

--- a/config/locales/responders.en.yml
+++ b/config/locales/responders.en.yml
@@ -14,3 +14,5 @@ en:
         debate: "Debate updated successfully."
         proposal: "Proposal updated successfully."
         spending_proposal: "Investment project updated succesfully."
+      destroy:
+        spending_proposal: "Spending proposal deleted succesfully."

--- a/config/locales/responders.es.yml
+++ b/config/locales/responders.es.yml
@@ -14,3 +14,5 @@ es:
         debate: "Debate actualizado correctamente."
         proposal: "Propuesta actualizada correctamente."
         spending_proposal: "Propuesta de inversión actualizada correctamente."
+      destroy:
+        spending_proposal: "Propuesta de inversión eliminada."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
   end
 
   scope '/participatory_budget' do
-    resources :spending_proposals, only: [:index, :new, :create, :show], path: 'investment_projects'
+    resources :spending_proposals, only: [:index, :new, :create, :show, :destroy], path: 'investment_projects'
   end
 
   resources :stats, only: [:index]

--- a/spec/features/spending_proposals_spec.rb
+++ b/spec/features/spending_proposals_spec.rb
@@ -163,4 +163,24 @@ feature 'Spending proposals' do
     expect(page).to have_content("You do not have permission to access this page")
   end
 
+  context "Destroy" do
+
+    scenario "User can destroy owned spending proposals" do
+      user = create(:user, :level_two)
+      spending_proposal = create(:spending_proposal, author: user)
+      login_as(user)
+
+      visit user_path(user)
+      within("#spending_proposal_#{spending_proposal.id}") do
+        click_link "Delete"
+      end
+
+      expect(page).to have_content("Spending proposal deleted succesfully.")
+
+      visit user_path(user)
+      expect(page).not_to have_css("spending_proposal_list")
+    end
+
+  end
+
 end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -203,7 +203,7 @@ feature 'Users' do
 
       background do
         @author = create(:user)
-        create(:spending_proposal, author: @author, title: 'Build a school')
+        @spending_proposal = create(:spending_proposal, author: @author, title: 'Build a school')
       end
 
       scenario 'is not shown if no user logged in' do
@@ -238,6 +238,22 @@ feature 'Users' do
         login_as(@author)
         visit user_path(@author)
         expect(page).to have_content('Build a school')
+      end
+
+      scenario 'delete button is shown if logged in user is author' do
+        login_as(@author)
+        visit user_path(@author)
+        within("#spending_proposal_#{@spending_proposal.id}") do
+          expect(page).to have_content('Delete')
+        end
+      end
+
+      scenario 'delete button is not shown if logged in user is admin' do
+        login_as(create(:administrator).user)
+        visit user_path(@author)
+        within("#spending_proposal_#{@spending_proposal.id}") do
+          expect(page).to_not have_content('Delete')
+        end
       end
 
     end

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -30,6 +30,7 @@ describe "Abilities::Common" do
 
   it { should be_able_to(:index, SpendingProposal) }
   it { should_not be_able_to(:create, SpendingProposal) }
+  it { should_not be_able_to(:destroy, SpendingProposal) }
 
   it { should_not be_able_to(:comment_as_administrator, debate) }
   it { should_not be_able_to(:comment_as_moderator, debate) }
@@ -83,20 +84,26 @@ describe "Abilities::Common" do
   end
 
   describe "when level 2 verified" do
+    let(:own_spending_proposal) { create(:spending_proposal, author: user) }
     before{ user.update(residence_verified_at: Time.now, confirmed_phone: "1") }
 
     it { should be_able_to(:vote, Proposal) }
     it { should be_able_to(:vote_featured, Proposal) }
 
     it { should be_able_to(:create, SpendingProposal) }
+    it { should_not be_able_to(:destroy, create(:spending_proposal)) }
+    it { should be_able_to(:destroy, own_spending_proposal) }
   end
 
   describe "when level 3 verified" do
+    let(:own_spending_proposal) { create(:spending_proposal, author: user) }
     before{ user.update(verified_at: Time.now) }
 
     it { should be_able_to(:vote, Proposal) }
     it { should be_able_to(:vote_featured, Proposal) }
 
     it { should be_able_to(:create, SpendingProposal) }
+    it { should_not be_able_to(:destroy, create(:spending_proposal)) }
+    it { should be_able_to(:destroy, own_spending_proposal) }
   end
 end


### PR DESCRIPTION
Adds button to 'My activity' page to delete the user's own spending proposal.

note: destroy without paranoia, spending proposal data is really deleted.