### PR TITLE
Gemfile cleanup

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,14 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 23
-# Cop supports --auto-correct.
-# Configuration parameters: Include, TreatCommentsAsGroupSeparators.
-# Include: **/Gemfile, **/gems.rb
-Bundler/OrderedGems:
-  Exclude:
-    - 'Gemfile'
-
 # Offense count: 45
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedHashRocketStyle, SupportedHashRocketStyles, EnforcedColonStyle, SupportedColonStyles, EnforcedLastArgumentHashStyle, SupportedLastArgumentHashStyles.

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,6 @@ gem 'sass-rails', '~> 5.0', '>= 5.0.4'
 gem 'uglifier', '~> 3.2.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2.1'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
-
 # Use jquery as the JavaScript library
 gem 'jquery-rails', '~> 4.3.1'
 gem 'jquery-ui-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,6 @@ gem 'sprockets', '~> 3.7.1'
 
 gem 'devise', '~> 3.5.7'
 gem 'devise_security_extension'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
 gem 'omniauth'
 gem 'omniauth-twitter'
 gem 'omniauth-facebook', '~> 4.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,70 +2,62 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.2.9'
 
-gem 'pg', '~> 0.20.0'
-gem 'sass-rails', '~> 5.0', '>= 5.0.4'
-gem 'uglifier', '~> 3.2.0'
-gem 'coffee-rails', '~> 4.2.1'
-gem 'jquery-rails', '~> 4.3.1'
-gem 'jquery-ui-rails'
-gem 'turbolinks'
-
-gem 'sprockets', '~> 3.7.1'
-
-gem 'devise', '~> 3.5.7'
-gem 'devise_security_extension'
-gem 'omniauth'
-gem 'omniauth-twitter'
-gem 'omniauth-facebook', '~> 4.0.0'
-gem 'omniauth-google-oauth2', '~> 0.4.0'
-
-gem 'kaminari', '~> 1.0.1'
-gem 'ancestry', '~> 2.2.2'
 gem 'acts-as-taggable-on'
-gem 'responders', '~> 2.4.0'
+gem 'acts_as_votable'
+gem 'ahoy_matey', '~> 1.6.0'
+gem 'ancestry', '~> 2.2.2'
+gem 'browser'
+gem 'cancancan', '~> 1.16.0'
+gem 'ckeditor', '~> 4.2.3'
+gem 'cocoon'
+gem 'coffee-rails', '~> 4.2.1'
+gem 'daemons'
+gem 'dalli'
+gem 'delayed_job_active_record', '~> 4.1.0'
+gem 'devise', '~> 3.5.7'
+gem 'devise-async'
+gem 'devise_security_extension'
 gem 'foundation-rails', '~> 6.2.4.0'
 gem 'foundation_rails_helper', '~> 2.0.0'
-gem 'acts_as_votable'
-gem 'ckeditor', '~> 4.2.3'
-gem 'invisible_captcha', '~> 0.9.2'
-gem 'cancancan', '~> 1.16.0'
-gem 'social-share-button', '~> 0.10'
-gem 'initialjs-rails', '0.2.0.5'
-gem 'unicorn', '~> 5.3.0'
-gem 'paranoia', '~> 2.3.1'
-gem 'rinku', '~> 2.0.2', require: 'rails_rinku'
-gem 'savon'
-gem 'dalli'
-gem 'rollbar', '~> 2.14.1'
-gem 'delayed_job_active_record', '~> 4.1.0'
-gem 'daemons'
-gem 'devise-async'
-gem 'newrelic_rpm', '~> 4.1.0.333'
-gem 'whenever', require: false
-gem 'pg_search'
-gem 'sitemap_generator', '~> 5.3.1'
-
-gem 'ahoy_matey', '~> 1.6.0'
-gem 'groupdate', '~> 3.2.0' # group temporary data
-
-gem 'browser'
-gem 'turnout', '~> 2.4.0'
-gem 'redcarpet', '~> 3.4.0'
-gem 'rubyzip', '~> 1.2.0'
-
-gem 'paperclip'
-gem 'rails-assets-markdown-it', source: 'https://rails-assets.org'
-
-gem 'cocoon'
-
-gem 'graphql', '~> 1.6.3'
 gem 'graphiql-rails', '~> 1.4.1'
+gem 'graphql', '~> 1.6.3'
+gem 'groupdate', '~> 3.2.0' # group temporary data
+gem 'initialjs-rails', '0.2.0.5'
+gem 'invisible_captcha', '~> 0.9.2'
+gem 'jquery-rails', '~> 4.3.1'
+gem 'jquery-ui-rails'
+gem 'kaminari', '~> 1.0.1'
+gem 'newrelic_rpm', '~> 4.1.0.333'
+gem 'omniauth'
+gem 'omniauth-facebook', '~> 4.0.0'
+gem 'omniauth-google-oauth2', '~> 0.4.0'
+gem 'omniauth-twitter'
+gem 'paperclip'
+gem 'paranoia', '~> 2.3.1'
+gem 'pg', '~> 0.20.0'
+gem 'pg_search'
+gem 'rails-assets-markdown-it', source: 'https://rails-assets.org'
+gem 'redcarpet', '~> 3.4.0'
+gem 'responders', '~> 2.4.0'
+gem 'rinku', '~> 2.0.2', require: 'rails_rinku'
+gem 'rollbar', '~> 2.14.1'
+gem 'rubyzip', '~> 1.2.0'
+gem 'sass-rails', '~> 5.0', '>= 5.0.4'
+gem 'savon'
+gem 'sitemap_generator', '~> 5.3.1'
+gem 'social-share-button', '~> 0.10'
+gem 'sprockets', '~> 3.7.1'
+gem 'turbolinks'
+gem 'turnout', '~> 2.4.0'
+gem 'uglifier', '~> 3.2.0'
+gem 'unicorn', '~> 5.3.0'
+gem 'whenever', require: false
 
 group :development, :test do
   gem "bullet", '~> 5.5.1'
-  gem "faker", '~> 1.7.3'
   gem 'byebug'
   gem 'factory_girl_rails', '~> 4.8.0'
+  gem "faker", '~> 1.7.3'
   gem 'i18n-tasks', '~> 0.9.15'
   gem 'knapsack'
   gem 'launchy'
@@ -81,15 +73,14 @@ group :test do
   gem 'coveralls', '~> 0.8.21', require: false
   gem 'database_cleaner'
   gem 'email_spec'
-  gem 'fuubar'
   gem 'poltergeist', '~> 1.15.0'
   gem 'rspec-rails', '~> 3.6'
 end
 
 group :development do
-  gem "capistrano-rails", '~> 1.2.3', require: false
   gem 'capistrano', '~> 3.8.1', require: false
   gem 'capistrano-bundler', '~> 1.2', require: false
+  gem "capistrano-rails", '~> 1.2.3', require: false
   gem 'capistrano3-delayed-job', '~> 1.7.3'
   gem 'mdl', require: false
   gem 'rvm1-capistrano3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,77 +2,77 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.2.9'
 
-gem 'acts-as-taggable-on'
-gem 'acts_as_votable'
+gem 'acts-as-taggable-on', '~> 4.0.0'
+gem 'acts_as_votable', '~> 0.10.0'
 gem 'ahoy_matey', '~> 1.6.0'
 gem 'ancestry', '~> 2.2.2'
-gem 'browser'
+gem 'browser', '~> 2.3.0'
 gem 'cancancan', '~> 1.16.0'
 gem 'ckeditor', '~> 4.2.3'
-gem 'cocoon'
+gem 'cocoon', '~> 1.2.9'
 gem 'coffee-rails', '~> 4.2.1'
-gem 'daemons'
-gem 'dalli'
+gem 'daemons', '~> 1.2.4'
+gem 'dalli', '~> 2.7.6'
 gem 'delayed_job_active_record', '~> 4.1.0'
 gem 'devise', '~> 3.5.7'
-gem 'devise-async'
-gem 'devise_security_extension'
+gem 'devise-async', '~> 0.10.2'
+gem 'devise_security_extension', '~> 0.10.0'
 gem 'foundation-rails', '~> 6.2.4.0'
 gem 'foundation_rails_helper', '~> 2.0.0'
 gem 'graphiql-rails', '~> 1.4.1'
 gem 'graphql', '~> 1.6.3'
-gem 'groupdate', '~> 3.2.0' # group temporary data
-gem 'initialjs-rails', '0.2.0.5'
+gem 'groupdate', '~> 3.2.0'
+gem 'initialjs-rails', '~> 0.2.0.5'
 gem 'invisible_captcha', '~> 0.9.2'
 gem 'jquery-rails', '~> 4.3.1'
-gem 'jquery-ui-rails'
+gem 'jquery-ui-rails', '~> 6.0.1'
 gem 'kaminari', '~> 1.0.1'
 gem 'newrelic_rpm', '~> 4.1.0.333'
-gem 'omniauth'
+gem 'omniauth', '~> 1.6.1'
 gem 'omniauth-facebook', '~> 4.0.0'
 gem 'omniauth-google-oauth2', '~> 0.4.0'
-gem 'omniauth-twitter'
-gem 'paperclip'
+gem 'omniauth-twitter', '~> 1.4.0'
+gem 'paperclip', '~> 5.1.0'
 gem 'paranoia', '~> 2.3.1'
 gem 'pg', '~> 0.20.0'
-gem 'pg_search'
-gem 'rails-assets-markdown-it', source: 'https://rails-assets.org'
+gem 'pg_search', '~> 2.0.1'
+gem 'rails-assets-markdown-it', '~> 8.2.1', source: 'https://rails-assets.org'
 gem 'redcarpet', '~> 3.4.0'
 gem 'responders', '~> 2.4.0'
 gem 'rinku', '~> 2.0.2', require: 'rails_rinku'
 gem 'rollbar', '~> 2.14.1'
 gem 'rubyzip', '~> 1.2.0'
 gem 'sass-rails', '~> 5.0', '>= 5.0.4'
-gem 'savon'
+gem 'savon', '~> 2.11.1'
 gem 'sitemap_generator', '~> 5.3.1'
 gem 'social-share-button', '~> 0.10'
 gem 'sprockets', '~> 3.7.1'
-gem 'turbolinks'
+gem 'turbolinks', '~> 2.5.3'
 gem 'turnout', '~> 2.4.0'
 gem 'uglifier', '~> 3.2.0'
 gem 'unicorn', '~> 5.3.0'
-gem 'whenever', require: false
+gem 'whenever', '~> 0.9.7', require: false
 
 group :development, :test do
   gem "bullet", '~> 5.5.1'
-  gem 'byebug'
+  gem 'byebug', '~> 9.0.6'
   gem 'factory_girl_rails', '~> 4.8.0'
   gem "faker", '~> 1.7.3'
   gem 'i18n-tasks', '~> 0.9.15'
-  gem 'knapsack'
-  gem 'launchy'
+  gem 'knapsack', '~> 1.13.3'
+  gem 'launchy', '~> 2.4.3'
   gem 'letter_opener_web', '~> 1.3.1'
-  gem 'quiet_assets'
+  gem 'quiet_assets', '~> 1.1.0'
   gem 'rubocop', '~> 0.49.1', require: false
-  gem 'spring'
-  gem 'spring-commands-rspec'
+  gem 'spring', '~> 2.0.1'
+  gem 'spring-commands-rspec', '~> 1.0.4'
 end
 
 group :test do
   gem 'capybara', '~> 2.14.0'
   gem 'coveralls', '~> 0.8.21', require: false
-  gem 'database_cleaner'
-  gem 'email_spec'
+  gem 'database_cleaner', '~> 1.5.3'
+  gem 'email_spec', '~> 2.1.0'
   gem 'poltergeist', '~> 1.15.0'
   gem 'rspec-rails', '~> 3.6'
 end
@@ -82,10 +82,10 @@ group :development do
   gem 'capistrano-bundler', '~> 1.2', require: false
   gem "capistrano-rails", '~> 1.2.3', require: false
   gem 'capistrano3-delayed-job', '~> 1.7.3'
-  gem 'mdl', require: false
-  gem 'rvm1-capistrano3', require: false
-  gem 'scss_lint', require: false
-  gem 'web-console', '3.3.0'
+  gem 'mdl', '~> 0.4.0', require: false
+  gem 'rvm1-capistrano3', '~> 1.4.0', require: false
+  gem 'scss_lint', '~> 0.53.0', require: false
+  gem 'web-console', '~> 3.3.0'
 end
 
 eval_gemfile './Gemfile_custom'

--- a/Gemfile
+++ b/Gemfile
@@ -74,39 +74,39 @@ gem 'graphql', '~> 1.6.3'
 gem 'graphiql-rails', '~> 1.4.1'
 
 group :development, :test do
-  gem 'byebug'
-  gem 'spring'
-  gem 'spring-commands-rspec'
-  gem 'factory_girl_rails', '~> 4.8.0'
-  gem 'launchy'
-  gem 'quiet_assets'
-  gem 'letter_opener_web', '~> 1.3.1'
-  gem 'i18n-tasks', '~> 0.9.15'
   gem "bullet", '~> 5.5.1'
   gem "faker", '~> 1.7.3'
-  gem 'rubocop', '~> 0.49.1', require: false
+  gem 'byebug'
+  gem 'factory_girl_rails', '~> 4.8.0'
+  gem 'i18n-tasks', '~> 0.9.15'
   gem 'knapsack'
+  gem 'launchy'
+  gem 'letter_opener_web', '~> 1.3.1'
+  gem 'quiet_assets'
+  gem 'rubocop', '~> 0.49.1', require: false
+  gem 'spring'
+  gem 'spring-commands-rspec'
 end
 
 group :test do
-  gem 'database_cleaner'
-  gem 'poltergeist', '~> 1.15.0'
-  gem 'coveralls', '~> 0.8.21', require: false
-  gem 'email_spec'
-  gem 'rspec-rails', '~> 3.6'
   gem 'capybara', '~> 2.14.0'
+  gem 'coveralls', '~> 0.8.21', require: false
+  gem 'database_cleaner'
+  gem 'email_spec'
   gem 'fuubar'
+  gem 'poltergeist', '~> 1.15.0'
+  gem 'rspec-rails', '~> 3.6'
 end
 
 group :development do
-  gem 'mdl', require: false
-  gem 'scss_lint', require: false
-  gem 'web-console', '3.3.0'
+  gem "capistrano-rails", '~> 1.2.3', require: false
   gem 'capistrano', '~> 3.8.1', require: false
   gem 'capistrano-bundler', '~> 1.2', require: false
-  gem "capistrano-rails", '~> 1.2.3', require: false
-  gem 'rvm1-capistrano3', require: false
   gem 'capistrano3-delayed-job', '~> 1.7.3'
+  gem 'mdl', require: false
+  gem 'rvm1-capistrano3', require: false
+  gem 'scss_lint', require: false
+  gem 'web-console', '3.3.0'
 end
 
 eval_gemfile './Gemfile_custom'

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,15 @@
 source 'https://rubygems.org'
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.9'
-# Use PostgreSQL
+
 gem 'pg', '~> 0.20.0'
-# Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0', '>= 5.0.4'
-# Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '~> 3.2.0'
-# Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2.1'
-# Use jquery as the JavaScript library
 gem 'jquery-rails', '~> 4.3.1'
 gem 'jquery-ui-rails'
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
 
-# Fix sprockets on the
 gem 'sprockets', '~> 3.7.1'
 
 gem 'devise', '~> 3.5.7'

--- a/Gemfile
+++ b/Gemfile
@@ -74,24 +74,14 @@ gem 'graphql', '~> 1.6.3'
 gem 'graphiql-rails', '~> 1.4.1'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-commands-rspec'
-  gem 'rspec-rails', '~> 3.6'
-  gem 'capybara', '~> 2.14.0'
   gem 'factory_girl_rails', '~> 4.8.0'
-  gem 'fuubar'
   gem 'launchy'
   gem 'quiet_assets'
   gem 'letter_opener_web', '~> 1.3.1'
   gem 'i18n-tasks', '~> 0.9.15'
-  gem 'capistrano', '~> 3.8.1', require: false
-  gem 'capistrano-bundler', '~> 1.2', require: false
-  gem "capistrano-rails", '~> 1.2.3', require: false
-  gem 'rvm1-capistrano3', require: false
-  gem 'capistrano3-delayed-job', '~> 1.7.3'
   gem "bullet", '~> 5.5.1'
   gem "faker", '~> 1.7.3'
   gem 'rubocop', '~> 0.49.1', require: false
@@ -103,14 +93,20 @@ group :test do
   gem 'poltergeist', '~> 1.15.0'
   gem 'coveralls', '~> 0.8.21', require: false
   gem 'email_spec'
+  gem 'rspec-rails', '~> 3.6'
+  gem 'capybara', '~> 2.14.0'
+  gem 'fuubar'
 end
 
 group :development do
   gem 'mdl', require: false
-  # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'scss_lint', require: false
   gem 'web-console', '3.3.0'
-
+  gem 'capistrano', '~> 3.8.1', require: false
+  gem 'capistrano-bundler', '~> 1.2', require: false
+  gem "capistrano-rails", '~> 1.2.3', require: false
+  gem 'rvm1-capistrano3', require: false
+  gem 'capistrano3-delayed-job', '~> 1.7.3'
 end
 
 eval_gemfile './Gemfile_custom'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,13 +480,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  acts-as-taggable-on
-  acts_as_votable
+  acts-as-taggable-on (~> 4.0.0)
+  acts_as_votable (~> 0.10.0)
   ahoy_matey (~> 1.6.0)
   ancestry (~> 2.2.2)
-  browser
+  browser (~> 2.3.0)
   bullet (~> 5.5.1)
-  byebug
+  byebug (~> 9.0.6)
   cancancan (~> 1.16.0)
   capistrano (~> 3.8.1)
   capistrano-bundler (~> 1.2)
@@ -494,17 +494,17 @@ DEPENDENCIES
   capistrano3-delayed-job (~> 1.7.3)
   capybara (~> 2.14.0)
   ckeditor (~> 4.2.3)
-  cocoon
+  cocoon (~> 1.2.9)
   coffee-rails (~> 4.2.1)
   coveralls (~> 0.8.21)
-  daemons
-  dalli
-  database_cleaner
+  daemons (~> 1.2.4)
+  dalli (~> 2.7.6)
+  database_cleaner (~> 1.5.3)
   delayed_job_active_record (~> 4.1.0)
   devise (~> 3.5.7)
-  devise-async
-  devise_security_extension
-  email_spec
+  devise-async (~> 0.10.2)
+  devise_security_extension (~> 0.10.0)
+  email_spec (~> 2.1.0)
   factory_girl_rails (~> 4.8.0)
   faker (~> 1.7.3)
   foundation-rails (~> 6.2.4.0)
@@ -513,28 +513,28 @@ DEPENDENCIES
   graphql (~> 1.6.3)
   groupdate (~> 3.2.0)
   i18n-tasks (~> 0.9.15)
-  initialjs-rails (= 0.2.0.5)
+  initialjs-rails (~> 0.2.0.5)
   invisible_captcha (~> 0.9.2)
   jquery-rails (~> 4.3.1)
-  jquery-ui-rails
+  jquery-ui-rails (~> 6.0.1)
   kaminari (~> 1.0.1)
-  knapsack
-  launchy
+  knapsack (~> 1.13.3)
+  launchy (~> 2.4.3)
   letter_opener_web (~> 1.3.1)
-  mdl
+  mdl (~> 0.4.0)
   newrelic_rpm (~> 4.1.0.333)
-  omniauth
+  omniauth (~> 1.6.1)
   omniauth-facebook (~> 4.0.0)
   omniauth-google-oauth2 (~> 0.4.0)
-  omniauth-twitter
-  paperclip
+  omniauth-twitter (~> 1.4.0)
+  paperclip (~> 5.1.0)
   paranoia (~> 2.3.1)
   pg (~> 0.20.0)
-  pg_search
+  pg_search (~> 2.0.1)
   poltergeist (~> 1.15.0)
-  quiet_assets
+  quiet_assets (~> 1.1.0)
   rails (= 4.2.9)
-  rails-assets-markdown-it!
+  rails-assets-markdown-it (~> 8.2.1)!
   redcarpet (~> 3.4.0)
   responders (~> 2.4.0)
   rinku (~> 2.0.2)
@@ -542,21 +542,21 @@ DEPENDENCIES
   rspec-rails (~> 3.6)
   rubocop (~> 0.49.1)
   rubyzip (~> 1.2.0)
-  rvm1-capistrano3
+  rvm1-capistrano3 (~> 1.4.0)
   sass-rails (~> 5.0, >= 5.0.4)
-  savon
-  scss_lint
+  savon (~> 2.11.1)
+  scss_lint (~> 0.53.0)
   sitemap_generator (~> 5.3.1)
   social-share-button (~> 0.10)
-  spring
-  spring-commands-rspec
+  spring (~> 2.0.1)
+  spring-commands-rspec (~> 1.0.4)
   sprockets (~> 3.7.1)
-  turbolinks
+  turbolinks (~> 2.5.3)
   turnout (~> 2.4.0)
   uglifier (~> 3.2.0)
   unicorn (~> 5.3.0)
-  web-console (= 3.3.0)
-  whenever
+  web-console (~> 3.3.0)
+  whenever (~> 0.9.7)
 
 BUNDLED WITH
    1.15.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,9 +170,6 @@ GEM
       activesupport (>= 4.1)
       railties (>= 4.1)
       tzinfo (~> 1.2, >= 1.2.2)
-    fuubar (2.2.0)
-      rspec-core (~> 3.0)
-      ruby-progressbar (~> 1.4)
     geocoder (1.4.3)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -512,7 +509,6 @@ DEPENDENCIES
   faker (~> 1.7.3)
   foundation-rails (~> 6.2.4.0)
   foundation_rails_helper (~> 2.0.0)
-  fuubar
   graphiql-rails (~> 1.4.1)
   graphql (~> 1.6.3)
   groupdate (~> 3.2.0)


### PR DESCRIPTION
What
====
- Doing a bit of house clean chore on Gemfile

How
===
- Reorganizing gems development and test groups (some wheren't needed on both)
- Sorting alphabetically gems on all groups
- Removing commented gems (since first commit) and unnecessary comments

Screenshots
===========
No need

Test
====
No need

Deployment
==========
As usual

Warnings
========
Still I have some questions about remaining gems:
- launchy, quiet_assets, spring are needed on test group?
- fuubar seems no longer in use 