### PR TITLE
Fix DirectMessage today scope

### DIFF
--- a/app/models/direct_message.rb
+++ b/app/models/direct_message.rb
@@ -8,7 +8,7 @@ class DirectMessage < ActiveRecord::Base
   validates :receiver, presence: true
   validate  :max_per_day
 
-  scope :today, lambda { where('DATE(created_at) = ?', Date.current) }
+  scope :today, lambda { where('DATE(created_at) = DATE(?)', Time.current) }
 
   def max_per_day
     return if errors.any?

--- a/spec/models/direct_message_spec.rb
+++ b/spec/models/direct_message_spec.rb
@@ -65,9 +65,9 @@ describe DirectMessage do
 
     describe "today" do
       it "should return direct messages created today" do
-        direct_message1 = create(:direct_message, created_at: Time.current.beginning_of_day + 3.hours)
-        direct_message2 = create(:direct_message, created_at: Time.current)
-        direct_message3 = create(:direct_message, created_at: Time.current.end_of_day)
+        direct_message1 = create(:direct_message, created_at: Time.now.utc.beginning_of_day + 3.hours)
+        direct_message2 = create(:direct_message, created_at: Time.now.utc)
+        direct_message3 = create(:direct_message, created_at: Time.now.utc.end_of_day)
 
         expect(DirectMessage.today.count).to eq 3
       end


### PR DESCRIPTION
## What
DirectMessage `today` scope was comparing dates without taking into account that `created_at` is a timestamp with timezone.

## How
Database stores created_at as timestamp with the timezone, so when comparing DATE(created_at) to something we have to convert it to DATE as well with the postresql native function, but using Time.current instead of Date.current to take into account the user timezone

## Screenshots
No need

## Tests

Modified to use utc timezone when directly changing the `created_at` attribute.

## Deployment

As usual

## Warnings

This is related with my last try to fix flaky tests https://github.com/consul/consul/pull/1634 but on that PR I just tried to use timezone, but still kept using Date instead of Time
