### PR TITLE
Polls show 

### DIFF
--- a/app/views/polls/_gallery.html.erb
+++ b/app/views/polls/_gallery.html.erb
@@ -16,7 +16,7 @@
       </button>
     </li>
 
-    <% answer.images.each_with_index do |image, index| %>
+    <% answer.images.reverse.each_with_index do |image, index| %>
       <li class="orbit-slide <%= active_class(index) %>">
         <%= link_to image.attachment.url(:original), target: "_blank" do %>
           <%= image_tag image.attachment.url(:medium),

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -60,25 +60,28 @@
   </div>
 
   <div class="expanded poll-more-info-answers">
-    <div class="row padding">
+    <div class="row padding" data-equalizer>
 
       <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
         <div class="small-12 medium-6 column end" id="answer_<%= answer.id %>"
-             data-toggler=".medium-6">
+             data-toggler=".medium-6" data-equalizer-watch>
 
-          <h3><%= answer.title %></h3>
+          <% if answer.description.present? %>
+            <h3><%= answer.title %></h3>
+          <% end %>
 
           <% if answer.images.any? %>
             <%= render "gallery", answer: answer %>
           <% end %>
 
-          <div class="margin-top">
-            <%= safe_html_with_links simple_format(answer.description) %>
-          </div>
+          <% if answer.description.present? %>
+            <div class="margin-top">
+              <%= safe_html_with_links simple_format(answer.description) %>
+            </div>
+          <% end %>
 
         </div>
       <% end %>
     </div>
-
   </div>
 </div>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -52,10 +52,12 @@
         <%= safe_html_with_links simple_format(@poll.description) %>
       </div>
 
-      <aside class="small-12 medium-3 column">
+      <% if false %>
+        <aside class="small-12 medium-3 column">
           <div class="sidebar-divider"></div>
           <h2><%= t("polls.show.documents") %></h2>
-      </aside>
+        </aside>
+      <% end %>
     </div>
   </div>
 


### PR DESCRIPTION
What
====
- Shows answer title on polls show only if answer description is present.
- Includes `data-equalizer` to get same height on answers descriptions containers.
- Reverse gallery images order.
- Hides _temporally_ documents sidebar on poll/show (this feature is not available yet).