### PR TITLE
Official position badges

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -25,7 +25,7 @@ class AccountController < ApplicationController
       if @account.organization?
         params.require(:account).permit(:phone_number, :email_on_comment, :email_on_comment_reply, :newsletter, organization_attributes: [:name, :responsible_name])
       else
-        params.require(:account).permit(:username, :public_activity, :email_on_comment, :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter)
+        params.require(:account).permit(:username, :public_activity, :email_on_comment, :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter, :official_position_badge)
       end
     end
 

--- a/app/controllers/spending_proposals_controller.rb
+++ b/app/controllers/spending_proposals_controller.rb
@@ -1,7 +1,7 @@
 class SpendingProposalsController < ApplicationController
   include FeatureFlags
 
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action -> { flash.now[:notice] = flash[:notice].html_safe if flash[:html_safe] && flash[:notice] }
 
   load_and_authorize_resource

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,6 +133,16 @@ class User < ActiveRecord::Base
     update official_position: nil, official_level: 0
   end
 
+  def has_official_email?
+    domain = Setting['email_domain_for_officials']
+    !email.blank? && ( (email.end_with? "@#{domain}") || (email.end_with? ".#{domain}") )
+  end
+
+  def display_official_position_badge?
+    return true if official_level > 1
+    official_position_badge? && official_level == 1
+  end
+
   def block
     debates_ids = Debate.where(author_id: id).pluck(:id)
     comments_ids = Comment.where(user_id: id).pluck(:id)
@@ -195,11 +205,6 @@ class User < ActiveRecord::Base
 
   def email_required?
     !erased?
-  end
-
-  def has_official_email?
-    domain = Setting['email_domain_for_officials']
-    !email.blank? && ( (email.end_with? "@#{domain}") || (email.end_with? ".#{domain}") )
   end
 
   def locale

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -87,16 +87,18 @@
             <% end %>
           </div>
 
-          <div>
-            <%= f.label :official_position_badge do %>
-              <%= f.check_box :official_position_badge,
-                               title: t('account.show.official_position_badge_label'),
-                               label: false %>
-              <span class="checkbox">
-                <%= t("account.show.official_position_badge_label") %>
-              </span>
-            <% end %>
-          </div>
+          <% if @account.official_level == 1 %>
+            <div>
+              <%= f.label :official_position_badge do %>
+                <%= f.check_box :official_position_badge,
+                                 title: t('account.show.official_position_badge_label'),
+                                 label: false %>
+                <span class="checkbox">
+                  <%= t("account.show.official_position_badge_label") %>
+                </span>
+              <% end %>
+            </div>
+          <% end %>
 
           <%= f.submit t("account.show.save_changes_submit"), class: "button" %>
         </div>

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -87,6 +87,17 @@
             <% end %>
           </div>
 
+          <div>
+            <%= f.label :official_position_badge do %>
+              <%= f.check_box :official_position_badge,
+                               title: t('account.show.official_position_badge_label'),
+                               label: false %>
+              <span class="checkbox">
+                <%= t("account.show.official_position_badge_label") %>
+              </span>
+            <% end %>
+          </div>
+
           <%= f.submit t("account.show.save_changes_submit"), class: "button" %>
         </div>
 

--- a/app/views/admin/stats/proposal_notifications.html.erb
+++ b/app/views/admin/stats/proposal_notifications.html.erb
@@ -7,14 +7,18 @@
     <div class="small-12 medium-3 column">
       <p class="featured">
         <%= t("admin.stats.proposal_notifications.total") %><br>
-        <span id="proposal_notifications_count" class="number"><%= @proposal_notifications %></span>
+        <span id="proposal_notifications_count" class="number">
+          <%= @proposal_notifications.count %>
+        </span>
       </p>
     </div>
 
     <div class="small-12 medium-6 column end">
       <p>
         <%= t("admin.stats.proposal_notifications.proposals_with_notifications") %><br>
-        <span id="proposals_with_notifications_count" class="number"><%= @proposals_with_notifications %></span>
+        <span id="proposals_with_notifications_count" class="number">
+          <%= @proposals_with_notifications %>
+        </span>
       </p>
     </div>
   </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -36,7 +36,7 @@
                 <span class="user-name"><%= t("comments.comment.user_deleted") %></span>
               <% else %>
                 <span class="user-name"><%= link_to comment.user.name, user_path(comment.user) %></span>
-                <% if comment.user.official? %>
+                <% if comment.user.display_official_position_badge? %>
                   &nbsp;&bull;&nbsp;
                   <span class="label round level-<%= comment.user.official_level %>">
                     <%= comment.user.official_position %>

--- a/app/views/debates/_debate.html.erb
+++ b/app/views/debates/_debate.html.erb
@@ -24,7 +24,7 @@
                 <span class="author">
                   <%= debate.author.name %>
                 </span>
-                <% if debate.author.official? %>
+                <% if debate.author.display_official_position_badge? %>
                   <span class="bullet">&nbsp;&bull;&nbsp;</span>
                   <span class="label round level-<%= debate.author.official_level %>">
                     <%= debate.author.official_position %>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -26,7 +26,7 @@
                 <span class="author">
                   <%= proposal.author.name %>
                 </span>
-                <% if proposal.author.official? %>
+                <% if proposal.author.display_official_position_badge? %>
                   <span class="bullet">&nbsp;&bull;&nbsp;</span>
                   <span class="label round level-<%= proposal.author.official_level %>">
                     <%= proposal.author.official_position %>

--- a/app/views/proposals/summary.html.erb
+++ b/app/views/proposals/summary.html.erb
@@ -20,7 +20,7 @@
                           <span class="author"><%= t("proposals.show.author_deleted") %></span>
                         <% else %>
                           <span class="author"><%= proposal.author.name %></span>
-                          <% if proposal.author.official? %>
+                          <% if proposal.author.display_official_position_badge? %>
                             <span class="label round level-<%= proposal.author.official_level %>">
                               <%= proposal.author.official_position %>
                             </span>

--- a/app/views/shared/_author_info.html.erb
+++ b/app/views/shared/_author_info.html.erb
@@ -15,7 +15,7 @@
     </span>
   <% end %>
 
-  <% if resource.author.official? %>
+  <% if resource.author.display_official_position_badge? %>
     &nbsp;&bull;&nbsp;
     <span class="label round level-<%= resource.author.official_level %>">
       <%= resource.author.official_position %>

--- a/app/views/spending_proposals/_spending_proposal.html.erb
+++ b/app/views/spending_proposals/_spending_proposal.html.erb
@@ -23,7 +23,7 @@
                 <span class="author">
                   <%= spending_proposal.author.name %>
                 </span>
-                <% if spending_proposal.author.official? %>
+                <% if spending_proposal.author.display_official_position_badge? %>
                   <span class="bullet">&nbsp;&bull;&nbsp;</span>
                   <span class="label round level-<%= spending_proposal.author.official_level %>">
                     <%= spending_proposal.author.official_position %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
       subscription_to_website_newsletter_label: Receive by email website relevant information
       email_on_direct_message_label: Receive emails about direct messages
       email_digest_label: Receive a summary of proposal notifications
+      official_position_badge_label: Show official position badge
       title: My account
       user_permission_debates: Participate on debates
       user_permission_info: With your account you can...

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -17,6 +17,7 @@ es:
       subscription_to_website_newsletter_label: Recibir emails con información interesante sobre la web
       email_on_direct_message_label: Recibir emails con mensajes privados
       email_digest_label: Recibir resumen de notificaciones sobre propuestas
+      official_position_badge_label: Mostrar etiqueta de tipo de usuario
       title: Mi cuenta
       user_permission_debates: Participar en debates
       user_permission_info: Con tu cuenta ya puedes...

--- a/db/migrate/20160617172616_add_badge_to_users.rb
+++ b/db/migrate/20160617172616_add_badge_to_users.rb
@@ -1,0 +1,5 @@
+class AddBadgeToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :official_position_badge, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160614160949) do
+ActiveRecord::Schema.define(version: 20160617172616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -462,6 +462,7 @@ ActiveRecord::Schema.define(version: 20160614160949) do
     t.boolean  "email_on_proposal_notification",            default: true
     t.boolean  "email_digest",                              default: true
     t.boolean  "email_on_direct_message",                   default: true
+    t.boolean  "official_position_badge",                   default: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -37,7 +37,6 @@ feature 'Account' do
     check 'account_email_on_comment_reply'
     uncheck 'account_email_digest'
     uncheck 'account_email_on_direct_message'
-    check   'account_official_position_badge'
     click_button 'Save changes'
 
     expect(page).to have_content "Changes saved"
@@ -49,7 +48,6 @@ feature 'Account' do
     expect(find("#account_email_on_comment_reply")).to be_checked
     expect(find("#account_email_digest")).to_not be_checked
     expect(find("#account_email_on_direct_message")).to_not be_checked
-    expect(find("#account_official_position_badge")).to be_checked
   end
 
   scenario 'Edit Organization' do
@@ -69,6 +67,39 @@ feature 'Account' do
     expect(page).to have_selector("input[value='Google']")
     expect(find("#account_email_on_comment")).to be_checked
     expect(find("#account_email_on_comment_reply")).to be_checked
+  end
+
+  context "Option to display badge for official position" do
+
+    scenario "Users with official position of level 1" do
+      official_user = create(:user, official_level: 1)
+
+      login_as(official_user)
+      visit account_path
+
+      check 'account_official_position_badge'
+      click_button 'Save changes'
+      expect(page).to have_content "Changes saved"
+
+      visit account_path
+      expect(find("#account_official_position_badge")).to be_checked
+    end
+
+    scenario "Users with official position of level 2 and above" do
+      official_user2 = create(:user, official_level: 2)
+      official_user3 = create(:user, official_level: 3)
+
+      login_as(official_user2)
+      visit account_path
+
+      expect(page).to_not have_css '#account_official_position_badge'
+
+      login_as(official_user3)
+      visit account_path
+
+      expect(page).to_not have_css '#account_official_position_badge'
+    end
+
   end
 
   scenario "Errors on edit" do

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -37,6 +37,7 @@ feature 'Account' do
     check 'account_email_on_comment_reply'
     uncheck 'account_email_digest'
     uncheck 'account_email_on_direct_message'
+    check   'account_official_position_badge'
     click_button 'Save changes'
 
     expect(page).to have_content "Changes saved"
@@ -48,6 +49,7 @@ feature 'Account' do
     expect(find("#account_email_on_comment_reply")).to be_checked
     expect(find("#account_email_digest")).to_not be_checked
     expect(find("#account_email_on_direct_message")).to_not be_checked
+    expect(find("#account_official_position_badge")).to be_checked
   end
 
   scenario 'Edit Organization' do

--- a/spec/features/official_positions_spec.rb
+++ b/spec/features/official_positions_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+feature 'Official positions' do
+
+  context "Badge" do
+
+    background do
+      @user1 = create(:user, official_level: 1, official_position: "Employee", official_position_badge: true)
+      @user2 = create(:user, official_level: 0, official_position: "")
+    end
+
+    scenario "Comments" do
+      proposal = create(:proposal)
+      comment1 = create(:comment, commentable: proposal, user: @user1)
+      comment2 = create(:comment, commentable: proposal, user: @user2)
+
+      visit proposal_path(proposal)
+
+      expect_badge_for("comment", comment1)
+      expect_no_badge_for("comment", comment2)
+    end
+
+    context "Debates" do
+
+      background do
+        @debate1 = create(:debate, author: @user1)
+        @debate2 = create(:debate, author: @user2)
+      end
+
+      scenario "Index" do
+        visit debates_path
+
+        expect_badge_for("debate", @debate1)
+        expect_no_badge_for("debate", @debate2)
+      end
+
+      scenario "Show" do
+        visit debate_path(@debate1)
+        expect_badge_for("debate", @debate1)
+
+        visit debate_path(@debate2)
+        expect_no_badge_for("debate", @debate2)
+      end
+
+    end
+
+    context "Proposals" do
+
+      background do
+        @proposal1 = create(:proposal, author: @user1)
+        @proposal2 = create(:proposal, author: @user2)
+
+        featured_proposals = 3.times { create(:proposal) }
+      end
+
+      scenario "Index" do
+        visit proposals_path
+
+        expect_badge_for("proposal", @proposal1)
+        expect_no_badge_for("proposal", @proposal2)
+      end
+
+      scenario "Show" do
+        visit proposal_path(@proposal1)
+        expect_badge_for("proposal", @proposal1)
+
+        visit proposal_path(@proposal2)
+        expect_no_badge_for("proposal", @proposal2)
+      end
+
+    end
+
+    context "Spending proposals" do
+
+      background do
+        @spending_proposal1 = create(:spending_proposal, author: @user1)
+        @spending_proposal2 = create(:spending_proposal, author: @user2)
+      end
+
+      scenario "Index" do
+        visit spending_proposals_path
+
+        expect_badge_for("spending_proposal", @spending_proposal1)
+        expect_no_badge_for("spending_proposal", @spending_proposal2)
+      end
+
+      scenario "Show" do
+        visit spending_proposal_path(@spending_proposal1)
+        expect_badge_for("spending_proposal", @spending_proposal1)
+
+        visit spending_proposal_path(@spending_proposal2)
+        expect_no_badge_for("spending_proposal", @spending_proposal2)
+      end
+
+    end
+  end
+end

--- a/spec/features/spending_proposals_spec.rb
+++ b/spec/features/spending_proposals_spec.rb
@@ -178,9 +178,6 @@ feature 'Spending proposals' do
   end
 
   scenario "Show" do
-    user = create(:user)
-    login_as(user)
-
     spending_proposal = create(:spending_proposal,
                                 geozone: create(:geozone),
                                 association_name: 'People of the neighbourhood')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -289,6 +289,42 @@ describe User do
     end
   end
 
+  describe "official_position_badge" do
+
+    describe "Users of level 1" do
+
+      it "displays the badge if set in preferences" do
+        user = create(:user, official_level: 1, official_position_badge: true)
+
+        expect(user.display_official_position_badge?).to eq true
+      end
+
+      it "does not display the badge if set in preferences" do
+        user = create(:user, official_level: 1, official_position_badge: false)
+
+        expect(user.display_official_position_badge?).to eq false
+      end
+
+    end
+
+    describe "Users higher than level 1" do
+
+      it "displays the badge regardless of preferences" do
+        user1 = create(:user, official_level: 2, official_position_badge: false)
+        user2 = create(:user, official_level: 3, official_position_badge: false)
+        user3 = create(:user, official_level: 4, official_position_badge: false)
+        user4 = create(:user, official_level: 5, official_position_badge: false)
+
+        expect(user1.display_official_position_badge?).to eq true
+        expect(user2.display_official_position_badge?).to eq true
+        expect(user3.display_official_position_badge?).to eq true
+        expect(user4.display_official_position_badge?).to eq true
+      end
+
+    end
+
+  end
+
   describe "self.search" do
     it "find users by email" do
       user1 = create(:user, email: "larry@madrid.es")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -95,6 +95,12 @@ describe User do
         expect(subject.email_on_direct_message).to eq(true)
       end
     end
+
+    describe 'official_position_badge' do
+      it 'should be false by default' do
+        expect(subject.official_position_badge).to eq(false)
+      end
+    end
   end
 
   describe "administrator?" do

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -231,4 +231,18 @@ module CommonActions
     DirectMessage.last
   end
 
+  def expect_badge_for(resource_name, resource)
+    within("##{resource_name}_#{resource.id}") do
+      expect(page).to have_css ".label.round"
+      expect(page).to have_content "Employee"
+    end
+  end
+
+  def expect_no_badge_for(resource_name, resource)
+    within("##{resource_name}_#{resource.id}") do
+      expect(page).to_not have_css ".label.round"
+      expect(page).to_not have_content "Employee"
+    end
+  end
+
 end


### PR DESCRIPTION
- Add option in my account to show the official position badge. 
- By default the option to show your badge is set to false.

Closes #1157