### PR TITLE
Recommendations on new items

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -3,3 +3,9 @@
 // * English: https://github.com/consul/consul/blob/master/CUSTOMIZE_EN.md#css
 // * Spanish: https://github.com/consul/consul/blob/master/CUSTOMIZE_ES.md#css
 //
+
+.tip {
+  position: absolute;
+  width: 300px;
+  z-index: 10;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -6,6 +6,6 @@
 
 .tip {
   position: absolute;
-  width: 300px;
+  margin-right: 10px;
   z-index: 10;
 }

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -2,57 +2,91 @@
   <%= render 'shared/errors', resource: @investment %>
 
   <div class="row">
-    <div class="small-12 medium-8 column">
+    <div class="small-12 medium-9 column">
       <%= f.select :heading_id, budget_heading_select_options(@budget), {include_blank: true, } %>
     </div>
+  </div>
 
-    <div class="small-12 column">
-      <%= f.text_field :title, maxlength: SpendingProposal.title_max_length, data: { js_suggest_result: "js_suggest_result", js_suggest: "#js-suggest", js_url: suggest_budget_investments_path(@budget) }%>
+  <div class="row">
+    <div class="small-12 medium-9 column">
+      <%= f.text_field :title, maxlength: SpendingProposal.title_max_length,
+                               data: {
+                                 js_suggest_result: "js_suggest_result",
+                                 js_suggest: "#js-suggest",
+                                 js_url: suggest_budget_investments_path(@budget),
+                                 toggle_focus: "title-suggestions"
+                               } %>
     </div>
+    <%= render 'shared/suggest_message', id: 'title-suggestions',
+                                         message: t("spending_proposals.suggestions.title") %>
     <div id="js-suggest"></div>
 
     <%= f.invisible_captcha :subtitle %>
+  </div>
 
-    <div class="ckeditor small-12 column">
-      <%= f.cktext_area :description, maxlength: SpendingProposal.description_max_length, ckeditor: { language: I18n.locale } %>
+  <div class="row">
+    <div class="ckeditor small-12 medium-9 column">
+      <%= f.cktext_area :description, maxlength: SpendingProposal.description_max_length,
+                                      ckeditor: { language: I18n.locale } %>
     </div>
+  </div>
 
-    <% if feature?(:allow_images) %>
-      <div class="images small-12 column">
-        <%= render 'images/nested_image', imageable: @investment, f: f %>
-      </div>
-    <% end %>
+  <div class="row">
+    <div class="small-12 medium-9 column">
+      <%= f.text_field :external_url, data: { toggle_focus: "external-url-suggestions" } %>
+    </div>
+    <%= render 'shared/suggest_message', id: 'external-url-suggestions',
+                                         message: t("spending_proposals.suggestions.external_url") %>
+  </div>
 
-    <% if feature?(:allow_attached_documents) %>
-      <div class="documents small-12 column">
-        <%= render 'documents/nested_documents', documentable: @investment, f: f %>
-      </div>
-    <% end %>
+  <div class="row">
+    <div class="images small-12 column">
+      <%= render 'images/nested_image', imageable: @investment, f: f %>
+    </div>
+  </div>
 
-    <% if feature?(:map) %>
-      <div class="small-12 column">
+  <% if feature?(:allow_attached_documents) %>
+    <div class="documents small-12 column">
+      <%= render 'documents/nested_documents', documentable: @investment, f: f %>
+    </div>
+  <% end %>
 
-        <%= render 'map_locations/form_fields',
-                   form:     f,
-                   map_location: @investment.map_location || MapLocation.new,
-                   label:    t("budgets.investments.form.map_location"),
-                   help:     t("budgets.investments.form.map_location_instructions"),
-                   remove_marker_label: t("budgets.investments.form.map_remove_marker"),
-                   parent_class: "budget_investment",
-                   i18n_namespace: "budgets.investments" %>
-
-      </div>
-    <% end %>
-
+  <% if feature?(:map) %>
     <div class="small-12 column">
+      <%= render 'map_locations/form_fields',
+                 form:     f,
+                 map_location: @investment.map_location || MapLocation.new,
+                 label:    t("budgets.investments.form.map_location"),
+                 help:     t("budgets.investments.form.map_location_instructions"),
+                 remove_marker_label: t("budgets.investments.form.map_remove_marker"),
+                 parent_class: "budget_investment",
+                 i18n_namespace: "budgets.investments" %>
+
+    </div>
+  <% end %>
+
+  <div class="row">
+    <div class="small-12 medium-9 column">
       <%= f.label :location, t("budgets.investments.form.location") %>
-      <%= f.text_field :location, label: false %>
+      <%= f.text_field :location, label: false, data: { toggle_focus: "location-suggestions" } %>
     </div>
+      <%= render 'shared/suggest_message', id: 'location-suggestions',
+                                           message: t("spending_proposals.suggestions.location") %>
+  </div>
 
-    <div class="small-12 column">
-      <%= f.text_field :organization_name %>
+  <div class="small-12 column">
+    <%= f.label :location, t("budgets.investments.form.location") %>
+    <%= f.text_field :location, label: false %>
+  </div>
+
+  <div class="row">
+    <div class="small-12 medium-9 column">
+      <%= f.text_field :organization_name, data: {toggle_focus: "organization-name-suggestions"} %>
     </div>
+    <%= render 'shared/suggest_message', id: 'organization-name-suggestions', message: "#{t("spending_proposals.suggestions.organization_name")}" %>
+  </div>
 
+  <div class="row">
     <div class="small-12 column">
       <%= f.label :tag_list, t("budgets.investments.form.tags_label") %>
       <p class="help-text" id="tags-list-help-text"><%= t("budgets.investments.form.tags_instructions") %></p>
@@ -63,31 +97,36 @@
           <a class="js-add-tag-link"><%= tag.name %></a>
         <% end %>
       </div>
-
-      <br>
-      <%= f.text_field :tag_list, value: @investment.tag_list.to_s,
-                        label: false,
-                        placeholder: t("budgets.investments.form.tags_placeholder"),
-                        aria: {describedby: "tags-list-help-text"},
-                        class: 'js-tag-list tag-autocomplete',
-                        data: {js_url: suggest_tags_path} %>
     </div>
+    <div class="small-12 medium-9 column">
+    <%= f.text_field :tag_list, value: @investment.tag_list.to_s,
+                      label: false,
+                      placeholder: t("budgets.investments.form.tags_placeholder"),
+                      aria: {describedby: "tags-list-help-text"},
+                      class: 'js-tag-list tag-autocomplete',
+                      data: {js_url: suggest_tags_path, toggle_focus: "tag-list-suggestions"} %>
+    </div>
+    <%= render 'shared/suggest_message', id: 'tag-list-suggestions', message: "#{t("spending_proposals.suggestions.tag_list")}" %>
+  </div>
 
     <% unless current_user.manager? %>
 
-      <div class="small-12 column">
-        <%= f.label :terms_of_service do %>
-          <%= f.check_box :terms_of_service, title: t('form.accept_terms_title'), label: false %>
-          <span class="checkbox">
-            <%= t("form.accept_terms",
-                policy: link_to(t("form.policy"), "/privacy", target: "blank"),
-                conditions: link_to(t("form.conditions"), "/conditions", target: "blank")).html_safe %>
-          </span>
-        <% end %>
+      <div class="row">
+        <div class="small-12 medium-9 column">
+          <%= f.label :terms_of_service do %>
+            <%= f.check_box :terms_of_service, title: t('form.accept_terms_title'), label: false %>
+            <span class="checkbox">
+              <%= t("form.accept_terms",
+                  policy: link_to(t("form.policy"), "/privacy", target: "blank"),
+                  conditions: link_to(t("form.conditions"), "/conditions", target: "blank")).html_safe %>
+            </span>
+          <% end %>
+        </div>
       </div>
 
     <% end %>
 
+  <div class="row">
     <div class="actions small-12 medium-6 large-4 end column">
       <%= f.submit(nil, class: "button expanded") %>
     </div>

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -3,7 +3,7 @@
 
   <div class="row">
     <div class="small-12 medium-9 column">
-      <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true, } %>
+      <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true } %>
     </div>
   </div>
 
@@ -29,14 +29,6 @@
       <%= f.cktext_area :description, maxlength: SpendingProposal.description_max_length,
                                       ckeditor: { language: I18n.locale } %>
     </div>
-  </div>
-
-  <div class="row">
-    <div class="small-12 medium-9 column">
-      <%= f.text_field :external_url, data: { toggle_focus: "external-url-suggestions" } %>
-    </div>
-    <%= render "shared/suggest_message", id: "external-url-suggestions",
-                                         message: t("spending_proposals.suggestions.external_url") %>
   </div>
 
   <% if feature?(:allow_images) %>
@@ -82,7 +74,7 @@
 
   <div class="row">
     <div class="small-12 medium-9 column">
-      <%= f.text_field :organization_name, data: {toggle_focus: "organization-name-suggestions"} %>
+      <%= f.text_field :organization_name, data: { toggle_focus: "organization-name-suggestions" } %>
     </div>
     <%= render "shared/suggest_message", id: "organization-name-suggestions",
                                          message: t("spending_proposals.suggestions.organization_name") %>

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_for(@investment, url: form_url, method: :post, html: { multipart: true }) do |f| %>
-  <%= render 'shared/errors', resource: @investment %>
+  <%= render "shared/errors", resource: @investment %>
 
   <div class="row">
     <div class="small-12 medium-9 column">
-      <%= f.select :heading_id, budget_heading_select_options(@budget), {include_blank: true, } %>
+      <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true, } %>
     </div>
   </div>
 
@@ -17,7 +17,7 @@
                                  toggle_focus: "title-suggestions"
                                } %>
     </div>
-    <%= render 'shared/suggest_message', id: 'title-suggestions',
+    <%= render "shared/suggest_message", id: "title-suggestions",
                                          message: t("spending_proposals.suggestions.title") %>
     <div id="js-suggest"></div>
 
@@ -35,33 +35,39 @@
     <div class="small-12 medium-9 column">
       <%= f.text_field :external_url, data: { toggle_focus: "external-url-suggestions" } %>
     </div>
-    <%= render 'shared/suggest_message', id: 'external-url-suggestions',
+    <%= render "shared/suggest_message", id: "external-url-suggestions",
                                          message: t("spending_proposals.suggestions.external_url") %>
   </div>
 
-  <div class="row">
-    <div class="images small-12 column">
-      <%= render 'images/nested_image', imageable: @investment, f: f %>
+  <% if feature?(:allow_images) %>
+    <div class="row">
+      <div class="images small-12 column">
+        <%= render "images/nested_image", imageable: @investment, f: f %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <% if feature?(:allow_attached_documents) %>
-    <div class="documents small-12 column">
-      <%= render 'documents/nested_documents', documentable: @investment, f: f %>
+    <div class="row">
+      <div class="documents small-12 column">
+        <%= render "documents/nested_documents", documentable: @investment, f: f %>
+      </div>
     </div>
   <% end %>
 
   <% if feature?(:map) %>
-    <div class="small-12 column">
-      <%= render 'map_locations/form_fields',
-                 form:     f,
-                 map_location: @investment.map_location || MapLocation.new,
-                 label:    t("budgets.investments.form.map_location"),
-                 help:     t("budgets.investments.form.map_location_instructions"),
-                 remove_marker_label: t("budgets.investments.form.map_remove_marker"),
-                 parent_class: "budget_investment",
-                 i18n_namespace: "budgets.investments" %>
+    <div class="row">
+      <div class="small-12 column">
+        <%= render "map_locations/form_fields",
+                   form: f,
+                   map_location: @investment.map_location || MapLocation.new,
+                   label: t("budgets.investments.form.map_location"),
+                   help: t("budgets.investments.form.map_location_instructions"),
+                   remove_marker_label: t("budgets.investments.form.map_remove_marker"),
+                   parent_class: "budget_investment",
+                   i18n_namespace: "budgets.investments" %>
 
+      </div>
     </div>
   <% end %>
 
@@ -70,20 +76,16 @@
       <%= f.label :location, t("budgets.investments.form.location") %>
       <%= f.text_field :location, label: false, data: { toggle_focus: "location-suggestions" } %>
     </div>
-      <%= render 'shared/suggest_message', id: 'location-suggestions',
-                                           message: t("spending_proposals.suggestions.location") %>
-  </div>
-
-  <div class="small-12 column">
-    <%= f.label :location, t("budgets.investments.form.location") %>
-    <%= f.text_field :location, label: false %>
+    <%= render "shared/suggest_message", id: "location-suggestions",
+                                         message: t("spending_proposals.suggestions.location") %>
   </div>
 
   <div class="row">
     <div class="small-12 medium-9 column">
       <%= f.text_field :organization_name, data: {toggle_focus: "organization-name-suggestions"} %>
     </div>
-    <%= render 'shared/suggest_message', id: 'organization-name-suggestions', message: "#{t("spending_proposals.suggestions.organization_name")}" %>
+    <%= render "shared/suggest_message", id: "organization-name-suggestions",
+                                         message: t("spending_proposals.suggestions.organization_name") %>
   </div>
 
   <div class="row">
@@ -98,33 +100,36 @@
         <% end %>
       </div>
     </div>
+
     <div class="small-12 medium-9 column">
-    <%= f.text_field :tag_list, value: @investment.tag_list.to_s,
-                      label: false,
-                      placeholder: t("budgets.investments.form.tags_placeholder"),
-                      aria: {describedby: "tags-list-help-text"},
-                      class: 'js-tag-list tag-autocomplete',
-                      data: {js_url: suggest_tags_path, toggle_focus: "tag-list-suggestions"} %>
+      <%= f.text_field :tag_list, value: @investment.tag_list.to_s,
+                                  label: false,
+                                  placeholder: t("budgets.investments.form.tags_placeholder"),
+                                  aria: { describedby: "tags-list-help-text" },
+                                  class: "js-tag-list tag-autocomplete",
+                                  data: {
+                                    js_url: suggest_tags_path,
+                                    toggle_focus: "tag-list-suggestions"
+                                  } %>
     </div>
-    <%= render 'shared/suggest_message', id: 'tag-list-suggestions', message: "#{t("spending_proposals.suggestions.tag_list")}" %>
+    <%= render "shared/suggest_message", id: "tag-list-suggestions",
+                                        message: t("spending_proposals.suggestions.tag_list") %>
   </div>
 
-    <% unless current_user.manager? %>
-
-      <div class="row">
-        <div class="small-12 medium-9 column">
-          <%= f.label :terms_of_service do %>
-            <%= f.check_box :terms_of_service, title: t('form.accept_terms_title'), label: false %>
-            <span class="checkbox">
-              <%= t("form.accept_terms",
-                  policy: link_to(t("form.policy"), "/privacy", target: "blank"),
-                  conditions: link_to(t("form.conditions"), "/conditions", target: "blank")).html_safe %>
-            </span>
-          <% end %>
-        </div>
+  <% unless current_user.manager? %>
+    <div class="row">
+      <div class="small-12 medium-9 column">
+        <%= f.label :terms_of_service do %>
+          <%= f.check_box :terms_of_service, title: t("form.accept_terms_title"), label: false %>
+          <span class="checkbox">
+            <%= t("form.accept_terms",
+                    policy: link_to(t("form.policy"), "/privacy", target: "blank"),
+                    conditions: link_to(t("form.conditions"), "/conditions", target: "blank")).html_safe %>
+          </span>
+        <% end %>
       </div>
-
-    <% end %>
+    </div>
+  <% end %>
 
   <div class="row">
     <div class="actions small-12 medium-6 large-4 end column">

--- a/app/views/budgets/investments/new.html.erb
+++ b/app/views/budgets/investments/new.html.erb
@@ -1,7 +1,8 @@
-<div class="budget-investment-new row">
-  <div class="small-12 medium-9 column">
-    <h1><%= t("management.budget_investments.create") %></h1>
-
-    <%= render '/budgets/investments/form', form_url: budget_investments_path(@budget) %>
-  </div>
+<div class="budget-investment-new">
+  <div class="row">
+    <div class="small-12 medium-9 column">
+      <h1><%= t("management.budget_investments.create") %></h1>
+    </div>    
+  </div>  
+  <%= render '/budgets/investments/form', form_url: budget_investments_path(@budget) %>
 </div>

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -5,40 +5,57 @@
   <div class="row">
     <div class="small-12 column">
       <%= f.label :title, t("debates.form.debate_title") %>
-      <%= f.text_field :title, maxlength: Debate.title_max_length, placeholder: t("debates.form.debate_title"), label: false, data: {js_suggest_result: "js_suggest_result", js_suggest: "#js-suggest", js_url: suggest_debates_path}%>
     </div>
+    <div class="small-12 medium-9 column">
+      <%= f.text_field :title, maxlength: Debate.title_max_length, placeholder: t("debates.form.debate_title"), label: false, data: {js_suggest_result: "js_suggest_result", js_suggest: "#js-suggest", js_url: suggest_debates_path, toggle_focus: "title-suggestions"}%>
+    </div>
+    <%= render 'shared/suggest_message', id: 'title-suggestions', message: "#{t("debates.suggestions.title")}" %>
     <div id="js-suggest"></div>
-    <div class="ckeditor small-12 column">
+  </div>
+
+  <div class="row">
+    <div class="small-12 column">
       <%= f.label :description, t("debates.form.debate_text") %>
+    </div>
+    <div class="ckeditor small-12 medium-9 column">
       <%= f.cktext_area :description, maxlength: Debate.description_max_length, ckeditor: { language: I18n.locale }, label: false %>
     </div>
 
-    <%= f.invisible_captcha :subtitle %>
+      <%= f.invisible_captcha :subtitle %>  
+  </div>
 
+  <div class="row">
     <div class="small-12 column">
       <%= f.label :tag_list, t("debates.form.tags_label") %>
       <p class="help-text" id="tag-list-help-text"><%= t("debates.form.tags_instructions") %></p>
-
+    </div>
+    <div class="small-12 medium-9 column">
       <%= f.text_field :tag_list, value: @debate.tag_list.to_s,
-                        label: false,
-                        placeholder: t("debates.form.tags_placeholder"),
-                        aria: {describedby: "tag-list-help-text"},
-                        data: {js_url: suggest_tags_path},
-                        class: 'tag-autocomplete'%>
+                          label: false,
+                          placeholder: t("debates.form.tags_placeholder"),
+                          aria: {describedby: "tag-list-help-text"},
+                          data: {js_url: suggest_tags_path, toggle_focus: "tag-list-suggestions"},
+                          class: 'tag-autocomplete'%>
     </div>
-    <div class="small-12 column">
-      <% if @debate.new_record? %>
-        <%= f.label :terms_of_service do %>
-          <%= f.check_box :terms_of_service, title: t('form.accept_terms_title'), label: false %>
-          <span class="checkbox">
-            <%= t("form.accept_terms",
-                policy: link_to(t("form.policy"), "/privacy", target: "blank"),
-                conditions: link_to(t("form.conditions"), "/conditions", target: "blank")).html_safe %>
-          </span>
-        <% end %>
-      <% end %>
-    </div>
+    <%= render 'shared/suggest_message', id: 'tag-list-suggestions', message: "#{t("debates.suggestions.tag_list")}" %>      
+  </div>
 
+  <div class="row">
+      <div class="small-12 column">
+        <% if @debate.new_record? %>
+          <%= f.label :terms_of_service do %>
+            <%= f.check_box :terms_of_service, title: t('form.accept_terms_title'), label: false %>
+            <span class="checkbox">
+              <%= t("form.accept_terms",
+                  policy: link_to(t("form.policy"), "/privacy", target: "blank"),
+                  conditions: link_to(t("form.conditions"), "/conditions", target: "blank")).html_safe %>
+            </span>
+          <% end %>
+        <% end %>
+      </div>  
+  </div>
+  
+  <div class="row">
     <div class="actions small-12 column">
       <%= f.submit(class: "button", value: t("debates.#{action_name}.form.submit_button")) %>
     </div>

--- a/app/views/debates/new.html.erb
+++ b/app/views/debates/new.html.erb
@@ -1,27 +1,15 @@
-<div class="debate-form row">
-
+<div class="debate-form">
   <div class="small-12 medium-9 column">
     <%= back_link_to debates_path %>
 
     <h1><%= t("debates.new.start_new") %></h1>
     <div data-alert class="callout primary">
-      <%= t("debates.new.info",
-      info_link: link_to(t("debates.new.info_link"), new_proposal_path )).html_safe %>
+      <%= t("debates.new.info", info_link: link_to(t("debates.new.info_link"), new_proposal_path )).html_safe %>
       <%= link_to help_path, title: t('shared.target_blank_html'), target: "_blank" do %>
         <strong><%= t("debates.new.more_info") %></strong>
       <% end %>
     </div>
-    <%= render "form" %>
   </div>
 
-  <div class="small-12 medium-3 column">
-    <span class="icon-debates float-right"></span>
-    <h2><%= t("debates.new.recommendations_title") %></h2>
-    <ul class="recommendations">
-      <li><%= t("debates.new.recommendation_one") %></li>
-      <li><%= t("debates.new.recommendation_two") %></li>
-      <li><%= t("debates.new.recommendation_three") %></li>
-      <li><%= t("debates.new.recommendation_four") %></li>
-    </ul>
-  </div>
+  <%= render "form" %>
 </div>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -4,80 +4,146 @@
   <div class="row">
     <div class="small-12 column">
       <%= f.label :title, t("proposals.form.proposal_title") %>
-      <%= f.text_field :title, maxlength: Proposal.title_max_length, placeholder: t("proposals.form.proposal_title"), label: false, data: {js_suggest_result: "js_suggest_result", js_suggest: "#js-suggest", js_url: suggest_proposals_path}%>
     </div>
+
+    <div class="small-12 medium-9 column">
+      <%= f.text_field :title, maxlength: Proposal.title_max_length,
+                               placeholder: t("proposals.form.proposal_title"),
+                               label: false,
+                               data: {
+                                 js_suggest_result: "js_suggest_result",
+                                 js_suggest: "#js-suggest",
+                                 js_url: suggest_proposals_path,
+                                 toggle_focus: "title-suggestions"
+                               } %>
+    </div>
+
+    <%= render 'shared/suggest_message', id: 'title-suggestions',
+                                         message: t("proposals.suggestions.title") %>
+
     <div id="js-suggest"></div>
 
     <%= f.invisible_captcha :subtitle %>
+  </div>
 
+  <div class="row">
     <div class="small-12 column">
       <%= f.label :question, t("proposals.form.proposal_question") %>
       <p class="help-text" id="question-help-text">
         <%= t("proposals.form.proposal_question_example_html") %>
       </p>
+    </div>
+
+    <div class="small-12 medium-9 column">
       <%= f.text_field :question, maxlength: Proposal.question_max_length,
                                   placeholder: t("proposals.form.proposal_question"),
                                   label: false,
-                                  aria: {describedby: "question-help-text"} %>
+                                  aria: { describedby: "question-help-text" },
+                                  data: { toggle_focus: "question-suggestions" } %>
     </div>
 
+    <%= render 'shared/suggest_message', id: 'question-suggestions',
+                                         message: t("proposals.suggestions.question") %>
+  </div>
+
+  <div class="row">
     <div class="small-12 column">
       <%= f.label :summary, t("proposals.form.proposal_summary") %>
       <p class="help-text" id="summary-help-text"><%= t("proposals.form.proposal_summary_note") %></p>
+    </div>
+
+    <div class="small-12 medium-9 column">
       <%= f.text_area :summary, rows: 4, maxlength: 200, label: false,
                       placeholder: t('proposals.form.proposal_summary'),
-                      aria: {describedby: "summary-help-text"} %>
+                      aria: { describedby: "summary-help-text" },
+                      data: { toggle_focus: "summary-suggestions" } %>
     </div>
 
-    <div class="ckeditor small-12 column">
+    <%= render 'shared/suggest_message', id: 'summary-suggestions',
+                                         message: t("proposals.suggestions.summary") %>
+  </div>
+
+  <div class="row">
+    <div class="small-12 column">
       <%= f.label :description, t("proposals.form.proposal_text") %>
-      <%= f.cktext_area :description, maxlength: Proposal.description_max_length, ckeditor: { language: I18n.locale }, label: false %>
     </div>
+    <div class="ckeditor small-12 medium-9 column">
+      <%= f.cktext_area :description, maxlength: Proposal.description_max_length,
+                                      ckeditor: { language: I18n.locale },
+                                      label: false,
+                                      data: { toggle_focus: "description-suggestions" } %>
+    </div>
+    <%= render 'shared/suggest_message', id: 'description-suggestions',
+                                         message: t("proposals.suggestions.description") %>
+  </div>
 
+  <div class="row">
     <div class="small-12 column">
       <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
       <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
-      <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false,
-                                   aria: {describedby: "video-url-help-text"} %>
     </div>
 
+    <div class="small-12 medium-9 column">
+      <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"),
+                                   label: false,
+                                   aria: { describedby: "video-url-help-text" },
+                                   data: { toggle_focus: "video-url-suggestions" } %>
+    </div>
+
+    <%= render 'shared/suggest_message', id: 'video-url-suggestions',
+                                         message: t("proposals.suggestions.video_url") %>
+  </div>
+
+  <div class="row">
     <div class="small-12 column">
       <%= f.label :external_url, t("proposals.form.proposal_external_url") %>
-      <%= f.text_field :external_url, placeholder: t("proposals.form.proposal_external_url"), label: false %>
     </div>
 
-    <% if feature?(:allow_images) %>
-      <div class="images small-12 column">
-        <%= render 'images/nested_image', imageable: @proposal, f: f %>
-      </div>
-    <% end %>
+    <div class="small-12 medium-9 column">
+      <%= f.text_field :external_url, placeholder: t("proposals.form.proposal_external_url"),
+                                      label: false,
+                                      data: { toggle_focus: "external-url-suggestions" } %>
+    </div>
 
-    <% if feature?(:allow_attached_documents) %>
-      <div class="documents small-12 column">
-        <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
-      </div>
-    <% end %>
+    <%= render 'shared/suggest_message', id: 'external-url-suggestions',
+                                         message: t("proposals.suggestions.external_url") %>
+  </div>
 
+  <% if feature?(:allow_images) %>
+    <div class="images small-12 column">
+      <%= render 'images/nested_image', imageable: @proposal, f: f %>
+    </div>
+  <% end %>
+
+  <% if feature?(:allow_attached_documents) %>
+    <div class="documents small-12 column">
+      <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
+    </div>
+  <% end %>
+
+  <div class="row">
     <div class="small-12 medium-6 column">
       <%= f.label :geozone_id,  t("proposals.form.geozone") %>
-      <%= f.select :geozone_id, geozone_select_options, {include_blank: t("geozones.none"), label: false} %>
+      <%= f.select :geozone_id, geozone_select_options, { include_blank: t("geozones.none"), label: false } %>
     </div>
+  </div>
 
-    <% if feature?(:map) %>
-      <div class="small-12 column">
+  <% if feature?(:map) %>
+    <div class="small-12 column">
 
-        <%= render 'map_locations/form_fields',
-                   form:     f,
-                   map_location: @proposal.map_location || MapLocation.new,
-                   label:    t("proposals.form.map_location"),
-                   help:     t("proposals.form.map_location_instructions"),
-                   remove_marker_label: t("proposals.form.map_remove_marker"),
-                   parent_class: "proposal",
-                   i18n_namespace: "proposals" %>
+      <%= render 'map_locations/form_fields',
+                 form:     f,
+                 map_location: @proposal.map_location || MapLocation.new,
+                 label:    t("proposals.form.map_location"),
+                 help:     t("proposals.form.map_location_instructions"),
+                 remove_marker_label: t("proposals.form.map_remove_marker"),
+                 parent_class: "proposal",
+                 i18n_namespace: "proposals" %>
 
-      </div>
-    <% end %>
+    </div>
+  <% end %>
 
+  <div class="row">
     <div class="small-12 column">
       <%= f.label :tag_list, t("proposals.form.tags_label") %>
       <p class="help-text" id="tag-list-help-text"><%= t("proposals.form.tags_instructions") %></p>
@@ -88,25 +154,41 @@
           <a class="js-add-tag-link"><%= tag.name %></a>
         <% end %>
       </div>
-
-      <br>
-      <%= f.text_field :tag_list, value: @proposal.tag_list.to_s,
-                        label: false,
-                        placeholder: t("proposals.form.tags_placeholder"),
-                        class: 'js-tag-list tag-autocomplete',
-                        aria: {describedby: "tag-list-help-text"},
-                        data: {js_url: suggest_tags_path} %>
     </div>
 
+    <div class="small-12 medium-9 column">
+      <%= f.text_field :tag_list, value: @proposal.tag_list.to_s,
+                                  label: false,
+                                  placeholder: t("proposals.form.tags_placeholder"),
+                                  class: 'js-tag-list tag-autocomplete',
+                                  aria: { describedby: "tag-list-help-text" },
+                                  data: {
+                                    js_url: suggest_tags_path,
+                                    toggle_focus: "tag-list-suggestions"
+                                  } %>
+
+    </div>
+
+    <%= render 'shared/suggest_message', id: 'tag-list-suggestions',
+                                         message: t("proposals.suggestions.tag_list") %>
+  </div>
+
+  <div class="row">
     <% if current_user.unverified? %>
       <div class="small-12 column">
         <%= f.label :responsible_name, t("proposals.form.proposal_responsible_name") %>
-        <p class="help-text" id="responsible-name-help-text"><%= t("proposals.form.proposal_responsible_name_note") %></p>
-        <%= f.text_field :responsible_name, placeholder: t("proposals.form.proposal_responsible_name"), label: false,
-                                            aria: {describedby: "responsible-name-help-text"} %>
+        <p class="help-text" id="responsible-name-help-text">
+          <%= t("proposals.form.proposal_responsible_name_note") %>
+        </p>
+
+        <%= f.text_field :responsible_name, placeholder: t("proposals.form.proposal_responsible_name"),
+                                            label: false,
+                                            aria: { describedby: "responsible-name-help-text" } %>
       </div>
     <% end %>
+  </div>
 
+  <div class="row">
     <div class="small-12 column">
       <% if @proposal.new_record? %>
         <%= f.label :terms_of_service do %>
@@ -119,7 +201,9 @@
         <% end %>
       <% end %>
     </div>
+  </div>
 
+  <div class="row">
     <div class="actions small-12 column">
       <%= f.submit(class: "button", value: t("proposals.#{action_name}.form.submit_button")) %>
     </div>

--- a/app/views/proposals/new.html.erb
+++ b/app/views/proposals/new.html.erb
@@ -1,7 +1,8 @@
-<div class="proposal-form row">
+<div class="proposal-form">
 
-  <div class="small-12 medium-9 column">
-    <%= back_link_to %>
+  <div class="row">
+    <div class="small-12 medium-9 column">
+      <%= back_link_to %>
 
     <h1><%= t("proposals.new.start_new") %></h1>
     <div data-alert class="callout primary">
@@ -9,16 +10,7 @@
         <%= t("proposals.new.more_info")%>
       <% end %>
     </div>
-    <%= render "proposals/form", form_url: proposals_url %>
   </div>
 
-  <div class="small-12 medium-3 column">
-    <span class="icon-proposals float-right"></span>
-    <h2><%= t("proposals.new.recommendations_title") %></h2>
-    <ul class="recommendations">
-      <li><%= t("proposals.new.recommendation_one") %></li>
-      <li><%= t("proposals.new.recommendation_two") %></li>
-      <li><%= t("proposals.new.recommendation_three") %></li>
-    </ul>
-  </div>
+  <%= render "proposals/form", form_url: proposals_url %>
 </div>

--- a/app/views/shared/_suggest_message.html.erb
+++ b/app/views/shared/_suggest_message.html.erb
@@ -1,0 +1,5 @@
+<div class="small-12 medium-3 column">
+  <div id="<%=id%>" class="tip callout is-hidden" data-toggler="is-hidden">
+    <%= message %>
+  </div>        
+</div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -142,11 +142,6 @@ en:
       info: If you want to make a proposal, this is the wrong section, enter %{info_link}.
       info_link: create new proposal
       more_info: More information
-      recommendation_four: Enjoy this space and the voices that fill it. It belongs to you too.
-      recommendation_one: Do not use capital letters for the debate title or for whole sentences. On the internet, this is considered shouting. And nobody likes being shouted at.
-      recommendation_three: Ruthless criticism is very welcome. This is a space for reflection. But we recommend that you stick to elegance and intelligence. The world is a better place with these virtues in it.
-      recommendation_two: Any debate or comment suggesting illegal action will be deleted, as well as those intending to sabotage the debate spaces. Anything else is allowed.
-      recommendations_title: Recommendations for creating a debate
       start_new: Start a debate
     show:
       author_deleted: User deleted
@@ -395,10 +390,6 @@ en:
       form:
         submit_button: Create proposal
       more_info: How do citizen proposals work?
-      recommendation_one: Do not use capital letters for the proposal title or for whole sentences. On the internet, this is considered shouting. And nobody likes being shouted at.
-      recommendation_three: Enjoy this space and the voices that fill it. It belongs to you too.
-      recommendation_two: Any proposal or comment suggesting illegal action will be deleted, as well as those intending to sabotage the debate spaces. Anything else is allowed.
-      recommendations_title: Recommendations for creating a proposal
       start_new: Create new proposal
     notice:
       retired: Proposal retired

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -163,6 +163,9 @@ en:
     update:
       form:
         submit_button: Save changes
+    suggestions:
+      title: "Do not use capital letters for the debate title or for whole sentences. On the internet, this is considered shouting. And nobody likes being shouted at."
+      tag_list: "Tagging your debate correctly makes its search easier and may be voted more."
   errors:
     messages:
       user_not_found: User not found
@@ -451,6 +454,14 @@ en:
     update:
       form:
         submit_button: Save changes
+    suggestions:
+      title: "Do not use capital letters for the proposal title or for whole sentences. On the internet, this is considered shouting. And nobody likes being shouted at."
+      question: "Simple questions are easier to understand and to answer."
+      summary: "Any proposal or comment suggesting illegal action will be deleted, as well as those intending to sabotage the debate spaces. Anything else is allowed."
+      description: "Description tip"
+      video_url: "Make your proposal more dynamic adding a video. All of us love them."
+      external_url: "There is not enough space for the proposal? Include an URL to let people access more information about it."
+      tag_list: "Tagging your proposal correctly makes its search easier and may be voted more."
   polls:
     all: "All"
     no_dates: "no date assigned"
@@ -683,6 +694,12 @@ en:
         one: 1 support
         other: "%{count} supports"
         zero: No supports
+    suggestions:
+      title: "Do not use capital letters for the project title or for whole sentences. On the internet, this is considered shouting. And nobody likes being shouted at."
+      external_url: "There is not enough space for the project development? Include an URL to let people access more information about it."
+      location: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+      organization_name: "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+      tag_list: "Tagging your project correctly makes its search easier and may be voted more."
   stats:
     index:
       visits: Visits

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -691,7 +691,6 @@ en:
         zero: No supports
     suggestions:
       title: "Do not use capital letters for the project title or for whole sentences. On the internet, this is considered shouting. And nobody likes being shouted at."
-      external_url: "There is not enough space for the project development? Include an URL to let people access more information about it."
       location: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
       organization_name: "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
       tag_list: "Tagging your project correctly makes its search easier and may be voted more."

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -390,6 +390,10 @@ en:
       form:
         submit_button: Create proposal
       more_info: How do citizen proposals work?
+      recommendations_title: Recommendations for creating a proposal
+      recommendation_one: Do not use capital letters for the proposal title or for whole sentences. On the internet, this is considered shouting. And nobody likes being shouted at.
+      recommendation_two: Any proposal or comment suggesting illegal action will be deleted, as well as those intending to sabotage the debate spaces. Anything else is allowed.
+      recommendation_three: Enjoy this space and the voices that fill it. It belongs to you too.
       start_new: Create new proposal
     notice:
       retired: Proposal retired

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -163,6 +163,9 @@ es:
     update:
       form:
         submit_button: Guardar cambios
+    suggestions:
+      title: "No escribas el título del debate o frases enteras en mayúsculas. En internet eso se considera gritar, y a nadie le gusta que le griten."
+      tag_list: "Etiquetar correctamente un debate hace que su búsqueda sea más sencilla y tiene más posibilidades de conseguir apoyos."
   errors:
     messages:
       user_not_found: Usuario no encontrado
@@ -451,6 +454,14 @@ es:
     update:
       form:
         submit_button: Guardar cambios
+    suggestions:
+      title: "No escribas el título de la propuesta o frases enteras en mayúsculas. En internet eso se considera gritar, y a nadie le gusta que le griten."
+      question: "Las preguntas simples son más fáciles de entender y, por tanto, de contestar."
+      summary: "Cualquier propuesta o comentario que implique una acción ilegal será eliminada, también las que tengan la intención de sabotear los espacios de propuesta, todo lo demás está permitido."
+      description: "Description tip"
+      video_url: "Da más dinamismo a la propuesta con un vídeo. A todos nos resulta más divertido."
+      external_url: "¿Se te ha quedado pequeño el espacio para la propuesta? Incluye un enlace para poder tener acceso a más información."
+      tag_list: "Etiquetar correctamente una propuesta hace que su búsqueda sea más sencilla y tiene más posibilidades de conseguir apoyos."
   polls:
     all: "Todas"
     no_dates: "sin fecha asignada"
@@ -682,6 +693,12 @@ es:
         zero: Sin apoyos
         one: 1 apoyo
         other: "%{count} apoyos"
+    suggestions:
+      title: "No escribas el título del pryecto o frases enteras en mayúsculas. En internet eso se considera gritar, y a nadie le gusta que le griten."
+      external_url: "¿Se te ha quedado pequeño el espacio para la propuesta? Incluye un enlace para poder tener acceso a más información."
+      location: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+      organization_name: "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+      tag_list: "Etiquetar correctamente un proyecto hace que su búsqueda sea más sencilla y tiene más posibilidades de conseguir apoyos."
   stats:
     index:
       visits: Visitas

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -690,7 +690,6 @@ es:
         other: "%{count} apoyos"
     suggestions:
       title: "No escribas el título del pryecto o frases enteras en mayúsculas. En internet eso se considera gritar, y a nadie le gusta que le griten."
-      external_url: "¿Se te ha quedado pequeño el espacio para la propuesta? Incluye un enlace para poder tener acceso a más información."
       location: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
       organization_name: "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
       tag_list: "Etiquetar correctamente un proyecto hace que su búsqueda sea más sencilla y tiene más posibilidades de conseguir apoyos."

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -390,6 +390,10 @@ es:
       form:
         submit_button: Crear propuesta
       more_info: '¿Cómo funcionan las propuestas ciudadanas?'
+      recommendations_title: Recomendaciones para crear una propuesta
+      recommendation_one: No escribas el título de la propuesta o frases enteras en mayúsculas. En internet eso se considera gritar. Y a nadie le gusta que le griten.
+      recommendation_two: Cualquier propuesta o comentario que implique una acción ilegal será eliminada, también las que tengan la intención de sabotear los espacios de propuesta, todo lo demás está permitido.
+      recommendation_three: Disfruta de este espacio, de las voces que lo llenan, también es tuyo.
       start_new: Crear una propuesta
     notice:
       retired: Propuesta retirada

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -142,11 +142,6 @@ es:
       info: Si lo que quieres es hacer una propuesta, esta es la sección incorrecta, entra en %{info_link}.
       info_link: crear nueva propuesta
       more_info: Más información
-      recommendation_four: Disfruta de este espacio, de las voces que lo llenan, también es tuyo.
-      recommendation_one: No escribas el título del debate o frases enteras en mayúsculas. En internet eso se considera gritar. Y a nadie le gusta que le griten.
-      recommendation_three: Las críticas despiadadas son muy bienvenidas. Este es un espacio de pensamiento. Pero te recomendamos conservar la elegancia y la inteligencia. El mundo es mejor con ellas presentes.
-      recommendation_two: Cualquier debate o comentario que implique una acción ilegal será eliminado, también los que tengan la intención de sabotear los espacios de debate, todo lo demás está permitido.
-      recommendations_title: Recomendaciones para crear un debate
       start_new: Empezar un debate
     show:
       author_deleted: Usuario eliminado
@@ -395,10 +390,6 @@ es:
       form:
         submit_button: Crear propuesta
       more_info: '¿Cómo funcionan las propuestas ciudadanas?'
-      recommendation_one: No escribas el título de la propuesta o frases enteras en mayúsculas. En internet eso se considera gritar. Y a nadie le gusta que le griten.
-      recommendation_three: Disfruta de este espacio, de las voces que lo llenan, también es tuyo.
-      recommendation_two: Cualquier propuesta o comentario que implique una acción ilegal será eliminada, también las que tengan la intención de sabotear los espacios de propuesta, todo lo demás está permitido.
-      recommendations_title: Recomendaciones para crear una propuesta
       start_new: Crear una propuesta
     notice:
       retired: Propuesta retirada


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1697

What
====
Make the recomendation list dynamic, showing a different tip for each `text_field` in the debates, proposals and investement projects forms.

How
===
Using Foundation Toggler on focus (as pointed out in the issue). Each `text_field`, when they are onfocus, it triggers the toggler, and the specified div shows. When the focus changes, this div hides again and the next is shown, and so on. I needed to change the grid layout for that.

Screenshots
===========
**On title focus**

![suggestions_1](https://user-images.githubusercontent.com/31625251/30952310-96eade2c-a427-11e7-8ec8-3a182e656bb9.jpg)

**On question focus**

![suggestions_2](https://user-images.githubusercontent.com/31625251/30952314-9aa6401a-a427-11e7-85e9-c4b95d3d5f8e.jpg)

**On summary focus**

![suggestions_3](https://user-images.githubusercontent.com/31625251/30952318-9df863e2-a427-11e7-9f89-09d4c827897f.jpg)

Test
====
Not apply.

Deployment
==========
Not apply.

Warnings
========
There are some texts in `general.yml` related to project investments that were filled with `Lorem Ipsum`.

