### PR TITLE
Change madrid.es to consul.dev - closes #1169

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ bin/rspec
 
 You can use the default admin user from the seeds file:
 
- **user:** admin@madrid.es
+ **user:** admin@consul.dev
  **pass:** 12345678
 
 But for some actions like voting, you will need a verified user, the seeds file also includes one:
 
- **user:** verified@madrid.es
+ **user:** verified@consul.dev
  **pass:** 12345678
 
 ### OAuth

--- a/README_ES.md
+++ b/README_ES.md
@@ -53,12 +53,12 @@ bin/rspec
 
 Puedes usar el usuario administrador por defecto del fichero seeds:
 
- **user:** admin@madrid.es
+ **user:** admin@consul.dev
  **pass:** 12345678
 
 Pero para ciertas acciones, como apoyar, necesitarás un usuario verificado, el fichero seeds proporciona uno:
 
- **user:** verified@madrid.es
+ **user:** verified@consul.dev
  **pass:** 12345678
 
 

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -43,24 +43,24 @@ def create_user(email, username = Faker::Name.name)
   User.create!(username: username, email: email, password: pwd, password_confirmation: pwd, confirmed_at: Time.now, terms_of_service: "1")
 end
 
-admin = create_user('admin@madrid.es', 'admin')
+admin = create_user('admin@consul.dev', 'admin')
 admin.create_administrator
 
-moderator = create_user('mod@madrid.es', 'mod')
+moderator = create_user('mod@consul.dev', 'mod')
 moderator.create_moderator
 
-valuator = create_user('valuator@madrid.es', 'valuator')
+valuator = create_user('valuator@consul.dev', 'valuator')
 valuator.create_valuator
 
-level_2 = create_user('leveltwo@madrid.es', 'level 2')
+level_2 = create_user('leveltwo@consul.dev', 'level 2')
 level_2.update(residence_verified_at: Time.now, confirmed_phone: Faker::PhoneNumber.phone_number, document_number: "2222222222", document_type: "1" )
 
-verified = create_user('verified@madrid.es', 'verified')
+verified = create_user('verified@consul.dev', 'verified')
 verified.update(residence_verified_at: Time.now, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1", verified_at: Time.now, document_number: "3333333333")
 
 (1..10).each do |i|
   org_name = Faker::Company.name
-  org_user = create_user("org#{i}@madrid.es", org_name)
+  org_user = create_user("org#{i}@consul.dev", org_name)
   org_responsible_name = Faker::Name.name
   org = org_user.create_organization(name: org_name, responsible_name: org_responsible_name)
 
@@ -73,12 +73,12 @@ verified.update(residence_verified_at: Time.now, confirmed_phone: Faker::PhoneNu
 end
 
 (1..5).each do |i|
-  official = create_user("official#{i}@madrid.es")
+  official = create_user("official#{i}@consul.dev")
   official.update(official_level: i, official_position: "Official position #{i}")
 end
 
 (1..40).each do |i|
-  user = create_user("user#{i}@madrid.es")
+  user = create_user("user#{i}@consul.dev")
   level = [1,2,3].sample
   if level >= 2 then
     user.update(residence_verified_at: Time.now, confirmed_phone: Faker::PhoneNumber.phone_number, document_number: Faker::Number.number(10), document_type: "1" )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 # Default admin user (change password after first deploy to a server!)
 if Administrator.count == 0 && !Rails.env.test?
-  admin = User.create!(username: 'admin', email: 'admin@madrid.es', password: '12345678', password_confirmation: '12345678', confirmed_at: Time.now, terms_of_service: "1")
+  admin = User.create!(username: 'admin', email: 'admin@consul.dev', password: '12345678', password_confirmation: '12345678', confirmed_at: Time.now, terms_of_service: "1")
   admin.create_administrator
 end
 

--- a/doc/locales/fr.yaml
+++ b/doc/locales/fr.yaml
@@ -1209,7 +1209,7 @@ fr:
           et plus riche quand c'est libérée.\r\n\r\nNon seulement vous pouvez utiliser
           ce portail pour votre propre collectivité, mais vous serez aussi aidé par
           la Mairie de Madrid autant que possible pour le faire. Si vous êtes intéressé,
-          n'hésitez pas à nous contacter : <a href='mailto:ag.gobiernoabierto@madrid.es'>ag.gobiernoabierto@madrid.es</a>\r\n\r\nSi
+          n'hésitez pas à nous contacter : <a href='mailto:ag.gobiernoabierto@consul.dev'>ag.gobiernoabierto@consul.dev</a>\r\n\r\nSi
           vous êtes développeur, vous pouvez voir le code et nous aider à l'améliorer
           sur [Consul app](https://github.com/ayuntamientomadrid 'consul github '
           )."

--- a/doc/locales/pt-br.yaml
+++ b/doc/locales/pt-br.yaml
@@ -1228,8 +1228,8 @@ pt-BR:
           compartilhada.\r\n\r\nNão somente você pode usar livremente este portal
           no governo local, mas você também será ajudado pelo conselho da cidade de
           Madrid, o tanto quanto possível para fazê-lo, por isso, se você estiver
-          interessado escreva-nos: <a href = \"mailto: ag.gobiernoabierto @ madrid.es
-          '> ag.gobiernoabierto@madrid.es </a>\r\n\r\nSe você é um programador, você
+          interessado escreva-nos: <a href = \"mailto: ag.gobiernoabierto@consul.dev
+          '> ag.gobiernoabierto@consul.dev </a>\r\n\r\nSe você é um programador, você
           pode ver o código e nos ajudar a melhorá-lo em [app Consul] (https://github.com/ayuntamientomadrid
           'cônsul github')."
       titles:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
 
   factory :user do
     sequence(:username) { |n| "Manuela#{n}" }
-    sequence(:email)    { |n| "manuela#{n}@madrid.es" }
+    sequence(:email)    { |n| "manuela#{n}@consul.dev" }
 
     password            'judgmentday'
     terms_of_service     '1'
@@ -78,7 +78,7 @@ FactoryGirl.define do
 
   factory :verification_letter, class: Verification::Letter do
     user
-    email 'user@madrid.es'
+    email 'user@consul.dev'
     password '1234'
     verification_code '5555'
   end

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -11,7 +11,7 @@ feature 'Emails' do
 
     email = open_last_email
     expect(email).to have_subject('Confirmation instructions')
-    expect(email).to deliver_to('manuela@madrid.es')
+    expect(email).to deliver_to('manuela@consul.dev')
     expect(email).to have_body_text(user_confirmation_path)
   end
 
@@ -20,7 +20,7 @@ feature 'Emails' do
 
     email = open_last_email
     expect(email).to have_subject('Instructions for resetting your password')
-    expect(email).to deliver_to('manuela@madrid.es')
+    expect(email).to deliver_to('manuela@consul.dev')
     expect(email).to have_body_text(edit_user_password_path)
   end
 
@@ -118,7 +118,7 @@ feature 'Emails' do
 
     email = open_last_email
     expect(email).to have_subject('Confirmation instructions')
-    expect(email).to deliver_to('manuela@madrid.es')
+    expect(email).to deliver_to('manuela@consul.dev')
     expect(email).to have_body_text(user_confirmation_path)
   end
 

--- a/spec/features/registration_form_spec.rb
+++ b/spec/features/registration_form_spec.rb
@@ -28,7 +28,7 @@ feature 'Registration form' do
     visit new_user_registration_path(use_redeemable_code: 'true')
 
     fill_in 'user_username',              with: "NewUserWithCode77"
-    fill_in 'user_email',                 with: "new@madrid.es"
+    fill_in 'user_email',                 with: "new@consul.dev"
     fill_in 'user_password',              with: "password"
     fill_in 'user_password_confirmation', with: "password"
     fill_in 'user_redeemable_code',       with: "            "

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -8,7 +8,7 @@ feature 'Users' do
       click_link 'Register'
 
       fill_in 'user_username',              with: 'Manuela Carmena'
-      fill_in 'user_email',                 with: 'manuela@madrid.es'
+      fill_in 'user_email',                 with: 'manuela@consul.dev'
       fill_in 'user_password',              with: 'judgementday'
       fill_in 'user_password_confirmation', with: 'judgementday'
       check 'user_terms_of_service'
@@ -31,11 +31,11 @@ feature 'Users' do
     end
 
     scenario 'Sign in' do
-      create(:user, email: 'manuela@madrid.es', password: 'judgementday')
+      create(:user, email: 'manuela@consul.dev', password: 'judgementday')
 
       visit '/'
       click_link 'Sign in'
-      fill_in 'user_email',    with: 'manuela@madrid.es'
+      fill_in 'user_email',    with: 'manuela@consul.dev'
       fill_in 'user_password', with: 'judgementday'
       click_button 'Enter'
 
@@ -140,7 +140,7 @@ feature 'Users' do
       end
 
       scenario 'Sign in, user was already signed up with OAuth' do
-        user = create(:user, email: 'manuela@madrid.es', password: 'judgementday')
+        user = create(:user, email: 'manuela@consul.dev', password: 'judgementday')
         create(:identity, uid: '12345', provider: 'twitter', user: user)
         OmniAuth.config.add_mock(:twitter, twitter_hash)
 
@@ -159,7 +159,7 @@ feature 'Users' do
       end
 
       scenario 'Try to register with the username of an already existing user' do
-        create(:user, username: 'manuela', email: 'manuela@madrid.es', password: 'judgementday')
+        create(:user, username: 'manuela', email: 'manuela@consul.dev', password: 'judgementday')
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_verified_email)
 
         visit '/'
@@ -265,13 +265,13 @@ feature 'Users' do
   end
 
   scenario 'Reset password' do
-    create(:user, email: 'manuela@madrid.es')
+    create(:user, email: 'manuela@consul.dev')
 
     visit '/'
     click_link 'Sign in'
     click_link 'Forgotten your password?'
 
-    fill_in 'user_email', with: 'manuela@madrid.es'
+    fill_in 'user_email', with: 'manuela@consul.dev'
     click_button 'Send instructions'
 
     expect(page).to have_content "In a few minutes, you will receive an email containing instructions on resetting your password."

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -327,9 +327,9 @@ describe User do
 
   describe "self.search" do
     it "find users by email" do
-      user1 = create(:user, email: "larry@madrid.es")
-      create(:user, email: "bird@madrid.es")
-      search = User.search("larry@madrid.es")
+      user1 = create(:user, email: "larry@consul.dev")
+      create(:user, email: "bird@consul.dev")
+      search = User.search("larry@consul.dev")
       expect(search.size).to eq(1)
       expect(search.first).to eq(user1)
     end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -1,6 +1,6 @@
 module CommonActions
 
-  def sign_up(email='manuela@madrid.es', password='judgementday')
+  def sign_up(email='manuela@consul.dev', password='judgementday')
     visit '/'
 
     click_link 'Register'
@@ -51,13 +51,13 @@ module CommonActions
   end
 
   def reset_password
-    create(:user, email: 'manuela@madrid.es')
+    create(:user, email: 'manuela@consul.dev')
 
     visit '/'
     click_link 'Sign in'
     click_link 'Forgotten your password?'
 
-    fill_in 'user_email', with: 'manuela@madrid.es'
+    fill_in 'user_email', with: 'manuela@consul.dev'
     click_button 'Send instructions'
   end
 


### PR DESCRIPTION
This replaces @madrid.es to @consul.dev.

* changes on README:
 * README.md
 * README_ES.md

* changes on db (seeds):
 * db/dev_seeds.rb
 * db/seeds.rb

* changes on docs locales:
 * doc/locales/fr.yaml
 * doc/locales/pt-br.yaml

* changes on specs:
 * spec/factories.rb
 * spec/features/emails_spec.rb
 * spec/features/registration_form_spec.rb
 * spec/features/users_auth_spec.rb
 * spec/models/user_spec.rb
 * spec/support/common_actions.rb

I think nothing is left and we can close #1169.