### PR TITLE
Empty admin menu

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -40,6 +40,32 @@ module UsersHelper
     current_user && current_user.administrator?
   end
 
+  def current_moderator?
+    current_user && current_user.moderator?
+  end
+
+  def current_valuator?
+    current_user && current_user.valuator?
+  end
+
+  def current_manager?
+    current_user && current_user.manager?
+  end
+
+  def current_poll_officer?
+    current_user && current_user.poll_officer? && Poll.current.any?
+  end
+
+  def show_admin_menu?
+    if current_user
+      current_administrator? ||
+      current_moderator? ||
+      current_valuator? ||
+      current_manager? ||
+      current_poll_officer?
+    end
+  end
+
   def interests_title_text(user)
     if current_user == user
       t('account.show.public_interests_my_title_list')

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -57,13 +57,7 @@ module UsersHelper
   end
 
   def show_admin_menu?
-    if current_user
-      current_administrator? ||
-      current_moderator? ||
-      current_valuator? ||
-      current_manager? ||
-      current_poll_officer?
-    end
+    current_administrator? || current_moderator? || current_valuator? || current_manager? || current_poll_officer?
   end
 
   def interests_title_text(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -53,7 +53,7 @@ module UsersHelper
   end
 
   def current_poll_officer?
-    current_user && current_user.poll_officer? && Poll.current.any?
+    current_user && current_user.poll_officer?
   end
 
   def show_admin_menu?

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -1,4 +1,4 @@
-<% if current_user %>
+<% if show_admin_menu? %>
 <li>
   <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow" %>
   <ul class="menu">


### PR DESCRIPTION
What
====
- Now all the users without Admin role see the Admin menu link (empty) on the header. 😬 

How
===
- Adds helper `show_admin_menu?` to prevent show empty admin menu for all users and show only when the user have some admin role.
