### PR TITLE
When "Profiles" submenus are selected, the "Site custom" menu doesn't…

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -36,6 +36,10 @@ module AdminHelper
     ["banners"].include? controller_name
   end
 
+  def menu_customization?
+    ["pages", "images", "content_blocks"].include? controller_name
+  end
+  
   def official_level_options
     options = [["", 0]]
     (1..5).each do |i|

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -158,8 +158,8 @@
         <span class="icon-settings"></span>
         <strong><%= t("admin.menu.title_site_customization") %></strong>
       </a>
-      <ul <%= "class=is-active" if menu_profiles? %>>
-        <li <%= "class=active" if controller_name == "pages" %>>
+        <ul <%= "class=is-active" if menu_customization? %>>
+            <li <%= "class=active" if controller_name == "pages" %>>
           <%= link_to t("admin.menu.site_customization.pages"), admin_site_customization_pages_path %>
         </li>
 

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -158,8 +158,8 @@
         <span class="icon-settings"></span>
         <strong><%= t("admin.menu.title_site_customization") %></strong>
       </a>
-        <ul <%= "class=is-active" if menu_customization? %>>
-            <li <%= "class=active" if controller_name == "pages" %>>
+      <ul <%= "class=is-active" if menu_customization? %>>
+        <li <%= "class=active" if controller_name == "pages" %>>
           <%= link_to t("admin.menu.site_customization.pages"), admin_site_customization_pages_path %>
         </li>
 


### PR DESCRIPTION
… open. Moreover, when "Site custom" submenus are selected, the menu remains opened.

Where
=====
* **Related Issue:** #1871 

What
====
When, in admin menu, one of the profile submenus where selected, the "Site custom" menu was opened. Also, when one of the customization submenus was clicked, the "Site custom" menu was closed, even if the submenu was selected.

How
===
I created a new helper method to check if the user clicked one of the "Site customization" menu's category. If so, the menu remains active. If them clicked another option, the customization menu closes.

Screenshots
===========
First: The menu remains opened when clicked a submenu.

![menu_custom](https://user-images.githubusercontent.com/31625251/30479061-ccffe7be-9a13-11e7-8f5f-cee59a358d55.png)

Second: The menu remains closed when clicked a profile submenu.

![menu_profiles](https://user-images.githubusercontent.com/31625251/30479060-ccffd53a-9a13-11e7-9f51-85fd2a57482f.png)

Test
====
Not apply

Deployment
==========
Not apply

Warnings
========
Not apply
