### PR TITLE
Admin menu

### DIFF
--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="admin-sidebar" data-equalizer-watch>
-  <ul id="admin_menu" data-accordion-menu>
+  <ul id="admin_menu" data-accordion-menu data-multi-open="false">
 
     <li class="section-title">
       <a href="#">


### PR DESCRIPTION
What
====
- Prevent to expand more than one menu on admin section to avoid layout height errors (because `data-equalizer` only recalculates height when refresh the complete page)

How
===
- Sets `data-multi-open` to `false` on admin menu.
