### PR TITLE
Annotation on legislation

### DIFF
--- a/app/assets/stylesheets/annotator_overrides.scss
+++ b/app/assets/stylesheets/annotator_overrides.scss
@@ -105,23 +105,43 @@
   background: rgba(255, 249, 218, 0.75);
 
   &.weight-1 {
-    background: #fff9da;
+    background: hsla(50, 100, 93, 0.5);
+
+    .weight-1 {
+      background: hsla(50, 100, 93, 0.75);
+    }
   }
 
   &.weight-2 {
-    background: #f4f7be;
+    background: hsla(63, 78, 86, 0.5);
+
+    .weight-2 {
+      background: hsla(63, 78, 86, 0.75);
+    }
   }
 
   &.weight-3 {
-    background: #fff5b2;
+    background: hsla(52, 100, 85, 0.5);
+
+    .weight-3 {
+      background: hsla(52, 100, 85, 0.75);
+    }
   }
 
   &.weight-4 {
-    background: #f9e784;
+    background: hsla(51, 91, 75, 0.5);
+
+    .weight-4 {
+     background: hsla(51, 91, 75, 0.75);
+    }
   }
 
   &.weight-5 {
-    background: #eec643;
+    background: hsla(46, 83, 60, 0.5);
+
+    .weight-5 {
+      background: hsla(46, 83, 60, 0.5);
+    }
   }
 }
 

--- a/app/assets/stylesheets/annotator_overrides.scss
+++ b/app/assets/stylesheets/annotator_overrides.scss
@@ -102,27 +102,27 @@
 
 .annotator-hl {
   cursor: pointer;
-  background: rgba(255, 255, 10, 0.2);
-}
+  background: rgba(255, 249, 218, 0.75);
 
-.annotator-hl.weight-1 {
-  background: #fff9da;
-}
+  &.weight-1 {
+    background: #fff9da;
+  }
 
-.annotator-hl.weight-2 {
-  background: #fff5bc;
-}
+  &.weight-2 {
+    background: #f4f7be;
+  }
 
-.annotator-hl.weight-3 {
-  background: #fff1a2;
-}
+  &.weight-3 {
+    background: #fff5b2;
+  }
 
-.annotator-hl.weight-4 {
-  background: #ffef8c;
-}
+  &.weight-4 {
+    background: #f9e784;
+  }
 
-.annotator-hl.weight-5 {
-  background: #ffe95f;
+  &.weight-5 {
+    background: #eec643;
+  }
 }
 
 .current-annotation {

--- a/app/views/legislation/annotations/_form.html.erb
+++ b/app/views/legislation/annotations/_form.html.erb
@@ -16,9 +16,7 @@
 
           <div class="comment-actions">
             <a class="cancel-comment" href="#" data-cancel-annotation><%= t('legislation.annotations.comments.cancel') %></a>
-            <%= f.submit class: 'button publish-comment' do %>
-              <strong><%= t('legislation.annotations.comments.publish_comment') %></strong>
-            <% end %>
+            <%= f.submit value: t('legislation.annotations.comments.publish_comment'), class: 'button publish-comment' %>
           </div>
 
           <%= f.hidden_field :quote %>

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -154,11 +154,11 @@ feature 'Legislation Draft Versions' do
 
       page.find(:css, ".legislation-annotatable").double_click
       page.find(:css, ".annotator-adder button").click
-      page.click_button "Create Annotation"
+      page.click_button "Publish Comment"
       expect(page).to have_content "Comment can't be blank"
 
       fill_in 'legislation_annotation_text', with: 'this is my annotation'
-      page.click_button "Create Annotation"
+      page.click_button "Publish Comment"
 
       expect(page).to have_css ".annotator-hl"
       first(:css, ".annotator-hl").click


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1585 

What
====
- This PR improves the color palette commented on #1585. Also fixes a publish comment button text.

How
===
- I create a new palette of colors. Finally I used HEX colors instead of HSLA because every browser interprets the colors a little bit different:

![color_palette](https://user-images.githubusercontent.com/631897/27633481-b4d8ef3e-5bff-11e7-8464-6dacf5d27c75.png)

Pending to do
===========
- The main problem are not the colors. Is the implementation of JS. The problem is the nesting of `weight-N` classes, for example: 

**You annotate over a text already annotated:**

<img width="196" alt="screen shot 2017-06-28 at 12 38 09" src="https://user-images.githubusercontent.com/631897/27633515-ddc708d6-5bff-11e7-9ad6-b351b31100c9.png">

**This is the HTML code generated:**

<img width="557" alt="screen shot 2017-06-28 at 12 38 24" src="https://user-images.githubusercontent.com/631897/27633525-e6fdb4e0-5bff-11e7-9d5c-b43b50850003.png">

**A `weight-2` inside of another `weight-2` doesn't work at all.** 😔
**The correct situation would be if the new annotation maintain `weight-2` class and is deleted from his parent:**

<img width="566" alt="screen shot 2017-06-28 at 12 39 02" src="https://user-images.githubusercontent.com/631897/27633595-2170c130-5c00-11e7-8ffa-7bd69c4dd311.png">

**So the result would be OK:** 👍🏻

<img width="168" alt="screen shot 2017-06-28 at 12 39 08" src="https://user-images.githubusercontent.com/631897/27633603-2c322bf4-5c00-11e7-8fe4-bc3d36df0eb1.png">




