### PR TITLE
Rubocop autocorrections 🤖

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -440,6 +440,8 @@ Style/AccessorMethodName:
 Style/BracesAroundHashParameters:
   Exclude:
     - 'app/models/concerns/searchable.rb'
+    - 'spec/features/budgets/investments_spec.rb'
+    - 'spec/features/proposals_spec.rb'
 
 # Offense count: 119
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,8 +26,8 @@ class UsersController < ApplicationController
       when "proposals" then load_proposals
       when "debates"   then load_debates
       when "budget_investments" then load_budget_investments
-      when "comments"  then load_comments
-      when "follows"  then load_follows
+      when "comments" then load_comments
+      when "follows" then load_follows
       else load_available_activity
       end
     end

--- a/app/helpers/followables_helper.rb
+++ b/app/helpers/followables_helper.rb
@@ -20,7 +20,7 @@ module FollowablesHelper
   end
 
   def followable_class_name(followable)
-    followable.class.to_s.parameterize.gsub('-', '_')
+    followable.class.to_s.parameterize('_')
   end
 
   def find_or_build_follow(user, followable)

--- a/app/models/concerns/followable.rb
+++ b/app/models/concerns/followable.rb
@@ -7,7 +7,7 @@ module Followable
   end
 
   def followed_by?(user)
-    followers.include?(user)  
+    followers.include?(user)
   end
 
 end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -5,5 +5,4 @@ class Follow < ActiveRecord::Base
   validates :user_id, presence: true
   validates :followable_id, presence: true
   validates :followable_type, presence: true
-
 end

--- a/doc/api/examples/ruby/example_1.rb
+++ b/doc/api/examples/ruby/example_1.rb
@@ -1,16 +1,16 @@
 require 'http'
 
-API_ENDPOINT = 'https://decide.madrid.es/graphql'
+API_ENDPOINT = 'https://decide.madrid.es/graphql'.freeze
 
 def make_request(query_string)
   HTTP.headers('User-Agent' => 'Mozilla/5.0', accept: 'application/json')
       .get(
         API_ENDPOINT,
-        params: { query: query_string.gsub("\n", '').gsub(" ", '') }
+        params: { query: query_string.delete("\n").delete(" ") }
       )
 end
 
-query = """
+query = <<-GRAPHQL
   {
     proposal(id: 1) {
         id,
@@ -18,7 +18,7 @@ query = """
         public_created_at
     }
   }
-"""
+GRAPHQL
 
 response = make_request(query)
 

--- a/doc/api/examples/ruby/example_2.rb
+++ b/doc/api/examples/ruby/example_2.rb
@@ -1,12 +1,12 @@
 require 'http'
 
-API_ENDPOINT = 'https://decide.madrid.es/graphql'
+API_ENDPOINT = 'https://decide.madrid.es/graphql'.freeze
 
 def make_request(query_string)
   HTTP.headers('User-Agent' => 'Mozilla/5.0', accept: 'application/json')
       .get(
         API_ENDPOINT,
-        params: { query: query_string.gsub("\n", '').gsub(" ", '') }
+        params: { query: query_string.delete("\n").delete(" ") }
       )
 end
 
@@ -15,9 +15,9 @@ def build_query(options = {})
   page_size_parameter = "first: #{page_size}"
 
   page_number = options[:page_number] || 0
-  after_parameter = page_number > 0 ? ", after: \"#{options[:next_cursor]}\"" : ""
+  after_parameter = page_number.positive? ? ", after: \"#{options[:next_cursor]}\"" : ""
 
-  """
+  <<-GRAPHQL
   {
     proposals(#{page_size_parameter}#{after_parameter}) {
       pageInfo {
@@ -33,7 +33,7 @@ def build_query(options = {})
       }
     }
   }
-  """
+  GRAPHQL
 end
 
 page_number = 0
@@ -41,7 +41,7 @@ next_cursor = nil
 proposals   = []
 
 loop do
-  
+
   puts "> Requesting page #{page_number}"
 
   query = build_query(page_size: 25, page_number: page_number, next_cursor: next_cursor)
@@ -61,5 +61,5 @@ loop do
 
   page_number += 1
 
-  break if !has_next_page
+  break unless has_next_page
 end

--- a/lib/local_census.rb
+++ b/lib/local_census.rb
@@ -28,7 +28,9 @@ class LocalCensus
     end
 
     def district_code
-      @body.district_code rescue nil
+        @body.district_code
+    rescue
+        nil
     end
 
     def gender
@@ -43,7 +45,9 @@ class LocalCensus
     end
 
     def name
-      "#{@body.nombre} #{@body.apellido1}" rescue nil
+        "#{@body.nombre} #{@body.apellido1}"
+    rescue
+        nil
     end
 
     private

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -219,7 +219,7 @@ feature 'Users' do
     end
 
     scenario 'Display interests' do
-      proposal =  create(:proposal, tag_list: "Sport")
+      proposal = create(:proposal, tag_list: "Sport")
       create(:follow, :followed_proposal, followable: proposal, user: @user)
 
       login_as(@user)
@@ -375,7 +375,7 @@ feature 'Users' do
 
       visit user_path(@user, filter: "follows")
 
-      expect(page).to have_selector(".activity li.active", text: "1 Following" )
+      expect(page).to have_selector(".activity li.active", text: "1 Following")
     end
 
     describe 'Proposals' do
@@ -471,7 +471,7 @@ feature 'Users' do
       end
 
       scenario 'Display budget investment with action buttons inside accordion budget investment tab when current user is a verified user and author', :js do
-        user =  create(:user, :level_two)
+        user = create(:user, :level_two)
         budget_investment = create(:budget_investment, author: user)
         create(:follow, followable: budget_investment, user: user)
         login_as user
@@ -484,7 +484,7 @@ feature 'Users' do
       end
 
       scenario 'Display budget investment with action buttons inside accordion budget investment tab when there is no logged user', :js do
-        user =  create(:user, :level_two)
+        user = create(:user, :level_two)
         budget_investment = create(:budget_investment, author: user)
         create(:follow, followable: budget_investment, user: user)
 
@@ -496,7 +496,7 @@ feature 'Users' do
       end
 
       scenario 'Display budget investment without action buttons inside accordion budget investment tab when current user is not budget investment author', :js do
-        user =  create(:user, :level_two)
+        user = create(:user, :level_two)
         budget_investment = create(:budget_investment)
         create(:follow, followable: budget_investment, user: user)
         login_as user

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -5,7 +5,7 @@ describe CensusCaller do
 
   describe '#call' do
     it "returns data from local_census_records if census API is not available" do
-      census_api_response = CensusApi::Response.new({:get_habita_datos_response=>{:get_habita_datos_return=>{:datos_habitante=>{}, :datos_vivienda=>{}}}})
+      census_api_response = CensusApi::Response.new(get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}, datos_vivienda: {}}})
       local_census_response = LocalCensus::Response.new(create(:local_census_record))
 
       CensusApi.any_instance.stub(:call).and_return(census_api_response)
@@ -20,7 +20,7 @@ describe CensusCaller do
     end
 
     it "returns data from census API if it's available and valid" do
-      census_api_response = CensusApi::Response.new({get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {item: {fecha_nacimiento_string: "1-1-1980"}}}}})
+      census_api_response = CensusApi::Response.new(get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {item: {fecha_nacimiento_string: "1-1-1980"}}}})
       local_census_response = LocalCensus::Response.new(create(:local_census_record))
 
       CensusApi.any_instance.stub(:call).and_return(census_api_response)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -658,10 +658,10 @@ describe User do
   end
 
   describe "#interests" do
-    let(:user)     { create(:user) }
+    let(:user) { create(:user) }
 
     it "should return followed object tags" do
-      proposal =  create(:proposal, tag_list: "Sport")
+      proposal = create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal, user: user)
 
       expect(user.interests).to eq ["Sport"]
@@ -670,7 +670,7 @@ describe User do
     it "should discard followed objects duplicated tags" do
       proposal1 =  create(:proposal, tag_list: "Sport")
       proposal2 =  create(:proposal, tag_list: "Sport")
-      budget_investment =  create(:budget_investment, tag_list: "Sport")
+      budget_investment = create(:budget_investment, tag_list: "Sport")
 
       create(:follow, followable: proposal1, user: user)
       create(:follow, followable: proposal2, user: user)

--- a/spec/shared/features/followable.rb
+++ b/spec/shared/features/followable.rb
@@ -3,7 +3,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
   let!(:arguments) { {} }
   let!(:followable) { create(followable_class_name) }
-  let!(:followable_dom_name) { followable_class_name.gsub('_', '-') }
+  let!(:followable_dom_name) { followable_class_name.tr('_', '-') }
 
   before do
     followable_path_arguments.each do |argument_name, path_to_value|


### PR DESCRIPTION
# What

Automatic rubocop cleanup:

*   Redundant spaces
*   Redundant curly braces around a hash parameter.
*   tr => gsub (http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Performance/StringReplacement)

# How

`rubocop -a` as we have already existent issue at `.rubocop_todo.yml`

# Screenshots

No need

# Test

Hope they'll pass :D

# Deployment

As usual

# Warnings

None