### PR TITLE
Cleanup Settings values modified after specs are run

### DIFF
--- a/spec/controllers/debates_controller_spec.rb
+++ b/spec/controllers/debates_controller_spec.rb
@@ -22,6 +22,10 @@ describe DebatesController do
   end
 
   describe "Vote with too many anonymous votes" do
+    after do
+      Setting['max_ratio_anon_votes_on_debates'] = 50
+    end
+
     it 'should allow vote if user is allowed' do
       Setting["max_ratio_anon_votes_on_debates"] = 100
       debate = create(:debate)

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -11,8 +11,15 @@ feature 'Admin budget investments' do
 
   context "Feature flag" do
 
-    scenario 'Disabled with a feature flag' do
+    background do
       Setting['feature.budgets'] = nil
+    end
+
+    after do
+      Setting['feature.budgets'] = true
+    end
+
+    scenario 'Disabled with a feature flag' do
       expect{ visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -9,8 +9,15 @@ feature 'Admin budgets' do
 
   context 'Feature flag' do
 
-    scenario 'Disabled with a feature flag' do
+    background do
       Setting['feature.budgets'] = nil
+    end
+
+    after do
+      Setting['feature.budgets'] = true
+    end
+
+    scenario 'Disabled with a feature flag' do
       expect{ visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 

--- a/spec/features/admin/debates_spec.rb
+++ b/spec/features/admin/debates_spec.rb
@@ -8,6 +8,8 @@ feature 'Admin debates' do
     login_as(admin.user)
 
     expect{ visit admin_debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+
+    Setting['feature.debates'] = true
   end
 
   background do

--- a/spec/features/admin/feature_flags_spec.rb
+++ b/spec/features/admin/feature_flags_spec.rb
@@ -3,10 +3,16 @@ require 'rails_helper'
 feature 'Admin feature flags' do
 
   background do
-    Setting["feature.spending_proposals"] = true
+    Setting['feature.spending_proposals'] = true
     Setting['feature.spending_proposal_features.voting_allowed'] = true
     login_as(create(:administrator).user)
   end
+
+  after do
+    Setting['feature.spending_proposals'] = nil
+    Setting['feature.spending_proposal_features.voting_allowed'] = nil
+  end
+
 
   scenario 'Enabled features are listed on menu' do
     visit admin_root_path

--- a/spec/features/admin/spending_proposals_spec.rb
+++ b/spec/features/admin/spending_proposals_spec.rb
@@ -9,6 +9,11 @@ feature 'Admin spending proposals' do
     login_as(admin.user)
   end
 
+  after do
+    Setting['feature.spending_proposals'] = nil
+    Setting['feature.spending_proposal_features.voting_allowed'] = nil
+  end
+
   context "Feature flag" do
 
     scenario 'Disabled with a feature flag' do

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -74,6 +74,8 @@ feature 'Admin' do
     expect(page).to have_link('Moderation')
     expect(page).to have_link('Valuation')
     expect(page).to have_link('Management')
+
+    Setting['feature.spending_proposals'] = nil
   end
 
   scenario 'Admin dashboard' do

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -6,6 +6,7 @@ feature 'Debates' do
   scenario 'Disabled with a feature flag' do
     Setting['feature.debates'] = nil
     expect{ visit debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    Setting['feature.debates'] = true
   end
 
   scenario 'Index' do

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -148,6 +148,8 @@ feature 'Emails' do
     expect(email).to have_body_text(spending_proposal.title)
     expect(email).to have_body_text(spending_proposal.code)
     expect(email).to have_body_text(spending_proposal.feasible_explanation)
+
+    Setting["feature.spending_proposals"] = nil
   end
 
   context "Direct Message" do

--- a/spec/features/management/spending_proposals_spec.rb
+++ b/spec/features/management/spending_proposals_spec.rb
@@ -3,9 +3,14 @@ require 'rails_helper'
 feature 'Spending Proposals' do
 
   background do
-    Setting["feature.spending_proposals"] = true
+    Setting['feature.spending_proposals'] = true
     Setting['feature.spending_proposal_features.voting_allowed'] = true
     login_as_manager
+  end
+
+  after do
+    Setting['feature.spending_proposals'] = nil
+    Setting['feature.spending_proposal_features.voting_allowed'] = nil
   end
 
   context "Create" do

--- a/spec/features/moderation/debates_spec.rb
+++ b/spec/features/moderation/debates_spec.rb
@@ -8,6 +8,8 @@ feature 'Moderate debates' do
     login_as(moderator.user)
 
     expect{ visit moderation_debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+
+    Setting['feature.debates'] = true
   end
 
   scenario 'Hide', :js do

--- a/spec/features/official_positions_spec.rb
+++ b/spec/features/official_positions_spec.rb
@@ -78,6 +78,10 @@ feature 'Official positions' do
         @spending_proposal2 = create(:spending_proposal, author: @user2)
       end
 
+      after do
+        Setting["feature.spending_proposals"] = nil
+      end
+
       scenario "Index" do
         visit spending_proposals_path
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -536,6 +536,7 @@ feature 'Proposals' do
     expect(current_path).not_to eq(edit_proposal_path(proposal))
     expect(current_path).to eq(proposals_path)
     expect(page).to have_content 'You do not have permission'
+    Setting["max_votes_for_proposal_edit"] = 1000
   end
 
   scenario 'Update should be posible for the author of an editable proposal' do

--- a/spec/features/spending_proposals_spec.rb
+++ b/spec/features/spending_proposals_spec.rb
@@ -5,8 +5,13 @@ feature 'Spending proposals' do
   let(:author) { create(:user, :level_two, username: 'Isabel') }
 
   background do
-    Setting["feature.spending_proposals"] = true
+    Setting['feature.spending_proposals'] = true
     Setting['feature.spending_proposal_features.voting_allowed'] = true
+  end
+
+  after do
+    Setting['feature.spending_proposals'] = nil
+    Setting['feature.spending_proposal_features.voting_allowed'] = nil
   end
 
   scenario 'Index' do

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -252,6 +252,9 @@ feature 'Users' do
       Setting['feature.budgets'] = nil
       visit user_path(user)
       expect(page).to have_content('4 Comments')
+
+      Setting['feature.debates'] = true
+      Setting['feature.budgets'] = true
     end
   end
 

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -11,6 +11,8 @@ feature 'Valuation budget investments' do
   scenario 'Disabled with a feature flag' do
     Setting['feature.budgets'] = nil
     expect{ visit valuation_budget_budget_investments_path(create(:budget)) }.to raise_exception(FeatureFlags::FeatureDisabled)
+
+    Setting['feature.budgets'] = true
   end
 
   scenario 'Display link to valuation section' do

--- a/spec/features/valuation/budgets_spec.rb
+++ b/spec/features/valuation/budgets_spec.rb
@@ -10,6 +10,8 @@ feature 'Valuation budgets' do
   scenario 'Disabled with a feature flag' do
     Setting['feature.budgets'] = nil
     expect{ visit valuation_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+
+    Setting['feature.budgets'] = true
   end
 
   context 'Index' do

--- a/spec/features/valuation/spending_proposals_spec.rb
+++ b/spec/features/valuation/spending_proposals_spec.rb
@@ -3,10 +3,15 @@ require 'rails_helper'
 feature 'Valuation spending proposals' do
 
   background do
-    Setting["feature.spending_proposals"] = true
+    Setting['feature.spending_proposals'] = true
     Setting['feature.spending_proposal_features.voting_allowed'] = true
     @valuator = create(:valuator, user: create(:user, username: 'Rachel', email: 'rachel@valuators.org'))
     login_as(@valuator.user)
+  end
+
+  after do
+    Setting['feature.spending_proposals'] = nil
+    Setting['feature.spending_proposal_features.voting_allowed'] = nil
   end
 
   scenario 'Disabled with a feature flag' do

--- a/spec/features/valuation_spec.rb
+++ b/spec/features/valuation_spec.rb
@@ -4,8 +4,13 @@ feature 'Valuation' do
   let(:user) { create(:user) }
 
   background do
-    Setting["feature.spending_proposals"] = true
+    Setting['feature.spending_proposals'] = true
     Setting['feature.spending_proposal_features.voting_allowed'] = true
+  end
+
+  after do
+    Setting['feature.spending_proposals'] = nil
+    Setting['feature.spending_proposal_features.voting_allowed'] = nil
   end
 
   scenario 'Access as regular user is not authorized' do

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -364,9 +364,14 @@ feature 'Votes' do
 
   feature 'Spending Proposals' do
     background do
-     Setting["feature.spending_proposals"] = true
+     Setting['feature.spending_proposals'] = true
      Setting['feature.spending_proposal_features.voting_allowed'] = true
      login_as(@manuela)
+    end
+
+    after do
+      Setting['feature.spending_proposals'] = nil
+      Setting['feature.spending_proposal_features.voting_allowed'] = nil
     end
 
     feature 'Index' do

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -84,6 +84,7 @@ describe Debate do
   describe "#editable?" do
     let(:debate) { create(:debate) }
     before(:each) { Setting["max_votes_for_debate_edit"] = 3 }
+    after(:each) { Setting["max_votes_for_debate_edit"] = 1000 }
 
     it "should be true if debate has no votes yet" do
       expect(debate.total_votes).to eq(0)
@@ -106,6 +107,7 @@ describe Debate do
   describe "#editable_by?" do
     let(:debate) { create(:debate) }
     before(:each) { Setting["max_votes_for_debate_edit"] = 1 }
+    after(:each) { Setting["max_votes_for_debate_edit"] = 1000 }
 
     it "should be true if user is the author and debate is editable" do
       expect(debate.editable_by?(debate.author)).to be true

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -138,11 +138,14 @@ describe Proposal do
     Setting["proposal_code_prefix"] = "TEST"
     proposal = create(:proposal)
     expect(proposal.code).to eq "TEST-#{proposal.created_at.strftime('%Y-%m')}-#{proposal.id}"
+
+    Setting["proposal_code_prefix"] = "MAD"
   end
 
   describe "#editable?" do
     let(:proposal) { create(:proposal) }
     before(:each) {Setting["max_votes_for_proposal_edit"] = 5}
+    after(:each) {Setting["max_votes_for_proposal_edit"] = 1000}
 
     it "should be true if proposal has no votes yet" do
       expect(proposal.total_votes).to eq(0)

--- a/spec/models/spending_proposal_spec.rb
+++ b/spec/models/spending_proposal_spec.rb
@@ -290,9 +290,14 @@ describe SpendingProposal do
     let(:city_sp)     { create(:spending_proposal) }
     let(:district_sp) { create(:spending_proposal, geozone: district) }
 
-    before(:each) do
+    before do
       Setting["feature.spending_proposals"] = true
       Setting['feature.spending_proposal_features.voting_allowed'] = true
+    end
+
+    after do
+      Setting["feature.spending_proposals"] = nil
+      Setting['feature.spending_proposal_features.voting_allowed'] = nil
     end
 
     describe '#reason_for_not_being_votable_by' do
@@ -327,6 +332,8 @@ describe SpendingProposal do
         Setting["feature.spending_proposal_features.voting_allowed"] = true
         expect(city_sp.reason_for_not_being_votable_by(user)).to be_nil
         expect(district_sp.reason_for_not_being_votable_by(user)).to be_nil
+
+        Setting["feature.spending_proposal_features.voting_allowed"] = nil
       end
     end
   end
@@ -348,9 +355,17 @@ describe SpendingProposal do
   end
 
   describe "total votes" do
-    it "takes into account physical votes in addition to web votes" do
+    before do
       Setting["feature.spending_proposals"] = true
       Setting['feature.spending_proposal_features.voting_allowed'] = true
+    end
+
+    after do
+      Setting["feature.spending_proposals"] = nil
+      Setting['feature.spending_proposal_features.voting_allowed'] = nil
+    end
+
+    it "takes into account physical votes in addition to web votes" do
 
       sp = create(:spending_proposal)
       sp.register_vote(create(:user, :level_two), true)


### PR DESCRIPTION
## What
On scenarios sometimes its needed to change a value from `Setting` to completely test a feature. But if the Setting value is not restored to the original "default" one, depending on the order we execute the specs we could see flaky tests appearing.

Many times I've seen errors like:
<details>
  <summary>Click to expand specs failing details</summary>
  2) Admin spending proposals Index Filtering by geozone
     Failure/Error: raise klass.new(json['error'])

     Capybara::Poltergeist::JavascriptError:
       One or more errors were raised in the Javascript code on the page. If you don't care about these errors, you can ignore them by setting js_errors: false in your Poltergeist configuration (see documentation for details).

       TypeError: null is not an object (evaluating 'a.ui.space("top").unselectable')
       TypeError: null is not an object (evaluating 'a.ui.space("top").unselectable')
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23898 in b
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23894
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23563 in p
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23565
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23566 in fire
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23565 in fireOnce
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23566 in fireOnce
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23817
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23797 in f
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23797 in load
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23816
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23804
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23802
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23797 in f
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23797 in load
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23802 in load
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23803 in k
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23804
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23815 in B
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23814
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:24044
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23802
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23797 in f
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23797 in B
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23797 in u
           at http://127.0.0.1:61186/assets/application-2f10f7015bb7220bfb1bf861a827f91308b26f715508960ffa4d3421b01b7c23.js:23798
     # /Users/bertocq/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/poltergeist-1.15.0/lib/capybara/poltergeist/browser.rb:377:in `command'
     # /Users/bertocq/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/poltergeist-1.15.0/lib/capybara/poltergeist/browser.rb:113:in `visible?'
     # /Users/bertocq/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/poltergeist-1.15.0/lib/capybara/poltergeist/node.rb:17:in `command'
     # /Users/bertocq/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/poltergeist-1.15.0/lib/capybara/poltergeist/node.rb:115:in `visible?'
     # /Users/bertocq/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/capybara-2.14.0/lib/capybara/node/element.rb:269:in `block in visible?'
     # /Users/bertocq/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/capybara-2.14.0/lib/capybara/node/base.rb:81:in `synchronize'
     # /Users/bertocq/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/capybara-2.14.0/lib/capybara/node/element.rb:269:in `visible?'
     # /Users/bertocq/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/capybara-2.14.0/lib/capybara/queries/selector_query.rb:80:in `matches_filters?'
     # /Users/bertocq/.rbenv/versions/2.3.2/lib/ruby/gems/2.3.0/gems/capybara-2.14.0/lib/capybara/result.rb:29:in `block in initialize'
     # /Users/bertocq/.rbenv/versions/2.3.2/bin/rspec:1:in `each'
     # /Users/bertocq/.rbenv/versions/2.3.2/bin/rspec:1:in `each'
     # /Users/bertocq/.rbenv/versions/2.3.2/bin/rspec:1:in `each'
     # /Users/bertocq/.rbenv/versions/2.3.2/bin/rspec:1:in `each'
     #
     #   Showing full backtrace because every line was filtered out.
     #   See docs for RSpec::Configuration#backtrace_exclusion_patterns and
     #   RSpec::Configuration#backtrace_inclusion_patterns for more information.
</details>
<br>
And after digging up all I could infer is that the fact that for example `Setting["feature.spending_proposals"]` is normally set to `nil` but in some scenarios it was being set to `true` and not restored afterwards the scenario ended.

## How
Just using `after` blocks to restore the Setting value to the default one, or add a final line on the scenario to restore the value when its just changed for one.

## Caveats
I think this is the easiest/quickest way to fix the problems. Although its not the solution that makes me the happiest... it could be improved:

**A**- By storing the value before changing it, and using that stored value to restore it later:
```
before do
  @spending_proposals = Setting["feature.spending_proposals"]
  Setting["feature.spending_proposals"] = true
end

after do
  Setting["feature.spending_proposals"] = @spending_proposals
end
```
That way it won't be any longer neccesary to match the value used to "restore" with the one written in the seeds.rb file (that act as default value).

**B**- Going all the way for me would be to have a clear point to gather all the default values, and use it directly to restore them. It could just be a setting.yml file, or a .env file, or just a hash constant  at the Setting model. But it's a much bigger refactor that I think should be discussed before tackling it with code... what do you think? 😃 