### PR TITLE
Add empty interests list message.

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -41,4 +41,20 @@ module UsersHelper
     current_user && current_user.administrator?
   end
 
+  def interests_title_text(user)
+    if current_user == user
+      t('account.show.public_interests_my_title_list')
+    else
+      t('account.show.public_interests_user_title_list')
+    end
+  end
+
+  def empty_interests_message_text(user)
+    if current_user == user
+      t('account.show.public_interests_my_empty_list')
+    else
+      t('account.show.public_interests_user_empty_list')
+    end
+  end
+
 end

--- a/app/views/users/_interests.html.erb
+++ b/app/views/users/_interests.html.erb
@@ -1,0 +1,24 @@
+<div id="public_interests" class="public-interests">
+  <h4><%= interests_title_text(user) %></h4>
+
+  <% if user.interests.any? %>
+
+    <% user.interests.in_groups_of(10, false) do |interests_group| %>
+      <div class="small-4 column end">
+        <ul class="no-bullet">
+          <% interests_group.each do |interest| %>
+            <li> <small><%= interest %></small> </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+  <% else %>
+
+    <div class="callout primary">
+      <%= empty_interests_message_text(user) %>
+    </div>
+
+  <% end %>
+
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -46,20 +46,7 @@
         <p><%= t('users.show.private_activity') %></p>
       <% end %>
 
-      <% if valid_interests_access? %>
-        <div id="public_interests" class="public-interests">
-          <h4><%= t('account.show.public_interests_title_list') %></h4>
-          <% @user.interests.in_groups_of(10, false) do |interests_group| %>
-            <div class="small-4 column end">
-              <ul class="no-bullet">
-                <% interests_group.each do |interest| %>
-                  <li> <small><%= interest %></small> </li>
-                <% end %>
-              </ul>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+      <%= render 'interests', user: @user if valid_interests_access? %>
 
     </div>
   </div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -14,7 +14,10 @@ en:
       phone_number_label: Phone number
       public_activity_label: Keep my list of activities public
       public_interests_label: Keep my interests public
-      public_interests_title_list: List of interests
+      public_interests_my_title_list: List of interests (Tags of elements you follow)
+      public_interests_user_title_list: List of interests (Tags of elements this user follows)
+      public_interests_my_empty_list: You do not follow any elements yet.
+      public_interests_user_empty_list: This user does not follow any elements yet.
       save_changes_submit: Save changes
       subscription_to_website_newsletter_label: Receive by email website relevant information
       email_on_direct_message_label: Receive emails about direct messages

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -14,7 +14,10 @@ es:
       phone_number_label: Teléfono
       public_activity_label: Mostrar públicamente mi lista de actividades
       public_interests_label: Mostrar públicamente mis intereses
-      public_interests_title_list: Lista de intereses
+      public_interests_my_title_list: Lista de intereses (Etiquetas de los elementos que sigues)
+      public_interests_user_title_list: Lista de intereses (Etiquetas de los elementos seguidos este usuario)
+      public_interests_my_empty_list: Aún no sigues ningún elemento.
+      public_interests_user_empty_list: Este usuario no sigue ningún elemento todavía.
       save_changes_submit: Guardar cambios
       subscription_to_website_newsletter_label: Recibir emails con información interesante sobre la web
       email_on_direct_message_label: Recibir emails con mensajes privados

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -213,7 +213,7 @@ feature 'Users' do
 
   end
 
-  feature 'Public interest' do
+  feature 'Public interests' do
     background do
       @user = create(:user)
     end
@@ -310,6 +310,35 @@ feature 'Users' do
       expect(page).to have_css('#public_interests')
     end
 
+    scenario 'Should display generic interests title' do
+      @user.update(public_interests: true)
+      visit user_path(@user)
+
+      expect(page).to have_content("List of interests (Tags of elements this user follows)")
+    end
+
+    scenario 'Should display custom interests title when user is visiting own user page' do
+      @user.update(public_interests: true)
+      login_as(@user)
+      visit user_path(@user)
+
+      expect(page).to have_content("List of interests (Tags of elements you follow)")
+    end
+
+    scenario 'Should display generic empty interests list message when visited user has not interests defined' do
+      @user.update(public_interests: true)
+      visit user_path(@user)
+
+      expect(page).to have_content("This user does not follow any elements yet.")
+    end
+
+    scenario 'Should display custom empty interests list message when user has not interests defined and user is visiting own user page' do
+      @user.update(public_interests: true)
+      login_as(@user)
+      visit user_path(@user)
+
+      expect(page).to have_content("You do not follow any elements yet.")
+    end
   end
 
   feature 'Special comments' do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1767

What
=======
When current user is not following anything, his interests list is empty.

How
=====
When users is visiting own user page we should show:
```You don't follow any element yet.```

When users is visiting others user pages we should show:
```This user don't follow any element yet.```

Also in this PR we have included dynamic and more explicit user interests title, it works like empty messages:

When users is visiting own user page we should show:
```List of interest (Tags of elements you follow)```

When users is visiting others user pages we should show:
```List of interest (Tags of elements this user follow)```

Screenshots
=======

**Now**
![captura de pantalla 2017-07-24 a las 19 10 42](https://user-images.githubusercontent.com/15726/28535365-68ef09dc-70a4-11e7-83d5-d8cc9e3650ab.png)

**After this PR**
![captura de pantalla 2017-07-26 a las 16 54 17](https://user-images.githubusercontent.com/15726/28627916-6dc87bf2-7223-11e7-846d-90ae282de9e7.png)
![captura de pantalla 2017-07-26 a las 16 53 35](https://user-images.githubusercontent.com/15726/28627917-6dcab0d4-7223-11e7-9795-f96cdc7b450d.png)
