### PR TITLE
Available booths to assign shifts

### DIFF
--- a/app/controllers/admin/poll/booths_controller.rb
+++ b/app/controllers/admin/poll/booths_controller.rb
@@ -30,6 +30,11 @@ class Admin::Poll::BoothsController < Admin::BaseController
     end
   end
 
+  def available
+    @booths = Poll::Booth.available.order(name: :asc).page(params[:page])
+    render :index
+  end
+
   private
 
     def booth_params

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -25,7 +25,7 @@ module AdminHelper
   end
 
   def menu_polls?
-    ["polls", "questions", "officers", "booths", "officer_assignments", "booth_assignments", "recounts", "results"].include? controller_name
+    ["polls", "questions", "officers", "booths", "officer_assignments", "booth_assignments", "recounts", "results", "shifts"].include? controller_name
   end
 
   def menu_profiles?

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -57,7 +57,7 @@ module Abilities
       can [:index, :create, :edit, :update, :destroy], Geozone
 
       can [:read, :create, :update, :destroy, :add_question, :remove_question, :search_booths, :search_questions, :search_officers], Poll
-      can [:read, :create, :update, :destroy], Poll::Booth
+      can [:read, :create, :update, :destroy, :available], Poll::Booth
       can [:search, :create, :index, :destroy], ::Poll::Officer
       can [:create, :destroy], ::Poll::BoothAssignment
       can [:create, :destroy], ::Poll::OfficerAssignment

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -5,10 +5,15 @@ class Poll
     has_many :shifts
 
     validates :name, presence: true, uniqueness: true
-
+    
     def self.search(terms)
       return Booth.none if terms.blank?
       Booth.where("name ILIKE ? OR location ILIKE ?", "%#{terms}%", "%#{terms}%")
     end
+
+    def self.available
+      where(polls: { id: Poll.current_or_incoming }).includes(:polls)
+    end
+
   end
 end

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -73,12 +73,15 @@
             <%= link_to t('admin.menu.poll_officers'), admin_officers_path %>
           </li>
 
-          <li <%# "class=active" if controller_name == "booths" %>>
+          <li <%= "class=active" if controller_name == "booths" && 
+                                    action_name != "available" %>>
             <%= link_to t('admin.menu.poll_booths'), admin_booths_path %>
           </li>
 
-          <li <%= "class=active" if controller_name == "booths" %>>
-            <%= link_to t('admin.menu.poll_shifts'), admin_booths_path %>
+          <li <%= "class=active" if controller_name == "shifts" || 
+                                    controller_name == "booths" && 
+                                    action_name == "available" %>>
+            <%= link_to t('admin.menu.poll_shifts'), available_admin_booths_path %>
           </li>
         </ul>
       </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -287,6 +287,8 @@ Rails.application.routes.draw do
       end
 
       resources :booths do
+        get :available, on: :collection 
+        
         resources :shifts
       end
 

--- a/spec/features/admin/poll/booths_spec.rb
+++ b/spec/features/admin/poll/booths_spec.rb
@@ -36,6 +36,32 @@ feature 'Admin booths' do
     expect(page).to_not have_content "There are no booths"
   end
 
+  scenario "Available" do
+    booth_for_current_poll  = create(:poll_booth)
+    booth_for_incoming_poll = create(:poll_booth)
+    booth_for_expired_poll  = create(:poll_booth)
+
+    current_poll  = create(:poll, :current)
+    incoming_poll = create(:poll, :incoming)
+    expired_poll  = create(:poll, :expired)
+  
+    create(:poll_booth_assignment, poll: current_poll,  booth: booth_for_current_poll)
+    create(:poll_booth_assignment, poll: incoming_poll, booth: booth_for_incoming_poll)
+    create(:poll_booth_assignment, poll: expired_poll,  booth: booth_for_expired_poll)
+    
+    visit admin_root_path
+    
+    within('#side_menu') do
+      click_link "Manage shifts"
+    end
+
+    expect(page).to have_css(".booth", count: 2)
+
+    expect(page).to have_content booth_for_current_poll.name
+    expect(page).to have_content booth_for_incoming_poll.name
+    expect(page).to_not have_content booth_for_expired_poll.name
+  end
+
   scenario 'Show' do
     booth = create(:poll_booth)
 

--- a/spec/models/poll/booth_spec.rb
+++ b/spec/models/poll/booth_spec.rb
@@ -24,4 +24,25 @@ describe :booth do
     end
   end
 
+  describe "#available" do
+    
+    it "returns booths associated to current or incoming polls" do
+      booth_for_current_poll  = create(:poll_booth)
+      booth_for_incoming_poll = create(:poll_booth)
+      booth_for_expired_poll  = create(:poll_booth)
+  
+      current_poll  = create(:poll, :current)
+      incoming_poll = create(:poll, :incoming)
+      expired_poll  = create(:poll, :expired)
+    
+      create(:poll_booth_assignment, poll: current_poll,  booth: booth_for_current_poll)
+      create(:poll_booth_assignment, poll: incoming_poll, booth: booth_for_incoming_poll)
+      create(:poll_booth_assignment, poll: expired_poll,  booth: booth_for_expired_poll)
+  
+      expect(Poll::Booth.available).to include(booth_for_current_poll)
+      expect(Poll::Booth.available).to include(booth_for_incoming_poll)
+      expect(Poll::Booth.available).to_not include(booth_for_expired_poll)
+    end
+
+  end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/1785

What
====
- Displays only booths for current or incoming booths when managing shifts
- Highlights correct admin menu item (_booth location_ and _manage shifts_)

How
===
- Adding a new action for available booths
- Taking into account the current controller action to highlight the appropriate menu item

Screenshots
===========
- Available booths for shifts
![available booths](https://user-images.githubusercontent.com/4169/30229299-9f3b8464-94e1-11e7-99ac-c6ed530e93c4.png)
