### PR TITLE
Readme improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,7 @@ You can use the default admin user from the seeds file:
 
 But for some actions like voting, you will need to verify him, opening a console with `rails console` and then:
 ```
-a = User.first
-a.verified_at = Date.today
-a.level_two_verified_at = Date.today
-a.residence_verified_at = Date.today
-a.save
+User.first.update_attributes(verified_at: Date.today, residence_verified_at: Date.today, level_two_verified_at: Date.today)
 ```
 
 ### OAuth

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Run the tests with:
 bin/rspec
 ```
 
+You can use the default admin user from the seeds file:
+
+ **user:** admin@madrid.es
+ **pass:** 12345678
+
+But for some actions like voting, you will need to verify him, opening a console with `rails console` and then:
+```
+a = User.first
+a.verified_at = Date.today
+a.level_two_verified_at = Date.today
+a.residence_verified_at = Date.today
+a.save
+```
+
 ## Licence
 
 Code published under AFFERO GPL v3 (see [LICENSE-AGPLv3.txt](LICENSE-AGPLv3.txt))

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ a.residence_verified_at = Date.today
 a.save
 ```
 
+### OAuth
+
+To test authentication services with external OAuth suppliers - right now Twitter, Facebook and Google - you'll need to create an "application" in each of the supported platforms and set the *key* and *secret* provided in your *secrets.yml*
+
+In the case of Google, verify that the APIs *Contacts API* and *Google+ API* are enabled for the application.
+
 ## Licence
 
 Code published under AFFERO GPL v3 (see [LICENSE-AGPLv3.txt](LICENSE-AGPLv3.txt))

--- a/README_ES.md
+++ b/README_ES.md
@@ -62,11 +62,7 @@ Puedes usar el usuario administrador por defecto del fichero seeds:
 
 Pero para ciertas acciones, como apoyar, necesitarás verificarle, abre una consola con `rails console` y escribe:
 ```
-a = User.first
-a.verified_at = Date.today
-a.level_two_verified_at = Date.today
-a.residence_verified_at = Date.today
-a.save
+User.first.update_attributes(verified_at: Date.today, residence_verified_at: Date.today, level_two_verified_at: Date.today)
 ```
 
 ### OAuth

--- a/README_ES.md
+++ b/README_ES.md
@@ -55,6 +55,20 @@ Para ejecutar los tests:
 bin/rspec
 ```
 
+Puedes usar el usuario administrador por defecto del fichero seeds:
+
+ **user:** admin@madrid.es
+ **pass:** 12345678
+
+Pero para ciertas acciones, como apoyar, necesitarás verificarle, abre una consola con `rails console` y escribe:
+```
+a = User.first
+a.verified_at = Date.today
+a.level_two_verified_at = Date.today
+a.residence_verified_at = Date.today
+a.save
+```
+
 ### OAuth
 
 Para probar los servicios de autenticación mediante proveedores externos OAuth — en este momento Twitter, Facebook y Google —, necesitas crear una "aplicación" en cada una de las plataformas soportadas y configurar la *key* y el *secret* proporcionados en tu *secrets.yml*


### PR DESCRIPTION
Tras hacer el fork de AyuntamientoMadrid/consul y luego de consul/consul, intentando probar la funcionalidad de compartir en redes sociales tras apoyar un debate/propuesta, me costó un pelín entender la parte de verificar un usuario, acabé haciéndolo por consola con

```
User.first.update_attributes(verified_at: Date.today, residence_verified_at: Date.today, level_two_verified_at: Date.today)
```
Quizás es información demasiado específica para estar en el Readme y debería estar en un apartado del Wiki, pero como no veo que hay docu todavía, quizás ayude al siguiente que se anime a colaborar :).

Como bonus traduje el párrafo de OAuth del Readme en castellano al de inglés.