### PR TITLE
Signature sheets polish

### DIFF
--- a/app/models/signature_sheet.rb
+++ b/app/models/signature_sheet.rb
@@ -22,7 +22,7 @@ class SignatureSheet < ActiveRecord::Base
 
   def verify_signatures
     parsed_document_numbers.each do |document_number|
-      signature = signatures.create(document_number: document_number)
+      signature = self.signatures.where(document_number: document_number).first_or_create
       signature.verify
     end
     update(processed: true)

--- a/app/models/signature_sheet.rb
+++ b/app/models/signature_sheet.rb
@@ -29,7 +29,7 @@ class SignatureSheet < ActiveRecord::Base
   end
 
   def parsed_document_numbers
-    document_numbers.split(/\W+/)
+    document_numbers.split(/\r\n|\n|[,]/).collect {|d| d.gsub(/\s+/, '') }
   end
 
   def signable_found

--- a/app/views/admin/signature_sheets/show.html.erb
+++ b/app/views/admin/signature_sheets/show.html.erb
@@ -8,6 +8,11 @@
   <strong><%= @signature_sheet.author.name %></strong>
 </div>
 
+<h3 id="document_count" class="block">
+  <%= t("admin.signature_sheets.show.document_count") %>
+  <%= @signature_sheet.signatures.count %>
+</h3>
+
 <div class="callout margin-top">
   <p><strong><%= t("admin.signature_sheets.show.documents") %></strong></p>
   <%= simple_format @signature_sheet.document_numbers %>

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -6,7 +6,7 @@ end
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 2
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 30.seconds
+Delayed::Worker.max_run_time = 10.minutes
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.raise_signal_exceptions = :term

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -6,7 +6,7 @@ end
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 2
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 10.minutes
+Delayed::Worker.max_run_time = 30.minutes
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.raise_signal_exceptions = :term

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -312,6 +312,7 @@ en:
         created_at: Created
         author: Author
         documents: Documents
+        document_count: "Number of documents:"
         verified:
           one: "There is %{count} valid signature"
           other: "There are %{count} valid signatures"

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -310,6 +310,7 @@ es:
         created_at: Creado
         author: Autor
         documents: Documentos
+        document_count: "Número de documentos:"
         verified:
           one: "Hay %{count} firma válida"
           other: "Hay %{count} firmas válidas"

--- a/spec/features/admin/signature_sheets_spec.rb
+++ b/spec/features/admin/signature_sheets_spec.rb
@@ -59,6 +59,10 @@ feature 'Signature sheets' do
     expect(page).to have_content signature_sheet.created_at.strftime("%d %b %H:%M")
     expect(page).to have_content user.name
 
+    within("#document_count") do
+      expect(page).to have_content 3
+    end
+
     within("#verified_signatures") do
       expect(page).to have_content 1
     end

--- a/spec/models/signature_sheet_spec.rb
+++ b/spec/models/signature_sheet_spec.rb
@@ -76,6 +76,12 @@ describe SignatureSheet do
 
       expect(signature_sheet.parsed_document_numbers).to eq(['123A', '456B', '789C', '123B'])
     end
+
+    it "strips spaces between number and letter" do
+      signature_sheet.document_numbers = "123 A\n456 B \n 789C"
+
+      expect(signature_sheet.parsed_document_numbers).to eq(['123A', '456B', '789C'])
+    end
   end
 
 end


### PR DESCRIPTION
- Displays document count
- Makes signatures aware of spaces between numbers and letter
- Increases delayed job max run time
- Finds or creates signatures in case the delayed job is restarted