### PR TITLE
Improve A11y when using tab key

### DIFF
--- a/app/assets/javascripts/votes.js.coffee
+++ b/app/assets/javascripts/votes.js.coffee
@@ -5,7 +5,7 @@ App.Votes =
       'mouseenter focus': ->
         $("div.participation-not-allowed", this).show()
         $("div.participation-allowed", this).hide()
-      mouseleave: ->
+      'mouseleave blur': ->
         $("div.participation-not-allowed", this).hide()
         $("div.participation-allowed", this).show()
     }, votes


### PR DESCRIPTION
Where
=====
Fixes #1850

What
====
Before this change, when using the `tab` key on either Proposals or Debates pages **and** the user wasn't logged in, the "You need to sign up or log in to continue" message box wouldn't disappear unless the user hovered over said message box with the mouse, affecting the UX. This commit makes the aforementioned box to hide when focus is lost, whether the mouse or the `tab` key is used.

How
===
Added the missing `blur`[1] event on the `app/assets/javascripts/votes.js.coffee` file.

Test
====
Since this is a UX-related fix, manual testing is needed in order to see the changes.

Notes
====
[1] [blur (event)](https://developer.mozilla.org/en-US/docs/Web/Events/blur) on MDN
