### PR TITLE
changes default order in valuation/sps to votes up

### DIFF
--- a/app/controllers/valuation/spending_proposals_controller.rb
+++ b/app/controllers/valuation/spending_proposals_controller.rb
@@ -11,7 +11,7 @@ class Valuation::SpendingProposalsController < Valuation::BaseController
   def index
     @geozone_filters = geozone_filters
     if current_user.valuator?
-      @spending_proposals = SpendingProposal.scoped_filter(params_for_current_valuator, @current_filter).order(created_at: :desc).page(params[:page])
+      @spending_proposals = SpendingProposal.scoped_filter(params_for_current_valuator, @current_filter).order(cached_votes_up: :desc).page(params[:page])
     else
       @spending_proposals = SpendingProposal.none.page(params[:page])
     end
@@ -33,7 +33,6 @@ class Valuation::SpendingProposalsController < Valuation::BaseController
   private
 
     def geozone_filters
-
       spending_proposals = SpendingProposal.by_valuator(current_user.valuator.try(:id)).valuation_open.all.to_a
 
       [ { name: t('valuation.spending_proposals.index.geozone_filter_all'),

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -296,8 +296,8 @@ ActiveRecord::Schema.define(version: 20160406163649) do
     t.text     "description"
     t.integer  "author_id"
     t.string   "external_url"
-    t.datetime "created_at",                                            null: false
-    t.datetime "updated_at",                                            null: false
+    t.datetime "created_at",                                             null: false
+    t.datetime "updated_at",                                             null: false
     t.integer  "geozone_id"
     t.integer  "price",                       limit: 8
     t.boolean  "feasible"
@@ -305,14 +305,14 @@ ActiveRecord::Schema.define(version: 20160406163649) do
     t.text     "price_explanation"
     t.text     "feasible_explanation"
     t.text     "internal_comments"
-    t.boolean  "valuation_finished",                    default: false
+    t.boolean  "valuation_finished",                     default: false
     t.text     "explanations_log"
     t.integer  "administrator_id"
-    t.integer  "valuation_assignments_count",           default: 0
+    t.integer  "valuation_assignments_count",            default: 0
     t.integer  "price_first_year",            limit: 8
     t.string   "time_scope"
     t.datetime "unfeasible_email_sent_at"
-    t.integer  "cached_votes_up",      default: 0
+    t.integer  "cached_votes_up",                        default: 0
     t.tsvector "tsv"
     t.string   "responsible_name",            limit: 60
   end

--- a/spec/features/valuation/spending_proposals_spec.rb
+++ b/spec/features/valuation/spending_proposals_spec.rb
@@ -37,6 +37,21 @@ feature 'Valuation spending proposals' do
     expect(page).to_not have_content(spending_proposal2.title)
   end
 
+  scenario 'Index orders spending proposals by votes' do
+    spending_proposal10 = create(:spending_proposal, cached_votes_up: 10)
+    spending_proposal100 = create(:spending_proposal, cached_votes_up: 100)
+    spending_proposal1 = create(:spending_proposal, cached_votes_up: 1)
+
+    spending_proposal1.valuators << @valuator
+    spending_proposal10.valuators << @valuator
+    spending_proposal100.valuators << @valuator
+
+    visit valuation_spending_proposals_path
+
+    expect(spending_proposal100.title).to appear_before(spending_proposal10.title)
+    expect(spending_proposal10.title).to appear_before(spending_proposal1.title)
+  end
+
   scenario 'Index shows assignments info' do
     spending_proposal1 = create(:spending_proposal)
     spending_proposal2 = create(:spending_proposal)


### PR DESCRIPTION
Spending proposals in the index for valuators were ordered by `creation_at`. 
Changed to `cached_votes_up`