### PR TITLE
Legislation comments

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1784,6 +1784,7 @@ table {
 
     [class^="icon-"] {
       font-size: $base-font-size;
+      text-decoration: none;
       vertical-align: sub;
     }
   }
@@ -1814,6 +1815,7 @@ table {
       font-size: $base-font-size;
       left: -20px;
       position: absolute;
+      text-decoration: none;
       top: -1px;
     }
 

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -1113,7 +1113,6 @@ $epigraph-line-height: rem-calc(22);
   }
 
   .comment {
-    margin-bottom: 3rem;
 
     a {
       span {


### PR DESCRIPTION
What
====
- Removes `text-decoration` on icons and unnecessary `margin-bottom` on legislation process comments.

Screenshots
===========
![lesgislation_process_comments](https://user-images.githubusercontent.com/631897/28823129-6360eeea-76bc-11e7-9cdd-a23a79189bbb.jpg)


