### PR TITLE
Display Draft Version comments panel by default

### DIFF
--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -31,7 +31,7 @@
 
     </div>
 
-    <div class="row draft-allegation medium-collapse">
+    <div class="row draft-allegation medium-collapse comments-on">
       <div class="small-12 calc-index column <%= "js-toggle-allegations" unless @draft_version.final_version? %>">
         <div class="draft-panel">
           <div>

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -175,12 +175,14 @@ feature 'Legislation Draft Versions' do
       draft_version = create(:legislation_draft_version, :published)
       annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",       ranges: [{"start"=>"/p[1]", "startOffset"=>5, "end"=>"/p[1]", "endOffset"=>10}])
       annotation2 = create(:legislation_annotation, draft_version: draft_version, text: "my other annotation", ranges: [{"start"=>"/p[1]", "startOffset"=>12, "end"=>"/p[1]", "endOffset"=>19}])
+      comment = create(:comment, commentable: annotation1)
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
       expect(page).to have_css ".annotator-hl"
       first(:css, ".annotator-hl").click
       expect(page).to have_content "my annotation"
+      expect(page).to have_content comment.body
 
       all(".annotator-hl")[1].trigger('click')
       expect(page).to have_content "my other annotation"


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/1590

What
====
- Always open comments panel on Draft Version view, hidding table of contents side

How
===
- Just adding a `comments-on` class :D

Screenshots
===========
![screen shot 2017-06-21 at 02 33 33](https://user-images.githubusercontent.com/983242/27362227-32769d8e-562d-11e7-9627-4f3c22428bd9.jpg)

Test
====
Increased the draft version feature spec to expect the comment body to be visible on draft version view visit

Deployment
==========
As usual

Warnings
========
None