### PR TITLE
Iagirre remove documents questions

### DIFF
--- a/app/controllers/admin/poll/questions_controller.rb
+++ b/app/controllers/admin/poll/questions_controller.rb
@@ -56,8 +56,7 @@ class Admin::Poll::QuestionsController < Admin::Poll::BaseController
   private
 
     def question_params
-      params.require(:poll_question).permit(:poll_id, :title, :question, :proposal_id, :valid_answers, :video_url,
-                                            documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy])
+      params.require(:poll_question).permit(:poll_id, :title, :question, :proposal_id, :valid_answers, :video_url)
     end
 
     def search_params

--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -1,11 +1,6 @@
 class Poll::Question < ActiveRecord::Base
   include Measurable
   include Searchable
-  include Documentable
-  documentable max_documents_allowed: 1,
-               max_file_size: 3.megabytes,
-               accepted_content_types: [ "application/pdf" ]
-  accepts_nested_attributes_for :documents, allow_destroy: true
 
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases

--- a/app/views/admin/poll/questions/_form.html.erb
+++ b/app/views/admin/poll/questions/_form.html.erb
@@ -16,10 +16,6 @@
 
       <%= f.text_field :title, maxlength: Poll::Question.title_max_length %>
 
-      <div class="documents small-12">
-        <%= render 'documents/nested_documents', documentable: @question, f: f %>
-      </div>
-
       <div class="small-12">
         <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
         <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>

--- a/app/views/admin/poll/questions/show.html.erb
+++ b/app/views/admin/poll/questions/show.html.erb
@@ -56,13 +56,5 @@
         <a href="<%= @question.video_url %>"><%= @question.video_url %></a>
       </p>
     <% end %>
-
-    <% if @question.documents.any? %>
-      <p>
-        <strong><%= t("admin.questions.show.documents") %></strong>
-        <br>
-        <a href="<%= @question.documents.first.attachment.url %>"><%= @question.documents.first.title %></a>
-      </p>
-    <% end %>
   </div>
 </div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -594,7 +594,6 @@ en:
         valid_answers: Valid answers
         add_answer: "Add answer"
         video_url: External video
-        documents: Documents (1)
         answers:
           title: Answer
           description: Description

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -595,7 +595,6 @@ es:
         add_answer: "Añadir respuesta"
         description: Descripción
         video_url: Video externo
-        documents: Documentos (1)
         preview: Ver en la web
         answers:
           title: Respuesta

--- a/spec/features/admin/poll/questions_spec.rb
+++ b/spec/features/admin/poll/questions_spec.rb
@@ -111,22 +111,4 @@ feature 'Admin poll questions' do
 
   pending "Mark all city by default when creating a poll question from a successful proposal"
 
-  it_behaves_like "nested documentable",
-                  "administrator",
-                  "poll_question",
-                  "new_admin_question_path",
-                  { },
-                  "documentable_fill_new_valid_poll_question",
-                  "Save",
-                  "Star Wars: Episode IV - A New Hope"
-
-  it_behaves_like "nested documentable",
-                  "administrator",
-                  "poll_question",
-                  "edit_admin_question_path",
-                  { "id": "id" },
-                  nil,
-                  "Save",
-                  "Changes saved"
-
 end

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -263,7 +263,6 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
 
     end
 
-
   end
 
 end
@@ -275,7 +274,7 @@ rescue
   return
 end
 
-def documentable_attach_new_file(documentable_factory_name, index, path, success = true)
+def documentable_attach_new_file(_documentable_factory_name, index, path, success = true)
   click_link "Add new document"
   document = all(".document")[index]
   document_input = document.find("input[type=file]", visible: false)
@@ -317,9 +316,4 @@ def documentable_fill_new_valid_budget_investment
   fill_in :budget_investment_title, with: "Budget investment title"
   fill_in_ckeditor "budget_investment_description", with: "Budget investment description"
   check :budget_investment_terms_of_service
-end
-
-def documentable_fill_new_valid_poll_question
-  page.select documentable.poll.name, from: 'poll_question_poll_id'
-  fill_in 'poll_question_title', with: "Star Wars: Episode IV - A New Hope"
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1983

What
====
Remove the document attachment from admins questions creation/edition.

How
===
- Removing the file uploader from the form.
- Making the question model not documentable (removing the `include Documentable` and the rest of the configuration involved).
- Removing the html that showed the documents in admins questions.
- Modifying the specs to make them pass.
- The i18n keys related to documents and questions where also deleted.

Screenshots
===========
![remove question documentable](https://user-images.githubusercontent.com/31625251/31232351-f17b50f2-a9e9-11e7-9bd9-3303cb11d035.jpg)

Test
====
The test were modified to remove the documentable part from questions, because question model is no longer documentable.

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.