### PR TITLE
Translation problem fixed

### DIFF
--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -37,7 +37,7 @@ en:
       proposal:
         one: "Citizen proposal"
         other: "Citizen proposals"
-      spending_proposal:
+      spendingproposal:
         one: "Spending proposal"
         other: "Spending proposals"
     attributes:

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -67,7 +67,7 @@ es:
       organization:
         name: "Nombre de organización"
         responsible_name: "Persona responsable del colectivo"
-      spending_proposal:
+      spendingproposal:
         administrator_id: "Administrador"
     errors:
       models:


### PR DESCRIPTION
Issue #1027

That appears in the email subject: 
`commentable: t("activerecord.models.#{@commentable.class.name.downcase}"`

and  `SpendingProposal.name = "SpendingProposal" `