### PR TITLE
Show bottom proposals button only if proposals exists

### DIFF
--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -61,9 +61,11 @@
 
       <%= render 'shared/order_links', i18n_namespace: "proposals.index" %>
 
-      <div class="show-for-small-only">
-        <%= link_to t("proposals.index.start_proposal"), new_proposal_path, class: 'button expanded' %>
-      </div>
+      <% if @proposals.any? %>
+        <div class="show-for-small-only">
+          <%= link_to t("proposals.index.start_proposal"), new_proposal_path, class: 'button expanded' %>
+        </div>
+      <% end %>
 
       <div id="proposals-list">
         <%= render partial: 'proposals/proposal', collection: @proposals %>


### PR DESCRIPTION
What
====
- if there are no any proposals in responsive design renders two buttons for create proposal too close.
 

How
===
- Render bottom button only if proposals exists

Screenshots
===========

Before
====

![screen shot 2017-08-10 at 23 47 02](https://user-images.githubusercontent.com/1192122/29186838-12b2ff20-7e27-11e7-9b52-4796413e4570.png)


After
====
![screen shot 2017-08-10 at 23 47 15](https://user-images.githubusercontent.com/1192122/29186842-18a48de0-7e27-11e7-84a8-a4fd15eb3752.png)

Deployment
==========
- As usual
