### PR TITLE
Adjuments for Poll-related features

### DIFF
--- a/app/views/admin/poll/questions/_form.html.erb
+++ b/app/views/admin/poll/questions/_form.html.erb
@@ -12,13 +12,19 @@
                     label: t("admin.questions.new.poll_label") %>
     </div>
 
-    <%= f.text_field :title, maxlength: Poll::Question.title_max_length %>
+    <%= f.text_field :title %>
 
     <div class="small-12">
       <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
-      <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
-      <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false,
-                                   aria: {describedby: "video-url-help-text"} %>
+
+      <p class="help-text" id="video-url-help-text">
+        <%= t("proposals.form.proposal_video_url_note") %>
+      </p>
+
+      <%= f.text_field :video_url,
+                        placeholder: t("proposals.form.proposal_video_url"),
+                        label: false,
+                        aria: {describedby: "video-url-help-text"} %>
     </div>
 
     <div class="small-12 medium-6 large-4 margin-top">

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -74,9 +74,9 @@
           <div class="small-12 medium-6 column end" id="answer_<%= answer.id %>"
              data-toggler=".medium-6" data-equalizer-watch>
 
-            <% if answer.description.present? %>
-              <h3><%= answer.title %></h3>
+            <h3><%= answer.title %></h3>
 
+            <% if answer.description.present? %>
               <div class="margin-top">
                 <%= safe_html_with_links simple_format(answer.description) %>
               </div>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -69,10 +69,10 @@
   <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
     <% if answer.description.present? || answer.images.any? || answer.documents.present? %>
       <div class="expanded poll-more-info-answers">
-        <div class="row padding" data-equalizer>
+        <div class="row padding">
 
           <div class="small-12 medium-6 column end" id="answer_<%= answer.id %>"
-             data-toggler=".medium-6" data-equalizer-watch>
+             data-toggler=".medium-6">
 
             <h3><%= answer.title %></h3>
 

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -66,29 +66,29 @@
     </div>
   </div>
 
-  <div class="expanded poll-more-info-answers">
-    <div class="row padding">
+  <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
+    <% if answer.description.present? || answer.images.any? %>
+      <div class="expanded poll-more-info-answers">
+        <div class="row padding" data-equalizer>
 
-      <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
-        <div class="small-12 medium-6 column end" id="answer_<%= answer.id %>"
-             data-toggler=".medium-6">
+          <div class="small-12 medium-6 column end" id="answer_<%= answer.id %>"
+             data-toggler=".medium-6" data-equalizer-watch>
 
-          <% if answer.description.present? %>
-            <h3><%= answer.title %></h3>
-          <% end %>
+            <% if answer.description.present? %>
+              <h3><%= answer.title %></h3>
 
-          <% if answer.images.any? %>
-            <%= render "gallery", answer: answer %>
-          <% end %>
+              <div class="margin-top">
+                <%= safe_html_with_links simple_format(answer.description) %>
+              </div>
+            <% end %>
 
-          <% if answer.description.present? %>
-            <div class="margin-top">
-              <%= safe_html_with_links simple_format(answer.description) %>
-            </div>
-          <% end %>
+            <% if answer.images.any? %>
+              <%= render "gallery", answer: answer %>
+            <% end %>
 
+          </div>
         </div>
-      <% end %>
-    </div>
-  </div>
+      </div>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -67,7 +67,7 @@
   </div>
 
   <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
-    <% if answer.description.present? || answer.images.any? %>
+    <% if answer.description.present? || answer.images.any? || answer.documents.present? %>
       <div class="expanded poll-more-info-answers">
         <div class="row padding" data-equalizer>
 
@@ -86,7 +86,18 @@
               <%= render "gallery", answer: answer %>
             <% end %>
 
+            <% if answer.documents.present? %>
+              <% answer.documents.each do |document| %>
+                <tr>
+                  <td><%= link_to document.title,
+                                  document.attachment.url,
+                                  target: "_blank",
+                                  rel: "nofollow" %></td>
+                </tr>
+              <% end %>
+            <% end %>
           </div>
+
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Where
=====
* **Related Issues:** #1997, #1998, #2003

What
====
* Adjustments for various Poll-related features

How
===
* Removed length limit for `title` attribute when creating a Poll::Question (commit d62c0d5)
* `poll-more-info-answers` div for Poll won't be rendered into the markup if no description is available or the answer does not have any associated records (commit 7fad604)
* Answer's associated documents are shown when users are voting on a Poll (commit a1907c6)
* Answer's title is shown if the answer has a description or any associated records (commit 8b8e8af)

Test
====
- Manual testing is needed
