### PR TITLE
Polls index

### DIFF
--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -1,6 +1,6 @@
 <% poll_group.each do |poll| %>
   <div class="poll with-image">
-    <% if !poll.votable_by?(current_user) %>
+    <% if user_signed_in? && !poll.votable_by?(current_user) %>
       <div class="icon-poll-answer already-answer" title="<%= t("polls.index.already_answer") %>">
         <span class="show-for-sr"><%= t("polls.index.already_answer") %></span>
       </div>

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -1,36 +1,8 @@
 <% poll_group.each do |poll| %>
   <div class="poll with-image">
-    <% if poll.answerable_by?(current_user) && poll.votable_by?(current_user) %>
-      <%= link_to poll,
-              class: "icon-poll-answer can-answer",
-              title: t("polls.index.can_answer") do %>
-          <span class="show-for-sr">
-            <%= t("polls.index.can_answer") %>
-          </span>
-      <% end %>
-    <% elsif current_user.nil? %>
-      <%= link_to new_user_session_path,
-              class: "icon-poll-answer not-logged-in",
-              title: t("polls.index.cant_answer_not_logged_in") do %>
-          <span class="show-for-sr">
-            <%= t("polls.index.cant_answer_not_logged_in") %>
-          </span>
-      <% end %>
-    <% elsif current_user.unverified? %>
-      <%= link_to verification_path,
-                  class: "icon-poll-answer unverified",
-                  title: t("polls.index.cant_answer_verify") do %>
-          <span class="show-for-sr">
-            <%= t("polls.index.cant_answer_verify") %>
-          </span>
-      <% end %>
-    <% elsif !poll.votable_by?(current_user) %>
+    <% if !poll.votable_by?(current_user) %>
       <div class="icon-poll-answer already-answer" title="<%= t("polls.index.already_answer") %>">
         <span class="show-for-sr"><%= t("polls.index.already_answer") %></span>
-      </div>
-    <% else %>
-      <div class="icon-poll-answer cant-answer" title="<%= t("polls.index.cant_answer") %>">
-        <span class="show-for-sr"><%= t("polls.index.cant_answer") %></span>
       </div>
     <% end %>
     <div class="row" data-equalizer>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -466,10 +466,6 @@ en:
       no_geozone_restricted: "All city"
       geozone_restricted: "Districts"
       geozone_info: "Can participate people in the Census of: "
-      can_answer: "You can participate in this poll!"
-      cant_answer: "This poll is not available on your geozone"
-      cant_answer_not_logged_in: "You must sign in or sign up to participate"
-      cant_answer_verify: "You must verify your account in order to answer"
       already_answer: "You already have participated in this poll"
       section_header:
         icon_alt: Voting icon

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -466,10 +466,6 @@ es:
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
       geozone_info: "Pueden participar las personas empadronadas en: "
-      can_answer: "¡Puedes participar en esta votación!"
-      cant_answer: "Esta votación no está disponible en tu zona"
-      cant_answer_not_logged_in: "Necesitas iniciar sesión o registrarte para participar"
-      cant_answer_verify: "Por favor verifica tu cuenta para poder responder"
       already_answer: "Ya has participado en esta votación"
       section_header:
         icon_alt: Icono de Votaciones


### PR DESCRIPTION
What
====
Now on `poll/index` view appear some icons on top right side on each poll to indicate to users if they can answer the poll or not.

How
===
This icons are a little confused (the user only view the meaning if mouse over them), so I remove them all except `already-answer` that appears when a user answer to a poll and this icon it's easier to understand.

Screenshots
===========
**REMOVED**
![wrong_icons](https://user-images.githubusercontent.com/631897/31232688-e2f488cc-a9ea-11e7-830c-7685da64d37d.png)

**STILL HERE**
<img width="101" alt="nice_icon" src="https://user-images.githubusercontent.com/631897/31232702-e69e9300-a9ea-11e7-9ba0-13facf5c4b91.png">
