### PR TITLE
Fix Poll factory name generation to guarantee uniqueness

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -388,7 +388,7 @@ FactoryGirl.define do
   end
 
   factory :poll do
-    sequence(:name) { |n| "Poll #{Faker::StarWars.character}" }
+    sequence(:name) { |n| "Poll #{SecureRandom.hex}" }
 
     starts_at { 1.month.ago }
     ends_at { 1.month.from_now }


### PR DESCRIPTION
## What
This is a fix related to https://github.com/consul/consul/pull/1567

Previous PR resolved the issue about using numbers on the Polls name... but I suspected that names should be unique, and forgot to use `.unique` with Faker. That lead to this flaky test:

![screen shot 2017-05-29 at 02 59 07](https://cloud.githubusercontent.com/assets/983242/26543556/b198b6b4-445e-11e7-90d3-4f75dd670292.jpg)

Also StarWars characters list is not as huge as I expected (only 33 items). Even using `unique` helper with Faker would lead to many `Faker::UniqueGenerator::RetryLimitExceeded` errors.

## How
The most reasonable way to avoid any future collisions between Poll names in specs I could come up with is using [SecureRandom](https://ruby-doc.org/stdlib-2.3.0/libdoc/securerandom/rdoc/SecureRandom.html) `hex` method (ie.  `p SecureRandom.hex #=> "eb693ec8252cd630102fd0d0fb7c3485"`)