### PR TITLE
Fixes failing spec for badges

### DIFF
--- a/app/views/proposals/_featured_proposal.html.erb
+++ b/app/views/proposals/_featured_proposal.html.erb
@@ -7,7 +7,14 @@
       <% else %>
         <%= proposal.author.name %>
       <% end %>
-      &nbsp;&bull;&nbsp;
+
+      <% if proposal.author.display_official_position_badge? %>
+        <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <span class="label round level-<%= proposal.author.official_level %>">
+          <%= proposal.author.official_position %>
+        </span>
+      <% end %>
+
       <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>
     </div>
   </div>

--- a/app/views/proposals/_featured_proposal.html.erb
+++ b/app/views/proposals/_featured_proposal.html.erb
@@ -8,11 +8,13 @@
         <%= proposal.author.name %>
       <% end %>
 
+      &nbsp;&bull;&nbsp;
+
       <% if proposal.author.display_official_position_badge? %>
-        <span class="bullet">&nbsp;&bull;&nbsp;</span>
         <span class="label round level-<%= proposal.author.official_level %>">
           <%= proposal.author.official_position %>
         </span>
+        &nbsp;&bull;&nbsp;
       <% end %>
 
       <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>


### PR DESCRIPTION
There's a failing spec at `spec/features/official_positions_spec.rb:56` - this fixes it by including the expected badge.

Not sure if this is the correct fix though, maybe badges shouldn't be shown for featured proposals for some reason?