### PR TITLE
Correct Poll Shift task & date restrictions

### DIFF
--- a/db/migrate/20171003212958_add_date_to_poll_shift_composed_index.rb
+++ b/db/migrate/20171003212958_add_date_to_poll_shift_composed_index.rb
@@ -1,0 +1,7 @@
+class AddDateToPollShiftComposedIndex < ActiveRecord::Migration
+  def change
+    remove_index "poll_shifts", name: "index_poll_shifts_on_booth_id_and_officer_id_and_task"
+    remove_index "poll_shifts", name: "index_poll_shifts_on_task"
+    add_index :poll_shifts, [:booth_id, :officer_id, :date, :task], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171003095936) do
+ActiveRecord::Schema.define(version: 20171003212958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -719,10 +719,9 @@ ActiveRecord::Schema.define(version: 20171003095936) do
     t.integer  "task",          default: 0, null: false
   end
 
-  add_index "poll_shifts", ["booth_id", "officer_id", "task"], name: "index_poll_shifts_on_booth_id_and_officer_id_and_task", unique: true, using: :btree
+  add_index "poll_shifts", ["booth_id", "officer_id", "date", "task"], name: "index_poll_shifts_on_booth_id_and_officer_id_and_date_and_task", unique: true, using: :btree
   add_index "poll_shifts", ["booth_id"], name: "index_poll_shifts_on_booth_id", using: :btree
   add_index "poll_shifts", ["officer_id"], name: "index_poll_shifts_on_officer_id", using: :btree
-  add_index "poll_shifts", ["task"], name: "index_poll_shifts_on_task", using: :btree
 
   create_table "poll_total_results", force: :cascade do |t|
     t.integer "author_id"

--- a/spec/models/poll/shift_spec.rb
+++ b/spec/models/poll/shift_spec.rb
@@ -34,6 +34,24 @@ describe :shift do
       expect(shift).to_not be_valid
     end
 
+    it "should not be valid with same booth, officer, date and task" do
+      recount_shift.save
+
+      expect(build(:poll_shift, booth: booth, officer: officer, date: Date.current, task: :recount_scrutiny)).to_not be_valid
+    end
+
+    it "should be valid with same booth, officer and date but different task" do
+      recount_shift.save
+
+      expect(build(:poll_shift, booth: booth, officer: officer, date: Date.current, task: :vote_collection)).to be_valid
+    end
+
+    it "should be valid with same booth, officer and task but different date" do
+      recount_shift.save
+
+      expect(build(:poll_shift, booth: booth, officer: officer, date: Date.tomorrow, task: :recount_scrutiny)).to be_valid
+    end
+
   end
 
   describe "officer_assignments" do

--- a/spec/models/poll/shift_spec.rb
+++ b/spec/models/poll/shift_spec.rb
@@ -1,9 +1,14 @@
 require 'rails_helper'
 
 describe :shift do
-  let(:shift) { build(:poll_shift) }
+  let(:poll) { create(:poll) }
+  let(:booth) { create(:poll_booth) }
+  let(:user) { create(:user, username: "Ana", email: "ana@example.com") }
+  let(:officer) { create(:poll_officer, user: user) }
+  let(:recount_shift) { build(:poll_shift, booth: booth, officer: officer, date: Date.current, task: :recount_scrutiny) }
 
   describe "validations" do
+    let(:shift) { build(:poll_shift) }
 
     it "should be valid" do
       expect(shift).to be_valid
@@ -34,14 +39,10 @@ describe :shift do
   describe "officer_assignments" do
 
     it "should create and destroy corresponding officer_assignments" do
-      poll1 = create(:poll)
       poll2 = create(:poll)
       poll3 = create(:poll)
 
-      booth = create(:poll_booth)
-      officer = create(:poll_officer)
-
-      booth_assignment1 = create(:poll_booth_assignment, poll: poll1, booth: booth)
+      booth_assignment1 = create(:poll_booth_assignment, poll: poll, booth: booth)
       booth_assignment2 = create(:poll_booth_assignment, poll: poll2, booth: booth)
 
       expect { create(:poll_shift, booth: booth, officer: officer, date: Date.current) }.to change {Poll::OfficerAssignment.all.count}.by(2)
@@ -66,13 +67,8 @@ describe :shift do
     end
 
     it "should create final officer_assignments" do
-      poll = create(:poll)
-      booth = create(:poll_booth)
-      officer = create(:poll_officer)
-
       booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-
-      shift = create(:poll_shift, booth: booth, officer: officer, date: Date.current, task: :recount_scrutiny)
+      recount_shift.save
 
       officer_assignments = Poll::OfficerAssignment.all
       expect(officer_assignments.count).to eq(1)
@@ -88,10 +84,7 @@ describe :shift do
   end
 
   describe "#persist_data" do
-
-    let(:user) { create(:user, username: "Ana", email: "ana@example.com") }
-    let(:officer) { create(:poll_officer, user: user) }
-    let(:shift) { create(:poll_shift, officer: officer) }
+    let(:shift) { create(:poll_shift, officer: officer, booth: booth) }
 
     it "should maintain officer data after destroying associated user" do
       shift.officer.user.destroy

--- a/spec/models/poll/shift_spec.rb
+++ b/spec/models/poll/shift_spec.rb
@@ -24,6 +24,11 @@ describe :shift do
       expect(shift).to_not be_valid
     end
 
+    it "should not be valid without a task" do
+      shift.task = nil
+      expect(shift).to_not be_valid
+    end
+
   end
 
   describe "officer_assignments" do


### PR DESCRIPTION
What
====
- Currently given an officer and booth, it can't have two shifts with the same task in different dates, that's not correct.

How
===
- Fixing the composed index on poll_shifts table (and removing a really not important one over task column)
- Extending shift model spec to cover scenarios most likely to fail
- Some cleanup & refactor on let statements on shift model spec

Screenshots
===========
No need

Test
====
Increased to check we're not going to get problems again :)

Deployment
==========
Asap to madrid fork!

Warnings
========
We could increase coverage much further, but hurry up polls are coming!