### PR TITLE
Validate presence 'poll_id' attribute on Poll::Question model

### DIFF
--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -20,6 +20,7 @@ class Poll::Question < ActiveRecord::Base
 
   validates :title, presence: true
   validates :author, presence: true
+  validates :poll_id, presence: true
 
   validates :title, length: { minimum: 4 }
   validates :description, length: { maximum: Poll::Question.description_max_length }

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -183,7 +183,7 @@ feature 'Admin polls' do
 
       scenario 'Add question to poll', :js do
         poll = create(:poll)
-        question = create(:poll_question, poll: nil, title: 'Should we rebuild the city?')
+        question = create(:poll_question, title: 'Should we rebuild the city?')
 
         visit admin_poll_path(poll)
 

--- a/spec/models/poll/question_spec.rb
+++ b/spec/models/poll/question_spec.rb
@@ -9,6 +9,20 @@ RSpec.describe Poll::Question, type: :model do
     end
   end
 
+  describe "#poll_question_id" do
+    it "should be invalid if a poll is not selected" do
+      q = create(:poll_question)
+      q.poll_id = nil
+      expect(q).to_not be_valid
+    end
+
+    it "should be valid if a poll is selected" do
+      q = create(:poll_question)
+      q.poll_id = 1
+      expect(q).to be_valid
+    end
+  end
+
   describe "#copy_attributes_from_proposal" do
     it "copies the attributes from the proposal" do
       create_list(:geozone, 3)

--- a/spec/models/poll/question_spec.rb
+++ b/spec/models/poll/question_spec.rb
@@ -1,25 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Poll::Question, type: :model do
+  let(:poll_question) { build(:poll_question) }
 
   describe "#valid_answers" do
     it "gets a comma-separated string, but returns an array" do
-      q = create(:poll_question, valid_answers: "Yes, No")
-      expect(q.valid_answers).to eq(["Yes", "No"])
+      poll_question.valid_answers = "Yes, No"
+      expect(poll_question.valid_answers).to eq(["Yes", "No"])
     end
   end
 
   describe "#poll_question_id" do
     it "should be invalid if a poll is not selected" do
-      q = create(:poll_question)
-      q.poll_id = nil
-      expect(q).to_not be_valid
+      poll_question.poll_id = nil
+      expect(poll_question).to_not be_valid
     end
 
     it "should be valid if a poll is selected" do
-      q = create(:poll_question)
-      q.poll_id = 1
-      expect(q).to be_valid
+      poll_question.poll_id = 1
+      expect(poll_question).to be_valid
     end
   end
 
@@ -27,13 +26,12 @@ RSpec.describe Poll::Question, type: :model do
     it "copies the attributes from the proposal" do
       create_list(:geozone, 3)
       p = create(:proposal)
-      q = create(:poll_question)
-      q.copy_attributes_from_proposal(p)
-      expect(q.valid_answers).to eq(['Yes', 'No'])
-      expect(q.author).to eq(p.author)
-      expect(q.author_visible_name).to eq(p.author.name)
-      expect(q.proposal_id).to eq(p.id)
-      expect(q.title).to eq(p.title)
+      poll_question.copy_attributes_from_proposal(p)
+      expect(poll_question.valid_answers).to eq(['Yes', 'No'])
+      expect(poll_question.author).to eq(p.author)
+      expect(poll_question.author_visible_name).to eq(p.author.name)
+      expect(poll_question.proposal_id).to eq(p.id)
+      expect(poll_question.title).to eq(p.title)
     end
   end
 


### PR DESCRIPTION
Where
=====
Fixes #1831

What
====
Validates presence of `poll_id` attribute on `Poll::Question` model, which previously allowed a question to be created with no association to a poll

How
===
Added the necessary validation on the `Poll::Question` model

Screenshots
===========
![screenshot-2017-9-14 admin](https://user-images.githubusercontent.com/9470839/30431798-c7b1c3cc-992d-11e7-93d0-123a52f4756f.png)
Here's how the form looks when a poll is not selected

Test
====
Added tests for both valid and invalid scenarios, also did a small refactor to improve DRYness for the related spec