### PR TITLE
Update Schema.rb for medialab-legislation

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,6 +63,36 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_index "annotations", ["legacy_legislation_id"], name: "index_annotations_on_legacy_legislation_id", using: :btree
   add_index "annotations", ["user_id"], name: "index_annotations_on_user_id", using: :btree
 
+  create_table "answers", force: :cascade do |t|
+    t.integer  "author_id"
+    t.text     "text"
+    t.string   "context"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "answers", ["author_id"], name: "index_answers_on_author_id", using: :btree
+  add_index "answers", ["context"], name: "index_answers_on_context", using: :btree
+
+  create_table "ballot_lines", force: :cascade do |t|
+    t.integer  "ballot_id"
+    t.integer  "spending_proposal_id"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
+
+  add_index "ballot_lines", ["ballot_id", "spending_proposal_id"], name: "index_ballot_lines_on_ballot_id_and_spending_proposal_id", unique: true, using: :btree
+  add_index "ballot_lines", ["spending_proposal_id"], name: "index_ballot_lines_on_spending_proposal_id", using: :btree
+
+  create_table "ballots", force: :cascade do |t|
+    t.integer  "user_id"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.datetime "confirmed_at"
+    t.integer  "geozone_id"
+    t.integer  "ballot_lines_count", default: 0
+  end
+
   create_table "banners", force: :cascade do |t|
     t.string   "title",           limit: 80
     t.string   "description"
@@ -102,6 +132,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   create_table "budget_groups", force: :cascade do |t|
     t.integer "budget_id"
     t.string  "name",      limit: 50
+    t.string  "slug"
   end
 
   add_index "budget_groups", ["budget_id"], name: "index_budget_groups_on_budget_id", using: :btree
@@ -110,6 +141,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.integer "group_id"
     t.string  "name",     limit: 50
     t.integer "price",    limit: 8
+    t.string  "slug"
   end
 
   add_index "budget_headings", ["group_id"], name: "index_budget_headings_on_group_id", using: :btree
@@ -148,6 +180,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.integer  "ballot_lines_count",                    default: 0
     t.integer  "previous_heading_id"
     t.boolean  "winner",                                default: false
+    t.string   "label"
   end
 
   add_index "budget_investments", ["administrator_id"], name: "index_budget_investments_on_administrator_id", using: :btree
@@ -163,6 +196,16 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.datetime "updated_at",    null: false
   end
 
+  create_table "budget_recommendations", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "investment_id"
+    t.integer  "budget_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "budget_recommendations", ["user_id"], name: "index_budget_recommendations_on_user_id", using: :btree
+
   create_table "budget_valuator_assignments", force: :cascade do |t|
     t.integer  "valuator_id"
     t.integer  "investment_id"
@@ -173,7 +216,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_index "budget_valuator_assignments", ["investment_id"], name: "index_budget_valuator_assignments_on_investment_id", using: :btree
 
   create_table "budgets", force: :cascade do |t|
-    t.string   "name",                          limit: 80
+    t.string   "name",                          limit: 50
     t.string   "currency_symbol",               limit: 10
     t.string   "phase",                         limit: 40, default: "accepting"
     t.datetime "created_at",                                                     null: false
@@ -185,6 +228,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.text     "description_balloting"
     t.text     "description_reviewing_ballots"
     t.text     "description_finished"
+    t.string   "slug"
   end
 
   create_table "campaigns", force: :cascade do |t|
@@ -227,8 +271,8 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.string   "title",                        limit: 80
     t.text     "description"
     t.integer  "author_id"
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
+    t.datetime "created_at",                                                  null: false
+    t.datetime "updated_at",                                                  null: false
     t.string   "visit_id"
     t.datetime "hidden_at"
     t.integer  "flags_count",                             default: 0
@@ -245,6 +289,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.integer  "geozone_id"
     t.tsvector "tsv"
     t.datetime "featured_at"
+    t.string   "comment_kind",                            default: "comment"
   end
 
   add_index "debates", ["author_id", "hidden_at"], name: "index_debates_on_author_id_and_hidden_at", using: :btree
@@ -312,6 +357,13 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_index "flags", ["flaggable_type", "flaggable_id"], name: "index_flags_on_flaggable_type_and_flaggable_id", using: :btree
   add_index "flags", ["user_id", "flaggable_type", "flaggable_id"], name: "access_inappropiate_flags", using: :btree
   add_index "flags", ["user_id"], name: "index_flags_on_user_id", using: :btree
+
+  create_table "forums", force: :cascade do |t|
+    t.string   "name"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "geozones", force: :cascade do |t|
     t.string   "name"
@@ -521,8 +573,9 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_index "poll_booth_assignments", ["poll_id"], name: "index_poll_booth_assignments_on_poll_id", using: :btree
 
   create_table "poll_booths", force: :cascade do |t|
-    t.string "name"
-    t.string "location"
+    t.string  "name"
+    t.string  "location"
+    t.boolean "physical", default: true
   end
 
   create_table "poll_final_recounts", force: :cascade do |t|
@@ -530,14 +583,26 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.integer  "officer_assignment_id"
     t.integer  "count"
     t.text     "count_log",                 default: ""
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
     t.text     "officer_assignment_id_log", default: ""
-    t.date     "date",                                   null: false
+    t.date     "date",                                        null: false
+    t.string   "origin",                    default: "booth"
   end
 
   add_index "poll_final_recounts", ["booth_assignment_id"], name: "index_poll_final_recounts_on_booth_assignment_id", using: :btree
   add_index "poll_final_recounts", ["officer_assignment_id"], name: "index_poll_final_recounts_on_officer_assignment_id", using: :btree
+
+  create_table "poll_letter_officer_logs", force: :cascade do |t|
+    t.string   "document_number"
+    t.string   "message"
+    t.integer  "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "postal_code"
+    t.string   "census_name"
+    t.string   "census_postal_code"
+  end
 
   create_table "poll_null_results", force: :cascade do |t|
     t.integer "author_id"
@@ -553,6 +618,22 @@ ActiveRecord::Schema.define(version: 20170519084239) do
 
   add_index "poll_null_results", ["booth_assignment_id"], name: "index_poll_null_results_on_booth_assignment_id", using: :btree
   add_index "poll_null_results", ["officer_assignment_id"], name: "index_poll_null_results_on_officer_assignment_id", using: :btree
+
+  create_table "poll_nvotes", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "poll_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "deleted_at"
+    t.string   "nvotes_poll_id"
+    t.string   "voter_hash"
+    t.integer  "officer_assignment_id"
+    t.integer  "booth_assignment_id"
+  end
+
+  add_index "poll_nvotes", ["deleted_at"], name: "index_poll_nvotes_on_deleted_at", using: :btree
+  add_index "poll_nvotes", ["user_id"], name: "index_poll_nvotes_on_user_id", using: :btree
+  add_index "poll_nvotes", ["voter_hash"], name: "index_poll_nvotes_on_voter_hash", using: :btree
 
   create_table "poll_officer_assignments", force: :cascade do |t|
     t.integer  "booth_assignment_id"
@@ -571,6 +652,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   create_table "poll_officers", force: :cascade do |t|
     t.integer "user_id"
     t.integer "failed_census_calls_count", default: 0
+    t.boolean "letter_officer",            default: false
   end
 
   add_index "poll_officers", ["user_id"], name: "index_poll_officers_on_user_id", using: :btree
@@ -642,6 +724,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.integer  "answer_id"
     t.integer  "officer_assignment_id"
     t.integer  "user_id"
+    t.string   "origin"
   end
 
   add_index "poll_voters", ["booth_assignment_id"], name: "index_poll_voters_on_booth_assignment_id", using: :btree
@@ -672,9 +755,42 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.datetime "ends_at"
     t.boolean  "published",          default: false
     t.boolean  "geozone_restricted", default: false
+    t.string   "nvotes_poll_id"
   end
 
   add_index "polls", ["starts_at", "ends_at"], name: "index_polls_on_starts_at_and_ends_at", using: :btree
+
+  create_table "probe_options", force: :cascade do |t|
+    t.string  "code"
+    t.string  "name"
+    t.integer "probe_id"
+    t.integer "probe_selections_count", default: 0
+    t.integer "debate_id"
+    t.integer "comments_count",         default: 0, null: false
+  end
+
+  add_index "probe_options", ["debate_id"], name: "index_probe_options_on_debate_id", using: :btree
+
+  create_table "probe_selections", force: :cascade do |t|
+    t.integer  "probe_id"
+    t.integer  "probe_option_id"
+    t.integer  "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "probe_selections", ["probe_id"], name: "index_probe_selections_on_probe_id", using: :btree
+  add_index "probe_selections", ["probe_option_id"], name: "index_probe_selections_on_probe_option_id", using: :btree
+  add_index "probe_selections", ["user_id"], name: "index_probe_selections_on_user_id", using: :btree
+
+  create_table "probes", force: :cascade do |t|
+    t.string   "codename"
+    t.boolean  "selecting_allowed", default: true
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "probes", ["codename"], name: "index_probes_on_codename", using: :btree
 
   create_table "proposal_notifications", force: :cascade do |t|
     t.string   "title"
@@ -709,6 +825,8 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.datetime "retired_at"
     t.string   "retired_reason"
     t.text     "retired_explanation"
+    t.string   "proceeding"
+    t.string   "sub_proceeding"
   end
 
   add_index "proposals", ["author_id", "hidden_at"], name: "index_proposals_on_author_id_and_hidden_at", using: :btree
@@ -719,10 +837,20 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_index "proposals", ["geozone_id"], name: "index_proposals_on_geozone_id", using: :btree
   add_index "proposals", ["hidden_at"], name: "index_proposals_on_hidden_at", using: :btree
   add_index "proposals", ["hot_score"], name: "index_proposals_on_hot_score", using: :btree
+  add_index "proposals", ["proceeding"], name: "index_proposals_on_proceeding", using: :btree
   add_index "proposals", ["question"], name: "index_proposals_on_question", using: :btree
+  add_index "proposals", ["sub_proceeding"], name: "index_proposals_on_sub_proceeding", using: :btree
   add_index "proposals", ["summary"], name: "index_proposals_on_summary", using: :btree
   add_index "proposals", ["title"], name: "index_proposals_on_title", using: :btree
   add_index "proposals", ["tsv"], name: "index_proposals_on_tsv", using: :gin
+
+  create_table "redeemable_codes", force: :cascade do |t|
+    t.string   "token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "redeemable_codes", ["token"], name: "index_redeemable_codes_on_token", using: :btree
 
   create_table "settings", force: :cascade do |t|
     t.string "key"
@@ -809,11 +937,29 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.tsvector "tsv"
     t.string   "responsible_name",            limit: 60
     t.integer  "physical_votes",                         default: 0
+    t.integer  "comments_count",                         default: 0
+    t.datetime "hidden_at"
+    t.integer  "confidence_score",                       default: 0,     null: false
+    t.boolean  "forum",                                  default: false
+    t.integer  "ballot_lines_count",                     default: 0
+    t.boolean  "compatible",                             default: true
   end
 
   add_index "spending_proposals", ["author_id"], name: "index_spending_proposals_on_author_id", using: :btree
   add_index "spending_proposals", ["geozone_id"], name: "index_spending_proposals_on_geozone_id", using: :btree
   add_index "spending_proposals", ["tsv"], name: "index_spending_proposals_on_tsv", using: :gin
+
+  create_table "stats", force: :cascade do |t|
+    t.string   "namespace"
+    t.string   "group"
+    t.string   "name"
+    t.integer  "value"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "stats", ["namespace", "group"], name: "index_stats_on_namespace_and_group", using: :btree
+  add_index "stats", ["namespace"], name: "index_stats_on_namespace", using: :btree
 
   create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"
@@ -871,30 +1017,30 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_index "tolk_translations", ["phrase_id", "locale_id"], name: "index_tolk_translations_on_phrase_id_and_locale_id", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                                     default: ""
-    t.string   "encrypted_password",                        default: "",                    null: false
+    t.string   "email",                                                       default: ""
+    t.string   "encrypted_password",                                          default: "",                    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                             default: 0,                     null: false
+    t.integer  "sign_in_count",                                               default: 0,                     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                                                                null: false
-    t.datetime "updated_at",                                                                null: false
+    t.datetime "created_at",                                                                                  null: false
+    t.datetime "updated_at",                                                                                  null: false
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
-    t.boolean  "email_on_comment",                          default: false
-    t.boolean  "email_on_comment_reply",                    default: false
-    t.string   "phone_number",                   limit: 30
+    t.boolean  "email_on_comment",                                            default: false
+    t.boolean  "email_on_comment_reply",                                      default: false
+    t.string   "phone_number",                                     limit: 30
     t.string   "official_position"
-    t.integer  "official_level",                            default: 0
+    t.integer  "official_level",                                              default: 0
     t.datetime "hidden_at"
     t.string   "sms_confirmation_code"
-    t.string   "username",                       limit: 60
+    t.string   "username",                                         limit: 60
     t.string   "document_number"
     t.string   "document_type"
     t.datetime "residence_verified_at"
@@ -905,28 +1051,34 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.datetime "letter_requested_at"
     t.datetime "confirmed_hide_at"
     t.string   "letter_verification_code"
-    t.integer  "failed_census_calls_count",                 default: 0
+    t.integer  "failed_census_calls_count",                                   default: 0
     t.datetime "level_two_verified_at"
     t.string   "erase_reason"
     t.datetime "erased_at"
-    t.boolean  "public_activity",                           default: true
-    t.boolean  "newsletter",                                default: true
-    t.integer  "notifications_count",                       default: 0
-    t.boolean  "registering_with_oauth",                    default: false
+    t.boolean  "public_activity",                                             default: true
+    t.boolean  "newsletter",                                                  default: true
+    t.integer  "notifications_count",                                         default: 0
+    t.boolean  "registering_with_oauth",                                      default: false
     t.string   "locale"
     t.string   "oauth_email"
     t.integer  "geozone_id"
     t.string   "redeemable_code"
-    t.string   "gender",                         limit: 10
+    t.string   "gender",                                           limit: 10
     t.datetime "date_of_birth"
-    t.boolean  "email_on_proposal_notification",            default: true
-    t.boolean  "email_digest",                              default: true
-    t.boolean  "email_on_direct_message",                   default: true
-    t.boolean  "official_position_badge",                   default: false
-    t.datetime "password_changed_at",                       default: '2016-11-23 10:59:20', null: false
-    t.boolean  "created_from_signature",                    default: false
-    t.integer  "failed_email_digests_count",                default: 0
-    t.text     "former_users_data_log",                     default: ""
+    t.boolean  "email_on_proposal_notification",                              default: true
+    t.boolean  "email_digest",                                                default: true
+    t.boolean  "email_on_direct_message",                                     default: true
+    t.boolean  "official_position_badge",                                     default: false
+    t.datetime "password_changed_at",                                         default: '2016-11-23 10:59:20', null: false
+    t.boolean  "created_from_signature",                                      default: false
+    t.integer  "failed_email_digests_count",                                  default: 0
+    t.text     "former_users_data_log",                                       default: ""
+    t.integer  "district_wide_spending_proposals_supported_count",            default: 10
+    t.integer  "city_wide_spending_proposals_supported_count",                default: 10
+    t.integer  "supported_spending_proposals_geozone_id"
+    t.integer  "representative_id"
+    t.boolean  "accepted_delegation_alert",                                   default: false
+    t.boolean  "officing_voter",                                              default: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
@@ -997,6 +1149,52 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_index "visits", ["started_at"], name: "index_visits_on_started_at", using: :btree
   add_index "visits", ["user_id"], name: "index_visits_on_user_id", using: :btree
 
+  create_table "volunteer_polls", force: :cascade do |t|
+    t.string  "email"
+    t.string  "turns"
+    t.boolean "any_district"
+    t.boolean "arganzuela"
+    t.boolean "barajas"
+    t.boolean "carabanchel"
+    t.boolean "centro"
+    t.boolean "chamartin"
+    t.boolean "chamberi"
+    t.boolean "ciudad_lineal"
+    t.boolean "fuencarral_el_pardo"
+    t.boolean "hortaleza"
+    t.boolean "latina"
+    t.boolean "moncloa_aravaca"
+    t.boolean "moratalaz"
+    t.boolean "puente_de_vallecas"
+    t.boolean "retiro"
+    t.boolean "salamanca"
+    t.boolean "san_blas_canillejas"
+    t.boolean "tetuan"
+    t.boolean "usera"
+    t.boolean "vicalvaro"
+    t.boolean "villa_de_vallecas"
+    t.boolean "villaverde"
+    t.string  "first_name"
+    t.string  "last_name"
+    t.string  "document_number"
+    t.string  "phone"
+    t.boolean "monday_13_morning"
+    t.boolean "monday_13_afternoon"
+    t.boolean "tuesday_14_morning"
+    t.boolean "tuesday_14_afternoon"
+    t.boolean "wednesday_15_morning"
+    t.boolean "wednesday_15_afternoon"
+    t.boolean "thursday_16_morning"
+    t.boolean "thursday_16_afternoon"
+    t.boolean "friday_17_morning"
+    t.boolean "friday_17_afternoon"
+    t.boolean "saturday_18_morning"
+    t.boolean "saturday_18_afternoon"
+    t.boolean "sunday_19_morning"
+    t.boolean "sunday_19_afternoon"
+    t.boolean "monday_20_morning"
+  end
+
   create_table "votes", force: :cascade do |t|
     t.integer  "votable_id"
     t.string   "votable_type"
@@ -1017,6 +1215,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_foreign_key "administrators", "users"
   add_foreign_key "annotations", "legacy_legislations"
   add_foreign_key "annotations", "users"
+  add_foreign_key "budget_recommendations", "users"
   add_foreign_key "failed_census_calls", "poll_officers"
   add_foreign_key "failed_census_calls", "users"
   add_foreign_key "flags", "users"
@@ -1035,6 +1234,8 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_foreign_key "poll_final_recounts", "poll_officer_assignments", column: "officer_assignment_id"
   add_foreign_key "poll_null_results", "poll_booth_assignments", column: "booth_assignment_id"
   add_foreign_key "poll_null_results", "poll_officer_assignments", column: "officer_assignment_id"
+  add_foreign_key "poll_nvotes", "poll_booth_assignments", column: "booth_assignment_id"
+  add_foreign_key "poll_nvotes", "poll_officer_assignments", column: "officer_assignment_id"
   add_foreign_key "poll_officer_assignments", "poll_booth_assignments", column: "booth_assignment_id"
   add_foreign_key "poll_partial_results", "poll_booth_assignments", column: "booth_assignment_id"
   add_foreign_key "poll_partial_results", "poll_officer_assignments", column: "officer_assignment_id"
@@ -1048,6 +1249,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
   add_foreign_key "poll_voters", "polls"
   add_foreign_key "poll_white_results", "poll_booth_assignments", column: "booth_assignment_id"
   add_foreign_key "poll_white_results", "poll_officer_assignments", column: "officer_assignment_id"
+  add_foreign_key "probe_options", "debates"
   add_foreign_key "users", "geozones"
   add_foreign_key "valuators", "users"
 end

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -71,7 +71,7 @@ feature 'Admin legislation processes' do
 
       click_link "An example legislation process"
 
-      expect(page).to have_selector("h1", text: "An example legislation process")
+      expect(page).to have_selector("h2", text: "An example legislation process")
       expect(find("#debate_phase_active")).to be_checked
 
       uncheck "debate_phase_active"

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -154,11 +154,11 @@ feature 'Legislation Draft Versions' do
 
       page.find(:css, ".legislation-annotatable").double_click
       page.find(:css, ".annotator-adder button").click
-      page.click_button "Publish Comment"
+      page.click_button "Create Annotation"
       expect(page).to have_content "Comment can't be blank"
 
       fill_in 'legislation_annotation_text', with: 'this is my annotation'
-      page.click_button "Publish Comment"
+      page.click_button "Create Annotation"
 
       expect(page).to have_css ".annotator-hl"
       first(:css, ".annotator-hl").click


### PR DESCRIPTION
After `rake db:migrate` on `medialab-legislation`branch, schema.rb showed many changes. I suppose it was by mistake/forgotten... but maybe I'm missing a good reason not to update this file?

PD: Had to cherry-pick both 0ecb0f150f0328870e4d62c253269578d5e6db1f and  b17333d231566167feabf6da0e8c5af9876f13cc in order to get already broken tests passing :D