### PR TITLE
Add Poll::Admin answer videos

### DIFF
--- a/app/controllers/admin/poll/questions/answers/videos_controller.rb
+++ b/app/controllers/admin/poll/questions/answers/videos_controller.rb
@@ -1,0 +1,57 @@
+class Admin::Poll::Questions::Answers::VideosController < Admin::Poll::BaseController
+  before_action :load_answer, only: [:index, :new, :create]
+  before_action :load_video, only: [:edit, :update, :destroy]
+
+  def index
+  end
+
+  def new
+    @video = ::Poll::Question::Answer::Video.new
+  end
+
+  def create
+    @video = ::Poll::Question::Answer::Video.new(video_params)
+
+    if @video.save
+      redirect_to admin_answer_videos_path(@answer),
+               notice: t("flash.actions.create.poll_question_answer_video")
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @video.update(video_params)
+      redirect_to admin_answer_videos_path(@video.answer_id),
+               notice: t("flash.actions.save_changes.notice")
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @video.destroy
+      notice = t("flash.actions.destroy.poll_question_answer_video")
+    else
+      notice = t("flash.actions.destroy.error")
+    end
+    redirect_to :back, notice: notice
+  end
+
+  private
+
+    def video_params
+      params.require(:poll_question_answer_video).permit(:title, :url, :answer_id)
+    end
+
+    def load_answer
+      @answer = ::Poll::Question::Answer.find(params[:answer_id])
+    end
+
+    def load_video
+      @video = ::Poll::Question::Answer::Video.find(params[:id])
+    end
+end

--- a/app/controllers/admin/poll/questions/answers_controller.rb
+++ b/app/controllers/admin/poll/questions/answers_controller.rb
@@ -21,7 +21,7 @@ class Admin::Poll::Questions::AnswersController < Admin::Poll::BaseController
   private
 
     def answer_params
-      params.require(:poll_question_answer).permit(:title, :description, :poll_question_id)
+      params.require(:poll_question_answer).permit(:title, :description, :question_id)
     end
 
     def load_question

--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -1,5 +1,6 @@
 class Poll::Question::Answer < ActiveRecord::Base
   belongs_to :question, class_name: 'Poll::Question', foreign_key: 'question_id'
+  has_many :videos, class_name: 'Poll::Question::Answer::Video'
 
   validates :title, presence: true
 

--- a/app/models/poll/question/answer/video.rb
+++ b/app/models/poll/question/answer/video.rb
@@ -1,0 +1,16 @@
+class Poll::Question::Answer::Video < ActiveRecord::Base
+  belongs_to :answer, class_name: 'Poll::Question::Answer', foreign_key: 'answer_id'
+
+  VIMEO_REGEX = /vimeo.*(staffpicks\/|channels\/|videos\/|video\/|\/)([^#\&\?]*).*/
+  YOUTUBE_REGEX = /youtu.*(be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
+
+  validates :title, presence: true
+  validate :valid_url?
+
+  def valid_url?
+    return if url.blank?
+    return if url.match(VIMEO_REGEX)
+    return if url.match(YOUTUBE_REGEX)
+    errors.add(:url, :invalid)
+  end
+end

--- a/app/views/admin/poll/questions/answers/videos/_form.html.erb
+++ b/app/views/admin/poll/questions/answers/videos/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_for(@video, url: form_url) do |f| %>
+
+  <%= render 'shared/errors', resource: @video %>
+
+  <%= f.hidden_field :answer_id, value: @video.answer_id || @answer.id %>
+
+  <div class="row">
+    <div class="small-12 column">
+
+      <%= f.text_field :title %>
+      <%= f.text_field :url %>
+
+      <div class="row">
+        <div class="actions small-12 medium-4 column margin-top">
+          <%= f.submit(class: "button expanded", value: t("shared.save")) %>
+        </div>
+      </div>
+
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/poll/questions/answers/videos/edit.html.erb
+++ b/app/views/admin/poll/questions/answers/videos/edit.html.erb
@@ -1,0 +1,9 @@
+<%= back_link_to %>
+
+<h2>
+  <%= t("admin.answers.videos.edit.title") %>
+</h2>
+
+<div class="poll-question-answer-video-form">
+  <%= render "form", form_url: admin_video_path(@video) %>
+</div>

--- a/app/views/admin/poll/questions/answers/videos/index.html.erb
+++ b/app/views/admin/poll/questions/answers/videos/index.html.erb
@@ -1,0 +1,47 @@
+<%= back_link_to admin_question_path(@answer.question_id) %>
+
+<div class="clear"></div>
+
+<h2 class="inline-block">
+  <%= t("admin.answers.videos.index.title") %>
+</h2>
+
+<%= link_to t("admin.answers.videos.index.add_video"),
+            new_admin_answer_video_path,
+            class: "button success float-right" %>
+
+<div>
+
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("admin.answers.videos.index.video_title") %></th>
+        <th><%= t("admin.answers.videos.index.video_url") %></th>
+        <th class="text-right">
+          <%= t("admin.actions.actions") %>
+        </th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @answer.videos.each do |video| %>
+        <tr id="<%= dom_id(video) %>" class="poll_question_answer_video">
+          <td><%= video.title %></td>
+          <td><%= link_to "#{video.url}", video.url %></td>
+          <td class="text-right">
+
+            <%= link_to t("shared.edit"),
+                          edit_admin_video_path(video),
+                          class: "button hollow" %>
+
+            <%= link_to t("shared.delete"),
+                        admin_video_path(video),
+                        class: "button hollow alert",
+                        method: :delete %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+</div>

--- a/app/views/admin/poll/questions/answers/videos/new.html.erb
+++ b/app/views/admin/poll/questions/answers/videos/new.html.erb
@@ -1,0 +1,9 @@
+<%= back_link_to admin_answer_videos_path(@answer) %>
+
+<h2>
+  <%= t('admin.answers.videos.new.title') %>
+</h2>
+
+<div class="poll-question-answer-video-form">
+  <%= render "form", form_url: admin_answer_videos_path %>
+</div>

--- a/app/views/admin/poll/questions/show.html.erb
+++ b/app/views/admin/poll/questions/show.html.erb
@@ -24,29 +24,35 @@
       <%= link_to @question.author.name, user_path(@question.author) %>
     </p>
 
-    <table>
-      <tr>
-        <th colspan="1" scope="colgroup">
-          <%= t('admin.questions.show.valid_answers') %>
-        </th>
-        <th colspan="1" scope="colgroup">
-          <%= link_to t("admin.questions.show.add_answer"), 
-                      new_admin_question_answer_path(@question), 
-                      class: "button hollow float-right" %>
-        </th>
-      </tr>
+    <table cellspacing="0" cellpadding="0">
+      <thead>
+        <tr>
+          <th colspan="1" scope="col">
+            <%= t('admin.questions.show.valid_answers') %>
+          </th>
+          <th colspan="2" scope="col">
+            <%= link_to t("admin.questions.show.add_answer"),
+                        new_admin_question_answer_path(@question),
+                        class: "button hollow float-right" %>
+          </th>
+        </tr>
 
-      <tr>
-        <th scope="col"><%= t("admin.questions.show.answers.title") %></th>
-        <th scope="col"><%= t("admin.questions.show.answers.description") %></th>
-      </tr>
+        <tr>
+          <th scope="col"><%= t("admin.questions.show.answers.title") %></th>
+          <th scope="col"><%= t("admin.questions.show.answers.description") %></th>
+          <th scope="col"><%= t("admin.questions.show.answers.videos") %></th>
+        </tr>
+      </thead>
 
-      <% @question.question_answers.each do |answer| %>
-        <tr id="<%= dom_id(answer) %>" class="poll_question_answer">
-          <th scope="col"><%= answer.title %></th>
-          <th scope="col"><%= answer.description %></th>
-        </tr>  
-      <% end %>
+      <tbody>
+        <% @question.question_answers.each do |answer| %>
+          <tr id="<%= dom_id(answer) %>" class="poll_question_answer">
+            <td><%= answer.title %></td>
+            <td><%= answer.description %></td>
+            <td><%= link_to t("admin.questions.show.answers.video_list", count: 0), "#" %></td>
+          </tr>
+        <% end %>
+      </tbody>
     </table>
 
     <% if @question.video_url.present? %>

--- a/app/views/admin/poll/questions/show.html.erb
+++ b/app/views/admin/poll/questions/show.html.erb
@@ -24,13 +24,13 @@
       <%= link_to @question.author.name, user_path(@question.author) %>
     </p>
 
-    <table cellspacing="0" cellpadding="0">
+    <table>
       <thead>
         <tr>
-          <th colspan="1" scope="col">
+          <th>
             <%= t('admin.questions.show.valid_answers') %>
           </th>
-          <th colspan="2" scope="col">
+          <th colspan="2">
             <%= link_to t("admin.questions.show.add_answer"),
                         new_admin_question_answer_path(@question),
                         class: "button hollow float-right" %>
@@ -38,9 +38,9 @@
         </tr>
 
         <tr>
-          <th scope="col"><%= t("admin.questions.show.answers.title") %></th>
-          <th scope="col"><%= t("admin.questions.show.answers.description") %></th>
-          <th scope="col"><%= t("admin.questions.show.answers.videos") %></th>
+          <th><%= t("admin.questions.show.answers.title") %></th>
+          <th><%= t("admin.questions.show.answers.description") %></th>
+          <th><%= t("admin.questions.show.answers.videos") %></th>
         </tr>
       </thead>
 
@@ -49,7 +49,9 @@
           <tr id="<%= dom_id(answer) %>" class="poll_question_answer">
             <td><%= answer.title %></td>
             <td><%= answer.description %></td>
-            <td><%= link_to t("admin.questions.show.answers.video_list", count: 0), "#" %></td>
+            <td><%= link_to t("admin.questions.show.answers.video_list",
+                            count: answer.videos.count),
+                            admin_answer_videos_path(answer) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -213,7 +213,7 @@ en:
       image:
         title: Title
         attachment: Attachment
-      poll/question_answer:
+      poll/question/answer:
         title: "Answer"
         description: "Description"
     errors:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -216,6 +216,9 @@ en:
       poll/question/answer:
         title: "Answer"
         description: "Description"
+      poll/question/answer/video:
+        title: Title
+        url: External video
     errors:
       models:
         user:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -602,7 +602,17 @@ en:
           video_list: Video list (%{count})
     answers:
       new:
-        title: "New answer"
+        title: New answer
+      videos:
+        index:
+          title: Videos
+          add_video: Add video
+          video_title: Title
+          video_url: External video
+        new:
+          title: New video
+        edit:
+          title: Edit video
     recounts:
       index:
         title: "Recounts"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -592,12 +592,14 @@ en:
         author: Author
         title: Title
         valid_answers: Valid answers
-        add_answer: "Add answer"
+        add_answer: Add answer
         video_url: External video
         documents: Documents (1)
         answers:
           title: Answer
           description: Description
+          videos: Videos
+          video_list: Video list (%{count})
     answers:
       new:
         title: "New answer"

--- a/config/locales/en/responders.yml
+++ b/config/locales/en/responders.yml
@@ -9,6 +9,7 @@ en:
         poll: "Poll created successfully."
         poll_booth: "Booth created successfully."
         poll_question_answer: "Answer created successfully"
+        poll_question_answer_video: "Video created successfully"
         proposal: "Proposal created successfully."
         proposal_notification: "Your message has been sent correctly."
         spending_proposal: "Spending proposal created successfully. You can access it from %{activity}"
@@ -31,3 +32,4 @@ en:
         budget_investment: "Investment project deleted succesfully."
         error: "Could not delete"
         topic: "Topic deleted successfully."
+        poll_question_answer_video: "Answer video deleted successfully."

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -210,6 +210,9 @@ es:
       poll/question/answer:
         title: "Respuesta"
         description: "Descripción"
+      poll/question/answer/video:
+        title: Título
+        url: Vídeo externo
     errors:
       models:
         user:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -207,7 +207,7 @@ es:
       image:
         title: Título
         attachment: Archivo adjunto
-      poll/question_answer:
+      poll/question/answer:
         title: "Respuesta"
         description: "Descripción"
     errors:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -606,6 +606,16 @@ es:
         title: "Nueva respuesta"
         video_url: Video externo
         documents: Documentos (1)
+      videos:
+        index:
+          title: Vídeos
+          add_video: Añadir vídeo
+          video_title: Título
+          video_url: External video
+        new:
+          title: Nuevo video
+        edit:
+          title: Editar vídeo
     recounts:
       index:
         title: "Recuentos"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -592,14 +592,15 @@ es:
         author: Autor
         title: Título
         valid_answers: Respuestas válidas
-        add_answer: "Añadir respuesta"
-        description: Descripción
+        add_answer: Añadir respuesta
         video_url: Video externo
         documents: Documentos (1)
         preview: Ver en la web
         answers:
           title: Respuesta
           description: Descripción
+          videos: Vídeos
+          video_list: Lista de vídeos (%{count})
     answers:
       new:
         title: "Nueva respuesta"

--- a/config/locales/es/responders.yml
+++ b/config/locales/es/responders.yml
@@ -9,6 +9,7 @@ es:
         poll: "Votación creada correctamente."
         poll_booth: "Urna creada correctamente."
         poll_question_answer: "Respuesta creada correctamente"
+        poll_question_answer_video: "Vídeo creado correctamente"
         proposal: "Propuesta creada correctamente."
         proposal_notification: "Tu message ha sido enviado correctamente."
         spending_proposal: "Propuesta de inversión creada correctamente. Puedes acceder a ella desde %{activity}"
@@ -31,3 +32,4 @@ es:
         budget_investment: "Propuesta de inversión eliminada."
         error: "No se pudo borrar"
         topic: "Tema eliminado."
+        poll_question_answer_video: "Vídeo de respuesta eliminado."

--- a/config/locales/fr/activerecord.yml
+++ b/config/locales/fr/activerecord.yml
@@ -150,6 +150,9 @@ fr:
       poll/question/answer:
         title: "Réponse"
         description: "Description"
+      poll/question/answer/video:
+        title: Titre
+        url: Vidéo externe
     errors:
       models:
         user:

--- a/config/locales/fr/activerecord.yml
+++ b/config/locales/fr/activerecord.yml
@@ -147,7 +147,7 @@ fr:
         name: Nom
         locale: Langue
         body: Contenu
-      poll/question_answer:
+      poll/question/answer:
         title: "Réponse"
         description: "Description"
     errors:

--- a/config/locales/fr/admin.yml
+++ b/config/locales/fr/admin.yml
@@ -393,6 +393,16 @@ fr:
     answers:
       new:
         title: "Nouvelle réponse"
+      videos:
+        index:
+          title: Vidéos
+          add_video: Ajouter une vidéo
+          video_title: Titre
+          video_url: Vidéo externe
+        new:
+          title: Nouveau vidéo
+        edit:
+          title: Modifier la vidéo
     recounts:
       index:
         title: "Dépouillements"

--- a/config/locales/fr/admin.yml
+++ b/config/locales/fr/admin.yml
@@ -382,10 +382,14 @@ fr:
         author: Auteur
         title: Titre
         valid_answers: Réponses valides
-        add_answer: "Ajouter une réponse"
-        answer: "Réponse"
-        description: Description
+        add_answer: Ajouter une réponse
+        documents: Documents (1)
         preview: Voir l'aperçu
+        answers:
+          title: Réponse
+          description: Description
+          videos: Vidéos
+          video_list: Liste des vidéos (%{count})
     answers:
       new:
         title: "Nouvelle réponse"

--- a/config/locales/fr/responders.yml
+++ b/config/locales/fr/responders.yml
@@ -8,6 +8,8 @@ fr:
         direct_message: "Votre message a été envoyé avec succès."
         poll: "Vote créé avec succès."
         poll_booth: "Urne créée avec succès."
+        poll_question_answer: "Réponse créée avec succès"
+        poll_question_answer_video: "Vidéo créée avec succès"
         proposal: "Proposition créée avec succès."
         proposal_notification: "Votre message a correctement été envoyé."
         spending_proposal: "Proposition de dépense créée avec succès. Vous pouvez y accéder depuis %{activity}"
@@ -27,3 +29,4 @@ fr:
         spending_proposal: "Proposition de dépense supprimée avec succès."
         budget_investment: "Budget d'investissement supprimé avec succès."
         error: "Suppression impossible"
+        poll_question_answer_video: "Réponse vidéo supprimée avec succès."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -300,8 +300,10 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :questions do
-        resources :answers, only: [:new, :create], controller: 'questions/answers'
+      resources :questions, shallow: true do
+        resources :answers, only: [:new, :create], controller: 'questions/answers' do
+          resources :videos, controller: 'questions/answers/videos'
+        end
       end
     end
 

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -559,7 +559,6 @@ print "Creating Poll Questions"
   open_at = rand(2.months.ago..2.months.from_now)
   question = Poll::Question.create!(author: author,
                                     title: Faker::Lorem.sentence(3).truncate(60),
-                                    description: description,
                                     valid_answers: Faker::Lorem.words((2..7).to_a.sample).join(', '),
                                     poll: poll)
 end

--- a/db/migrate/20171004210108_create_poll_question_answer_videos.rb
+++ b/db/migrate/20171004210108_create_poll_question_answer_videos.rb
@@ -1,0 +1,11 @@
+class CreatePollQuestionAnswerVideos < ActiveRecord::Migration
+  def change
+    create_table :poll_question_answer_videos do |t|
+      t.string :title
+      t.string :url
+      t.integer :answer_id, index: true
+    end
+
+    add_foreign_key :poll_question_answer_videos, :poll_question_answers, column: :answer_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171004151553) do
+ActiveRecord::Schema.define(version: 20171004210108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -668,6 +668,14 @@ ActiveRecord::Schema.define(version: 20171004151553) do
   add_index "poll_partial_results", ["origin"], name: "index_poll_partial_results_on_origin", using: :btree
   add_index "poll_partial_results", ["question_id"], name: "index_poll_partial_results_on_question_id", using: :btree
 
+  create_table "poll_question_answer_videos", force: :cascade do |t|
+    t.string  "title"
+    t.string  "url"
+    t.integer "answer_id"
+  end
+
+  add_index "poll_question_answer_videos", ["answer_id"], name: "index_poll_question_answer_videos_on_answer_id", using: :btree
+
   create_table "poll_question_answers", force: :cascade do |t|
     t.string  "title"
     t.text    "description"
@@ -1152,6 +1160,7 @@ ActiveRecord::Schema.define(version: 20171004151553) do
   add_foreign_key "poll_partial_results", "poll_officer_assignments", column: "officer_assignment_id"
   add_foreign_key "poll_partial_results", "poll_questions", column: "question_id"
   add_foreign_key "poll_partial_results", "users", column: "author_id"
+  add_foreign_key "poll_question_answer_videos", "poll_question_answers", column: "answer_id"
   add_foreign_key "poll_question_answers", "poll_questions", column: "question_id"
   add_foreign_key "poll_questions", "polls"
   add_foreign_key "poll_questions", "proposals"

--- a/spec/features/admin/poll/questions/answers/videos/videos_spec.rb
+++ b/spec/features/admin/poll/questions/answers/videos/videos_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+feature 'Videos' do
+
+  background do
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
+
+  scenario "Create" do
+    question = create(:poll_question)
+    answer = create(:poll_question_answer, question: question)
+    video_title = "'Magical' by Junko Ohashi"
+    video_url = "https://www.youtube.com/watch?v=-JMf43st-1A"
+
+    visit admin_question_path(question)
+
+    within("#poll_question_answer_#{answer.id}") do
+      click_link "Video list (#{answer.videos.count})"
+    end
+
+    click_link "Add video"
+
+    fill_in 'poll_question_answer_video_title', with: video_title
+    fill_in 'poll_question_answer_video_url', with: video_url
+
+    click_button "Save"
+
+    expect(page).to have_content(video_title)
+    expect(page).to have_content(video_url)
+  end
+
+end


### PR DESCRIPTION
Where
=====
* **Related Issues:** #1855, #1950, #1951, #1952
* **Related PRs:** #1977, #1988 

What
====
* Adapt the Admin::Poll questions UI to the new design discussed in #1855

How
===
* Did the necessary database migrations
* Adapted the views/forms according to the new design
* Created the necessary controllers/models
* Appended the necessary routes
* Added translated labels in English, Spanish and French

Screenshots
===========
* See mockups on #1951 

Test
====
- Added test for the new feature

Notes
========
* The model created on this PR takes the custom validation for `video_url` implemented in #1854, which it's not DRY at all. @iagirre created a concern to solve #1865 and the PR is pending. As soon as that PR is done and merged, I'll handle the refactor to maximize DRYness.

* Some errors were made on #1977, but were fixed on this PR. See commits' description for further information.

* Since #1988 is done and waiting for approval/merge, we should be careful when merging since both PRs handle the `routes.rb` file and English/Spanish locales, as well as the Questions 'show' view. This is important since we want to keep the markup clean and tidy