### PR TITLE
Fixes values of official_level options for selects in search filters.

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,13 +1,8 @@
 module SearchHelper
 
   def official_level_search_options
-    options_for_select([
-      [t("shared.advanced_search.author_type_1"), 1],
-      [t("shared.advanced_search.author_type_2"), 2],
-      [t("shared.advanced_search.author_type_3"), 3],
-      [t("shared.advanced_search.author_type_4"), 4],
-      [t("shared.advanced_search.author_type_5"), 5]],
-      params[:advanced_search].try(:[], :official_level))
+    options_for_select((1..5).map{ |i| [setting["official_level_#{i}_name"], i] },
+                       params[:advanced_search].try(:[], :official_level))
   end
 
   def date_range_options

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,11 +400,6 @@ en:
     advanced_search:
       author_type: 'By author category'
       author_type_blank: 'Select a category'
-      author_type_1: 'Public employee'
-      author_type_2: 'Municipal Organization'
-      author_type_3: 'General director'
-      author_type_4: 'City councillor'
-      author_type_5: 'Mayoress'
       date: 'By date'
       date_placeholder: 'DD/MM/YYYY'
       date_range_blank: 'Choose a date'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -400,11 +400,6 @@ es:
     advanced_search:
       author_type: 'Por categoría de autor'
       author_type_blank: 'Elige una categoría'
-      author_type_1: 'Empleado público'
-      author_type_2: 'Organización Municipal'
-      author_type_3: 'Director general'
-      author_type_4: 'Concejal'
-      author_type_5: 'Alcaldesa'
       date: 'Por fecha'
       date_placeholder: 'DD/MM/AAAA'
       date_range_blank: 'Elige una fecha'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1361,11 +1361,6 @@ fr:
   shared:
     advanced_search:
       author_type: Par catégorie d'auteur
-      author_type_1: Fonctionnaire
-      author_type_2: Organisation municipale
-      author_type_3: Directeur général
-      author_type_4: Conseiller municipal
-      author_type_5: Maire
       author_type_blank: Sélectionner une catégorie
       date: Par date
       date_1: Dernières 24 heures

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1383,11 +1383,6 @@ pt-BR:
   shared:
     advanced_search:
       author_type: Por categoria de autor
-      author_type_1: Servidor público
-      author_type_2: Organização municipal
-      author_type_3: Diretor geral
-      author_type_4: Conselheiro municipal
-      author_type_5: Prefeita
       author_type_blank: Selecione um categoria
       date: Por data
       date_1: "Últimas 24 horas"

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -515,7 +515,7 @@ feature 'Debates' do
           visit debates_path
 
           click_link "Advanced search"
-          select "Public employee", from: "advanced_search_official_level"
+          select Setting['official_level_1_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 debates")
@@ -538,7 +538,7 @@ feature 'Debates' do
           visit debates_path
 
           click_link "Advanced search"
-          select "Municipal Organization", from: "advanced_search_official_level"
+          select Setting['official_level_2_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 debates")
@@ -561,7 +561,7 @@ feature 'Debates' do
           visit debates_path
 
           click_link "Advanced search"
-          select "General director", from: "advanced_search_official_level"
+          select Setting['official_level_3_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 debates")
@@ -584,7 +584,7 @@ feature 'Debates' do
           visit debates_path
 
           click_link "Advanced search"
-          select "City councillor", from: "advanced_search_official_level"
+          select Setting['official_level_4_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 debates")
@@ -607,7 +607,7 @@ feature 'Debates' do
           visit debates_path
 
           click_link "Advanced search"
-          select "Mayoress", from: "advanced_search_official_level"
+          select Setting['official_level_5_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 debates")
@@ -741,7 +741,7 @@ feature 'Debates' do
 
           click_link "Advanced search"
           fill_in "Write the text", with: "Schwifty"
-          select "Public employee", from: "advanced_search_official_level"
+          select Setting['official_level_1_name'], from: "advanced_search_official_level"
           select "Last 24 hours",   from: "js-advanced-search-date-min"
 
           click_button "Filter"
@@ -757,14 +757,14 @@ feature 'Debates' do
           click_link "Advanced search"
 
           fill_in "Write the text", with: "Schwifty"
-          select "Public employee", from: "advanced_search_official_level"
+          select Setting['official_level_1_name'], from: "advanced_search_official_level"
           select "Last 24 hours", from: "js-advanced-search-date-min"
 
           click_button "Filter"
 
           within "#js-advanced-search" do
             expect(page).to have_selector("input[name='search'][value='Schwifty']")
-            expect(page).to have_select('advanced_search[official_level]', selected: 'Public employee')
+            expect(page).to have_select('advanced_search[official_level]', selected: Setting['official_level_1_name'])
             expect(page).to have_select('advanced_search[date_min]', selected: 'Last 24 hours')
           end
         end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -873,7 +873,7 @@ feature 'Proposals' do
           visit proposals_path
 
           click_link "Advanced search"
-          select "Public employee", from: "advanced_search_official_level"
+          select Setting['official_level_1_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 citizen proposals")
@@ -896,7 +896,7 @@ feature 'Proposals' do
           visit proposals_path
 
           click_link "Advanced search"
-          select "Municipal Organization", from: "advanced_search_official_level"
+          select Setting['official_level_2_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 citizen proposals")
@@ -919,7 +919,7 @@ feature 'Proposals' do
           visit proposals_path
 
           click_link "Advanced search"
-          select "General director", from: "advanced_search_official_level"
+          select Setting['official_level_3_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 citizen proposals")
@@ -942,7 +942,7 @@ feature 'Proposals' do
           visit proposals_path
 
           click_link "Advanced search"
-          select "City councillor", from: "advanced_search_official_level"
+          select Setting['official_level_4_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 citizen proposals")
@@ -965,7 +965,7 @@ feature 'Proposals' do
           visit proposals_path
 
           click_link "Advanced search"
-          select "Mayoress", from: "advanced_search_official_level"
+          select Setting['official_level_5_name'], from: "advanced_search_official_level"
           click_button "Filter"
 
           expect(page).to have_content("There are 2 citizen proposals")
@@ -1099,7 +1099,7 @@ feature 'Proposals' do
 
           click_link "Advanced search"
           fill_in "Write the text", with: "Schwifty"
-          select "Public employee", from: "advanced_search_official_level"
+          select Setting['official_level_1_name'], from: "advanced_search_official_level"
           select "Last 24 hours",   from: "js-advanced-search-date-min"
 
           click_button "Filter"
@@ -1116,7 +1116,7 @@ feature 'Proposals' do
           click_link "Advanced search"
 
           fill_in "Write the text", with: "Schwifty"
-          select "Public employee", from: "advanced_search_official_level"
+          select Setting['official_level_1_name'], from: "advanced_search_official_level"
           select "Last 24 hours", from: "js-advanced-search-date-min"
 
           click_button "Filter"
@@ -1125,7 +1125,7 @@ feature 'Proposals' do
 
           within "#js-advanced-search" do
             expect(page).to have_selector("input[name='search'][value='Schwifty']")
-            expect(page).to have_select('advanced_search[official_level]', selected: 'Public employee')
+            expect(page).to have_select('advanced_search[official_level]', selected: Setting['official_level_1_name'])
             expect(page).to have_select('advanced_search[date_min]', selected: 'Last 24 hours')
           end
         end


### PR DESCRIPTION
En el filtro de búsqueda avanzada de la página de debates, el select de "Por categoría de autor" siempre mostraba los textos de los valores a partir de las traducciones del i18n. 
Estas categorías se pueden editar sus textos en la página de administración desde la opción de "Configuración global", por lo que los valores que se muestren en este select tienen que ser los que se han guardado en los settings.