### PR TITLE
Legislative Process summary

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -35,8 +35,7 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
     def process_params
       params.require(:legislation_process).permit(
         :title,
-        :description_summary,
-        :target_summary,
+        :summary,
         :description,
         :target,
         :how_to_participate,

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -166,6 +166,19 @@
 
   <div class="row">
     <div class="small-12 medium-4 column">
+      <%= f.label :summary %>
+      <small><%= t('admin.legislation.processes.form.use_markdown') %></small>
+    </div>
+    <div class="small-12 medium-8 column">
+      <%= f.text_area :summary,
+                       label: false,
+                       rows: 2,
+                       placeholder: t('admin.legislation.processes.form.summary_placeholder') %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="small-12 medium-4 column">
       <%= f.label :description %>
       <small><%= t('admin.legislation.processes.form.use_markdown') %></small>
     </div>

--- a/app/views/legislation/processes/_process.html.erb
+++ b/app/views/legislation/processes/_process.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <div class="small-12 medium-11 column end">
-      <%= markdown(first_paragraph(process.description)) %>
+      <%= markdown(process.summary.present? ? process.summary : first_paragraph(process.description)) %>
     </div>
   </div>
 

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -206,6 +206,7 @@ en:
           end: End
           use_markdown: Use Markdown to format the text
           title_placeholder: The title of the process
+          summary_placeholder: Short summary of the description
           description_placeholder: Add a description of the process
           target_placeholder: Describe who is the target of the process
           how_to_participate_placeholder: Describe how to participate

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -206,6 +206,7 @@ es:
           end: Fin
           use_markdown: Usa Markdown para formatear el texto
           title_placeholder: Escribe el título del proceso
+          summary_placeholder: Resumen corto de la descripción
           description_placeholder: Añade una descripción del proceso
           target_placeholder: Describe a quién va dirigido
           how_to_participate_placeholder: Describe cómo participar

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -634,6 +634,7 @@ print "Creating legislation processes"
 (1..5).each do |i|
   process = ::Legislation::Process.create!(title: Faker::Lorem.sentence(3).truncate(60),
                                            description: Faker::Lorem.paragraphs.join("\n\n"),
+                                           summary: Faker::Lorem.paragraph,
                                            target: Faker::Lorem.paragraphs.join("\n\n"),
                                            how_to_participate: Faker::Lorem.paragraphs.join("\n\n"),
                                            additional_info: Faker::Lorem.paragraphs.join("\n\n"),

--- a/db/migrate/20170602162155_add_summary_to_legislative_process.rb
+++ b/db/migrate/20170602162155_add_summary_to_legislative_process.rb
@@ -1,0 +1,5 @@
+class AddSummaryToLegislativeProcess < ActiveRecord::Migration
+  def change
+    add_column :legislation_processes, :summary, :text, limit: 280
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170519084239) do
+ActiveRecord::Schema.define(version: 20170602162155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -418,6 +418,7 @@ ActiveRecord::Schema.define(version: 20170519084239) do
     t.datetime "hidden_at"
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
+    t.text     "summary"
   end
 
   add_index "legislation_processes", ["allegations_end_date"], name: "index_legislation_processes_on_allegations_end_date", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -603,6 +603,7 @@ FactoryGirl.define do
   factory :legislation_process, class: 'Legislation::Process' do
     title "A collaborative legislation process"
     description "Description of the process"
+    summary "Summary of the process"
     target "Who will affected by this law?"
     how_to_participate "You can participate by answering some questions"
     start_date Date.current - 5.days

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -39,6 +39,7 @@ feature 'Admin legislation processes' do
       click_link "New process"
 
       fill_in 'legislation_process_title', with: 'An example legislation process'
+      fill_in 'legislation_process_summary', with: 'Summary of the process'
       fill_in 'legislation_process_description', with: 'Describing the process'
       fill_in 'legislation_process_target', with: 'This thing affects people'
       fill_in 'legislation_process_how_to_participate', with: 'You can partipate in this thing by doing...'
@@ -57,12 +58,30 @@ feature 'Admin legislation processes' do
       click_button 'Create process'
 
       expect(page).to have_content 'An example legislation process'
+      expect(page).to have_content 'Process created successfully'
+
+      click_link 'Click to visit'
+
+      expect(page).to have_content 'An example legislation process'
+      expect(page).not_to have_content 'Summary of the process'
+      expect(page).to have_content 'Describing the process'
+      expect(page).to have_content 'This thing affects people'
+
+      visit legislation_processes_path
+
+      expect(page).to have_content 'An example legislation process'
+      expect(page).to have_content 'Summary of the process'
+      expect(page).not_to have_content 'Describing the process'
+      expect(page).not_to have_content 'This thing affects people'
     end
   end
 
   context 'Update' do
-    scenario 'Deactivate debate phase', :js do
-      process = create(:legislation_process, title: 'An example legislation process')
+    scenario 'Deactivate debate phase', js: true do
+      process = create(:legislation_process,
+                       title: 'An example legislation process',
+                       summary: 'Summarizing the process',
+                       description: 'Description of the process')
       visit admin_root_path
 
       within('#side_menu') do
@@ -75,11 +94,16 @@ feature 'Admin legislation processes' do
       expect(find("#debate_phase_active")).to be_checked
 
       uncheck "debate_phase_active"
+      fill_in 'legislation_process_summary', with: ''
       click_button "Save changes"
 
       expect(page).to have_content "Process updated successfully"
       expect(find("#debate_start_date").value).to be_blank
       expect(find("#debate_end_date").value).to be_blank
+
+      visit legislation_processes_path
+      expect(page).not_to have_content 'Summarizing the process'
+      expect(page).to have_content 'Description of the process'
     end
   end
 end


### PR DESCRIPTION
## What:
This closes: https://github.com/consul/consul/issues/1586

## How
- Adding a new `summary` field to the legislative process table, guided by a [previous summary migration for proposals](https://github.com/consul/consul/blob/master/db/migrate/20150914173834_add_summary_to_proposals.rb)

- Adding summary field on the process list view (keeping the description first paragraph as fallback since neither description or summary are required fields).

- Increasing current feature spec for Admin legislative process to also check the user Detail and List views after create & update

- Also adding new summary field on the admin process form, factory and dev_seeds file.

PLUS: Fix already failing specs
- `spec/features/legislation/draft_versions_spec.rb`
- `spec/features/admin/legislation/processes_spec.rb`

## Caveats:
Also I'm not sure if the new summary field should be used as well on the full detail view of the process (I assumed not) or on other process list that I'm not aware of.