### PR TITLE
User activity

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -16,10 +16,8 @@ module UsersHelper
     if commentable.nil?
       deleted_commentable_text(comment)
     elsif commentable.hidden?
-      "<del>".html_safe + commentable.title.html_safe + "</del>".html_safe + ' ' +
-      '<span class="small">'.html_safe +
-      '(' + deleted_commentable_text(comment) + ')' +
-      "</span>".html_safe
+      content_tag(:del, commentable.title) + ' ' +
+      content_tag(:span, '(' + deleted_commentable_text(comment) + ')', class: 'small')
     else
       link_to(commentable.title, comment)
     end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -16,9 +16,10 @@ module UsersHelper
     if commentable.nil?
       deleted_commentable_text(comment)
     elsif commentable.hidden?
-      "<abbr title='#{deleted_commentable_text(comment)}'>".html_safe +
-      commentable.title +
-      "</abbr>".html_safe
+      "<del>".html_safe + commentable.title.html_safe + "</del>".html_safe + ' ' +
+      '<span class="small">'.html_safe +
+      '(' + deleted_commentable_text(comment) + ')' +
+      "</span>".html_safe
     else
       link_to(commentable.title, comment)
     end

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -649,8 +649,8 @@ es:
     show:
       deleted: Eliminado
       deleted_debate: Este debate ha sido eliminado
-      deleted_proposal: Este propuesta ha sido eliminada
-      deleted_budget_investment: Este propuesta de inversión ha sido eliminada
+      deleted_proposal: Esta propuesta ha sido eliminada
+      deleted_budget_investment: Esta propuesta de inversión ha sido eliminada
       filters:
         comments:
           one: 1 Comentario

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -17,7 +17,7 @@ describe UsersHelper do
 
       debate.hide
 
-      expect(comment_commentable_title(comment)).to eq "<abbr title='This debate has been deleted'>#{comment.commentable.title}</abbr>"
+      expect(comment_commentable_title(comment)).to eq '<del>' + comment.commentable.title + '</del> <span class="small">(This debate has been deleted)</span>'
     end
 
     it "should return the appropriate message for deleted proposals" do
@@ -26,7 +26,7 @@ describe UsersHelper do
 
       proposal.hide
 
-      expect(comment_commentable_title(comment)).to eq "<abbr title='This proposal has been deleted'>#{comment.commentable.title}</abbr>"
+      expect(comment_commentable_title(comment)).to eq '<del>' + comment.commentable.title + '</del> <span class="small">(This proposal has been deleted)</span>'
     end
 
     it "should return the appropriate message for deleted budget investment" do
@@ -35,7 +35,7 @@ describe UsersHelper do
 
       investment.hide
 
-      expect(comment_commentable_title(comment)).to eq "<abbr title='This investment has been deleted'>#{comment.commentable.title}</abbr>"
+      expect(comment_commentable_title(comment)).to eq '<del>' + comment.commentable.title + '</del> <span class="small">(This investment has been deleted)</span>'
     end
   end
 
@@ -48,7 +48,7 @@ describe UsersHelper do
     it "should return a hint if the commentable has been deleted" do
       comment = create(:comment)
       comment.commentable.hide
-      expect(comment_commentable_title(comment)).to eq "<abbr title='This debate has been deleted'>#{comment.commentable.title}</abbr>"
+      expect(comment_commentable_title(comment)).to eq '<del>' + comment.commentable.title + '</del> <span class="small">(This debate has been deleted)</span>'
     end
   end
 


### PR DESCRIPTION
What
====
- Now when the user comment an element and this is hidden, appears a `<abbr>` tag with the title `This X has been deleted`. 

How
===
- Improves styles and replace `abbr title` with an explicit text.

Screenshots
===========
`BEFORE`
![activity_before](https://user-images.githubusercontent.com/631897/28824171-2f3815da-76c1-11e7-95fa-0d2fbb199d5c.png)

`AFTER`
<img width="568" alt="activity_after" src="https://user-images.githubusercontent.com/631897/28824175-344ac568-76c1-11e7-8ee2-74952fadff12.png">

