### PR TITLE
Share button WhatsApp

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -311,7 +311,8 @@
 .polls-show,
 .debate-quiz,
 .budget-investment-show,
-.draft-panels {
+.draft-panels,
+.debate-questions {
 
   p {
     word-wrap: break-word;
@@ -328,10 +329,13 @@
   .whatsapp::before {
     background-color: #43d854;
     color: #fff;
-    font-size: 1.7em;
-    margin-left: rem-calc(0.5);
-    padding: rem-calc(9.5) rem-calc(9.8);
-    vertical-align: rem-calc(10);
+    display: inline-block;
+    font-size: rem-calc(30);
+    height: rem-calc(48);
+    padding-top: rem-calc(9);
+    text-align: center;
+    vertical-align: top;
+    width: rem-calc(48);
   }
 
   .edit-debate,

--- a/app/views/legislation/annotations/_slim_version_chooser.html.erb
+++ b/app/views/legislation/annotations/_slim_version_chooser.html.erb
@@ -18,7 +18,7 @@
   <aside class="small-12 medium-3 column">
     <div class="sidebar-divider"></div>
     <h2><%= t('legislation.shared.share') %></h2>
-      <%= render '/legislation/shared/share_buttons',
+      <%= render '/shared/social_share',
                  title: t('legislation.shared.share_comment', version_name: @draft_version.title.downcase, process_name: @process.title),
                  url: legislation_process_draft_version_path(process, draft_version)
       %>

--- a/app/views/legislation/annotations/show.html.erb
+++ b/app/views/legislation/annotations/show.html.erb
@@ -33,7 +33,7 @@
           <aside class="small-12 medium-3 column">
             <div class="sidebar-divider"></div>
             <h2><%= t('legislation.shared.share') %></h2>
-            <%= render '/legislation/shared/share_buttons',
+            <%= render '/shared/social_share',
                        title: t('legislation.shared.share_comment', version_name: @draft_version.title.downcase, process_name: @process.title),
                        url: legislation_process_draft_version_annotations_path(@process, @draft_version)
             %>

--- a/app/views/legislation/questions/show.html.erb
+++ b/app/views/legislation/questions/show.html.erb
@@ -38,7 +38,7 @@
     <aside class="small-12 medium-3 column">
       <div id="social-share" class="sidebar-divider"></div>
       <h3><%= t('.share') %></h3>
-      <%= render '/legislation/shared/share_buttons', title: @question.title, url: legislation_process_question_url(@question.process, @question) %>
+      <%= render '/shared/social_share', title: @question.title, url: legislation_process_question_url(@question.process, @question) %>
     </aside>
   </div>
 

--- a/app/views/legislation/shared/_share_buttons.html.erb
+++ b/app/views/legislation/shared/_share_buttons.html.erb
@@ -1,9 +1,0 @@
-<div class="social-share-full">
-  <%= social_share_button_tag("#{title} #{setting['twitter_hashtag']}") %>
-  <% if browser.device.mobile? %>
-    <a href="whatsapp://send?text=<%= title %> <%= url %>" data-action="share/whatsapp/share">
-      <span class="icon-whatsapp whatsapp"></span>
-      <span class="show-for-sr"><%= t("social.whatsapp") %></span>
-    </a>
-  <% end %>
-</div>

--- a/app/views/shared/_social_share.html.erb
+++ b/app/views/shared/_social_share.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 <div class="social-share-full">
   <%= social_share_button_tag("#{title} #{setting['twitter_hashtag']}") %>
-  <a href="whatsapp://send?text=<%= title.gsub(/\s|"|'/, '%20') %>&nbsp;<%= url %>"
+  <a href="whatsapp://send?text=<%= CGI.escape(title) %>&nbsp;<%= url %>"
      class="show-for-small-only" data-action="share/whatsapp/share">
     <span class="icon-whatsapp whatsapp"></span>
     <span class="show-for-sr"><%= t("social.whatsapp") %></span>

--- a/app/views/shared/_social_share.html.erb
+++ b/app/views/shared/_social_share.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 <div class="social-share-full">
   <%= social_share_button_tag("#{title} #{setting['twitter_hashtag']}") %>
-  <a href="whatsapp://send?text=<%= title.gsub(/\s/, '%20') %>&nbsp;<%= url %>"
+  <a href="whatsapp://send?text=<%= title.gsub(/\s|"|'/, '%20') %>&nbsp;<%= url %>"
      class="show-for-small-only" data-action="share/whatsapp/share">
     <span class="icon-whatsapp whatsapp"></span>
     <span class="show-for-sr"><%= t("social.whatsapp") %></span>


### PR DESCRIPTION
What
====
- Now some elements titles have quotation marks, `Make a new "awesome" street`  for example, and this is generating a HTML validation error:

<img width="1350" alt="whatsapp_error" src="https://user-images.githubusercontent.com/631897/29361656-e6652590-8288-11e7-863f-c2118944b9bd.png">
 
How
===
- Escape `"` and `'` symbols on WhatsApp share links.  

Moreover removes a duplicated partial to social buttons on legislation views `legislation/shared/_share_buttons.html.erb`.