### PR TITLE
Comment link

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -20,7 +20,7 @@ module UsersHelper
       commentable.title +
       "</abbr>".html_safe
     else
-      link_to(commentable.title, commentable)
+      link_to(commentable.title, comment)
     end
   end
 

--- a/app/views/users/_comments.html.erb
+++ b/app/views/users/_comments.html.erb
@@ -1,6 +1,6 @@
 <table class="clear activity-comments">
   <% @comments.each do |comment| %>
-    <tr id="debate_<%= comment.id %>">
+    <tr id="comment_<%= comment.id %>">
       <td>
         <%= comment_commentable_title(comment) %>
         <br>

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -31,9 +31,9 @@ describe UsersHelper do
   end
 
   describe '#comment_commentable_title' do
-    it "should return a link to the commentable" do
+    it "should return a link to the comment" do
       comment = create(:comment)
-      expect(comment_commentable_title(comment)).to eq link_to comment.commentable.title, comment.commentable
+      expect(comment_commentable_title(comment)).to eq link_to comment.commentable.title, comment
     end
 
     it "should return a hint if the commentable has been deleted" do


### PR DESCRIPTION
Links in comments list in 'My activity' now points to the comment show page, not to the commentable show page.
Re: #947 