### PR TITLE
Admin tags

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -54,7 +54,7 @@ $admin-color: #cf3638;
     }
   }
 
-  th {
+  th, td {
     text-align: left;
 
     &.text-center {

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -19,7 +19,7 @@
 <table>
   <% @tags.each do |tag| %>
     <tr>
-      <td>
+      <td class="with-button">
         <%= form_for(tag,
             url: admin_tag_path(tag),
             as: :tag,


### PR DESCRIPTION
Where
=====
Closes #1830 

What
====
- Avoids button overflow on admin tags table.

How
===
- Uses `.with-button` class for table cells/headings containing buttons.

Screenshots
===========

<img width="654" alt="table_fixed" src="https://user-images.githubusercontent.com/631897/30344707-aea201e8-9802-11e7-8387-b06bfc6da719.png">

**Fixed!** 🎉 