### PR TITLE
Allow re-casting an answer after singout

### DIFF
--- a/app/controllers/polls/questions_controller.rb
+++ b/app/controllers/polls/questions_controller.rb
@@ -9,6 +9,7 @@ class Polls::QuestionsController < ApplicationController
     answer = @question.answers.find_or_initialize_by(author: current_user)
 
     answer.answer = params[:answer]
+    answer.touch if answer.persisted?
     answer.save!
     answer.record_voter_participation
 

--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -42,7 +42,7 @@ module PollsHelper
   end
 
   def voted_before_sign_in(question)
-    current_user.current_sign_in_at >= question.answers.find_or_initialize_by(author: current_user).updated_at
+    question.answers.where(author: current_user).any? { |vote| current_user.current_sign_in_at >= vote.updated_at }
   end
 
 end

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -255,5 +255,39 @@ feature 'Polls' do
       expect(page).to have_link('Han Solo')
     end
 
+    scenario 'Level 2 votes, signs out, signs in, votes again', :js do
+      poll.update(geozone_restricted: true)
+      poll.geozones << geozone
+
+      question = create(:poll_question, poll: poll)
+      answer1 = create(:poll_question_answer, question: question, title: 'Han Solo')
+      answer2 = create(:poll_question_answer, question: question, title: 'Chewbacca')
+
+      user = create(:user, :level_two, geozone: geozone)
+
+      login_as user
+      visit poll_path(poll)
+      click_link 'Han Solo'
+
+      expect(page).to_not have_link('Han Solo')
+      expect(page).to have_link('Chewbacca')
+
+      click_link "Sign out"
+      login_as user
+      visit poll_path(poll)
+      click_link 'Han Solo'
+
+      expect(page).to_not have_link('Han Solo')
+      expect(page).to have_link('Chewbacca')
+
+      click_link "Sign out"
+      login_as user
+      visit poll_path(poll)
+      click_link 'Chewbacca'
+
+      expect(page).to_not have_link('Chewbacca')
+      expect(page).to have_link('Han Solo')
+    end
+
   end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2002

What
====
If you vote an answer, signout & signin and try to vote same answer, it doesn't work.

How
===
- Touching the answer record if it already existed. Current logic was comparing the`updated_at` of  any answer by the user on the question with the last sign in time, but it doesn't change on just a save.

Screenshots
===========
- No need

Test
====
- Added scenario to check this reported issue

Deployment
==========
- As usual

Warnings
========
None