### PR TITLE
Fix Table of Contents rotated text margin&line height

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -759,12 +759,13 @@ $epigraph-line-height: rem-calc(22);
 
       .draft-index-rotated {
         @include breakpoint(medium) {
+          line-height: 1;
           display: block;
           font-size: $small-font-size;
           text-transform: uppercase;
           font-weight: 700;
           color: #696969;
-          margin-top: 1rem;
+          margin-top: $line-height;
           -webkit-transform: rotate(-90deg);
           -moz-transform: rotate(-90deg);
           -ms-transform: rotate(-90deg);


### PR DESCRIPTION

What
====
When you go to a legislative process to see a draft version (i.e. http://localhost:3000/legislation/processes/1/draft_versions/15) in spanish you get a very nice "Indice" text on the side: ![screen shot 2017-06-12 at 17 23 56](https://user-images.githubusercontent.com/983242/27041610-c425d320-4f94-11e7-9633-a421606682d0.jpg)
 but on English the text "Table of Contents" looks a bit strange (touching left, top and right borders) ![screen shot 2017-06-12 at 17 24 13](https://user-images.githubusercontent.com/983242/27041625-cd1765ac-4f94-11e7-873c-f6aa0ac9a375.jpg)

How
===
Just reducing the default inherited `line-height` from 1.5 to 1, and also increasing the margin-top to give it some room.

Screenshots
===========
After the changes the spanish version its the same, but english version is improved:
![screen shot 2017-06-12 at 17 30 44](https://user-images.githubusercontent.com/983242/27041687-f0a5c090-4f94-11e7-8d6f-d7f06b07ab37.jpg)


Test
====
None, just visual changes

Deployment
==========
As usual

Warnings
========
Not a frontend guy, not a designer, this is just an opinion from my inner OCD :D