### PR TITLE
Management delete accounts

### DIFF
--- a/app/controllers/management/account_controller.rb
+++ b/app/controllers/management/account_controller.rb
@@ -1,19 +1,13 @@
 class Management::AccountController < Management::BaseController
 
-  before_action :check_verified_user
+  before_action :only_verified_users
 
   def show
   end
 
   private
-    def check_verified_user
-      unless current_user.level_two_or_three_verified?
-        redirect_to management_document_verifications_path, alert: t("management.account.alert.unverified_user")
-      end
-    end
-
-    def current_user
-      managed_user
+    def only_verified_users
+      check_verified_user t("management.account.alert.unverified_user")
     end
 
 end

--- a/app/controllers/management/account_controller.rb
+++ b/app/controllers/management/account_controller.rb
@@ -1,0 +1,19 @@
+class Management::AccountController < Management::BaseController
+
+  before_action :check_verified_user
+
+  def show
+  end
+
+  private
+    def check_verified_user
+      unless current_user.level_two_or_three_verified?
+        redirect_to management_document_verifications_path, alert: t("management.account.alert.unverified_user")
+      end
+    end
+
+    def current_user
+      managed_user
+    end
+
+end

--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -20,6 +20,16 @@ class Management::BaseController < ActionController::Base
       @managed_user ||= Verification::Management::ManagedUser.find(session[:document_type], session[:document_number])
     end
 
+    def current_user
+      managed_user
+    end
+
+    def check_verified_user(alert_msg)
+      unless current_user.level_two_or_three_verified?
+        redirect_to management_document_verifications_path, alert: alert_msg
+      end
+    end
+
     def set_locale
       if params[:locale] && I18n.available_locales.include?(params[:locale].to_sym)
         session[:locale] = params[:locale]

--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -2,7 +2,7 @@ class Management::ProposalsController < Management::BaseController
   include HasOrders
   include CommentableActions
 
-  before_action :check_verified_user, except: :print
+  before_action :only_verified_users, except: :print
   before_action :set_proposal, only: [:vote, :show]
   before_action :parse_search_terms, only: :index
   before_action :load_categories, only: [:new, :edit]
@@ -40,14 +40,8 @@ class Management::ProposalsController < Management::BaseController
       Proposal
     end
 
-    def check_verified_user
-      unless current_user.level_two_or_three_verified?
-        redirect_to management_document_verifications_path, alert: t("management.proposals.alert.unverified_user")
-      end
-    end
-
-    def current_user
-      managed_user
+    def only_verified_users
+      check_verified_user t("management.proposals.alert.unverified_user")
     end
 
     ### Duplicated in application_controller. Move to a concern.

--- a/app/controllers/management/spending_proposals_controller.rb
+++ b/app/controllers/management/spending_proposals_controller.rb
@@ -1,6 +1,6 @@
 class Management::SpendingProposalsController < Management::BaseController
 
-  before_action :check_verified_user, except: :print
+  before_action :only_verified_users, except: :print
   before_action :set_spending_proposal, only: [:vote, :show]
 
   def index
@@ -48,14 +48,8 @@ class Management::SpendingProposalsController < Management::BaseController
       params.require(:spending_proposal).permit(:title, :description, :external_url, :geozone_id, :terms_of_service, :captcha, :captcha_key)
     end
 
-    def check_verified_user
-      unless current_user.level_two_or_three_verified?
-        redirect_to management_document_verifications_path, alert: t("management.spending_proposals.alert.unverified_user")
-      end
-    end
-
-    def current_user
-      managed_user
+    def only_verified_users
+      check_verified_user t("management.spending_proposals.alert.unverified_user")
     end
 
     # This should not be necessary. Maybe we could create a specific show view for managers.

--- a/app/controllers/management/users_controller.rb
+++ b/app/controllers/management/users_controller.rb
@@ -18,6 +18,12 @@ class Management::UsersController < Management::BaseController
     end
   end
 
+  def erase
+    managed_user.erase(t("management.users.erased_by_manager", manager: current_manager['login'])) if current_manager.present?
+    destroy_session
+    redirect_to management_document_verifications_path, notice: t("management.users.erased_notice")
+  end
+
   def logout
     destroy_session
     redirect_to management_root_url, notice: t("management.sessions.signed_out_managed_user")

--- a/app/views/management/_menu.html.erb
+++ b/app/views/management/_menu.html.erb
@@ -13,6 +13,13 @@
       <% end %>
     </li>
 
+    <li <%= "class=active" if controller_name == "account" %>>
+      <%= link_to management_account_path do %>
+        <span class="icon-user"></span>
+        <%= t("management.menu.edit_user_accounts") %>
+      <% end %>
+    </li>
+
     <li <%= "class=active" if controller_name == "proposals" and action_name == "new" %>>
       <%= link_to new_management_proposal_path do %>
         <span class="icon-proposals"></span>

--- a/app/views/management/account/show.html.erb
+++ b/app/views/management/account/show.html.erb
@@ -1,0 +1,3 @@
+<h2><%= t("management.account.show.title") %></h2>
+
+<%= render 'management/users/erase_user_account' %>

--- a/app/views/management/dashboard/index.html.erb
+++ b/app/views/management/dashboard/index.html.erb
@@ -1,14 +1,6 @@
 <div class="dashboard">
   <h2><%= t("management.dashboard.index.title") %></h2>
 
-  <p>Desde aquí puedes gestionar usuarios a través de las siguientes acciones:</p>
-
-  <h3>Usuarios</h3>
-
-  <h3>Crear propuesta</h3>
-
-  <h3>Apoyar propuesta</h3>
-
-  <h3>Imprimir propuestas</h3>
+  <p><%= t("management.dashboard.index.info") %></p>
 
 </div>

--- a/app/views/management/document_verifications/new.html.erb
+++ b/app/views/management/document_verifications/new.html.erb
@@ -14,13 +14,4 @@
   <%= f.submit t("management.document_verifications.verify"), class: "button success" %>
 <% end %>
 
-
-<%= link_to t("management.document_verifications.erase_account_link"), "#", class: "delete js-toggle-link", data: { "toggle-selector" => "#erase-account-form" } %>
-
-<div id="erase-account-form" style="display:none">
-  <div class="callout alert medium-6">
-    <%= t("management.document_verifications.erase_warning") %>
-  </div>
-
-  <%= link_to t("management.document_verifications.erase_submit"), erase_management_users_path, method: :delete, class: "button alert", data: { confirm: t("management.document_verifications.erase_account_confirm") } %>
-</div>
+<%= render 'management/users/erase_user_account' %>

--- a/app/views/management/document_verifications/new.html.erb
+++ b/app/views/management/document_verifications/new.html.erb
@@ -13,3 +13,14 @@
   <%= f.hidden_field :document_number %>
   <%= f.submit t("management.document_verifications.verify"), class: "button success" %>
 <% end %>
+
+
+<%= link_to t("management.document_verifications.erase_account_link"), "#", class: "delete js-toggle-link", data: { "toggle-selector" => "#erase-account-form" } %>
+
+<div id="erase-account-form" style="display:none">
+  <div class="callout alert medium-6">
+    <%= t("management.document_verifications.erase_warning") %>
+  </div>
+
+  <%= link_to t("management.document_verifications.erase_submit"), erase_management_users_path, method: :delete, class: "button alert", data: { confirm: t("management.document_verifications.erase_account_confirm") } %>
+</div>

--- a/app/views/management/users/_erase_user_account.html.erb
+++ b/app/views/management/users/_erase_user_account.html.erb
@@ -1,0 +1,9 @@
+<%= link_to t("management.users.erase_account_link"), "#", class: "delete js-toggle-link", data: { "toggle-selector" => "#erase-account-form" } %>
+
+<div id="erase-account-form" style="display:none">
+  <div class="callout alert medium-6">
+    <%= t("management.users.erase_warning") %>
+  </div>
+
+  <%= link_to t("management.users.erase_submit"), erase_management_users_path, method: :delete, class: "button alert", data: { confirm: t("management.users.erase_account_confirm") } %>
+</div>

--- a/config/locales/management.en.yml
+++ b/config/locales/management.en.yml
@@ -24,6 +24,10 @@ en:
       title: User management
       under_age: You must be over 16 to verify your account.
       verify: Verify
+      erase_account_link: Delete user
+      erase_account_confirm: Are you sure you want to erase the account? This action can not be undone
+      erase_warning: This action can not be undone. Please make sure you want to erase this account.
+      erase_submit: Delete account
     email_label: Email
     email_verifications:
       already_verified: This user account is already verified.
@@ -84,3 +88,5 @@ en:
       create_user_info: 'We will create an account with the following data:'
       create_user_submit: Create user
       create_user_success_html: We have sent an email to the email address <b>%{email}</b> in order to verify that it belongs to this user. It contains a link they have to click. Then they will have to set their access password before being able to log in to the website
+      erased_notice: User account deleted.
+      erased_by_manager: "Deleted by manager: %{manager}"

--- a/config/locales/management.en.yml
+++ b/config/locales/management.en.yml
@@ -1,6 +1,11 @@
 ---
 en:
   management:
+    account:
+      alert:
+        unverified_user: No verified user logged in yet
+      show:
+        title: User account
     account_info:
       change_user: Change user
       document_number_label: 'Document number:'
@@ -45,6 +50,7 @@ en:
       support_spending_proposals: Support spending proposals
       title: Management
       users: Users
+      edit_user_accounts: Edit user account
     permissions:
       create_proposals: Create proposals
       debates: Engage in debates

--- a/config/locales/management.en.yml
+++ b/config/locales/management.en.yml
@@ -17,6 +17,7 @@ en:
     dashboard:
       index:
         title: Management
+        info: Here you can manage users through all actions listed in the left menu.
     document_number: Document number
     document_type_label: Document type
     document_verifications:

--- a/config/locales/management.en.yml
+++ b/config/locales/management.en.yml
@@ -24,10 +24,6 @@ en:
       title: User management
       under_age: You must be over 16 to verify your account.
       verify: Verify
-      erase_account_link: Delete user
-      erase_account_confirm: Are you sure you want to erase the account? This action can not be undone
-      erase_warning: This action can not be undone. Please make sure you want to erase this account.
-      erase_submit: Delete account
     email_label: Email
     email_verifications:
       already_verified: This user account is already verified.
@@ -90,3 +86,7 @@ en:
       create_user_success_html: We have sent an email to the email address <b>%{email}</b> in order to verify that it belongs to this user. It contains a link they have to click. Then they will have to set their access password before being able to log in to the website
       erased_notice: User account deleted.
       erased_by_manager: "Deleted by manager: %{manager}"
+      erase_account_link: Delete user
+      erase_account_confirm: Are you sure you want to erase the account? This action can not be undone
+      erase_warning: This action can not be undone. Please make sure you want to erase this account.
+      erase_submit: Delete account

--- a/config/locales/management.es.yml
+++ b/config/locales/management.es.yml
@@ -24,10 +24,6 @@ es:
       title: Gestión de usuarios
       under_age: Debes ser mayor de 16 años para verificar tu cuenta.
       verify: Verificar usuario
-      erase_account_link: Borrar cuenta
-      erase_account_confirm: ¿Seguro que quieres borrar a este usuario? Esta acción no se puede deshacer
-      erase_warning: Esta acción no se puede deshacer. Por favor asegurese de que quiere eliminar esta cuenta.
-      erase_submit: Borrar cuenta
     email_label: Email
     email_verifications:
       already_verified: Esta cuenta de usuario ya está verificada.
@@ -90,3 +86,7 @@ es:
       create_user_success_html: Hemos enviado un correo electrónico a <b>%{email}</b> para verificar que es suya. El correo enviado contiene un link que el usuario deberá pulsar. Entonces podrá seleccionar una clave de acceso, y entrar en la web de participación.
       erased_notice: Cuenta de usuario borrada.
       erased_by_manager: "Borrada por el manager: %{manager}"
+      erase_account_link: Borrar cuenta
+      erase_account_confirm: ¿Seguro que quieres borrar a este usuario? Esta acción no se puede deshacer
+      erase_warning: Esta acción no se puede deshacer. Por favor asegurese de que quiere eliminar esta cuenta.
+      erase_submit: Borrar cuenta

--- a/config/locales/management.es.yml
+++ b/config/locales/management.es.yml
@@ -1,6 +1,11 @@
 ---
 es:
   management:
+    account:
+      alert:
+        unverified_user: Solo se pueden editar cuentas de usuarios verificados
+      show:
+        title: Cuenta de usuario
     account_info:
       change_user: Cambiar usuario
       document_number_label: 'Número de documento:'
@@ -45,6 +50,7 @@ es:
       support_spending_proposals: Apoyar propts. de inversión
       title: Gestión
       users: Usuarios
+      edit_user_accounts: Editar cuenta de usuario
     permissions:
       create_proposals: Crear nuevas propuestas
       debates: Participar en debates

--- a/config/locales/management.es.yml
+++ b/config/locales/management.es.yml
@@ -17,6 +17,7 @@ es:
     dashboard:
       index:
         title: Gestión
+        info: Desde aquí puedes gestionar usuarios a través de las acciones listadas en el menú de la izquierda.
     document_number: Número de documento
     document_type_label: Tipo de documento
     document_verifications:

--- a/config/locales/management.es.yml
+++ b/config/locales/management.es.yml
@@ -24,6 +24,10 @@ es:
       title: Gestión de usuarios
       under_age: Debes ser mayor de 16 años para verificar tu cuenta.
       verify: Verificar usuario
+      erase_account_link: Borrar cuenta
+      erase_account_confirm: ¿Seguro que quieres borrar a este usuario? Esta acción no se puede deshacer
+      erase_warning: Esta acción no se puede deshacer. Por favor asegurese de que quiere eliminar esta cuenta.
+      erase_submit: Borrar cuenta
     email_label: Email
     email_verifications:
       already_verified: Esta cuenta de usuario ya está verificada.
@@ -84,3 +88,5 @@ es:
       create_user_info: 'Procedemos a crear un usuario con la siguiente información:'
       create_user_submit: Crear usuario
       create_user_success_html: Hemos enviado un correo electrónico a <b>%{email}</b> para verificar que es suya. El correo enviado contiene un link que el usuario deberá pulsar. Entonces podrá seleccionar una clave de acceso, y entrar en la web de participación.
+      erased_notice: Cuenta de usuario borrada.
+      erased_by_manager: "Borrada por el manager: %{manager}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,6 +220,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resource :account, controller: "account", only: [:show]
+
     get 'sign_in', to: 'sessions#create'
 
     resource :session, only: [:create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,7 +214,10 @@ Rails.application.routes.draw do
     resources :email_verifications, only: [:new, :create]
 
     resources :users, only: [:new, :create] do
-      delete :logout, on: :collection
+      collection do
+        delete :logout
+        delete :erase
+      end
     end
 
     get 'sign_in', to: 'sessions#create'

--- a/lib/manager_authenticator.rb
+++ b/lib/manager_authenticator.rb
@@ -1,7 +1,7 @@
 class ManagerAuthenticator
 
   def initialize(data={})
-    @manager = {login: data[:login], user_key: data[:clave_usuario], date: data[:fecha_conexion]}
+    @manager = {login: data[:login], user_key: data[:clave_usuario], date: data[:fecha_conexion]}.with_indifferent_access
   end
 
   def auth

--- a/spec/features/management/account_spec.rb
+++ b/spec/features/management/account_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+feature 'Account' do
+
+  background do
+    login_as_manager
+  end
+
+  scenario "Should not allow unverified users to create spending proposals" do
+    user = create(:user)
+    login_managed_user(user)
+
+    click_link "Edit user account"
+
+    expect(page).to have_content "No verified user logged in yet"
+  end
+
+  scenario 'Delete a user account', :js do
+    user = create(:user, :level_two)
+    login_managed_user(user)
+
+    visit management_account_path
+
+    click_link "Delete user"
+    click_link "Delete account"
+
+    expect(page).to have_content "User account deleted."
+
+    expect(user.reload.erase_reason).to eq "Deleted by manager: JJB042"
+  end
+
+end

--- a/spec/features/management/users_spec.rb
+++ b/spec/features/management/users_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
-feature 'users' do
+feature 'Users' do
+
+  background do
+    login_as_manager
+  end
 
   scenario 'Create a level 3 user from scratch' do
-
-    login_as_manager
 
     visit management_document_verifications_path
     fill_in 'document_verification_document_number', with: '1234'
@@ -44,7 +46,6 @@ feature 'users' do
 
   scenario 'Delete a level 2 user account from document verification page', :js do
     level_2_user = create(:user, :level_two, document_number: 13579)
-    login_as_manager
 
     visit management_document_verifications_path
     fill_in 'document_verification_document_number', with: '13579'

--- a/spec/features/management/users_spec.rb
+++ b/spec/features/management/users_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'users' do
 
-  scenario 'Creating a level 3 user from scratch' do
+  scenario 'Create a level 3 user from scratch' do
 
     login_as_manager
 
@@ -40,6 +40,31 @@ feature 'users' do
     expect(user.reload).to be_confirmed
 
     expect(page).to have_content "Your account has been confirmed."
+  end
+
+  scenario 'Delete a level 2 user account from document verification page', :js do
+    level_2_user = create(:user, :level_two, document_number: 13579)
+    login_as_manager
+
+    visit management_document_verifications_path
+    fill_in 'document_verification_document_number', with: '13579'
+    click_button 'Check'
+
+    expect(page).to_not have_content "This user account is already verified."
+    expect(page).to have_content "This user can participate in the website with the following permissions"
+
+    click_link "Delete user"
+    click_link "Delete account"
+
+    expect(page).to have_content "User account deleted."
+
+    expect(level_2_user.reload.erase_reason).to eq "Deleted by manager: JJB042"
+
+    visit management_document_verifications_path
+    fill_in 'document_verification_document_number', with: '13579'
+    click_button 'Check'
+
+    expect(page).to have_content "no user account associated to it"
   end
 
 end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -27,7 +27,7 @@ module CommonActions
 
   def login_as_manager
     login, user_key, date = "JJB042", "31415926", Time.now.strftime("%Y%m%d%H%M%S")
-    allow_any_instance_of(ManagerAuthenticator).to receive(:auth).and_return({login: login, user_key: user_key, date: date})
+    allow_any_instance_of(ManagerAuthenticator).to receive(:auth).and_return({login: login, user_key: user_key, date: date}.with_indifferent_access)
     visit management_sign_in_path(login: login, clave_usuario: user_key, fecha_conexion: date)
   end
 


### PR DESCRIPTION
Added to Management the ability to erase user accounts.
In two places: 
 - A dedicated menu tab
 - When checking level_2 accounts, in case a user states an account with her dni is not hers.