### PR TITLE
makes age errors visible

### DIFF
--- a/app/models/officing/residence.rb
+++ b/app/models/officing/residence.rb
@@ -63,7 +63,7 @@ class Officing::Residence
     return unless @census_api_response.valid?
 
     unless allowed_age?
-      errors.add(:date_of_birth, I18n.t('verification.residence.new.error_not_allowed_age'))
+      errors.add(:year_of_birth, I18n.t('verification.residence.new.error_not_allowed_age'))
     end
   end
 

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -30,13 +30,13 @@ describe Officing::Residence do
       it "should not be valid if user is under allowed age" do
         allow_any_instance_of(Officing::Residence).to receive(:date_of_birth).and_return(15.years.ago)
         expect(residence).to_not be_valid
-        expect(residence.errors[:date_of_birth]).to include("You don't have the required age to participate")
+        expect(residence.errors[:year_of_birth]).to include("You don't have the required age to participate")
       end
 
       it "should be valid if user is above allowed age" do
         allow_any_instance_of(Officing::Residence).to receive(:date_of_birth).and_return(16.years.ago)
         expect(residence).to be_valid
-        expect(residence.errors[:date_of_birth]).to be_empty
+        expect(residence.errors[:year_of_birth]).to be_empty
       end
     end
 


### PR DESCRIPTION
When a user is underaged, instead of a generic "1 error prevented this form from being sent" you get a proper "this user is too young to participate" error.