### PR TITLE
Active class on subnavigation

### DIFF
--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -20,7 +20,7 @@
       <li>
         <%= layout_menu_link_to t("layouts.header.poll_questions"),
                                   polls_path,
-                                  controller_name == "polls" || controller_name == "questions",
+                                  controller_name == "polls" || (controller_name == "questions" && controller.class.parent == Polls),
                                   accesskey: "3",
                                   title: t("shared.go_to_page") + t("layouts.header.poll_questions") %>
       </li>


### PR DESCRIPTION
What
====
- Fixes duplicated active class on subnavigation when users visit `/legislation/processes/N/questions/N`

How
===
- Include `controller.class.parent == Polls` on polls link menu.

Screenshots
===========
**Duplicated active class**
<img width="490" alt="duplicated active" src="https://user-images.githubusercontent.com/631897/30640453-4c236848-9e03-11e7-9d9f-44c6a5fc3c94.png">
