### PR TITLE
Issue#1595 results url permissions

### DIFF
--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -4,6 +4,7 @@ module Budgets
     load_and_authorize_resource :budget
 
     def show
+      authorize! :read_results, @budget
       @result = load_result
     end
 

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -17,6 +17,7 @@ module Abilities
       can [:read], Budget
       can [:read], Budget::Group
       can [:read, :print], Budget::Investment
+      can :read_results, Budget, phase: "finished"
       can :new, DirectMessage
       can [:read, :debate, :draft_publication, :allegations, :final_version_publication], Legislation::Process
       can [:read, :changes, :go_to_version], Legislation::DraftVersion

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -45,4 +45,13 @@ feature 'Results' do
     end
   end
 
+  scenario "If budget is in a phase different from finished results can't be accessed" do
+    budget.update phase: (Budget::PHASES - ["finished"]).sample
+    visit budget_path(budget)
+    expect(page).not_to have_link "See results"
+
+    visit budget_results_path(budget, heading_id: budget.headings.first)
+    expect(page).to have_content "You do not have permission to carry out the action"
+  end
+
 end


### PR DESCRIPTION
## Summary
Since Result model doesn't inherits from `ActiveRecord`, the budget cannot be accessed from the `Ability` class, so something like:
```ruby
can [:create, :show], Budget::Result, budget: { phase: "finished" }
```
or
```ruby
can [:create, :show], Budget::Result do |result|
  result.budget.finished?
end
```
won't work. Instead we can ask permissions to instanciated `@budget` in actions of results controller.
