### PR TITLE
Issue#1354 suggest on investments creation

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -24,6 +24,7 @@ module Budgets
 
     invisible_captcha only: [:create, :update], honeypot: :subtitle, scope: :budget_investment
 
+    helper_method :resource_model, :resource_name
     respond_to :html, :js
 
     def index
@@ -71,6 +72,14 @@ module Budgets
     end
 
     private
+
+      def resource_model
+        Budget::Investment
+      end
+
+      def resource_name
+        "budget_investment"
+      end
 
       def load_investment_votes(investments)
         @investment_votes = current_user ? current_user.budget_investment_votes(investments) : {}

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -20,7 +20,7 @@ module Budgets
 
     has_orders %w{most_voted newest oldest}, only: :show
     has_orders ->(c) { c.instance_variable_get(:@budget).investments_orders }, only: :index
-    has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: [:index, :show]
+    has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: [:index, :show, :suggest]
 
     invisible_captcha only: [:create, :update], honeypot: :subtitle, scope: :budget_investment
 
@@ -69,6 +69,12 @@ module Budgets
         format.html { redirect_to budget_investments_path(heading_id: @investment.heading.id) }
         format.js
       end
+    end
+
+    def suggest
+      @resource_path_method = :namespaced_budget_investment_path
+      @resource_relation    = resource_model.where(budget: @budget).apply_filters_and_search(@budget, params, @current_filter)
+      super
     end
 
     private

--- a/app/controllers/concerns/commentable_actions.rb
+++ b/app/controllers/concerns/commentable_actions.rb
@@ -34,7 +34,7 @@ module CommentableActions
 
   def suggest
     @limit = 5
-    @resources = @search_terms.present? ? resource_model.search(@search_terms) : nil
+    @resources = @search_terms.present? ? resource_relation.search(@search_terms) : nil
   end
 
   def create

--- a/app/controllers/concerns/polymorphic.rb
+++ b/app/controllers/concerns/polymorphic.rb
@@ -10,6 +10,10 @@ module Polymorphic
       @resource_name ||= resource_model.to_s.downcase
     end
 
+    def resource_relation
+      @resource_relation ||= resource_model.all
+    end
+
     def set_resource_instance
       instance_variable_set("@#{resource_name}", @resource)
     end

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -46,6 +46,7 @@ module Abilities
         can :create, SpendingProposal
 
         can :create, Budget::Investment,               budget: { phase: "accepting" }
+        can :suggest, Budget::Investment,              budget: { phase: "accepting" }
         can :destroy, Budget::Investment,              budget: { phase: ["accepting", "reviewing"] }, author_id: user.id
         can :vote,   Budget::Investment,               budget: { phase: "selecting" }
         can [:show, :create], Budget::Ballot,          budget: { phase: "balloting" }

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -7,8 +7,9 @@
     </div>
 
     <div class="small-12 column">
-      <%= f.text_field :title, maxlength: SpendingProposal.title_max_length %>
+      <%= f.text_field :title, maxlength: SpendingProposal.title_max_length, data: { js_suggest_result: "js_suggest_result", js_suggest: "#js-suggest", js_url: suggest_budget_investments_path(@budget) }%>
     </div>
+    <div id="js-suggest"></div>
 
     <%= f.invisible_captcha :subtitle %>
 

--- a/app/views/budgets/investments/suggest.js.erb
+++ b/app/views/budgets/investments/suggest.js.erb
@@ -1,0 +1,1 @@
+<%= render "shared/suggest" %>

--- a/app/views/shared/_suggest.html.erb
+++ b/app/views/shared/_suggest.html.erb
@@ -9,7 +9,7 @@
 
       <ul>
         <% @resources.limit(@limit).each do |resource| %>
-          <li><%= link_to resource.title, resource %></li>
+          <li><%= link_to resource.title, @resource_path_method.present? ? send(@resource_path_method, resource) : resource  %></li>
         <% end %>
       </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -511,6 +511,12 @@ en:
           other: "There are debates with the term '%{query}', you can participate in them instead of opening a new one."
         message: "You are seeing %{limit} of %{count} debates containing the term '%{query}'"
         see_all: "Ver todos"
+      budget_investment:
+        found:
+          one: "There is an investment with the term '%{query}', you can participate in it instead of opening a new one."
+          other: "There are investments with the term '%{query}', you can participate in them instead of opening a new one."
+        message: "You are seeing %{limit} of %{count} investments containing the term '%{query}'"
+        see_all: "See all"
       proposal:
         found:
           one: "There is a proposal with the term '%{query}', you can contribute to it instead of creating a new"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -511,6 +511,12 @@ es:
           other: "Existen debates con el término '%{query}', puedes participar en ellos en vez de abrir uno nuevo."
         message: "Estás viendo %{limit} de %{count} debates que contienen el término '%{query}'"
         see_all: "Ver todos"
+      budget_investment:
+        found:
+          one: "Existe una propuesta de inversión con el término '%{query}', puedes participar en ella en vez de abrir una nueva."
+          other: "Existen propuestas de inversión con el término '%{query}', puedes participar en ellas en vez de abrir una nueva."
+        message: "Estás viendo %{limit} de %{count} propuestas de inversión que contienen el término '%{query}'"
+        see_all: "Ver todas"
       proposal:
         found:
           one: "Existe una propuesta con el término '%{query}', puedes participar en ella en vez de abrir uno nuevo."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,8 @@ Rails.application.routes.draw do
   resources :budgets, only: [:show, :index] do
     resources :groups, controller: "budgets/groups", only: [:show]
     resources :investments, controller: "budgets/investments", only: [:index, :new, :create, :show, :destroy] do
-      member { post :vote }
+      member     { post :vote }
+      collection { get :suggest }
     end
     resource :ballot, only: :show, controller: "budgets/ballots" do
       resources :lines, controller: "budgets/ballot/lines", only: [:create, :destroy]


### PR DESCRIPTION
## Summary

* Some changes has been made on `CommentableActions` and `Polymorphic` concerns to allow filter items to be suggested. With debates and proposals the search is sent directly to the model, but investments are nested resources of budgets, so suggested investments should be selected among those who belong to the budget.

* The original link creation in the partial `shared/suggest` failed with investments due to routes nesting. Also there is a helper method `namespaced_budget_investment_path` to build the path to investments that is used in lists. I've decided to allow the use of custom methods to build the path to resources in the partial using an instance variable and I've used the mentioned helper method.

* The same custom filter used in `index` controller action to show investments is applied for suggestions. In this way there is no difference between what the suggestions counter shows when it exceeds 5 results and the index to which the associated link leads.

* I've only included i18n labels for es and en locales.