### PR TITLE
Fix broken link

### DIFF
--- a/app/views/proposals/new.html.erb
+++ b/app/views/proposals/new.html.erb
@@ -5,7 +5,7 @@
 
     <h1><%= t("proposals.new.start_new") %></h1>
     <div data-alert class="callout primary">
-      <%= link_to "/proposals_info",title: t('shared.target_blank_html'), target: "_blank" do %>
+      <%= link_to more_info_path(anchor: "proposals") ,title: t('shared.target_blank_html'), target: "_blank" do %>
         <%= t("proposals.new.more_info")%>
       <% end %>
     </div>


### PR DESCRIPTION
The link just before the new proposal form was broken, with this PR it points to the more info page, to the proposals section