### PR TITLE
Fix no money error

### DIFF
--- a/app/controllers/budgets/ballot/lines_controller.rb
+++ b/app/controllers/budgets/ballot/lines_controller.rb
@@ -27,7 +27,6 @@ module Budgets
 
         @line.destroy
         load_investments
-        #@ballot.reset_geozone
       end
 
       private

--- a/app/controllers/budgets/ballot/lines_controller.rb
+++ b/app/controllers/budgets/ballot/lines_controller.rb
@@ -18,9 +18,7 @@ module Budgets
         load_investment
         load_heading
 
-        unless @ballot.add_investment(@investment)
-          head :bad_request
-        end
+        @ballot.add_investment(@investment)
       end
 
       def destroy

--- a/app/models/budget/ballot.rb
+++ b/app/models/budget/ballot.rb
@@ -9,7 +9,7 @@ class Budget
     has_many :headings, -> { uniq }, through: :groups
 
     def add_investment(investment)
-      lines.create!(investment: investment)
+      lines.create(investment: investment).persisted?
     end
 
     def total_amount_spent

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -592,7 +592,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario 'Insufficient functs (removed after destroying from sidebar)', :js do
+    scenario 'Insufficient funds (removed after destroying from sidebar)', :js do
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)
       bi2 = create(:budget_investment, :selected, heading: california, price: 500)
 
@@ -618,6 +618,29 @@ feature 'Ballots' do
         find("div.ballot").hover
         expect(page).to_not have_content('Price is higher than the available amount left')
         expect(page).to have_selector('.in-favor a', visible: true)
+      end
+    end
+
+    scenario "Edge case voting a non-elegible investment", :js do
+      investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000)
+
+      login_as(user)
+      visit budget_path(budget)
+      click_link "States"
+      click_link "New York"
+
+      new_york.update(price: 10)
+
+      within("#budget_investment_#{investment1.id}") do
+        expect(page).to have_selector('.in-favor a', visible: true)
+        find('.add a').trigger('click')
+
+        expect(page.status_code).to eq(200)
+        expect(page).to_not have_content "Remove"
+        expect(page).to have_selector('.participation-not-allowed', visible: false)
+        find("div.ballot").hover
+        expect(page).to have_selector('.participation-not-allowed', visible: true)
+        expect(page).to have_selector('.in-favor a', visible: false)
       end
     end
 


### PR DESCRIPTION
Removes exception on invalid votes (no money/double click/already voted) and responds rendering correct error message instead