### PR TITLE
HTML Tag

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1821,6 +1821,7 @@ table {
 
     .divider {
       color: $text-light;
+      display: inline-block;
     }
 
     form {

--- a/app/views/comments/_flag_actions.html.erb
+++ b/app/views/comments/_flag_actions.html.erb
@@ -6,13 +6,13 @@
     title="<%= t('shared.flag') %>">
       <span class="icon-flag flag-disable"></span>
     </a>
-    <div id="flag-drop-comment-<%= comment.id %>"
+    <span id="flag-drop-comment-<%= comment.id %>"
          class="dropdown-pane"
          data-dropdown
          data-auto-focus="true">
       <%= link_to t("shared.flag"), flag_comment_path(comment), method: :put,
                   remote: true, id: "flag-comment-#{comment.id}" %>
-    </div>
+    </span>
   <% end %>
 
   <% if show_unflag_action? comment %>
@@ -22,9 +22,9 @@
        title="<%= t('shared.unflag') %>">
       <span class="icon-flag flag-active"></span>
     </a>
-    <div class="dropdown-pane" id="unflag-drop-comment-<%= comment.id %>" data-dropdown data-auto-focus="true">
+    <span class="dropdown-pane" id="unflag-drop-comment-<%= comment.id %>" data-dropdown data-auto-focus="true">
       <%= link_to t("shared.unflag"), unflag_comment_path(comment), method: :put,
                   remote: true, id: "unflag-comment-#{comment.id}" %>
-    </div>
+    </span>
   <% end %>
 </span>

--- a/app/views/debates/_flag_actions.html.erb
+++ b/app/views/debates/_flag_actions.html.erb
@@ -3,17 +3,17 @@
     <a id="flag-expand-debate-<%= debate.id %>" data-toggle="flag-drop-debate-<%= debate.id %>" title="<%= t('shared.flag') %>">
       <span class="icon-flag flag-disable"></span>
     </a>
-    <div class="dropdown-pane" id="flag-drop-debate-<%= debate.id %>" data-dropdown data-auto-focus="true">
+    <span class="dropdown-pane" id="flag-drop-debate-<%= debate.id %>" data-dropdown data-auto-focus="true">
       <%= link_to t('shared.flag'), flag_debate_path(debate), method: :put, remote: true, id: "flag-debate-#{ debate.id }" %>
-    </div>
+    </span>
   <% end %>
 
   <% if show_unflag_action? debate %>
     <a id="unflag-expand-debate-<%= debate.id %>" data-toggle="unflag-drop-debate-<%= debate.id %>" title="<%= t('shared.unflag') %>">
       <span class="icon-flag flag-active"></span>
     </a>
-    <div class="dropdown-pane" id="unflag-drop-debate-<%= debate.id %>" data-dropdown data-auto-focus="true">
+    <span class="dropdown-pane" id="unflag-drop-debate-<%= debate.id %>" data-dropdown data-auto-focus="true">
       <%= link_to t('shared.unflag'), unflag_debate_path(debate), method: :put, remote: true, id: "unflag-debate-#{ debate.id }" %>
-    </div>
+    </span>
   <% end %>
 </span>

--- a/app/views/proposals/_flag_actions.html.erb
+++ b/app/views/proposals/_flag_actions.html.erb
@@ -4,18 +4,18 @@
       <a id="flag-expand-proposal-<%= proposal.id %>" data-toggle="flag-drop-proposal-<%= proposal.id %>" title="<%= t('shared.flag') %>">
         <span class="icon-flag flag-disable"></span>
       </a>
-      <div class="dropdown-pane" id="flag-drop-proposal-<%= proposal.id %>" data-dropdown data-auto-focus="true">
+      <span class="dropdown-pane" id="flag-drop-proposal-<%= proposal.id %>" data-dropdown data-auto-focus="true">
         <%= link_to t('shared.flag'), flag_proposal_path(proposal), method: :put, remote: true, id: "flag-proposal-#{ proposal.id }" %>
-      </div>
+      </span>
     <% end %>
 
     <% if show_unflag_action? proposal %>
       <a id="unflag-expand-proposal-<%= proposal.id %>" data-toggle="unflag-drop-proposal-<%= proposal.id %>" title="<%= t('shared.unflag') %>">
         <span class="icon-flag flag-active"></span>
       </a>
-      <div class="dropdown-pane" id="unflag-drop-proposal-<%= proposal.id %>" data-dropdown data-auto-focus="true">
+      <span class="dropdown-pane" id="unflag-drop-proposal-<%= proposal.id %>" data-dropdown data-auto-focus="true">
         <%= link_to t('shared.unflag'), unflag_proposal_path(proposal), method: :put, remote: true, id: "unflag-proposal-#{ proposal.id }" %>
-      </div>
+      </span>
     <% end %>
   </span>
 </span>


### PR DESCRIPTION
What
====
Now there is some miss placing `<div>` tags inside `<span>` on flag elements container and this is not a valid HTML standard.

Moreover this PR fixes a missing style to show `.divider` lines.

Screenshots
===========

![comments_divider](https://user-images.githubusercontent.com/631897/29420510-6c4015be-8372-11e7-962d-e8c257c07f4b.png)
