### PR TITLE
Make heading amount info a link

### DIFF
--- a/app/views/budgets/ballot/_ballot.html.erb
+++ b/app/views/budgets/ballot/_ballot.html.erb
@@ -28,8 +28,9 @@
             <%= group.name %> - <%= @ballot.heading_for_group(group).name %>
           </h3>
           <strong>
-            <%= t("budgets.ballots.show.remaining",
-                  amount: @ballot.formatted_amount_available(@ballot.heading_for_group(group))).html_safe %>
+            <%= link_to t("budgets.ballots.show.remaining",
+                        amount: @ballot.formatted_amount_available(@ballot.heading_for_group(group))).html_safe,
+                        budget_group_path(@budget, group) %>
           </strong>
         </div>
         <% if @ballot.has_lines_in_group?(group) %>

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -340,7 +340,7 @@ feature 'Ballots' do
       within("#budget_group_#{group1.id}") do
         expect(page).to have_content "#{group1.name} - #{heading1.name}"
         expect(page).to have_content "Amount spent €20"
-        expect(page).to have_content "You still have €80 to invest"
+        expect(page).to have_link "You still have €80 to invest.", href: budget_group_path(budget, group1)
       end
 
       within("#budget_group_#{group2.id}") do


### PR DESCRIPTION
Changes heading amount info into a link, to push users to keep up voting

![link](https://cloud.githubusercontent.com/assets/6528/25848250/c611770c-34b9-11e7-93a4-b53772b313ac.png)
