### PR TITLE
Rubocop 🤖  The LineLength Truncation ⚡️

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -351,12 +351,6 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 10
 
-# Offense count: 171
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
-# URISchemes: http, https
-Metrics/LineLength:
-  Max: 2542
-
 # Offense count: 53
 # Configuration parameters: CountComments.
 Metrics/MethodLength:

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -23,9 +23,11 @@ class AccountController < ApplicationController
 
     def account_params
       if @account.organization?
-        params.require(:account).permit(:phone_number, :email_on_comment, :email_on_comment_reply, :newsletter, organization_attributes: [:name, :responsible_name])
+        params.require(:account).permit(:phone_number, :email_on_comment, :email_on_comment_reply, :newsletter,
+                                        organization_attributes: [:name, :responsible_name])
       else
-        params.require(:account).permit(:username, :public_activity, :email_on_comment, :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter, :official_position_badge)
+        params.require(:account).permit(:username, :public_activity, :email_on_comment, :email_on_comment_reply,
+                                        :email_on_direct_message, :email_digest, :newsletter, :official_position_badge)
       end
     end
 

--- a/app/controllers/admin/legislation/draft_versions_controller.rb
+++ b/app/controllers/admin/legislation/draft_versions_controller.rb
@@ -8,7 +8,8 @@ class Admin::Legislation::DraftVersionsController < Admin::Legislation::BaseCont
 
   def create
     if @draft_version.save
-      redirect_to admin_legislation_process_draft_versions_path, notice: t('admin.legislation.draft_versions.create.notice', link: legislation_process_draft_version_path(@process, @draft_version).html_safe)
+      link = legislation_process_draft_version_path(@process, @draft_version).html_safe
+      redirect_to admin_legislation_process_draft_versions_path, notice: t('admin.legislation.draft_versions.create.notice', link: link)
     else
       flash.now[:error] = t('admin.legislation.draft_versions.create.error')
       render :new
@@ -17,7 +18,9 @@ class Admin::Legislation::DraftVersionsController < Admin::Legislation::BaseCont
 
   def update
     if @draft_version.update(draft_version_params)
-      redirect_to edit_admin_legislation_process_draft_version_path(@process, @draft_version), notice: t('admin.legislation.draft_versions.update.notice', link: legislation_process_draft_version_path(@process, @draft_version).html_safe)
+      link = legislation_process_draft_version_path(@process, @draft_version).html_safe
+      notice = t('admin.legislation.draft_versions.update.notice', link: link)
+      redirect_to edit_admin_legislation_process_draft_version_path(@process, @draft_version), notice: notice
     else
       flash.now[:error] = t('admin.legislation.draft_versions.update.error')
       render :edit

--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -9,7 +9,8 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
 
   def create
     if @process.save
-      redirect_to edit_admin_legislation_process_path(@process), notice: t('admin.legislation.processes.create.notice', link: legislation_process_path(@process).html_safe)
+      link = legislation_process_path(@process).html_safe
+      redirect_to edit_admin_legislation_process_path(@process), notice: t('admin.legislation.processes.create.notice', link: link)
     else
       flash.now[:error] = t('admin.legislation.processes.create.error')
       render :new
@@ -18,7 +19,8 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
 
   def update
     if @process.update(process_params)
-      redirect_to edit_admin_legislation_process_path(@process), notice: t('admin.legislation.processes.update.notice', link: legislation_process_path(@process).html_safe)
+      link = legislation_process_path(@process).html_safe
+      redirect_to edit_admin_legislation_process_path(@process), notice: t('admin.legislation.processes.update.notice', link: link)
     else
       flash.now[:error] = t('admin.legislation.processes.update.error')
       render :edit

--- a/app/controllers/admin/legislation/questions_controller.rb
+++ b/app/controllers/admin/legislation/questions_controller.rb
@@ -13,7 +13,8 @@ class Admin::Legislation::QuestionsController < Admin::Legislation::BaseControll
   def create
     @question.author = current_user
     if @question.save
-      redirect_to admin_legislation_process_questions_path, notice: t('admin.legislation.questions.create.notice', link: legislation_process_question_path(@process, @question).html_safe)
+      notice = t('admin.legislation.questions.create.notice', link: legislation_process_question_path(@process, @question).html_safe)
+      redirect_to admin_legislation_process_questions_path, notice: notice
     else
       flash.now[:error] = t('admin.legislation.questions.create.error')
       render :new
@@ -22,7 +23,8 @@ class Admin::Legislation::QuestionsController < Admin::Legislation::BaseControll
 
   def update
     if @question.update(question_params)
-      redirect_to edit_admin_legislation_process_question_path(@process, @question), notice: t('admin.legislation.questions.update.notice', link: legislation_process_question_path(@process, @question).html_safe)
+      notice = t('admin.legislation.questions.update.notice', link: legislation_process_question_path(@process, @question).html_safe)
+      redirect_to edit_admin_legislation_process_question_path(@process, @question), notice: notice
     else
       flash.now[:error] = t('admin.legislation.questions.update.error')
       render :edit

--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -15,12 +15,14 @@ class Admin::Poll::BoothAssignmentsController < Admin::BaseController
   end
 
   def show
-    @booth_assignment = @poll.booth_assignments.includes(:recounts, :final_recounts, :voters, officer_assignments: [officer: [:user]]).find(params[:id])
+    @booth_assignment = @poll.booth_assignments.includes(:recounts, :final_recounts, :voters,
+                                                         officer_assignments: [officer: [:user]]).find(params[:id])
     @voters_by_date = @booth_assignment.voters.group_by {|v| v.created_at.to_date}
   end
 
   def create
-    @booth_assignment = ::Poll::BoothAssignment.new(poll_id: booth_assignment_params[:poll_id], booth_id: booth_assignment_params[:booth_id])
+    @booth_assignment = ::Poll::BoothAssignment.new(poll_id: booth_assignment_params[:poll_id],
+                                                    booth_id: booth_assignment_params[:booth_id])
 
     if @booth_assignment.save
       notice = t("admin.poll_booth_assignments.flash.create")

--- a/app/controllers/admin/poll/officer_assignments_controller.rb
+++ b/app/controllers/admin/poll/officer_assignments_controller.rb
@@ -43,7 +43,9 @@ class Admin::Poll::OfficerAssignmentsController < Admin::BaseController
     else
       notice = t("admin.poll_officer_assignments.flash.error_create")
     end
-    redirect_to by_officer_admin_poll_officer_assignments_path(poll_id: create_params[:poll_id], officer_id: create_params[:officer_id]), notice: notice
+
+    redirect_params = { poll_id: create_params[:poll_id], officer_id: create_params[:officer_id] }
+    redirect_to by_officer_admin_poll_officer_assignments_path(redirect_params), notice: notice
   end
 
   def destroy
@@ -54,7 +56,9 @@ class Admin::Poll::OfficerAssignmentsController < Admin::BaseController
     else
       notice = t("admin.poll_officer_assignments.flash.error_destroy")
     end
-    redirect_to by_officer_admin_poll_officer_assignments_path(poll_id: @officer_assignment.poll_id, officer_id: @officer_assignment.officer_id), notice: notice
+
+    redirect_params = { poll_id: @officer_assignment.poll_id, officer_id: @officer_assignment.officer_id }
+    redirect_to by_officer_admin_poll_officer_assignments_path(redirect_params), notice: notice
   end
 
   private
@@ -68,7 +72,8 @@ class Admin::Poll::OfficerAssignmentsController < Admin::BaseController
     end
 
     def load_booth_assignment
-      @booth_assignment = ::Poll::BoothAssignment.includes(:poll).find_by(poll_id: create_params[:poll_id], booth_id: create_params[:booth_id])
+      find_params = { poll_id: create_params[:poll_id], booth_id: create_params[:booth_id] }
+      @booth_assignment = ::Poll::BoothAssignment.includes(:poll).find_by(find_params)
     end
 
     def load_poll

--- a/app/controllers/admin/spending_proposals_controller.rb
+++ b/app/controllers/admin/spending_proposals_controller.rb
@@ -7,7 +7,9 @@ class Admin::SpendingProposalsController < Admin::BaseController
   load_and_authorize_resource
 
   def index
-    @spending_proposals = SpendingProposal.scoped_filter(params, @current_filter).order(cached_votes_up: :desc, created_at: :desc).page(params[:page])
+    @spending_proposals = SpendingProposal.scoped_filter(params, @current_filter)
+                                          .order(cached_votes_up: :desc, created_at: :desc)
+                                          .page(params[:page])
   end
 
   def show
@@ -33,13 +35,15 @@ class Admin::SpendingProposalsController < Admin::BaseController
 
   def summary
     @spending_proposals = SpendingProposal.group(:geozone).sum(:price).sort_by{|geozone, count| geozone.present? ? geozone.name : "z"}
-    @spending_proposals_with_supports = SpendingProposal.with_supports.group(:geozone).sum(:price).sort_by{|geozone, count| geozone.present? ? geozone.name : "z"}
+    @spending_proposals_with_supports = SpendingProposal.with_supports.group(:geozone).sum(:price)
+                                                        .sort_by{|geozone, count| geozone.present? ? geozone.name : "z"}
   end
 
   private
 
     def spending_proposal_params
-      params.require(:spending_proposal).permit(:title, :description, :external_url, :geozone_id, :association_name, :administrator_id, :tag_list, valuator_ids: [])
+      params.require(:spending_proposal).permit(:title, :description, :external_url, :geozone_id, :association_name,
+                                                :administrator_id, :tag_list, valuator_ids: [])
     end
 
     def load_admins

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -28,7 +28,8 @@ module Budgets
     respond_to :html, :js
 
     def index
-      @investments = @investments.apply_filters_and_search(@budget, params, @current_filter).send("sort_by_#{@current_order}").page(params[:page]).per(10).for_render
+      @investments = @investments.apply_filters_and_search(@budget, params, @current_filter)
+                                 .send("sort_by_#{@current_order}").page(params[:page]).per(10).for_render
       @investment_ids = @investments.pluck(:id)
       load_investment_votes(@investments)
       @tag_cloud = tag_cloud
@@ -102,7 +103,8 @@ module Budgets
       end
 
       def investment_params
-        params.require(:budget_investment).permit(:title, :description, :external_url, :heading_id, :tag_list, :organization_name, :location, :terms_of_service)
+        params.require(:budget_investment).permit(:title, :description, :external_url, :heading_id, :tag_list,
+                                                  :organization_name, :location, :terms_of_service)
       end
 
       def load_ballot

--- a/app/controllers/concerns/commentable_actions.rb
+++ b/app/controllers/concerns/commentable_actions.rb
@@ -88,7 +88,8 @@ module CommentableActions
     end
 
     def set_geozone
-      @resource.geozone = Geozone.find(params[resource_name.to_sym].try(:[], :geozone_id)) if params[resource_name.to_sym].try(:[], :geozone_id).present?
+      geozone_id = params[resource_name.to_sym].try(:[], :geozone_id)
+      @resource.geozone = Geozone.find(geozone_id) if geozone_id.present?
     end
 
     def load_categories

--- a/app/controllers/legislation/annotations_controller.rb
+++ b/app/controllers/legislation/annotations_controller.rb
@@ -102,8 +102,9 @@ class Legislation::AnnotationsController < ApplicationController
     end
 
     def convert_ranges_parameters
-      if params[:legislation_annotation] && params[:legislation_annotation][:ranges] && params[:legislation_annotation][:ranges].is_a?(String)
-        params[:legislation_annotation][:ranges] = JSON.parse(params[:legislation_annotation][:ranges])
+      annotation = params[:legislation_annotation]
+      if annotation && annotation[:ranges] && annotation[:ranges].is_a?(String)
+        params[:legislation_annotation][:ranges] = JSON.parse(annotation[:ranges])
       end
     rescue JSON::ParserError
     end

--- a/app/controllers/legislation/answers_controller.rb
+++ b/app/controllers/legislation/answers_controller.rb
@@ -18,9 +18,10 @@ class Legislation::AnswersController < Legislation::BaseController
         format.html { redirect_to legislation_process_question_path(@process, @question) }
       end
     else
+      alert = t('legislation.questions.participation.phase_not_open')
       respond_to do |format|
         format.js { render json: {}, status: :not_found }
-        format.html { redirect_to legislation_process_question_path(@process, @question), alert: t('legislation.questions.participation.phase_not_open') }
+        format.html { redirect_to legislation_process_question_path(@process, @question), alert: alert }
       end
     end
   end

--- a/app/controllers/management/document_verifications_controller.rb
+++ b/app/controllers/management/document_verifications_controller.rb
@@ -43,7 +43,8 @@ class Management::DocumentVerificationsController < Management::BaseController
     end
 
     def clean_document_number
-      params[:document_verification][:document_number] = params[:document_verification][:document_number].gsub(/[^a-z0-9]+/i, "").upcase unless params[:document_verification][:document_number].blank?
+      return if params[:document_verification][:document_number].blank?
+      params[:document_verification][:document_number] = params[:document_verification][:document_number].gsub(/[^a-z0-9]+/i, "").upcase
     end
 
 end

--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -34,7 +34,8 @@ class Management::ProposalsController < Management::BaseController
     end
 
     def proposal_params
-      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url, :responsible_name, :tag_list, :terms_of_service, :geozone_id)
+      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
+                                       :responsible_name, :tag_list, :terms_of_service, :geozone_id)
     end
 
     def resource_model

--- a/app/controllers/management/spending_proposals_controller.rb
+++ b/app/controllers/management/spending_proposals_controller.rb
@@ -17,7 +17,8 @@ class Management::SpendingProposalsController < Management::BaseController
     @spending_proposal.author = managed_user
 
     if @spending_proposal.save
-      redirect_to management_spending_proposal_path(@spending_proposal), notice: t('flash.actions.create.notice', resource_name: t("activerecord.models.spending_proposal", count: 1))
+      notice = t('flash.actions.create.notice', resource_name: t("activerecord.models.spending_proposal", count: 1))
+      redirect_to management_spending_proposal_path(@spending_proposal), notice: notice
     else
       render :new
     end

--- a/app/controllers/officing/final_recounts_controller.rb
+++ b/app/controllers/officing/final_recounts_controller.rb
@@ -15,7 +15,8 @@ class Officing::FinalRecountsController < Officing::BaseController
   end
 
   def create
-    @final_recount = ::Poll::FinalRecount.find_or_initialize_by(booth_assignment_id: @officer_assignment.booth_assignment_id, date: final_recount_params[:date])
+    @final_recount = ::Poll::FinalRecount.find_or_initialize_by(booth_assignment_id: @officer_assignment.booth_assignment_id,
+                                                                date: final_recount_params[:date])
     @final_recount.officer_assignment_id = @officer_assignment.id
     @final_recount.count = final_recount_params[:count]
 

--- a/app/controllers/officing/recounts_controller.rb
+++ b/app/controllers/officing/recounts_controller.rb
@@ -14,7 +14,8 @@ class Officing::RecountsController < Officing::BaseController
   end
 
   def create
-    @recount = ::Poll::Recount.find_or_initialize_by(booth_assignment_id: @officer_assignment.booth_assignment_id, date: @officer_assignment.date)
+    @recount = ::Poll::Recount.find_or_initialize_by(booth_assignment_id: @officer_assignment.booth_assignment_id,
+                                                     date: @officer_assignment.date)
     @recount.officer_assignment_id = @officer_assignment.id
     @recount.count = recount_params[:count]
 

--- a/app/controllers/officing/results_controller.rb
+++ b/app/controllers/officing/results_controller.rb
@@ -126,7 +126,8 @@ class Officing::ResultsController < Officing::BaseController
 
     def load_partial_results
       if @officer_assignments.present?
-        @partial_results = ::Poll::PartialResult.where(officer_assignment_id: @officer_assignments.map(&:id)).order(:booth_assignment_id, :date)
+        @partial_results = ::Poll::PartialResult.where(officer_assignment_id: @officer_assignments.map(&:id))
+                                                .order(:booth_assignment_id, :date)
       end
     end
 

--- a/app/controllers/organizations/registrations_controller.rb
+++ b/app/controllers/organizations/registrations_controller.rb
@@ -32,7 +32,8 @@ class Organizations::RegistrationsController < Devise::RegistrationsController
   private
 
     def sign_up_params
-      params.require(:user).permit(:email, :password, :phone_number, :password_confirmation, :terms_of_service, organization_attributes: [:name, :responsible_name])
+      params.require(:user).permit(:email, :password, :phone_number, :password_confirmation, :terms_of_service,
+                                   organization_attributes: [:name, :responsible_name])
     end
 
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -74,7 +74,8 @@ class ProposalsController < ApplicationController
   private
 
     def proposal_params
-      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url, :responsible_name, :tag_list, :terms_of_service, :geozone_id)
+      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
+                                       :responsible_name, :tag_list, :terms_of_service, :geozone_id)
     end
 
     def retired_params
@@ -109,7 +110,8 @@ class ProposalsController < ApplicationController
     end
 
     def load_featured
-      @featured_proposals = Proposal.not_archived.sort_by_confidence_score.limit(3) if (!@advanced_search_terms && @search_terms.blank? && @tag_filter.blank? && params[:retired].blank?)
+      return unless !@advanced_search_terms && @search_terms.blank? && @tag_filter.blank? && params[:retired].blank?
+      @featured_proposals = Proposal.not_archived.sort_by_confidence_score.limit(3)
       if @featured_proposals.present?
         set_featured_proposal_votes(@featured_proposals)
         @resources = @resources.where('proposals.id NOT IN (?)', @featured_proposals.map(&:id))

--- a/app/controllers/spending_proposals_controller.rb
+++ b/app/controllers/spending_proposals_controller.rb
@@ -30,7 +30,8 @@ class SpendingProposalsController < ApplicationController
     @spending_proposal.author = current_user
 
     if @spending_proposal.save
-      notice = t('flash.actions.create.spending_proposal', activity: "<a href='#{user_path(current_user, filter: :spending_proposals)}'>#{t('layouts.header.my_activity_link')}</a>")
+      activity = "<a href='#{user_path(current_user, filter: :spending_proposals)}'>#{t('layouts.header.my_activity_link')}</a>"
+      notice = t('flash.actions.create.spending_proposal', activity: activity)
       redirect_to @spending_proposal, notice: notice, flash: { html_safe: true }
     else
       render :new

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -12,11 +12,13 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
 
   def index
     @heading_filters = heading_filters
-    if current_user.valuator? && @budget.present?
-      @investments = @budget.investments.scoped_filter(params_for_current_valuator, @current_filter).order(cached_votes_up: :desc).page(params[:page])
-    else
-      @investments = Budget::Investment.none.page(params[:page])
-    end
+    @investments = if current_user.valuator? && @budget.present?
+      @budget.investments.scoped_filter(params_for_current_valuator, @current_filter)
+             .order(cached_votes_up: :desc)
+             .page(params[:page])
+                   else
+      Budget::Investment.none.page(params[:page])
+                   end
   end
 
   def valuate
@@ -63,11 +65,14 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     end
 
     def valuation_params
-      params.require(:budget_investment).permit(:price, :price_first_year, :price_explanation, :feasibility, :unfeasibility_explanation, :duration, :valuation_finished, :internal_comments)
+      params.require(:budget_investment).permit(:price, :price_first_year, :price_explanation, :feasibility, :unfeasibility_explanation,
+                                                :duration, :valuation_finished, :internal_comments)
     end
 
     def restrict_access_to_assigned_items
-      raise ActionController::RoutingError.new('Not Found') unless current_user.administrator? || Budget::ValuatorAssignment.exists?(investment_id: params[:id], valuator_id: current_user.valuator.id)
+      return if current_user.administrator? ||
+                Budget::ValuatorAssignment.exists?(investment_id: params[:id], valuator_id: current_user.valuator.id)
+      raise ActionController::RoutingError.new('Not Found')
     end
 
     def valid_price_params?

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -78,7 +78,9 @@ module CommentsHelper
   def require_verified_resident_for_commentable?(commentable, current_user)
     return false if current_user.administrator? || current_user.moderator?
 
-    commentable.respond_to?(:comments_for_verified_residents_only?) && commentable.comments_for_verified_residents_only? && !current_user.residence_verified?
+    commentable.respond_to?(:comments_for_verified_residents_only?) &&
+      commentable.comments_for_verified_residents_only? &&
+      !current_user.residence_verified?
   end
 
   def comments_closed_for_commentable?(commentable)

--- a/app/helpers/valuation_helper.rb
+++ b/app/helpers/valuation_helper.rb
@@ -2,7 +2,9 @@ module ValuationHelper
 
   def valuator_select_options(valuator = nil)
     if valuator.present?
-      Valuator.where.not(id: valuator.id).order("description ASC").order("users.email ASC").includes(:user).collect { |v| [ v.description_or_email, v.id ] }.prepend([valuator.description_or_email, valuator.id])
+      Valuator.where.not(id: valuator.id).order("description ASC").order("users.email ASC")
+              .includes(:user).collect { |v| [ v.description_or_email, v.id ] }
+              .prepend([valuator.description_or_email, valuator.id])
     else
       Valuator.all.order("description ASC").order("users.email ASC").includes(:user).collect { |v| [ v.description_or_email, v.id ] }
     end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -11,7 +11,8 @@ class Mailer < ApplicationMailer
     @email_to = @commentable.author.email
 
     with_user(@commentable.author) do
-      mail(to: @email_to, subject: t('mailers.comment.subject', commentable: t("activerecord.models.#{@commentable.class.name.underscore}", count: 1).downcase)) if @commentable.present? && @commentable.author.present?
+      subject = t('mailers.comment.subject', commentable: t("activerecord.models.#{@commentable.class.name.underscore}", count: 1).downcase)
+      mail(to: @email_to, subject: subject) if @commentable.present? && @commentable.author.present?
     end
   end
 

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -32,7 +32,8 @@ module Abilities
       can :mark_featured, Debate
       can :unmark_featured, Debate
 
-      can :comment_as_administrator, [Debate, Comment, Proposal, Poll::Question, Budget::Investment, Legislation::Question, Legislation::Annotation]
+      can :comment_as_administrator, [Debate, Comment, Proposal, Poll::Question, Budget::Investment,
+                                      Legislation::Question, Legislation::Annotation]
 
       can [:search, :create, :index, :destroy], ::Administrator
       can [:search, :create, :index, :destroy], ::Moderator

--- a/app/models/abilities/moderator.rb
+++ b/app/models/abilities/moderator.rb
@@ -5,7 +5,8 @@ module Abilities
     def initialize(user)
       merge Abilities::Moderation.new(user)
 
-      can :comment_as_moderator, [Debate, Comment, Proposal, Budget::Investment, Poll::Question, Legislation::Question, Legislation::Annotation]
+      can :comment_as_moderator, [Debate, Comment, Proposal, Budget::Investment, Poll::Question,
+                                  Legislation::Question, Legislation::Annotation]
     end
   end
 end

--- a/app/models/budget/ballot/line.rb
+++ b/app/models/budget/ballot/line.rb
@@ -22,7 +22,8 @@ class Budget
       end
 
       def check_valid_heading
-        errors.add(:heading, "This heading's budget is invalid, or a heading on the same group was already selected") unless ballot.valid_heading?(heading)
+        return if ballot.valid_heading?(heading)
+        errors.add(:heading, "This heading's budget is invalid, or a heading on the same group was already selected")
       end
 
       def check_selected

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,8 @@ class Comment < ActiveRecord::Base
   include HasPublicAuthor
   include Graphqlable
 
+  COMMENTABLE_TYPES = %w(Debate Proposal Budget::Investment Poll::Question Legislation::Question Legislation::Annotation).freeze
+
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
   acts_as_votable
@@ -13,7 +15,7 @@ class Comment < ActiveRecord::Base
   validates :body, presence: true
   validates :user, presence: true
 
-  validates :commentable_type, inclusion: { in: ["Debate", "Proposal", "Budget::Investment", "Poll::Question", "Legislation::Question", "Legislation::Annotation"] }
+  validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }
 
   validate :validate_body_length
 

--- a/app/models/legislation/answer.rb
+++ b/app/models/legislation/answer.rb
@@ -2,8 +2,10 @@ class Legislation::Answer < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
-  belongs_to :question, class_name: 'Legislation::Question', foreign_key: 'legislation_question_id', inverse_of: :answers, counter_cache: true
-  belongs_to :question_option, class_name: 'Legislation::QuestionOption', foreign_key: 'legislation_question_option_id', inverse_of: :answers, counter_cache: true
+  belongs_to :question, class_name: 'Legislation::Question', foreign_key: 'legislation_question_id',
+                        inverse_of: :answers, counter_cache: true
+  belongs_to :question_option, class_name: 'Legislation::QuestionOption', foreign_key: 'legislation_question_option_id',
+                               inverse_of: :answers, counter_cache: true
   belongs_to :user, dependent: :destroy, inverse_of: :legislation_answers
 
   validates :question, presence: true, uniqueness: { scope: :user_id}

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -4,8 +4,10 @@ class Legislation::Process < ActiveRecord::Base
 
   PHASES_AND_PUBLICATIONS = %i(debate_phase allegations_phase draft_publication result_publication).freeze
 
-  has_many :draft_versions, -> { order(:id) }, class_name: 'Legislation::DraftVersion', foreign_key: 'legislation_process_id', dependent: :destroy
-  has_one :final_draft_version, -> { where final_version: true, status: 'published' }, class_name: 'Legislation::DraftVersion', foreign_key: 'legislation_process_id'
+  has_many :draft_versions, -> { order(:id) }, class_name: 'Legislation::DraftVersion',
+                                               foreign_key: 'legislation_process_id', dependent: :destroy
+  has_one :final_draft_version, -> { where final_version: true, status: 'published' }, class_name: 'Legislation::DraftVersion',
+                                                                                       foreign_key: 'legislation_process_id'
   has_many :questions, -> { order(:id) }, class_name: 'Legislation::Question', foreign_key: 'legislation_process_id', dependent: :destroy
 
   validates :title, presence: true
@@ -64,7 +66,9 @@ class Legislation::Process < ActiveRecord::Base
     def valid_date_ranges
       errors.add(:end_date, :invalid_date_range) if end_date && start_date && end_date < start_date
       errors.add(:debate_end_date, :invalid_date_range) if debate_end_date && debate_start_date && debate_end_date < debate_start_date
-      errors.add(:allegations_end_date, :invalid_date_range) if allegations_end_date && allegations_start_date && allegations_end_date < allegations_start_date
+      if allegations_end_date && allegations_start_date && allegations_end_date < allegations_start_date
+        errors.add(:allegations_end_date, :invalid_date_range)
+      end
     end
 
 end

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -5,7 +5,8 @@ class Legislation::Question < ActiveRecord::Base
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
   belongs_to :process, class_name: 'Legislation::Process', foreign_key: 'legislation_process_id'
 
-  has_many :question_options, -> { order(:id) }, class_name: 'Legislation::QuestionOption', foreign_key: 'legislation_question_id', dependent: :destroy, inverse_of: :question
+  has_many :question_options, -> { order(:id) }, class_name: 'Legislation::QuestionOption', foreign_key: 'legislation_question_id',
+                                                 dependent: :destroy, inverse_of: :question
   has_many :answers, class_name: 'Legislation::Answer', foreign_key: 'legislation_question_id', dependent: :destroy, inverse_of: :question
   has_many :comments, as: :commentable, dependent: :destroy
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -35,7 +35,11 @@ class Organization < ActiveRecord::Base
   end
 
   def self.search(text)
-    text.present? ? joins(:user).where("users.email = ? OR users.phone_number = ? OR organizations.name ILIKE ?", text, text, "%#{text}%") : none
+    if text.present?
+      joins(:user).where("users.email = ? OR users.phone_number = ? OR organizations.name ILIKE ?", text, text, "%#{text}%")
+    else
+      none
+    end
   end
 
   def self.name_max_length

--- a/app/models/proposal_notification.rb
+++ b/app/models/proposal_notification.rb
@@ -14,8 +14,10 @@ class ProposalNotification < ActiveRecord::Base
 
   def minimum_interval
     return true if proposal.try(:notifications).blank?
-    if proposal.notifications.last.created_at > (Time.current - Setting[:proposal_notification_minimum_interval_in_days].to_i.days).to_datetime
-      errors.add(:title, I18n.t('activerecord.errors.models.proposal_notification.attributes.minimum_interval.invalid', interval: Setting[:proposal_notification_minimum_interval_in_days]))
+    interval = Setting[:proposal_notification_minimum_interval_in_days]
+    minimum_interval = (Time.current - interval.to_i.days).to_datetime
+    if proposal.notifications.last.created_at > minimum_interval
+      errors.add(:title, I18n.t('activerecord.errors.models.proposal_notification.attributes.minimum_interval.invalid', interval: interval))
     end
   end
 

--- a/app/models/verification/residence.rb
+++ b/app/models/verification/residence.rb
@@ -38,8 +38,8 @@ class Verification::Residence
   end
 
   def allowed_age
-    return if errors[:date_of_birth].any?
-    errors.add(:date_of_birth, I18n.t('verification.residence.new.error_not_allowed_age')) unless Age.in_years(date_of_birth) >= User.minimum_required_age
+    return if errors[:date_of_birth].any? || Age.in_years(date_of_birth) >= User.minimum_required_age
+    errors.add(:date_of_birth, I18n.t('verification.residence.new.error_not_allowed_age'))
   end
 
   def document_number_uniqueness

--- a/lib/census_api.rb
+++ b/lib/census_api.rb
@@ -92,7 +92,27 @@ class CensusApi
     end
 
     def stubbed_valid_response
-      {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: { item: {fecha_nacimiento_string: "31-12-1980", identificador_documento: "12345678Z", descripcion_sexo: "Varón", nombre: "José", apellido1: "García" }}, datos_vivienda: {item: {codigo_postal: "28013", codigo_distrito: "01"}}}}}
+      {
+        get_habita_datos_response: {
+          get_habita_datos_return: {
+            datos_habitante: {
+              item: {
+                fecha_nacimiento_string: "31-12-1980",
+                identificador_documento: "12345678Z",
+                descripcion_sexo: "Varón",
+                nombre: "José",
+                apellido1: "García"
+              }
+            },
+            datos_vivienda: {
+              item: {
+                codigo_postal: "28013",
+                codigo_distrito: "01"
+              }
+            }
+          }
+        }
+      }
     end
 
     def stubbed_invalid_response

--- a/spec/controllers/legislation/answers_controller_spec.rb
+++ b/spec/controllers/legislation/answers_controller_spec.rb
@@ -13,7 +13,8 @@ describe Legislation::AnswersController do
     it 'should create an ahoy event' do
       sign_in @user
 
-      post :create, process_id: @process.id, question_id: @question.id, legislation_answer: { legislation_question_option_id: @question_option.id }
+      post :create, process_id: @process.id, question_id: @question.id,
+                    legislation_answer: { legislation_question_option_id: @question_option.id }
       expect(Ahoy::Event.where(name: :legislation_answer_created).count).to eq 1
       expect(Ahoy::Event.last.properties['legislation_answer_id']).to eq Legislation::Answer.last.id
     end
@@ -22,7 +23,8 @@ describe Legislation::AnswersController do
       sign_in @user
 
       expect do
-        xhr :post, :create, process_id: @process.id, question_id: @question.id, legislation_answer: { legislation_question_option_id: @question_option.id }
+        xhr :post, :create, process_id: @process.id, question_id: @question.id,
+                            legislation_answer: { legislation_question_option_id: @question_option.id }
       end.to change { @question.reload.answers_count }.by(1)
     end
 
@@ -31,7 +33,8 @@ describe Legislation::AnswersController do
       @process.update_attribute(:debate_end_date, Date.current - 1.day)
 
       expect do
-        xhr :post, :create, process_id: @process.id, question_id: @question.id, legislation_answer: { legislation_question_option_id: @question_option.id }
+        xhr :post, :create, process_id: @process.id, question_id: @question.id,
+                            legislation_answer: { legislation_question_option_id: @question_option.id }
       end.to_not change { @question.reload.answers_count }
     end
   end

--- a/spec/features/admin/poll/questions_spec.rb
+++ b/spec/features/admin/poll/questions_spec.rb
@@ -33,8 +33,10 @@ feature 'Admin poll questions' do
     poll = create(:poll, name: 'Movies')
     title = "Star Wars: Episode IV - A New Hope"
     description = %{
-      During the battle, Rebel spies managed to steal secret plans to the Empire's ultimate weapon, the DEATH STAR, an armored space station with enough power to destroy an entire planet.
-      Pursued by the Empire's sinister agents, Princess Leia races home aboard her starship, custodian of the stolen plans that can save her people and restore freedom to the galaxy....
+      During the battle, Rebel spies managed to steal secret plans to the Empire's ultimate weapon, the DEATH STAR, an armored space station
+       with enough power to destroy an entire planet.
+      Pursued by the Empire's sinister agents, Princess Leia races home aboard her starship, custodian of the stolen plans that can save her
+       people and restore freedom to the galaxy....
     }
 
     visit admin_questions_path

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -593,9 +593,9 @@ feature 'Budget Investments' do
     end
 
     scenario 'Order by cost (only when balloting)' do
-      create(:budget_investment, :selected, heading: heading, title: 'Build a nice house',  price:  1000).update_column(:confidence_score, 10)
-      create(:budget_investment, :selected, heading: heading, title: 'Build an ugly house', price:  1000).update_column(:confidence_score, 5)
-      create(:budget_investment, :selected, heading: heading, title: 'Build a skyscraper',  price: 20000)
+      create(:budget_investment, :selected, heading: heading, title: 'Build a nice house', price: 1000).update_column(:confidence_score, 10)
+      create(:budget_investment, :selected, heading: heading, title: 'Build an ugly house', price: 1000).update_column(:confidence_score, 5)
+      create(:budget_investment, :selected, heading: heading, title: 'Build a skyscraper', price: 20000)
 
       visit budget_investments_path(budget, heading_id: heading.id)
 

--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -62,9 +62,12 @@ feature 'Commenting Budget::Investments' do
   end
 
   scenario 'Comment order' do
-    c1 = create(:comment, :with_confidence_score, commentable: investment, cached_votes_up: 100, cached_votes_total: 120, created_at: Time.current - 2)
-    c2 = create(:comment, :with_confidence_score, commentable: investment, cached_votes_up: 10, cached_votes_total: 12, created_at: Time.current - 1)
-    c3 = create(:comment, :with_confidence_score, commentable: investment, cached_votes_up: 1, cached_votes_total: 2, created_at: Time.current)
+    c1 = create(:comment, :with_confidence_score, commentable: investment, cached_votes_up: 100,
+                                                  cached_votes_total: 120, created_at: Time.current - 2)
+    c2 = create(:comment, :with_confidence_score, commentable: investment, cached_votes_up: 10,
+                                                  cached_votes_total: 12, created_at: Time.current - 1)
+    c3 = create(:comment, :with_confidence_score, commentable: investment, cached_votes_up: 1,
+                                                  cached_votes_total: 2, created_at: Time.current)
 
     visit budget_investment_path(investment.budget, investment, order: :most_voted)
 
@@ -118,7 +121,8 @@ feature 'Commenting Budget::Investments' do
   end
 
   scenario 'Sanitizes comment body for security' do
-    create :comment, commentable: investment, body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
+    create :comment, commentable: investment,
+                     body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
     visit budget_investment_path(investment.budget, investment)
 

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -62,9 +62,12 @@ feature 'Commenting debates' do
   end
 
   scenario 'Comment order' do
-    c1 = create(:comment, :with_confidence_score, commentable: debate, cached_votes_up: 100, cached_votes_total: 120, created_at: Time.current - 2)
-    c2 = create(:comment, :with_confidence_score, commentable: debate, cached_votes_up: 10, cached_votes_total: 12, created_at: Time.current - 1)
-    c3 = create(:comment, :with_confidence_score, commentable: debate, cached_votes_up: 1, cached_votes_total: 2, created_at: Time.current)
+    c1 = create(:comment, :with_confidence_score, commentable: debate, cached_votes_up: 100,
+                                                  cached_votes_total: 120, created_at: Time.current - 2)
+    c2 = create(:comment, :with_confidence_score, commentable: debate, cached_votes_up: 10,
+                                                  cached_votes_total: 12, created_at: Time.current - 1)
+    c3 = create(:comment, :with_confidence_score, commentable: debate, cached_votes_up: 1,
+                                                  cached_votes_total: 2, created_at: Time.current)
 
     visit debate_path(debate, order: :most_voted)
 
@@ -118,7 +121,8 @@ feature 'Commenting debates' do
   end
 
   scenario 'Sanitizes comment body for security' do
-    create :comment, commentable: debate, body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
+    create :comment, commentable: debate,
+                     body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
     visit debate_path(debate)
 

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -8,7 +8,9 @@ feature 'Commenting legislation questions' do
   scenario 'Index' do
     3.times { create(:comment, commentable: legislation_annotation) }
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     expect(page).to have_css('.comment', count: 4)
 
@@ -24,6 +26,9 @@ feature 'Commenting legislation questions' do
     parent_comment = create(:comment, commentable: legislation_annotation)
     first_child    = create(:comment, commentable: legislation_annotation, parent: parent_comment)
     second_child   = create(:comment, commentable: legislation_annotation, parent: parent_comment)
+    href           = legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                                       legislation_annotation.draft_version,
+                                                                       legislation_annotation)
 
     visit comment_path(parent_comment)
 
@@ -32,7 +37,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content first_child.body
     expect(page).to have_content second_child.body
 
-    expect(page).to have_link "Go back to #{legislation_annotation.title}", href: legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    expect(page).to have_link "Go back to #{legislation_annotation.title}", href: href
   end
 
   scenario 'Collapsable comments', :js do
@@ -40,7 +45,9 @@ feature 'Commenting legislation questions' do
     child_comment  = create(:comment, body: "First subcomment", commentable: legislation_annotation, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: legislation_annotation, parent: child_comment)
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     expect(page).to have_css('.comment', count: 3)
 
@@ -62,21 +69,33 @@ feature 'Commenting legislation questions' do
   end
 
   scenario 'Comment order' do
-    c1 = create(:comment, :with_confidence_score, commentable: legislation_annotation, cached_votes_up: 100, cached_votes_total: 120, created_at: Time.current - 2)
-    c2 = create(:comment, :with_confidence_score, commentable: legislation_annotation, cached_votes_up: 10, cached_votes_total: 12, created_at: Time.current - 1)
-    c3 = create(:comment, :with_confidence_score, commentable: legislation_annotation, cached_votes_up: 1, cached_votes_total: 2, created_at: Time.current)
+    c1 = create(:comment, :with_confidence_score, commentable: legislation_annotation, cached_votes_up: 100,
+                                                  cached_votes_total: 120, created_at: Time.current - 2)
+    c2 = create(:comment, :with_confidence_score, commentable: legislation_annotation, cached_votes_up: 10,
+                                                  cached_votes_total: 12, created_at: Time.current - 1)
+    c3 = create(:comment, :with_confidence_score, commentable: legislation_annotation, cached_votes_up: 1,
+                                                  cached_votes_total: 2, created_at: Time.current)
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation, order: :most_voted)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation,
+                                                            order: :most_voted)
 
     expect(c1.body).to appear_before(c2.body)
     expect(c2.body).to appear_before(c3.body)
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation, order: :newest)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation,
+                                                            order: :newest)
 
     expect(c3.body).to appear_before(c2.body)
     expect(c2.body).to appear_before(c1.body)
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation, order: :oldest)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation,
+                                                            order: :oldest)
 
     expect(c1.body).to appear_before(c2.body)
     expect(c2.body).to appear_before(c3.body)
@@ -88,17 +107,26 @@ feature 'Commenting legislation questions' do
     old_child = create(:comment, commentable: legislation_annotation, parent_id: new_root.id, created_at: Time.current - 10)
     new_child = create(:comment, commentable: legislation_annotation, parent_id: new_root.id, created_at: Time.current)
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation, order: :most_voted)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation,
+                                                            order: :most_voted)
 
     expect(new_root.body).to appear_before(old_root.body)
     expect(old_child.body).to appear_before(new_child.body)
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation, order: :newest)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation,
+                                                            order: :newest)
 
     expect(new_root.body).to appear_before(old_root.body)
     expect(new_child.body).to appear_before(old_child.body)
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation, order: :oldest)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation,
+                                                            order: :oldest)
 
     expect(old_root.body).to appear_before(new_root.body)
     expect(old_child.body).to appear_before(new_child.body)
@@ -107,7 +135,9 @@ feature 'Commenting legislation questions' do
   scenario 'Turns links into html links' do
     create :comment, commentable: legislation_annotation, body: 'Built with http://rubyonrails.org/'
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     within all('.comment').last do
       expect(page).to have_content 'Built with http://rubyonrails.org/'
@@ -118,9 +148,12 @@ feature 'Commenting legislation questions' do
   end
 
   scenario 'Sanitizes comment body for security' do
-    create :comment, commentable: legislation_annotation, body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
+    create :comment, commentable: legislation_annotation,
+                     body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     within all('.comment').last do
       expect(page).to have_content "click me http://www.url.com"
@@ -133,7 +166,9 @@ feature 'Commenting legislation questions' do
     per_page = 10
     (per_page + 2).times { create(:comment, commentable: legislation_annotation)}
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     expect(page).to have_css('.comment', count: per_page)
     within("ul.pagination") do
@@ -149,7 +184,9 @@ feature 'Commenting legislation questions' do
   feature 'Not logged user' do
     scenario 'can not see comments forms' do
       create(:comment, commentable: legislation_annotation)
-      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                              legislation_annotation.draft_version,
+                                                              legislation_annotation)
 
       expect(page).to have_content 'You must Sign in or Sign up to leave a comment'
       within('#comments') do
@@ -161,7 +198,9 @@ feature 'Commenting legislation questions' do
 
   scenario 'Create', :js do
     login_as(user)
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     fill_in "comment-body-legislation_annotation_#{legislation_annotation.id}", with: 'Have you thought about...?'
     click_button 'Publish comment'
@@ -174,7 +213,9 @@ feature 'Commenting legislation questions' do
 
   scenario 'Errors on create', :js do
     login_as(user)
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     click_button 'Publish comment'
 
@@ -188,7 +229,9 @@ feature 'Commenting legislation questions' do
     comment = legislation_annotation.comments.first
 
     login_as(manuela)
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     click_link "Reply"
 
@@ -208,7 +251,9 @@ feature 'Commenting legislation questions' do
     comment = legislation_annotation.comments.first
 
     login_as(user)
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     click_link "Reply"
 
@@ -227,7 +272,10 @@ feature 'Commenting legislation questions' do
       parent = parent.children.first
     end
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
+
     expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
   end
 
@@ -235,7 +283,9 @@ feature 'Commenting legislation questions' do
     comment = create(:comment, commentable: legislation_annotation)
 
     login_as(user)
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     within "#comment_#{comment.id}" do
       page.find("#flag-expand-comment-#{comment.id}").click
@@ -252,7 +302,9 @@ feature 'Commenting legislation questions' do
     Flag.flag(user, comment)
 
     login_as(user)
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     within "#comment_#{comment.id}" do
       page.find("#unflag-expand-comment-#{comment.id}").click
@@ -269,7 +321,9 @@ feature 'Commenting legislation questions' do
     comment = create(:comment, commentable: legislation_annotation)
 
     login_as(user)
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     within "#comment_#{comment.id}" do
       page.find("#flag-expand-comment-#{comment.id}").click
@@ -282,7 +336,10 @@ feature 'Commenting legislation questions' do
     comment = create(:comment, commentable: legislation_annotation, body: 'this should be visible')
     comment.user.erase
 
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
+
     within "#comment_#{comment.id}" do
       expect(page).to have_content('User deleted')
       expect(page).to have_content('this should be visible')
@@ -292,7 +349,10 @@ feature 'Commenting legislation questions' do
   scenario 'Submit button is disabled after clicking', :js do
     legislation_annotation = create(:legislation_annotation)
     login_as(user)
-    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
 
     fill_in "comment-body-legislation_annotation_#{legislation_annotation.id}", with: 'Testing submit button!'
     click_button 'Publish comment'
@@ -309,7 +369,9 @@ feature 'Commenting legislation questions' do
       moderator = create(:moderator)
 
       login_as(moderator.user)
-      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                              legislation_annotation.draft_version,
+                                                              legislation_annotation)
 
       fill_in "comment-body-legislation_annotation_#{legislation_annotation.id}", with: "I am moderating!"
       check "comment-as-moderator-legislation_annotation_#{legislation_annotation.id}"
@@ -331,7 +393,9 @@ feature 'Commenting legislation questions' do
       comment = legislation_annotation.comments.first
 
       login_as(manuela)
-      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                              legislation_annotation.draft_version,
+                                                              legislation_annotation)
 
       click_link "Reply"
 
@@ -355,7 +419,9 @@ feature 'Commenting legislation questions' do
       moderator = create(:moderator)
 
       login_as(moderator.user)
-      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                              legislation_annotation.draft_version,
+                                                              legislation_annotation)
 
       expect(page).to_not have_content "Comment as administrator"
     end
@@ -366,7 +432,9 @@ feature 'Commenting legislation questions' do
       admin = create(:administrator)
 
       login_as(admin.user)
-      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                              legislation_annotation.draft_version,
+                                                              legislation_annotation)
 
       fill_in "comment-body-legislation_annotation_#{legislation_annotation.id}", with: "I am your Admin!"
       check "comment-as-administrator-legislation_annotation_#{legislation_annotation.id}"
@@ -388,7 +456,9 @@ feature 'Commenting legislation questions' do
       comment = legislation_annotation.comments.first
 
       login_as(manuela)
-      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                              legislation_annotation.draft_version,
+                                                              legislation_annotation)
 
       click_link "Reply"
 
@@ -412,7 +482,9 @@ feature 'Commenting legislation questions' do
       admin = create(:administrator)
 
       login_as(admin.user)
-      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process, legislation_annotation.draft_version, legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                              legislation_annotation.draft_version,
+                                                              legislation_annotation)
 
       expect(page).to_not have_content "Comment as moderator"
     end
@@ -432,7 +504,9 @@ feature 'Commenting legislation questions' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
-      visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process, @legislation_annotation.draft_version, @legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process,
+                                                              @legislation_annotation.draft_version,
+                                                              @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
         within(".in_favor") do
@@ -448,7 +522,9 @@ feature 'Commenting legislation questions' do
     end
 
     scenario 'Create', :js do
-      visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process, @legislation_annotation.draft_version, @legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process,
+                                                              @legislation_annotation.draft_version,
+                                                              @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
         find(".in_favor a").click
@@ -466,7 +542,9 @@ feature 'Commenting legislation questions' do
     end
 
     scenario 'Update', :js do
-      visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process, @legislation_annotation.draft_version, @legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process,
+                                                              @legislation_annotation.draft_version,
+                                                              @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
@@ -485,7 +563,9 @@ feature 'Commenting legislation questions' do
     end
 
     xscenario 'Trying to vote multiple times', :js do
-      visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process, @legislation_annotation.draft_version, @legislation_annotation)
+      visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process,
+                                                              @legislation_annotation.draft_version,
+                                                              @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
@@ -510,8 +590,14 @@ feature 'Commenting legislation questions' do
 
   feature "Merged comment threads", :js do
     let!(:draft_version) { create(:legislation_draft_version, :published) }
-    let!(:annotation1) { create(:legislation_annotation, draft_version: draft_version, text: "my annotation",       ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5}]) }
-    let!(:annotation2) { create(:legislation_annotation, draft_version: draft_version, text: "my other annotation", ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10}]) }
+    let!(:annotation1) do
+      create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
+                                      ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5}])
+    end
+    let!(:annotation2) do
+      create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
+                                      ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10}])
+    end
 
     background do
       login_as user

--- a/spec/features/comments/legislation_questions_spec.rb
+++ b/spec/features/comments/legislation_questions_spec.rb
@@ -25,6 +25,7 @@ feature 'Commenting legislation questions' do
     parent_comment = create(:comment, commentable: legislation_question)
     first_child    = create(:comment, commentable: legislation_question, parent: parent_comment)
     second_child   = create(:comment, commentable: legislation_question, parent: parent_comment)
+    href           = legislation_process_question_path(legislation_question.process, legislation_question)
 
     visit comment_path(parent_comment)
 
@@ -33,7 +34,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content first_child.body
     expect(page).to have_content second_child.body
 
-    expect(page).to have_link "Go back to #{legislation_question.title}", href: legislation_process_question_path(legislation_question.process, legislation_question)
+    expect(page).to have_link "Go back to #{legislation_question.title}", href: href
   end
 
   scenario 'Collapsable comments', :js do
@@ -63,9 +64,12 @@ feature 'Commenting legislation questions' do
   end
 
   scenario 'Comment order' do
-    c1 = create(:comment, :with_confidence_score, commentable: legislation_question, cached_votes_up: 100, cached_votes_total: 120, created_at: Time.current - 2)
-    c2 = create(:comment, :with_confidence_score, commentable: legislation_question, cached_votes_up: 10, cached_votes_total: 12, created_at: Time.current - 1)
-    c3 = create(:comment, :with_confidence_score, commentable: legislation_question, cached_votes_up: 1, cached_votes_total: 2, created_at: Time.current)
+    c1 = create(:comment, :with_confidence_score, commentable: legislation_question, cached_votes_up: 100,
+                                                  cached_votes_total: 120, created_at: Time.current - 2)
+    c2 = create(:comment, :with_confidence_score, commentable: legislation_question, cached_votes_up: 10,
+                                                  cached_votes_total: 12, created_at: Time.current - 1)
+    c3 = create(:comment, :with_confidence_score, commentable: legislation_question, cached_votes_up: 1,
+                                                  cached_votes_total: 2, created_at: Time.current)
 
     visit legislation_process_question_path(legislation_question.process, legislation_question, order: :most_voted)
 
@@ -119,7 +123,8 @@ feature 'Commenting legislation questions' do
   end
 
   scenario 'Sanitizes comment body for security' do
-    create :comment, commentable: legislation_question, body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
+    create :comment, commentable: legislation_question,
+                     body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -62,9 +62,12 @@ feature 'Commenting proposals' do
   end
 
   scenario 'Comment order' do
-    c1 = create(:comment, :with_confidence_score, commentable: proposal, cached_votes_up: 100, cached_votes_total: 120, created_at: Time.current - 2)
-    c2 = create(:comment, :with_confidence_score, commentable: proposal, cached_votes_up: 10, cached_votes_total: 12, created_at: Time.current - 1)
-    c3 = create(:comment, :with_confidence_score, commentable: proposal, cached_votes_up: 1, cached_votes_total: 2, created_at: Time.current)
+    c1 = create(:comment, :with_confidence_score, commentable: proposal, cached_votes_up: 100,
+                                                  cached_votes_total: 120, created_at: Time.current - 2)
+    c2 = create(:comment, :with_confidence_score, commentable: proposal, cached_votes_up: 10,
+                                                  cached_votes_total: 12, created_at: Time.current - 1)
+    c3 = create(:comment, :with_confidence_score, commentable: proposal, cached_votes_up: 1,
+                                                  cached_votes_total: 2, created_at: Time.current)
 
     visit proposal_path(proposal, order: :most_voted)
 
@@ -118,7 +121,8 @@ feature 'Commenting proposals' do
   end
 
   scenario 'Sanitizes comment body for security' do
-    create :comment, commentable: proposal, body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
+    create :comment, commentable: proposal,
+                     body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
     visit proposal_path(proposal)
 

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -189,11 +189,12 @@ feature 'Debates' do
 
   scenario 'JS injection is prevented but autolinking is respected' do
     author = create(:user)
+    js_injection_string = "<script>alert('hey')</script> <a href=\"javascript:alert('surprise!')\">click me<a/> http://example.org"
     login_as(author)
 
     visit new_debate_path
     fill_in 'debate_title', with: 'Testing auto link'
-    fill_in 'debate_description', with: "<script>alert('hey')</script> <a href=\"javascript:alert('surprise!')\">click me<a/> http://example.org"
+    fill_in 'debate_description', with: js_injection_string
     check 'debate_terms_of_service'
 
     click_button 'Start a debate'

--- a/spec/features/legacy_legislation_spec.rb
+++ b/spec/features/legacy_legislation_spec.rb
@@ -77,8 +77,10 @@ feature 'Legacy Legislation' do
 
     scenario 'Search' do
       legacy_legislation = create(:legacy_legislation)
-      annotation1 = create(:annotation, legacy_legislation: legacy_legislation, text: "my annotation",       ranges: [{"start" => "/div[1]", "startOffset" => 5, "end" => "/div[1]", "endOffset" => 10}])
-      annotation2 = create(:annotation, legacy_legislation: legacy_legislation, text: "my other annotation", ranges: [{"start" => "/div[1]", "startOffset" => 12, "end" => "/div[1]", "endOffset" => 19}])
+      annotation1 = create(:annotation, legacy_legislation: legacy_legislation, text: "my annotation",
+                                        ranges: [{"start" => "/div[1]", "startOffset" => 5, "end" => "/div[1]", "endOffset" => 10}])
+      annotation2 = create(:annotation, legacy_legislation: legacy_legislation, text: "my other annotation",
+                                        ranges: [{"start" => "/div[1]", "startOffset" => 12, "end" => "/div[1]", "endOffset" => 19}])
 
       visit legacy_legislation_path(legacy_legislation)
 

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -10,9 +10,12 @@ feature 'Legislation Draft Versions' do
   context "See draft text page" do
     before(:each) do
       @process = create(:legislation_process)
-      @draft_version_1 = create(:legislation_draft_version, process: @process, title: "Version 1", body: "Body of the first version", status: "published")
-      @draft_version_2 = create(:legislation_draft_version, process: @process, title: "Version 2", body: "Body of the second version", status: "published")
-      @draft_version_3 = create(:legislation_draft_version, process: @process, title: "Version 3", body: "Body of the third version", status: "draft")
+      @draft_version_1 = create(:legislation_draft_version, process: @process, title: "Version 1",
+                                                            body: "Body of the first version", status: "published")
+      @draft_version_2 = create(:legislation_draft_version, process: @process, title: "Version 2",
+                                                            body: "Body of the second version", status: "published")
+      @draft_version_3 = create(:legislation_draft_version, process: @process, title: "Version 3",
+                                                            body: "Body of the third version", status: "draft")
     end
 
     it "shows the text body for this version" do
@@ -64,7 +67,8 @@ feature 'Legislation Draft Versions' do
 
     context "for final versions" do
       it "does not show the comments panel" do
-        final_version = create(:legislation_draft_version, process: @process, title: "Final version", body: "Final body", status: "published", final_version: true)
+        final_version = create(:legislation_draft_version, process: @process, title: "Final version",
+                                                           body: "Final body", status: "published", final_version: true)
 
         visit legislation_process_draft_version_path(@process, final_version)
 
@@ -78,9 +82,12 @@ feature 'Legislation Draft Versions' do
   context "See changes page" do
     before(:each) do
       @process = create(:legislation_process)
-      @draft_version_1 = create(:legislation_draft_version, process: @process, title: "Version 1", body: "Body of the first version", changelog: "Changes for first version", status: "published")
-      @draft_version_2 = create(:legislation_draft_version, process: @process, title: "Version 2", body: "Body of the second version", changelog: "Changes for second version", status: "published")
-      @draft_version_3 = create(:legislation_draft_version, process: @process, title: "Version 3", body: "Body of the third version", changelog: "Changes for third version", status: "draft")
+      @draft_version_1 = create(:legislation_draft_version, process: @process, title: "Version 1", body: "Body of the first version",
+                                                            changelog: "Changes for first version", status: "published")
+      @draft_version_2 = create(:legislation_draft_version, process: @process, title: "Version 2", body: "Body of the second version",
+                                                            changelog: "Changes for second version", status: "published")
+      @draft_version_3 = create(:legislation_draft_version, process: @process, title: "Version 3", body: "Body of the third version",
+                                                            changelog: "Changes for third version", status: "draft")
     end
 
     it "shows the changes for this version" do
@@ -173,8 +180,10 @@ feature 'Legislation Draft Versions' do
 
     scenario 'View annotations and comments' do
       draft_version = create(:legislation_draft_version, :published)
-      annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",       ranges: [{"start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10}])
-      annotation2 = create(:legislation_annotation, draft_version: draft_version, text: "my other annotation", ranges: [{"start" => "/p[1]", "startOffset" => 12, "end" => "/p[1]", "endOffset" => 19}])
+      annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
+                                                    ranges: [{"start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10}])
+      create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
+                                      ranges: [{"start" => "/p[1]", "startOffset" => 12, "end" => "/p[1]", "endOffset" => 19}])
       comment = create(:comment, commentable: annotation1)
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
@@ -190,7 +199,8 @@ feature 'Legislation Draft Versions' do
 
     scenario "Publish new comment for an annotation from comments box" do
       draft_version = create(:legislation_draft_version, :published)
-      annotation = create(:legislation_annotation, draft_version: draft_version, text: "my annotation", ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
+      annotation = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
+                                                   ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
@@ -212,8 +222,10 @@ feature 'Legislation Draft Versions' do
 
     scenario 'View annotations and comments in an included range' do
       draft_version = create(:legislation_draft_version, :published)
-      annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",       ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5}])
-      annotation2 = create(:legislation_annotation, draft_version: draft_version, text: "my other annotation", ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10}])
+      annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
+                                                    ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5}])
+      annotation2 = create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
+                                                    ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10}])
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
@@ -232,8 +244,10 @@ feature 'Legislation Draft Versions' do
   context "Annotations page" do
     background do
       @draft_version = create(:legislation_draft_version, :published)
-      @annotation_1 = create(:legislation_annotation, draft_version: @draft_version, text: "my annotation",       quote: "ipsum", ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
-      @annotation_2 = create(:legislation_annotation, draft_version: @draft_version, text: "my other annotation", quote: "audiam", ranges: [{"start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}])
+      create(:legislation_annotation, draft_version: @draft_version, text: "my annotation",       quote: "ipsum",
+                                      ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
+      create(:legislation_annotation, draft_version: @draft_version, text: "my other annotation", quote: "audiam",
+                                      ranges: [{"start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}])
     end
 
     scenario "See all annotations for a draft version" do
@@ -246,10 +260,14 @@ feature 'Legislation Draft Versions' do
     context "switching versions" do
       background do
         @process = create(:legislation_process)
-        @draft_version_1 = create(:legislation_draft_version, :published, process: @process, title: "Version 1", body: "Text with quote for version 1")
-        @annotation_1 = create(:legislation_annotation, draft_version: @draft_version_1, text: "annotation for version 1", quote: "quote for version 1", ranges: [{"start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30}])
-        @draft_version_2 = create(:legislation_draft_version, :published, process: @process, title: "Version 2", body: "Text with quote for version 2")
-        @annotation_1 = create(:legislation_annotation, draft_version: @draft_version_2, text: "annotation for version 2", quote: "quote for version 2", ranges: [{"start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30}])
+        @draft_version_1 = create(:legislation_draft_version, :published, process: @process,
+                                                                          title: "Version 1", body: "Text with quote for version 1")
+        create(:legislation_annotation, draft_version: @draft_version_1, text: "annotation for version 1", quote: "quote for version 1",
+                                        ranges: [{"start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30}])
+        @draft_version_2 = create(:legislation_draft_version, :published, process: @process,
+                                                                          title: "Version 2", body: "Text with quote for version 2")
+        create(:legislation_annotation, draft_version: @draft_version_2, text: "annotation for version 2", quote: "quote for version 2",
+                                        ranges: [{"start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30}])
       end
 
       scenario "without js" do
@@ -278,12 +296,14 @@ feature 'Legislation Draft Versions' do
   context "Annotation comments page" do
     background do
       @draft_version = create(:legislation_draft_version, :published)
-      @annotation_1 = create(:legislation_annotation, draft_version: @draft_version, text: "my annotation",       quote: "ipsum", ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
-      @annotation_2 = create(:legislation_annotation, draft_version: @draft_version, text: "my other annotation", quote: "audiam", ranges: [{"start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}])
+      create(:legislation_annotation, draft_version: @draft_version, text: "my annotation", quote: "ipsum",
+                                      ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
+      @annotation = create(:legislation_annotation, draft_version: @draft_version, text: "my other annotation", quote: "audiam",
+                                                    ranges: [{"start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}])
     end
 
     scenario "See one annotation with replies for a draft version" do
-      visit legislation_process_draft_version_annotation_path(@draft_version.process, @draft_version, @annotation_2)
+      visit legislation_process_draft_version_annotation_path(@draft_version.process, @draft_version, @annotation)
 
       expect(page).to_not have_content "ipsum"
       expect(page).to_not have_content "my annotation"

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -84,13 +84,16 @@ feature 'Budget Investments' do
         expect(page).to have_css('.budget-investment', count: 1)
         expect(page).to have_content(budget_investment1.title)
         expect(page).to_not have_content(budget_investment2.title)
-        expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment1)}']", text: budget_investment1.title)
+        expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment1)}']",
+                                 text: budget_investment1.title)
       end
     end
 
     scenario "by heading" do
-      budget_investment1 = create(:budget_investment, budget: @budget, title: "Hey ho", heading: create(:budget_heading, name: "District 9"))
-      budget_investment2 = create(:budget_investment, budget: @budget, title: "Let's go", heading: create(:budget_heading, name: "Area 52"))
+      budget_investment1 = create(:budget_investment, budget: @budget, title: "Hey ho",
+                                                      heading: create(:budget_heading, name: "District 9"))
+      budget_investment2 = create(:budget_investment, budget: @budget, title: "Let's go",
+                                                      heading: create(:budget_heading, name: "Area 52"))
 
       user = create(:user, :level_two)
       login_managed_user(user)
@@ -108,7 +111,8 @@ feature 'Budget Investments' do
         expect(page).to have_css('.budget-investment', count: 1)
         expect(page).to_not have_content(budget_investment1.title)
         expect(page).to have_content(budget_investment2.title)
-        expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment2)}']", text: budget_investment2.title)
+        expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment2)}']",
+                                 text: budget_investment2.title)
       end
     end
   end
@@ -135,8 +139,10 @@ feature 'Budget Investments' do
 
     within("#budget-investments") do
       expect(page).to have_css('.budget-investment', count: 2)
-      expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment1)}']", text: budget_investment1.title)
-      expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment2)}']", text: budget_investment2.title)
+      expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment1)}']",
+                               text: budget_investment1.title)
+      expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment2)}']",
+                               text: budget_investment2.title)
     end
   end
 

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -65,7 +65,8 @@ feature 'Proposal Notifications' do
   scenario "Show notifications" do
     proposal = create(:proposal)
     notification1 = create(:proposal_notification, proposal: proposal, title: "Hey guys", body: "Just wanted to let you know that...")
-    notification2 = create(:proposal_notification, proposal: proposal, title: "Another update", body: "We are almost there please share with your peoples!")
+    notification2 = create(:proposal_notification, proposal: proposal, title: "Another update",
+                                                   body: "We are almost there please share with your peoples!")
 
     visit proposal_path(proposal)
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -331,13 +331,14 @@ feature 'Proposals' do
 
   scenario 'JS injection is prevented but autolinking is respected' do
     author = create(:user)
+    js_injection_string = "<script>alert('hey')</script> <a href=\"javascript:alert('surprise!')\">click me<a/> http://example.org"
     login_as(author)
 
     visit new_proposal_path
     fill_in 'proposal_title', with: 'Testing auto link'
     fill_in 'proposal_question', with: 'Should I stay or should I go?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
-    fill_in 'proposal_description', with: "<script>alert('hey')</script> <a href=\"javascript:alert('surprise!')\">click me<a/> http://example.org"
+    fill_in 'proposal_description', with: js_injection_string
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -6,6 +6,7 @@ feature 'Users' do
     context 'Sign up' do
 
       scenario 'Success' do
+        message = "You have been sent a message containing a verification link. Please click on this link to activate your account."
         visit '/'
         click_link 'Register'
 
@@ -17,7 +18,7 @@ feature 'Users' do
 
         click_button 'Register'
 
-        expect(page).to have_content "You have been sent a message containing a verification link. Please click on this link to activate your account."
+        expect(page).to have_content message
 
         confirm_email
 

--- a/spec/features/verification/letter_spec.rb
+++ b/spec/features/verification/letter_spec.rb
@@ -11,7 +11,8 @@ feature 'Verify Letter' do
 
     click_link "Send me a letter with the code"
 
-    expect(page).to have_content "Thank you for requesting your maximum security code (only required for the final votes). In a few days we will send it to the address featuring in the data we have on file."
+    expect(page).to have_content "Thank you for requesting your maximum security code (only required for the final votes). In a few days"\
+                                 " we will send it to the address featuring in the data we have on file."
 
     user.reload
 

--- a/spec/features/verification/level_three_verification_spec.rb
+++ b/spec/features/verification/level_three_verification_spec.rb
@@ -87,6 +87,7 @@ feature 'Level three verification' do
 
     click_link "Send me a letter with the code"
 
-    expect(page).to have_content "Thank you for requesting your maximum security code (only required for the final votes). In a few days we will send it to the address featuring in the data we have on file."
+    expect(page).to have_content "Thank you for requesting your maximum security code (only required for the final votes)."\
+                                 " In a few days we will send it to the address featuring in the data we have on file."
   end
 end

--- a/spec/lib/census_api_spec.rb
+++ b/spec/lib/census_api_spec.rb
@@ -23,13 +23,25 @@ describe CensusApi do
     end
 
     it 'adds upper and lowercase letter when the letter is present' do
-      expect(api.get_document_number_variants(1, '1234567A')).to eq(['1234567', '01234567', '1234567a', '1234567A', '01234567a', '01234567A'])
+      expect(api.get_document_number_variants(1, '1234567A')).to eq(%w(1234567 01234567 1234567a 1234567A 01234567a 01234567A))
     end
   end
 
   describe '#call' do
     let(:invalid_body) { {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}}}} }
-    let(:valid_body){ {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {item: {fecha_nacimiento_string: "1-1-1980"}}}}} }
+    let(:valid_body) do
+      {
+        get_habita_datos_response: {
+          get_habita_datos_return: {
+            datos_habitante: {
+              item: {
+                fecha_nacimiento_string: "1-1-1980"
+              }
+            }
+          }
+        }
+      }
+    end
 
     it "returns the response for the first valid variant" do
       allow(api).to receive(:get_response_body).with(1, "00123456").and_return(invalid_body)

--- a/spec/lib/manager_authenticator_spec.rb
+++ b/spec/lib/manager_authenticator_spec.rb
@@ -51,8 +51,9 @@ describe ManagerAuthenticator do
     end
 
     it 'should call the verification user method' do
+      message = { ub: {user_key: "31415926", date: "20151031135905"} }
       allow(@authenticator).to receive(:application_authorized?).and_return(true)
-      expect(@authenticator.send(:client)).to receive(:call).with(:get_status_user_data, message: { ub: {user_key: "31415926", date: "20151031135905"} })
+      expect(@authenticator.send(:client)).to receive(:call).with(:get_status_user_data, message: message)
       @authenticator.auth
     end
 

--- a/spec/models/legislation/annotation_spec.rb
+++ b/spec/models/legislation/annotation_spec.rb
@@ -10,38 +10,102 @@ RSpec.describe Legislation::Annotation, type: :model do
   end
 
   it "calculates the context for multinode annotations" do
+    quote = "ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam"\
+            " erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex"\
+            " ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum"\
+            " dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril"\
+            " delenit augue duis dolore te feugait nulla facilisi."\
+            "\n\n"\
+            "Expetenda tincidunt in sed, ex partem placerat sea, porro commodo ex eam. His putant aeterno interesset at. Usu ea mundi"\
+            " tincidunt, omnium virtute aliquando ius ex. Ea aperiri sententiae duo. Usu nullam dolorum quaestio ei, sit vidit facilisis"\
+            " ea. Per ne impedit iracundia neglegentur. Consetetur neglegentur eum ut, vis animal legimus inimicus id."\
+            "\n\n"\
+            "His audiam"
     annotation = create(:legislation_annotation,
       draft_version: draft_version,
-      quote: "ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
-
-Expetenda tincidunt in sed, ex partem placerat sea, porro commodo ex eam. His putant aeterno interesset at. Usu ea mundi tincidunt, omnium virtute aliquando ius ex. Ea aperiri sententiae duo. Usu nullam dolorum quaestio ei, sit vidit facilisis ea. Per ne impedit iracundia neglegentur. Consetetur neglegentur eum ut, vis animal legimus inimicus id.
-
-His audiam",
+      quote: quote,
       ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}]
     )
 
-    expect(annotation.context).to eq("Lorem <span class=annotator-hl>ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.\n\nExpetenda tincidunt in sed, ex partem placerat sea, porro commodo ex eam. His putant aeterno interesset at. Usu ea mundi tincidunt, omnium virtute aliquando ius ex. Ea aperiri sententiae duo. Usu nullam dolorum quaestio ei, sit vidit facilisis ea. Per ne impedit iracundia neglegentur. Consetetur neglegentur eum ut, vis animal legimus inimicus id.\n\nHis audiam</span>deserunt in, eum ubique voluptatibus te. In reque dicta usu. Ne rebum dissentiet eam, vim omnis deseruisse id. Ullum deleniti vituperata at quo, insolens complectitur te eos, ea pri dico munere propriae. Vel ferri facilis ut, qui paulo ridens praesent ad. Possim alterum qui cu. Accusamus consulatu ius te, cu decore soleat appareat usu.")
+    context = "Lorem <span class=annotator-hl>ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt"\
+              " ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper"\
+              " suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit"\
+              " esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui"\
+              " blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.\n\nExpetenda tincidunt in sed, ex"\
+              " partem placerat sea, porro commodo ex eam. His putant aeterno interesset at. Usu ea mundi tincidunt, omnium virtute"\
+              " aliquando ius ex. Ea aperiri sententiae duo. Usu nullam dolorum quaestio ei, sit vidit facilisis ea. Per ne impedit"\
+              " iracundia neglegentur. Consetetur neglegentur eum ut, vis animal legimus inimicus id.\n\nHis audiam</span>deserunt in, eum"\
+              " ubique voluptatibus te. In reque dicta usu. Ne rebum dissentiet eam, vim omnis deseruisse id. Ullum deleniti vituperata at"\
+              " quo, insolens complectitur te eos, ea pri dico munere propriae. Vel ferri facilis ut, qui paulo ridens praesent ad. Possim"\
+              " alterum qui cu. Accusamus consulatu ius te, cu decore soleat appareat usu."
+    expect(annotation.context).to eq(context)
   end
 
   it "calculates the context for multinode annotations 2" do
+    quote = "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla"\
+            " facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore"\
+            " te feugait nulla facilisi.\r\n\r\nExpetenda tincidunt in sed, ex partem placerat sea, porro commodo ex eam. His putant"\
+            " aeterno interesset at. Usu ea mundi tincidunt, omnium virtute aliquando ius ex. Ea aperiri sententiae duo"
     annotation = create(:legislation_annotation,
       draft_version: draft_version,
-      quote: "Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.\r\n\r\nExpetenda tincidunt in sed, ex partem placerat sea, porro commodo ex eam. His putant aeterno interesset at. Usu ea mundi tincidunt, omnium virtute aliquando ius ex. Ea aperiri sententiae duo",
+      quote: quote,
       ranges: [{"start" => "/p[1]", "startOffset" => 273, "end" => "/p[2]", "endOffset" => 190}]
     )
 
-    expect(annotation.context).to eq("Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. <span class=annotator-hl>Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.\r\n\r\nExpetenda tincidunt in sed, ex partem placerat sea, porro commodo ex eam. His putant aeterno interesset at. Usu ea mundi tincidunt, omnium virtute aliquando ius ex. Ea aperiri sententiae duo</span>. Usu nullam dolorum quaestio ei, sit vidit facilisis ea. Per ne impedit iracundia neglegentur. Consetetur neglegentur eum ut, vis animal legimus inimicus id.")
+    context = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna"\
+              " aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut"\
+              " aliquip ex ea commodo consequat. <span class=annotator-hl>Duis autem vel eum iriure dolor in hendrerit in vulputate velit"\
+              " esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui"\
+              " blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.\r\n\r\nExpetenda tincidunt in sed, ex"\
+              " partem placerat sea, porro commodo ex eam. His putant aeterno interesset at. Usu ea mundi tincidunt, omnium virtute"\
+              " aliquando ius ex. Ea aperiri sententiae duo</span>. Usu nullam dolorum quaestio ei, sit vidit facilisis ea. Per ne impedit"\
+              " iracundia neglegentur. Consetetur neglegentur eum ut, vis animal legimus inimicus id."
+    expect(annotation.context).to eq(context)
   end
 
   it "calculates the context for multinode annotations 3" do
-    draft_version = create(:legislation_draft_version, body: "The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.\r\n\r\nThe licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.\r\n\r\nWhen we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.\r\n\r\nDevelopers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.\r\n\r\nA secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate. Many developers of free software are heartened and encouraged by the resulting cooperation. However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.\r\n\r\nThe GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community. It requires the operator of a network server to provide the source code of the modified version running there to the users of that server. Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.\r\n\r\nAn older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals. This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.")
+    body = "The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed"\
+           " to ensure cooperation with the community in the case of network server software.\r\n\r\nThe licenses for most software and"\
+           " other practical works are designed to take away your freedom to share and change the works. By contrast, our General Public"\
+           " Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free"\
+           " software for all its users.\r\n\r\nWhen we speak of free software, we are referring to freedom, not price. Our General"\
+           " Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for"\
+           " them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces"\
+           " of it in new free programs, and that you know you can do these things.\r\n\r\nDevelopers that use our General Public Licenses"\
+           " protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you"\
+           " legal permission to copy, distribute and/or modify the software.\r\n\r\nA secondary benefit of defending all users' freedom"\
+           " is that improvements made in alternate versions of the program, if they receive widespread use, become available for other"\
+           " developers to incorporate. Many developers of free software are heartened and encouraged by the resulting cooperation."\
+           " However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License"\
+           " permits making a modified version and letting the public access it on a server without ever releasing its source code to the"\
+           " public.\r\n\r\nThe GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified"\
+           " source code becomes available to the community. It requires the operator of a network server to provide the source code of"\
+           " the modified version running there to the users of that server. Therefore, public use of a modified version, on a publicly"\
+           " accessible server, gives the public access to the source code of the modified version.\r\n\r\nAn older license, called the"\
+           " Affero General Public License and published by Affero, was designed to accomplish similar goals. This is a different license,"\
+           " not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this"\
+           " license."
+    draft_version = create(:legislation_draft_version, body: body)
+
+    quote = "By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a"\
+            " program--to make sure it remains free software for all its users.\r\n\r\nWhen we speak of free software, we are referring to"\
+            " freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of"\
+            " free software (and charge for them if you wish)"
 
     annotation = create(:legislation_annotation,
       draft_version: draft_version,
-      quote: "By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.\r\n\r\nWhen we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish)",
+      quote: quote,
       ranges: [{"start" => "/p[2]", "startOffset" => 127, "end" => "/p[3]", "endOffset" => 223}]
     )
 
-    expect(annotation.context).to eq("The licenses for most software and other practical works are designed to take away your freedom to share and change the works. <span class=annotator-hl>By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.\r\n\r\nWhen we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish)</span>, that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.")
+    context = "The licenses for most software and other practical works are designed to take away your freedom to share and change the"\
+              " works. <span class=annotator-hl>By contrast, our General Public Licenses are intended to guarantee your freedom to share"\
+              " and change all versions of a program--to make sure it remains free software for all its users.\r\n\r\nWhen we speak of"\
+              " free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have"\
+              " the freedom to distribute copies of free software (and charge for them if you wish)</span>, that you receive source code"\
+              " or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know"\
+              " you can do these things."
+
+    expect(annotation.context).to eq(context)
   end
 end

--- a/spec/models/residence_spec.rb
+++ b/spec/models/residence_spec.rb
@@ -25,7 +25,9 @@ describe Verification::Residence do
     end
 
     it "should validate user has allowed age" do
-      residence = Verification::Residence.new("date_of_birth(3i)" => "1", "date_of_birth(2i)" => "1", "date_of_birth(1i)" => (5.years.ago.year).to_s)
+      residence = Verification::Residence.new("date_of_birth(3i)" => "1",
+                                              "date_of_birth(2i)" => "1",
+                                              "date_of_birth(1i)" => (5.years.ago.year).to_s)
       expect(residence).to_not be_valid
       expect(residence.errors[:date_of_birth]).to include("You don't have the required age to participate")
     end

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -25,7 +25,10 @@ describe Verification::Management::Document do
     end
 
     it "returns false when the user is user's minimum required age" do
-      census_response = double(date_of_birth: Date.new(User.minimum_required_age.years.ago.year, User.minimum_required_age.years.ago.month, User.minimum_required_age.years.ago.day))
+      date_of_birth = Date.new(User.minimum_required_age.years.ago.year,
+                      User.minimum_required_age.years.ago.month,
+                      User.minimum_required_age.years.ago.day)
+      census_response = double(date_of_birth: date_of_birth)
       expect(Verification::Management::Document.new.under_age?(census_response)).to be false
     end
 

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -25,8 +25,9 @@ module CommonActions
   end
 
   def login_as_authenticated_manager
+    expected_response = {login: login, user_key: user_key, date: date}.with_indifferent_access
     login, user_key, date = "JJB042", "31415926", Time.current.strftime("%Y%m%d%H%M%S")
-    allow_any_instance_of(ManagerAuthenticator).to receive(:auth).and_return({login: login, user_key: user_key, date: date}.with_indifferent_access)
+    allow_any_instance_of(ManagerAuthenticator).to receive(:auth).and_return(expected_response)
     visit management_sign_in_path(login: login, clave_usuario: user_key, fecha_conexion: date)
   end
 
@@ -219,8 +220,11 @@ module CommonActions
   end
 
   def create_archived_proposals
-    [create(:proposal, title: "This is an expired proposal", created_at: Setting["months_to_archive_proposals"].to_i.months.ago),
-     create(:proposal, title: "This is an oldest expired proposal", created_at: (Setting["months_to_archive_proposals"].to_i + 2).months.ago)]
+    months_to_archive_proposals = Setting["months_to_archive_proposals"].to_i
+    [
+      create(:proposal, title: "This is an expired proposal", created_at: months_to_archive_proposals.months.ago),
+      create(:proposal, title: "This is an oldest expired proposal", created_at: (months_to_archive_proposals + 2).months.ago)
+    ]
   end
 
   def tag_names(tag_cloud)

--- a/spec/support/verifiable.rb
+++ b/spec/support/verifiable.rb
@@ -65,7 +65,8 @@ shared_examples_for "verifiable" do
 
         user2 = create(:user, verified_at: nil, residence_verified_at: Time.current, unconfirmed_phone: nil)
         user3 = create(:user, verified_at: nil, confirmed_phone: nil)
-        user4 = create(:user, verified_at: Time.current, residence_verified_at: Time.current, unconfirmed_phone: "123456789", confirmed_phone: "123456789")
+        user4 = create(:user, verified_at: Time.current, residence_verified_at: Time.current,
+                              unconfirmed_phone: "123456789", confirmed_phone: "123456789")
 
         expect(model.incomplete_verification).to include(user1)
         expect(model.incomplete_verification).to include(user2)


### PR DESCRIPTION
What
====
Line length should be 140 chars or less 🤖

How
===
- Manually resolving each issue

- Trying to still keep each modification as readable as possible

Warnings
========
This might be one of the most controvert rubocop PR's :) since it could be easily argued that a longer line may be easier to read in some cases than the 140-compliant fix. I would rather find/propose an alternative fix than keeping file exclusions on the `.rubocop_todo.yml` file