### PR TITLE
Use a random word on the Poll factory name attribute

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -388,7 +388,7 @@ FactoryGirl.define do
   end
 
   factory :poll do
-    sequence(:name) { |n| "Poll #{n}" }
+    sequence(:name) { |n| "Poll #{Faker::StarWars.character}" }
 
     starts_at { 1.month.ago }
     ends_at { 1.month.from_now }


### PR DESCRIPTION
## What

There is a flaky test created by the fact that at https://github.com/consul/consul/blob/master/spec/features/officing/recount_spec.rb#L85 the check tries to see if the "Count" value is no longer "100" but "42". The problem is that the test is looking just for a `100` value, without context... and in a particular test run scenario there could be a `100` in the page due to the Poll factory using on its name attribute `sequence(:name) { |n| "Poll #{n}" }` so in the case of creating the 100th poll factory, on that page there would be a `100` but a "valid" one :)

## Where
Saw this happening as:
```ruby
  1) Officing Recount Edit recount
     Failure/Error: expect(page).to_not have_content('100')
       expected not to find text "100" in "× Validate document Store recount Final recounts and results Language: English Español Français Português Go back to Consul Consul Menu Consul | Polling Polling officers Notifications My activity My account Sign out Admin menu Validate document Store recount Final recounts and results × Data added Poll 100 - Add daily recount Booth and date Select booth and dateBooth 41: May 25, 2017 Vote count Your recounts Date Booth Vote count May 25, 2017 Booth 41 42"
     # ./spec/features/officing/recount_spec.rb:85:in `block (2 levels) in <top (required)>'
```

## How

Just avoiding putting the factory sequence number on the Poll factory name attribute could be enough, but as "unique or almost unique" poll name attributes are needed, using a Faker generator could be a good idea... Yes :) starwars character is not very unique but is geek enough right? :D Could be anything else really :D