### PR TITLE
Proposal creation thanks/share page

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -57,6 +57,9 @@ class ProposalsController < ApplicationController
   end
 
   def share
+    if Setting['proposal_improvement_url'].present?
+      @proposal_improvement_url = root_url + Setting['proposal_improvement_url']
+    end
   end
 
   def vote_featured

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -23,11 +23,10 @@ class ProposalsController < ApplicationController
   end
 
   def create
-    @proposal = Proposal.new(proposal_params)
-    @proposal.author = current_user
+    @proposal = Proposal.new(proposal_params.merge(author: current_user))
 
     if @proposal.save
-      redirect_to share_proposal_path(@proposal), notice: I18n.t("flash.actions.create.proposal")
+      redirect_to share_proposal_path(@proposal), notice: I18n.t('flash.actions.create.proposal')
     else
       render :new
     end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -3,7 +3,7 @@ class ProposalsController < ApplicationController
   include FlagActions
 
   before_action :parse_tag_filter, only: :index
-  before_action :load_categories, only: [:index, :new, :edit, :map, :summary]
+  before_action :load_categories, only: [:index, :new, :create, :edit, :map, :summary]
   before_action :load_geozones, only: [:edit, :map, :summary]
   before_action :authenticate_user!, except: [:index, :show, :map, :summary]
 
@@ -20,6 +20,17 @@ class ProposalsController < ApplicationController
     super
     @notifications = @proposal.notifications
     redirect_to proposal_path(@proposal), status: :moved_permanently if request.path != proposal_path(@proposal)
+  end
+
+  def create
+    @proposal = Proposal.new(proposal_params)
+    @proposal.author = current_user
+
+    if @proposal.save
+      redirect_to share_proposal_path(@proposal), notice: I18n.t("flash.actions.create.proposal")
+    else
+      render :new
+    end
   end
 
   def index_customization

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -45,6 +45,9 @@ class ProposalsController < ApplicationController
   def retire_form
   end
 
+  def share
+  end
+
   def vote_featured
     @proposal.register_vote(current_user, 'yes')
     set_featured_proposal_votes(@proposal)

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -4,7 +4,7 @@ module Abilities
 
     def initialize(user)
       can [:read, :map], Debate
-      can [:read, :map, :summary], Proposal
+      can [:read, :map, :summary, :share], Proposal
       can :read, Comment
       can :read, Poll
       can :read, Poll::Question

--- a/app/views/proposals/share.html.erb
+++ b/app/views/proposals/share.html.erb
@@ -22,7 +22,6 @@
           <strong><%= @proposal.code %></strong>
         </p>
 
-
         <p><%= t("proposals.proposal.share.guide").html_safe %></p>
 
         <%= render partial: 'shared/social_share', locals: {
@@ -30,11 +29,17 @@
           url: proposal_url(@proposal)
         } %>
 
-        <!-- <p>También puedes ver más información de como mejorar tu campaña.</p> -->
+        <br/>
 
-        <%= link_to proposal_path(@proposal), class: 'proposal button hollow float-right' do %>
+        <% if @proposal_improvement_url.present? %>
+        <p><%= t('proposals.proposal.improve_info', improve_info_link: link_to(t('proposals.proposal.improve_info_link'), @proposal_improvement_url)).html_safe %></p>
+        <% end %>
+
+        <p>
+        <%= link_to proposal_path(@proposal), class: 'proposal' do %>
           <%= t("proposals.proposal.share.view_proposal") %>
         <% end %>
+        </p>
 
       </div>
     </div>

--- a/app/views/proposals/share.html.erb
+++ b/app/views/proposals/share.html.erb
@@ -1,0 +1,42 @@
+<% provide :title do %><%= @proposal.title %><% end %>
+<% provide :social_media_meta_tags do %>
+<%= render "shared/social_media_meta_tags",
+            social_url: proposal_url(@proposal),
+            social_title: @proposal.title,
+            social_description: @proposal.summary %>
+<% end %>
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: proposal_url(@proposal) %>
+<% end %>
+
+<% cache [locale_and_user_status(@proposal), @proposal, @proposal.author, Flag.flagged?(current_user, @proposal), @proposal_votes] do %>
+  <div class="proposal-show">
+    <div id="<%= dom_id(@proposal) %>" class="row">
+      <div class="small-12 medium-9 column">
+
+        <h1><%= t("proposals.proposal.created") %></h1>
+
+        <h2><%= @proposal.title %></h2>
+        <p>
+          <%= t("proposals.show.code") %>
+          <strong><%= @proposal.code %></strong>
+        </p>
+
+
+        <p><%= t("proposals.proposal.share.guide").html_safe %></p>
+
+        <%= render partial: 'shared/social_share', locals: {
+          title: @proposal.title,
+          url: proposal_url(@proposal)
+        } %>
+
+        <!-- <p>También puedes ver más información de como mejorar tu campaña.</p> -->
+
+        <%= link_to proposal_path(@proposal), class: 'proposal button hollow float-right' do %>
+          <%= t("proposals.proposal.share.view_proposal") %>
+        <% end %>
+
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_social_share.html.erb
+++ b/app/views/shared/_social_share.html.erb
@@ -1,5 +1,7 @@
+<% if local_assigns[:share_title].present? %>
 <div id="social-share" class="sidebar-divider"></div>
 <h2><%= share_title %></h2>
+<% end %>
 <div class="social-share-full">
   <%= social_share_button_tag("#{title} #{setting['twitter_hashtag']}") %>
   <a href="whatsapp://send?text=<%= title.gsub(/\s/, '%20') %>&nbsp;<%= url %>"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,6 +351,12 @@ en:
     notice:
       retired: Proposal retired
     proposal:
+      created: "You've created a new proposal!"
+      share:
+        guide: "Now you can share it through Twitter, Facebook, Google+, Telegram or Whatsapp (if you're using a mobile device) so people can start supporting.<br><br>Before it gets shared you'll be able to change the text as you like."
+        view_proposal: Not now, go to my proposal
+      improve_info: "You can also %{improve_info_link} about improving your campaign"
+      improve_info_link: see more information
       already_supported: You have already supported this proposal. Share it!
       comments:
         one: 1 comment

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -351,6 +351,12 @@ es:
     notice:
       retired: Propuesta retirada
     proposal:
+      created: "¡Has creado una nueva propuesta!"
+      share:
+        guide: "Ahora puedes compartirla en Twitter, Facebook, Google+, Telegram o Whatsapp (si utilizas un dispositivo móvil) para que la gente empieze a apoyarla.<br><br>Antes de que se publique el texto en las redes sociales podrás modificarlo a tu gusto"
+        view_proposal: "Ahora no, ver mi propuesta"
+      improve_info: "También puedes %{improve_info_link} de como mejorar tu campaña"
+      improve_info_link: ver más información
       already_supported: "¡Ya has apoyado esta propuesta, compártela!"
       comments:
         one: 1 Comentario

--- a/config/locales/settings.en.yml
+++ b/config/locales/settings.en.yml
@@ -44,3 +44,4 @@ en:
     meta_keywords: "Keywords (SEO)"
     verification_offices_url: Verification offices URL
     min_age_to_participate: Minimum age needed to participate
+    proposal_improvement_url: Proposal improvement info internal link

--- a/config/locales/settings.es.yml
+++ b/config/locales/settings.es.yml
@@ -44,3 +44,4 @@ es:
     meta_keywords: "Palabras clave (SEO)"
     verification_offices_url: URL oficinas verificación
     min_age_to_participate: Edad mínima para participar
+    proposal_improvement_url: Link a información para mejorar propuestas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
       put :flag
       put :unflag
       get :retire_form
+      get :share
       patch :retire
     end
     collection do

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -44,6 +44,7 @@ Setting.create(key: 'meta_description', value: 'Citizen Participation and Open G
 Setting.create(key: 'meta_keywords', value: 'citizen participation, open government')
 Setting.create(key: 'verification_offices_url', value: 'http://oficinas-atencion-ciudadano.url/')
 Setting.create(key: 'min_age_to_participate', value: '16')
+Setting.create(key: 'proposal_improvement_url', value: nil)
 
 puts " ✅"
 print "Creating Geozones"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -103,3 +103,6 @@ Setting['mailer_from_address'] = 'noreply@consul.dev'
 # Verification settings
 Setting['verification_offices_url'] = 'http://oficinas-atencion-ciudadano.url/'
 Setting['min_age_to_participate'] = 16
+
+# Proposal improvement url path ('more-information/proposal-improvement')
+Setting['proposal_improvement_url'] = nil

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -90,6 +90,7 @@ feature 'Proposals' do
   end
 
   context "Embedded video"  do
+
     scenario "Show YouTube video" do
       proposal = create(:proposal, video_url: "http://www.youtube.com/watch?v=a7UFm6ErMPU")
       visit proposal_path(proposal)
@@ -135,11 +136,13 @@ feature 'Proposals' do
     fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
     check 'proposal_terms_of_service'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
+    expect(page).to have_content 'Help refugees'
+    expect(page).not_to have_content 'You can also see more information about improving your campaign'
 
-    click_link I18n.t('proposals.proposal.share.view_proposal')
+    click_link 'Not now, go to my proposal'
 
     expect(page).to have_content 'Help refugees'
     expect(page).to have_content '¿Would you like to give assistance to war refugees?'
@@ -151,6 +154,34 @@ feature 'Proposals' do
     expect(page).to have_content 'Refugees'
     expect(page).to have_content 'Solidarity'
     expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)
+  end
+
+  scenario 'Create with proposal improvement info link' do
+    Setting['proposal_improvement_url'] = 'more-information/proposal-improvement'
+    author = create(:user)
+    login_as(author)
+
+    visit new_proposal_path
+    fill_in 'proposal_title', with: 'Help refugees'
+    fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
+    fill_in 'proposal_summary', with: 'In summary, what we want is...'
+    fill_in 'proposal_description', with: 'This is very important because...'
+    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
+    fill_in 'proposal_video_url', with: 'http://youtube.com'
+    fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
+    fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
+    check 'proposal_terms_of_service'
+
+    click_button 'Create proposal'
+
+    expect(page).to have_content 'Proposal created successfully.'
+    expect(page).to have_content 'You can also see more information about improving your campaign'
+
+    click_link 'Not now, go to my proposal'
+
+    expect(page).to have_content 'Help refugees'
+
+    Setting['proposal_improvement_url'] = nil
   end
 
   scenario 'Create with invisible_captcha honeypot field' do
@@ -167,7 +198,7 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Some other robot'
     check 'proposal_terms_of_service'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page.status_code).to eq(200)
     expect(page.html).to be_empty
@@ -189,7 +220,7 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Some other robot'
     check 'proposal_terms_of_service'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content 'Sorry, that was too quick! Please resubmit'
 
@@ -210,11 +241,11 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
 
-    click_link I18n.t('proposals.proposal.share.view_proposal')
+    click_link 'Not now, go to my proposal'
 
     expect(Proposal.last.responsible_name).to eq('Isabel Garcia')
   end
@@ -233,10 +264,10 @@ feature 'Proposals' do
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     check 'proposal_terms_of_service'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
     expect(page).to have_content 'Proposal created successfully.'
 
-    click_link I18n.t('proposals.proposal.share.view_proposal')
+    click_link 'Not now, go to my proposal'
 
     expect(Proposal.last.responsible_name).to eq(author.document_number)
   end
@@ -246,7 +277,7 @@ feature 'Proposals' do
     login_as(author)
 
     visit new_proposal_path
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content error_message
   end
@@ -264,11 +295,11 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
 
-    click_link I18n.t('proposals.proposal.share.view_proposal')
+    click_link 'Not now, go to my proposal'
 
     expect(page).to have_content 'Testing an attack'
     expect(page.html).to include '<p>This is alert("an attack");</p>'
@@ -288,11 +319,11 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
 
-    click_link I18n.t('proposals.proposal.share.view_proposal')
+    click_link 'Not now, go to my proposal'
 
     expect(page).to have_content 'Testing auto link'
     expect(page).to have_link('www.example.org', href: 'http://www.example.org')
@@ -310,11 +341,11 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
 
-    click_link I18n.t('proposals.proposal.share.view_proposal')
+    click_link 'Not now, go to my proposal'
 
     expect(page).to have_content 'Testing auto link'
     expect(page).to have_link('http://example.org', href: 'http://example.org')
@@ -345,11 +376,11 @@ feature 'Proposals' do
       fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
       check 'proposal_terms_of_service'
 
-      click_button I18n.t('proposals.new.form.submit_button')
+      click_button 'Create proposal'
 
       expect(page).to have_content 'Proposal created successfully.'
 
-      click_link I18n.t('proposals.proposal.share.view_proposal')
+      click_link 'Not now, go to my proposal'
 
       within "#geozone" do
         expect(page).to have_content 'All city'
@@ -374,11 +405,11 @@ feature 'Proposals' do
       check 'proposal_terms_of_service'
 
       select('California', from: 'proposal_geozone_id')
-      click_button I18n.t('proposals.new.form.submit_button')
+      click_button 'Create proposal'
 
       expect(page).to have_content 'Proposal created successfully.'
 
-      click_link I18n.t('proposals.proposal.share.view_proposal')
+      click_link 'Not now, go to my proposal'
 
       within "#geozone" do
         expect(page).to have_content 'California'

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -135,9 +135,12 @@ feature 'Proposals' do
     fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
     check 'proposal_terms_of_service'
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content 'Proposal created successfully.'
+
+    click_link I18n.t('proposals.proposal.share.view_proposal')
+
     expect(page).to have_content 'Help refugees'
     expect(page).to have_content '¿Would you like to give assistance to war refugees?'
     expect(page).to have_content 'In summary, what we want is...'
@@ -164,7 +167,7 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Some other robot'
     check 'proposal_terms_of_service'
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page.status_code).to eq(200)
     expect(page.html).to be_empty
@@ -186,7 +189,7 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Some other robot'
     check 'proposal_terms_of_service'
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content 'Sorry, that was too quick! Please resubmit'
 
@@ -207,9 +210,12 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content 'Proposal created successfully.'
+
+    click_link I18n.t('proposals.proposal.share.view_proposal')
+
     expect(Proposal.last.responsible_name).to eq('Isabel Garcia')
   end
 
@@ -227,9 +233,10 @@ feature 'Proposals' do
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     check 'proposal_terms_of_service'
 
-    click_button 'Create proposal'
-
+    click_button I18n.t('proposals.new.form.submit_button')
     expect(page).to have_content 'Proposal created successfully.'
+
+    click_link I18n.t('proposals.proposal.share.view_proposal')
 
     expect(Proposal.last.responsible_name).to eq(author.document_number)
   end
@@ -239,7 +246,8 @@ feature 'Proposals' do
     login_as(author)
 
     visit new_proposal_path
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
+
     expect(page).to have_content error_message
   end
 
@@ -256,9 +264,12 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content 'Proposal created successfully.'
+
+    click_link I18n.t('proposals.proposal.share.view_proposal')
+
     expect(page).to have_content 'Testing an attack'
     expect(page.html).to include '<p>This is alert("an attack");</p>'
     expect(page.html).to_not include '<script>alert("an attack");</script>'
@@ -277,9 +288,12 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content 'Proposal created successfully.'
+
+    click_link I18n.t('proposals.proposal.share.view_proposal')
+
     expect(page).to have_content 'Testing auto link'
     expect(page).to have_link('www.example.org', href: 'http://www.example.org')
   end
@@ -296,9 +310,12 @@ feature 'Proposals' do
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content 'Proposal created successfully.'
+
+    click_link I18n.t('proposals.proposal.share.view_proposal')
+
     expect(page).to have_content 'Testing auto link'
     expect(page).to have_link('http://example.org', href: 'http://example.org')
     expect(page).not_to have_link('click me')
@@ -328,9 +345,12 @@ feature 'Proposals' do
       fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
       check 'proposal_terms_of_service'
 
-      click_button 'Create proposal'
+      click_button I18n.t('proposals.new.form.submit_button')
 
       expect(page).to have_content 'Proposal created successfully.'
+
+      click_link I18n.t('proposals.proposal.share.view_proposal')
+
       within "#geozone" do
         expect(page).to have_content 'All city'
       end
@@ -354,9 +374,12 @@ feature 'Proposals' do
       check 'proposal_terms_of_service'
 
       select('California', from: 'proposal_geozone_id')
-      click_button 'Create proposal'
+      click_button I18n.t('proposals.new.form.submit_button')
 
       expect(page).to have_content 'Proposal created successfully.'
+
+      click_link I18n.t('proposals.proposal.share.view_proposal')
+
       within "#geozone" do
         expect(page).to have_content 'California'
       end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -230,6 +230,8 @@ feature 'Proposals' do
     click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
+
+    expect(Proposal.last.responsible_name).to eq(author.document_number)
   end
 
   scenario 'Errors on create' do

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -77,9 +77,12 @@ feature 'Tags' do
     fill_in 'proposal_tag_list', with: 'Economía, Hacienda'
     check 'proposal_terms_of_service'
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content 'Proposal created successfully.'
+
+    click_link I18n.t('proposals.proposal.share.view_proposal')
+
     expect(page).to have_content 'Economía'
     expect(page).to have_content 'Hacienda'
   end
@@ -103,9 +106,11 @@ feature 'Tags' do
     check 'proposal_terms_of_service'
 
     find('.js-add-tag-link', text: 'Education').click
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content 'Proposal created successfully.'
+
+    click_link I18n.t('proposals.proposal.share.view_proposal')
 
     within "#tags_proposal_#{Proposal.last.id}" do
       expect(page).to have_content 'Education'
@@ -124,7 +129,7 @@ feature 'Tags' do
 
     fill_in 'proposal_tag_list', with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content error_message
     expect(page).to have_content 'tags must be less than or equal to 6'
@@ -146,9 +151,12 @@ feature 'Tags' do
 
     fill_in 'proposal_tag_list', with: 'user_id=1, &a=3, <script>alert("hey");</script>'
 
-    click_button 'Create proposal'
+    click_button I18n.t('proposals.new.form.submit_button')
 
     expect(page).to have_content 'Proposal created successfully.'
+
+    click_link I18n.t('proposals.proposal.share.view_proposal')
+
     expect(page).to have_content 'user_id1'
     expect(page).to have_content 'a3'
     expect(page).to have_content 'scriptalert("hey");script'

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -77,11 +77,11 @@ feature 'Tags' do
     fill_in 'proposal_tag_list', with: 'Economía, Hacienda'
     check 'proposal_terms_of_service'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
 
-    click_link I18n.t('proposals.proposal.share.view_proposal')
+    click_link 'Not now, go to my proposal'
 
     expect(page).to have_content 'Economía'
     expect(page).to have_content 'Hacienda'
@@ -106,11 +106,11 @@ feature 'Tags' do
     check 'proposal_terms_of_service'
 
     find('.js-add-tag-link', text: 'Education').click
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
 
-    click_link I18n.t('proposals.proposal.share.view_proposal')
+    click_link 'Not now, go to my proposal'
 
     within "#tags_proposal_#{Proposal.last.id}" do
       expect(page).to have_content 'Education'
@@ -129,7 +129,7 @@ feature 'Tags' do
 
     fill_in 'proposal_tag_list', with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content error_message
     expect(page).to have_content 'tags must be less than or equal to 6'
@@ -151,11 +151,11 @@ feature 'Tags' do
 
     fill_in 'proposal_tag_list', with: 'user_id=1, &a=3, <script>alert("hey");</script>'
 
-    click_button I18n.t('proposals.new.form.submit_button')
+    click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
 
-    click_link I18n.t('proposals.proposal.share.view_proposal')
+    click_link 'Not now, go to my proposal'
 
     expect(page).to have_content 'user_id1'
     expect(page).to have_content 'a3'


### PR DESCRIPTION
## What
Issue: https://github.com/consul/consul/issues/1474

A proposal share page to make the user more aware of that feature and optionally inform of ways to improve his proposal

![screen shot 2017-05-30 at 22 32 50](https://cloud.githubusercontent.com/assets/983242/26606233/75513be8-4591-11e7-9af1-5b88e59d13b7.jpg)

## How
- Adding a new Proposal share view and endpoint at `/proposals/:id/share` that everyone has ability to access

- Making the create proposal action redirect to the new proposal share view.

- Adding a new Setting `Setting['proposal_improvement_url'] = 'mas-informacion/kit-decide'` to allow some forks like Madrid configure their own "Improve your proposal" page and automagically™ the share view will display a link to it (requested at https://github.com/consul/consul/issues/1474#issuecomment-304932435)

- Adding `Setting['proposal_improvement_url']` to both seeds.rb and dev_seeds.rb with a default `nil`value

- Update Proposal feature specs to make use of the new Share step in between expectations

- Increase Proposal feature spec to check new Share view and also the scenario where the `Setting['proposal_improvement_url']` is active.

## Caveats
Beware this PR is based on the branch from https://github.com/consul/consul/pull/1578, I extracted that social share partial refactor in order to make it easier to review. I would merge that one first to make this review smaller and easier to handle... I've created this one anyway just to let @decabeza start checking it.