### PR TITLE
20170913 - fixed overflow for deletion button on tags

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -246,6 +246,7 @@ $button-sizes: (
   small: 0.75rem,
   default: 0.9rem,
   large: 1.25rem,
+  custom: 0.8rem
 );
 $button-opacity-disabled: 0.25;
 

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -29,7 +29,7 @@
               <strong><%= tag.name %></strong>
             </span>
 
-            <%= link_to t("admin.tags.destroy"), admin_tag_path(tag), method: :delete, class: "button hollow alert on-hover" %>
+            <%= link_to t("admin.tags.destroy"), admin_tag_path(tag), method: :delete, class: "button custom hollow alert on-hover" %>
         <% end %>
       </td>
     </tr>


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1830 


What
====
- It solves the overflow in tag deletion button

How
===
- Created a "custom" button class in foundation settings.

Screenshots
===========
![captura de pantalla_2017-09-13_11-22-33](https://user-images.githubusercontent.com/1562834/30369777-e5fbdce0-9875-11e7-97c8-d84c63f3b007.png)

Test
====
- N/A, since it's a UI issue.

Deployment
==========
- N/A

Warnings
========
- N/A
