### PR TITLE
Issue#1674 enabled legislation process

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -49,7 +49,8 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         :debate_phase_enabled,
         :allegations_phase_enabled,
         :draft_publication_enabled,
-        :result_publication_enabled
+        :result_publication_enabled,
+        :published
       )
     end
 end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -13,14 +13,13 @@ class Legislation::ProcessesController < Legislation::BaseController
     if @process.allegations_phase.enabled? && @process.allegations_phase.started? && draft_version.present?
       redirect_to legislation_process_draft_version_path(@process, draft_version)
     elsif @process.debate_phase.enabled?
-      redirect_to legislation_process_debate_path(@process)
+      redirect_to debate_legislation_process_path(@process)
     else
-      redirect_to legislation_process_allegations_path(@process)
+      redirect_to allegations_legislation_process_path(@process)
     end
   end
 
   def debate
-    set_process
     @phase = :debate_phase
 
     if @process.debate_phase.started?
@@ -31,7 +30,6 @@ class Legislation::ProcessesController < Legislation::BaseController
   end
 
   def draft_publication
-    set_process
     @phase = :draft_publication
 
     if @process.draft_publication.started?
@@ -48,7 +46,6 @@ class Legislation::ProcessesController < Legislation::BaseController
   end
 
   def allegations
-    set_process
     @phase = :allegations_phase
 
     if @process.allegations_phase.started?
@@ -65,7 +62,6 @@ class Legislation::ProcessesController < Legislation::BaseController
   end
 
   def result_publication
-    set_process
     @phase = :result_publication
 
     if @process.result_publication.started?
@@ -81,9 +77,5 @@ class Legislation::ProcessesController < Legislation::BaseController
     end
   end
 
-  private
 
-    def set_process
-      @process = ::Legislation::Process.find(params[:process_id])
-    end
 end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -4,7 +4,7 @@ class Legislation::ProcessesController < Legislation::BaseController
 
   def index
     @current_filter ||= 'open'
-    @processes = ::Legislation::Process.send(@current_filter).page(params[:page])
+    @processes = ::Legislation::Process.send(@current_filter).published.page(params[:page])
   end
 
   def show

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -19,7 +19,7 @@ module Abilities
       can [:read, :print], Budget::Investment
       can :read_results, Budget, phase: "finished"
       can :new, DirectMessage
-      can [:read, :debate, :draft_publication, :allegations, :result_publication], Legislation::Process
+      can [:read, :debate, :draft_publication, :allegations, :result_publication], Legislation::Process, published: true
       can [:read, :changes, :go_to_version], Legislation::DraftVersion
       can [:read], Legislation::Question
       can [:create], Legislation::Answer

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -21,6 +21,8 @@ class Legislation::Process < ActiveRecord::Base
   scope :next, -> { where("start_date > ?", Date.current).order('id DESC') }
   scope :past, -> { where("end_date < ?", Date.current).order('id DESC') }
 
+  scope :published, -> { where(published: true) }
+
   def debate_phase
     Legislation::Process::Phase.new(debate_start_date, debate_end_date, debate_phase_enabled)
   end

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -39,6 +39,9 @@
                         class: "js-calendar-full",
                         id: "end_date" %>
     </div>
+    <div class="small-12 medium-2 column">
+      <%= f.check_box :published, checked: @process.published?, label: t('admin.legislation.processes.form.enabled') %>
+    </div>
 
     <div class="small-12 column">
       <hr>

--- a/app/views/legislation/processes/_key_dates.html.erb
+++ b/app/views/legislation/processes/_key_dates.html.erb
@@ -9,7 +9,7 @@
     <ul>
       <% if process.debate_phase.enabled? %>
         <li <%= "class=active" if phase == :debate_phase %>>
-          <%= link_to legislation_process_debate_path(process) do %>
+          <%= link_to debate_legislation_process_path(process) do %>
             <h4><%= t('legislation.processes.shared.debate_dates') %></h4>
             <p><%= format_date(process.debate_start_date) %> - <%= format_date(process.debate_end_date) %></p>
           <% end %>
@@ -18,7 +18,7 @@
 
       <% if process.draft_publication.enabled? %>
         <li <%= "class=active" if phase == :draft_publication %>>
-          <%= link_to legislation_process_draft_publication_path(process) do %>
+          <%= link_to draft_publication_legislation_process_path(process) do %>
             <h4><%= t('legislation.processes.shared.draft_publication_date') %></h4>
             <p><%= format_date(process.draft_publication_date) %></p>
           <% end %>
@@ -27,7 +27,7 @@
 
       <% if process.allegations_phase.enabled? %>
         <li <%= "class=active" if phase == :allegations_phase %>>
-          <%= link_to legislation_process_allegations_path(process) do %>
+          <%= link_to allegations_legislation_process_path(process) do %>
             <h4><%= t('legislation.processes.shared.allegations_dates') %></h4>
             <p><%= format_date(process.allegations_start_date) %> - <%= format_date(process.allegations_end_date) %></p>
           <% end %>
@@ -36,7 +36,7 @@
 
       <% if process.result_publication.enabled? %>
         <li <%= "class=active" if phase == :result_publication %>>
-          <%= link_to legislation_process_result_publication_path(process) do %>
+          <%= link_to result_publication_legislation_process_path(process) do %>
             <h4><%= t('legislation.processes.shared.result_publication_date') %></h4>
             <p><%= format_date(process.result_publication_date) %></p>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,10 +109,12 @@ Rails.application.routes.draw do
 
   namespace :legislation do
     resources :processes, only: [:index, :show] do
-      get :debate
-      get :draft_publication
-      get :allegations
-      get :result_publication
+      member do
+        get :debate
+        get :draft_publication
+        get :allegations
+        get :result_publication
+      end
       resources :questions, only: [:show] do
         resources :answers, only: [:create]
       end

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -651,7 +651,8 @@ print "Creating legislation processes"
                                            debate_phase_enabled: true,
                                            allegations_phase_enabled: true,
                                            draft_publication_enabled: true,
-                                           result_publication_enabled: true
+                                           result_publication_enabled: true,
+                                           published: true
   )
 end
 

--- a/db/migrate/20170626081337_add_published_to_legislation_processes.rb
+++ b/db/migrate/20170626081337_add_published_to_legislation_processes.rb
@@ -1,0 +1,5 @@
+class AddPublishedToLegislationProcesses < ActiveRecord::Migration
+  def change
+    add_column :legislation_processes, :published, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170623141655) do
+ActiveRecord::Schema.define(version: 20170626081337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -429,6 +429,7 @@ ActiveRecord::Schema.define(version: 20170623141655) do
     t.boolean  "allegations_phase_enabled",  default: false
     t.boolean  "draft_publication_enabled",  default: false
     t.boolean  "result_publication_enabled", default: false
+    t.boolean  "published",                  default: true
   end
 
   add_index "legislation_processes", ["allegations_end_date"], name: "index_legislation_processes_on_allegations_end_date", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -629,6 +629,7 @@ FactoryGirl.define do
     allegations_phase_enabled true
     draft_publication_enabled true
     result_publication_enabled true
+    published true
 
     trait :next do
       start_date Date.current + 2.days
@@ -662,6 +663,11 @@ FactoryGirl.define do
       allegations_end_date Date.current + 3.days
       result_publication_date Date.current + 5.days
     end
+
+    trait :not_published do
+      published false
+    end
+
   end
 
   factory :legislation_draft_version, class: 'Legislation::DraftVersion' do

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -88,6 +88,7 @@ feature 'Admin legislation processes' do
 
       expect(page).to have_selector("h2", text: "An example legislation process")
       expect(find("#legislation_process_debate_phase_enabled")).to be_checked
+      expect(find("#legislation_process_published")).to be_checked
 
       fill_in 'legislation_process_summary', with: ''
       click_button "Save changes"

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -70,7 +70,7 @@ feature 'Legislation' do
       scenario 'not open' do
         process = create(:legislation_process, draft_publication_date: Date.current + 1.day)
 
-        visit legislation_process_draft_publication_path(process)
+        visit draft_publication_legislation_process_path(process)
 
         expect(page).to have_content("This phase is not open yet")
       end
@@ -78,7 +78,7 @@ feature 'Legislation' do
       scenario 'open' do
         process = create(:legislation_process, draft_publication_date: Date.current)
 
-        visit legislation_process_draft_publication_path(process)
+        visit draft_publication_legislation_process_path(process)
 
         expect(page).to have_content("Nothing published yet")
       end
@@ -88,7 +88,7 @@ feature 'Legislation' do
       scenario 'not open' do
         process = create(:legislation_process, allegations_start_date: Date.current + 1.day, allegations_end_date: Date.current + 2.days)
 
-        visit legislation_process_allegations_path(process)
+        visit allegations_legislation_process_path(process)
 
         expect(page).to have_content("This phase is not open yet")
       end
@@ -96,7 +96,7 @@ feature 'Legislation' do
       scenario 'open' do
         process = create(:legislation_process, allegations_start_date: Date.current - 1.day, allegations_end_date: Date.current + 2.days)
 
-        visit legislation_process_allegations_path(process)
+        visit allegations_legislation_process_path(process)
 
         expect(page).to have_content("Nothing published yet")
       end
@@ -106,7 +106,7 @@ feature 'Legislation' do
       scenario 'not open' do
         process = create(:legislation_process, result_publication_date: Date.current + 1.day)
 
-        visit legislation_process_result_publication_path(process)
+        visit result_publication_legislation_process_path(process)
 
         expect(page).to have_content("This phase is not open yet")
       end
@@ -114,7 +114,7 @@ feature 'Legislation' do
       scenario 'open' do
         process = create(:legislation_process, result_publication_date: Date.current)
 
-        visit legislation_process_result_publication_path(process)
+        visit result_publication_legislation_process_path(process)
 
         expect(page).to have_content("Nothing published yet")
       end

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -2,6 +2,27 @@ require 'rails_helper'
 
 feature 'Legislation' do
 
+  let!(:administrator) { create(:administrator).user }
+  shared_examples "not published permissions" do |path|
+
+    let(:not_published_process) { create(:legislation_process, :not_published, title: "Process not published") }
+    let!(:not_permission_message) { "You do not have permission to carry out the action" }
+
+    it "is forbidden for a normal user" do
+      visit send(path, not_published_process)
+
+      expect(page).to have_content not_permission_message
+      expect(page).to_not have_content("Process not published")
+    end
+
+    it "is available for an administrator user" do
+      login_as(administrator)
+      visit send(path, not_published_process)
+
+      expect(page).to have_content("Process not published")
+    end
+  end
+
   context 'processes home page' do
 
     scenario 'Processes can be listed' do
@@ -45,9 +66,57 @@ feature 'Legislation' do
       expect(page).to_not have_content('Process next')
       expect(page).to have_content('Process past')
     end
+
+    context "not published processes" do
+      before do
+        create(:legislation_process, title: "published")
+        create(:legislation_process, :not_published, title: "not published")
+        [:next, :past].each do |trait|
+          create(:legislation_process, trait, title: "#{trait} published")
+          create(:legislation_process, :not_published, trait, title: "#{trait} not published")
+        end
+      end
+
+      it "aren't listed" do
+        visit legislation_processes_path
+        expect(page).to_not have_content('not published')
+        expect(page).to have_content('published')
+
+        login_as(administrator)
+        visit legislation_processes_path
+        expect(page).to_not have_content('not published')
+        expect(page).to have_content('published')
+      end
+
+      it "aren't listed with next filter" do
+        visit legislation_processes_path(filter: 'next')
+        expect(page).to_not have_content('not published')
+        expect(page).to have_content('next published')
+
+        login_as(administrator)
+        visit legislation_processes_path(filter: 'next')
+        expect(page).to_not have_content('not published')
+        expect(page).to have_content('next published')
+      end
+
+      it "aren't listed with past filter" do
+        visit legislation_processes_path(filter: 'past')
+        expect(page).to_not have_content('not published')
+        expect(page).to have_content('past published')
+
+        login_as(administrator)
+        visit legislation_processes_path(filter: 'past')
+        expect(page).to_not have_content('not published')
+        expect(page).to have_content('past published')
+      end
+    end
   end
 
   context 'process page' do
+    context "show" do
+      include_examples "not published permissions", :legislation_process_path
+    end
+
     context 'debate phase' do
       scenario 'not open' do
         process = create(:legislation_process, debate_start_date: Date.current + 1.day, debate_end_date: Date.current + 2.days)
@@ -64,6 +133,8 @@ feature 'Legislation' do
 
         expect(page).to have_content("Participate in the debate")
       end
+
+      include_examples "not published permissions", :debate_legislation_process_path
     end
 
     context 'draft publication phase' do
@@ -82,6 +153,8 @@ feature 'Legislation' do
 
         expect(page).to have_content("Nothing published yet")
       end
+
+      include_examples "not published permissions", :draft_publication_legislation_process_path
     end
 
     context 'allegations phase' do
@@ -100,6 +173,8 @@ feature 'Legislation' do
 
         expect(page).to have_content("Nothing published yet")
       end
+
+      include_examples "not published permissions", :allegations_legislation_process_path
     end
 
     context 'final version publication phase' do
@@ -118,6 +193,8 @@ feature 'Legislation' do
 
         expect(page).to have_content("Nothing published yet")
       end
+
+      include_examples "not published permissions", :result_publication_legislation_process_path
     end
   end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1674

What
====
- Add a new column `published` to `Legislation::Process` associated table.
- Allow administrators set this attribute from `admin/legislation/processes` section.
- A not published process should be hidden from lists in `legislation/processes` for all filters.
- Also a not published process should be inaccessible to any user which is not administrator, through any of the actions of the processes controller.

How
===
- I've added a column `published` to `legislation_processes` table, and a scope `published` to associated model. By default this value is `true`. In this way, visibility of previously created legislation processes will be preserved.
- This scope has been used in the query to set `@processes` in the `#index` action of  `legislation/processes`.
- A checkbox has been added in the admin part to set published status.
- `debate`,  `draft_publication`, `allegations` and `result_publication` has been defined in routes as member actions of processes.
- Last actions and read permissions has been changed in `Everyone` abilities to permit only published processes.

Screenshots
===========
`admin/legislation/processes/new`
![image](https://user-images.githubusercontent.com/446459/27739853-520e9de2-5db0-11e7-816d-798eb8099521.png)

Test
====
- Some test where added to cover visibility of not published processes and verify the presence of published checkbox in admin edition part. 

Deployment
==========
- Don't forget to run migrations!

Warnings
========
none
