### PR TITLE
improves styles of change credentials button

### DIFF
--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -1,7 +1,7 @@
 <div class="row account">
   <div class="small-12 column">
     <div class="float-right text-right">
-      <%= link_to t("account.show.change_credentials_link"), edit_user_registration_path, class: "button secondary" %>
+      <%= link_to t("account.show.change_credentials_link"), edit_user_registration_path, class: "button hollow" %>
       <br>
       <%= link_to t("account.show.erase_account_link"), users_registrations_delete_form_path, class: "delete" %>
     </div>


### PR DESCRIPTION
What
====
- In `account/show` there is a "Change my credentials" button that seems disabled, but its not.

Screenshots
===========
**Before** (`the button seems disabled`)
<img width="269" alt="screen shot 2017-07-17 at 17 21 16" src="https://user-images.githubusercontent.com/631897/28275676-e7d21752-6b14-11e7-9bc7-0dc14ea7d5fa.png">

**After** (`a normal button!`)
<img width="321" alt="screen shot 2017-07-17 at 17 25 24" src="https://user-images.githubusercontent.com/631897/28275681-ef092d9e-6b14-11e7-8cb1-edc36bd5eee7.png">
