### PR TITLE
Fix Flaky test related with Time/Date in Search concern

### DIFF
--- a/app/controllers/concerns/search.rb
+++ b/app/controllers/concerns/search.rb
@@ -41,11 +41,11 @@ module Search
   end
 
   def search_finish_date
-    (params[:advanced_search][:date_max].to_date rescue Date.today) || Date.today
+    (params[:advanced_search][:date_max].to_date rescue Date.current) || Date.current
   end
 
   def search_date_range
-    [100.years.ago, search_start_date].max.beginning_of_day..[search_finish_date, Date.today].min.end_of_day
+    [100.years.ago, search_start_date].max.beginning_of_day..[search_finish_date, Date.current].min.end_of_day
   end
 
   def set_search_order

--- a/app/controllers/officing/residence_controller.rb
+++ b/app/controllers/officing/residence_controller.rb
@@ -26,7 +26,7 @@ class Officing::ResidenceController < Officing::BaseController
       @officer_assignments = current_user.poll_officer.
                                officer_assignments.
                                voting_days.
-                               where(date: Time.current.to_date)
+                               where(date: Date.current)
     end
 
     def validate_officer_assignment

--- a/app/models/direct_message.rb
+++ b/app/models/direct_message.rb
@@ -8,7 +8,7 @@ class DirectMessage < ActiveRecord::Base
   validates :receiver, presence: true
   validate  :max_per_day
 
-  scope :today, lambda { where('DATE(created_at) = ?', Date.today) }
+  scope :today, lambda { where('DATE(created_at) = ?', Date.current) }
 
   def max_per_day
     return if errors.any?

--- a/app/models/poll/voter.rb
+++ b/app/models/poll/voter.rb
@@ -50,7 +50,7 @@ class Poll
         if dob.blank?
           nil
         else
-          now = Time.current.to_date
+          now = Date.current
           now.year - dob.year - (now.month > dob.month || (now.month == dob.month && now.day >= dob.day) ? 0 : 1)
         end
       end

--- a/app/views/management/proposals/print.html.erb
+++ b/app/views/management/proposals/print.html.erb
@@ -8,7 +8,7 @@
       <%= image_tag "header_print_proposals.jpg", class: "for-print-only" %>
 
       <div class="filters">
-        <span class="for-print-only date-for-print"><%= l Date.today, format: :long %></span>
+        <span class="for-print-only date-for-print"><%= l Date.current, format: :long %></span>
 
         <h2 class="inline-block">
           <span class="not-print"><%= t("proposals.index.select_order_long") %></span>

--- a/lib/age.rb
+++ b/lib/age.rb
@@ -1,5 +1,5 @@
 module Age
-  def self.in_years(dob, now = Time.current.to_date)
+  def self.in_years(dob, now = Date.current)
     return nil if dob.blank?
     # reference: http://stackoverflow.com/questions/819263/get-persons-age-in-ruby#comment21200772_819263
     now.year - dob.year - (now.month > dob.month || (now.month == dob.month && now.day >= dob.day) ? 0 : 1)

--- a/lib/migrate_spending_proposals_to_investments.rb
+++ b/lib/migrate_spending_proposals_to_investments.rb
@@ -1,7 +1,7 @@
 class MigrateSpendingProposalsToInvestments
 
   def import(sp)
-    budget = Budget.last || Budget.create!(name: Date.today.year.to_s, currency_symbol: "€")
+    budget = Budget.last || Budget.create!(name: Date.current.year.to_s, currency_symbol: "€")
 
     group = nil
     heading = nil

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -429,7 +429,7 @@ FactoryGirl.define do
   factory :poll_officer_assignment, class: 'Poll::OfficerAssignment' do
     association :officer, factory: :poll_officer
     association :booth_assignment, factory: :poll_booth_assignment
-    date Time.current.to_date
+    date Date.current
 
     trait :final do
       final true

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -144,7 +144,7 @@ feature 'Admin booths assignments' do
       poll = create(:poll)
       booth = create(:poll_booth)
       booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-      today = Time.current.to_date
+      today = Date.current
       officer_assignment = create(:poll_officer_assignment, booth_assignment: booth_assignment, date: today)
 
       recount = create(:poll_recount,


### PR DESCRIPTION
## Where

I've been getting the following flaky tests failures at night for weeks:

![screen shot 2017-06-11 at 10 41 24](https://user-images.githubusercontent.com/983242/27009608-b01f7bfe-4e92-11e7-8867-fbc9ddf2456c.jpg)
![screen shot 2017-06-11 at 10 41 17](https://user-images.githubusercontent.com/983242/27009609-b0283dde-4e92-11e7-9214-b3f0885260ff.jpg)

<details>
  <summary>Click to expand text version</summary>
<code>
   1) Proposals Search Advanced search Search by date Search by multiple filters
     Failure/Error: expect(page).to have_content("There is 1 citizen proposal")
       expected to find text "There is 1 citizen proposal" in "Consul Language: Transparency Open data Consul Sign in Register Debates You are in Proposals Voting Legislation processes Participatory budgeting More information Searcher Search Search Proposals Search results citizen proposals cannot be found Advanced search With the text By author category By date most active highest rated newest relevance Archived Create a proposal CATEGORIES TRENDING DISTRICTS TOP WEEKLY The most supported proposals by category RETIRED PROPOSALS Proposals retired by the author Open government This portal uses the Consul application which is open-source software. For technical assistance enters technical assistance Participation Decide how to shape the city you want to live in. Transparency Find out anything about the city. Open data Every detail about the City Council is yours to access. Consul, 2017 | Privacy Policy | Terms and conditions of use | Accessibility"
     # ./spec/features/proposals_spec.rb:1079:in `block (5 levels) in <top (required)>'
  2) Proposals Search Advanced search Search by date Predefined date ranges Last day
     Failure/Error: expect(page).to have_content("There are 2 citizen proposals")
       expected to find text "There are 2 citizen proposals" in "Consul Language: Transparency Open data Consul Sign in Register Debates You are in Proposals Voting Legislation processes Participatory budgeting More information Searcher Search Search Proposals Search results There is 1 citizen proposal Advanced search With the text By author category By date most active highest rated newest Archived Proposal 410 title No comments • 2017-06-10 • Manuela2283 In summary, what we want is... 473 0% / 100% No supports 53,726 supports needed Support Create a proposal CATEGORIES TRENDING DISTRICTS TOP WEEKLY The most supported proposals by category RETIRED PROPOSALS Proposals retired by the author Open government This portal uses the Consul application which is open-source software. For technical assistance enters technical assistance Participation Decide how to shape the city you want to live in. Transparency Find out anything about the city. Open data Every detail about the City Council is yours to access. Consul, 2017 | Privacy Policy | Terms and conditions of use | Accessibility"
     # ./spec/features/proposals_spec.rb:947:in `block (6 levels) in <top (required)>'

  1) DirectMessage scopes today should return direct messages created today
     Failure/Error: expect(DirectMessage.today.count).to eq 3
     
       expected: 3
            got: 1
     
       (compared using ==)
     # ./spec/models/direct_message_spec.rb:72:in `block (4 levels) in <top (required)>'
  2) Debates Search Advanced search Search by date Search by multiple filters
     Failure/Error: expect(page).to have_css('.debate', count: 1)
       expected to find css ".debate" 1 time but there were no matches
     # ./spec/features/debates_spec.rb:684:in `block (6 levels) in <top (required)>'
     # ./spec/features/debates_spec.rb:683:in `block (5 levels) in <top (required)>'
  3) Debates Search Advanced search Search by date Predefined date ranges Last day
     Failure/Error: expect(page).to have_css('.debate', count: 2)
       expected to find css ".debate" 2 times, found 1 match: "Debate 340 title No comments • 2017-06-10 • Manuela2470 Debate description I agree 0% I disagree 0% No votes"
     # ./spec/features/debates_spec.rb:552:in `block (7 levels) in <top (required)>'
     # ./spec/features/debates_spec.rb:551:in `block (6 levels) in <top (required)>'
</code>
</details>

## What
The problem was that although almost all `Time.` usages are time-zone aware... on the search concern there were some `Date.today` that are not time-zone aware... and for some hours at night the search results weren't taking into account the time difference between UTC+2 and UTC.

## How
- Just using [`Date.current`](http://api.rubyonrails.org/v5.1/classes/Date.html#method-c-current) > Returns Time.zone.today when Time.zone or config.time_zone are set, otherwise just returns Date.today.
- As bonus refactor changing all `Time.current.to_date` for a shorter and equal result:  `Date.current`

## Screenshots
No need, if tests pass at night all the time then we're good :)

## Deployment
As usual

## Warnings
I found this occurrences manually, but further rubocop cleanups will help tracking this issues down faster.