### PR TITLE
Update graphql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'rails-assets-markdown-it', source: 'https://rails-assets.org'
 
 gem 'cocoon'
 
-gem 'graphql', '~> 1.5.12'
+gem 'graphql', '~> 1.6.3'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
       activesupport (>= 4.1.0)
     graphiql-rails (1.4.1)
       rails
-    graphql (1.5.12)
+    graphql (1.6.3)
     groupdate (3.2.0)
     gyoku (1.3.1)
       builder (>= 2.1.2)
@@ -507,7 +507,7 @@ DEPENDENCIES
   foundation_rails_helper (~> 2.0.0)
   fuubar
   graphiql-rails (~> 1.4.1)
-  graphql (~> 1.5.12)
+  graphql (~> 1.6.3)
   groupdate (~> 3.2.0)
   i18n-tasks (~> 0.9.15)
   initialjs-rails (= 0.2.0.4)


### PR DESCRIPTION
Upgrades GraphQL to latest version (1.6.3)
[Changelog](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md) revised. No breaking changes to current code.