### PR TITLE
Add Budget Investments filter by winners

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -3,7 +3,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
   feature_flag :budgets
 
   has_filters(%w{valuation_open without_admin managed valuating valuation_finished
-                 valuation_finished_feasible selected all},
+                 valuation_finished_feasible selected winners all},
               only: [:index, :toggle_selection])
 
   before_action :load_budget

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -49,6 +49,7 @@ class Budget
     scope :undecided,                   -> { where(feasibility: "undecided") }
     scope :with_supports,               -> { where('cached_votes_up > 0') }
     scope :selected,                    -> { feasible.where(selected: true) }
+    scope :winners,                     -> { selected.where(winner: true) }
     scope :unselected,                  -> { not_unfeasible.where(selected: false) }
     scope :last_week,                   -> { where("created_at >= ?", 7.days.ago)}
 

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -12,6 +12,7 @@
       <th><%= t("admin.budget_investments.index.table_feasibility") %></th>
       <th class="text-center"><%= t("admin.budget_investments.index.table_valuation_finished") %></th>
       <th class="text-center"><%= t("admin.budget_investments.index.table_selection") %></th>
+      <th class="text-center"><%= t("admin.budget_investments.index.table_winner") %></th>
     </tr>
   </thead>
 
@@ -73,6 +74,9 @@
             <%= t("admin.budget_investments.index.select") %>
           <% end %>
         <% end %>
+      </td>
+      <td class="small text-center">
+        <%= investment.winner? ? t('shared.yes'): t('shared.no') %>
       </td>
     </tr>
   <% end %>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -135,6 +135,7 @@ en:
         table_feasibility: "Feasibility"
         table_valuation_finished: "Val. Fin."
         table_selection: "Selection"
+        table_winner: "Winner"
       show:
         assigned_admin: Assigned administrator
         assigned_valuators: Assigned valuators

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -135,6 +135,7 @@ es:
         table_feasibility: "Viabilidad"
         table_valuation_finished: "Ev. Fin."
         table_selection: "Selección"
+        table_winner: "Ganadora"
       show:
         assigned_admin: Administrador asignado
         assigned_valuators: Evaluadores asignados

--- a/config/locales/admin.fr.yml
+++ b/config/locales/admin.fr.yml
@@ -135,6 +135,7 @@ fr:
         table_feasibility: "Faisabilité"
         table_valuation_finished: "Ev. Ter."
         table_selection: "Sélection"
+        table_winner: "Winner"
       show:
         assigned_admin: Administrateur assigné
         assigned_valuators: Évaluateur assigné

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -135,6 +135,7 @@ nl:
         table_feasibility: "Feasibility"
         table_valuation_finished: "Val. Fin."
         table_selection: "Selection"
+        table_winner: "Winner"
       show:
         assigned_admin: Assigned administrator
         assigned_valuators: Assigned valuators

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -291,6 +291,12 @@ FactoryGirl.define do
       selected true
       feasibility "feasible"
       valuation_finished true
+
+    end
+
+    trait :winner do
+      selected
+      winner true
     end
 
     trait :unselected do

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -463,6 +463,7 @@ feature 'Admin budget investments' do
     let!(:feasible_bi)    { create(:budget_investment, :feasible, budget: @budget, title: "Feasible project") }
     let!(:feasible_vf_bi) { create(:budget_investment, :feasible, :finished, budget: @budget, title: "Feasible, VF project") }
     let!(:selected_bi)    { create(:budget_investment, :selected, budget: @budget, title: "Selected project") }
+    let!(:winner_bi)      { create(:budget_investment, :winner, budget: @budget, title: "Winner project") }
 
     scenario "Filtering by valuation and selection" do
       visit admin_budget_budget_investments_path(@budget)
@@ -472,18 +473,28 @@ feature 'Admin budget investments' do
       expect(page).to_not have_content(feasible_bi.title)
       expect(page).to have_content(feasible_vf_bi.title)
       expect(page).to have_content(selected_bi.title)
+      expect(page).to have_content(winner_bi.title)
 
       within('#filter-subnav') { click_link 'Val. fin. Feasible' }
       expect(page).to_not have_content(unfeasible_bi.title)
       expect(page).to_not have_content(feasible_bi.title)
       expect(page).to have_content(feasible_vf_bi.title)
       expect(page).to have_content(selected_bi.title)
+      expect(page).to have_content(winner_bi.title)
 
       within('#filter-subnav') { click_link 'Selected' }
       expect(page).to_not have_content(unfeasible_bi.title)
       expect(page).to_not have_content(feasible_bi.title)
       expect(page).to_not have_content(feasible_vf_bi.title)
       expect(page).to have_content(selected_bi.title)
+      expect(page).to have_content(winner_bi.title)
+
+      within('#filter-subnav') { click_link 'Winners' }
+      expect(page).to_not have_content(unfeasible_bi.title)
+      expect(page).to_not have_content(feasible_bi.title)
+      expect(page).to_not have_content(feasible_vf_bi.title)
+      expect(page).to_not have_content(selected_bi.title)
+      expect(page).to have_content(winner_bi.title)
     end
 
     scenario "Showing the selection buttons", :js do
@@ -532,14 +543,14 @@ feature 'Admin budget investments' do
       visit admin_budget_budget_investments_path(@budget)
       within('#filter-subnav') { click_link 'Selected' }
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content('There are 2 investments')
 
       within("#budget_investment_#{selected_bi.id}") do
         click_link('Selected')
       end
 
       expect(page).to_not have_content(selected_bi.title)
-      expect(page).to have_content('investments cannot be found')
+      expect(page).to have_content('There is 1 investment')
 
       within('#filter-subnav') { click_link 'All' }
 


### PR DESCRIPTION
What
====
- Budget Investments list needed a filter to see the Winner ones, as well as a column with that value for other filters

How
===
- Adding a new winners scope on Budget::Investment model
- Adding a new filter on both controller and view for admin budget investments list
- Adding a Winner column on admin budget investments list with yes/no values

- Adding translations for all new labels

Screenshots
===========
### Budget Investments Winners filter:
![screen shot 2017-06-21 at 00 16 57](https://user-images.githubusercontent.com/983242/27361280-88b37584-5626-11e7-8452-bd488b2109df.jpg)

Test
====
- Increased the Budget spec test to cover the new 'Winners' filter in the Investments list

Deployment
==========
As usual

Warnings
========
None