### PR TITLE
Improve budget results

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -236,6 +236,11 @@ a {
       border-bottom: 2px solid $brand;
       color: $brand;
     }
+
+    &.bold {
+      font-weight: bold;
+      color: $brand;
+    }
   }
 
   &.no-margin-top {

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -20,7 +20,7 @@ class Admin::BudgetsController < Admin::BaseController
 
   def calculate_winners
     return unless @budget.balloting_process?
-    @budget.headings.each { |heading| Budget::Result.new(@budget, heading).calculate_winners }
+    @budget.headings.each { |heading| Budget::Result.new(@budget, heading).delay.calculate_winners }
     redirect_to admin_budget_budget_investments_path(budget_id: @budget.id, filter: 'winners'),
                 notice: I18n.t("admin.budgets.winners.calculated")
   end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -204,7 +204,7 @@ class Budget
     end
 
     def recalculate_heading_winners
-      Budget::Result.new(budget, heading).calculate_winners if incompatible_changed? && winner? && incompatible?
+      Budget::Result.new(budget, heading).calculate_winners if incompatible_changed?
     end
 
     def set_responsible_name

--- a/app/models/budget/result.rb
+++ b/app/models/budget/result.rb
@@ -15,7 +15,6 @@ class Budget
         set_winner if inside_budget?
       end
     end
-    handle_asynchronously :calculate_winners
 
     def investments
       heading.investments.selected.sort_by_ballots

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -63,6 +63,7 @@
 
 
   <div class="row margin-top">
+    <% if @investment.incompatible? || @investment.winner? %>
     <div class="small-12 medium-3 column">
       <h2 id="incompatible"><%= t("admin.budget_investments.edit.compatibility") %></h2>
       <%= f.label :incompatible do %>
@@ -70,6 +71,7 @@
         <span class="checkbox"><%= t("admin.budget_investments.edit.mark_as_incompatible") %></span>
       <% end %>
     </div>
+    <% end %>
     <div class="small-12 medium-3 column float-left">
       <h2 id="selected"><%= t("admin.budget_investments.edit.selection") %></h2>
       <%= f.label :selected do %>

--- a/app/views/budgets/results/_results_table.html.erb
+++ b/app/views/budgets/results/_results_table.html.erb
@@ -1,4 +1,6 @@
-<div class="small-12 medium-9 column <%= results_type == :compatible ? 'success' : 'js-discarded' %>" id="<%= results_type %>-container">
+<div class="small-12 medium-9 column <%= results_type == :compatible ? 'success' : 'js-discarded' %>"
+     style="<%= results_type != :compatible ? 'display: none' : '' %>"
+     id="<%= results_type %>-container">
 
   <h3 class="inline-block">
     <%= title %>
@@ -28,7 +30,9 @@
     <tbody>
       <% amount_available = heading_price %>
       <% investments.each do |investment| %>
-          <tr id="<%= dom_id(investment) %>" class="budget-investments <%= investment.winner? ? 'success' : 'js-discarded' %>">
+          <tr id="<%= dom_id(investment) %>"
+              class="budget-investments <%= investment.winner? ? 'success' : 'js-discarded' %>"
+              style="<%= investment.winner? ? '' : 'display: none' %>">
             <td>
               <% if investment.winner? %>
                 <span class="icon-check">

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -26,7 +26,8 @@
       </li>
 
       <% @budget.headings.each do |heading| %>
-        <li>
+        <% active_class = heading.id.to_s == params[:heading_id] ? 'bold' : '' %>
+        <li class="<%= active_class %>">
           <%= link_to heading.name,
                       budget_results_path(@budget, heading_id: heading.id) %>
         </li>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -35,7 +35,7 @@
     </ul>
   </div>
 
-  <span class="float-right"><%= link_to t("budgets.results.hide_discarded_link"), "#", class: "js-toggle-link button hollow margin-bottom", data: {'toggle-selector' => '.js-discarded', 'toggle-text' => t("budgets.results.show_all_link")} %></span>
+  <span class="float-right"><%= link_to t("budgets.results.show_all_link"), "#", class: "js-toggle-link button hollow margin-bottom", data: {'toggle-selector' => '.js-discarded', 'toggle-text' => t("budgets.results.hide_discarded_link")} %></span>
 
 
   <%= render 'results_table', results_type: :compatible,

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -42,8 +42,10 @@
                               heading_price: @heading.price,
                               investments: @investments.compatible %>
 
-  <%= render 'results_table', results_type: :incompatible,
-                              title: t("budgets.results.incompatibles"),
-                              heading_price: @heading.price,
-                              investments: @investments.incompatible %>
+  <% if @investments.incompatible.present? %>
+    <%= render 'results_table', results_type: :incompatible,
+                                title: t("budgets.results.incompatibles"),
+                                heading_price: @heading.price,
+                                investments: @investments.incompatible %>
+  <% end %>
 </div>

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -312,7 +312,7 @@ feature 'Admin budget investments' do
   context "Edit" do
 
     scenario "Change title, incompatible, description or heading" do
-      budget_investment = create(:budget_investment, :selected)
+      budget_investment = create(:budget_investment, :incompatible)
       create(:budget_heading, group: budget_investment.group, name: "Barbate")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -321,7 +321,7 @@ feature 'Admin budget investments' do
       fill_in 'budget_investment_title', with: 'Potatoes'
       fill_in 'budget_investment_description', with: 'Carrots'
       select "#{budget_investment.group.name}: Barbate", from: 'budget_investment[heading_id]'
-      check "budget_investment_incompatible"
+      uncheck "budget_investment_incompatible"
       check "budget_investment_selected"
 
       click_button 'Update'
@@ -329,8 +329,19 @@ feature 'Admin budget investments' do
       expect(page).to have_content 'Potatoes'
       expect(page).to have_content 'Carrots'
       expect(page).to have_content 'Barbate'
-      expect(page).to have_content 'Incompatible'
+      expect(page).to have_content 'Compatibility: Compatible'
       expect(page).to have_content 'Selected'
+    end
+
+    scenario "Compatible non-winner can't edit incompatibility" do
+      budget_investment = create(:budget_investment, :selected)
+      create(:budget_heading, group: budget_investment.group, name: "Tetuan")
+
+      visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
+      click_link 'Edit'
+
+      expect(page).not_to have_content 'Compatibility'
+      expect(page).not_to have_content 'Mark as incompatible'
     end
 
     scenario "Add administrator" do

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -20,6 +20,21 @@ feature 'Results' do
     within("#budget-investments-compatible") do
       expect(page).to have_content investment1.title
       expect(page).to have_content investment2.title
+      expect(page).not_to have_content investment3.title
+      expect(page).not_to have_content investment4.title
+
+      expect(investment1.title).to appear_before(investment2.title)
+    end
+  end
+
+  scenario "Show non winner & incomaptible investments", :js do
+    visit budget_path(budget)
+    click_link "See results"
+    click_link "Show all"
+
+    within("#budget-investments-compatible") do
+      expect(page).to have_content investment1.title
+      expect(page).to have_content investment2.title
       expect(page).to have_content investment4.title
 
       expect(investment1.title).to appear_before(investment2.title)
@@ -28,21 +43,6 @@ feature 'Results' do
 
     within("#budget-investments-incompatible") do
       expect(page).to have_content investment3.title
-    end
-  end
-
-  scenario "Displays non winner investments", :js do
-    visit budget_path(budget)
-    click_link "See results"
-    click_link "Hide discarded"
-
-    within("#budget-investments-compatible") do
-      expect(page).to have_content investment1.title
-      expect(page).to have_content investment2.title
-      expect(page).not_to have_content investment3.title
-      expect(page).not_to have_content investment4.title
-
-      expect(investment1.title).to appear_before(investment2.title)
     end
   end
 

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -55,4 +55,14 @@ feature 'Results' do
     expect(page).to have_content "You do not have permission to carry out the action"
   end
 
+  scenario "No incompatible investments", :js do
+    investment3.incompatible = false
+    investment3.save
+
+    visit budget_path(budget)
+    click_link "See results"
+
+    expect(page).not_to have_content "Incompatibles"
+  end
+
 end

--- a/spec/models/budget/result_spec.rb
+++ b/spec/models/budget/result_spec.rb
@@ -15,7 +15,7 @@ describe Budget::Result do
         investment4 = create(:budget_investment, :selected, heading: heading, price: 500, ballot_lines_count: 600, winner: false)
         investment5 = create(:budget_investment, :selected, heading: heading, price: 100, ballot_lines_count: 500, winner: false)
 
-        Budget::Result.new(budget, heading).calculate_winners
+        described_class.new(budget, heading).calculate_winners
 
         expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment4.id])
       end
@@ -29,7 +29,7 @@ describe Budget::Result do
         investment4 = create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 600)
         investment5 = create(:budget_investment, :winner, heading: heading, price: 100, ballot_lines_count: 500)
 
-        Budget::Result.new(budget, heading).calculate_winners
+        described_class.new(budget, heading).calculate_winners
 
         expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment4.id])
       end
@@ -49,6 +49,20 @@ describe Budget::Result do
         expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment4.id])
       end
     end
-  end
 
+    context "When an incompatible is flagged as compatible again" do
+      it "recalculates winners taking it in consideration" do
+        investment1 = create(:budget_investment, :winner, heading: heading, price: 200, ballot_lines_count: 900)
+        investment2 = create(:budget_investment, :winner, heading: heading, price: 300, ballot_lines_count: 800)
+        investment3 = create(:budget_investment, :incompatible, heading: heading, price: 500, ballot_lines_count: 700)
+        investment4 = create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 600)
+        investment5 = create(:budget_investment, :winner, heading: heading, price: 100, ballot_lines_count: 500)
+
+        investment3.incompatible = false
+        investment3.save
+
+        expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment3.id])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/1737

What
====
1.  Highlight current heading
2. Calculate winners synchronously
3. Do not display incompatible investment's table if empty
4. Show incompatibility checkbox only if winner or incompatible (not for compatible non-winners)
5. Always recalculate heading winners on incompatibility change

How
===
1. Adding a new "bold" class for menu.vertical.li and applying it based on heading_id param value https://github.com/consul/consul/commit/49f48ddf4be50b932799739143bbbf3455bc410c
2. Making use of `.delay` explicitly, avoiding the `handle_asynchronously` that modified all calls. https://github.com/consul/consul/commit/efacd0def32df2850deb19998ddf7d94b788146b
3. Not rendering the results table with incompatible investments if none present https://github.com/consul/consul/commit/2fba9de33b697a9c6ff62045c807a61c61b031e7
4. Checking that investment is either winner or incompatible https://github.com/consul/consul/commit/741a342bb0fd26a385356788c84dc2b788b41426
5. Removing extra unnecessary conditions for recalculation https://github.com/consul/consul/commit/2b85deabec96371f51530ca452e9011cc165f901

Screenshots
===========
## 1.Highlight current heading && 3. Do not display incompatible investment's table if empty
![screen shot 2017-07-10 at 17 47 27](https://user-images.githubusercontent.com/983242/28027523-a08dc628-6599-11e7-9b9a-6ce7706cb8df.jpg)

## 4. Show incompatibility checkbox only if winner or incompatible (not for compatible non-winners)
![screen shot 2017-07-10 at 18 01 48](https://user-images.githubusercontent.com/983242/28027601-e44dde98-6599-11e7-81c3-d1d3eebe5434.jpg)

Test
====
Extended coverage for all new scenarios. Better check each commit to see in detail

Deployment
==========
As usual

Warnings
========
None