### PR TITLE
Fix logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![Logo of Consul]
-(https://raw.githubusercontent.com/consul/consul/master/public/consul_logo.png)
+![Logo of Consul](https://raw.githubusercontent.com/consul/consul/master/public/consul_logo.png)
 
 # Consul
 


### PR DESCRIPTION
Not sure it it relates to the [recent change to Github's GFM parser](https://githubengineering.com/a-formal-spec-for-github-markdown/), but the extra whitespace in the logo reference were preventing it from displaying as an image.