### PR TITLE
Specs added for branch polls-show in consul and thumbnail for poll im…

### DIFF
--- a/app/views/images/_admin_image.html.erb
+++ b/app/views/images/_admin_image.html.erb
@@ -2,7 +2,6 @@
     <div>
       <%= f.label :image, t("images.form.admin_title") %>
       
-
       <%= link_to_add_association t('images.form.add_new_image'), f, :image,
                             force_non_association_create: true,
                             partial: "images/image_fields",
@@ -15,6 +14,8 @@
                               association_insertion_node: "#nested-image",
                               association_insertion_method: "append"
                             } %>
+      
+      <%= render_image(f.object.image, :thumb, false) if f.object.image %>
 
       <div id="nested-image">
         <%= f.fields_for :image do |image_builder| %>
@@ -26,17 +27,11 @@
 
             <%= image_builder.text_field :title, placeholder: t("images.form.title_placeholder"), label: "#{t("images.form.admin_alt_text")}" %>
 
-
             <div class="attachment-actions">
               <div class="small-12 column action-add attachment-errors image-attachment">
                 <%= render_image_attachment(image_builder, imageable, image_builder.object) %>
               </div>
             </div>
-
-            <div class="small-12 column">
-              <div class="progress-bar-placeholder"><div class="loading-bar"></div></div>
-            </div>
-
           </div>
         
         <% end %>

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -70,14 +70,18 @@ feature 'Admin polls' do
 
   scenario "Edit" do
     poll = create(:poll)
+    create(:image, imageable: poll)
 
     visit admin_poll_path(poll)
     click_link "Edit"
 
     end_date = 1.year.from_now
 
+    expect(page).to have_css("img[alt='#{poll.image.title}']")
+
     fill_in "poll_name", with: "Next Poll"
     fill_in 'poll_ends_at', with: end_date.strftime("%d/%m/%Y")
+
     click_button "Update poll"
 
     expect(page).to have_content "Poll updated successfully"

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -6,11 +6,15 @@ feature 'Polls' do
 
     scenario 'Polls can be listed' do
       polls = create_list(:poll, 3)
+      create(:image, imageable: polls[0])
+      create(:image, imageable: polls[1])
+      create(:image, imageable: polls[2])
 
       visit polls_path
 
       polls.each do |poll|
         expect(page).to have_content(poll.name)
+        expect(page).to have_css("img[alt='#{poll.image.title}']")
         expect(page).to have_link("Participate in this poll")
       end
     end
@@ -59,7 +63,7 @@ feature 'Polls' do
 
   context 'Show' do
     let(:geozone) { create(:geozone) }
-    let(:poll) { create(:poll) }
+    let(:poll) { create(:poll, summary: "Summary", description: "Description") }
 
     scenario 'Lists questions from proposals as well as regular ones' do
       normal_question = create(:poll_question, poll: poll)
@@ -67,6 +71,8 @@ feature 'Polls' do
 
       visit poll_path(poll)
       expect(page).to have_content(poll.name)
+      expect(page).to have_content(poll.summary)
+      expect(page).to have_content(poll.description)
 
       expect(page).to have_content(normal_question.title)
       expect(page).to have_content(proposal_question.title)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1973 and #1974
* **Related PR's:** #1971

What
====

- Add the specs that were missing
- Add a thumbnail of polls' main image for polls edit in admin

How
===
I added the thumbnail image to the polls edit view next to the 'Add image' button, and it's shown only if there exists one.
Spects added to:
- check if the thumbnail appears
- check the polls summary and description in polls show (as user)
- check the images in polls index (as user)

Screenshots
===========
Screenshots for the thumbnail:

![thumbnail](https://user-images.githubusercontent.com/31625251/31182607-a05a38d4-a924-11e7-8be0-2f768c216a8a.jpg)

Test
====
As it's said previously, the test coverage has been increased to test the thumbnail, the polls summary and description and the images in the polls index.

Deployment
==========
Nothing to apply

Warnings
========
This is an extension of a branch already merged to consul/master.
