### PR TITLE
Comment reply link

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -26,9 +26,9 @@
         <div class="comment-info">
 
           <% if comment.as_administrator? %>
-            <span class="user-name"><%= t("comments.comment.admin") %> #<%= comment.administrator_id%></span>
+            <span class="user-name"><%= t("comments.comment.admin") %> #<%= comment.administrator_id %></span>
           <% elsif comment.as_moderator? %>
-            <span class="user-name"><%= t("comments.comment.moderator") %> #<%= comment.moderator_id%></span>
+            <span class="user-name"><%= t("comments.comment.moderator") %> #<%= comment.moderator_id %></span>
           <% else %>
 
             <% if comment.user.hidden? || comment.user.erased? %>
@@ -72,7 +72,7 @@
           </div>
 
           <% if comment.children.size > 0 %>
-            <%= link_to "", class: "js-toggle-children relative", data:  {'id': "#{dom_id(comment)}"} do %>
+            <%= link_to "", class: "js-toggle-children relative", data: {'id': "#{dom_id(comment)}"} do %>
               <span class="show-for-sr js-child-toggle" style="display: none;"><%= t("shared.show") %></span>
               <span class="show-for-sr js-child-toggle"><%= t("shared.hide") %></span>
               <span id="<%= dom_id(comment) %>_children_arrow" class="icon-arrow-down"></span> <%= t("comments.comment.responses", count: comment.children.size) %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -72,7 +72,7 @@
           </div>
 
           <% if comment.children.size > 0 %>
-            <%= link_to "#{dom_id(comment)}", class: "js-toggle-children relative", data:  {'id': "#{dom_id(comment)}"} do %>
+            <%= link_to "", class: "js-toggle-children relative", data:  {'id': "#{dom_id(comment)}"} do %>
               <span class="show-for-sr js-child-toggle" style="display: none;"><%= t("shared.show") %></span>
               <span class="show-for-sr js-child-toggle"><%= t("shared.hide") %></span>
               <span id="<%= dom_id(comment) %>_children_arrow" class="icon-arrow-down"></span> <%= t("comments.comment.responses", count: comment.children.size) %>


### PR DESCRIPTION
What
====
- Now on the comments with children there is a link to `N responses`. The function of this link is show/hide children comments tree but is generating a incorrect URL (indexed by search engines) something like: `http://localhost:3000/debates/comment_154`

How
===
- Removes this link content.
