### PR TITLE
Add investment selected checbox & improve view

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -51,7 +51,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
     def budget_investment_params
       params.require(:budget_investment)
-            .permit(:title, :description, :external_url, :heading_id, :administrator_id, :valuation_tag_list, :incompatible, valuator_ids: [])
+            .permit(:title, :description, :external_url, :heading_id, :administrator_id, :valuation_tag_list, :incompatible,
+                    :selected, valuator_ids: [])
     end
 
     def load_budget

--- a/app/views/admin/budget_investments/_written_by_author.html.erb
+++ b/app/views/admin/budget_investments/_written_by_author.html.erb
@@ -6,27 +6,49 @@
 <h1 class="inline-block"><%= @investment.title %></h1>
 
 <div class="row small-collapse spending-proposal-info">
-  <div class="small-12 medium-4 column">
-    <p title="<%= t("admin.budget_investments.show.group") %>: <%= @investment.group.name %>">
-      <strong><%= t("admin.budget_investments.show.heading") %>:</strong>
-      <%= @investment.heading.name %>
-    </p>
+  <div class="row">
+    <div class="small-12 medium-4 column">
+      <p title="<%= t("admin.budget_investments.show.group") %>: <%= @investment.group.name %>">
+        <strong><%= t("admin.budget_investments.show.heading") %>:</strong>
+        <%= @investment.heading.name %>
+      </p>
+    </div>
+
+    <div class="small-12 medium-4 column">
+      <p>
+        <strong><%= t("admin.budget_investments.show.by") %>:</strong>
+        <%= link_to @investment.author.name, admin_hidden_user_path(@investment.author) %>
+      </p>
+    </div>
+
+    <div class="small-12 medium-4 column">
+      <p>
+        <strong><%= t("admin.budget_investments.show.sent") %>:</strong>
+        <%= l @investment.created_at, format: :datetime %>
+      </p>
+    </div>
   </div>
 
-  <div class="small-12 medium-4 column">
-    <p>
-      <strong><%= t("admin.budget_investments.show.by") %>:</strong>
-      <%= link_to @investment.author.name, admin_hidden_user_path(@investment.author) %>
-    </p>
+  <div class="row">
+    <div class="small-12 medium-4 column">
+      <p>
+        <strong><%= t("admin.budget_investments.show.compatibility.title") %>:</strong>
+        <%= t("admin.budget_investments.show.compatibility.#{@investment.incompatible?}") %>
+      </p>
+    </div>
+    <div class="small-12 medium-4 column">
+      <p>
+        <strong><%= t("admin.budget_investments.show.selection.title") %>:</strong>
+        <%= t("admin.budget_investments.show.selection.#{@investment.selected?}") %>
+      </p>
+    </div>
+    <div class="small-12 medium-4 column">
+      <p>
+        <strong><%= t("admin.budget_investments.show.winner.title") %>:</strong>
+        <%= t("admin.budget_investments.show.winner.#{@investment.winner?}") %>
+      </p>
+    </div>
   </div>
-
-  <div class="small-12 medium-4 column">
-    <p>
-      <strong><%= t("admin.budget_investments.show.sent") %>:</strong>
-      <%= l @investment.created_at, format: :datetime %>
-    </p>
-  </div>
-
 </div>
 
 <% if @investment.external_url.present? %>

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -61,13 +61,20 @@
     </div>
   </div>
 
-  <h2 id="incompatible"><%= t("admin.budget_investments.edit.compatibility") %></h2>
 
-  <div class="row">
-    <div class="small-12 medium-8 column">
+  <div class="row margin-top">
+    <div class="small-12 medium-3 column">
+      <h2 id="incompatible"><%= t("admin.budget_investments.edit.compatibility") %></h2>
       <%= f.label :incompatible do %>
         <%= f.check_box :incompatible, title: t('admin.budget_investments.edit.compatibility'), label: false %>
         <span class="checkbox"><%= t("admin.budget_investments.edit.mark_as_incompatible") %></span>
+      <% end %>
+    </div>
+    <div class="small-12 medium-3 column float-left">
+      <h2 id="selected"><%= t("admin.budget_investments.edit.selection") %></h2>
+      <%= f.label :selected do %>
+        <%= f.check_box :selected, title: t('admin.budget_investments.edit.selection'), label: false %>
+        <span class="checkbox"><%= t("admin.budget_investments.edit.mark_as_selected") %></span>
       <% end %>
     </div>
   </div>

--- a/app/views/admin/budget_investments/show.html.erb
+++ b/app/views/admin/budget_investments/show.html.erb
@@ -56,8 +56,3 @@
 <p>
   <%= link_to t("admin.budget_investments.show.new_milestone"), new_admin_budget_budget_investment_budget_investment_milestone_path(@budget, @investment) %>
 </p>
-
-<h2 id="incompatible"><%= t("admin.budget_investments.show.compatibility.title") %></h2>
-<p id="incompatible">
-  <%= t("admin.budget_investments.show.compatibility.#{@investment.incompatible?}") %>
-</p>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -166,7 +166,9 @@ en:
       edit:
         classification: Clasification
         compatibility: Compatibility
-        mark_as_incompatible: Mark this investement project as incompatible
+        mark_as_incompatible: Mark as incompatible
+        selection: Selection
+        mark_as_selected: Mark as selected
         assigned_valuators: Valuators
         select_heading: Select heading
         submit_button: Update

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -163,6 +163,14 @@ en:
           title: Compatibility
           "true": Incompatible
           "false": Compatible
+        selection:
+          title: Selection
+          "true": Selected
+          "false": Not selected
+        winner:
+          title: Winner
+          "true": "Yes"
+          "false": "No"
       edit:
         classification: Clasification
         compatibility: Compatibility

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -166,7 +166,9 @@ es:
       edit:
         classification: Clasificación
         compatibility: Compatibilidad
-        mark_as_incompatible: Marcar esta propuesta de inversión como incompatible
+        mark_as_incompatible: Marcar como incompatible
+        selected: Selección
+        mark_as_selected: Marcar como seleccionado
         assigned_valuators: Evaluadores
         select_heading: Seleccionar partida
         submit_button: Actualizar

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -163,11 +163,19 @@ es:
           title: Compatibilidad
           "true": Incompatible
           "false": Compatible
+        selection:
+          title: Selección
+          "true": Seleccionado
+          "false": No seleccionado
+        winner:
+          title: Ganador
+          "true": "Si"
+          "false": "No"
       edit:
         classification: Clasificación
         compatibility: Compatibilidad
         mark_as_incompatible: Marcar como incompatible
-        selected: Selección
+        selection: Selección
         mark_as_selected: Marcar como seleccionado
         assigned_valuators: Evaluadores
         select_heading: Seleccionar partida

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -312,7 +312,7 @@ feature 'Admin budget investments' do
   context "Edit" do
 
     scenario "Change title, incompatible, description or heading" do
-      budget_investment = create(:budget_investment)
+      budget_investment = create(:budget_investment, :selected)
       create(:budget_heading, group: budget_investment.group, name: "Barbate")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -322,6 +322,7 @@ feature 'Admin budget investments' do
       fill_in 'budget_investment_description', with: 'Carrots'
       select "#{budget_investment.group.name}: Barbate", from: 'budget_investment[heading_id]'
       check "budget_investment_incompatible"
+      check "budget_investment_selected"
 
       click_button 'Update'
 
@@ -329,6 +330,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content 'Carrots'
       expect(page).to have_content 'Barbate'
       expect(page).to have_content 'Incompatible'
+      expect(page).to have_content 'Selected'
     end
 
     scenario "Add administrator" do


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/1723

What
====
- Admins need to easily mark/unmark an investment as selected on the edit form

- As a bonus: Improving the investment detail page with winner/compatible/selected flags

How
===
- Adding a checkbox on admin investment form for selected flag near the existing one for Compatibility

- Adding another row of info on top of admin investment view with Winner / Compatibility / Selection flags to easy access that info.
 
Screenshots
===========
### New Selection checkbox at the bottom of the form:
![screen shot 2017-07-04 at 23 34 56](https://user-images.githubusercontent.com/983242/27843435-b3512410-6113-11e7-9494-1506df2bdb56.jpg)

### New info row with winner / compatibility / selection flags output:
![screen shot 2017-07-04 at 23 45 02](https://user-images.githubusercontent.com/983242/27843436-b3558ee2-6113-11e7-812a-0a0c5d31f727.jpg)

Test
====
- Increased the edit scenario to cover the new checkbox on the admin budget investment feature 

Deployment
==========
- As usual, tell Miguel Arana when it gets to Madrid's fork, he was interested on this one.

Warnings
========
None