### PR TITLE
Polls index

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -5,7 +5,7 @@ class PollsController < ApplicationController
   has_filters %w{current expired incoming}
 
   def index
-    @polls = @polls.send(@current_filter).sort_for_list.page(params[:page])
+    @polls = @polls.send(@current_filter).includes(:geozones).sort_for_list.page(params[:page])
   end
 
   def show

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -4,6 +4,8 @@ class PollsController < ApplicationController
 
   has_filters %w{current expired incoming}
 
+  ::Poll::Answer # trigger autoload
+
   def index
     @polls = @polls.send(@current_filter).includes(:geozones).sort_for_list.page(params[:page])
   end
@@ -12,7 +14,7 @@ class PollsController < ApplicationController
     @questions = @poll.questions.for_render.sort_for_list
 
     @answers_by_question_id = {}
-    poll_answers = Poll::Answer.by_question(@poll.question_ids).by_author(current_user.try(:id))
+    poll_answers = ::Poll::Answer.by_question(@poll.question_ids).by_author(current_user.try(:id))
     poll_answers.each do |answer|
       @answers_by_question_id[answer.question_id] = answer.answer
     end

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -53,8 +53,8 @@ module Abilities
 
       can [:index, :create, :edit, :update, :destroy], Geozone
 
-      can [:manage], Poll
-      can [:manage], Poll::Booth
+      can [:read, :create, :update, :destroy, :add_question, :remove_question, :search_booths, :search_questions, :search_officers], Poll
+      can [:read, :create, :update, :destroy], Poll::Booth
       can [:search, :create, :index, :destroy], ::Poll::Officer
       can [:create, :destroy], ::Poll::BoothAssignment
       can [:create, :destroy], ::Poll::OfficerAssignment

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -18,7 +18,7 @@ class Poll < ActiveRecord::Base
   scope :published,  -> { where('published = ?', true) }
   scope :by_geozone_id, ->(geozone_id) { where(geozones: {id: geozone_id}.joins(:geozones)) }
 
-  scope :sort_for_list, -> { order(:starts_at) }
+  scope :sort_for_list, -> { order(:geozone_restricted, :starts_at, :name) }
 
   def current?(timestamp = DateTime.current)
     starts_at <= timestamp && timestamp <= ends_at

--- a/app/views/polls/_reasons_for_not_answering.html.erb
+++ b/app/views/polls/_reasons_for_not_answering.html.erb
@@ -1,0 +1,24 @@
+<% if poll.incoming? %>
+  <div class="callout alert">
+    <%= t('poll_questions.show.cant_answer_incoming') %>
+  </div>
+<% elsif poll.expired? %>
+  <div class="callout primary">
+    <%= t('poll_questions.show.cant_answer_expired') %>
+  </div>
+<% elsif current_user.nil? %>
+  <div class="callout primary">
+    <%= t("poll_questions.show.not_logged_in",
+        signin: link_to(t("poll_questions.show.signin"), new_user_session_path, class: "probe-message"),
+        signup: link_to(t("poll_questions.show.signup"), new_user_registration_path, class: "probe-message")).html_safe %>
+  </div>
+<% elsif current_user.unverified? %>
+  <div class="callout warning">
+    <%= t('poll_questions.show.cant_answer_verify_html',
+           verify_link: link_to(t('poll_questions.show.verify_link'), verification_path)) %>
+  </div>
+<% else %>
+  <div class="callout warning">
+    <%= t('poll_questions.show.cant_answer_wrong_geozone') %>
+  </div>
+<% end %>

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -21,6 +21,11 @@
           <div class="small-12 medium-6 column">
             <h3><%= poll.name %></h3>
             <p class="dates"><%= poll_dates(poll) %></p>
+            <ul class="no-bullet margin-top tags">
+              <% poll.geozones.each do |g| %>
+                <li class="inline-block"><span><%= g.name %></span></li>
+              <% end %>
+            </ul>
           </div>
           <div class="small-12 medium-6 column text-right">
             <%= link_to t("polls.index.button"),

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -28,10 +28,12 @@
             </ul>
           </div>
           <div class="small-12 medium-6 column text-right">
-            <%= link_to t("polls.index.button"),
-                        poll,
-                        class: "button",
-                        title: t("polls.index.button") + ": " + (poll.name) %>
+            <% if can? :answer, poll %>
+              <%= link_to t("polls.index.participate_button"), poll, class: "button" %>
+            <% else %>
+              <%= render 'polls/reasons_for_not_answering', poll: poll %>
+              <%= link_to t("polls.index.view_button"), poll, class: "button info small" %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/polls/questions/show.html.erb
+++ b/app/views/polls/questions/show.html.erb
@@ -54,30 +54,7 @@
         %>
       </div>
     <% else %>
-      <% if @question.poll.incoming? %>
-        <div class="callout alert">
-          <%= t('poll_questions.show.cant_answer_incoming') %>
-        </div>
-      <% elsif @question.poll.expired? %>
-        <div class="callout primary">
-          <%= t('poll_questions.show.cant_answer_expired') %>
-        </div>
-      <% elsif current_user.nil? %>
-        <div class="callout primary">
-          <%= t("poll_questions.show.not_logged_in",
-              signin: link_to(t("poll_questions.show.signin"), new_user_session_path, class: "probe-message"),
-              signup: link_to(t("poll_questions.show.signup"), new_user_registration_path, class: "probe-message")).html_safe %>
-        </div>
-      <% elsif current_user.unverified? %>
-        <div class="callout warning">
-          <%= t('poll_questions.show.cant_answer_verify_html',
-                 verify_link: link_to(t('poll_questions.show.verify_link'), verification_path)) %>
-        </div>
-      <% else %>
-        <div class="callout warning">
-          <%= t('poll_questions.show.cant_answer_wrong_geozone') %>
-        </div>
-      <% end %>
+      <%= render 'polls/reasons_for_not_answering', poll: @question.poll %>
 
       <div class="small-12 small-centered text-center column">
         <div id="<%= dom_id(@question) %>_answers">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,7 +401,8 @@ en:
         incoming: "Incoming"
         expired: "Expired"
       title: "Polls"
-      button: "Participate in this poll"
+      participate_button: "Participate in this poll"
+      view_button: "View details about this poll"
     show:
       dates_title: "Participation dates"
       cant_answer_not_logged_in: "You must %{signin} or %{signup} to participate."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -401,7 +401,8 @@ es:
         incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
-      button: "Participar en esta votación"
+      participate_button: "Participar en esta votación"
+      view_button: "Ver detalles de la votación"
     show:
       dates_title: "Fechas de participación"
       cant_answer_not_logged_in: "Necesitas %{signin} o %{signup} para participar."

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -20,6 +20,7 @@ feature 'Admin booths assignments' do
 
     fill_in 'search-booths', with: booth.name
     click_button 'Search'
+    expect(page).to have_content(booth.name)
 
     within('#search-booths-results') do
       click_link 'Assign booth'

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -11,7 +11,7 @@ feature 'Polls' do
 
       polls.each do |poll|
         expect(page).to have_content(poll.name)
-        expect(page).to have_link("Participate in this poll")
+        expect(page).to have_link("View details about this poll")
       end
     end
 

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -57,9 +57,6 @@ describe "Abilities::Administrator" do
   it { should be_able_to(:valuate, SpendingProposal) }
   it { should be_able_to(:destroy, SpendingProposal) }
 
-  it { should be_able_to(:manage, Poll) }
-  it { should be_able_to(:manage, Poll::Booth) }
-
   it { should be_able_to(:create, Budget) }
   it { should be_able_to(:update, Budget) }
 


### PR DESCRIPTION
This PR changes several things in poll/index

* Changes the order in which polls are sorted
* Presents the geozones a poll applies to in geozone_restricted polls
* If the user can not participate on a poll, the button says "view poll details" instead of "participate in  this poll"
* It also lists the reason why the person can not participate on the poll.

![screen shot 2017-01-30 at 11 31 46](https://cloud.githubusercontent.com/assets/63131/22419930/067b6a28-e6e0-11e6-8f9b-0b0f5af2edaa.png)

Note that I had to change the administrator permissions. This is because they had 'manage'. This meant they could always answer polls, even when they where not opened yet, or finished.


