### PR TITLE
Fixes styles

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -278,6 +278,10 @@ $admin-color: #cf3638;
     a {
       font-weight: normal;
     }
+
+    .active {
+      border-bottom: 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/legislation.scss
+++ b/app/assets/stylesheets/legislation.scss
@@ -37,20 +37,20 @@
     @include breakpoint(medium) {
       margin: 1.5rem 0;
     }
-  }
 
-  li {
-    display: block;
-    cursor: pointer;
-    margin-bottom: 1rem;
+    li {
+      display: block;
+      cursor: pointer;
+      margin-bottom: 1rem;
 
-    @include breakpoint(medium) {
-      margin-bottom: 2rem;
-      max-width: 80%;
-    }
+      @include breakpoint(medium) {
+        margin-bottom: 2rem;
+        max-width: 80%;
+      }
 
-    &.active {
-      font-weight: 700;
+      &.active {
+        font-weight: 700;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -69,15 +69,6 @@ $epigraph-line-height: rem-calc(22);
           float: left;
         }
       }
-
-      p {
-        font-size: $epigraph-font-size;
-        line-height: $epigraph-line-height;
-
-        @include breakpoint(medium) {
-          margin-left: 25%;
-        }
-      }
     }
   }
 


### PR DESCRIPTION
What
====
-  Fixes legislation processes menu `[screenshot 1]`
-  Removes unnecessary margin on legislation allegations  `[screenshot 2]`
- Fixes submenu active class on admin sidebar  `[screenshot 3]`

Screenshots
===========

`[screenshot 1]`

<img width="294" alt="screen shot 2017-06-20 at 18 45 45" src="https://user-images.githubusercontent.com/631897/27345055-b463a71e-55e8-11e7-913f-f88cbade7b17.png">

`[screenshot 2]`

<img width="1227" alt="screen shot 2017-06-20 at 18 31 42" src="https://user-images.githubusercontent.com/631897/27345062-b94b2a68-55e8-11e7-835c-cd0438c64f08.png">


 `[screenshot 3]`

<img width="431" alt="screen shot 2017-06-20 at 18 46 23" src="https://user-images.githubusercontent.com/631897/27345102-c939f6de-55e8-11e7-8ffd-0ab4ec4bb80d.png">
