### PR TITLE
Fixed already-answered logic

### DIFF
--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -1,6 +1,6 @@
 <% poll_group.each do |poll| %>
   <div class="poll with-image">
-    <% if user_signed_in? && !poll.votable_by?(current_user) %>
+    <% if user_signed_in? && !current_user.unverified? && !poll.votable_by?(current_user) %>
       <div class="icon-poll-answer already-answer" title="<%= t("polls.index.already_answer") %>">
         <span class="show-for-sr"><%= t("polls.index.already_answer") %></span>
       </div>

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -94,6 +94,9 @@ feature 'Polls' do
     end
 
     scenario 'Level 1 users' do
+      visit polls_path
+      expect(page).to_not have_selector('.already-answer')
+
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 


### PR DESCRIPTION
Added condition to check if user is unverified to avoid showing the ui element that lets users know they already voted a poll.

Test
====
As usual

Deployment
==========
As usual.