### PR TITLE
SMS verification consistency

### DIFF
--- a/app/controllers/verification/letter_controller.rb
+++ b/app/controllers/verification/letter_controller.rb
@@ -44,7 +44,7 @@ class Verification::LetterController < ApplicationController
     end
 
     def verify_phone!
-      unless current_user.confirmed_phone?
+      unless current_user.sms_verified?
         redirect_to verified_user_path, alert: t('verification.letter.alert.unconfirmed_code')
       end
     end


### PR DESCRIPTION
What
====
- Checks sms verification in a more consistent way

How
===
-  Calling method [`sms_verified?`](https://github.com/consul/consul/blob/verification-consistency/app/models/concerns/verification.rb#L29) instead of db attribute `confirmed_phone`

Why
===
- To make it easier to skip sms verification by just setting to `true` the return value of method `sms_verified?`

Test
====
- Not needed

Deployment
==========
- As usual

Warnings
========
- None
