### PR TITLE
Rename proposal_improvement_url to proposal_improvement_path

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -56,8 +56,8 @@ class ProposalsController < ApplicationController
   end
 
   def share
-    if Setting['proposal_improvement_url'].present?
-      @proposal_improvement_url = root_url + Setting['proposal_improvement_url']
+    if Setting['proposal_improvement_path'].present?
+      @proposal_improvement_url = root_url + Setting['proposal_improvement_path']
     end
   end
 

--- a/config/locales/settings.en.yml
+++ b/config/locales/settings.en.yml
@@ -44,4 +44,4 @@ en:
     meta_keywords: "Keywords (SEO)"
     verification_offices_url: Verification offices URL
     min_age_to_participate: Minimum age needed to participate
-    proposal_improvement_url: Proposal improvement info internal link
+    proposal_improvement_path: Proposal improvement info internal link

--- a/config/locales/settings.es.yml
+++ b/config/locales/settings.es.yml
@@ -44,4 +44,4 @@ es:
     meta_keywords: "Palabras clave (SEO)"
     verification_offices_url: URL oficinas verificación
     min_age_to_participate: Edad mínima para participar
-    proposal_improvement_url: Link a información para mejorar propuestas
+    proposal_improvement_path: Link a información para mejorar propuestas

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -44,7 +44,7 @@ Setting.create(key: 'meta_description', value: 'Citizen Participation and Open G
 Setting.create(key: 'meta_keywords', value: 'citizen participation, open government')
 Setting.create(key: 'verification_offices_url', value: 'http://oficinas-atencion-ciudadano.url/')
 Setting.create(key: 'min_age_to_participate', value: '16')
-Setting.create(key: 'proposal_improvement_url', value: nil)
+Setting.create(key: 'proposal_improvement_path', value: nil)
 
 puts " ✅"
 print "Creating Geozones"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -105,4 +105,4 @@ Setting['verification_offices_url'] = 'http://oficinas-atencion-ciudadano.url/'
 Setting['min_age_to_participate'] = 16
 
 # Proposal improvement url path ('more-information/proposal-improvement')
-Setting['proposal_improvement_url'] = nil
+Setting['proposal_improvement_path'] = nil

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -157,7 +157,7 @@ feature 'Proposals' do
   end
 
   scenario 'Create with proposal improvement info link' do
-    Setting['proposal_improvement_url'] = 'more-information/proposal-improvement'
+    Setting['proposal_improvement_path'] = 'more-information/proposal-improvement'
     author = create(:user)
     login_as(author)
 
@@ -181,7 +181,7 @@ feature 'Proposals' do
 
     expect(page).to have_content 'Help refugees'
 
-    Setting['proposal_improvement_url'] = nil
+    Setting['proposal_improvement_path'] = nil
   end
 
   scenario 'Create with invisible_captcha honeypot field' do


### PR DESCRIPTION
As @xuanxu stated at https://github.com/consul/consul/pull/1580#issuecomment-305154034

The Setting variable `proposal_improvement_url` truly holds the path of the proposal improvement page (instead of the url). So in order to make it easier to understand and avoid possible errors on configuration I'm renaming it as proposed.