### PR TITLE
Remove Officer recounts, add Final&Totals votes

### DIFF
--- a/app/views/admin/poll/booth_assignments/show.html.erb
+++ b/app/views/admin/poll/booth_assignments/show.html.erb
@@ -45,25 +45,34 @@
 
   <div class="tabs-panel" id="tab-recounts">
     <h3><%= t("admin.poll_booth_assignments.show.recounts_list") %></h3>
+
+    <table id="totals">
+      <thead>
+        <tr>
+          <th class="text-center"><%= t("admin.poll_booth_assignments.show.count_final") %></th>
+          <th class="text-center"><%= t("admin.poll_booth_assignments.show.total_system") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="text-center" id="total_final"><%= total_recounts_by_booth(@booth_assignment) || '-'  %></td>
+          <td class="text-center" id="total_system"><%= @booth_assignment.voters.count %></td>
+        </tr>
+      </tbody>
+    </table>
+
     <table id="recounts_list">
       <thead>
         <tr>
           <th><%= t("admin.poll_booth_assignments.show.date") %></th>
-          <th class="text-center"><%= t("admin.poll_booth_assignments.show.total_recount") %></th>
           <th class="text-center"><%= t("admin.poll_booth_assignments.show.count_by_system") %></th>
         </tr>
       </thead>
       <tbody>
       <% (@poll.starts_at.to_date..@poll.ends_at.to_date).each do |voting_date| %>
-        <% total_recount = @booth_assignment.total_results.where(date: voting_date).first %>
         <% system_count = @voters_by_date[voting_date].present? ? @voters_by_date[voting_date].size : 0 %>
         <tr id="recounting_<%= voting_date.strftime('%Y%m%d') %>">
           <td><%= l voting_date %></td>
-          <% if total_recount.present? %>
-            <td class="text-center <%= 'count-error' if total_recount.amount != system_count %>" title="<%= total_recount.officer_assignment.officer.name %>"><%= total_recount.amount %></td>
-          <% else %>
-            <td class="text-center" title=""> - </td>
-          <% end %>
           <td class="text-center"><%= system_count %></td>
         </tr>
       <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -532,8 +532,9 @@ en:
         recounts: "Recounts"
         recounts_list: "Recount list for this booth"
         date: "Date"
-        total_recount: "Total recount (by officer)"
+        count_final: "Final recount (by officer)"
         count_by_system:  "Votes (automatic)"
+        total_system: Total votes (automatic)
       index:
         booths_title: "List of booths"
         no_booths: "There are no booths assigned to this poll."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -532,8 +532,9 @@ es:
         recounts: "Recuentos"
         recounts_list: "Lista de recuentos de esta urna"
         date: "Fecha"
-        total_recount: "Recuento total (presidente de mesa)"
+        count_final: "Recuento final (presidente de mesa)"
         count_by_system:  "Votos (automático)"
+        total_system: "Votos totales acumulados(automático)"
       index:
         booths_title: "Listado de urnas asignadas"
         no_booths: "No hay urnas asignadas a esta votación."

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -97,11 +97,8 @@ feature 'Admin booths assignments' do
       officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment, date: poll.ends_at)
       final_officer_assignment = create(:poll_officer_assignment, :final, booth_assignment: booth_assignment, date: poll.ends_at)
 
-      total_recount = create(:poll_total_result,
-                         booth_assignment: booth_assignment,
-                         officer_assignment: final_officer_assignment,
-                         date: final_officer_assignment.date,
-                         amount: 5678)
+      create(:poll_voter, poll: poll, booth_assignment: booth_assignment, created_at: poll.starts_at.to_date)
+      create(:poll_voter, poll: poll, booth_assignment: booth_assignment, created_at: poll.ends_at.to_date)
 
       booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
 
@@ -111,9 +108,20 @@ feature 'Admin booths assignments' do
       within('#assigned_booths_list') { click_link booth.name }
 
       click_link 'Recounts'
+
+      within('#totals') do
+        within("#total_system") { expect(page).to have_content "2" }
+      end
+
       within('#recounts_list') do
-        within("#recounting_#{total_recount.date.strftime('%Y%m%d')}") do
-          expect(page).to have_content total_recount.amount
+        within("#recounting_#{poll.starts_at.to_date.strftime('%Y%m%d')}") do
+          expect(page).to have_content 1
+        end
+        within("#recounting_#{(poll.ends_at.to_date - 5.days).strftime('%Y%m%d')}") do
+          expect(page).to have_content '-'
+        end
+        within("#recounting_#{poll.ends_at.to_date.strftime('%Y%m%d')}") do
+          expect(page).to have_content 1
         end
       end
     end


### PR DESCRIPTION
Where
=====
Internal request

What
====
- Remove Daily recount (by officer)
- Add Final recount (by officer)
- Add Total votes (automatic)

How
===
- Picking changes from Madrid's fork

Screenshots
===========
## Before
![screen shot 2017-09-25 at 18 44 43](https://user-images.githubusercontent.com/983242/30820669-e875b548-a222-11e7-8ff2-049498836ed7.jpg)

## After (with new cool Admin design by @decabeza )
![screen shot 2017-09-25 at 18 53 39](https://user-images.githubusercontent.com/983242/30820662-ddf0b280-a222-11e7-869c-1a0c3f5267f5.jpg)

Test
====
- updated to cover new features

Deployment
==========
- As usual

Warnings
========
Don't worry about admin design .. its just that screenshot was taken on madrid's fork :) instead of on consul codebase (sorry for that, but we still don't have a nice dev_seeds for poll data on consul)
