### PR TITLE
Rake task to migrate Setting per_page_code to per_page_code_header

### DIFF
--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -1,0 +1,11 @@
+namespace :settings do
+
+  desc "Changes Setting key per_page_code for per_page_code_head"
+  task per_page_code_migration: :environment do
+    per_page_code_setting = Setting.where(key: 'per_page_code').first
+
+    Setting['per_page_code_head'] = per_page_code_setting&.value.to_s if Setting.where(key: 'per_page_code_head').first.blank?
+    per_page_code_setting.destroy if per_page_code_setting.present?
+  end
+
+end

--- a/spec/lib/tasks/settings_spec.rb
+++ b/spec/lib/tasks/settings_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'Settings Rake' do
+
+  describe '#per_page_code_migration' do
+
+    before do
+      Rake.application.rake_require "tasks/settings"
+      Rake::Task.define_task(:environment)
+    end
+
+    let :run_rake_task do
+      Rake::Task['settings:per_page_code_migration'].reenable
+      Rake.application.invoke_task 'settings:per_page_code_migration'
+    end
+
+    after(:all) do
+      Setting['per_page_code_head'] = ''
+    end
+
+    context 'Neither per_page_code_head or per_page_code Settings exist' do
+      before do
+        Setting.where(key: 'per_page_code').first&.destroy
+        Setting.where(key: 'per_page_code_head').first&.destroy
+        run_rake_task
+      end
+
+      it 'should have per_page_code_head setting present and no per_page_code' do
+        expect(Setting.where(key: 'per_page_code_head').count).to eq(1)
+        expect(Setting['per_page_code_head']).to eq(nil)
+        expect(Setting.where(key: 'per_page_code').count).to eq(0)
+      end
+    end
+
+    context 'Both per_page_code_head or per_page_code Settings exist' do
+      before do
+        Setting['per_page_code'] = 'per_page_code'
+        Setting['per_page_code_head'] = 'per_page_code_head'
+        run_rake_task
+      end
+
+      it 'should have per_page_code_head setting present and no per_page_code' do
+        expect(Setting.where(key: 'per_page_code_head').count).to eq(1)
+        expect(Setting['per_page_code_head']).to eq('per_page_code_head')
+        expect(Setting.where(key: 'per_page_code').count).to eq(0)
+      end
+    end
+
+    context 'per_page_code_head exists, but per_page_code does not' do
+      before do
+        Setting.where(key: 'per_page_code').first&.destroy
+        Setting['per_page_code_head'] = 'per_page_code_head'
+        run_rake_task
+      end
+
+      it 'should have per_page_code_head setting present and no per_page_code' do
+        expect(Setting.where(key: 'per_page_code_head').count).to eq(1)
+        expect(Setting['per_page_code_head']).to eq('per_page_code_head')
+        expect(Setting.where(key: 'per_page_code').count).to eq(0)
+      end
+    end
+
+    context 'per_page_code_head does not exist, but per_page_code does' do
+      before do
+        Setting['per_page_code'] = 'per_page_code'
+        Setting.where(key: 'per_page_code_head').first&.destroy
+        run_rake_task
+      end
+
+      it 'should have per_page_code_head setting present and no per_page_code' do
+        expect(Setting.where(key: 'per_page_code_head').count).to eq(1)
+        expect(Setting['per_page_code_head']).to eq('per_page_code')
+        expect(Setting.where(key: 'per_page_code').count).to eq(0)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This resolves https://github.com/consul/consul/issues/1472

Since I'm not fully aware of all the Setting "scenarios" that any consul installation could have, I've just thought about all the 4 posibilities:

1. **Neither `per_page_code_head` or `per_page_code` Settings exist:** Just create `per_page_code_head` with an empty value.

2. **Both `per_page_code_head` or `per_page_code` Settings exist:** Just delete `per_page_code`


3. **`per_page_code_head` exist, but `per_page_code` doesn't:** 👌  nothing to be done.

4. **`per_page_code_head` doesn't exist, but `per_page_code` does:** The scenario from the issue... just rename `Setting['per_page_code']` key to `per_page_code_head` to keep the same value and remove the old key at the same time.

And reflectet them on 4 scenarios in a new settings rake spec. Maybe bit overkill just for a rake task that would be used once? 😄  