### PR TITLE
Remove trailing whitespaces from french translation files

### DIFF
--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -59,7 +59,7 @@ fr:
       budget:
         name: "Nom"
         description_accepting: "Description durant la phase d'acceptation"
-        description_reviewing: "Description durant la phase de revue" 
+        description_reviewing: "Description durant la phase de revue"
         description_selecting: "Description durant la phase de sélection"
         description_valuating: "Description durant la phase d'évaluation"
         description_balloting: "Description durant la phase de vote"

--- a/config/locales/admin.fr.yml
+++ b/config/locales/admin.fr.yml
@@ -502,7 +502,7 @@ fr:
         tags_filter_all: Toutes les étiquettes
         filters:
           valuation_open: Ouvert
-          without_admin: Sans administrateur affecté 
+          without_admin: Sans administrateur affecté
           managed: Géré
           valuating: Sous évaluation
           valuation_finished: Évaluation terminée
@@ -588,7 +588,7 @@ fr:
       new:
         title: Nouvelle feuilles de signature
         document_numbers_note: "Saisir les numéros séparés par des virgules (,)"
-        submit: Créer la feuille de signature 
+        submit: Créer la feuille de signature
       show:
         created_at: Créé le
         author: Auteur
@@ -627,18 +627,18 @@ fr:
         budgets_title: Budgets participatifs
         visits_title: Visites
         direct_messages: Messages privés
-        proposal_notifications: Notifications des propositions 
-        incomplete_verifications: Vérifications incomplètes 
+        proposal_notifications: Notifications des propositions
+        incomplete_verifications: Vérifications incomplètes
       direct_messages:
         title: Messages privés
         total: Total
         users_who_have_sent_message: Utilisateurs ayant envoyé un message privé
       proposal_notifications:
-        title: Notifications des propositions 
+        title: Notifications des propositions
         total: Total
         proposals_with_notifications: Propositions avec notifications
     tags:
-      create: Créer un sujet 
+      create: Créer un sujet
       destroy: Supprimer un sujet
       index:
         add_tag: Ajouter un nouveau sujet de proposition
@@ -677,7 +677,7 @@ fr:
           error: Le bloc de contenu n'a pas pu être créé
         update:
           notice: Bloc de contenu mis-à-jour avec succès
-          error: Le bloc de contenu n'a pas pu être mis-à-jour 
+          error: Le bloc de contenu n'a pas pu être mis-à-jour
         destroy:
           notice: Bloc de contenu supprimé avec succès
         edit:
@@ -709,7 +709,7 @@ fr:
       pages:
         create:
           notice: Page créée avec succès
-          error: La page n'a pas pu être créée 
+          error: La page n'a pas pu être créée
         update:
           notice: Page mise-à-jour avec succès
           error: La page n'a pas pu être mise-à-jour

--- a/config/locales/moderation.fr.yml
+++ b/config/locales/moderation.fr.yml
@@ -74,5 +74,5 @@ fr:
         hide: Bloquer
         search: Rechercher
         search_placeholder: courriel ou nom de l'utilisateur
-        title: Bloquer les utilisateurs 
+        title: Bloquer les utilisateurs
       notice_hide: Utilisateur bloqué. Tous les débats et les propositions de cet utilisateur ont été masqués.

--- a/config/locales/settings.fr.yml
+++ b/config/locales/settings.fr.yml
@@ -31,7 +31,7 @@ fr:
       budgets: Budgets participatifs
       twitter_login: Se connecter avec Twitter
       facebook_login: Se connecter avec Facebook
-      google_login: Se connecter avec Google 
+      google_login: Se connecter avec Google
       debates: Débats
       polls: Votes
       signature_sheets: Feuilles de signature

--- a/config/locales/valuation.fr.yml
+++ b/config/locales/valuation.fr.yml
@@ -66,7 +66,7 @@ fr:
         feasibility: Faisabilité
         feasible: Faisable
         unfeasible: Infaisable
-        undefined_feasible: Indécis 
+        undefined_feasible: Indécis
         feasible_explanation_html: "Informations sur la non-viabilité <small>(le cas échéant, données publiques)</small>"
         valuation_finished: Évaluation terminée
         duration_html: "Délai d'exécution <small>(optionnel, données non publiques)</small>"

--- a/config/locales/verification.fr.yml
+++ b/config/locales/verification.fr.yml
@@ -62,11 +62,11 @@ fr:
         error_not_allowed_age: Vous n'avez pas l'âge requis pour participer
         error_not_allowed_postal_code: Vous devez être enregistré pour être vérifié.
         error_verifying_census: Le recensement n'a pas pu vérifier vos informations. Merci de confirmer que vos informations sont correctes en appelant la mairie ou en visitant n'importe quel %{offices}.
-        error_verifying_census_offices: Bureaux de conseil aux citoyens 
+        error_verifying_census_offices: Bureaux de conseil aux citoyens
         form_errors: ont empêché la vérification de votre résidence
         postal_code: Code postal
         postal_code_note: Pour vérifier votre compte, vous devez être enregistrés.
-        terms: les termes et conditions d'accès 
+        terms: les termes et conditions d'accès
         title: Vérifier la résidence
         verify_residence: Vérifier la résidence
     sms:
@@ -98,7 +98,7 @@ fr:
     step_3: Vérification finale
     user_permission_debates: Participer aux débats
     user_permission_info: En vérifiant votre compte vous pourrez...
-    user_permission_proposal: Créer de nouvelles propositions 
+    user_permission_proposal: Créer de nouvelles propositions
     user_permission_support_proposal: Soutenir des propositions
     user_permission_votes: Participer au vote final*
     verified_user:


### PR DESCRIPTION
What
====
Dealing with another issue I found myself with too much changes on french yml files.

Since I have [editorconfig](http://editorconfig.org) plugin on my editor, it did the trick by himself because of the [.editorconfig](https://github.com/consul/consul/blob/master/.editorconfig#L9) the project has

I didn't want to populate the other PR with this changes

How
===
Automagically™