### PR TITLE
Avoid creating objects, on poll recount spec, with fixed id numbers

### DIFF
--- a/spec/models/poll/recount_spec.rb
+++ b/spec/models/poll/recount_spec.rb
@@ -23,18 +23,21 @@ describe :recount do
     expect(recount.count_log).to eq("")
 
     recount.count = 33
-    recount.officer_assignment = create(:poll_officer_assignment, id: 11)
+    poll_officer_assignment_1 = create(:poll_officer_assignment)
+    recount.officer_assignment = poll_officer_assignment_1
     recount.save
 
     recount.count = 32
-    recount.officer_assignment = create(:poll_officer_assignment, id: 12)
+    poll_officer_assignment_2 = create(:poll_officer_assignment)
+    recount.officer_assignment = poll_officer_assignment_2
     recount.save
 
     recount.count = 34
-    recount.officer_assignment = create(:poll_officer_assignment, id: 13)
+    poll_officer_assignment_3 = create(:poll_officer_assignment)
+    recount.officer_assignment = poll_officer_assignment_3
     recount.save
 
-    expect(recount.officer_assignment_id_log).to eq(":11:12")
+    expect(recount.officer_assignment_id_log).to eq(":#{poll_officer_assignment_1.id}:#{poll_officer_assignment_2.id}")
   end
 
 end


### PR DESCRIPTION
## What

Lines like `create(:poll_officer_assignment, id: 11)` where creating objects with specific Id values that where being spected later on. 

That's not a very good practice, but the problem is that other specs where also creating objects from that model and in a particular spec order those id's (11, 12, 13) where already taken so the database rejected the creating due to the unique value violation of the primary key.

```ruby
  1) recount should update officer_assignment_id_log if count changes
     Failure/Error: recount.officer_assignment = create(:poll_officer_assignment, id: 12)
     
     ActiveRecord::RecordNotUnique:
       PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "poll_officer_assignments_pkey"
       DETAIL:  Key (id)=(12) already exists.
       : INSERT INTO "poll_officer_assignments" ("officer_id", "booth_assignment_id", "date", "id", "created_at", "updated_at", "user_data_log") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"
     # ./spec/models/poll/recount_spec.rb:30:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # PG::UniqueViolation:
     #   ERROR:  duplicate key value violates unique constraint "poll_officer_assignments_pkey"
     #   DETAIL:  Key (id)=(12) already exists.
     #   ./spec/models/poll/recount_spec.rb:30:in `block (2 levels) in <top (required)>'
```

## How

Just by not expecting fixed id values, but checking on test run time the value of the created objects id's.