### PR TITLE
Polls subnavigation

### DIFF
--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -20,7 +20,7 @@
       <li>
         <%= layout_menu_link_to t("layouts.header.poll_questions"),
                                   polls_path,
-                                  controller_name == "polls",
+                                  controller_name == "polls" || controller_name == "questions",
                                   accesskey: "3",
                                   title: t("shared.go_to_page") + t("layouts.header.poll_questions") %>
       </li>


### PR DESCRIPTION
What
====
- Now when visit a poll question `/questions/N` the active class for polls link on subnavigation dissappear.

How
===
- Includes `question` controller name on polls subnavigation link.
