### PR TITLE
More flexibility on tags administration, tags can be checked as featu…

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -26,7 +26,12 @@ class Admin::TagsController < Admin::BaseController
   private
 
     def tag_params
-      params.require(:tag).permit(:featured, :name)
+      if (params[:tag][:kind] == "1")
+        params[:tag][:kind] = "category"
+      else
+        params[:tag][:kind] = nil
+      end
+      params.require(:tag).permit(:featured, :name, :kind)
     end
 
     def find_tag

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -8,6 +8,7 @@ class DebatesController < ApplicationController
   before_action :parse_tag_filter, only: :index
   before_action :set_search_order, only: :index
   before_action :authenticate_user!, except: [:index, :show, :map]
+  before_action :load_featured_tags, only: [:new, :edit]
 
   feature_flag :debates
 
@@ -47,12 +48,16 @@ class DebatesController < ApplicationController
 
   private
 
-    def debate_params
-      params.require(:debate).permit(:title, :description, :tag_list, :terms_of_service)
-    end
+  def debate_params
+    params.require(:debate).permit(:title, :description, :tag_list, :terms_of_service)
+  end
 
-    def resource_model
-      Debate
-    end
+  def resource_model
+    Debate
+  end
+
+  def load_featured_tags
+    @featured_tags = ActsAsTaggableOn::Tag.where(featured: true).order(:name)
+  end
 
 end

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -3,15 +3,22 @@
 <%= form_for(@tag, url: admin_tags_path, as: :tag) do |f| %>
 
   <div class="row">
-    <div class="small-12 medium-6 column">
+    <div class="small-12 medium-4 column">
       <%= f.label :name, t("admin.tags.name.placeholder") %>
       <%= f.text_field :name, placeholder: t("admin.tags.name.placeholder"), label: false  %>
     </div>
 
-    <div class="is-featured small-12 medium-6 column">
+    <div class="is-featured small-12 medium-4 column">
       <%= f.label :featured do %>
         <%= f.check_box :featured, title: t('admin.tags.mark_as_featured'), label: false %>
         <span class="checkbox"><%= t("admin.tags.mark_as_featured") %></span>
+      <% end %>
+    </div>
+
+    <div class="is-featured small-12 medium-4 column">
+      <%= f.label :kind do %>
+        <%= f.check_box :kind, title: t('admin.tags.proposals_category'), label: false %>
+        <span class="checkbox"><%= t("admin.tags.proposals_category") %></span>
       <% end %>
     </div>
   </div>
@@ -36,6 +43,10 @@
               <%= f.label "featured_#{tag.id}" do %>
                 <%= f.check_box :featured, title: t('admin.tags.mark_as_featured'), label: false, id: "tag_featured_#{tag.id}", class: "inline-block" %>
                 <span class="checkbox inline-block"><%= t("admin.tags.mark_as_featured") %></span>
+                <span class="checkbox inline-block">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
+                <%= f.check_box :kind, title: t('admin.tags.proposals_category'), label: false, id: "tag_kind_#{tag.id}", class: "inline-block",
+                                checked: (tag.kind == 'category' ? true : false) %>
+                <span class="checkbox inline-block"><%= t("admin.tags.proposals_category") %></span>
               <% end %>
             </span>
 

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -19,9 +19,16 @@
       <%= f.label :tag_list, t("debates.form.tags_label") %>
       <p class="note"><%= t("debates.form.tags_instructions") %></p>
 
+      <div id="category_tags" class="tags">
+        <%= f.label :featured_tag_list, t("debates.form.tag_featured_label") %>
+        <% @featured_tags.each do |tag| %>
+          <a class="js-add-tag-link"><%= tag.name %></a>
+        <% end if @featured_tags%>
+      </div>
+
       <%= f.text_field :tag_list, value: @debate.tag_list.to_s,
-                        label: false,
-                        placeholder: t("debates.form.tags_placeholder") %>
+                       label: false,
+                       placeholder: t("debates.form.tags_placeholder"), class: 'js-tag-list' %>
     </div>
     <div class="small-12 column">
       <% if @debate.new_record? %>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -455,6 +455,7 @@ en:
       mark_as_featured: Propose topic upon creating debate
       name:
         placeholder: Type the name of the topic
+      proposals_category: Use as a Category in Proposals
       update: Update Topic
     users:
       index:

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -455,6 +455,7 @@ es:
       mark_as_featured: Proponer tema al crear debate
       name:
         placeholder: Escribe el nombre del tema
+      proposals_category: Usar como Categoría en Propuestas
       update: Actualizar Tema
     users:
       index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,7 +86,8 @@ en:
     form:
       debate_text: Initial debate text
       debate_title: Debate title
-      tags_instructions: Tag this debate.
+      tag_featured_label: Proposed topics
+      tags_instructions: Tag this debate. You can choose from proposed topics or add your own
       tags_label: Topics
       tags_placeholder: "Enter the tags you would like to use, separated by commas (',')"
     index:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -86,7 +86,8 @@ es:
     form:
       debate_text: Texto inicial del debate
       debate_title: Título del debate
-      tags_instructions: Etiqueta este debate.
+      tag_featured_label: Temas propuestos
+      tags_instructions: Etiqueta este debate. Puedes elegir entre los temas propuestos o introducir los que desees
       tags_label: Temas
       tags_placeholder: "Escribe las etiquetas que desees separadas por coma (',')"
     index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -291,6 +291,7 @@ fr:
       mark_as_featured: Proposer un sujet après création d'un débat
       name:
         placeholder: "Écrire le nom du sujet"
+      proposals_category: Utiliser comme catégorie dans les propositions
       update: Mettre à jour le sujet
     users:
       index:
@@ -470,7 +471,8 @@ fr:
     form:
       debate_text: Texte initial du debat
       debate_title: Titre du débat
-      tags_instructions: "Étiquetter ce débat"
+      tag_featured_label: Sujets proposées
+      tags_instructions: "Étiquetter ce débat. Vous pouvez choisir parmi les sujets proposées ou ajouter les vôtres"
       tags_label: Sujets
       tags_placeholder: Entrez les étiquettes que vous voulez utiliser, séparées par
         des virgules (',')

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -292,6 +292,7 @@ pt-BR:
       mark_as_featured: Propor tópico na criação do debate
       name:
         placeholder: Digitar  o nome do tópico
+      proposals_category: Use como Categoria no Propostas
       update: Atualizar tópico
     users:
       index:
@@ -469,7 +470,8 @@ pt-BR:
     form:
       debate_text: Texto inicial do debate
       debate_title: Título do debate
-      tags_instructions: Marcar este debate.
+      tag_featured_label: Tópicos propostos
+      tags_instructions: Marcar este debate. Você pode escolher entre os tópicos propostos ou adicionar seu próprio
       tags_label: Tópicos
       tags_placeholder: Entrar com as marcações que deseja usar, separadas por vírgulas
         (',')

--- a/spec/features/admin/tags_spec.rb
+++ b/spec/features/admin/tags_spec.rb
@@ -37,12 +37,15 @@ feature 'Admin tags' do
 
     within("#edit_tag_#{@tag1.id}") do
       check "tag_featured_#{@tag1.id}"
+      check "tag_kind_#{@tag1.id}"
       click_button 'Update Topic'
     end
 
     visit admin_tags_path
     featured_checkbox = find("#tag_featured_#{@tag1.id}")
     expect(featured_checkbox.checked?).to eq(true)
+    kind_checkbox = find("#tag_kind_#{@tag1.id}")
+    expect(kind_checkbox.checked?).to eq(true)
   end
 
   scenario 'Delete' do

--- a/spec/features/tags/debates_spec.rb
+++ b/spec/features/tags/debates_spec.rb
@@ -149,6 +149,30 @@ feature 'Tags' do
     expect(page).to_not have_content 'Economía'
   end
 
+  scenario 'Featured tags', :js do
+    education = create(:tag, name: 'Education', featured: true)
+    health    = create(:tag, name: 'Health',    featured: true)
+
+    user = create(:user)
+    login_as(user)
+
+    visit new_debate_path
+
+    fill_in 'debate_title', with: 'Title'
+    fill_in_ckeditor 'debate_description', with: 'Description'
+    check 'debate_terms_of_service'
+
+    page.find('.js-add-tag-link', text: 'Education').click
+    click_button 'Start a debate'
+
+    expect(page).to have_content 'Debate created successfully.'
+
+    within('.tags') do
+      expect(page).to have_content 'Education'
+      expect(page).to_not have_content 'Health'
+    end
+  end
+
   context "Filter" do
 
     scenario "From index" do


### PR DESCRIPTION
More flexibility on tags administration, tags can be checked as featured on debates or/and as categories on proposals.
Featured tags are proposed during debates creation/edition.