### PR TITLE
downgrades sprockets to 3.6.3 to avoid warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,9 @@ gem 'jquery-ui-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
 
+# Fix sprockets on the
+gem 'sprockets', '~> 3.6.3'
+
 gem 'devise', '~> 3.5.7'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,7 +375,7 @@ GEM
     spring (1.7.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.7.0)
+    sprockets (3.6.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.0)
@@ -496,6 +496,7 @@ DEPENDENCIES
   social-share-button
   spring
   spring-commands-rspec
+  sprockets (~> 3.6.3)
   tolk
   turbolinks
   turnout


### PR DESCRIPTION
The latest version of sprokets generates lots of warnings with sass-rails and a couple warnings with rails itself. They are especially visible when doing a deploy. This version downgrade eliminates the warnings, and it is used in other communities (jekyll).