### PR TITLE
changes order for valuator list

### DIFF
--- a/app/controllers/admin/spending_proposals_controller.rb
+++ b/app/controllers/admin/spending_proposals_controller.rb
@@ -15,7 +15,7 @@ class Admin::SpendingProposalsController < Admin::BaseController
 
   def edit
     @admins = Administrator.includes(:user).all
-    @valuators = Valuator.includes(:user).all.order("users.username ASC")
+    @valuators = Valuator.includes(:user).all.order("users.email ASC")
     @tags = ActsAsTaggableOn::Tag.spending_proposal_tags
   end
 


### PR DESCRIPTION
The list of valuators in the admin interface shows only the email. Now that list is alphabetically ordered.