### PR TITLE
keeps Budget::Investment's group in sync with heading

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -259,7 +259,7 @@ class Budget
     private
 
       def set_denormalized_ids
-        self.group_id ||= self.heading.try(:group_id)
+        self.group_id = self.heading.try(:group_id) if self.heading_id_changed?
         self.budget_id ||= self.heading.try(:group).try(:budget_id)
       end
   end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -35,6 +35,25 @@ describe Budget::Investment do
     expect(investment.description).to eq("alert('danger');")
   end
 
+  it "set correct group and budget ids" do
+    budget = create(:budget)
+    group_1 = create(:budget_group, budget: budget)
+    group_2 = create(:budget_group, budget: budget)
+
+    heading_1 = create(:budget_heading, group: group_1)
+    heading_2 = create(:budget_heading, group: group_2)
+
+    investment = create(:budget_investment, heading: heading_1)
+
+    expect(investment.budget_id).to eq budget.id
+    expect(investment.group_id).to eq group_1.id
+
+    investment.update(heading: heading_2)
+
+    expect(investment.budget_id).to eq budget.id
+    expect(investment.group_id).to eq group_2.id
+  end
+
   describe "#unfeasibility_explanation" do
     it "should be valid if valuation not finished" do
       investment.unfeasibility_explanation = ""


### PR DESCRIPTION
When heading is updated (for instance in the admin's edit form), the group is updated automagically