### PR TITLE
fixes text format on direct messages

### DIFF
--- a/app/views/direct_messages/show.html.erb
+++ b/app/views/direct_messages/show.html.erb
@@ -13,6 +13,6 @@
     </div>
 
     <h1><%= @direct_message.title %></h1>
-    <p><%= @direct_message.body %></p>
+    <p><%= simple_format text_with_links(@direct_message.body), {}, sanitize: false  %></p>
   </div>
 </div>

--- a/app/views/mailer/direct_message_for_receiver.html.erb
+++ b/app/views/mailer/direct_message_for_receiver.html.erb
@@ -3,9 +3,9 @@
     <%= @direct_message.title %>
   </h1>
 
-  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= @direct_message.body %>
-  </p>
+  <div style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= simple_format text_with_links(@direct_message.body), {}, sanitize: false  %>
+  </div>
 
   <table style="width: 100%; border-top: 1px solid #DEE0E3; margin-top: 60px;">
     <tbody>

--- a/app/views/mailer/direct_message_for_sender.html.erb
+++ b/app/views/mailer/direct_message_for_sender.html.erb
@@ -9,7 +9,7 @@
     <%= @direct_message.title %>
   </h2>
 
-  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= @direct_message.body %>
-  </p>
+  <div style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= simple_format text_with_links(@direct_message.body), {}, sanitize: false  %>
+  </div>
 </td>


### PR DESCRIPTION
Fixes text format (allows paragraphs) on:

- Show of direct message:

![screen shot 2016-10-18 at 16 37 40](https://cloud.githubusercontent.com/assets/631897/19482576/cd85fa60-9551-11e6-9233-93cab5c4031c.png)

- Email to sender:

![screen shot 2016-10-18 at 16 37 53](https://cloud.githubusercontent.com/assets/631897/19482606/e22d542c-9551-11e6-82ce-90d8c2995aef.png)

- Email to receiver:

![screen shot 2016-10-18 at 16 38 03](https://cloud.githubusercontent.com/assets/631897/19482614/e6527dca-9551-11e6-94fd-c37a92d82c56.png)

