### PR TITLE
Already voted in booth can't vote on website

### DIFF
--- a/app/views/polls/questions/_answers.html.erb
+++ b/app/views/polls/questions/_answers.html.erb
@@ -1,5 +1,5 @@
 <div class="poll-question-answers">
-  <% if can? :answer, question %>
+  <% if can?(:answer, question) && question.poll.voted_in_booth?(current_user) %>
     <% question.question_answers.each do |answer| %>
       <% if @answers_by_question_id[question.id] == answer.title && !voted_before_sign_in(question) %>
         <span class="button answered"

--- a/app/views/polls/questions/_answers.html.erb
+++ b/app/views/polls/questions/_answers.html.erb
@@ -1,7 +1,9 @@
 <div class="poll-question-answers">
-  <% if can?(:answer, question) && question.poll.voted_in_booth?(current_user) %>
+  <% if can?(:answer, question) %>
     <% question.question_answers.each do |answer| %>
-      <% if @answers_by_question_id[question.id] == answer.title && !voted_before_sign_in(question) %>
+      <% if @answers_by_question_id[question.id] == answer.title && 
+            (!voted_before_sign_in(question) || 
+             question.poll.voted_in_booth?(current_user)) %>
         <span class="button answered"
               title="<%= t("poll_questions.show.voted", answer: answer.title)%>">
           <%= answer.title %>

--- a/spec/features/admin/poll/questions/answers/answers_spec.rb
+++ b/spec/features/admin/poll/questions/answers/answers_spec.rb
@@ -26,7 +26,7 @@ feature 'Answers' do
 
   scenario 'Update' do
     question = create(:poll_question)
-    answer = create(:poll_question_answer, question: question)
+    answer = create(:poll_question_answer, question: question, title: "Answer title")
 
     visit admin_answer_path(answer)
 

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -288,6 +288,42 @@ feature 'Polls' do
       expect(page).to_not have_link('Chewbacca')
       expect(page).to have_link('Han Solo')
     end
+  end
+
+  context 'Booth & Website' do
+
+    let(:poll) { create(:poll, summary: "Summary", description: "Description") }
+    let(:booth) { create(:poll_booth) }
+    let(:officer) { create(:poll_officer) }
+
+    scenario 'Already voted on booth cannot vote on website', :js do
+
+      create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
+      booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+      create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      question = create(:poll_question, poll: poll)
+      create(:poll_question_answer, question: question, title: 'Han Solo')
+      create(:poll_question_answer, question: question, title: 'Chewbacca')
+      user = create(:user, :level_two, :in_census)
+
+      login_as(officer.user)
+      visit new_officing_residence_path
+      officing_verify_residence
+      click_button "Confirm vote"
+
+      expect(page).to have_content "Vote introduced!"
+
+      visit new_officing_residence_path
+      click_link "Sign out"
+      login_as user
+      visit poll_path(poll)
+
+      expect(page).to have_content "You have already participated in a physical booth. You can not participate again."
+      expect(page).to have_content('Han Solo')
+      expect(page).to have_content('Chewbacca')
+      expect(page).to_not have_link('Han Solo')
+      expect(page).to_not have_link('Chewbacca')
+    end
 
   end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2000

What
====
A user that voted in a booth can't vote in the website:
- Disable answer links on polls show 
- Add scenario to check this important part

How
===
- User `Poll#voted_in_booth?` helper method to prevent answer links to be rendered, and show disabled span's insted
- Add scenario, quite awful because its a mix of  `/spec/features/polls/polls_spec.rb` and `/spec/features/officing/voters_spec.rb` but ... better than nothing!

Screenshots
===========
- Go check on madrid pre server please

Test
====
- Covered problematic scenario

Deployment
==========
- Asap to madrid's fork :D

Warnings
========
- Test could be way better DRY and stuff
