### PR TITLE
Add links in ballot view to no voted groups

### DIFF
--- a/app/views/budgets/ballot/_ballot.html.erb
+++ b/app/views/budgets/ballot/_ballot.html.erb
@@ -19,9 +19,9 @@
 </div>
 
 <div class="row ballot">
-  <% @ballot.groups.order(name: :asc).each do |group| %>
-    <div id="<%= dom_id(group) %>"
-        class="small-12 medium-6 column end">
+  <% ballot_groups = @ballot.groups.order(name: :asc) %>
+  <% ballot_groups.each do |group| %>
+    <div id="<%= dom_id(group) %>" class="small-12 medium-6 column end">
       <div class="margin-top ballot-content">
         <div class="subtitle">
           <h3>
@@ -52,4 +52,21 @@
       </div>
     </div>
   <% end %>
+
+  <% no_balloted_groups = @budget.groups.order(name: :asc) - ballot_groups %>
+  <% no_balloted_groups.each do |group| %>
+    <div id="<%= dom_id(group) %>" class="small-12 medium-6 column end">
+      <div class="margin-top ballot-content">
+        <div class="subtitle">
+          <h3>
+            <%= group.name %>
+          </h3>
+          <strong>
+            <%= link_to t("budgets.ballots.show.no_balloted_group_yet"), budget_group_path(@budget, group) %>
+          </strong>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
 </div>

--- a/config/locales/budgets.en.yml
+++ b/config/locales/budgets.en.yml
@@ -5,6 +5,7 @@ en:
         title: Your ballot
         amount_spent: Amount spent
         remaining: "You still have <span>%{amount}</span> to invest."
+        no_balloted_group_yet: "You have not voted on this group yet, go vote!"
         remove: Remove vote
         voted_html:
           one: "You have voted <span>one</span> proposal."

--- a/config/locales/budgets.es.yml
+++ b/config/locales/budgets.es.yml
@@ -5,6 +5,7 @@ es:
         title: Mis votos
         amount_spent: Coste total
         remaining: "Te quedan <span>%{amount}</span> para invertir"
+        no_balloted_group_yet: "Todavía no has votado proyectos de este grupo, ¡vota!"
         remove: Quitar voto
         voted_html:
           one: "Has votado <span>una</span> propuesta."

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -350,6 +350,18 @@ feature 'Ballots' do
       end
     end
 
+    scenario 'Display links to vote on groups with no investments voted yet' do
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, name: "District 1", group: group, price: 100)
+
+      ballot = create(:budget_ballot, user: user, budget: budget)
+
+      login_as(user)
+      visit budget_ballot_path(budget)
+
+      expect(page).to have_link "You have not voted on this group yet, go vote!", href: budget_group_path(budget, group)
+    end
+
   end
 
   scenario 'Removing investments from ballot', :js do


### PR DESCRIPTION
Now only groups with voted headings are visible in the ballot, this PR adds a link encouraging to vote on the missing groups:

![captura de pantalla 2017-05-09 a las 11 19 06](https://cloud.githubusercontent.com/assets/6528/25844397/9bba576c-34aa-11e7-8a4c-072e96353798.png)
