### PR TITLE
Minimum age setting

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -196,6 +196,10 @@ class User < ActiveRecord::Base
     @@username_max_length ||= self.columns.find { |c| c.name == 'username' }.limit || 60
   end
 
+  def self.minimum_required_age
+    (Setting['min_age_to_participate'] || 16).to_i
+  end
+
   def show_welcome_screen?
     sign_in_count == 1 && unverified? && !organization && !administrator?
   end

--- a/app/models/verification/management/document.rb
+++ b/app/models/verification/management/document.rb
@@ -23,7 +23,7 @@ class Verification::Management::Document
   end
 
   def valid_age?(response)
-    if under_sixteen?(response)
+    if under_age?(response)
       errors.add(:age, true)
       return false
     else
@@ -31,8 +31,8 @@ class Verification::Management::Document
     end
   end
 
-  def under_sixteen?(response)
-    16.years.ago.beginning_of_day < response.date_of_birth.beginning_of_day
+  def under_age?(response)
+    User.minimum_required_age.years.ago.beginning_of_day < response.date_of_birth.beginning_of_day
   end
 
   def verified?

--- a/app/models/verification/residence.rb
+++ b/app/models/verification/residence.rb
@@ -36,7 +36,7 @@ class Verification::Residence
 
   def allowed_age
     return if errors[:date_of_birth].any?
-    errors.add(:date_of_birth, I18n.t('verification.residence.new.error_not_allowed_age')) unless self.date_of_birth <= 16.years.ago
+    errors.add(:date_of_birth, I18n.t('verification.residence.new.error_not_allowed_age')) unless self.date_of_birth <= User.minimum_required_age.years.ago
   end
 
   def document_number_uniqueness

--- a/config/locales/management.en.yml
+++ b/config/locales/management.en.yml
@@ -29,7 +29,7 @@ en:
       not_in_census_info: 'Citizens not in the Census can participate in the website with the following permissions:'
       please_check_account_data: Please check that the account data above are correct.
       title: User management
-      under_age: You must be over 16 to verify your account.
+      under_age: "You don't have the required age to verify your account."
       verify: Verify
     email_label: Email
     email_verifications:

--- a/config/locales/management.es.yml
+++ b/config/locales/management.es.yml
@@ -29,7 +29,7 @@ es:
       not_in_census_info: 'Las personas no empadronadas pueden participar en el Portal de Gobierno Abierto con las siguientes posibilidades:'
       please_check_account_data: Compruebe que los datos anteriores son correctos para proceder a verificar la cuenta completamente.
       title: Gestión de usuarios
-      under_age: Debes ser mayor de 16 años para verificar tu cuenta.
+      under_age: No tienes edad suficiente para verificar tu cuenta.
       verify: Verificar usuario
     email_label: Email
     email_verifications:

--- a/config/locales/settings.en.yml
+++ b/config/locales/settings.en.yml
@@ -37,3 +37,4 @@ en:
     meta_description: "Site description (SEO)"
     meta_keywords: "Keywords (SEO)"
     verification_offices_url: Verification offices URL
+    min_age_to_participate: Minimum age needed to participate

--- a/config/locales/settings.es.yml
+++ b/config/locales/settings.es.yml
@@ -37,3 +37,4 @@ es:
     meta_description: "Descripción del sitio (SEO)"
     meta_keywords: "Palabras clave (SEO)"
     verification_offices_url: URL oficinas verificación
+    min_age_to_participate: Edad mínima para participar

--- a/config/locales/verification.en.yml
+++ b/config/locales/verification.en.yml
@@ -59,7 +59,7 @@ en:
           residence_card: Residence card
           spanish_id: DNI
         document_type_label: Document type
-        error_not_allowed_age: You must be at least 16 years old
+        error_not_allowed_age: You don't have the required age to participate
         error_not_allowed_postal_code: In order to be verified, you must be registered.
         error_verifying_census: The Census was unable to verify your information. Please confirm that your census details are correct by calling to City Council or visit one %{offices}.
         error_verifying_census_offices: Citizen Support Office

--- a/config/locales/verification.es.yml
+++ b/config/locales/verification.es.yml
@@ -59,7 +59,7 @@ es:
           residence_card: Tarjeta de residencia
           spanish_id: DNI
         document_type_label: Tipo de documento
-        error_not_allowed_age: Hay que tener al menos 16 años
+        error_not_allowed_age: No tienes la edad mínima para participar
         error_not_allowed_postal_code: Para verificarte debes estar empadronado.
         error_verifying_census: El Padrón no pudo verificar tu información. Por favor, confirma que tus datos de empadronamiento sean correctos llamando al Ayuntamiento o visitando una %{offices}.
         error_verifying_census_offices: oficina de Atención al ciudadano

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -39,6 +39,7 @@ Setting.create(key: 'mailer_from_address', value: 'noreply@consul.dev')
 Setting.create(key: 'meta_description', value: 'Citizen Participation and Open Government Application')
 Setting.create(key: 'meta_keywords', value: 'citizen participation, open government')
 Setting.create(key: 'verification_offices_url', value: 'http://oficinas-atencion-ciudadano.url/')
+Setting.create(key: 'min_age_to_participate', value: '16')
 
 puts "Creating Geozones"
 ('A'..'Z').each { |i| Geozone.create(name: "District #{i}", external_code: i.ord, census_code: i.ord) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,3 +94,4 @@ Setting['mailer_from_address'] = 'noreply@consul.dev'
 
 # Verification settings
 Setting['verification_offices_url'] = 'http://oficinas-atencion-ciudadano.url/'
+Setting['min_age_to_participate'] = 16

--- a/spec/features/management/document_verifications_spec.rb
+++ b/spec/features/management/document_verifications_spec.rb
@@ -63,13 +63,13 @@ feature 'DocumentVerifications' do
   end
 
   scenario 'User age is checked' do
-    expect_any_instance_of(Verification::Management::Document).to receive(:under_sixteen?).and_return(true)
+    expect_any_instance_of(Verification::Management::Document).to receive(:under_age?).and_return(true)
 
     visit management_document_verifications_path
     fill_in 'document_verification_document_number', with: '12345678Z'
     click_button 'Check'
 
-    expect(page).to have_content "You must be over 16 to verify your account."
+    expect(page).to have_content "You don't have the required age to verify your account."
   end
 
 end

--- a/spec/models/residence_spec.rb
+++ b/spec/models/residence_spec.rb
@@ -27,7 +27,7 @@ describe Verification::Residence do
     it "should validate user has allowed age" do
       residence = Verification::Residence.new({"date_of_birth(3i)"=>"1", "date_of_birth(2i)"=>"1", "date_of_birth(1i)"=>"#{5.year.ago.year}"})
       expect(residence).to_not be_valid
-      expect(residence.errors[:date_of_birth]).to include("You must be at least 16 years old")
+      expect(residence.errors[:date_of_birth]).to include("You don't have the required age to participate")
     end
 
     it "should validate uniquness of document_number" do

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -18,20 +18,20 @@ describe Verification::Management::Document do
     end
   end
 
-  describe "#under_sixteen?" do
-    it "returns true when the user is younger than sixteen years old" do
-      census_response = double(date_of_birth: Date.new(16.years.ago.year, 12, 31))
-      expect(Verification::Management::Document.new.under_sixteen?(census_response)).to be true
+  describe "#under_age?" do
+    it "returns true when the user is younger than the user's minimum required age" do
+      census_response = double(date_of_birth: Date.new(User.minimum_required_age.years.ago.year, 12, 31))
+      expect(Verification::Management::Document.new.under_age?(census_response)).to be true
     end
 
-    it "returns false when the user is sixteen years old" do
-      census_response = double(date_of_birth: Date.new(16.years.ago.year, 16.years.ago.month, 16.years.ago.day))
-      expect(Verification::Management::Document.new.under_sixteen?(census_response)).to be false
+    it "returns false when the user is user's minimum required age" do
+      census_response = double(date_of_birth: Date.new(User.minimum_required_age.years.ago.year, User.minimum_required_age.years.ago.month, User.minimum_required_age.years.ago.day))
+      expect(Verification::Management::Document.new.under_age?(census_response)).to be false
     end
 
-    it "returns false when the user is older than sixteen years old" do
-      census_response = double(date_of_birth: Date.new(33.years.ago.year, 12, 31))
-      expect(Verification::Management::Document.new.under_sixteen?(census_response)).to be false
+    it "returns false when the user is older than user's minimum required age" do
+      census_response = double(date_of_birth: Date.new((User.minimum_required_age + 10).years.ago.year, 12, 31))
+      expect(Verification::Management::Document.new.under_age?(census_response)).to be false
     end
   end
 end

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 describe Verification::Management::Document do
   describe "#valid_age?" do
-    it "returns false when the user is younger than sixteen years old" do
-      census_response = double(date_of_birth: Date.new(16.years.ago.year, 12, 31))
+    it "returns false when the user is younger than the user's minimum required age" do
+      census_response = double(date_of_birth: Date.new(User.minimum_required_age.years.ago.year, 12, 31))
       expect(Verification::Management::Document.new.valid_age?(census_response)).to be false
     end
 
-    it "returns true when the user is sixteen years old" do
-      census_response = double(date_of_birth: Date.new(16.years.ago.year, 16.years.ago.month, 16.years.ago.day))
+    it "returns true when the user has the user's minimum required age" do
+      census_response = double(date_of_birth: Date.new(User.minimum_required_age.years.ago.year, 16.years.ago.month, 16.years.ago.day))
       expect(Verification::Management::Document.new.valid_age?(census_response)).to be true
     end
 
-    it "returns true when the user is older than sixteen years old" do
-      census_response = double(date_of_birth: Date.new(33.years.ago.year, 12, 31))
+    it "returns true when the user is older than the user's minimum required age" do
+      census_response = double(date_of_birth: Date.new((User.minimum_required_age + 10).years.ago.year, 12, 31))
       expect(Verification::Management::Document.new.valid_age?(census_response)).to be true
     end
   end


### PR DESCRIPTION
This PR removes current (16 years) hardcoded age restriction and moves minimum age to participate to a setting accesible via `User.minimum_required_age` method that defaults to 16.