### PR TITLE
Improve proposal

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -806,7 +806,7 @@ form {
     }
   }
 
-  [type]:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]) {
+  [type]:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]):not(.close-button) {
     background: #f8f8f8;
     height: $line-height * 2;
     margin-bottom: rem-calc(16);
@@ -893,7 +893,7 @@ form {
 .callout {
   font-size: $small-font-size;
 
-  a {
+  a:not(.button) {
     font-weight: bold;
     text-decoration: underline;
   }
@@ -942,6 +942,14 @@ form {
 
   a {
     color: $color-alert;
+  }
+}
+
+.callout {
+
+  &.highlight,
+  &.light {
+    border: 0;
   }
 }
 

--- a/app/views/proposals/share.html.erb
+++ b/app/views/proposals/share.html.erb
@@ -12,35 +12,39 @@
 <% cache [locale_and_user_status(@proposal), @proposal, @proposal.author, Flag.flagged?(current_user, @proposal), @proposal_votes] do %>
   <div class="proposal-show">
     <div id="<%= dom_id(@proposal) %>" class="row">
-      <div class="small-12 medium-9 column">
+      <div class="small-12 medium-8 column">
 
         <h1><%= t("proposals.proposal.created") %></h1>
 
-        <h2><%= @proposal.title %></h2>
         <p>
-          <%= t("proposals.show.code") %>
-          <strong><%= @proposal.code %></strong>
+          <span class="lead"><%= t("proposals.proposal.share.guide") %></span><br>
+          <%= t("proposals.proposal.share.edit") %>
         </p>
-
-        <p><%= t("proposals.proposal.share.guide").html_safe %></p>
 
         <%= render partial: 'shared/social_share', locals: {
           title: @proposal.title,
           url: proposal_url(@proposal)
         } %>
 
-        <br/>
-
         <% if @proposal_improvement_path.present? %>
-        <p><%= t('proposals.proposal.improve_info', improve_info_link: link_to(t('proposals.proposal.improve_info_link'), @proposal_improvement_path)).html_safe %></p>
+          <div class="callout highlight margin-top text-center">
+            <p class="lead"><strong><%= t("proposals.proposal.improve_info") %></strong></p>
+            <%= link_to t("proposals.proposal.improve_info_link"), @proposal_improvement_path, class: "button" %>
+          </div>
         <% end %>
 
-        <p>
-        <%= link_to proposal_path(@proposal), class: 'proposal' do %>
-          <%= t("proposals.proposal.share.view_proposal") %>
-        <% end %>
-        </p>
+        <div class="small margin-bottom">
+          <%= link_to t("proposals.proposal.share.view_proposal"), proposal_path(@proposal) %>
+        </div>
+      </div>
 
+      <div class="small-12 medium-4 column">
+        <div class="callout light">
+          <p>
+            <strong><%= @proposal.title %></strong><br>
+            <%= t("proposals.show.code") %> <%= @proposal.code %>
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,12 +357,13 @@ en:
     notice:
       retired: Proposal retired
     proposal:
-      created: "You've created a new proposal!"
+      created: "You've created a proposal!"
       share:
-        guide: "Now you can share it through Twitter, Facebook, Google+, Telegram or Whatsapp (if you're using a mobile device) so people can start supporting.<br><br>Before it gets shared you'll be able to change the text as you like."
+        guide: "Now you can share it so people can start supporting."
+        edit: "Before it gets shared you'll be able to change the text as you like."
         view_proposal: Not now, go to my proposal
-      improve_info: "You can also %{improve_info_link} about improving your campaign"
-      improve_info_link: see more information
+      improve_info: "Improve your campaign and get more supports"
+      improve_info_link: "See more information"
       already_supported: You have already supported this proposal. Share it!
       comments:
         one: 1 comment

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -357,12 +357,13 @@ es:
     notice:
       retired: Propuesta retirada
     proposal:
-      created: "¡Has creado una nueva propuesta!"
+      created: "¡Has creado una propuesta!"
       share:
-        guide: "Ahora puedes compartirla en Twitter, Facebook, Google+, Telegram o Whatsapp (si utilizas un dispositivo móvil) para que la gente empieze a apoyarla.<br><br>Antes de que se publique el texto en las redes sociales podrás modificarlo a tu gusto"
-        view_proposal: "Ahora no, ver mi propuesta"
-      improve_info: "También puedes %{improve_info_link} de como mejorar tu campaña"
-      improve_info_link: ver más información
+        guide: "Compártela para que la gente empieze a apoyarla."
+        edit: "Antes de que se publique podrás modificar el texto a tu gusto."
+        view_proposal: "Ahora no, ir a mi propuesta"
+      improve_info: "Mejora tu campaña y consigue más apoyos"
+      improve_info_link: "Ver más información"
       already_supported: "¡Ya has apoyado esta propuesta, compártela!"
       comments:
         one: 1 Comentario

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -175,7 +175,7 @@ feature 'Proposals' do
     click_button 'Create proposal'
 
     expect(page).to have_content 'Proposal created successfully.'
-    expect(page).to have_content 'You can also see more information about improving your campaign'
+    expect(page).to have_content 'Improve your campaign and get more supports'
 
     click_link 'Not now, go to my proposal'
 


### PR DESCRIPTION
What
====
Improves styles and texts of page to share proposal after creating.

Screenshots
===========

This is the page `before`:

<img width="930" alt="before" src="https://user-images.githubusercontent.com/631897/27489989-de15659c-583c-11e7-967c-be0dcdd59712.png">

This is the page `after`:
(More clean, legible and highlight the improve proposal action)

<img width="1208" alt="after" src="https://user-images.githubusercontent.com/631897/27489981-d865aea4-583c-11e7-9832-f4c51b902c92.png">


Note
====

This PR also fixed a global style to all `close-button` on form error messages.
