### PR TITLE
Github Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,30 @@
+PR_TITLE_GOES_HERE
+
+Where
+=====
+* **Related Issue:** LINK_OR_#_REF
+* **Related PR's:** LINK_OR_#_REF_IF_ANY
+
+What
+====
+> Whats the objective of this changes ?
+
+How
+===
+> How you implemented/achieved the objective ?
+
+Screenshots
+===========
+> If changes affect UI just show them drag&dropping images here
+
+Test
+====
+> Is manual test needed or you just increased/fixed coverage?
+
+Deployment
+==========
+> Any details to remember when this feature is deployed?
+
+Warnings
+========
+> Some caveats or important things to notice?


### PR DESCRIPTION
### What
Github allows to create a markdown file that will be used as template when opening a PullRequest manually from the web UI. As easy as following tutorial https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/

I think talking with @voodoorai2000 this came up so I'm just making a proposal... we actually didn't discuss about template contents and if it was a good idea for this repo or maybe it would be better at https://github.com/AyuntamientoMadrid/consul

### How
Just adding `.github/PULL_REQUEST_TEMPLATE` file.

**Why am I using the `=====` syntax for the headers?** Well it's to avoid using `#` on the file in case you edit the PR text in your editor and git removes those lines with `#` because it thinks it's a comment.

**Who would edit a PR text in a editor?** Well me 😄  I like to write text on my editor and don't use mouse to click on things if I can:

So I just use command line with a custom [git alias](https://github.com/bertocq/dotfiles/blob/master/.gitconfig#L83) that pops the editor with [a custom version of the PR template](https://github.com/bertocq/dotfiles/blob/master/.github_template.md) and once I close the file it uses [hub](https://hub.github.com/) to create the PR at github and finally opens the url at my browser. Note that I'm using [hub 2.3.0-pre9](https://github.com/github/hub/releases/tag/v2.3.0-pre9) that needs to be manually downloaded instead of using brew.

### Warnings
Yeah, I'm not fully using the proposed template for this very own PR 😂  but you can see it in action on this other one https://github.com/consul/consul/pull/1632.
