### PR TITLE
Fix datepicker in advanced search

### DIFF
--- a/app/views/shared/_advanced_search.html.erb
+++ b/app/views/shared/_advanced_search.html.erb
@@ -36,7 +36,6 @@
               </label>
               <%= text_field_tag 'advanced_search[date_min]',
                                   params[:advanced_search].try(:[], :date_min),
-                                  type: "date",
                                   class: 'js-calendar' %>
             </div>
             <div class='small-12 large-6 column'>
@@ -45,7 +44,6 @@
               </label>
               <%= text_field_tag 'advanced_search[date_max]',
                                   params[:advanced_search].try(:[], :date_max),
-                                  type: "date",
                                   class: 'js-calendar' %>
             </div>
           </div>


### PR DESCRIPTION
Advanced search by custom date range is not working in some browsers (i.e. chrome) because of a mismatch of the format of the selected date in the datepicker and the browser-expected format of a date field. This PR fixes it.