### PR TITLE
adds validation on feasible_explanation

### DIFF
--- a/app/models/spending_proposal.rb
+++ b/app/models/spending_proposal.rb
@@ -16,6 +16,7 @@ class SpendingProposal < ActiveRecord::Base
   validates :title, presence: true
   validates :author, presence: true
   validates :description, presence: true
+  validates_presence_of :feasible_explanation, if: :valuation_finished?
 
   validates :title, length: { in: 4..SpendingProposal.title_max_length }
   validates :description, length: { maximum: SpendingProposal.description_max_length }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -183,6 +183,7 @@ FactoryGirl.define do
   factory :spending_proposal do
     sequence(:title)     { |n| "Spending Proposal #{n} title" }
     description          'Spend money on this'
+    feasible_explanation 'This proposal is not viable because...'
     external_url         'http://external_documention.org'
     terms_of_service     '1'
     association :author, factory: :user

--- a/spec/models/spending_proposal_spec.rb
+++ b/spec/models/spending_proposal_spec.rb
@@ -42,6 +42,18 @@ describe SpendingProposal do
     end
   end
 
+  describe "#feasible_explanation" do
+    it "should be valid if valuation not finished" do
+      spending_proposal.valuation_finished = false
+      expect(spending_proposal).to be_valid
+    end
+
+    it "should not be valid if valuation finished" do
+      spending_proposal.valuation_finished = true
+      expect(spending_proposal).to_not be_valid
+    end
+  end
+
   describe "dossier info" do
     describe "#feasibility" do
       it "can be feasible" do

--- a/spec/models/spending_proposal_spec.rb
+++ b/spec/models/spending_proposal_spec.rb
@@ -44,11 +44,13 @@ describe SpendingProposal do
 
   describe "#feasible_explanation" do
     it "should be valid if valuation not finished" do
+      spending_proposal.feasible_explanation = ""
       spending_proposal.valuation_finished = false
       expect(spending_proposal).to be_valid
     end
 
     it "should not be valid if valuation finished" do
+      spending_proposal.feasible_explanation = ""
       spending_proposal.valuation_finished = true
       expect(spending_proposal).to_not be_valid
     end


### PR DESCRIPTION
- Avoids valuators marking spending proposals as finished without filling out the unfeasible explanation.