### PR TITLE
Budget results meta tags

### DIFF
--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -1,22 +1,31 @@
 module Budgets
   class ResultsController < ApplicationController
+    before_action :load_budget
+    before_action :load_heading
 
     load_and_authorize_resource :budget
 
     def show
       authorize! :read_results, @budget
       @investments = load_result.investments
-      @heading = heading
     end
 
     private
 
       def load_result
-        Budget::Result.new(@budget, heading)
+        Budget::Result.new(@budget, @heading)
       end
 
-      def heading
-        @budget.headings.find(params[:heading_id])
+      def load_budget
+        @budget = Budget.find_by(id: params[:budget_id])
+      end
+
+      def load_heading
+        if params[:heading_id].present?
+          @heading = @budget.headings.find(params[:heading_id])
+        else
+          @heading = @budget.headings.first
+        end
       end
 
   end

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -1,6 +1,13 @@
 <% provide :title, t("budgets.results.page_title", budget: @budget.name) %>
+<% content_for :meta_description do %><%= @budget.description_finished %><% end %>
+<% provide :social_media_meta_tags do %>
+<%= render "shared/social_media_meta_tags",
+            social_url: budget_results_url(@budget),
+            social_title: @budget.name,
+            social_description: @budget.description_finished %>
+<% end %>
 <% content_for :canonical do %>
-  <%= render "shared/canonical", href: budget_results_url(@budget, heading_id: @heading) %>
+  <%= render "shared/canonical", href: budget_results_url(@budget) %>
 <% end %>
 
 <div class="expanded budget no-margin-top">

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -46,6 +46,18 @@ feature 'Results' do
     end
   end
 
+  scenario "Load first budget heading if not specified" do
+    other_heading = create(:budget_heading, group: group)
+    other_investment = create(:budget_investment, :winner, heading: other_heading)
+
+    visit budget_results_path(budget)
+
+    within("#budget-investments-compatible") do
+      expect(page).to have_content investment1.title
+      expect(page).to_not have_content other_investment.title
+    end
+  end
+
   scenario "If budget is in a phase different from finished results can't be accessed" do
     budget.update phase: (Budget::PHASES - ["finished"]).sample
     visit budget_path(budget)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1655 

What
====
- Add social meta tags for budget results

How
===
- Adding results url to meta tags
- Adding budget's finished description to meta tags

Bonus
===
- Displays results for first heading if no heading_id param is specified

Warnings
===
- If using custom urls for budget results, change `social_url`and `canonical_url` appropriately