### PR TITLE
Proposal show

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -395,6 +395,8 @@
     }
   }
 
+  .tags,
+  .geozone {
 
     li {
       margin-bottom: 0;
@@ -476,6 +478,7 @@
 
   .tags {
     display: block;
+    margin-bottom: 0;
 
     a {
       margin-right: rem-calc(6);

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -395,8 +395,6 @@
     }
   }
 
-  &.tags,
-  &.geozone {
 
     li {
       margin-bottom: 0;
@@ -607,6 +605,14 @@
         }
       }
     }
+  }
+}
+
+.show-actions-menu {
+
+  [class^="icon-"] {
+    display: inline-block;
+    vertical-align: middle;
   }
 }
 

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -32,16 +32,16 @@ module ProposalsHelper
     Proposal::RETIRE_OPTIONS.collect { |option| [ t("proposals.retire_options.#{option}"), option ] }
   end
 
-  def can_create_document?
-    can?(:create, @document) && @proposal.documents.size < Proposal.max_documents_allowed
+  def can_create_document?(document, proposal)
+    can?(:create, document) && proposal.documents.size < Proposal.max_documents_allowed
   end
 
-  def author_of_proposal?
-    author_of?(@proposal, current_user)
+  def author_of_proposal?(proposal)
+    author_of?(proposal, current_user)
   end
 
-  def current_editable?
-    current_user && @proposal.editable_by?(current_user)
+  def current_editable?(proposal)
+    current_user && proposal.editable_by?(current_user)
   end
 
 end

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -44,8 +44,4 @@ module ProposalsHelper
     current_user && @proposal.editable_by?(current_user)
   end
 
-  def show_actions_menu?
-    can_create_document? || author_of_proposal? || current_editable?
-  end
-
 end

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -32,4 +32,20 @@ module ProposalsHelper
     Proposal::RETIRE_OPTIONS.collect { |option| [ t("proposals.retire_options.#{option}"), option ] }
   end
 
+  def can_create_document?
+    can?(:create, @document) && @proposal.documents.size < Proposal.max_documents_allowed
+  end
+
+  def author_of_proposal?
+    author_of?(@proposal, current_user)
+  end
+
+  def current_editable?
+    current_user && @proposal.editable_by?(current_user)
+  end
+
+  def show_actions_menu?
+    can_create_document? || author_of_proposal? || current_editable?
+  end
+
 end

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -104,11 +104,11 @@
       </div>
 
       <aside class="small-12 medium-3 column">
-        <% if can_create_document? || author_of_proposal? || current_editable? %>
+        <% if can_create_document?(@document, @proposal) || author_of_proposal?(@proposal) || current_editable?(@proposal) %>
           <div class="sidebar-divider"></div>
           <h2><%= t("proposals.show.author") %></h2>
           <div class="show-actions-menu">
-            <% if can_create_document? %>
+            <% if can_create_document?(@document, @proposal) %>
               <%= link_to new_document_path(documentable_id: @proposal, documentable_type: @proposal.class.name, from: request.url),
                           class: 'button hollow expanded' do %>
                           <span class="icon-document"></span>
@@ -116,7 +116,7 @@
               <% end %>
             <% end %>
 
-            <% if author_of_proposal? %>
+            <% if author_of_proposal?(@proposal) %>
               <%= link_to new_proposal_notification_path(proposal_id: @proposal.id),
                           class: 'button hollow expanded' do %>
                           <span class="icon-no-notification"></span>
@@ -124,7 +124,7 @@
               <% end %>
             <% end %>
 
-            <% if current_editable? %>
+            <% if current_editable?(@proposal) %>
               <%= link_to edit_proposal_path(@proposal), class: 'edit-proposal button hollow expanded' do %>
                 <span class="icon-edit"></span>
                 <%= t("proposals.show.edit_proposal_link") %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -16,24 +16,6 @@
       <div class="small-12 medium-9 column">
         <%= back_link_to %>
 
-        <% if can?(:create, @document) && @proposal.documents.size < Proposal.max_documents_allowed %>
-          <%= link_to t("documents.upload_document"),
-                      new_document_path(documentable_id: @proposal, documentable_type: @proposal.class.name, from: request.url),
-                      class: 'button hollow float-right' %>
-        <% end %>
-
-        <% if author_of?(@proposal, current_user) %>
-          <%= link_to t("proposals.show.send_notification"),
-                      new_proposal_notification_path(proposal_id: @proposal.id),
-                      class: 'button hollow float-right' %>
-        <% end %>
-
-        <% if current_user && @proposal.editable_by?(current_user) %>
-          <%= link_to edit_proposal_path(@proposal), class: 'edit-proposal button hollow float-right' do %>
-            <%= t("proposals.show.edit_proposal_link") %>
-          <% end %>
-        <% end %>
-
         <h1><%= @proposal.title %></h1>
         <% if @proposal.retired? %>
           <div data-alert class="callout alert margin-top proposal-retired">
@@ -122,6 +104,35 @@
       </div>
 
       <aside class="small-12 medium-3 column">
+        <% if show_actions_menu? %>
+          <div class="sidebar-divider"></div>
+          <h2><%= t("proposals.show.author") %></h2>
+          <div class="show-actions-menu">
+            <% if can?(:create, @document) && @proposal.documents.size < Proposal.max_documents_allowed %>
+              <%= link_to new_document_path(documentable_id: @proposal, documentable_type: @proposal.class.name, from: request.url),
+                          class: 'button hollow expanded' do %>
+                          <span class="icon-document"></span>
+                          <%= t("documents.upload_document") %>
+              <% end %>
+            <% end %>
+
+            <% if author_of?(@proposal, current_user) %>
+              <%= link_to new_proposal_notification_path(proposal_id: @proposal.id),
+                          class: 'button hollow expanded' do %>
+                          <span class="icon-no-notification"></span>
+                          <%= t("proposals.show.send_notification") %>
+              <% end %>
+            <% end %>
+
+            <% if current_user && @proposal.editable_by?(current_user) %>
+              <%= link_to edit_proposal_path(@proposal), class: 'edit-proposal button hollow expanded' do %>
+                <span class="icon-edit"></span>
+                <%= t("proposals.show.edit_proposal_link") %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+
         <div class="sidebar-divider"></div>
         <h2><%= t("votes.supports") %></h2>
         <div id="<%= dom_id(@proposal) %>_votes">

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -104,11 +104,11 @@
       </div>
 
       <aside class="small-12 medium-3 column">
-        <% if show_actions_menu? %>
+        <% if can_create_document? || author_of_proposal? || current_editable? %>
           <div class="sidebar-divider"></div>
           <h2><%= t("proposals.show.author") %></h2>
           <div class="show-actions-menu">
-            <% if can?(:create, @document) && @proposal.documents.size < Proposal.max_documents_allowed %>
+            <% if can_create_document? %>
               <%= link_to new_document_path(documentable_id: @proposal, documentable_type: @proposal.class.name, from: request.url),
                           class: 'button hollow expanded' do %>
                           <span class="icon-document"></span>
@@ -116,7 +116,7 @@
               <% end %>
             <% end %>
 
-            <% if author_of?(@proposal, current_user) %>
+            <% if author_of_proposal? %>
               <%= link_to new_proposal_notification_path(proposal_id: @proposal.id),
                           class: 'button hollow expanded' do %>
                           <span class="icon-no-notification"></span>
@@ -124,7 +124,7 @@
               <% end %>
             <% end %>
 
-            <% if current_user && @proposal.editable_by?(current_user) %>
+            <% if current_editable? %>
               <%= link_to edit_proposal_path(@proposal), class: 'edit-proposal button hollow expanded' do %>
                 <span class="icon-edit"></span>
                 <%= t("proposals.show.edit_proposal_link") %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -433,6 +433,7 @@ en:
       embed_video_title: "Video on %{proposal}"
       title_external_url: "Additional documentation"
       title_video_url: "External video"
+      author: Author
     update:
       form:
         submit_button: Save changes

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -433,6 +433,7 @@ es:
       embed_video_title: "Vídeo en %{proposal}"
       title_external_url: "Documentación adicional"
       title_video_url: "Vídeo externo"
+      author: Autor
     update:
       form:
         submit_button: Guardar cambios


### PR DESCRIPTION
What
====
- Now the actions for user on their own proposals shows before the title without any space.

How
===
- Moves this buttons to the proposal/show sidebar.
- Creates a helper to show this actions only to users/admins with permissions.
- Also improves margins for tags and geozone tags on proposal show.

Screenshots
===========
**Buttons before** _OMG!_
<img width="1209" alt="ugly_buttons" src="https://user-images.githubusercontent.com/631897/30541974-cf3fb59c-9c7d-11e7-8b3e-068a237d46af.png">

**Buttons after** 😌 
<img width="1313" alt="buttons_sidebar" src="https://user-images.githubusercontent.com/631897/30542006-f8f145f4-9c7d-11e7-8789-879d9fd33d6b.png">


**Tags before** 😬 
<img width="145" alt="tags before" src="https://user-images.githubusercontent.com/631897/30542003-f558f842-9c7d-11e7-9773-9fabf7b29ce0.png">


**Tags after** 😄 
<img width="127" alt="tags_after" src="https://user-images.githubusercontent.com/631897/30542002-f3fac1f6-9c7d-11e7-9657-6a4021543f86.png">
