### PR TITLE
Iagirre comments empty html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 
 public/sitemap.xml
 public/system/
+
+#Netbeans projects files
+/nbproject

--- a/app/assets/javascripts/comments.js.coffee
+++ b/app/assets/javascripts/comments.js.coffee
@@ -5,6 +5,8 @@ App.Comments =
     this.update_comments_count()
 
   add_reply: (parent_id, response_html) ->
+    if $("##{parent_id} .comment-children").length == 0
+      $("##{parent_id}").append("<li><ul id='#{parent_id}_children' class='no-bullet comment-children'></ul></li>")
     $("##{parent_id} .comment-children:first").prepend($(response_html))
     this.update_comments_count()
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -93,7 +93,7 @@
         </div>
       <% end %>
     </li>
-    <%unless child_comments_of(comment).empty?%>
+    <% unless child_comments_of(comment).empty? %>
     <li>
       <ul id="<%= dom_id(comment) %>_children" class="no-bullet comment-children">
         <% child_comments_of(comment).each do |child| %>
@@ -103,6 +103,6 @@
         <% end %>
       </ul>
     </li>
-    <%end%>
+    <% end %>
   </ul>
 <% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -93,6 +93,7 @@
         </div>
       <% end %>
     </li>
+    <%unless child_comments_of(comment).empty?%>
     <li>
       <ul id="<%= dom_id(comment) %>_children" class="no-bullet comment-children">
         <% child_comments_of(comment).each do |child| %>
@@ -102,5 +103,6 @@
         <% end %>
       </ul>
     </li>
+    <%end%>
   </ul>
 <% end %>

--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -33,6 +33,10 @@ feature 'Commenting Budget::Investments' do
     expect(page).to have_content second_child.body
 
     expect(page).to have_link "Go back to #{investment.title}", href: budget_investment_path(investment.budget, investment)
+
+    expect(page).to have_selector("ul#comment_#{parent_comment.id}>li", count: 2)
+    expect(page).to have_selector("ul#comment_#{first_child.id}>li", count: 1)
+    expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
   scenario 'Collapsable comments', :js do

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -33,6 +33,10 @@ feature 'Commenting debates' do
     expect(page).to have_content second_child.body
 
     expect(page).to have_link "Go back to #{debate.title}", href: debate_path(debate)
+    
+    expect(page).to have_selector("ul#comment_#{parent_comment.id}>li", count: 2)
+    expect(page).to have_selector("ul#comment_#{first_child.id}>li", count: 1)
+    expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
   scenario 'Collapsable comments', :js do

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -38,6 +38,10 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content second_child.body
 
     expect(page).to have_link "Go back to #{legislation_annotation.title}", href: href
+
+    expect(page).to have_selector("ul#comment_#{parent_comment.id}>li", count: 2)
+    expect(page).to have_selector("ul#comment_#{first_child.id}>li", count: 1)
+    expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
   scenario 'Collapsable comments', :js do

--- a/spec/features/comments/legislation_questions_spec.rb
+++ b/spec/features/comments/legislation_questions_spec.rb
@@ -35,6 +35,10 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content second_child.body
 
     expect(page).to have_link "Go back to #{legislation_question.title}", href: href
+
+    expect(page).to have_selector("ul#comment_#{parent_comment.id}>li", count: 2)
+    expect(page).to have_selector("ul#comment_#{first_child.id}>li", count: 1)
+    expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
   scenario 'Collapsable comments', :js do

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -33,6 +33,10 @@ feature 'Commenting proposals' do
     expect(page).to have_content second_child.body
 
     expect(page).to have_link "Go back to #{proposal.title}", href: proposal_path(proposal)
+
+    expect(page).to have_selector("ul#comment_#{parent_comment.id}>li", count: 2)
+    expect(page).to have_selector("ul#comment_#{first_child.id}>li", count: 1)
+    expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
   scenario 'Collapsable comments', :js do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1775

What
====
- Whats the objective of this changes ?

Erase the extra empty HTML code that was generated for comments without any reply.

How
===
- How you implemented/achieved the objective ?

The HTML for comments' replies is only rendered if there are any replies for them. When a new reply is made, it first checks if the container exists. If so, JS adds the reply as normal. If not, the container is created and the reply is added.

Screenshots
===========
- If changes affect UI just show them drag&dropping images here

Not needed

Test
====
- Is manual test needed or you just increased/fixed coverage?

Increased the test coverage for comments#show.

Deployment
==========
- Any details to remember when this feature is deployed?
No

Warnings
========
- Some caveats or important things to notice?
No
