### PR TITLE
Admin menu

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -412,6 +412,32 @@ header {
       box-shadow: 0 7px 0 #fff, 0 14px 0 #fff;
     }
   }
+
+  .menu {
+
+    &.is-dropdown-submenu {
+      margin: 0;
+      margin-top: rem-calc(-24);
+      padding: 0;
+    }
+
+    .is-submenu-item {
+      display: block;
+      height: auto;
+      margin-bottom: 0;
+
+      a {
+        color: $text;
+      }
+    }
+  }
+}
+
+.dropdown.menu > li {
+
+  &.is-dropdown-submenu-parent > a::after {
+    border-color: #fff transparent transparent;
+  }
 }
 
 .top-links {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -28,7 +28,7 @@
         </div>
 
         <div class="top-bar-right">
-          <ul class="menu">
+          <ul class="dropdown menu" data-dropdown-menu>
             <%= render "shared/admin_login_items" %>
             <%= render "devise/menu/login_items" %>
           </ul>

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -1,32 +1,37 @@
 <% if current_user %>
-  <% if current_user.administrator? %>
-    <li>
-      <%= link_to t("layouts.header.administration"), admin_root_path %>
-    </li>
-  <% end %>
+<li>
+  <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow" %>
+  <ul class="menu">
+    <% if current_user.administrator? %>
+      <li>
+        <%= link_to t("layouts.header.administration"), admin_root_path %>
+      </li>
+    <% end %>
 
-  <% if current_user.administrator? || current_user.moderator? %>
-    <li>
-      <%= link_to t("layouts.header.moderation"), moderation_root_path %>
-    </li>
-  <% end %>
+    <% if current_user.administrator? || current_user.moderator? %>
+      <li>
+        <%= link_to t("layouts.header.moderation"), moderation_root_path %>
+      </li>
+    <% end %>
 
-  <% if (feature?(:spending_proposals) || feature?(:budgets)) &&
-        (current_user.administrator? || current_user.valuator?) %>
-    <li>
-      <%= link_to t("layouts.header.valuation"), valuation_root_path %>
-    </li>
-  <% end %>
+    <% if (feature?(:spending_proposals) || feature?(:budgets)) &&
+          (current_user.administrator? || current_user.valuator?) %>
+      <li>
+        <%= link_to t("layouts.header.valuation"), valuation_root_path %>
+      </li>
+    <% end %>
 
-  <% if current_user.administrator? || current_user.manager? %>
-    <li>
-      <%= link_to t("layouts.header.management"), management_sign_in_path %>
-    </li>
-  <% end %>
+    <% if current_user.administrator? || current_user.manager? %>
+      <li>
+        <%= link_to t("layouts.header.management"), management_sign_in_path %>
+      </li>
+    <% end %>
 
-  <% if current_user.administrator? || current_user.poll_officer? %>
-    <li>
-      <%= link_to t("layouts.header.officing"), officing_root_path %>
-    </li>
-  <% end %>
+    <% if current_user.administrator? || current_user.poll_officer? %>
+      <li>
+        <%= link_to t("layouts.header.officing"), officing_root_path %>
+      </li>
+    <% end %>
+  </ul>
+</li>
 <% end %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -191,6 +191,7 @@ en:
       transparency_title: Transparency
       transparency_url: https://transparency.consul
     header:
+      administration_menu: Administration
       administration: Administration
       available_locales: Available languages
       collaborative_legislation: Legislation processes

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -191,7 +191,7 @@ en:
       transparency_title: Transparency
       transparency_url: https://transparency.consul
     header:
-      administration_menu: Administration
+      administration_menu: Admin
       administration: Administration
       available_locales: Available languages
       collaborative_legislation: Legislation processes

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -191,6 +191,7 @@ es:
       transparency_title: Transparencia
       transparency_url: https://transparency.consul
     header:
+      administration_menu: Administración
       administration: Administrar
       available_locales: Idiomas disponibles
       collaborative_legislation: Procesos legislativos

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -191,7 +191,7 @@ es:
       transparency_title: Transparencia
       transparency_url: https://transparency.consul
     header:
-      administration_menu: Administración
+      administration_menu: Admin
       administration: Administrar
       available_locales: Idiomas disponibles
       collaborative_legislation: Procesos legislativos


### PR DESCRIPTION
What
====
- The menu is growing up and the  items go to two lines on some screen sizes.

How
===
- Adds dropdown on admin menu links.

Screenshots
===========
- `Before (a lot of links)`
<img width="765" alt="admin_menu_before" src="https://user-images.githubusercontent.com/631897/28391655-2cd28a46-6cdf-11e7-9306-414f0d2b4e68.png">

- `After (more neat!)`
<img width="560" alt="admin_menu_after" src="https://user-images.githubusercontent.com/631897/28391661-328ff086-6cdf-11e7-85ed-bf500acca663.png">
