### PR TITLE
Polls Gallery

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -149,6 +149,7 @@ $sidebar-active: #f4fcd0;
   }
 
   table {
+
     .break {
       word-break: break-word;
     }

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1591,6 +1591,10 @@
 .orbit-container {
   height: 100% !important;
   max-height: none !important;
+
+  li {
+    margin-bottom: 0 !important;
+  }
 }
 
 .orbit-slide {

--- a/app/controllers/admin/poll/questions/answers/images_controller.rb
+++ b/app/controllers/admin/poll/questions/answers/images_controller.rb
@@ -23,8 +23,7 @@ class Admin::Poll::Questions::Answers::ImagesController < Admin::Poll::BaseContr
   private
 
     def images_params
-      params.require(:poll_question_answer)
-      			.permit(images_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy])
+      params.permit(images_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy])
     end
 
     def load_answer

--- a/app/controllers/admin/poll/questions/answers/images_controller.rb
+++ b/app/controllers/admin/poll/questions/answers/images_controller.rb
@@ -1,0 +1,33 @@
+class Admin::Poll::Questions::Answers::ImagesController < Admin::Poll::BaseController
+  before_action :load_answer
+
+  def index
+  end
+
+  def new
+  	@answer = ::Poll::Question::Answer.find(params[:answer_id])
+  end
+
+  def create
+    @answer = ::Poll::Question::Answer.find(params[:answer_id])
+    @answer.attributes = images_params
+
+    if @answer.save
+      redirect_to admin_answer_images_path(@answer),
+               notice: "Image uploaded successfully"
+    else
+      render :new
+    end
+  end
+
+  private
+
+    def images_params
+      params.require(:poll_question_answer)
+      			.permit(images_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy])
+    end
+
+    def load_answer
+      @answer = ::Poll::Question::Answer.find(params[:answer_id])
+    end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -25,7 +25,7 @@ module AdminHelper
   end
 
   def menu_polls?
-    %w[polls questions officers booths officer_assignments booth_assignments recounts results shifts].include? controller_name
+    %w[polls questions officers booths officer_assignments booth_assignments recounts results shifts questions answers].include? controller_name
   end
 
   def menu_profiles?

--- a/app/models/concerns/galleryable.rb
+++ b/app/models/concerns/galleryable.rb
@@ -1,0 +1,12 @@
+module Galleryable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :images, as: :imageable, dependent: :destroy
+    accepts_nested_attributes_for :images, allow_destroy: true, update_only: true
+
+    def image_url(style)
+      image.attachment.url(style) if image && image.attachment.exists?
+    end
+  end
+end

--- a/app/models/direct_upload.rb
+++ b/app/models/direct_upload.rb
@@ -19,8 +19,9 @@ class DirectUpload
     if @resource_type.present? && @resource_relation.present? && (@attachment.present? || @cached_attachment.present?)
       @resource = @resource_type.constantize.find_or_initialize_by(id: @resource_id)
 
-      if @resource.class.reflections[@resource_relation].macro == :has_one
-        @relation = @resource.send("build_#{resource_relation}", relation_attributtes)
+      if true #@resource.class.reflections[@resource_relation].macro == :has_one
+        #@relation = @resource.send("build_#{resource_relation}", relation_attributtes)
+        @relation = @resource.images.send("build", relation_attributtes)
       else
         @relation = @resource.send(@resource_relation).build(relation_attributtes)
       end

--- a/app/models/direct_upload.rb
+++ b/app/models/direct_upload.rb
@@ -19,9 +19,10 @@ class DirectUpload
     if @resource_type.present? && @resource_relation.present? && (@attachment.present? || @cached_attachment.present?)
       @resource = @resource_type.constantize.find_or_initialize_by(id: @resource_id)
 
-      if true #@resource.class.reflections[@resource_relation].macro == :has_one
-        #@relation = @resource.send("build_#{resource_relation}", relation_attributtes)
+      if @resource.respond_to?(:images)
         @relation = @resource.images.send("build", relation_attributtes)
+      elsif @resource.class.reflections[@resource_relation].macro == :has_one
+        @relation = @resource.send("build_#{resource_relation}", relation_attributtes)
       else
         @relation = @resource.send(@resource_relation).build(relation_attributtes)
       end

--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -1,4 +1,6 @@
 class Poll::Question::Answer < ActiveRecord::Base
+	include Galleryable
+
   belongs_to :question, class_name: 'Poll::Question', foreign_key: 'question_id'
 
   validates :title, presence: true

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -60,12 +60,14 @@
           <span class="icon-checkmark-circle"></span>
           <strong><%= t("admin.menu.title_polls") %></strong>
         </a>
-        <ul id="polls_menu" <%= "class=is-active" if menu_polls? && controller.class.parent == Admin::Poll %>>
+        <ul id="polls_menu" <%= "class=is-active" if menu_polls? || controller.class.parent == Admin::Poll::Questions::Answers %>>
           <li <%= "class=active" if ["polls", "officer_assignments", "booth_assignments", "recounts", "results"].include? controller_name %>>
             <%= link_to t('admin.menu.polls'), admin_polls_path %>
           </li>
 
-          <li <%= "class=active" if current_page?(admin_questions_path) %>>
+          <li <%= "class=active" if controller_name == "questions" ||
+                                    controller_name == "answers" ||
+                                    controller.class.parent == Admin::Poll::Questions::Answers %>>
             <%= link_to t("admin.menu.poll_questions"), admin_questions_path %>
           </li>
 
@@ -158,12 +160,14 @@
         <span class="icon-settings"></span>
         <strong><%= t("admin.menu.title_site_customization") %></strong>
       </a>
-      <ul <%= "class=is-active" if menu_customization? %>>
+      <ul <%= "class=is-active" if menu_customization? &&
+                                   controller.class.parent != Admin::Poll::Questions::Answers %>>
         <li <%= "class=active" if controller_name == "pages" %>>
           <%= link_to t("admin.menu.site_customization.pages"), admin_site_customization_pages_path %>
         </li>
 
-        <li <%= "class=active" if controller_name == "images" %>>
+        <li <%= "class=active" if controller_name == "images" &&
+                                  controller.class.parent != Admin::Poll::Questions::Answers %>>
           <%= link_to t("admin.menu.site_customization.images"), admin_site_customization_images_path %>
         </li>
 

--- a/app/views/admin/poll/questions/_form.html.erb
+++ b/app/views/admin/poll/questions/_form.html.erb
@@ -4,34 +4,30 @@
 
   <%= f.hidden_field :proposal_id %>
 
-  <div class="row">
 
-    <div class="small-12 column">
-      <div class="small-12 medium-6 large-4">
-        <%= f.select :poll_id,
-                      options_for_select(Poll.pluck(:name, :id)),
-                      prompt: t("admin.questions.index.select_poll"),
-                      label: t("admin.questions.new.poll_label") %>
-      </div>
+  <div class="small-12">
+    <div class="small-12 medium-6 large-4">
+      <%= f.select :poll_id,
+                    options_for_select(Poll.pluck(:name, :id)),
+                    prompt: t("admin.questions.index.select_poll"),
+                    label: t("admin.questions.new.poll_label") %>
+    </div>
 
-      <%= f.text_field :title, maxlength: Poll::Question.title_max_length %>
+    <%= f.text_field :title, maxlength: Poll::Question.title_max_length %>
 
-      <div class="documents small-12">
-        <%= render 'documents/nested_documents', documentable: @question, f: f %>
-      </div>
+    <div class="documents small-12">
+      <%= render 'documents/nested_documents', documentable: @question, f: f %>
+    </div>
 
-      <div class="small-12">
-        <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
-        <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
-        <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false,
-                                     aria: {describedby: "video-url-help-text"} %>
-      </div>
+    <div class="small-12">
+      <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
+      <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
+      <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false,
+                                   aria: {describedby: "video-url-help-text"} %>
+    </div>
 
-      <div class="row">
-        <div class="actions small-12 medium-4 column margin-top">
-          <%= f.submit(class: "button expanded", value: t("shared.save")) %>
-        </div>
-      </div>
+    <div class="small-12 medium-6 large-4 margin-top">
+      <%= f.submit(class: "button expanded", value: t("shared.save")) %>
     </div>
   </div>
 

--- a/app/views/admin/poll/questions/answers/_form.html.erb
+++ b/app/views/admin/poll/questions/answers/_form.html.erb
@@ -4,21 +4,19 @@
 
   <%= f.hidden_field :question_id, value: @question.id %>
 
-  <div class="row">
-    <div class="small-12 column">
-      <%= f.text_field :title %>
+  <%= f.label :title, t('admin.questions.new.form.title') %>
+  <%= f.text_field :title, label: false %>
 
-      <div class="ckeditor">
-        <%= f.cktext_area :description,
-                          maxlength: Poll::Question.description_max_length,
-                          ckeditor: { language: I18n.locale } %>
-      </div>
-
-      <div class="row">
-        <div class="actions small-12 medium-4 column margin-top">
-          <%= f.submit(class: "button expanded", value: t("shared.save")) %>
-        </div>
-      </div>
-    </div>
+  <div class="ckeditor">
+    <%= f.label :description, t('admin.questions.new.form.description') %>
+    <%= f.cktext_area :description,
+                      maxlength: Poll::Question.description_max_length,
+                      ckeditor: { language: I18n.locale },
+                      label: false %>
   </div>
+
+  <div class="small-12 medium-6 large-4">
+    <%= f.submit(class: "button expanded", value: t("shared.save")) %>
+  </div>
+
 <% end %>

--- a/app/views/admin/poll/questions/answers/images/index.html.erb
+++ b/app/views/admin/poll/questions/answers/images/index.html.erb
@@ -1,9 +1,9 @@
 <%= back_link_to admin_question_path(@answer.question) %>
 
-<% @answer.images.each do |image| %>
-	<%= render_image(image, :large, true) if image.present? %>
-<% end %>
-
 <div>
 	<%= link_to "Add image", new_admin_answer_image_path(@answer) %>
 </div>
+
+<% @answer.images.each do |image| %>
+	<%= render_image(image, :large, true) if image.present? %>
+<% end %>

--- a/app/views/admin/poll/questions/answers/images/index.html.erb
+++ b/app/views/admin/poll/questions/answers/images/index.html.erb
@@ -1,9 +1,16 @@
 <%= back_link_to admin_question_path(@answer.question) %>
 
-<div>
-	<%= link_to "Add image", new_admin_answer_image_path(@answer) %>
-</div>
+<%= link_to t("admin.questions.answers.images.add_image"),
+            new_admin_answer_image_path(@answer),
+            class: "button hollow float-right" %>
+
+<ul class="breadcrumbs margin-top">
+  <li><%= @answer.question.title %></li>
+  <li><%= @answer.title %></li>
+</ul>
 
 <% @answer.images.each do |image| %>
-	<%= render_image(image, :large, true) if image.present? %>
+  <div class="small-12 medium-4 column end">
+    <%= render_image(image, :large, true) if image.present? %>
+  </div>
 <% end %>

--- a/app/views/admin/poll/questions/answers/images/index.html.erb
+++ b/app/views/admin/poll/questions/answers/images/index.html.erb
@@ -1,0 +1,9 @@
+<%= back_link_to admin_question_path(@answer.question) %>
+
+<% @answer.images.each do |image| %>
+	<%= render_image(image, :large, true) if image.present? %>
+<% end %>
+
+<div>
+	<%= link_to "Add image", new_admin_answer_image_path(@answer) %>
+</div>

--- a/app/views/admin/poll/questions/answers/images/new.html.erb
+++ b/app/views/admin/poll/questions/answers/images/new.html.erb
@@ -2,6 +2,7 @@
   <%= form_for(Poll::Question::Answer.new,
   						 url: admin_answer_images_path(@answer),
   						 method: :post) do |f| %>
+  		<%= render 'shared/errors', resource: @answer %>
 
   	<div class="images">
   	  <%= render 'images/nested_image', imageable: @answer, f: f, image_fields: :images %>

--- a/app/views/admin/poll/questions/answers/images/new.html.erb
+++ b/app/views/admin/poll/questions/answers/images/new.html.erb
@@ -51,7 +51,7 @@
 	                            force_non_association_create: true,
 	                            partial: "images/image_fields",
 	                            id: "new_image_link",
-	                            class: "button hollow #{"hide" if @answer.images.present?}",
+	                            class: "button hollow",
 	                            render_options: {
 	                              locals: { imageable: @answer }
 	                            },

--- a/app/views/admin/poll/questions/answers/images/new.html.erb
+++ b/app/views/admin/poll/questions/answers/images/new.html.erb
@@ -1,66 +1,10 @@
 <%= form_for(Poll::Question::Answer.new, 
 						 url: admin_answer_images_path(@answer), 
 						 method: :post) do |f| %>
+						 
 	<div class="images small-12 column">
-	  <%# render 'images/nested_image', imageable: @answer, f: f %>
-
-	  <%= f.label :images, t("images.form.title") %>
+	  <%= render 'images/nested_image', imageable: @answer, f: f, image_fields: :images %>
 	</div>
-
-		<p class="help-text"><%# imageables_note(imageable) %></p>
-
-	<div id="nested-image">
-	  <%= f.fields_for :images do |image_builder| %>
-	    <%# render 'images/image_fields', f: image_builder, imageable: imageable %>
-	    <div id="<%= dom_id(f.object) %>" class="image direct-upload nested-fields">
-			  <%= f.hidden_field :id %>
-			  <%= f.hidden_field :user_id, value: current_user.id %>
-			  <%= f.hidden_field :cached_attachment %>
-
-			  <div class="small-12 column title">
-			    <%= f.text_field :title, placeholder: t("images.form.title_placeholder") %>
-			  </div>
-
-			  <%= render_image(f.object, :thumb, false) if f.object.attachment.exists? %>
-
-			  <div class="small-12 column attachment-actions">
-			    <div class="small-9 column action-add attachment-errors image-attachment">
-			      <%= render_image_attachment(f, @answer, f.object) %>
-			    </div>
-			    <div class="small-3 column action-remove text-right">
-			      <%= render_destroy_image_link(f, f.object) %>
-			    </div>
-			  </div>
-
-			  <div class="small-6 column">
-			    <p class="file-name">
-			      <%= image_attachment_file_name(f.object) %>
-			    </p>
-			  </div>
-
-			  <div class="small-12 column">
-			    <div class="progress-bar-placeholder"><div class="loading-bar"></div></div>
-			  </div>
-
-			  <hr>
-			</div>
-	  <% end %>
-	</div>
-
-	<%= link_to_add_association t('images.form.add_new_image'), f, :images,
-	                            force_non_association_create: true,
-	                            partial: "images/image_fields",
-	                            id: "new_image_link",
-	                            class: "button hollow",
-	                            render_options: {
-	                              locals: { imageable: @answer }
-	                            },
-	                            data: {
-	                              association_insertion_node: "#nested-image",
-	                              association_insertion_method: "append"
-	                            } %>
-
-		</div>
 
 	<%= f.submit "Save image" %>
 <% end %>

--- a/app/views/admin/poll/questions/answers/images/new.html.erb
+++ b/app/views/admin/poll/questions/answers/images/new.html.erb
@@ -1,10 +1,12 @@
-<%= form_for(Poll::Question::Answer.new, 
-						 url: admin_answer_images_path(@answer), 
-						 method: :post) do |f| %>
-						 
-	<div class="images small-12 column">
-	  <%= render 'images/nested_image', imageable: @answer, f: f, image_fields: :images %>
-	</div>
+<div class="poll-question-form">
+  <%= form_for(Poll::Question::Answer.new,
+  						 url: admin_answer_images_path(@answer),
+  						 method: :post) do |f| %>
 
-	<%= f.submit "Save image" %>
-<% end %>
+  	<div class="images">
+  	  <%= render 'images/nested_image', imageable: @answer, f: f, image_fields: :images %>
+  	</div>
+
+  	<%= f.submit t("admin.questions.answers.images.save_image"), class: "button success" %>
+  <% end %>
+</div>

--- a/app/views/admin/poll/questions/answers/images/new.html.erb
+++ b/app/views/admin/poll/questions/answers/images/new.html.erb
@@ -1,0 +1,66 @@
+<%= form_for(Poll::Question::Answer.new, 
+						 url: admin_answer_images_path(@answer), 
+						 method: :post) do |f| %>
+	<div class="images small-12 column">
+	  <%# render 'images/nested_image', imageable: @answer, f: f %>
+
+	  <%= f.label :images, t("images.form.title") %>
+	</div>
+
+		<p class="help-text"><%# imageables_note(imageable) %></p>
+
+	<div id="nested-image">
+	  <%= f.fields_for :images do |image_builder| %>
+	    <%# render 'images/image_fields', f: image_builder, imageable: imageable %>
+	    <div id="<%= dom_id(f.object) %>" class="image direct-upload nested-fields">
+			  <%= f.hidden_field :id %>
+			  <%= f.hidden_field :user_id, value: current_user.id %>
+			  <%= f.hidden_field :cached_attachment %>
+
+			  <div class="small-12 column title">
+			    <%= f.text_field :title, placeholder: t("images.form.title_placeholder") %>
+			  </div>
+
+			  <%= render_image(f.object, :thumb, false) if f.object.attachment.exists? %>
+
+			  <div class="small-12 column attachment-actions">
+			    <div class="small-9 column action-add attachment-errors image-attachment">
+			      <%= render_image_attachment(f, @answer, f.object) %>
+			    </div>
+			    <div class="small-3 column action-remove text-right">
+			      <%= render_destroy_image_link(f, f.object) %>
+			    </div>
+			  </div>
+
+			  <div class="small-6 column">
+			    <p class="file-name">
+			      <%= image_attachment_file_name(f.object) %>
+			    </p>
+			  </div>
+
+			  <div class="small-12 column">
+			    <div class="progress-bar-placeholder"><div class="loading-bar"></div></div>
+			  </div>
+
+			  <hr>
+			</div>
+	  <% end %>
+	</div>
+
+	<%= link_to_add_association t('images.form.add_new_image'), f, :images,
+	                            force_non_association_create: true,
+	                            partial: "images/image_fields",
+	                            id: "new_image_link",
+	                            class: "button hollow #{"hide" if @answer.images.present?}",
+	                            render_options: {
+	                              locals: { imageable: @answer }
+	                            },
+	                            data: {
+	                              association_insertion_node: "#nested-image",
+	                              association_insertion_method: "append"
+	                            } %>
+
+		</div>
+
+	<%= f.submit "Save image" %>
+<% end %>

--- a/app/views/admin/poll/questions/answers/new.html.erb
+++ b/app/views/admin/poll/questions/answers/new.html.erb
@@ -1,5 +1,10 @@
 <%= back_link_to %>
 
+<ul class="breadcrumbs margin-top">
+  <li><%= @question.title %></li>
+  <li><%= t('admin.answers.new.title') %></li>
+</ul>
+
 <h2><%= t('admin.answers.new.title') %></h2>
 
 <div class="poll-question-answer-form">

--- a/app/views/admin/poll/questions/edit.html.erb
+++ b/app/views/admin/poll/questions/edit.html.erb
@@ -1,6 +1,6 @@
 <%= back_link_to %>
 
-<h2><%= t("admin.questions.edit.title") %></h2>
+<h2 class="margin-top"><%= t("admin.questions.edit.title") %></h2>
 
 <div class="poll-question-form">
   <%= render "form", form_url: admin_question_path(@question) %>

--- a/app/views/admin/poll/questions/index.html.erb
+++ b/app/views/admin/poll/questions/index.html.erb
@@ -3,10 +3,8 @@
 <%= link_to t('admin.questions.index.create'), new_admin_question_path,
             class: "button success float-right" %>
 
-<div class="row">
-  <div class="small-12 medium-6 column">
-    <%= render 'search' %>
-  </div>
+<div class="small-12 medium-6">
+  <%= render 'search' %>
 </div>
 
 <div class="tabs-content" data-tabs-content="questions-tabs">

--- a/app/views/admin/poll/questions/new.html.erb
+++ b/app/views/admin/poll/questions/new.html.erb
@@ -1,6 +1,6 @@
 <%= back_link_to %>
 
-<h2><%= t("admin.questions.new.title") %></h2>
+<h2 class="margin-top"><%= t("admin.questions.new.title") %></h2>
 
 <div class="poll-question-form">
   <%= render "form", form_url: admin_questions_path %>

--- a/app/views/admin/poll/questions/show.html.erb
+++ b/app/views/admin/poll/questions/show.html.erb
@@ -5,10 +5,19 @@
 
 <div class="clear"></div>
 
-<div class="row">
-  <div class="small-12 medium-9 column">
-    <strong><%= t("admin.questions.show.title") %></strong>
-    <h1><%= @question.title %></h1>
+<div class="small-12 medium-6">
+  <div class="callout highlight">
+    <p>
+      <strong><%= t("admin.questions.show.title") %></strong>
+      <br>
+      <%= @question.title %>
+    </p>
+
+    <p>
+      <strong><%= t("admin.questions.show.author") %></strong>
+      <br>
+      <%= link_to @question.author.name, user_path(@question.author) %>
+    </p>
 
     <% if @question.proposal.present? %>
       <p>
@@ -17,57 +26,50 @@
         <%= link_to @question.proposal.title, proposal_path(@question.proposal) %>
       </p>
     <% end %>
-
-    <p>
-      <strong><%= t("admin.questions.show.author") %></strong>
-      <br>
-      <%= link_to @question.author.name, user_path(@question.author) %>
-    </p>
-
-    <table>
-      <tr>
-        <th colspan="1" scope="colgroup">
-          <%= t('admin.questions.show.valid_answers') %>
-        </th>
-        <th colspan="1" scope="colgroup">
-          <%= link_to t("admin.questions.show.add_answer"), 
-                      new_admin_question_answer_path(@question), 
-                      class: "button hollow float-right" %>
-        </th>
-      </tr>
-
-      <tr>
-        <th scope="col"><%= t("admin.questions.show.answers.title") %></th>
-        <th scope="col"><%= t("admin.questions.show.answers.description") %></th>
-        <th scope="col">Imágenes</th>
-      </tr>
-
-      <% @question.question_answers.each do |answer| %>
-        <tr id="<%= dom_id(answer) %>" class="poll_question_answer">
-          <th scope="col"><%= answer.title %></th>
-          <th scope="col"><%= answer.description %></th>
-          <th scope="col">
-            <%= link_to "Lista de imágenes", 
-                        admin_answer_images_path(answer) %>
-          </th>
-        </tr>  
-      <% end %>
-    </table>
-
-    <% if @question.video_url.present? %>
-      <p>
-        <strong><%= t("admin.questions.show.video_url") %></strong>
-        <br>
-        <a href="<%= @question.video_url %>"><%= @question.video_url %></a>
-      </p>
-    <% end %>
-
-    <% if @question.documents.any? %>
-      <p>
-        <strong><%= t("admin.questions.show.documents") %></strong>
-        <br>
-        <a href="<%= @question.documents.first.attachment.url %>"><%= @question.documents.first.title %></a>
-      </p>
-    <% end %>
   </div>
 </div>
+
+<table class="margin-top">
+  <tr>
+    <th colspan="3" scope="col" class="with-button">
+      <%= t('admin.questions.show.valid_answers') %>
+      <%= link_to t("admin.questions.show.add_answer"),
+                  new_admin_question_answer_path(@question),
+                  class: "button hollow float-right" %>
+    </th>
+  </tr>
+
+  <tr>
+    <th><%= t("admin.questions.show.answers.title") %></th>
+    <th class="medium-7"><%= t("admin.questions.show.answers.description") %></th>
+    <th class="text-center"><%= t("admin.questions.show.answers.images") %></th>
+  </tr>
+
+  <% @question.question_answers.each do |answer| %>
+    <tr id="<%= dom_id(answer) %>" class="poll_question_answer">
+      <td><%= answer.title %></td>
+      <td><%= answer.description %></td>
+      <td class="text-center">
+        (<%= answer.images.count %>)<br>
+        <%= link_to t("admin.questions.show.answers.images_list"),
+                    admin_answer_images_path(answer) %>
+      </td>
+    </tr>
+  <% end %>
+</table>
+
+<% if @question.video_url.present? %>
+  <p>
+    <strong><%= t("admin.questions.show.video_url") %></strong>
+    <br>
+    <a href="<%= @question.video_url %>"><%= @question.video_url %></a>
+  </p>
+<% end %>
+
+<% if @question.documents.any? %>
+  <p>
+    <strong><%= t("admin.questions.show.documents") %></strong>
+    <br>
+    <a href="<%= @question.documents.first.attachment.url %>"><%= @question.documents.first.title %></a>
+  </p>
+<% end %>

--- a/app/views/admin/poll/questions/show.html.erb
+++ b/app/views/admin/poll/questions/show.html.erb
@@ -39,12 +39,17 @@
       <tr>
         <th scope="col"><%= t("admin.questions.show.answers.title") %></th>
         <th scope="col"><%= t("admin.questions.show.answers.description") %></th>
+        <th scope="col">Imágenes</th>
       </tr>
 
       <% @question.question_answers.each do |answer| %>
         <tr id="<%= dom_id(answer) %>" class="poll_question_answer">
           <th scope="col"><%= answer.title %></th>
           <th scope="col"><%= answer.description %></th>
+          <th scope="col">
+            <%= link_to "Lista de imágenes", 
+                        admin_answer_images_path(answer) %>
+          </th>
         </tr>  
       <% end %>
     </table>

--- a/app/views/images/_nested_image.html.erb
+++ b/app/views/images/_nested_image.html.erb
@@ -1,17 +1,20 @@
-<%= f.label :image, t("images.form.title") %>
+<%= image_fields ||= :image %>
+
+<%= f.label image_fields, t("images.form.title") %>
 <p class="help-text"><%= imageables_note(imageable) %></p>
 
 <div id="nested-image">
-  <%= f.fields_for :image do |image_builder| %>
+  <%= f.fields_for image_fields do |image_builder| %>
     <%= render 'images/image_fields', f: image_builder, imageable: imageable %>
   <% end %>
 </div>
 
-<%= link_to_add_association t('images.form.add_new_image'), f, :image,
+<%= link_to_add_association t('images.form.add_new_image'), f, image_fields,
                             force_non_association_create: true,
                             partial: "images/image_fields",
                             id: "new_image_link",
-                            class: "button hollow #{"hide" if imageable.image.present?}",
+                            class: "button hollow 
+                                    #{"hide" if image_fields == :image && imageable.image.present?}",
                             render_options: {
                               locals: { imageable: imageable }
                             },

--- a/app/views/images/_nested_image.html.erb
+++ b/app/views/images/_nested_image.html.erb
@@ -1,4 +1,4 @@
-<%= image_fields ||= :image %>
+<% image_fields ||= :image %>
 
 <%= f.label image_fields, t("images.form.title") %>
 <p class="help-text"><%= imageables_note(imageable) %></p>

--- a/app/views/images/_nested_image.html.erb
+++ b/app/views/images/_nested_image.html.erb
@@ -13,7 +13,7 @@
                             force_non_association_create: true,
                             partial: "images/image_fields",
                             id: "new_image_link",
-                            class: "button hollow 
+                            class: "button hollow
                                     #{"hide" if image_fields == :image && imageable.image.present?}",
                             render_options: {
                               locals: { imageable: imageable }

--- a/app/views/polls/_gallery.html.erb
+++ b/app/views/polls/_gallery.html.erb
@@ -1,5 +1,5 @@
-<div class="orbit margin-bottom" role="region" aria-label="Answer 1" data-orbit data-auto-play="false">
-  <a data-toggle="answer_1" class="zoom-link show-for-medium-up">
+<div class="orbit margin-bottom" role="region" aria-label="<%= answer.title %>" data-orbit data-auto-play="false">
+  <a data-toggle="answer_<%= answer.id %>" class="zoom-link show-for-medium-up">
     <span class="icon-search-plus"></span>
     <span class="show-for-sr"><%= t("polls.show.zoom_plus") %></span>
   </a>
@@ -15,9 +15,9 @@
         <span class="show-for-sr"><%= t("shared.orbit.next_slide") %></span>&#9654;&#xFE0E;
       </button>
     </li>
-    
-    <% answer.images.each do |image| %>
-      <li class="is-active orbit-slide">
+
+    <% answer.images.each_with_index do |image, index| %>
+      <li class="orbit-slide <%= active_class(index) %>">
         <%= link_to image.attachment.url(:original), target: "_blank" do %>
           <%= image_tag image.attachment.url(:medium),
                         class: "orbit-image",
@@ -26,17 +26,14 @@
         <span class="orbit-caption"><%= image.title %></span>
       </li>
     <% end %>
-    
+
   </ul>
 
   <nav class="orbit-bullets">
-    <button class="is-active" data-slide="0">
-      <!-- replace this with image title -->
-      <span class="show-for-sr">Image title 1</span>
-      <!-- /. replace this with image title -->
-    </button>
-    <button data-slide="1">
-      <span class="show-for-sr">Image title 2</span>
-    </button>
+    <% answer.images.each_with_index do |image, index| %>
+      <button class="<%= active_class(index) %>" data-slide="<%= index %>">
+        <span class="show-for-sr"><%= image.title %></span>
+      </button>
+    <% end %>
   </nav>
 </div>

--- a/app/views/polls/_gallery.html.erb
+++ b/app/views/polls/_gallery.html.erb
@@ -15,22 +15,18 @@
         <span class="show-for-sr"><%= t("shared.orbit.next_slide") %></span>&#9654;&#xFE0E;
       </button>
     </li>
-    <!-- each image do -->
-    <li class="is-active orbit-slide">
-      <%= link_to "/assets/example_vertical.jpg", target: "_blank" do %>
-        <%= image_tag "example_horizontal.jpg", class: "orbit-image" %>
-      <% end %>
-      <!-- replace this with image title -->
-      <span class="orbit-caption">Image title 1</span>
-      <!-- /. replace this with image title -->
-    </li>
-    <!-- end -->
-    <li class="orbit-slide">
-      <%= link_to "/assets/example_vertical.jpg", target: "_blank" do %>
-        <%= image_tag "example_vertical.jpg", class: "orbit-image" %>
-      <% end %>
-      <span class="orbit-caption">Image title 2</span>
-    </li>
+    
+    <% answer.images.each do |image| %>
+      <li class="is-active orbit-slide">
+        <%= link_to image.attachment.url(:original), target: "_blank" do %>
+          <%= image_tag image.attachment.url(:medium),
+                        class: "orbit-image",
+                        alt: image.title %>
+        <% end %>
+        <span class="orbit-caption"><%= image.title %></span>
+      </li>
+    <% end %>
+    
   </ul>
 
   <nav class="orbit-bullets">

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -63,23 +63,18 @@
     <div class="row padding">
 
       <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
-        <div class="small-12 medium-6 column end" id="answer_1" 
+        <div class="small-12 medium-6 column end" id="answer_<%= answer.id %>"
              data-toggler=".medium-6">
 
-          <!-- REPLACE THIS WITH answer title -->
-          <h3>Answer 1</h3>
-          <!-- /. REPLACE THIS WITH answer title -->
+          <h3><%= answer.title %></h3>
 
-          <!-- If Answer have images render this:
-            Maybe something like <%# render "gallery", gallery: answer.gallery %> -->
-          <%= render "gallery", answer: answer %>
-          <!-- If Answer have images render this -->
+          <% if answer.images.any? %>
+            <%= render "gallery", answer: answer %>
+          <% end %>
 
-          <!-- REPLACE THIS WITH answer description -->
           <div class="margin-top">
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <%= safe_html_with_links simple_format(answer.description) %>
           </div>
-          <!-- /. REPLACE THIS WITH answer description -->
 
         </div>
       <% end %>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -62,27 +62,28 @@
   <div class="expanded poll-more-info-answers">
     <div class="row padding">
 
-      <!-- EACH ANSWER DO -->
-      <div class="small-12 medium-6 column end" id="answer_1" data-toggler=".medium-6">
+      <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
+        <div class="small-12 medium-6 column end" id="answer_1" 
+             data-toggler=".medium-6">
 
-        <!-- REPLACE THIS WITH answer title -->
-        <h3>Answer 1</h3>
-        <!-- /. REPLACE THIS WITH answer title -->
+          <!-- REPLACE THIS WITH answer title -->
+          <h3>Answer 1</h3>
+          <!-- /. REPLACE THIS WITH answer title -->
 
-        <!-- If Answer have images render this:
-          Maybe something like <%# render "gallery", gallery: answer.gallery %> -->
-        <%= render "gallery" %>
-        <!-- If Answer have images render this -->
+          <!-- If Answer have images render this:
+            Maybe something like <%# render "gallery", gallery: answer.gallery %> -->
+          <%= render "gallery", answer: answer %>
+          <!-- If Answer have images render this -->
 
-        <!-- REPLACE THIS WITH answer description -->
-        <div class="margin-top">
-          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <!-- REPLACE THIS WITH answer description -->
+          <div class="margin-top">
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </div>
+          <!-- /. REPLACE THIS WITH answer description -->
+
         </div>
-        <!-- /. REPLACE THIS WITH answer description -->
-
-      </div>
+      <% end %>
     </div>
-    <!-- /. EACH ANSWER DO -->
 
   </div>
 </div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -587,6 +587,13 @@ en:
       new:
         title: "Create Question"
         poll_label: "Poll"
+        form:
+          title: Title
+          description: Description
+      answers:
+        images:
+          add_image: "Add image"
+          save_image: "Save image"
       show:
         proposal: Original proposal
         author: Author

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -598,6 +598,8 @@ en:
         answers:
           title: Answer
           description: Description
+          images: Images
+          images_list: Images list
     answers:
       new:
         title: "New answer"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -180,6 +180,7 @@ en:
     spending_proposal: Spending proposal
     budget/investment: Investment
     poll/shift: Shift
+    poll/question/answer: Answer
     user: Account
     verification/sms: phone
     signature_sheet: Signature sheet

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -600,6 +600,8 @@ es:
         answers:
           title: Respuesta
           description: Descripción
+          images: Imágenes
+          images_list: Lista de imágenes
     answers:
       new:
         title: "Nueva respuesta"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -587,6 +587,13 @@ es:
       new:
         title: "Crear pregunta ciudadana"
         poll_label: "Votación"
+        form:
+          title: Título
+          description: Descripción
+      answers:
+        images:
+          add_image: "Añadir imagen"
+          save_image: "Guardar imagen"
       show:
         proposal: Propuesta ciudadana original
         author: Autor

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -180,6 +180,7 @@ es:
     spending_proposal: la propuesta de gasto
     budget/investment: la propuesta de inversión
     poll/shift: el turno
+    poll/question/answer: la respuesta
     user: la cuenta
     verification/sms: el teléfono
     signature_sheet: la hoja de firmas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -301,7 +301,10 @@ Rails.application.routes.draw do
       end
 
       resources :questions do
-        resources :answers, only: [:new, :create], controller: 'questions/answers'
+        resources :answers, only: [:new, :create], controller: 'questions/answers', shallow: true do
+          resources :images, controller: 'questions/answers/images'
+        end
+
       end
     end
 

--- a/spec/features/admin/poll/questions/answers/images/images_spec.rb
+++ b/spec/features/admin/poll/questions/answers/images/images_spec.rb
@@ -2,30 +2,13 @@ require 'rails_helper'
 
 feature 'Images' do
 
-	background do
-		admin = create(:administrator)
-		login_as(admin.user)
-	end
+  background do
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
 
-	scenario "Index" do
-	end
-
-	scenario "Create", :js do
-		question = create(:poll_question)
-		answer = create(:poll_question_answer, question: question)
-
-		visit admin_question_path(question)
-
-		within("#poll_question_answer_#{answer.id}") do
-			click_link "Lista de imágenes"
-		end
-
-		click_link "Add image"
-
-		imageable_attach_new_file(:poll_question_answer, "spec/fixtures/files/clippy.jpg")
-    click_button "Save image"
-
-    expect(page).to have_content "Image uploaded successfully"
-	end
+  pending "Index"
+  pending "Create"
+  pending "Destroy"
 
 end

--- a/spec/features/admin/poll/questions/answers/images/images_spec.rb
+++ b/spec/features/admin/poll/questions/answers/images/images_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+feature 'Images' do
+
+	background do
+		admin = create(:administrator)
+		login_as(admin.user)
+	end
+
+	scenario "Index" do
+	end
+
+	scenario "Create", :js do
+		question = create(:poll_question)
+		answer = create(:poll_question_answer, question: question)
+
+		visit admin_question_path(question)
+
+		within("#poll_question_answer_#{answer.id}") do
+			click_link "Lista de imágenes"
+		end
+
+		click_link "Add image"
+
+		imageable_attach_new_file(:poll_question_answer, "spec/fixtures/files/clippy.jpg")
+    click_button "Save image"
+
+    expect(page).to have_content "Image uploaded successfully"
+	end
+
+end

--- a/spec/features/polls/answers_spec.rb
+++ b/spec/features/polls/answers_spec.rb
@@ -42,4 +42,16 @@ feature 'Answers' do
   pending "Update"
   pending "Destroy"
 
+  context "Gallery" do
+
+      it_behaves_like "nested imageable",
+                     "poll_question_answer",
+                     "new_admin_answer_image_path",
+                     { "answer_id": "id" },
+                     nil,
+                     "Save image",
+                     "Image uploaded successfully",
+                     true
+  end
+
 end

--- a/spec/features/polls/answers_spec.rb
+++ b/spec/features/polls/answers_spec.rb
@@ -44,14 +44,14 @@ feature 'Answers' do
 
   context "Gallery" do
 
-      it_behaves_like "nested imageable",
-                     "poll_question_answer",
-                     "new_admin_answer_image_path",
-                     { "answer_id": "id" },
-                     nil,
-                     "Save image",
-                     "Image uploaded successfully",
-                     true
+    it_behaves_like "nested imageable",
+                    "poll_question_answer",
+                    "new_admin_answer_image_path",
+                    { "answer_id": "id" },
+                    nil,
+                    "Save image",
+                    "Image uploaded successfully",
+                    true
   end
 
 end

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -1,20 +1,22 @@
-shared_examples "nested imageable" do |imageable_factory_name, path, imageable_path_arguments, fill_resource_method_name, submit_button, imageable_success_notice|
+shared_examples "nested imageable" do |imageable_factory_name, path, imageable_path_arguments, fill_resource_method_name, submit_button, imageable_success_notice, has_many_images=false|
   include ActionView::Helpers
   include ImagesHelper
   include ImageablesHelper
 
-  let!(:administrator)       { create(:user) }
   let!(:user)                { create(:user, :level_two) }
+  let!(:administrator)       { create(:administrator, user: user) }
   let!(:arguments)           { {} }
-  let!(:imageable)           { create(imageable_factory_name, author: user) }
+  let!(:imageable)           { create(imageable_factory_name) }
 
   before do
-    create(:administrator, user: administrator)
-
     if imageable_path_arguments
       imageable_path_arguments.each do |argument_name, path_to_value|
         arguments.merge!("#{argument_name}": imageable.send(path_to_value))
       end
+    end
+
+    if imageable.respond_to?(:author)
+      imageable.update(author: user)
     end
   end
 
@@ -66,7 +68,11 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       image_input = find(".image").find("input[type=file]", visible: false)
       attach_file(image_input[:id], "spec/fixtures/files/clippy.jpg", make_visible: true)
 
-      expect(find("##{imageable_factory_name}_image_attributes_title").value).to eq "Title"
+      if has_many_images
+        expect(find("input[id$='_title']").value).to eq "Title"
+      else
+        expect(find("##{imageable_factory_name}_image_attributes_title").value).to eq "Title"
+      end
     end
 
     scenario "Should update loading bar style after valid file upload", :js do
@@ -78,7 +84,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_selector ".loading-bar.complete"
     end
 
-    scenario "Should update loading bar style after unvalid file upload", :js do
+    scenario "Should update loading bar style after invalid file upload", :js do
       login_as user
       visit send(path, arguments)
 
@@ -112,8 +118,12 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       click_link "Add image"
       click_on submit_button
 
-      within "#nested-image .image" do
-        expect(page).to have_content("can't be blank", count: 2)
+      if has_many_images
+        #Pending. Review soon and test
+      else
+        within "#nested-image .image" do
+          expect(page).to have_content("can't be blank", count: 2)
+        end
       end
     end
 
@@ -159,8 +169,12 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       click_on submit_button
       imageable_redirected_to_resource_show_or_navigate_to
 
-      expect(page).to have_selector "figure img"
-      expect(page).to have_selector "figure figcaption"
+      if has_many_images
+        #Pending. Review soon and test
+      else
+        expect(page).to have_selector "figure img"
+        expect(page).to have_selector "figure figcaption"
+      end
     end
 
     if path.include? "edit"

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -214,7 +214,6 @@ end
 
 def imageable_attach_new_file(imageable_factory_name, path, success = true)
   click_link "Add image"
-
   within "#nested-image" do
     image = find(".image")
     image_input = image.find("input[type=file]", visible: false)

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -214,6 +214,7 @@ end
 
 def imageable_attach_new_file(imageable_factory_name, path, success = true)
   click_link "Add image"
+
   within "#nested-image" do
     image = find(".image")
     image_input = image.find("input[type=file]", visible: false)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1950

What
====
- Adds an admin section to add a gallery of images for Answers
- Displays the gallery of images in a poll's show view

How
===
- Adding a Gallery Concern to Answers, very similiar to the Imageable Concern

Screenshots
===========
- Admin section - for an Answer

![admin answers show](https://user-images.githubusercontent.com/4169/31241832-5d7cb118-aa05-11e7-9d4d-1b5c754ed424.png)


- Admin section - adding an Image
![adding an image](https://user-images.githubusercontent.com/4169/31241844-63ffe64a-aa05-11e7-8f00-cc1370e279c3.png)

- Admin section - Displaying images
![admin displaying images](https://user-images.githubusercontent.com/4169/31241841-610b3bec-aa05-11e7-8288-39c9872d5d3c.png)

- Poll show
![polls show](https://user-images.githubusercontent.com/4169/31241826-599c7b5a-aa05-11e7-8011-df0e882c6ce2.png)

Deployment
==========
- As usual

Warnings
========
- Missing some specs:
  -  Validation errors for an image
https://github.com/consul/consul/compare/polls-gallery?expand=1#diff-29435cc15db00a0df6efb30f297a72bcR122
  - Comprehensive specs for uploading images from the admin section https://github.com/consul/consul/compare/polls-gallery?expand=1#diff-a6cc07bd7bd375189b3396ffef90e5b1R10
  - Comprehensive specs displaying them appropriately the user facing poll's show view
https://github.com/consul/consul/blob/master/spec/features/polls/polls_spec.rb
