### PR TITLE
Persist a shift's officer data

### DIFF
--- a/app/models/poll/shift.rb
+++ b/app/models/poll/shift.rb
@@ -8,6 +8,7 @@ class Poll
     validates :date, presence: true
     validates :date, uniqueness: { scope: [:officer_id, :booth_id] }
     
+    before_create :persist_data
     after_create :create_officer_assignments
 
     def create_officer_assignments
@@ -18,5 +19,11 @@ class Poll
         Poll::OfficerAssignment.create!(attrs)
       end
     end
+
+    def persist_data      
+      self.officer_name = officer.name
+      self.officer_email = officer.email
+    end
+
   end
  end

--- a/app/views/admin/poll/shifts/_shifts.html.erb
+++ b/app/views/admin/poll/shifts/_shifts.html.erb
@@ -11,7 +11,7 @@
     <% @shifts.each do |shift| %>
       <tr id="shift_<%= shift.id %>" class="shift">
         <td><%= l(shift.date.to_date, format: :long) %></td>
-        <td><%= shift.officer.name %></td>
+        <td><%= shift.officer_name %></td>
         <td class="text-right">
           <%= link_to t("admin.poll_shifts.new.remove_assignment"),
                       admin_booth_shift_path(@booth, shift),

--- a/db/migrate/20170908175149_add_officer_data_to_poll_shifts.rb
+++ b/db/migrate/20170908175149_add_officer_data_to_poll_shifts.rb
@@ -1,0 +1,6 @@
+class AddOfficerDataToPollShifts < ActiveRecord::Migration
+  def change
+    add_column :poll_shifts, :officer_name, :string
+    add_column :poll_shifts, :officer_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170822144743) do
+ActiveRecord::Schema.define(version: 20170908175149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -682,6 +682,8 @@ ActiveRecord::Schema.define(version: 20170822144743) do
     t.date     "date"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "officer_name"
+    t.string   "officer_email"
   end
 
   add_index "poll_shifts", ["booth_id", "officer_id"], name: "index_poll_shifts_on_booth_id_and_officer_id", using: :btree

--- a/spec/features/admin/poll/shifts_spec.rb
+++ b/spec/features/admin/poll/shifts_spec.rb
@@ -76,6 +76,20 @@ feature 'Admin shifts' do
     expect(page).to have_css(".shift", count: 0)
   end
 
+  scenario "Destroy an officer" do
+    poll = create(:poll)
+    booth = create(:poll_booth)
+    officer = create(:poll_officer)
+
+    shift = create(:poll_shift, officer: officer, booth: booth)
+    officer.destroy
+
+    visit new_admin_booth_shift_path(booth)
+
+    expect(page).to have_css(".shift", count: 1)
+    expect(page).to have_content(officer.name)
+  end
+
   scenario "Empty" do
     poll = create(:poll)
     booth = create(:poll_booth)

--- a/spec/models/poll/shift_spec.rb
+++ b/spec/models/poll/shift_spec.rb
@@ -57,5 +57,27 @@ describe :shift do
     end
 
   end
+
+  describe "#persist_data" do
+    
+    let(:user) { create(:user, username: "Ana", email: "ana@example.com") } 
+    let(:officer) { create(:poll_officer, user: user) } 
+    let(:shift) { create(:poll_shift, officer: officer) } 
+
+    it "should maintain officer data after destroying associated user" do
+      shift.officer.user.destroy
+
+      expect(shift.officer_name).to eq "Ana"
+      expect(shift.officer_email).to eq "ana@example.com"
+    end
+
+    it "should maintain officer data after destroying officer role" do
+      shift.officer.destroy
+
+      expect(shift.officer_name).to eq "Ana"
+      expect(shift.officer_email).to eq "ana@example.com"
+    end
+
+  end
   
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/1784

What
====
- Persists a shift's officer data, after destroying either the officer role or the user

How
===
- Adding `officer_name` and `officer_email` attributes to the shift's table
- Using these attributes instead of the associated record in the view
