### PR TITLE
Mark current Category as active on proposal/budget list

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -653,7 +653,8 @@ footer {
   background: $highlight;
   color: $link;
 
-  &:hover {
+  &:hover,
+  &.active {
     background: $brand;
     color: #fff;
   }

--- a/app/views/budgets/investments/_categories.html.erb
+++ b/app/views/budgets/investments/_categories.html.erb
@@ -5,7 +5,8 @@
 <ul id="categories" class="no-bullet categories">
   <% @categories.each do |category| %>
     <li class="inline-block">
-      <%= link_to category.name,
-                  budget_investments_path(@budget, search: category.name) %></li>
+      <% css_class = { class: 'active' } if params[:search] == category.name %>
+      <%= link_to category.name, budget_investments_path(@budget, search: category.name), css_class || {} %>
+    </li>
   <% end %>
 </ul>

--- a/app/views/proposals/_categories.html.erb
+++ b/app/views/proposals/_categories.html.erb
@@ -4,6 +4,9 @@
 
 <ul id="categories" class="no-bullet categories">
   <% @categories.each do |category| %>
-    <li class="inline-block"><%= link_to category.name, proposals_path(search: category.name) %></li>
+    <li class="inline-block">
+      <% css_class = { class: 'active' } if params[:search] == category.name %>
+      <%= link_to category.name, proposals_path(search: category.name), css_class || {} %>
+    </li>
   <% end %>
 </ul>


### PR DESCRIPTION
What
====
Figuring out another thing, I realized that when you filter by a category proposals or budgets, the sidebar category list doesn't reflect your choice as "active"

How
===
Just using :hover css for a new .active class and setting it correctly on both proposals and budgets partials for categories

I didn't merge both partials into a shared one (and I was very tempted, and even got it working with a block and yield and stuff) because I think Proposals are going away soon and having a shared partial that is only being used by one thing... its going to have to be refactored back later on :D... maybe not worth the code change and hassle.

Screenshots
===========
### Before
![screen shot 2017-06-19 at 23 02 59](https://user-images.githubusercontent.com/983242/27305808-76ed022c-5543-11e7-934f-ac595cb3f157.jpg)

### After
![screen shot 2017-06-19 at 23 02 00](https://user-images.githubusercontent.com/983242/27305793-6a1399f8-5543-11e7-90cf-26ea07f0825d.jpg)

Test
====
Well seemed a bit overkill to add a test just to check the presence of the `.active` class, since there is none for the search/filter by category... Maybe it makes sense to create that search/filter by category spec?

Locally can be tested going to http://localhost:3000/proposals?search=Asociaciones

Deployment
==========
As usual

Warnings
========
None