### PR TITLE
Login items menu

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -533,6 +533,14 @@ header {
   }
 }
 
+.top-bar-right {
+
+  .active {
+    font-weight: bold;
+    text-decoration: underline;
+  }
+}
+
 .submenu {
   border-bottom: 1px solid $border;
   clear: both;

--- a/app/views/devise/menu/_login_items.html.erb
+++ b/app/views/devise/menu/_login_items.html.erb
@@ -12,12 +12,20 @@
     <% end %>
   </li>
   <li>
-    <%= link_to t("layouts.header.my_activity_link"),
-                user_path(current_user), rel: "nofollow" %>
+    <%= layout_menu_link_to t("layouts.header.my_activity_link"),
+                              user_path(current_user),
+                              controller_name == 'users',
+                              rel: "nofollow",
+                              title: t("shared.go_to_page") +
+                                     t("layouts.header.my_activity_link") %>
   </li>
   <li>
-    <%= link_to t("layouts.header.my_account_link"),
-                account_path, rel: "nofollow" %>
+    <%= layout_menu_link_to t("layouts.header.my_account_link"),
+                              account_path,
+                              controller_name == 'account',
+                              rel: "nofollow",
+                              title: t("shared.go_to_page") +
+                                     t("layouts.header.my_account_link") %>
   </li>
   <li>
     <%= link_to t("devise_views.menu.login_items.logout"),


### PR DESCRIPTION
What
====
- Now when the user visits **"My account"** or **"My activity"** section, there is no styles to indicate the current section.

How
===
- Adds `active` class on login items menu using the `layout_menu_link_to` helper.

Screenshots
===========
`Before (no changes)`
<img width="104" alt="screen shot 2017-07-19 at 17 16 04" src="https://user-images.githubusercontent.com/631897/28374784-0d4b3fbc-6ca6-11e7-8ec4-f9bab4cd4ee5.png">

`After (yay!)`
<img width="112" alt="screen shot 2017-07-19 at 17 16 27" src="https://user-images.githubusercontent.com/631897/28374792-119c7658-6ca6-11e7-8104-654394d67229.png">