### PR TITLE
Add enable/disable option for 'Proposals' feature

### DIFF
--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -1,5 +1,9 @@
 class Admin::ProposalsController < Admin::BaseController
+  include FeatureFlags
+
   has_filters %w{without_confirmed_hide all with_confirmed_hide}, only: :index
+
+  feature_flag :proposals
 
   before_action :load_proposal, only: [:confirm_hide, :restore]
 

--- a/app/controllers/moderation/proposals_controller.rb
+++ b/app/controllers/moderation/proposals_controller.rb
@@ -1,8 +1,11 @@
 class Moderation::ProposalsController < Moderation::BaseController
   include ModerateActions
+  include FeatureFlags
 
   has_filters %w{pending_flag_review all with_ignored_flag}, only: :index
   has_orders %w{flags created_at}, only: :index
+
+  feature_flag :proposals
 
   before_action :load_resources, only: [:index, :moderate]
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -1,4 +1,5 @@
 class ProposalsController < ApplicationController
+  include FeatureFlags
   include CommentableActions
   include FlagActions
 
@@ -6,6 +7,8 @@ class ProposalsController < ApplicationController
   before_action :load_categories, only: [:index, :new, :create, :edit, :map, :summary]
   before_action :load_geozones, only: [:edit, :map, :summary]
   before_action :authenticate_user!, except: [:index, :show, :map, :summary]
+
+  feature_flag :proposals
 
   invisible_captcha only: [:create, :update], honeypot: :subtitle
 

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -19,9 +19,11 @@
         <strong><%= t("admin.menu.title_moderated_content") %></strong>
       </a>
       <ul <%= "class=is-active" if menu_moderated_content? %>>
-        <li <%= "class=active" if controller_name == "proposals" && controller.class.parent != Admin::Legislation %>>
-          <%= link_to t("admin.menu.hidden_proposals"), admin_proposals_path %>
-        </li>
+        <% if feature?(:proposals) %>
+          <li <%= "class=active" if controller_name == "proposals" && controller.class.parent != Admin::Legislation %>>
+            <%= link_to t("admin.menu.hidden_proposals"), admin_proposals_path %>
+          </li>
+        <% end %>
 
         <% if feature?(:debates) %>
           <li <%= "class=active" if controller_name == "debates" %>>

--- a/app/views/moderation/_menu.html.erb
+++ b/app/views/moderation/_menu.html.erb
@@ -4,12 +4,14 @@
       <%= link_to t("moderation.dashboard.index.title"), moderation_root_path %>
     </li>
 
-    <li <%= "class=active" if controller_name == "proposals" %>>
-      <%= link_to moderation_proposals_path do %>
-        <span class="icon-proposals"></span>
-        <%= t("moderation.menu.proposals") %>
-      <% end %>
-    </li>
+    <% if feature?(:proposals) %>
+      <li <%= "class=active" if controller_name == "proposals" %>>
+        <%= link_to moderation_proposals_path do %>
+          <span class="icon-proposals"></span>
+          <%= t("moderation.menu.proposals") %>
+        <% end %>
+      </li>
+    <% end %>
 
     <% if feature?(:debates) %>
       <li <%= "class=active" if controller_name == "debates" %>>

--- a/app/views/pages/more_info/_menu.html.erb
+++ b/app/views/pages/more_info/_menu.html.erb
@@ -6,9 +6,11 @@
         <%= link_to t("pages.more_info.menu.debates"), "#debates", class: "button hollow expanded" %>
       </li>
       <% end %>
-      <li>
-        <%= link_to t("pages.more_info.menu.proposals"), "#proposals", class: "button hollow expanded" %>
-      </li>
+      <% if feature?(:proposals) %>
+        <li>
+          <%= link_to t("pages.more_info.menu.proposals"), "#proposals", class: "button hollow expanded" %>
+        </li>
+      <% end %>
       <% if feature?(:budgets) %>
       <li>
         <%= link_to t("pages.more_info.menu.budgets"), "#budgets", class: "button hollow expanded" %>

--- a/app/views/pages/more_info/index.html.erb
+++ b/app/views/pages/more_info/index.html.erb
@@ -22,7 +22,9 @@
         <%= render "pages/more_info/debates" %>
       <% end %>
 
-      <%= render "pages/more_info/proposals" %>
+      <% if feature?(:proposals) %>
+        <%= render "pages/more_info/proposals" %>
+      <% end %>
 
       <% if feature?(:budgets) %>
         <%= render "pages/more_info/budgets" %>

--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -9,13 +9,15 @@
                                 title: t("shared.go_to_page") + t("layouts.header.debates") %>
       </li>
     <% end %>
-    <li>
-      <%= layout_menu_link_to t("layouts.header.proposals"),
+    <% if feature?(:proposals) %>
+      <li>
+        <%= layout_menu_link_to t("layouts.header.proposals"),
                                 proposals_path,
                                 controller_name == 'proposals' && !controller.class.parent == Legislation,
                                 accesskey: "2",
                                 title: t("shared.go_to_page") + t("layouts.header.proposals") %>
-    </li>
+      </li>
+    <% end %>
     <% if feature?(:polls) %>
       <li>
         <%= layout_menu_link_to t("layouts.header.poll_questions"),

--- a/app/views/users/_activity_page.html.erb
+++ b/app/views/users/_activity_page.html.erb
@@ -1,5 +1,5 @@
 <%= render "following" if @follows.present? %>
-<%= render "proposals" if @proposals.present? %>
+<%= render "proposals" if @proposals.present? && feature?(:proposals) %>
 <%= render "debates" if @debates.present? && feature?(:debates) %>
 <%= render "budget_investments" if @budget_investments.present? && feature?(:budgets) %>
 <%= render "comments" if @comments.present? %>

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -32,6 +32,7 @@ en:
       twitter_login: Twitter login
       facebook_login: Facebook login
       google_login: Google login
+      proposals: Proposals
       debates: Debates
       polls: Polls
       signature_sheets: Signature sheets

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -32,6 +32,7 @@ es:
       twitter_login: Registro con Twitter
       facebook_login: Registro con Facebook
       google_login: Registro con Google
+      proposals: Propuestas
       debates: Debates
       polls: Votaciones
       signature_sheets: Hojas de firmas

--- a/config/locales/fr/settings.yml
+++ b/config/locales/fr/settings.yml
@@ -32,6 +32,7 @@ fr:
       twitter_login: Se connecter avec Twitter
       facebook_login: Se connecter avec Facebook
       google_login: Se connecter avec Google
+      proposals: Propositions
       debates: Débats
       polls: Votes
       signature_sheets: Feuilles de signature

--- a/config/locales/nl/settings.yml
+++ b/config/locales/nl/settings.yml
@@ -31,6 +31,7 @@ nl:
       twitter_login: Twitter login
       facebook_login: Facebook login
       google_login: Google login
+      proposals: Proposals
       debates: Debates
       polls: Polls
       signature_sheets: Signature sheets

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -38,6 +38,7 @@ section "Creating Settings" do
   Setting.create(key: 'org_name', value: 'CONSUL')
   Setting.create(key: 'place_name', value: 'City')
   Setting.create(key: 'feature.debates', value: "true")
+  Setting.create(key: 'feature.proposals', value: "true")
   Setting.create(key: 'feature.polls', value: "true")
   Setting.create(key: 'feature.spending_proposals', value: nil)
   Setting.create(key: 'feature.spending_proposal_features.voting_allowed', value: nil)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -70,6 +70,7 @@ Setting["meta_keywords"] = nil
 
 # Feature flags
 Setting['feature.debates'] = true
+Setting['feature.proposals'] = true
 Setting['feature.spending_proposals'] = nil
 Setting['feature.polls'] = true
 Setting['feature.twitter_login'] = true

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -7,6 +7,16 @@ feature 'Admin proposals' do
     login_as(admin.user)
   end
 
+  scenario 'Disabled with a feature flag' do
+    Setting['feature.proposals'] = nil
+    admin = create(:administrator)
+    login_as(admin.user)
+
+    expect{ visit admin_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+
+    Setting['feature.proposals'] = true
+  end
+
   scenario 'List shows all relevant info' do
     proposal = create(:proposal, :hidden)
     visit admin_proposals_path

--- a/spec/features/moderation/proposals_spec.rb
+++ b/spec/features/moderation/proposals_spec.rb
@@ -2,6 +2,16 @@ require 'rails_helper'
 
 feature 'Moderate proposals' do
 
+  scenario 'Disabled with a feature flag' do
+    Setting['feature.proposals'] = nil
+    moderator = create(:moderator)
+    login_as(moderator.user)
+
+    expect{ visit moderation_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+
+    Setting['feature.proposals'] = true
+  end
+
   scenario 'Hide', :js do
     citizen = create(:user)
     moderator = create(:moderator)

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 
 feature 'Proposals' do
 
+  scenario 'Disabled with a feature flag' do
+    Setting['feature.proposals'] = nil
+    expect{ visit proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    Setting['feature.proposals'] = true
+  end
+
   context 'Index' do
     scenario 'Lists featured and regular proposals' do
       featured_proposals = create_featured_proposals


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1886 

What
====
Allow the admins to enable or disable the 'Proposals' feature

How
===
* Modified `seeds.rb` and `dev_seeds.rb` to enable the feature by default
* Modified related views and controllers to respond properly whether the 'Proposals' feature is enabled or not
* Added tests to make sure the application behaves properly when the feature is disabled

Test
====
- Coverage is slightly increased to test when the feature is disabled
