### PR TITLE
Fixes bug. Compiles all locales for ckeditor.

### DIFF
--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -1,4 +1,4 @@
 Ckeditor.setup do |config|
-  config.assets_languages = I18n.available_locales.map(&:to_s)
+  config.assets_languages = Rails.application.config.i18n.available_locales.map{|l| l.to_s.downcase}
   config.assets_plugins = []
 end


### PR DESCRIPTION
Fixes a bug when compile locales for ckeditor in production environment.
Now compile all locales defined in config/application.rb.