### PR TITLE
Add officer to Poll::Voter

### DIFF
--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -13,7 +13,8 @@ class Officing::VotersController < Officing::BaseController
                              document_number: @user.document_number,
                              user: @user,
                              poll: @poll,
-                             origin: "booth")
+                             origin: "booth",
+                             officer: current_user.poll_officer)
     @voter.save!
   end
 

--- a/app/models/poll/voter.rb
+++ b/app/models/poll/voter.rb
@@ -8,6 +8,7 @@ class Poll
     belongs_to :geozone
     belongs_to :booth_assignment
     belongs_to :officer_assignment
+    belongs_to :officer
 
     validates :poll_id, presence: true
     validates :user_id, presence: true

--- a/db/migrate/20171003223152_add_officer_to_poll_voter.rb
+++ b/db/migrate/20171003223152_add_officer_to_poll_voter.rb
@@ -1,0 +1,5 @@
+class AddOfficerToPollVoter < ActiveRecord::Migration
+  def change
+    add_column :poll_voters, :officer_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171003212958) do
+ActiveRecord::Schema.define(version: 20171003223152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -752,6 +752,7 @@ ActiveRecord::Schema.define(version: 20171003212958) do
     t.integer  "officer_assignment_id"
     t.integer  "user_id"
     t.string   "origin"
+    t.integer  "officer_id"
   end
 
   add_index "poll_voters", ["booth_assignment_id"], name: "index_poll_voters_on_booth_assignment_id", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -531,6 +531,7 @@ FactoryGirl.define do
   factory :poll_voter, class: 'Poll::Voter' do
     poll
     association :user, :level_two
+    association :officer, factory: :poll_officer
     origin "web"
 
     trait :from_booth do

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -26,6 +26,8 @@ feature 'Voters' do
     page.evaluate_script("window.location.reload()")
     expect(page).to have_content "Has already participated in this poll"
     expect(page).to_not have_button "Confirm vote"
+
+    expect(Poll::Voter.last.officer_id).to eq(officer.id)
   end
 
   scenario "Already voted", :js do

--- a/spec/models/poll/answer_spec.rb
+++ b/spec/models/poll/answer_spec.rb
@@ -51,6 +51,7 @@ describe Poll::Answer do
 
       expect(voter.document_number).to eq(answer.author.document_number)
       expect(voter.poll_id).to eq(answer.poll.id)
+      expect(voter.officer_id).to eq(nil)
     end
 
     it "updates a poll_voter with user and poll data" do


### PR DESCRIPTION
What
====
- We need to be able to trace any Poll Voter creation from the officing panel for both security and history

How
===
- Adding a relation to Poll::Officer on Poll::Voter that is not mandatory (Voter created from web by the user won't have a officer associated)

Screenshots
===========
No need

Test
====
Extended to cover both scenarios (officer_id present on officing panel created Voter, an empty when user created the Voter)

Deployment
==========
As usual

Warnings
========
none