### PR TITLE
Enquiries comments

### DIFF
--- a/app/controllers/enquiries_controller.rb
+++ b/app/controllers/enquiries_controller.rb
@@ -9,7 +9,7 @@ class EnquiriesController < ApplicationController
   end
 
   def show
-    @commentable = @enquiry
+    @commentable = @enquiry.proposal.present? ? @enquiry.proposal : @enquiry
     @comment_tree = CommentTree.new(@commentable, params[:page], @current_order)
     set_comment_flags(@comment_tree.comments)
   end

--- a/app/controllers/enquiries_controller.rb
+++ b/app/controllers/enquiries_controller.rb
@@ -2,12 +2,16 @@ class EnquiriesController < ApplicationController
   load_and_authorize_resource
 
   has_filters %w{opened expired incoming}
+  has_orders %w{most_voted newest oldest}, only: :show
 
   def index
     @enquiries = @enquiries.send(@current_filter).sort_for_list.for_render.page(params[:page])
   end
 
   def show
+    @commentable = @enquiry
+    @comment_tree = CommentTree.new(@commentable, params[:page], @current_order)
+    set_comment_flags(@comment_tree.comments)
   end
 
 end

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -36,7 +36,7 @@ module Abilities
       can :mark_featured, Debate
       can :unmark_featured, Debate
 
-      can :comment_as_administrator, [Debate, Comment, Proposal]
+      can :comment_as_administrator, [Debate, Comment, Proposal, Enquiry]
 
       can [:search, :create, :index, :destroy], ::Moderator
       can [:search, :create, :index, :summary], ::Valuator

--- a/app/models/abilities/moderator.rb
+++ b/app/models/abilities/moderator.rb
@@ -5,7 +5,7 @@ module Abilities
     def initialize(user)
       self.merge Abilities::Moderation.new(user)
 
-      can :comment_as_moderator, [Debate, Comment, Proposal]
+      can :comment_as_moderator, [Debate, Comment, Proposal, Enquiry]
     end
   end
 end

--- a/app/views/enquiries/_comments.html.erb
+++ b/app/views/enquiries/_comments.html.erb
@@ -1,0 +1,31 @@
+<% cache [locale_and_user_status, @current_order, commentable_cache_key(@commentable), @comment_tree.comments, @comment_tree.comment_authors, @commentable.comments_count, @comment_flags] do %>
+  <section class="row-full comments">
+    <div class="row">
+      <div id="comments" class="small-12 column">
+        <h2>
+          <%= t("shared.comments.title") %>
+          <span class="js-comments-count">(<%= @commentable.comments_count %>)</span>
+        </h2>
+
+        <%= render 'shared/wide_order_selector', i18n_namespace: "comments" %>
+
+        <% if user_signed_in? %>
+          <%= render 'comments/form', {commentable: @commentable, parent_id: nil, toggeable: false} %>
+        <% else %>
+        <br>
+
+        <div data-alert class="callout primary">
+          <%= t("shared.comments.login_to_comment",
+              signin: link_to(t("votes.signin"), new_user_session_path),
+              signup: link_to(t("votes.signup"), new_user_registration_path)).html_safe %>
+          </div>
+        <% end %>
+
+        <% @comment_tree.root_comments.each do |comment| %>
+          <%= render 'comments/comment', comment: comment  %>
+        <% end %>
+        <%= paginate @comment_tree.root_comments %>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/app/views/enquiries/show.html.erb
+++ b/app/views/enquiries/show.html.erb
@@ -61,6 +61,10 @@
 <div class="row margin-top">
   <div class="small-12 medium-9 column">
     <h3><%= t('enquiries.show.more_info') %></h3>
-    <%= safe_html_with_links @enquiry.description %>
+    <%= @enquiry.description %>
   </div>
 </div>
+
+
+<%= render "enquiries/comments" %>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -421,6 +421,9 @@ en:
     edit: 'Edit'
     save: 'Save'
     delete: 'Delete'
+    comments:
+      title: 'Comments'
+      login_to_comment: 'You must %{signin} or %{signup} to leave a comment.'
     advanced_search:
       author_type: 'By author category'
       author_type_blank: 'Select a category'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -421,6 +421,9 @@ es:
     edit: 'Editar'
     save: 'Guardar'
     delete: 'Borrar'
+    comments:
+      title: 'Comentarios'
+      login_to_comment: 'Necesitas %{signin} o %{signup} para comentar.'
     advanced_search:
       author_type: 'Por categoría de autor'
       author_type_blank: 'Elige una categoría'

--- a/spec/features/comments/enquiries_spec.rb
+++ b/spec/features/comments/enquiries_spec.rb
@@ -5,6 +5,40 @@ feature 'Commenting enquiries' do
   let(:user)   { create :user }
   let(:enquiry) { create :enquiry }
 
+  context 'Enquiries about proposals' do
+    scenario 'Index' do
+      proposal = create(:proposal)
+      comment = create(:comment, commentable: proposal)
+      enquiry = create(:enquiry, proposal: proposal)
+
+      visit enquiry_path(enquiry)
+
+      expect(page).to have_content comment.body
+    end
+
+    scenario 'Create', :js do
+      proposal = create(:proposal)
+      enquiry = create(:enquiry, proposal: proposal)
+      login_as(user)
+      visit enquiry_path(enquiry)
+
+      fill_in "comment-body-proposal_#{proposal.id}", with: 'Have you thought about...?'
+      click_button 'Publish comment'
+
+      within "#comments" do
+        expect(page).to have_content 'Have you thought about...?'
+      end
+
+      visit proposal_path(proposal)
+
+      within "#comments" do
+        expect(page).to have_content 'Have you thought about...?'
+      end
+    end
+
+
+  end
+
   scenario 'Index' do
     3.times { create(:comment, commentable: enquiry) }
 

--- a/spec/features/comments/enquiries_spec.rb
+++ b/spec/features/comments/enquiries_spec.rb
@@ -1,0 +1,508 @@
+require 'rails_helper'
+include ActionView::Helpers::DateHelper
+
+feature 'Commenting enquiries' do
+  let(:user)   { create :user }
+  let(:enquiry) { create :enquiry }
+
+  scenario 'Index' do
+    3.times { create(:comment, commentable: enquiry) }
+
+    visit enquiry_path(enquiry)
+
+    expect(page).to have_css('.comment', count: 3)
+
+    comment = Comment.last
+    within first('.comment') do
+      expect(page).to have_content comment.user.name
+      expect(page).to have_content I18n.l(comment.created_at, format: :datetime)
+      expect(page).to have_content comment.body
+    end
+  end
+
+  scenario 'Show' do
+    parent_comment = create(:comment, commentable: enquiry)
+    first_child    = create(:comment, commentable: enquiry, parent: parent_comment)
+    second_child   = create(:comment, commentable: enquiry, parent: parent_comment)
+
+    visit comment_path(parent_comment)
+
+    expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content parent_comment.body
+    expect(page).to have_content first_child.body
+    expect(page).to have_content second_child.body
+
+    expect(page).to have_link "Go back to #{enquiry.title}", href: enquiry_path(enquiry)
+  end
+
+  scenario 'Collapsable comments', :js do
+    parent_comment = create(:comment, body: "Main comment", commentable: enquiry)
+    child_comment  = create(:comment, body: "First subcomment", commentable: enquiry, parent: parent_comment)
+    grandchild_comment = create(:comment, body: "Last subcomment", commentable: enquiry, parent: child_comment)
+
+    visit enquiry_path(enquiry)
+
+    expect(page).to have_css('.comment', count: 3)
+
+    find("#comment_#{child_comment.id}_children_arrow").trigger('click')
+
+    expect(page).to have_css('.comment', count: 2)
+    expect(page).to_not have_content grandchild_comment.body
+
+    find("#comment_#{child_comment.id}_children_arrow").trigger('click')
+
+    expect(page).to have_css('.comment', count: 3)
+    expect(page).to have_content grandchild_comment.body
+
+    find("#comment_#{parent_comment.id}_children_arrow").trigger('click')
+
+    expect(page).to have_css('.comment', count: 1)
+    expect(page).to_not have_content child_comment.body
+    expect(page).to_not have_content grandchild_comment.body
+  end
+
+  scenario 'Comment order' do
+    c1 = create(:comment, :with_confidence_score, commentable: enquiry, cached_votes_up: 100, cached_votes_total: 120, created_at: Time.now - 2)
+    c2 = create(:comment, :with_confidence_score, commentable: enquiry, cached_votes_up: 10, cached_votes_total: 12, created_at: Time.now - 1)
+    c3 = create(:comment, :with_confidence_score, commentable: enquiry, cached_votes_up: 1, cached_votes_total: 2, created_at: Time.now)
+
+    visit enquiry_path(enquiry, order: :most_voted)
+
+    expect(c1.body).to appear_before(c2.body)
+    expect(c2.body).to appear_before(c3.body)
+
+    visit enquiry_path(enquiry, order: :newest)
+
+    expect(c3.body).to appear_before(c2.body)
+    expect(c2.body).to appear_before(c1.body)
+
+    visit enquiry_path(enquiry, order: :oldest)
+
+    expect(c1.body).to appear_before(c2.body)
+    expect(c2.body).to appear_before(c3.body)
+  end
+
+  scenario 'Creation date works differently in roots and in child comments, even when sorting by confidence_score' do
+    old_root = create(:comment, commentable: enquiry, created_at: Time.now - 10)
+    new_root = create(:comment, commentable: enquiry, created_at: Time.now)
+    old_child = create(:comment, commentable: enquiry, parent_id: new_root.id, created_at: Time.now - 10)
+    new_child = create(:comment, commentable: enquiry, parent_id: new_root.id, created_at: Time.now)
+
+    visit enquiry_path(enquiry, order: :most_voted)
+
+    expect(new_root.body).to appear_before(old_root.body)
+    expect(old_child.body).to appear_before(new_child.body)
+
+    visit enquiry_path(enquiry, order: :newest)
+
+    expect(new_root.body).to appear_before(old_root.body)
+    expect(new_child.body).to appear_before(old_child.body)
+
+    visit enquiry_path(enquiry, order: :oldest)
+
+    expect(old_root.body).to appear_before(new_root.body)
+    expect(old_child.body).to appear_before(new_child.body)
+  end
+
+  scenario 'Turns links into html links' do
+    create :comment, commentable: enquiry, body: 'Built with http://rubyonrails.org/'
+
+    visit enquiry_path(enquiry)
+
+    within first('.comment') do
+      expect(page).to have_content 'Built with http://rubyonrails.org/'
+      expect(page).to have_link('http://rubyonrails.org/', href: 'http://rubyonrails.org/')
+      expect(find_link('http://rubyonrails.org/')[:rel]).to eq('nofollow')
+      expect(find_link('http://rubyonrails.org/')[:target]).to eq('_blank')
+    end
+  end
+
+  scenario 'Sanitizes comment body for security' do
+    create :comment, commentable: enquiry, body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
+
+    visit enquiry_path(enquiry)
+
+    within first('.comment') do
+      expect(page).to have_content "click me http://www.url.com"
+      expect(page).to have_link('http://www.url.com', href: 'http://www.url.com')
+      expect(page).not_to have_link('click me')
+    end
+  end
+
+  scenario 'Paginated comments' do
+    per_page = 10
+    (per_page + 2).times { create(:comment, commentable: enquiry)}
+
+    visit enquiry_path(enquiry)
+
+    expect(page).to have_css('.comment', count: per_page)
+    within("ul.pagination") do
+      expect(page).to have_content("1")
+      expect(page).to have_content("2")
+      expect(page).to_not have_content("3")
+      click_link "Next", exact: false
+    end
+
+    expect(page).to have_css('.comment', count: 2)
+  end
+
+  feature 'Not logged user' do
+    scenario 'can not see comments forms' do
+      create(:comment, commentable: enquiry)
+      visit enquiry_path(enquiry)
+
+      expect(page).to have_content 'You must Sign in or Sign up to leave a comment'
+      within('#comments') do
+        expect(page).to_not have_content 'Write a comment'
+        expect(page).to_not have_content 'Reply'
+      end
+    end
+  end
+
+  scenario 'Create', :js do
+    login_as(user)
+    visit enquiry_path(enquiry)
+
+    fill_in "comment-body-enquiry_#{enquiry.id}", with: 'Have you thought about...?'
+    click_button 'Publish comment'
+
+    within "#comments" do
+      expect(page).to have_content 'Have you thought about...?'
+    end
+  end
+
+  scenario 'Errors on create', :js do
+    login_as(user)
+    visit enquiry_path(enquiry)
+
+    click_button 'Publish comment'
+
+    expect(page).to have_content "Can't be blank"
+  end
+
+  scenario 'Reply', :js do
+    citizen = create(:user, username: 'Ana')
+    manuela = create(:user, username: 'Manuela')
+    comment = create(:comment, commentable: enquiry, user: citizen)
+
+    login_as(manuela)
+    visit enquiry_path(enquiry)
+
+    click_link "Reply"
+
+    within "#js-comment-form-comment_#{comment.id}" do
+      fill_in "comment-body-comment_#{comment.id}", with: 'It will be done next week.'
+      click_button 'Publish reply'
+    end
+
+    within "#comment_#{comment.id}" do
+      expect(page).to have_content 'It will be done next week.'
+    end
+
+    expect(page).to_not have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
+  end
+
+  scenario 'Errors on reply', :js do
+    comment = create(:comment, commentable: enquiry, user: user)
+
+    login_as(user)
+    visit enquiry_path(enquiry)
+
+    click_link "Reply"
+
+    within "#js-comment-form-comment_#{comment.id}" do
+      click_button 'Publish reply'
+      expect(page).to have_content "Can't be blank"
+    end
+
+  end
+
+  scenario "N replies", :js do
+    parent = create(:comment, commentable: enquiry)
+
+    7.times do
+      create(:comment, commentable: enquiry, parent: parent)
+      parent = parent.children.first
+    end
+
+    visit enquiry_path(enquiry)
+    expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
+  end
+
+  scenario "Flagging as inappropriate", :js do
+    comment = create(:comment, commentable: enquiry)
+
+    login_as(user)
+    visit enquiry_path(enquiry)
+
+    within "#comment_#{comment.id}" do
+      page.find("#flag-expand-comment-#{comment.id}").click
+      page.find("#flag-comment-#{comment.id}").click
+
+      expect(page).to have_css("#unflag-expand-comment-#{comment.id}")
+    end
+
+    expect(Flag.flagged?(user, comment)).to be
+  end
+
+  scenario "Undoing flagging as inappropriate", :js do
+    comment = create(:comment, commentable: enquiry)
+    Flag.flag(user, comment)
+
+    login_as(user)
+    visit enquiry_path(enquiry)
+
+    within "#comment_#{comment.id}" do
+      page.find("#unflag-expand-comment-#{comment.id}").click
+      page.find("#unflag-comment-#{comment.id}").click
+
+      expect(page).to have_css("#flag-expand-comment-#{comment.id}")
+    end
+
+    expect(Flag.flagged?(user, comment)).to_not be
+  end
+
+  scenario "Flagging turbolinks sanity check", :js do
+    enquiry = create(:enquiry, title: "Should we change the world?")
+    comment = create(:comment, commentable: enquiry)
+
+    login_as(user)
+    visit enquiries_path
+    click_link "Should we change the world?"
+
+    within "#comment_#{comment.id}" do
+      page.find("#flag-expand-comment-#{comment.id}").click
+      expect(page).to have_selector("#flag-comment-#{comment.id}")
+    end
+  end
+
+  scenario "Erasing a comment's author" do
+    enquiry = create(:enquiry)
+    comment = create(:comment, commentable: enquiry, body: 'this should be visible')
+    comment.user.erase
+
+    visit enquiry_path(enquiry)
+    within "#comment_#{comment.id}" do
+      expect(page).to have_content('User deleted')
+      expect(page).to have_content('this should be visible')
+    end
+  end
+
+  scenario 'Submit button is disabled after clicking', :js do
+    enquiry = create(:enquiry)
+    login_as(user)
+    visit enquiry_path(enquiry)
+
+    fill_in "comment-body-enquiry_#{enquiry.id}", with: 'Testing submit button!'
+    click_button 'Publish comment'
+
+    # The button's text should now be "..."
+    # This should be checked before the Ajax request is finished
+    expect(page).to_not have_button 'Publish comment'
+
+    expect(page).to have_content('Testing submit button!')
+  end
+
+  feature "Moderators" do
+    scenario "can create comment as a moderator", :js do
+      moderator = create(:moderator)
+
+      login_as(moderator.user)
+      visit enquiry_path(enquiry)
+
+      fill_in "comment-body-enquiry_#{enquiry.id}", with: "I am moderating!"
+      check "comment-as-moderator-enquiry_#{enquiry.id}"
+      click_button "Publish comment"
+
+      within "#comments" do
+        expect(page).to have_content "I am moderating!"
+        expect(page).to have_content "Moderator ##{moderator.id}"
+        expect(page).to have_css "div.is-moderator"
+        expect(page).to have_css "img.moderator-avatar"
+      end
+    end
+
+    scenario "can create reply as a moderator", :js do
+      citizen = create(:user, username: "Ana")
+      manuela = create(:user, username: "Manuela")
+      moderator = create(:moderator, user: manuela)
+      comment = create(:comment, commentable: enquiry, user: citizen)
+
+      login_as(manuela)
+      visit enquiry_path(enquiry)
+
+      click_link "Reply"
+
+      within "#js-comment-form-comment_#{comment.id}" do
+        fill_in "comment-body-comment_#{comment.id}", with: "I am moderating!"
+        check "comment-as-moderator-comment_#{comment.id}"
+        click_button 'Publish reply'
+      end
+
+      within "#comment_#{comment.id}" do
+        expect(page).to have_content "I am moderating!"
+        expect(page).to have_content "Moderator ##{moderator.id}"
+        expect(page).to have_css "div.is-moderator"
+        expect(page).to have_css "img.moderator-avatar"
+      end
+
+      expect(page).to_not have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
+    end
+
+    scenario "can not comment as an administrator" do
+      moderator = create(:moderator)
+
+      login_as(moderator.user)
+      visit enquiry_path(enquiry)
+
+      expect(page).to_not have_content "Comment as administrator"
+    end
+  end
+
+  feature "Administrators" do
+    scenario "can create comment as an administrator", :js do
+      admin = create(:administrator)
+
+      login_as(admin.user)
+      visit enquiry_path(enquiry)
+
+      fill_in "comment-body-enquiry_#{enquiry.id}", with: "I am your Admin!"
+      check "comment-as-administrator-enquiry_#{enquiry.id}"
+      click_button "Publish comment"
+
+      within "#comments" do
+        expect(page).to have_content "I am your Admin!"
+        expect(page).to have_content "Administrator ##{admin.id}"
+        expect(page).to have_css "div.is-admin"
+        expect(page).to have_css "img.admin-avatar"
+      end
+    end
+
+    scenario "can create reply as an administrator", :js do
+      citizen = create(:user, username: "Ana")
+      manuela = create(:user, username: "Manuela")
+      admin   = create(:administrator, user: manuela)
+      comment = create(:comment, commentable: enquiry, user: citizen)
+
+      login_as(manuela)
+      visit enquiry_path(enquiry)
+
+      click_link "Reply"
+
+      within "#js-comment-form-comment_#{comment.id}" do
+        fill_in "comment-body-comment_#{comment.id}", with: "Top of the world!"
+        check "comment-as-administrator-comment_#{comment.id}"
+        click_button 'Publish reply'
+      end
+
+      within "#comment_#{comment.id}" do
+        expect(page).to have_content "Top of the world!"
+        expect(page).to have_content "Administrator ##{admin.id}"
+        expect(page).to have_css "div.is-admin"
+        expect(page).to have_css "img.admin-avatar"
+      end
+
+      expect(page).to_not have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
+    end
+
+    scenario "can not comment as a moderator" do
+      admin  = create(:administrator)
+
+      login_as(admin.user)
+      visit enquiry_path(enquiry)
+
+      expect(page).to_not have_content "Comment as moderator"
+    end
+  end
+
+  feature 'Voting comments' do
+    background do
+      @manuela = create(:user, verified_at: Time.now)
+      @pablo = create(:user)
+      @enquiry = create(:enquiry)
+      @comment = create(:comment, commentable: @enquiry)
+
+      login_as(@manuela)
+    end
+
+    scenario 'Show' do
+      create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
+      create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
+
+      visit enquiry_path(@enquiry)
+
+      within("#comment_#{@comment.id}_votes") do
+        within(".in_favor") do
+          expect(page).to have_content "1"
+        end
+
+        within(".against") do
+          expect(page).to have_content "1"
+        end
+
+        expect(page).to have_content "2 votes"
+      end
+    end
+
+    scenario 'Create', :js do
+      visit enquiry_path(@enquiry)
+
+      within("#comment_#{@comment.id}_votes") do
+        find(".in_favor a").click
+
+        within(".in_favor") do
+          expect(page).to have_content "1"
+        end
+
+        within(".against") do
+          expect(page).to have_content "0"
+        end
+
+        expect(page).to have_content "1 vote"
+      end
+    end
+
+    scenario 'Update', :js do
+      visit enquiry_path(@enquiry)
+
+      within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
+        find('.against a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "0"
+        end
+
+        within('.against') do
+          expect(page).to have_content "1"
+        end
+
+        expect(page).to have_content "1 vote"
+      end
+    end
+
+    xscenario 'Trying to vote multiple times', :js do
+      visit enquiry_path(@enquiry)
+
+      within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
+        find('.in_favor a').click
+        within('.in_favor') do
+          expect(page).to_not have_content "2"
+          expect(page).to have_content "1"
+        end
+
+        within('.against') do
+          expect(page).to have_content "0"
+        end
+
+        expect(page).to have_content "1 vote"
+      end
+    end
+  end
+
+end

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -56,6 +56,9 @@ describe "Abilities::Administrator" do
   it { should be_able_to(:comment_as_administrator, proposal) }
   it { should_not be_able_to(:comment_as_moderator, proposal) }
 
+  it { should be_able_to(:comment_as_administrator, enquiry) }
+  it { should_not be_able_to(:comment_as_moderator, enquiry) }
+
   it { should be_able_to(:manage, Annotation) }
 
   it { should be_able_to(:read, SpendingProposal) }

--- a/spec/models/abilities/moderator_spec.rb
+++ b/spec/models/abilities/moderator_spec.rb
@@ -11,6 +11,7 @@ describe "Abilities::Moderator" do
   let(:debate) { create(:debate) }
   let(:comment) { create(:comment) }
   let(:proposal) { create(:proposal) }
+  let(:enquiry) { create(:enquiry) }
 
   let(:own_debate) { create(:debate, author: user) }
   let(:own_comment) { create(:comment, author: user) }
@@ -101,7 +102,9 @@ describe "Abilities::Moderator" do
 
     it { should be_able_to(:comment_as_moderator, debate) }
     it { should be_able_to(:comment_as_moderator, proposal) }
+    it { should be_able_to(:comment_as_moderator, enquiry) }
     it { should_not be_able_to(:comment_as_administrator, debate) }
     it { should_not be_able_to(:comment_as_administrator, proposal) }
+    it { should_not be_able_to(:comment_as_administrator, enquiry) }
   end
 end


### PR DESCRIPTION
This does two things:

1) Makes enquiries commentable
2) Shares comments between proposals and enquiries (an enquiry about a proposal should use the same comments as the proposal itself, not a new tree of comments)