### PR TITLE
Avoid set_process on legislation/processes controller member actions

### DIFF
--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -83,7 +83,12 @@ class Legislation::ProcessesController < Legislation::BaseController
 
   private
 
+    def member_method?
+      params[:id].present?
+    end
+
     def set_process
+      return if member_method?
       @process = ::Legislation::Process.find(params[:process_id])
     end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1674
* **Related PR's:** #1714

What
====
Some test doesn't pass because in legislation/processes a [`set_process`](https://github.com/consul/consul/blob/d31e0ed79be3dd239d479c55ad8af921a4bb9010/app/controllers/legislation/processes_controller.rb#L86-L88) method can't set a `@process`because the actions calling it has a param `:id` instead of `:process_id:, since they are defined as member actions.

Different forks of consul works with that because they haven't changed yet the actions to be member actions.

How
===
I've made a change expected to be compatible with all forks. In `set_process` is previously checked if there is an `:id`param available. If so `set_process` do nothing and returns.

Warnings
=======
This is a temporary solution. May the commit 3e5c5d7 should be reverted or merged manually in the other forks by:

- defining `debate`, `draft_publication`, `allegations` and `result_publication` are as member actions in routes.
- replacing all path helper methods:
  - `legislation_process_debate_path` with `debate_legislation_process_path`
  - `legislation_process_draft_publication_path` with `draft_publication_legislation_process_path`
  - `legislation_process_allegations_path` with `allegations_legislation_process_path`
  - `legislation_process_result_publication_path` with `result_publication_legislation_process_path`

