### PR TITLE
Voting messages

### DIFF
--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -42,7 +42,7 @@ module PollsHelper
   end
 
   def voted_before_sign_in(question)
-    current_user.current_sign_in_at >= question.poll.voters.find_by_user_id(current_user).updated_at
+    current_user.current_sign_in_at >= question.answers.find_or_initialize_by(author: current_user).updated_at
   end
 
 end

--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -41,4 +41,8 @@ module PollsHelper
     booth.name + location
   end
 
+  def voted_before_sign_in(question)
+    current_user.current_sign_in_at >= question.poll.voters.find_by_user_id(current_user).updated_at
+  end
+
 end

--- a/app/views/polls/questions/_answers.html.erb
+++ b/app/views/polls/questions/_answers.html.erb
@@ -1,7 +1,7 @@
 <div class="poll-question-answers">
   <% if can? :answer, question %>
     <% question.question_answers.each do |answer| %>
-      <% if @answers_by_question_id[question.id] == answer.title %>
+      <% if @answers_by_question_id[question.id] == answer.title && !voted_before_sign_in(question) %>
         <span class="button answered"
               title="<%= t("poll_questions.show.voted", answer: answer.title)%>">
           <%= answer.title %>

--- a/app/views/polls/questions/_answers.html.erb
+++ b/app/views/polls/questions/_answers.html.erb
@@ -2,8 +2,8 @@
   <% if can? :answer, question %>
     <% question.question_answers.each do |answer| %>
       <% if @answers_by_question_id[question.id] == answer.title %>
-        <span class="button answered" 
-              title="<%= t("poll_questions.show.voted", answer: answer)%>">
+        <span class="button answered"
+              title="<%= t("poll_questions.show.voted", answer: answer.title)%>">
           <%= answer.title %>
         </span>
       <% else %>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -38,6 +38,11 @@
           <%= t("polls.show.already_voted_in_booth") %>
         </div>
       <% else %>
+        <% if current_user && !@poll.votable_by?(current_user) %>
+          <div class="callout warning">
+            <%= t("polls.show.already_voted_in_web") %>
+          </div>
+        <% end %>
         <% @questions.each do |question| %>
           <%= render 'polls/questions/question', question: question %>
         <% end %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -481,7 +481,8 @@ en:
         help_text_1: "Voting takes place when a citizen proposal supports reaches 1% of the census with voting rights. Voting can also include questions that the City Council ask to the citizens decision."
         help_text_2: "To participate in the next vote you have to sign up on %{org} and verify your account. All registered voters in the city over 16 years old can vote. The results of all votes are binding on the government."
     show:
-      already_voted_in_booth: "You have already participated in a booth for this poll."
+      already_voted_in_booth: "You have already participated in a physical booth. You can not participate again."
+      already_voted_in_web: "You have already participated in this poll. If you vote again it will be overwritten."
       back: Back to voting
       cant_answer_not_logged_in: "You must %{signin} or %{signup} to participate."
       signin: Sign in

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -481,7 +481,8 @@ es:
         help_text_1: "Las votaciones se convocan cuando una propuesta ciudadana alcanza el 1% de apoyos del censo con derecho a voto. En las votaciones también se pueden incluir cuestiones que el Ayuntamiento somete a decisión directa de la ciudadanía."
         help_text_2: "Para participar en la próxima votación tienes que registrarte en %{org} y verificar tu cuenta. Pueden votar todas las personas empadronadas en la ciudad mayores de 16 años. Los resultados de todas las votaciones serán vinculantes para el gobierno."
     show:
-      already_voted_in_booth: "Ya has participado en esta votación en una urna."
+      already_voted_in_booth: "Ya has participado en esta votación en urnas presenciales, no puedes volver a participar."
+      already_voted_in_web: "Ya has participado en esta votación. Si vuelves a votar se sobreescribirá tu resultado anterior."
       back: Volver a votaciones
       cant_answer_not_logged_in: "Necesitas %{signin} o %{signup} para participar."
       signin: iniciar sesión

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -209,8 +209,7 @@ feature 'Polls' do
       visit poll_path(poll)
 
       expect(page).to have_link('Han Solo')
-      expect(page).to_not have_link('Chewbacca')
-      expect(page).to have_content('Chewbacca')
+      expect(page).to have_link('Chewbacca')
     end
 
     scenario 'Level 2 users answering', :js do

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -91,8 +91,31 @@ feature "Voter" do
         visit poll_path(poll)
 
         expect(page).to_not have_link('Yes')
-        expect(page).to have_content "You have already participated in a booth for this poll."
+        expect(page).to have_content "You have already participated in a physical booth. You can not participate again."
         expect(Poll::Voter.count).to eq(1)
+      end
+
+      scenario "Trying to vote in web again", :js do
+        login_as user
+        vote_for_poll_via_web(poll, question)
+
+        visit poll_path(poll)
+
+        expect(page).to have_content "You have already participated in this poll. If you vote again it will be overwritten."
+        within("#poll_question_#{question.id}_answers") do
+          expect(page).to_not have_link('Yes')
+        end
+
+        click_link "Sign out"
+
+        login_as user
+        visit poll_path(poll)
+
+        within("#poll_question_#{question.id}_answers") do
+          expect(page).to have_link('Yes')
+          expect(page).to have_link('No')
+        end
+
       end
     end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1984

What
====
- In a poll, show messages to users that already voted in the web or in a physical booth.
- If a user has voted in the web, once it has closed the session if it starts a new one, the marks in the answers won't appear. 

How
===
The most delicate part of these changes is deciding when to show the user its votes -or not- based on the session.

The view helper `voted_before_sign_in` is used in the view responsible for rendering the question answers and compares the date of the last sign in (this is, when the current session started) with the date of the last modification of the votes. If the first date is higher than the last one, that means the user voted before signing in in a previous session, so its votes are hidden. In the opposite case is assumed that the user is still in the same session in which voted so the check marks remain.

Test
====
As usual.

Deployment
==========
As usual.