### PR TITLE
Removes unused validation

### DIFF
--- a/app/assets/javascripts/registration_form.js.coffee
+++ b/app/assets/javascripts/registration_form.js.coffee
@@ -9,7 +9,7 @@ App.RegistrationForm =
       $("small").remove()
 
     showUsernameMessage = (response) ->
-      klass = if response.available then "error no-error" else "error error"
+      klass = if response.available then "no-error" else "error"
       usernameInput.after $("<small class=\"#{klass}\" style=\"margin-top: -16px;\">#{response.message}</small>")
 
     validateUsername = (username) ->

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,9 +42,6 @@ class User < ActiveRecord::Base
   validates :official_level, inclusion: {in: 0..5}
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
 
-  validates :locale, inclusion: {in: I18n.available_locales.map(&:to_s),
-                                 allow_nil: true}
-
   validates_associated :organization, message: false
 
   accepts_nested_attributes_for :organization, update_only: true


### PR DESCRIPTION
Background
====
We saw an issue in the staging and production servers in Madrid preventing users from registering successfully. This locale validation was always returning false. We couldn't pinpoint the exact reason, but this validation is not needed anyways. 

What
====
Removes unnecessary locale validation for users

Bonus
====
Displays green text, instead of red text, when the chosen username is available.
This was a bug introduced recently.
