### PR TITLE
Swap Poll White/Null/Total Results for Poll Recount

### DIFF
--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -15,7 +15,7 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
   end
 
   def show
-    @booth_assignment = @poll.booth_assignments.includes(:total_results, :voters,
+    @booth_assignment = @poll.booth_assignments.includes(:recounts, :voters,
                                                          officer_assignments: [officer: [:user]]).find(params[:id])
     @voters_by_date = @booth_assignment.voters.group_by {|v| v.created_at.to_date}
   end

--- a/app/controllers/admin/poll/officer_assignments_controller.rb
+++ b/app/controllers/admin/poll/officer_assignments_controller.rb
@@ -18,7 +18,7 @@ class Admin::Poll::OfficerAssignmentsController < Admin::Poll::BaseController
     @officer = ::Poll::Officer.includes(:user).find(officer_assignment_params[:officer_id])
     @officer_assignments = ::Poll::OfficerAssignment.
                            joins(:booth_assignment).
-                           includes(:total_results, booth_assignment: :booth).
+                           includes(:recounts, booth_assignment: :booth).
                            where("officer_id = ? AND poll_booth_assignments.poll_id = ?", @officer.id, @poll.id).
                            order(:date)
   end

--- a/app/controllers/admin/poll/recounts_controller.rb
+++ b/app/controllers/admin/poll/recounts_controller.rb
@@ -3,7 +3,7 @@ class Admin::Poll::RecountsController < Admin::Poll::BaseController
 
   def index
     @booth_assignments = @poll.booth_assignments.
-                              includes(:booth, :total_results, :voters).
+                              includes(:booth, :recounts, :voters).
                               order("poll_booths.name").
                               page(params[:page]).per(50)
   end

--- a/app/helpers/poll_recounts_helper.rb
+++ b/app/helpers/poll_recounts_helper.rb
@@ -1,7 +1,7 @@
 module PollRecountsHelper
 
   def total_recounts_by_booth(booth_assignment)
-    booth_assignment.total_results.any? ? booth_assignment.total_results.to_a.sum(&:amount) : nil
+    booth_assignment.recounts.any? ? booth_assignment.recounts.to_a.sum(&:total_amount) : nil
   end
 
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -2,9 +2,7 @@ class Poll < ActiveRecord::Base
   has_many :booth_assignments, class_name: "Poll::BoothAssignment"
   has_many :booths, through: :booth_assignments
   has_many :partial_results, through: :booth_assignments
-  has_many :white_results, through: :booth_assignments
-  has_many :null_results, through: :booth_assignments
-  has_many :total_results, through: :booth_assignments
+  has_many :recounts, through: :booth_assignments
   has_many :voters
   has_many :officer_assignments, through: :booth_assignments
   has_many :officers, through: :officer_assignments

--- a/app/models/poll/booth_assignment.rb
+++ b/app/models/poll/booth_assignment.rb
@@ -7,8 +7,6 @@ class Poll
     has_many :officers, through: :officer_assignments
     has_many :voters
     has_many :partial_results
-    has_many :white_results
-    has_many :null_results
-    has_many :total_results
+    has_many :recounts
   end
 end

--- a/app/models/poll/officer_assignment.rb
+++ b/app/models/poll/officer_assignment.rb
@@ -3,9 +3,7 @@ class Poll
     belongs_to :officer
     belongs_to :booth_assignment
     has_many :partial_results
-    has_many :white_results
-    has_many :null_results
-    has_many :total_results
+    has_many :recounts
     has_many :voters
 
     validates :officer_id, presence: true

--- a/app/models/poll/recount.rb
+++ b/app/models/poll/recount.rb
@@ -1,0 +1,36 @@
+class Poll::Recount < ActiveRecord::Base
+
+  VALID_ORIGINS = %w{ web booth letter }
+
+  belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
+  belongs_to :booth_assignment
+  belongs_to :officer_assignment
+
+  validates :author, presence: true
+  validates :origin, inclusion: {in: VALID_ORIGINS}
+
+  scope :web,    -> { where(origin: 'web') }
+  scope :booth,  -> { where(origin: 'booth') }
+  scope :letter, -> { where(origin: 'letter') }
+
+  scope :by_author, ->(author_id) { where(author_id: author_id) }
+
+  before_save :update_logs
+
+  def update_logs
+    amounts_changed = false
+
+    [:white, :null, :total].each do |amount|
+      next unless send("#{amount}_amount_changed?") && send("#{amount}_amount_was").present?
+      self["#{amount}_amount_log"] += ":#{send("#{amount}_amount_was").to_s}"
+      amounts_changed = true
+    end
+
+    update_officer_author if amounts_changed
+  end
+
+  def update_officer_author
+      self.officer_assignment_id_log += ":#{officer_assignment_id_was.to_s}"
+      self.author_id_log += ":#{author_id_was.to_s}"
+  end
+end

--- a/app/views/admin/poll/officer_assignments/by_officer.html.erb
+++ b/app/views/admin/poll/officer_assignments/by_officer.html.erb
@@ -43,8 +43,8 @@
             <td><%= l(officer_assignment.date.to_date) %></td>
             <td><%= booth_name_with_location(officer_assignment.booth_assignment.booth) %></td>
             <td class="text-right">
-              <% if officer_assignment.total_results.any? %>
-                <%= officer_assignment.total_results.to_a.sum(&:amount) %>
+              <% if officer_assignment.recounts.any? %>
+                <%= officer_assignment.recounts.to_a.sum(&:total_amount) %>
               <% else %>
                 <span>-</span>
               <% end %>

--- a/app/views/admin/poll/results/index.html.erb
+++ b/app/views/admin/poll/results/index.html.erb
@@ -18,9 +18,9 @@
       </thead>
       <tbody>
         <tr>
-          <td id="white_results"><%= @poll.white_results.sum(:amount) %></td>
-          <td id="null_results"><%= @poll.null_results.sum(:amount) %></td>
-          <td id="total_results"><%= @poll.total_results.sum(:amount) %></td>
+          <td id="white_results"><%= @poll.recounts.sum(:white_amount) %></td>
+          <td id="null_results"><%= @poll.recounts.sum(:null_amount) %></td>
+          <td id="total_results"><%= @poll.recounts.sum(:total_amount) %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/officing/results/index.html.erb
+++ b/app/views/officing/results/index.html.erb
@@ -21,9 +21,9 @@
         </thead>
         <tbody>
           <tr>
-            <td id="white_results"><%= @whites %></td>
-            <td id="null_results"><%= @nulls %></td>
-            <td id="total_results"><%= @total %></td>
+            <td id="white_results"><%= @recounts.sum(:white_amount) %></td>
+            <td id="null_results"><%= @recounts.sum(:null_amount) %></td>
+            <td id="total_results"><%= @recounts.sum(:total_amount) %></td>
           </tr>
         </tbody>
       </table>

--- a/db/migrate/20171002122312_create_poll_recount.rb
+++ b/db/migrate/20171002122312_create_poll_recount.rb
@@ -1,0 +1,24 @@
+class CreatePollRecount < ActiveRecord::Migration
+  def change
+    create_table :poll_recounts do |t|
+      t.integer :author_id
+      t.string  :origin
+      t.date    :date
+      t.integer :booth_assignment_id
+      t.integer :officer_assignment_id
+      t.text    :officer_assignment_id_log,       default: ""
+      t.text    :author_id_log,                   default: ""
+      t.integer :white_amount
+      t.text    :white_amount_log,                default: ""
+      t.integer :null_amount
+      t.text    :null_amount_log,                 default: ""
+      t.integer :total_amount
+      t.text    :total_amount_log,                default: ""
+    end
+
+    add_index :poll_recounts, :booth_assignment_id
+    add_index :poll_recounts, :officer_assignment_id
+    add_foreign_key :poll_recounts, :poll_booth_assignments,   column: :booth_assignment_id
+    add_foreign_key :poll_recounts, :poll_officer_assignments, column: :officer_assignment_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170927110953) do
+ActiveRecord::Schema.define(version: 20171002122312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -690,6 +690,25 @@ ActiveRecord::Schema.define(version: 20170927110953) do
   add_index "poll_questions", ["proposal_id"], name: "index_poll_questions_on_proposal_id", using: :btree
   add_index "poll_questions", ["tsv"], name: "index_poll_questions_on_tsv", using: :gin
 
+  create_table "poll_recounts", force: :cascade do |t|
+    t.integer "author_id"
+    t.string  "origin"
+    t.date    "date"
+    t.integer "booth_assignment_id"
+    t.integer "officer_assignment_id"
+    t.text    "officer_assignment_id_log", default: ""
+    t.text    "author_id_log",             default: ""
+    t.integer "white_amount"
+    t.text    "white_amount_log",          default: ""
+    t.integer "null_amount"
+    t.text    "null_amount_log",           default: ""
+    t.integer "total_amount"
+    t.text    "total_amount_log",          default: ""
+  end
+
+  add_index "poll_recounts", ["booth_assignment_id"], name: "index_poll_recounts_on_booth_assignment_id", using: :btree
+  add_index "poll_recounts", ["officer_assignment_id"], name: "index_poll_recounts_on_officer_assignment_id", using: :btree
+
   create_table "poll_shifts", force: :cascade do |t|
     t.integer  "booth_id"
     t.integer  "officer_id"
@@ -1126,6 +1145,8 @@ ActiveRecord::Schema.define(version: 20170927110953) do
   add_foreign_key "poll_questions", "polls"
   add_foreign_key "poll_questions", "proposals"
   add_foreign_key "poll_questions", "users", column: "author_id"
+  add_foreign_key "poll_recounts", "poll_booth_assignments", column: "booth_assignment_id"
+  add_foreign_key "poll_recounts", "poll_officer_assignments", column: "officer_assignment_id"
   add_foreign_key "poll_voters", "polls"
   add_foreign_key "poll_white_results", "poll_booth_assignments", column: "booth_assignment_id"
   add_foreign_key "poll_white_results", "poll_officer_assignments", column: "officer_assignment_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -569,6 +569,11 @@ FactoryGirl.define do
     origin { 'web' }
   end
 
+  factory :poll_recount, class: 'Poll::Recount' do
+    association :author, factory: :user
+    origin { 'web' }
+  end
+
   factory :officing_residence, class: 'Officing::Residence' do
     user
     association :officer, factory: :poll_officer

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -249,18 +249,18 @@ feature 'Admin polls' do
         booth_assignment_final_recounted = create(:poll_booth_assignment, poll: poll)
 
         3.times do |i|
-          create(:poll_total_result,
+          create(:poll_recount,
                  booth_assignment: booth_assignment,
                  date: poll.starts_at + i.days,
-                 amount: 21)
+                 total_amount: 21)
         end
 
         2.times { create(:poll_voter, booth_assignment: booth_assignment_final_recounted) }
 
-        create(:poll_total_result,
+        create(:poll_recount,
                booth_assignment: booth_assignment_final_recounted,
                date: poll.ends_at,
-               amount: 55555)
+               total_amount: 55555)
 
         visit admin_poll_path(poll)
 
@@ -318,12 +318,10 @@ feature 'Admin polls' do
                   answer: 'Tomorrow',
                   amount: 5)
         end
-        create(:poll_white_result,
+        create(:poll_recount,
                booth_assignment: booth_assignment_1,
-               amount: 21)
-        create(:poll_null_result,
-               booth_assignment: booth_assignment_3,
-               amount: 44)
+               white_amount: 21,
+               null_amount: 44)
 
         visit admin_poll_path(poll)
 

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -127,21 +127,13 @@ feature 'Officing Results' do
                       date: @poll.ends_at,
                       question: @question_1,
                       amount: 33)
-    white_result = create(:poll_white_result,
+    poll_recount = create(:poll_recount,
                       officer_assignment: @officer_assignment,
                       booth_assignment: @officer_assignment.booth_assignment,
                       date: @poll.ends_at,
-                      amount: 21)
-    null_result = create(:poll_null_result,
-                      officer_assignment: @officer_assignment,
-                      booth_assignment: @officer_assignment.booth_assignment,
-                      date: @poll.ends_at,
-                      amount: 44)
-    total_result = create(:poll_total_result,
-                      officer_assignment: @officer_assignment,
-                      booth_assignment: @officer_assignment.booth_assignment,
-                      date: @poll.ends_at,
-                      amount: 66)
+                      white_amount: 21,
+                      null_amount: 44,
+                      total_amount: 66)
 
     visit officing_poll_results_path(@poll,
                                      date: I18n.l(@poll.ends_at.to_date),

--- a/spec/models/poll/recount_spec.rb
+++ b/spec/models/poll/recount_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+describe Poll::Recount do
+
+  describe "logging changes" do
+    let(:poll_recount) { create(:poll_recount) }
+
+    it "should update white_amount_log if white_amount changes" do
+      poll_recount.white_amount = 33
+
+      expect(poll_recount.white_amount_log).to eq("")
+
+      poll_recount.white_amount = 33
+      poll_recount.save
+      poll_recount.white_amount = 32
+      poll_recount.save
+      poll_recount.white_amount = 34
+      poll_recount.save
+
+      expect(poll_recount.white_amount_log).to eq(":33:32")
+    end
+
+    it "should update null_amount_log if null_amount changes" do
+      poll_recount.null_amount = 33
+
+      expect(poll_recount.null_amount_log).to eq("")
+
+      poll_recount.null_amount = 33
+      poll_recount.save
+      poll_recount.null_amount = 32
+      poll_recount.save
+      poll_recount.null_amount = 34
+      poll_recount.save
+
+      expect(poll_recount.null_amount_log).to eq(":33:32")
+    end
+
+    it "should update total_amount_log if total_amount changes" do
+      poll_recount.total_amount = 33
+
+      expect(poll_recount.total_amount_log).to eq("")
+
+      poll_recount.total_amount = 33
+      poll_recount.save
+      poll_recount.total_amount = 32
+      poll_recount.save
+      poll_recount.total_amount = 34
+      poll_recount.save
+
+      expect(poll_recount.total_amount_log).to eq(":33:32")
+    end
+
+    it "should update officer_assignment_id_log if amount changes" do
+      poll_recount.white_amount = 33
+
+      expect(poll_recount.white_amount_log).to eq("")
+      expect(poll_recount.officer_assignment_id_log).to eq("")
+
+      poll_recount.white_amount = 33
+      poll_recount.officer_assignment = create(:poll_officer_assignment, id: 101)
+      poll_recount.save
+
+      poll_recount.white_amount = 32
+      poll_recount.officer_assignment = create(:poll_officer_assignment, id: 102)
+      poll_recount.save
+
+      poll_recount.white_amount = 34
+      poll_recount.officer_assignment = create(:poll_officer_assignment, id: 103)
+      poll_recount.save
+
+      expect(poll_recount.white_amount_log).to eq(":33:32")
+      expect(poll_recount.officer_assignment_id_log).to eq(":101:102")
+    end
+
+    it "should update author_id if amount changes" do
+      poll_recount.white_amount = 33
+
+      expect(poll_recount.white_amount_log).to eq("")
+      expect(poll_recount.author_id_log).to eq("")
+
+      author_A = create(:poll_officer).user
+      author_B = create(:poll_officer).user
+      author_C = create(:poll_officer).user
+
+      poll_recount.white_amount = 33
+      poll_recount.author_id = author_A.id
+      poll_recount.save!
+
+      poll_recount.white_amount = 32
+      poll_recount.author_id = author_B.id
+      poll_recount.save!
+
+      poll_recount.white_amount = 34
+      poll_recount.author_id = author_C.id
+      poll_recount.save!
+
+      expect(poll_recount.white_amount_log).to eq(":33:32")
+      expect(poll_recount.author_id_log).to eq(":#{author_A.id}:#{author_B.id}")
+    end
+  end
+
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1870

This PR was started by a great work from @aitbw at https://github.com/consul/consul/pull/1893 but since there where some issues still pending to refactor, we ended up stopping work there in order to do a clean migration history and less duplication of logic.

What
====
We have three models `Poll::NullResult`, `Poll::TotalResult` and `Poll::WhiteResult` that duplicated a lot of logic in 3 tables, joining all in just one `Poll::Recount` to make things easier to maintain and less ddbb space.

How
===
- Created a `Poll::Recount` model with amount integer/log for white/null/total
- Swapped `Poll::NullResult`, `Poll::TotalResult` and `Poll::WhiteResult` usage for `Poll::Recount`
- Added spec for `Poll::Recount` model and updated officing Results spec.

Test
====
- Updated

Warnings
========
- Remember to create a rake on your fork to migrate data if you have some (like on Madrid's)