### PR TITLE
Try to avoid intermittent poltergeist error on hover

### DIFF
--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -517,7 +517,7 @@ feature 'Ballots' do
       add_to_ballot(bi1)
 
       within("#budget_investment_#{bi2.id}") do
-        find("div.ballot").hover
+        find("div.ballot").trigger("mouseover")
         expect(page).to have_content('Price is higher than the available amount left')
         expect(page).to have_selector('.in-favor a', visible: false)
       end


### PR DESCRIPTION
This spec was causing a lot of intermittent errors in the medialab-prado fork. 
The error message suggested to use `trigger("mouseover")` instead of hover.