### PR TITLE
Set default 0 for Poll Recount amounts

### DIFF
--- a/db/migrate/20171002191347_add_default_to_recount_amounts.rb
+++ b/db/migrate/20171002191347_add_default_to_recount_amounts.rb
@@ -1,0 +1,7 @@
+class AddDefaultToRecountAmounts < ActiveRecord::Migration
+  def change
+    change_column_default :poll_recounts, :white_amount, 0
+    change_column_default :poll_recounts, :null_amount, 0
+    change_column_default :poll_recounts, :total_amount, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171002122312) do
+ActiveRecord::Schema.define(version: 20171002191347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -698,11 +698,11 @@ ActiveRecord::Schema.define(version: 20171002122312) do
     t.integer "officer_assignment_id"
     t.text    "officer_assignment_id_log", default: ""
     t.text    "author_id_log",             default: ""
-    t.integer "white_amount"
+    t.integer "white_amount",              default: 0
     t.text    "white_amount_log",          default: ""
-    t.integer "null_amount"
+    t.integer "null_amount",               default: 0
     t.text    "null_amount_log",           default: ""
-    t.integer "total_amount"
+    t.integer "total_amount",              default: 0
     t.text    "total_amount_log",          default: ""
   end
 


### PR DESCRIPTION
What
====
- Set a default 0 value for Poll::Recount amount columns

How
===
- A migration setting each column default value

Screenshots
===========
- No need

Test
====
- Should work, problem comes at madrid's fork because of the migration we did (only one amount value on each Recount)

Deployment
==========
- As usual

Warnings
========
- None
