### PR TITLE
fixes html validation on whatsapp share

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -103,7 +103,7 @@
       <div class="social-share-full">
         <%= social_share_button_tag("#{investment.title} #{setting['twitter_hashtag']}") %>
         <% if browser.device.mobile? %>
-          <a href="whatsapp://send?text=<%= investment.title.gsub(/\s/, '&nbsp;' %>&nbsp;<%= budget_investment_url(budget_id: investment.budget_id, id: investment.id) %>" data-action="share/whatsapp/share">
+          <a href="whatsapp://send?text=<%= investment.title.gsub(/\s/, '&nbsp;') %>&nbsp;<%= budget_investment_url(budget_id: investment.budget_id, id: investment.id) %>" data-action="share/whatsapp/share">
             <span class="icon-whatsapp whatsapp"></span>
             <span class="sr-only"><%= t("social.whatsapp") %></span>
           </a>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -103,7 +103,7 @@
       <div class="social-share-full">
         <%= social_share_button_tag("#{investment.title} #{setting['twitter_hashtag']}") %>
         <% if browser.device.mobile? %>
-          <a href="whatsapp://send?text=<%= investment.title %> <%= budget_investment_url(budget_id: investment.budget_id, id: investment.id) %>" data-action="share/whatsapp/share">
+          <a href="whatsapp://send?text=<%= investment.title.gsub(/\s/, '&nbsp;' %>&nbsp;<%= budget_investment_url(budget_id: investment.budget_id, id: investment.id) %>" data-action="share/whatsapp/share">
             <span class="icon-whatsapp whatsapp"></span>
             <span class="sr-only"><%= t("social.whatsapp") %></span>
           </a>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -53,7 +53,7 @@
         <div class="social-share-full">
           <%= social_share_button_tag("#{@debate.title} #{setting['twitter_hashtag']}") %>
           <% if browser.device.mobile? %>
-            <a href="whatsapp://send?text=<%= @debate.title %> <%= debate_url(@debate) %>" data-action="share/whatsapp/share">
+            <a href="whatsapp://send?text=<%= @debate.title.gsub(/\s/, '&nbsp;' %>&nbsp;<%= debate_url(@debate) %>" data-action="share/whatsapp/share">
               <span class="icon-whatsapp whatsapp"></span>
               <span class="sr-only"><%= t("social.whatsapp") %></span>
             </a>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -53,7 +53,7 @@
         <div class="social-share-full">
           <%= social_share_button_tag("#{@debate.title} #{setting['twitter_hashtag']}") %>
           <% if browser.device.mobile? %>
-            <a href="whatsapp://send?text=<%= @debate.title.gsub(/\s/, '&nbsp;' %>&nbsp;<%= debate_url(@debate) %>" data-action="share/whatsapp/share">
+            <a href="whatsapp://send?text=<%= @debate.title.gsub(/\s/, '&nbsp;') %>&nbsp;<%= debate_url(@debate) %>" data-action="share/whatsapp/share">
               <span class="icon-whatsapp whatsapp"></span>
               <span class="sr-only"><%= t("social.whatsapp") %></span>
             </a>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -126,7 +126,7 @@
         <div class="social-share-full">
           <%= social_share_button_tag("#{@proposal.title} #{setting['twitter_hashtag']}") %>
           <% if browser.device.mobile? %>
-            <a href="whatsapp://send?text=<%= @proposal.title %> <%= proposal_url(@proposal) %>" data-action="share/whatsapp/share">
+            <a href="whatsapp://send?text=<%= @proposal.title.gsub(/\s/, '&nbsp;') %>&nbsp;<%= proposal_url(@proposal) %>" data-action="share/whatsapp/share">
               <span class="icon-whatsapp whatsapp"></span>
               <span class="sr-only"><%= t("social.whatsapp") %></span>
             </a>

--- a/app/views/spending_proposals/show.html.erb
+++ b/app/views/spending_proposals/show.html.erb
@@ -45,7 +45,7 @@
       <div class="social-share-full">
         <%= social_share_button_tag("#{@spending_proposal.title} #{setting['twitter_hashtag']}") %>
         <% if browser.device.mobile? %>
-          <a href="whatsapp://send?text=<%= @spending_proposal.title.gsub(/\s/, '&nbsp;' %>&nbsp;<%= spending_proposal_url(@spending_proposal) %>" data-action="share/whatsapp/share">
+          <a href="whatsapp://send?text=<%= @spending_proposal.title.gsub(/\s/, '&nbsp;') %>&nbsp;<%= spending_proposal_url(@spending_proposal) %>" data-action="share/whatsapp/share">
             <span class="icon-whatsapp whatsapp"></span>
             <span class="sr-only"><%= t("social.whatsapp") %></span>
           </a>

--- a/app/views/spending_proposals/show.html.erb
+++ b/app/views/spending_proposals/show.html.erb
@@ -45,7 +45,7 @@
       <div class="social-share-full">
         <%= social_share_button_tag("#{@spending_proposal.title} #{setting['twitter_hashtag']}") %>
         <% if browser.device.mobile? %>
-          <a href="whatsapp://send?text=<%= @spending_proposal.title %> <%= spending_proposal_url(@spending_proposal) %>" data-action="share/whatsapp/share">
+          <a href="whatsapp://send?text=<%= @spending_proposal.title.gsub(/\s/, '&nbsp;' %>&nbsp;<%= spending_proposal_url(@spending_proposal) %>" data-action="share/whatsapp/share">
             <span class="icon-whatsapp whatsapp"></span>
             <span class="sr-only"><%= t("social.whatsapp") %></span>
           </a>


### PR DESCRIPTION
This PR avoid the HTML validation error: `Bad value  for attribute “href” on element “a”: Illegal character in query: space is not allowed.`