### PR TITLE
Allow overriding faq and how-to-use pages with custom pages

### DIFF
--- a/app/models/site_customization/page.rb
+++ b/app/models/site_customization/page.rb
@@ -3,7 +3,7 @@ class SiteCustomization::Page < ActiveRecord::Base
 
   validates :slug, presence: true,
                    uniqueness: { case_sensitive: false },
-                   format: { with: /\A[0-9a-zA-Z\-_]*\Z/, message: :slug_format }
+                   format: { with: /\A[0-9a-zA-Z\-_\/]*\Z/, message: :slug_format }
   validates :title, presence: true
   validates :status, presence: true, inclusion: { in: VALID_STATUSES }
 

--- a/app/views/pages/more_info/faq/index.html.erb
+++ b/app/views/pages/more_info/faq/index.html.erb
@@ -2,20 +2,41 @@
   <%= render "shared/canonical", href: faq_url %>
 <% end %>
 
-<div class="row margin-top">
-  <div class="menu small-12 medium-3 column">
-    <%= render "shared/back_link" %>
+<% if custom_page = SiteCustomization::Page.published.find_by(slug: 'more-information/faq') %>
+  <% provide :title do %><%= custom_page.title %><% end %>
 
-    <ul class="menu vertical margin-top">
-      <li><a href="#1"><strong><%= t("pages.more_info.faq.page.faq_1_title") %></strong></a></li>
-    </ul>
+  <div class="row margin-top">
+    <div class="menu small-12 medium-3 column">
+      <%= render "shared/back_link" %>
+    </div>
+
+    <div class="text small-12 medium-9 column">
+      <h1 class="clear"><%= custom_page.title %></h1>
+      <%= "<h2>#{custom_page.subtitle}</h2>" if custom_page.subtitle %>
+
+      <%= raw custom_page.content %>
+    </div>
   </div>
 
-  <div class="text small-12 medium-9 column">
-    <h1 class="clear"><%= t("pages.more_info.faq.page.title") %></h1>
-    <p><%= t("pages.more_info.faq.page.description") %></p>
+<% else %>
+  <% provide :title do %><%= t("pages.more_info.faq.page.title") %><% end %>
 
-    <h2 id="1"><%= t("pages.more_info.faq.page.faq_1_title") %></h2>
-    <p><%= t("pages.more_info.faq.page.faq_1_description") %></p>
+  <div class="row margin-top">
+    <div class="menu small-12 medium-3 column">
+      <%= render "shared/back_link" %>
+
+      <ul class="menu vertical margin-top">
+        <li><a href="#1"><strong><%= t("pages.more_info.faq.page.faq_1_title") %></strong></a></li>
+      </ul>
+    </div>
+
+    <div class="text small-12 medium-9 column">
+      <h1 class="clear"><%= t("pages.more_info.faq.page.title") %></h1>
+      <p><%= t("pages.more_info.faq.page.description") %></p>
+
+      <h2 id="1"><%= t("pages.more_info.faq.page.faq_1_title") %></h2>
+      <p><%= t("pages.more_info.faq.page.faq_1_description") %></p>
+    </div>
   </div>
-</div>
+
+<% end %>

--- a/app/views/pages/more_info/how_to_use/index.html.erb
+++ b/app/views/pages/more_info/how_to_use/index.html.erb
@@ -2,12 +2,31 @@
   <%= render "shared/canonical", href: how_to_use_url %>
 <% end %>
 
-<div class="row margin-top">
-  <div class="text small-12 column">
-    <%= render "shared/back_link" %>
+<% if custom_page = SiteCustomization::Page.published.find_by(slug: 'more-information/how-to-use') %>
+  <% provide :title do %><%= custom_page.title %><% end %>
 
-    <h1><%= t('pages.more_info.titles.how_to_use') %></h1>
+  <div class="row margin-top">
+    <div class="text small-12 column">
+      <%= render "shared/back_link" %>
 
-    <%= markdown t('pages.more_info.how_to_use.text') %>
+      <h1><%= custom_page.title %></h1>
+      <%= "<h2>#{custom_page.subtitle}</h2>" if custom_page.subtitle %>
+
+      <%= raw custom_page.content %>
+    </div>
   </div>
-</div>
+
+<% else %>
+  <% provide :title do %><%= t('pages.more_info.titles.how_to_use') %><% end %>
+
+  <div class="row margin-top">
+    <div class="text small-12 column">
+      <%= render "shared/back_link" %>
+
+      <h1><%= t('pages.more_info.titles.how_to_use') %></h1>
+
+      <%= markdown t('pages.more_info.how_to_use.text') %>
+    </div>
+  </div>
+
+<% end %>

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -131,4 +131,36 @@ feature "Custom Pages" do
       expect(page).to have_content("New text for FAQ page")
     end
   end
+
+  context "Override more-information/how-to-use" do
+    scenario "See default content when custom page is not published" do
+      custom_page = create(:site_customization_page,
+        slug: "more-information/how-to-use",
+        title: "Custom How to use",
+        content: "New text for How to use page",
+        print_content_flag: true
+      )
+
+      visit custom_page.url
+
+      expect(page).to have_title("Use it in your local government")
+      expect(page).to have_selector("h1", text: "Use it in your local government")
+      expect(page).to have_content("Use it in your local government or help us to improve it, it is free software.")
+    end
+
+    scenario "See custom content when custom page is published" do
+      custom_page = create(:site_customization_page, :published,
+        slug: "more-information/how-to-use",
+        title: "Custom How to use",
+        content: "New text for How to use page",
+        print_content_flag: true
+      )
+
+      visit custom_page.url
+
+      expect(page).to have_title("Custom How to use")
+      expect(page).to have_selector("h1", text: "Custom How to use")
+      expect(page).to have_content("New text for How to use page")
+    end
+  end
 end

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -99,4 +99,36 @@ feature "Custom Pages" do
       end
     end
   end
+
+  context "Override more-information/faq" do
+    scenario "See default content when custom page is not published" do
+      custom_page = create(:site_customization_page,
+        slug: "more-information/faq",
+        title: "Custom FAQ",
+        content: "New text for FAQ page",
+        print_content_flag: true
+      )
+
+      visit custom_page.url
+
+      expect(page).to have_title("Frequently Asked Questions")
+      expect(page).to have_selector("h1", text: "Frequently Asked Questions")
+      expect(page).to have_content("Use this page to resolve the common FAQs to the users of site.")
+    end
+
+    scenario "See custom content when custom page is published" do
+      custom_page = create(:site_customization_page, :published,
+        slug: "more-information/faq",
+        title: "Custom FAQ",
+        content: "New text for FAQ page",
+        print_content_flag: true
+      )
+
+      visit custom_page.url
+
+      expect(page).to have_title("Custom FAQ")
+      expect(page).to have_selector("h1", text: "Custom FAQ")
+      expect(page).to have_content("New text for FAQ page")
+    end
+  end
 end


### PR DESCRIPTION
This PR changes the views files for `more-information/faq` and `more-information/how-to-use` to allow overriding its content with a custom page created from the admin panel. 

If there are no custom pages with these slugs created from the admin panel everything should work as before.