### PR TITLE
Polls gallery polish

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1574,11 +1574,11 @@
   border-bottom: 1px solid #eee;
 
   .column:nth-child(odd) {
-    border-right: 1px solid #eee;
+    border-right: 2px solid $text;
   }
 
   .answer-divider {
-    border-bottom: 1px solid #eee;
+    border-bottom: 2px solid $text;
     border-right: 0 !important;
     margin-bottom: $line-height;
     padding-bottom: $line-height;

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1576,6 +1576,13 @@
   .column:nth-child(odd) {
     border-right: 1px solid #eee;
   }
+
+  .answer-divider {
+    border-bottom: 1px solid #eee;
+    border-right: 0 !important;
+    margin-bottom: $line-height;
+    padding-bottom: $line-height;
+  }
 }
 
 .orbit-bullets button {

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1583,6 +1583,15 @@
     margin-bottom: $line-height;
     padding-bottom: $line-height;
   }
+
+  .answer-description {
+    height: 100%;
+
+    &.short {
+      height: $line-height * 12;
+      overflow: hidden;
+    }
+  }
 }
 
 .orbit-bullets button {

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1776,6 +1776,10 @@
     margin-right: $line-height / 4;
     min-width: rem-calc(168);
 
+    @include breakpoint(medium down) {
+      width: 100%;
+    }
+
     &.answered {
       background: #f4f8ec;
       border: 2px solid #92ba48;

--- a/app/controllers/admin/poll/questions/answers_controller.rb
+++ b/app/controllers/admin/poll/questions/answers_controller.rb
@@ -1,6 +1,6 @@
 class Admin::Poll::Questions::AnswersController < Admin::Poll::BaseController
-  before_action :load_question, except: [:show, :edit, :update]
   before_action :load_answer, only: [:show, :edit, :update, :documents]
+  before_action :load_question, except: [:show, :edit, :update]
 
   load_and_authorize_resource :question, class: "::Poll::Question"
 
@@ -51,7 +51,7 @@ class Admin::Poll::Questions::AnswersController < Admin::Poll::BaseController
     end
 
     def load_question
-      @question = ::Poll::Question.find(params[:question_id])
+      @question = @answer.question
     end
 
 end

--- a/app/views/admin/poll/questions/show.html.erb
+++ b/app/views/admin/poll/questions/show.html.erb
@@ -64,8 +64,9 @@
                     admin_answer_documents_path(answer) %>
       </td>
       <td class="text-center">
-        <%= link_to t("admin.questions.show.answers.video_list",
-                    count: answer.videos.count),
+        (<%= answer.videos.count %>)
+        <br>
+        <%= link_to t("admin.questions.show.answers.video_list"),
                     admin_answer_videos_path(answer) %>
       </td>
     </tr>

--- a/app/views/polls/_gallery.html.erb
+++ b/app/views/polls/_gallery.html.erb
@@ -1,6 +1,6 @@
 <div class="orbit margin-bottom" role="region" aria-label="<%= answer.title %>" data-orbit data-auto-play="false">
-  <a data-toggle="answer_<%= answer.id %>" class="zoom-link show-for-medium-up">
-    <span class="icon-search-plus"></span>
+  <a data-toggle="answer_<%= answer.id %> zoom_<%= answer.id %>" class="zoom-link show-for-medium-up">
+    <span id="zoom_<%= answer.id %>" class="icon-search-plus" data-toggler="icon-search-plus icon-search-minus"></span>
     <span class="show-for-sr"><%= t("polls.show.zoom_plus") %></span>
   </a>
 

--- a/app/views/polls/_gallery.html.erb
+++ b/app/views/polls/_gallery.html.erb
@@ -19,7 +19,7 @@
     <% answer.images.reverse.each_with_index do |image, index| %>
       <li class="orbit-slide <%= active_class(index) %>">
         <%= link_to image.attachment.url(:original), target: "_blank" do %>
-          <%= image_tag image.attachment.url(:large),
+          <%= image_tag image.attachment.url(:original),
                         class: "orbit-image",
                         alt: image.title %>
         <% end %>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -106,12 +106,19 @@
               <% end %>
 
               <% if answer.documents.present? %>
+              <div class="document-link">
+                <p>
+                  <span class="icon-document"></span>&nbsp;
+                  <strong><%= t("polls.show.documents") %></strong>
+                </p>
+
                 <% answer.documents.each do |document| %>
                     <%= link_to document.title,
                                 document.attachment.url,
                                 target: "_blank",
-                                rel: "nofollow" %>
+                                rel: "nofollow" %><br>
                 <% end %>
+              </div>
               <% end %>
             </div>
           <% end %>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -83,7 +83,20 @@
 
           <% if answer.description.present? %>
             <div class="margin-top">
-              <%= safe_html_with_links simple_format(answer.description) %>
+              <div id="answer_description_<%= answer.id %>" class="answer-description short" data-toggler="short">
+                <%= safe_html_with_links simple_format(answer.description) %>
+              </div>
+              <a id="read_more_<%= answer.id %>"
+                 data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
+                 data-toggler="hide">
+                <%= t("polls.show.read_more", answer: answer.title) %>
+              </a>
+              <a id="read_less_<%= answer.id %>"
+                 data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
+                 data-toggler="hide"
+                 class="hide">
+                <%= t("polls.show.read_less", answer: answer.title) %>
+              </a>
             </div>
           <% end %>
 

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -71,7 +71,7 @@
 
       <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
         <div class="small-12 medium-6 column end" id="answer_<%= answer.id %>"
-             data-toggler=".medium-6">
+             data-toggler="medium-6 answer-divider">
 
           <% if answer.description.present? %>
             <h3><%= answer.title %></h3>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -71,41 +71,41 @@
       <div class="expanded poll-more-info-answers">
         <div class="row padding">
 
-      <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
-        <div class="small-12 medium-6 column end" id="answer_<%= answer.id %>"
-             data-toggler="medium-6 answer-divider">
-            <h3><%= answer.title %></h3>
+          <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>
+            <div class="small-12 medium-6 column end" id="answer_<%= answer.id %>"
+                 data-toggler="medium-6 answer-divider">
+              <h3><%= answer.title %></h3>
 
-            <% if answer.description.present? %>
-              <div class="margin-top">
-                <%= safe_html_with_links simple_format(answer.description) %>
-              </div>
-            <% end %>
-
-            <% if answer.images.any? %>
-              <%= render "gallery", answer: answer %>
-            <% end %>
-
-            <% if answer.description.present? %>
-              <div class="margin-top">
-                <div id="answer_description_<%= answer.id %>" class="answer-description short" data-toggler="short">
+              <% if answer.description.present? %>
+                <div class="margin-top">
                   <%= safe_html_with_links simple_format(answer.description) %>
                 </div>
-                <a id="read_more_<%= answer.id %>"
-                   data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
-                   data-toggler="hide">
-                  <%= t("polls.show.read_more", answer: answer.title) %>
-                </a>
-                <a id="read_less_<%= answer.id %>"
-                   data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
-                   data-toggler="hide"
-                   class="hide">
-                  <%= t("polls.show.read_less", answer: answer.title) %>
-                </a>
-              </div>
-            <% end %>
+              <% end %>
 
-            <% if answer.documents.present? %>
+              <% if answer.images.any? %>
+                <%= render "gallery", answer: answer %>
+              <% end %>
+
+              <% if answer.description.present? %>
+                <div class="margin-top">
+                  <div id="answer_description_<%= answer.id %>" class="answer-description short" data-toggler="short">
+                    <%= safe_html_with_links simple_format(answer.description) %>
+                  </div>
+                  <a id="read_more_<%= answer.id %>"
+                     data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
+                     data-toggler="hide">
+                    <%= t("polls.show.read_more", answer: answer.title) %>
+                  </a>
+                  <a id="read_less_<%= answer.id %>"
+                     data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
+                     data-toggler="hide"
+                     class="hide">
+                    <%= t("polls.show.read_less", answer: answer.title) %>
+                  </a>
+                </div>
+              <% end %>
+
+              <% if answer.documents.present? %>
                 <% answer.documents.each do |document| %>
                     <%= link_to document.title,
                                 document.attachment.url,
@@ -113,8 +113,8 @@
                                 rel: "nofollow" %>
                 <% end %>
               <% end %>
-          </div>
-
+            </div>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -602,7 +602,7 @@ en:
           title: Answer
           description: Description
           videos: Videos
-          video_list: Video list (%{count})
+          video_list: Video list
           images: Images
           images_list: Images list
           documents: Documents

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -492,6 +492,8 @@ en:
       more_info_title: "More information"
       documents: Documents
       zoom_plus: Expand image
+      read_more: "Read more about %{answer}"
+      read_less: "Read less about %{answer}"
   poll_questions:
     create_question: "Create question"
     default_valid_answers: "Yes, No"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -602,7 +602,7 @@ es:
           title: Respuesta
           description: Descripción
           videos: Vídeos
-          video_list: Lista de vídeos (%{count})
+          video_list: Lista de vídeos
           images: Imágenes
           images_list: Lista de imágenes
           documents: Documentos

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -492,6 +492,8 @@ es:
       more_info_title: "Más información"
       documents: Documentación
       zoom_plus: Ampliar imagen
+      read_more: "Leer más sobre %{answer}"
+      read_less: "Leer menos sobre %{answer}"
   poll_questions:
     create_question: "Crear pregunta para votación"
     default_valid_answers: "Sí, No"

--- a/config/locales/fr/admin.yml
+++ b/config/locales/fr/admin.yml
@@ -389,7 +389,7 @@ fr:
           title: Réponse
           description: Description
           videos: Vidéos
-          video_list: Liste des vidéos (%{count})
+          video_list: Liste des vidéos
     answers:
       show:
         title: Titre

--- a/spec/features/admin/poll/questions/answers/videos/videos_spec.rb
+++ b/spec/features/admin/poll/questions/answers/videos/videos_spec.rb
@@ -16,7 +16,7 @@ feature 'Videos' do
     visit admin_question_path(question)
 
     within("#poll_question_answer_#{answer.id}") do
-      click_link "Video list (#{answer.videos.count})"
+      click_link "Video list"
     end
 
     click_link "Add video"


### PR DESCRIPTION
What
====
- Changes zoom plus to zoom minus when is active.
- Changes border right to bottom when expand gallery (this allows a better differentiation of answers information).
- Also changes link videos on table on polls question admin to add consistency.

Screenshots
===========

<img width="74" alt="zoom_plus" src="https://user-images.githubusercontent.com/631897/31302773-b12c76f4-ab04-11e7-9ffc-af1077477750.png">

<img width="88" alt="zoom_minus" src="https://user-images.githubusercontent.com/631897/31302772-b129bc7a-ab04-11e7-9bbd-69548a9bbe9e.png">

<img width="1205" alt="border_bottom" src="https://user-images.githubusercontent.com/631897/31302771-b1279670-ab04-11e7-82a9-f54890ba4628.png">

**Before**
<img width="393" alt="table_before" src="https://user-images.githubusercontent.com/631897/31307996-e2020d1a-ab6e-11e7-9f94-3a740aa14178.png">


**After**
<img width="386" alt="table_after" src="https://user-images.githubusercontent.com/631897/31307997-e400ee92-ab6e-11e7-8a68-34a4e0dbac6c.png">

