### PR TITLE
Extract social share buttons to shared partial view

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -107,16 +107,11 @@
           </p>
         </div>
       <% end %>
-      <div id="social-share" class="sidebar-divider"></div>
-      <h2><%= t("budgets.investments.show.share") %></h2>
-      <div class="social-share-full">
-        <%= social_share_button_tag("#{investment.title} #{setting['twitter_hashtag']}") %>
-        <a href="whatsapp://send?text=<%= investment.title.gsub(/\s/, '%20') %>&nbsp;<%= budget_investment_url(budget_id: investment.budget_id, id: investment.id) %>"
-           class="show-for-small-only" data-action="share/whatsapp/share">
-          <span class="icon-whatsapp whatsapp"></span>
-          <span class="sr-only"><%= t("social.whatsapp") %></span>
-        </a>
-      </div>
+      <%= render partial: 'shared/social_share', locals: {
+        share_title: t("budgets.investments.show.share"),
+        title: investment.title,
+        url: budget_investment_url(budget_id: investment.budget_id, id: investment.id)
+      } %>
      </aside>
   </div>
 </section>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -52,16 +52,11 @@
         <div id="<%= dom_id(@debate) %>_votes">
           <%= render 'debates/votes', debate: @debate %>
         </div>
-        <div class="sidebar-divider"></div>
-        <h2><%= t("debates.show.share") %></h2>
-        <div class="social-share-full">
-          <%= social_share_button_tag("#{@debate.title} #{setting['twitter_hashtag']}") %>
-          <a href="whatsapp://send?text=<%= @debate.title.gsub(/\s/, '%20') %>&nbsp;<%= debate_url(@debate) %>"
-             class="show-for-small-only" data-action="share/whatsapp/share">
-            <span class="icon-whatsapp whatsapp"></span>
-            <span class="sr-only"><%= t("social.whatsapp") %></span>
-          </a>
-        </div>
+        <%= render partial: 'shared/social_share', locals: {
+          share_title: t("debates.show.share"),
+          title: @debate.title,
+          url: debate_url(@debate)
+        } %>
       </aside>
     </div>
   </div>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -38,16 +38,11 @@
     </div>
 
     <aside class="small-12 medium-3 column">
-      <div id="social-share" class="sidebar-divider"></div>
-      <h2><%= t("proposals.show.share") %></h2>
-      <div class="social-share-full">
-        <%= social_share_button_tag("#{@poll.name} #{setting['twitter_hashtag']}") %>
-        <% if browser.device.mobile? %>
-          <a href="whatsapp://send?text=<%= @poll.name %> <%= poll_url %>" data-action="share/whatsapp/share">
-            <span class="icon-whatsapp whatsapp"></span>
-          </a>
-        <% end %>
-      </div>
+      <%= render partial: 'shared/social_share', locals: {
+        share_title: t("proposals.show.share"),
+        title: @poll.name,
+        url: poll_url
+      } %>
     </aside>
   </div>
 </div>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -131,16 +131,11 @@
                       { proposal: @proposal, vote_url: vote_proposal_path(@proposal, value: 'yes') } %>
           <% end %>
         </div>
-        <div id="social-share" class="sidebar-divider"></div>
-        <h2><%= t("proposals.show.share") %></h2>
-        <div class="social-share-full">
-          <%= social_share_button_tag("#{@proposal.title} #{setting['twitter_hashtag']}") %>
-          <a href="whatsapp://send?text=<%= @proposal.title.gsub(/\s/, '%20') %>&nbsp;<%= proposal_url(@proposal) %>"
-             class="show-for-small-only" data-action="share/whatsapp/share">
-            <span class="icon-whatsapp whatsapp"></span>
-            <span class="sr-only"><%= t("social.whatsapp") %></span>
-          </a>
-        </div>
+        <%= render partial: 'shared/social_share', locals: {
+          share_title: t("proposals.show.share"),
+          title: @proposal.title,
+          url: proposal_url(@proposal)
+        } %>
       </aside>
     </div>
   </div>

--- a/app/views/shared/_social_share.html.erb
+++ b/app/views/shared/_social_share.html.erb
@@ -1,0 +1,10 @@
+<div id="social-share" class="sidebar-divider"></div>
+<h2><%= share_title %></h2>
+<div class="social-share-full">
+  <%= social_share_button_tag("#{title} #{setting['twitter_hashtag']}") %>
+  <a href="whatsapp://send?text=<%= title.gsub(/\s/, '%20') %>&nbsp;<%= url %>"
+     class="show-for-small-only" data-action="share/whatsapp/share">
+    <span class="icon-whatsapp whatsapp"></span>
+    <span class="sr-only"><%= t("social.whatsapp") %></span>
+  </a>
+</div>

--- a/app/views/spending_proposals/show.html.erb
+++ b/app/views/spending_proposals/show.html.erb
@@ -40,16 +40,11 @@
                       { spending_proposal: @spending_proposal, vote_url: vote_spending_proposal_path(@spending_proposal, value: 'yes') } %>
         </div>
       </div>
-      <div class="sidebar-divider"></div>
-      <h3><%= t("spending_proposals.show.share") %></h3>
-      <div class="social-share-full">
-        <%= social_share_button_tag("#{@spending_proposal.title} #{setting['twitter_hashtag']}") %>
-        <a href="whatsapp://send?text=<%= @spending_proposal.title.gsub(/\s/, '%20') %>&nbsp;<%= spending_proposal_url(@spending_proposal) %>"
-           class="show-for-small-only" data-action="share/whatsapp/share">
-          <span class="icon-whatsapp whatsapp"></span>
-          <span class="sr-only"><%= t("social.whatsapp") %></span>
-        </a>
-      </div>
+      <%= render partial: 'shared/social_share', locals: {
+        share_title: t("spending_proposals.show.share"),
+        title: @spending_proposal.title,
+        url: spending_proposal_url(@spending_proposal)
+      } %>
     </aside>
 
   </div>


### PR DESCRIPTION
## What
I'm almost done with a PR for https://github.com/consul/consul/issues/1474 but I realized the social share buttons where on many views with exactly the same html code, just changing 3 variables.

In order to make smaller and more comprehensive PR's I've extracted the partial refactor to this PR. And will open the PR that will tackle the issue after this one is merged (assuming there is no drawback to this refactor 😄  )

## How
Just creating a shared partial, and using it on every view that had the same code, passing as variables:
- Share Title: (the title used over the social buttons), seems to be the same on translation files, but I didn't want to go that further refactoring this time.
- Item Title
- Item url