### PR TITLE
Fix rubocop_todo error because of renamed cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -461,7 +461,7 @@ Style/Lambda:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Exclude:
     - 'app/controllers/management/document_verifications_controller.rb'
 


### PR DESCRIPTION
## What
When running any `rubocop` command on master you get:
```ruby
Error: The `Style/MethodCallParentheses` cop has been renamed to `Style/MethodCallWithoutArgsParentheses`.
(obsolete configuration found in /Users/bertocq/work/projects/consul/consul/.rubocop_todo.yml, please update it)
```

## How
Just renaming the cop as stated on the prompted error

PS: I wonder what's the policy for rubocop usage in this project, I would happily volunteer to start cleaning up the violations on that `.rubocop_todo.yml` file plus the ones that have since appeared.