### PR TITLE
Documentable fix

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -48,6 +48,7 @@ class DocumentsController < ApplicationController
   def destroy_upload
     @document = Document.new(cached_attachment: params[:path])
     @document.set_attachment_from_cached_attachment
+    @document.cached_attachment = nil
     @document.documentable = @documentable
 
     if @document.attachment.destroy

--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -251,6 +251,41 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       expect(find("input[name='document[cached_attachment]']", visible: false).value).to include("empty.pdf")
     end
 
+    scenario "Should not show 'Choose document' button after valid upload", :js do
+      login_as documentable.author
+      visit new_document_path(documentable_type: documentable.class.name,
+                              documentable_id: documentable.id)
+
+      attach_file :document_attachment, "spec/fixtures/files/empty.pdf", make_visible: true
+      sleep 1
+
+      expect(page).not_to have_content "Choose document"
+    end
+
+    scenario "Should show 'Remove document' button after valid upload", :js do
+      login_as documentable.author
+      visit new_document_path(documentable_type: documentable.class.name,
+                              documentable_id: documentable.id)
+
+      attach_file :document_attachment, "spec/fixtures/files/empty.pdf", make_visible: true
+      sleep 1
+
+      expect(page).to have_link("Remove document")
+    end
+
+    scenario "Should show 'Choose document' button after remove valid upload", :js do
+      login_as documentable.author
+      visit new_document_path(documentable_type: documentable.class.name,
+                              documentable_id: documentable.id)
+
+      attach_file :document_attachment, "spec/fixtures/files/empty.pdf", make_visible: true
+      sleep 1
+      click_link "Remove document"
+      sleep 1
+
+      expect(page).to have_content "Choose document"
+    end
+
     scenario "Should not update document cached_attachment field after unvalid file upload", :js do
       login_as documentable.author
       visit new_document_path(documentable_type: documentable.class.name,


### PR DESCRIPTION
Where
=====
* **Related PR's:** #1809

What
====
Fix an error on documents single uploads.

When user attaches a file successfully and then clicks on "Remove document" file selector button it's not showing and user cannot select another file.

How
===
1. Removing cached attachment value after destroy uploaded file.
2. Increasing test coverage on document single uploads.

Test
====
Increased test coverage on documentable single uploads.

Deployment
==========
As usual
