### PR TITLE
Filter subnav

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -205,19 +205,40 @@ a {
 
 .menu.simple {
   border-bottom: 1px solid $border;
-  margin-bottom: $line-height;
+  clear: both;
+  margin-bottom: $line-height / 2;
 
   li {
-    padding-bottom: rem-calc(7);
+    margin-right: $line-height / 2;
+
+    @include breakpoint(medium) {
+      margin-right: $line-height * 1.5;
+    }
 
     a {
-      color: $text-medium;
+      color: $text;
+      display: inline-block;
+      font-weight: bold;
+      position: relative;
+      text-align: left;
+
+      &:hover {
+        color: $link;
+      }
     }
 
     &.active {
       border-bottom: 2px solid $brand;
       color: $brand;
     }
+
+    &:not(.active) {
+      margin-bottom: $line-height / 3;
+    }
+  }
+
+  h2 {
+    font-size: $base-font-size;
   }
 }
 

--- a/app/views/shared/_filter_subnav.html.erb
+++ b/app/views/shared/_filter_subnav.html.erb
@@ -3,7 +3,7 @@
 
   <% @valid_filters.each do |filter| %>
     <% if @current_filter == filter %>
-      <li class="active"><%= t("#{i18n_namespace}.filters.#{filter}") %></li>
+      <li class="active"><h2><%= t("#{i18n_namespace}.filters.#{filter}") %></h2></li>
     <% else %>
       <li><%= link_to t("#{i18n_namespace}.filters.#{filter}"),
         current_path_with_query_params(filter: filter, page: 1) %></li>


### PR DESCRIPTION
What
====
- We have two partial to show on lists:  `_order_links.html.erb` and `_filter_subnav.html.erb` with a similar behaviour but they have a little different styles.  

How
===
- This PR makes filter subnav has same styles than order links to add consistency on design.

Screenshots
===========
**Filter subnav BEFORE**
<img width="444" alt="filters" src="https://user-images.githubusercontent.com/631897/30754504-3d5b9d8c-9fc3-11e7-8941-52c6a836862c.png">

**Filter subnav AFTER**
<img width="460" alt="filters_ok" src="https://user-images.githubusercontent.com/631897/30754510-415cd84c-9fc3-11e7-9191-1ccbed5a50fd.png">
