### PR TITLE
Add awesome_print gem to dev and test gem groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development, :test do
   gem "faker", '~> 1.7.3'
   gem 'rubocop', '~> 0.48.1', require: false
   gem 'knapsack'
+  gem 'awesome_print'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       activerecord (>= 3.0.0)
     arel (6.0.4)
     ast (2.3.0)
+    awesome_print (1.7.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -472,6 +473,7 @@ DEPENDENCIES
   acts_as_votable
   ahoy_matey (~> 1.6.0)
   ancestry (~> 2.2.2)
+  awesome_print
   browser
   bullet (~> 5.5.1)
   byebug
@@ -542,4 +544,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.6
+   1.15.0


### PR DESCRIPTION
This is a bit of a personal preference, a tool that I found pretty useful when developing/debugging on local/staging/test environments (even on production in some scenarios)

Adding https://github.com/awesome-print/awesome_print we could get:
```
irb(main):005:0> ap Banner.last
  Banner Load (0.5ms)  SELECT  "banners".* FROM "banners" WHERE "banners"."hidden_at" IS NULL  ORDER BY "banners"."id" DESC LIMIT 1
#<Banner:0x007f995926b930> {
                 :id => 3,
              :title => "Illo inventore cumque delectus.",
        :description => "Nam est reprehenderit distinctio necessitatibus et facere similique harum consequatur et minima dicta perspiciatis ex facilis.",
         :target_url => "/proposals/75-doloremque-ex-placeat",
              :style => "banner-style banner-style-three",
              :image => "banner-img banner-img-two",
    :post_started_at => Sat, 20 May 2017,
      :post_ended_at => Mon, 29 May 2017,
          :hidden_at => nil,
         :created_at => Thu, 18 May 2017 15:48:34 CEST +02:00,
         :updated_at => Tue, 23 May 2017 15:32:37 CEST +02:00
}
=> nil
```
Instead of the normal:
```
irb(main):006:0> Banner.last
  Banner Load (0.7ms)  SELECT  "banners".* FROM "banners" WHERE "banners"."hidden_at" IS NULL  ORDER BY "banners"."id" DESC LIMIT 1
=> #<Banner id: 3, title: "Illo inventore cumque delectus.", description: "Nam est reprehenderit distinctio necessitatibus et...", target_url: "/proposals/75-doloremque-ex-placeat", style: "banner-style banner-style-three", image: "banner-img banner-img-two", post_started_at: "2017-05-20", post_ended_at: "2017-05-29", hidden_at: nil, created_at: "2017-05-18 13:48:34", updated_at: "2017-05-23 13:32:37">
```

Notice its not "by default", as you still have to prepend `ap ` before any code you want to "pretty print".

What do you think? :)