### PR TITLE
Admin notifications icon

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -48,11 +48,7 @@ $sidebar-active: #f4fcd0;
     color: #000;
     height: auto;
 
-    span {
-      padding-top: $line-height / 2;
-    }
-
-    [class^="icon-"] {
+    [class^="icon-"]:not(.icon-circle) {
       font-size: $base-font-size;
     }
   }
@@ -102,6 +98,10 @@ $sidebar-active: #f4fcd0;
       background: #000 !important;
       box-shadow: 0 7px 0 #000, 0 14px 0 #000 !important;
     }
+  }
+
+  .notifications .icon-circle {
+    color: $admin-color;
   }
 
   .dropdown.menu > .is-dropdown-submenu-parent > a::after {


### PR DESCRIPTION
What
====
- Fixes icon when user have notifications on admin header.

Screenshots
===========
**BEFORE** _(big yellow circle over white, difficult to see)_

<img width="332" alt="Notifications icon before" src="https://user-images.githubusercontent.com/631897/30821764-be8899cc-a226-11e7-96e8-3aa42039d465.png">


**AFTER** _($admin-color variable its better!)_

<img width="324" alt="Notifications icon after" src="https://user-images.githubusercontent.com/631897/30821731-a813b7a8-a226-11e7-955a-6ee292055d54.png">
