### PR TITLE
Help headers

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -205,7 +205,7 @@ a {
 
 .menu.simple {
   border-bottom: 1px solid $border;
-  margin: $line-height 0;
+  margin-bottom: $line-height;
 
   li {
     padding-bottom: rem-calc(7);

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -896,9 +896,14 @@
 }
 
 .help-header {
+  background: #fafafa;
+  border-bottom: 1px solid #eee;
+  padding-bottom: $line-height / 2;
+  padding-top: $line-height;
 
   h1 {
     font-size: rem-calc(24);
+    text-transform: uppercase;
   }
 }
 

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -32,6 +32,7 @@
       <p class="lead">
         <strong><%= t("budgets.index.section_footer.title") %></strong>
       </p>
+      <p><%= t("budgets.index.section_footer.description") %></p>
       <p><%= t("budgets.index.section_footer.help_text_1") %></p>
       <p><%= t("budgets.index.section_footer.help_text_2") %></p>
       <p><%= t("budgets.index.section_footer.help_text_3",

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -62,6 +62,7 @@
           <p class="lead">
             <strong><%= t("debates.index.section_footer.title") %></strong>
           </p>
+          <p><%= t("debates.index.section_footer.description") %></p>
           <p><%= t("debates.index.section_footer.help_text_1") %></p>
           <p><%= t("debates.index.section_footer.help_text_2",
                     org: link_to(setting['org_name'], new_user_registration_path)).html_safe %></p>

--- a/app/views/legislation/processes/index.html.erb
+++ b/app/views/legislation/processes/index.html.erb
@@ -23,6 +23,7 @@
         <p class="lead">
           <strong><%= t("legislation.processes.index.section_footer.title") %></strong>
         </p>
+        <p><%= t("legislation.processes.index.section_footer.description") %></p>
         <p><%= t("legislation.processes.index.section_footer.help_text_1") %></p>
         <p><%= t("legislation.processes.index.section_footer.help_text_2",
                   org: setting['org_name']) %></p>

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -27,6 +27,7 @@
       <p class="lead">
         <strong><%= t("polls.index.section_footer.title") %></strong>
       </p>
+      <p><%= t("polls.index.section_footer.description") %></p>
       <p><%= t("polls.index.section_footer.help_text_1") %></p>
       <p><%= t("polls.index.section_footer.help_text_2",
                 org: link_to(setting['org_name'], new_user_registration_path)).html_safe %></p>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -76,6 +76,7 @@
             <p class="lead">
               <strong><%= t("proposals.index.section_footer.title") %></strong>
             </p>
+            <p><%= t("proposals.index.section_footer.description") %></p>
             <p><%= t("proposals.index.section_footer.help_text_1") %></p>
             <p><%= t("proposals.index.section_footer.help_text_2",
                       org: link_to(setting['org_name'], new_user_registration_path)).html_safe %></p>

--- a/app/views/shared/_section_header.html.erb
+++ b/app/views/shared/_section_header.html.erb
@@ -1,12 +1,9 @@
-<div class="highlight jumbo help-header">
+<div class="help-header no-margin-top margin-bottom">
   <div class="row">
-    <div class="small-12 medium-9 column" data-magellan>
+    <div class="small-12 column" data-magellan>
       <%= image_tag "help/help_icon_#{image}.png", alt: t("#{i18n_namespace}.icon_alt"), class: "align-top" %>
       <h1 class="inline-block"><%= t("#{i18n_namespace}.title") %></h1>
-      <p>
-        <%= t("#{i18n_namespace}.description") %><br>
-        <%= link_to t("#{i18n_namespace}.help"), "#section_help" %>
-      </p>
+      <%= link_to t("#{i18n_namespace}.help"), "#section_help", class: "float-right" %>
     </div>
   </div>
 </div>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -41,10 +41,10 @@ en:
       section_header:
         icon_alt: Participatory budgets icon
         title: Participatory budgets
-        description: With the participatory budgets the citizens decide to which projects presented by the neighbors is destined a part of the municipal budget.
         help: Help about participatory budgets
       section_footer:
         title: Help about participatory budgets
+        description: With the participatory budgets the citizens decide to which projects presented by the neighbors is destined a part of the municipal budget.
         help_text_1: "Participatory budgets are processes in which citizens decide directly on what is spent part of the municipal budget. Any registered person over 16 years old can propose an investment project that is preselected in a phase of citizen supports."
         help_text_2: "The most voted projects are evaluated and passed to a final vote in which they decide the actions to be carried out by the City Council once the municipal budgets of the next year are approved."
         help_text_3: "The presentation of participatory budgeting projects takes place from January and over a period of one and a half months. To participate and propose proposals for the entire city and / or districts, you must sign up on %{org} and verify your account."

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -122,10 +122,10 @@ en:
       section_header:
         icon_alt: Debates icon
         title: Debates
-        description: Start a debate to share opinions with others about the topics you are concerned about.
         help: Help about debates
       section_footer:
         title: Help about debates
+        description: Start a debate to share opinions with others about the topics you are concerned about.
         help_text_1: "The space for citizen debates is aimed at anyone who can expose issues of their concern and those who want to share opinions with other people."
         help_text_2: 'To open a debate you need to sign up on %{org}. Users can also comment on open debates and rate them with the "I agree" or "I disagree" buttons found in each of them.'
         help_text_3: "Keep in mind that a debate does not start any specific action. If you want to make a %{proposal} for the city or raise a investment project of %{budget} when the phase is open, go to the corresponding section."
@@ -369,10 +369,10 @@ en:
       section_header:
         icon_alt: Proposals icon
         title: Proposals
-        description: Make a citizen proposal. If it gets enough supports it will go to voting phase, so you can get all the citizens to decide how they want their city to be.
         help: Help about proposals
       section_footer:
         title: Help about proposals
+        description: Make a citizen proposal. If it gets enough supports it will go to voting phase, so you can get all the citizens to decide how they want their city to be.
         help_text_1: "The citizen proposals are an opportunity for neighbours and collectives to decide directly how they want to shape their city. Any person can make a proposal about a topic or concern of their interest, for the City Council to make it, after it gets enough supports to be put to a citizens vote."
         help_text_2: "To create a proposal, you must sign up on %{org}. The proposals that get the support of 1% of the users in the web, goes to voting phase. To support proposals it is necessary to have a verified account."
         help_text_3: "A citizen vote is celebrated when the proposals get the necessary supports. Once celebrated, if there are more people in favor than against, the City Council assumes the proposal and carries it out."
@@ -461,10 +461,10 @@ en:
       section_header:
         icon_alt: Voting icon
         title: Voting
-        description: Sign up to vote on citizen proposals and questions the City Council ask to the neighbors. Make municipal decisions directly.
         help: Help about voting
       section_footer:
         title: Help about voting
+        description: Sign up to vote on citizen proposals and questions the City Council ask to the neighbors. Make municipal decisions directly.
         help_text_1: "Voting takes place when a citizen proposal supports reaches 1% of the census with voting rights. Voting can also include questions that the City Council ask to the citizens decision."
         help_text_2: "To participate in the next vote you have to sign up on %{org} and verify your account. All registered voters in the city over 16 years old can vote. The results of all votes are binding on the government."
     show:

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -66,10 +66,10 @@ en:
         section_header:
           icon_alt: Legislation processes icon
           title: Legislation processes
-          description: Participate in the debates and processes prior to the approval of a ordinance or a municipal action. Your opinion will be consider by the City Council.
           help: Help about legislation processes
         section_footer:
           title: Help about legislation processes
+          description: Participate in the debates and processes prior to the approval of a ordinance or a municipal action. Your opinion will be consider by the City Council.
           help_text_1: "In participatory processes, the City Council offers to its citizens the opportunity to participate in the drafting and modification of regulations, affecting the city and to be able to give their opinion on certain actions that it plans to carry out."
           help_text_2: "People registered in %{org} can participate with contributions in the public consultation of new ordinances, regulations and guidelines, among others. Your comments are analyzed by the corresponding area and considered for the final drafting of the ordinances."
           help_text_3: "The City Council also opens processes to receive contributions and opinions on municipal actions."

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -41,10 +41,10 @@ es:
       section_header:
         icon_alt: Icono de Presupuestos participativos
         title: Presupuestos participativos
-        description: Con los presupuestos participativos la ciudadanía decide a qué proyectos presentados por los vecinos y vecinas va destinada una parte del presupuesto municipal.
         help: Ayuda sobre presupuestos participativos
       section_footer:
         title: Ayuda sobre presupuestos participativos
+        description: Con los presupuestos participativos la ciudadanía decide a qué proyectos presentados por los vecinos y vecinas va destinada una parte del presupuesto municipal.
         help_text_1: "Los presupuestos participativos son unos procesos en los que la ciudadanía decide de forma directa en qué se gasta una parte del presupuesto municipal. Cualquier persona empadronada mayor de 16 años puede proponer un proyecto de gasto que se preselecciona en una fase de apoyos ciudadanos."
         help_text_2: "Los proyectos más votados se evalúan y pasan a una votación final en la que se deciden las actuaciones que llevará a cabo el Ayuntamiento una vez se aprueben los presupuestos municipales del año próximo."
         help_text_3: "La presentación de proyectos de presupuestos participativos se lleva a cabo desde enero y a lo largo de un periodo de mes y medio, aproximadamente. Para participar y plantear propuestas para toda la ciudad y/ los distritos hay que registrarse en %{org} y verificar la cuenta."

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -122,10 +122,10 @@ es:
       section_header:
         icon_alt: Icono de Debates
         title: Debates
-        description: Inicia un debate para compartir puntos de vista con otras personas sobre los temas que te preocupan.
         help: Ayuda sobre los debates
       section_footer:
         title: Ayuda sobre los debates
+        description: Inicia un debate para compartir puntos de vista con otras personas sobre los temas que te preocupan.
         help_text_1: "El espacio de debates ciudadanos está dirigido a que cualquier persona pueda exponer temas que le preocupan y sobre los que quiera compartir puntos de vista con otras personas."
         help_text_2: 'Para abrir un debate es necesario registrarse en %{org}. Los usuarios ya registrados también pueden comentar los debates abiertos y valorarlos con los botones de "Estoy de acuerdo" o "No estoy de acuerdo" que se encuentran en cada uno de ellos.'
         help_text_3: "Ten en cuenta que un debate no activa ningún mecanismo de actuación concreto. Si quieres hacer una %{proposal} para la ciudad o plantear un proyecto de %{budget} cuando se abra la convocatoria, ve a la sección correspondiente."
@@ -369,10 +369,10 @@ es:
       section_header:
         icon_alt: Icono de Propuestas
         title: Propuestas
-        description: Haz una propuesta ciudadana. Si obtiene los apoyos suficientes y pasa a votación, puedes conseguir que todos los habitantes decidan cómo quieren que sea nuestra ciudad.
         help: Ayuda sobre las propuestas
       section_footer:
         title: Ayuda sobre las propuestas
+        description: Haz una propuesta ciudadana. Si obtiene los apoyos suficientes y pasa a votación, puedes conseguir que todos los habitantes decidan cómo quieren que sea nuestra ciudad.
         help_text_1: "Las propuestas ciudadanas son una oportunidad para que los vecinos y colectivos decidan directamente cómo quieren que sea su ciudad. Cualquier persona puede hacer una propuesta sobre un tema que le interese o preocupe para que el ayuntamiento la lleve a cabo, después de conseguir los apoyos suficientes y de someterse a votación ciudadana."
         help_text_2: "Para crear una propuesta hay que registrarse en %{org}. Las propuestas que consigan el apoyo del 1% de la gente en la web, pasan a votación. Para apoyar propuestas es necesario tener una cuenta verificada."
         help_text_3: "Se convoca una votación ciudadana cuando las propuestas consiguen los apoyos necesarios. Una vez celebrada, si hay más gente a favor que en contra, el Consistorio asume la propuesta y la lleva a cabo."
@@ -461,10 +461,10 @@ es:
       section_header:
         icon_alt: Icono de Votaciones
         title: Votaciones
-        description: Regístrate para poder votar propuestas ciudadanas y las cuestiones que pregunta a sus vecinos el Ayuntamiento. Toma decisiones municipales de forma directa.
         help: Ayuda sobre las votaciones
       section_footer:
         title: Ayuda sobre las votaciones
+        description: Regístrate para poder votar propuestas ciudadanas y las cuestiones que pregunta a sus vecinos el Ayuntamiento. Toma decisiones municipales de forma directa.
         help_text_1: "Las votaciones se convocan cuando una propuesta ciudadana alcanza el 1% de apoyos del censo con derecho a voto. En las votaciones también se pueden incluir cuestiones que el Ayuntamiento somete a decisión directa de la ciudadanía."
         help_text_2: "Para participar en la próxima votación tienes que registrarte en %{org} y verificar tu cuenta. Pueden votar todas las personas empadronadas en la ciudad mayores de 16 años. Los resultados de todas las votaciones serán vinculantes para el gobierno."
     show:

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -66,10 +66,10 @@ es:
         section_header:
           icon_alt: Icono de Procesos legislativos
           title: Procesos legislativos
-          description: Participa en los debates y procesos previos a la aprobación de una norma o de una actuación municipal. Tu opinión será tenida en cuenta por el Ayuntamiento.
           help: Ayuda sobre procesos legislativos
         section_footer:
           title: Ayuda sobre procesos legislativos
+          description: Participa en los debates y procesos previos a la aprobación de una norma o de una actuación municipal. Tu opinión será tenida en cuenta por el Ayuntamiento.
           help_text_1: "En los procesos participativos, el Ayuntamiento ofrece a la ciudadanía la oportunidad de participar en la elaboración y modificación de normativa que afecta a la ciudad y de dar su opinión sobre ciertas actuaciones que tiene previsto llevar a cabo."
           help_text_2: "Las personas registradas en %{org} pueden participar con aportaciones en la consulta pública de nuevas ordenanzas, reglamentos y directrices, entre otros. Sus comentarios son analizados por el área correspondiente y tenidos en cuenta de cara a la redacción final de las normas."
           help_text_3: "El Ayuntamiento también abre procesos para recibir aportaciones y opiniones sobre actuaciones municipales."


### PR DESCRIPTION
Where
=====
Recently we added:

- Help headers and footers #1807 
- Section header #1813 

What
====
- The space of these header sections still are very big.

How
===
- Move description to help text on footer.
- Makes headers minimal (maintaining `<h1>` title and link to footer help).

Screenshots
===========

**Minimal version**

<img width="1253" alt="header minimal" src="https://user-images.githubusercontent.com/631897/30375331-70d7240c-9888-11e7-9773-119278615fd2.png">

Warnings
========
- Personal note for the future: don't test the element sizes on retina screen 😜 
