### PR TITLE
Only count active users in stats

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -13,11 +13,11 @@ class Admin::StatsController < Admin::BaseController
     @comment_votes = Vote.where(votable_type: 'Comment').count
     @votes = Vote.count
 
-    @user_level_two = User.with_hidden.level_two_verified.count
-    @user_level_three = User.with_hidden.level_three_verified.count
-    @verified_users = User.with_hidden.level_two_or_three_verified.count
-    @unverified_users = User.with_hidden.unverified.count
-    @users = User.with_hidden.count
+    @user_level_two = User.active.level_two_verified.count
+    @user_level_three = User.active.level_three_verified.count
+    @verified_users = User.active.level_two_or_three_verified.count
+    @unverified_users = User.active.unverified.count
+    @users = User.active.count
     @user_ids_who_voted_proposals = ActsAsVotable::Vote.where(votable_type: 'Proposal').distinct.count(:voter_id)
     @user_ids_who_didnt_vote_proposals = @verified_users - @user_ids_who_voted_proposals
     @spending_proposals = SpendingProposal.count

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -42,7 +42,11 @@ feature 'Stats' do
       expect(page).to have_content "Total votes 6"
     end
 
-    scenario 'Users' do
+  end
+
+  context "Users" do
+
+    scenario 'Summary' do
       1.times { create(:user, :level_three) }
       2.times { create(:user, :level_two) }
       3.times { create(:user) }
@@ -56,18 +60,46 @@ feature 'Stats' do
       expect(page).to have_content "Total users 7"
     end
 
-  end
+    scenario "Do not count erased users" do
+      1.times { create(:user, :level_three, erased_at: Time.current) }
+      2.times { create(:user, :level_two, erased_at: Time.current) }
+      3.times { create(:user, erased_at: Time.current) }
 
-  scenario 'Level 2 user' do
-    create(:geozone)
-    visit account_path
-    click_link 'Verify my account'
-    verify_residence
-    confirm_phone
+      visit admin_stats_path
 
-    visit admin_stats_path
+      expect(page).to have_content "Level three users 0"
+      expect(page).to have_content "Level two users 0"
+      expect(page).to have_content "Verified users 0"
+      expect(page).to have_content "Unverified users 1"
+      expect(page).to have_content "Total users 1"
+    end
 
-    expect(page).to have_content "Level 2 User (1)"
+    scenario "Do not count hidden users" do
+      1.times { create(:user, :level_three, hidden_at: Time.current) }
+      2.times { create(:user, :level_two, hidden_at: Time.current) }
+      3.times { create(:user, hidden_at: Time.current) }
+
+      visit admin_stats_path
+
+      expect(page).to have_content "Level three users 0"
+      expect(page).to have_content "Level two users 0"
+      expect(page).to have_content "Verified users 0"
+      expect(page).to have_content "Unverified users 1"
+      expect(page).to have_content "Total users 1"
+    end
+
+    scenario 'Level 2 user Graph' do
+      create(:geozone)
+      visit account_path
+      click_link 'Verify my account'
+      verify_residence
+      confirm_phone
+
+      visit admin_stats_path
+
+      expect(page).to have_content "Level 2 User (1)"
+    end
+
   end
 
   context "Proposal notifications" do


### PR DESCRIPTION
### What

Fixes AyuntamientoMadrid/consul#736

Makes user stats more accurate by not counting the following:
- Users that have been hidden by a moderator
- Users that have erased their account
- Users created from a signature sheet
- Users created from a postal mail vote
- Users created from a physical booth vote

## How
Not counting users with the attribute hidden_at present. These are hidden users.

Not counting users with the attribute erased_at present. These are users that have erased their account, been created from signature, postal mail vote or physical booth vote 
