### PR TITLE
Admins can see the preview of the budgets' results before the balloti…

### DIFF
--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -45,7 +45,7 @@ module Abilities
 
       can [:read, :update, :valuate, :destroy, :summary], SpendingProposal
 
-      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget
+      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners, :read_results], Budget
       can [:read, :create, :update, :destroy], Budget::Group
       can [:read, :create, :update, :destroy], Budget::Heading
       can [:hide, :update, :toggle_selection], Budget::Investment

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -36,7 +36,7 @@
         <% end %>
       <% end %>
 
-      <% if @budget.finished? %>
+      <% if @budget.finished? || (@budget.balloting? && can?(:read_results, @budget)) %>
         <%= link_to t("budgets.show.see_results"),
                     budget_results_path(@budget, heading_id: @budget.headings.first),
                     class: "button margin-top expanded" %>

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -69,6 +69,7 @@ describe "Abilities::Administrator" do
 
   it { should be_able_to(:create, Budget) }
   it { should be_able_to(:update, Budget) }
+  it { should be_able_to(:read_results, Budget) }
 
   it { should be_able_to(:create, Budget::ValuatorAssignment) }
 

--- a/spec/models/abilities/everyone_spec.rb
+++ b/spec/models/abilities/everyone_spec.rb
@@ -8,6 +8,9 @@ describe "Abilities::Everyone" do
   let(:debate) { create(:debate) }
   let(:proposal) { create(:proposal) }
 
+  let(:reviewing_ballot_budget) { create(:budget, phase: 'reviewing_ballots') }
+  let(:finished_budget) { create(:budget, phase: 'finished') }
+
   it { should be_able_to(:index, Debate) }
   it { should be_able_to(:show, debate) }
   it { should_not be_able_to(:edit, Debate) }
@@ -28,4 +31,7 @@ describe "Abilities::Everyone" do
   it { should_not be_able_to(:create, SpendingProposal) }
 
   it { should be_able_to(:index, Budget) }
+
+  it { should be_able_to(:read_results, finished_budget) }
+  it { should_not be_able_to(:read_results, reviewing_ballot_budget) }
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1880

What
====
Let the admins preview the results of the budget before the balloting phase finishes.

How
===
First, I added the permissions for the admins as seen in [this commit](https://github.com/AyuntamientoMadrid/consul/pull/840/files#diff-b607881ce04b1fa7d4dd113223378f85R52). Second, I added the specs needed for user and admin, as seen [here (user)](https://github.com/AyuntamientoMadrid/consul/pull/840/files#diff-635cabab9d4148990a6de3f660f8f0faR11) and [here (admin)](https://github.com/AyuntamientoMadrid/consul/pull/840/files#diff-1c352101b31f14f02ff413ffaceb075bR96). Thrid, I made the button to see the results visible if the budget is in balloting phase and `current_user` has permissions to preview the results.

Screenshots
===========
There aren't big changes, but I'll add an image of the button shown in balloting phase.

![preview_results](https://user-images.githubusercontent.com/31625251/30853309-b72ec8da-a2ae-11e7-8993-f7b0c2f0e876.png)

Test
====
Tests were added for user and admin abilities related to the results page.

Deployment
==========
Not apply.

Warnings
========
As it was specified in the issue, the results need to be calculated in admins budget section before they can be previewed.