### PR TITLE
Remove 'target' and 'how_to_participate' from Legislative Processes

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -37,7 +37,6 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         :title,
         :summary,
         :description,
-        :target,
         :additional_info,
         :start_date,
         :end_date,

--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -38,7 +38,6 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         :summary,
         :description,
         :target,
-        :how_to_participate,
         :additional_info,
         :start_date,
         :end_date,

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -192,19 +192,6 @@
 
   <div class="row">
     <div class="small-12 medium-4 column">
-      <%= f.label :target %>
-      <small><%= t('admin.legislation.processes.form.use_markdown') %></small>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_area :target,
-                       label: false,
-                       rows: 5,
-                       placeholder: t('admin.legislation.processes.form.target_placeholder') %>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="small-12 medium-4 column">
       <%= f.label :additional_info %>
       <small><%= t('admin.legislation.processes.form.use_markdown') %></small>
     </div>

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -205,19 +205,6 @@
 
   <div class="row">
     <div class="small-12 medium-4 column">
-      <%= f.label :how_to_participate %>
-      <small><%= t('admin.legislation.processes.form.use_markdown') %></small>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_area :how_to_participate,
-                       label: false,
-                       rows: 5,
-                       placeholder: t('admin.legislation.processes.form.how_to_participate_placeholder') %>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="small-12 medium-4 column">
       <%= f.label :additional_info %>
       <small><%= t('admin.legislation.processes.form.use_markdown') %></small>
     </div>

--- a/app/views/legislation/processes/_header.html.erb
+++ b/app/views/legislation/processes/_header.html.erb
@@ -7,7 +7,7 @@
     </div>
 
     <div id="debate-show" class="row description">
-      <div class="small-12 medium-4 column">
+      <div class="small-12 column">
         <% if process.description.present? %>
           <h4><%= t('legislation.processes.header_full.description') %></h4>
           <%= markdown process.description %>

--- a/app/views/legislation/processes/_header.html.erb
+++ b/app/views/legislation/processes/_header.html.erb
@@ -13,12 +13,6 @@
           <%= markdown process.description %>
         <% end %>
       </div>
-      <div class="small-12 medium-4 column">
-        <% if process.target.present? %>
-          <h4><%= t('legislation.processes.header_full.target') %></h4>
-          <%= markdown process.target %>
-        <% end %>
-      </div>
       <% if process.additional_info.present? %>
         <div class="small-12 column debate-add-info">
           <div class="debate-info-wrapper">
@@ -28,7 +22,7 @@
        <% end %>
     </div>
 
-    <% if process.description.present? || process.target.present? || process.additional_info.present? %>
+    <% if process.description.present? || process.additional_info.present? %>
       <div class="text-center half-gradient">
         <a class="button big text-center button-circle" title="<%= t('.view_process_information') %>" id="js-toggle-small-debate">
           <span class="icon-angle-down" aria-hidden="true"></span>

--- a/app/views/legislation/processes/_header.html.erb
+++ b/app/views/legislation/processes/_header.html.erb
@@ -19,12 +19,6 @@
           <%= markdown process.target %>
         <% end %>
       </div>
-      <div class="small-12 medium-4 column">
-        <% if process.how_to_participate.present? %>
-          <h4><%= t('legislation.processes.header_full.how_to_participate') %></h4>
-          <%= markdown process.how_to_participate %>
-        <% end %>
-      </div>
       <% if process.additional_info.present? %>
         <div class="small-12 column debate-add-info">
           <div class="debate-info-wrapper">
@@ -34,7 +28,7 @@
        <% end %>
     </div>
 
-    <% if process.description.present? || process.target.present? || process.how_to_participate.present? || process.additional_info.present? %>
+    <% if process.description.present? || process.target.present? || process.additional_info.present? %>
       <div class="text-center half-gradient">
         <a class="button big text-center button-circle" title="<%= t('.view_process_information') %>" id="js-toggle-small-debate">
           <span class="icon-angle-down" aria-hidden="true"></span>

--- a/app/views/legislation/processes/_header_full.html.erb
+++ b/app/views/legislation/processes/_header_full.html.erb
@@ -21,12 +21,6 @@
         <%= markdown process.target %>
       <% end %>
     </div>
-    <div class="small-12 medium-4 column">
-      <% if process.how_to_participate.present? %>
-        <h4><%= t('.how_to_participate') %></h4>
-        <%= markdown process.how_to_participate %>
-      <% end %>
-    </div>
     <% if process.additional_info.present? %>
       <div id="debate-show" class="small-12 column debate-add-info">
         <div class="debate-info-wrapper">

--- a/app/views/legislation/processes/_header_full.html.erb
+++ b/app/views/legislation/processes/_header_full.html.erb
@@ -15,12 +15,6 @@
         <%= markdown process.description %>
       <% end %>
     </div>
-    <div class="small-12 medium-4 column">
-      <% if process.target.present? %>
-        <h4><%= t('.target') %></h4>
-        <%= markdown process.target %>
-      <% end %>
-    </div>
     <% if process.additional_info.present? %>
       <div id="debate-show" class="small-12 column debate-add-info">
         <div class="debate-info-wrapper">

--- a/app/views/legislation/processes/_header_full.html.erb
+++ b/app/views/legislation/processes/_header_full.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="row description">
-    <div class="small-12 medium-4 column">
+    <div class="small-12 column">
       <% if process.description.present? %>
         <h4><%= t('.description') %></h4>
         <%= markdown process.description %>

--- a/app/views/sandbox/admin_legislation_info.html.erb
+++ b/app/views/sandbox/admin_legislation_info.html.erb
@@ -99,18 +99,6 @@
 
       <div class="row">
         <div class="small-12 medium-4 column">
-          <label for="legislation_process_target">A quién va dirigido</label>
-        </div>
-        <div class="small-12 medium-8 column">
-          <textarea rows="5" name="legislation_process[target]" id="legislation_process_target">- Ciudadanos con vivienda en propiedad
-- Profesionales de la construcción y reformas
-- Empresarios con locales comerciales
-        </textarea>
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="small-12 medium-4 column">
           <label for="legislation_process_additional_info">Información adicional</label>
           <small>Usa Markdown para formatear el texto</small>
         </div>

--- a/app/views/sandbox/admin_legislation_info.html.erb
+++ b/app/views/sandbox/admin_legislation_info.html.erb
@@ -36,8 +36,8 @@
         <div class="small-12 medium-2 column">
           <input class="js-calendar-full" id="debate_end_date" type="text" value="2016-12-21" name="legislation_process[debate_end_date]" />
         </div>
-        
-        
+
+
         <div class="small-12 medium-4 column">
           <label for="legislation_process_debate_start_date">Fase previa</label>
         </div>
@@ -53,7 +53,7 @@
         <div class="small-12 medium-2 column">
           <input class="js-calendar-full" id="debate_end_date" type="text" value="2016-12-21" name="legislation_process[debate_end_date]" />
         </div>
-        
+
         <div class="small-12 medium-4 column">
           <label for="legislation_process_debate_start_date">Fase alegaciones</label>
         </div>
@@ -69,7 +69,7 @@
         <div class="small-12 medium-2 column">
           <input class="js-calendar-full" id="debate_end_date" type="text" value="2016-12-21" name="legislation_process[debate_end_date]" />
         </div>
-        
+
         <div class="small-12 medium-4 column">
           <label for="legislation_process_final_publication_date">Publicación de resultados</label>
         </div>
@@ -111,17 +111,6 @@
 
       <div class="row">
         <div class="small-12 medium-4 column">
-          <label for="legislation_process_how_to_participate">Cómo puedes participar</label>
-        </div>
-        <div class="small-12 medium-8 column">
-          <textarea rows="5" name="legislation_process[how_to_participate]" id="legislation_process_how_to_participate">- **Participa en el debate previo** para identificar los problemas a solucionar, la necesidad de esta normativa, sus objetivos y posibles soluciones alternativas.
-- Después del debate el Ayuntamiento presentará un borrador del texto al cual podrás realizar **comentarios y alegaciones**.
-          </textarea>
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="small-12 medium-4 column">
           <label for="legislation_process_additional_info">Información adicional</label>
           <small>Usa Markdown para formatear el texto</small>
         </div>
@@ -151,7 +140,7 @@
           <input type="submit" name="commit" value="Guardar cambios" class="button expanded" />
         </div>
       </div>
-      
+
     </form>
   </div>
 </div>

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -167,7 +167,6 @@ en:
       legislation/process:
         title: Process Title
         description: Description
-        target: Target
         additional_info: Additional info
         start_date: Start date
         end_date: End date

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -168,7 +168,6 @@ en:
         title: Process Title
         description: Description
         target: Target
-        how_to_participate: How to participate
         additional_info: Additional info
         start_date: Start date
         end_date: End date

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -163,7 +163,6 @@ es:
         title: Título del proceso
         description: En qué consiste
         target: A quién afecta
-        how_to_participate: Cómo participar
         additional_info: Información adicional
         start_date: Fecha de inicio del proceso
         end_date: Fecha de fin del proceso

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -162,7 +162,6 @@ es:
       legislation/process:
         title: Título del proceso
         description: En qué consiste
-        target: A quién afecta
         additional_info: Información adicional
         start_date: Fecha de inicio del proceso
         end_date: Fecha de fin del proceso

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -221,7 +221,6 @@ en:
           title_placeholder: The title of the process
           summary_placeholder: Short summary of the description
           description_placeholder: Add a description of the process
-          target_placeholder: Describe who is the target of the process
           additional_info_placeholder: Add an additional information you consider useful
         index:
           create: New process

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -222,7 +222,6 @@ en:
           summary_placeholder: Short summary of the description
           description_placeholder: Add a description of the process
           target_placeholder: Describe who is the target of the process
-          how_to_participate_placeholder: Describe how to participate
           additional_info_placeholder: Add an additional information you consider useful
         index:
           create: New process

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -221,7 +221,6 @@ es:
           title_placeholder: Escribe el título del proceso
           summary_placeholder: Resumen corto de la descripción
           description_placeholder: Añade una descripción del proceso
-          target_placeholder: Describe a quién va dirigido
           additional_info_placeholder: Añade cualquier información adicional que pueda ser de interés
         index:
           create: Nuevo proceso

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -222,7 +222,6 @@ es:
           summary_placeholder: Resumen corto de la descripción
           description_placeholder: Añade una descripción del proceso
           target_placeholder: Describe a quién va dirigido
-          how_to_participate_placeholder: Describe cómo participar
           additional_info_placeholder: Añade cualquier información adicional que pueda ser de interés
         index:
           create: Nuevo proceso

--- a/config/locales/legislation.en.yml
+++ b/config/locales/legislation.en.yml
@@ -56,7 +56,6 @@ en:
         title: Participate
         description: Description
         target: Target
-        how_to_participate: How to participate
         more_info: More information and context
       index:
         filters:

--- a/config/locales/legislation.en.yml
+++ b/config/locales/legislation.en.yml
@@ -55,7 +55,6 @@ en:
       header_full:
         title: Participate
         description: Description
-        target: Target
         more_info: More information and context
       index:
         filters:

--- a/config/locales/legislation.es.yml
+++ b/config/locales/legislation.es.yml
@@ -56,7 +56,6 @@ es:
         title: Colabora en la elaboración de la normativa sobre
         description: En qué consiste
         target: A quién va dirigido
-        how_to_participate: Cómo puedes participar
         more_info: Más información y contexto
       index:
         filters:

--- a/config/locales/legislation.es.yml
+++ b/config/locales/legislation.es.yml
@@ -55,7 +55,6 @@ es:
       header_full:
         title: Colabora en la elaboración de la normativa sobre
         description: En qué consiste
-        target: A quién va dirigido
         more_info: Más información y contexto
       index:
         filters:

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -635,7 +635,6 @@ print "Creating legislation processes"
   process = ::Legislation::Process.create!(title: Faker::Lorem.sentence(3).truncate(60),
                                            description: Faker::Lorem.paragraphs.join("\n\n"),
                                            summary: Faker::Lorem.paragraph,
-                                           target: Faker::Lorem.paragraphs.join("\n\n"),
                                            additional_info: Faker::Lorem.paragraphs.join("\n\n"),
                                            start_date: Date.current - 3.days,
                                            end_date: Date.current + 3.days,

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -636,7 +636,6 @@ print "Creating legislation processes"
                                            description: Faker::Lorem.paragraphs.join("\n\n"),
                                            summary: Faker::Lorem.paragraph,
                                            target: Faker::Lorem.paragraphs.join("\n\n"),
-                                           how_to_participate: Faker::Lorem.paragraphs.join("\n\n"),
                                            additional_info: Faker::Lorem.paragraphs.join("\n\n"),
                                            start_date: Date.current - 3.days,
                                            end_date: Date.current + 3.days,

--- a/db/migrate/20170610211027_remove_ht_participate_and_target_from_leg_process.rb
+++ b/db/migrate/20170610211027_remove_ht_participate_and_target_from_leg_process.rb
@@ -1,0 +1,6 @@
+class RemoveHtParticipateAndTargetFromLegProcess < ActiveRecord::Migration
+  def change
+    remove_column :legislation_processes, :how_to_participate, :text
+    remove_column :legislation_processes, :target, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170602162155) do
+ActiveRecord::Schema.define(version: 20170610211027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -404,8 +404,6 @@ ActiveRecord::Schema.define(version: 20170602162155) do
   create_table "legislation_processes", force: :cascade do |t|
     t.string   "title"
     t.text     "description"
-    t.text     "target"
-    t.text     "how_to_participate"
     t.text     "additional_info"
     t.date     "start_date"
     t.date     "end_date"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -604,7 +604,6 @@ FactoryGirl.define do
     title "A collaborative legislation process"
     description "Description of the process"
     summary "Summary of the process"
-    target "Who will affected by this law?"
     start_date Date.current - 5.days
     end_date Date.current + 5.days
     debate_start_date Date.current - 5.days

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -605,7 +605,6 @@ FactoryGirl.define do
     description "Description of the process"
     summary "Summary of the process"
     target "Who will affected by this law?"
-    how_to_participate "You can participate by answering some questions"
     start_date Date.current - 5.days
     end_date Date.current + 5.days
     debate_start_date Date.current - 5.days

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -63,14 +63,12 @@ feature 'Admin legislation processes' do
       expect(page).to have_content 'An example legislation process'
       expect(page).not_to have_content 'Summary of the process'
       expect(page).to have_content 'Describing the process'
-      expect(page).to have_content 'This thing affects people'
 
       visit legislation_processes_path
 
       expect(page).to have_content 'An example legislation process'
       expect(page).to have_content 'Summary of the process'
       expect(page).not_to have_content 'Describing the process'
-      expect(page).not_to have_content 'This thing affects people'
     end
   end
 

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -41,7 +41,6 @@ feature 'Admin legislation processes' do
       fill_in 'legislation_process_title', with: 'An example legislation process'
       fill_in 'legislation_process_summary', with: 'Summary of the process'
       fill_in 'legislation_process_description', with: 'Describing the process'
-      fill_in 'legislation_process_target', with: 'This thing affects people'
 
       base_date = Date.current
       fill_in 'legislation_process[start_date]', with: base_date.strftime("%d/%m/%Y")

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -42,7 +42,6 @@ feature 'Admin legislation processes' do
       fill_in 'legislation_process_summary', with: 'Summary of the process'
       fill_in 'legislation_process_description', with: 'Describing the process'
       fill_in 'legislation_process_target', with: 'This thing affects people'
-      fill_in 'legislation_process_how_to_participate', with: 'You can partipate in this thing by doing...'
 
       base_date = Date.current
       fill_in 'legislation_process[start_date]', with: base_date.strftime("%d/%m/%Y")


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/1587

What
====
Just totally remove both fields from Legislative Processes

How
===
Remove fields from:
- Views
- i18n files
- factories
- specs
- seeds
- schema.rb (using a reversible migration)

Screenshots
===========
### User facing views:

![screen shot 2017-06-10 at 23 30 02](https://user-images.githubusercontent.com/983242/27006478-f4254d3c-4e34-11e7-8d86-91b7c3c628cd.jpg)
![screen shot 2017-06-10 at 23 30 11](https://user-images.githubusercontent.com/983242/27006479-f43f5baa-4e34-11e7-8d05-f8c97e48f2ac.jpg)

### Admin edit form: 
![screen shot 2017-06-10 at 23 30 32](https://user-images.githubusercontent.com/983242/27006480-f46ee960-4e34-11e7-84aa-788ade3a2766.jpg)

Test
====
Removed the fill of both fields, and the check for target text.

Deployment
==========
As usual

Warnings
========
None