### PR TITLE
Ckeditor conf

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,7 +16,7 @@
 //= require jquery-ui/datepicker-es
 //= require foundation
 //= require turbolinks
-//= require ckeditor/init
+//= require ckeditor/loader
 //= require_directory ./ckeditor
 //= require social-share-button
 //= require initial

--- a/app/assets/javascripts/ckeditor/loader.js.erb
+++ b/app/assets/javascripts/ckeditor/loader.js.erb
@@ -1,0 +1,3 @@
+//= require ckeditor/init
+
+CKEDITOR.config.customConfig = '<%= javascript_path 'ckeditor/config.js' %>';

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,7 +9,7 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
-Rails.application.config.assets.precompile += %w( ckeditor/* )
+Rails.application.config.assets.precompile += %w( ckeditor/config.js )
 Rails.application.config.assets.precompile += %w( ie_lt9.js )
 Rails.application.config.assets.precompile += %w( stat_graphs.js )
 Rails.application.config.assets.precompile += %w( print.css )

--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -1,0 +1,4 @@
+Ckeditor.setup do |config|
+  config.assets_languages = I18n.available_locales.map(&:to_s)
+  config.assets_plugins = []
+end


### PR DESCRIPTION
Tweaks in ckeditor to make it include less code. If this is done correctly, it should accelerate the asset compilation and make the tests less error-prone.

The reference for this is: galetahub/ckeditor#519

In order to test this, I have executed the following commands on a server:

    bin/rake assets:clobber
    bin/rake assets:precompile -v

This basically eliminates and recreates all the assets, listing them (with `-v`)

On the current master all the ckeditor files are included (a lot of ckeditor plugins are included, for example `ckeditor/filebrowser`).

When the ckeditor-conf branch is deployed, only the specified plugins (none) are loaded. There is no mention of `ckeditor/filebrowser` or `ckeditor/plugins` on the list produced by `assets:precompile`.

I have manually tested this on the server. Ckeditor behaves correctly - no missing styles, reloads correctly when using turbolinks, etc.