### PR TITLE
Users proposal list

### DIFF
--- a/app/views/users/_proposal.html.erb
+++ b/app/views/users/_proposal.html.erb
@@ -7,26 +7,32 @@
 
   <% if proposal.retired? %>
 
-    <td class="text-center">
+    <td class="text-center" colspan="2">
       <span class="label alert"><%= t('users.proposals.retired') %></span>
     </td>
 
   <% elsif author?(proposal) %>
 
-    <td class="text-center">
+    <td>
       <%= link_to t("users.proposals.send_notification"),
                   new_proposal_notification_path(proposal_id: proposal.id),
-                  class: 'button hollow' %>
+                  class: 'button hollow expanded' %>
     </td>
 
-    <td class="text-center">
+    <td>
       <% if proposal.retired? %>
         <span class="label alert"><%= t('users.proposals.retired') %></span>
       <% else %>
         <%= link_to t('users.proposals.retire'),
                     retire_form_proposal_path(proposal),
-                    class: 'button hollow alert' %>
+                    class: 'button hollow alert expanded' %>
       <% end %>
+    </td>
+
+  <% else %>
+
+    <td class="text-center" colspan="2">
+      <%= link_to t('users.proposals.see'), proposal, class: 'button hollow' %>
     </td>
 
   <% end %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -674,7 +674,7 @@ en:
     proposals:
       send_notification: "Send notification"
       retire: "Retire"
-      retired: "Retired"
+      retired: "Retired proposal"
       see: "See proposal"
   votes:
     agree: I agree

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -675,6 +675,7 @@ en:
       send_notification: "Send notification"
       retire: "Retire"
       retired: "Retired"
+      see: "See proposal"
   votes:
     agree: I agree
     anonymous: Too many anonymous votes to admit vote %{verify_account}.

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -674,7 +674,7 @@ es:
     proposals:
       send_notification: "Enviar notificación"
       retire: "Retirar"
-      retired: "Retirada"
+      retired: "Propuesta retirada"
       see: "Ver propuesta"
   votes:
     agree: Estoy de acuerdo

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -675,6 +675,7 @@ es:
       send_notification: "Enviar notificación"
       retire: "Retirar"
       retired: "Retirada"
+      see: "Ver propuesta"
   votes:
     agree: Estoy de acuerdo
     anonymous: Demasiados votos anónimos, para poder votar %{verify_account}.


### PR DESCRIPTION
What
====
- This PR fixes table on users proposal list, sometimes appears different number of `<td>` on each `<tr>` row generating a HTML warning validation.

<img width="747" alt="warning" src="https://user-images.githubusercontent.com/631897/29710533-0b420f40-8991-11e7-9f5f-420c3d47d82b.png">


For example, the proposal lis for a user if have some retired proposal:
<img width="1192" alt="user_wrong" src="https://user-images.githubusercontent.com/631897/29710454-a6050880-8990-11e7-8072-e13e0bac3ffa.png">

For another user viewing the same list:
<img width="1225" alt="other_wrong" src="https://user-images.githubusercontent.com/631897/29710500-d57b39ea-8990-11e7-808f-4a5955b2eed4.png">

This PR, adds a `colspan="2"` for the first case:
<img width="1199" alt="user_ok" src="https://user-images.githubusercontent.com/631897/29710495-cdab8832-8990-11e7-964b-baac74f38df9.png">

And a new `See proposal` button for the second case:
<img width="1204" alt="other_ok" src="https://user-images.githubusercontent.com/631897/29710498-cffcffd0-8990-11e7-9761-236395af688d.png">


