### PR TITLE
Show poll answers in poll show view after voting on a booth

### DIFF
--- a/app/views/polls/questions/_answers.html.erb
+++ b/app/views/polls/questions/_answers.html.erb
@@ -1,8 +1,8 @@
 <div class="poll-question-answers">
-  <% if can?(:answer, question) %>
+  <% if can?(:answer, question) && !question.poll.voted_in_booth?(current_user) %>
     <% question.question_answers.each do |answer| %>
-      <% if @answers_by_question_id[question.id] == answer.title && 
-            (!voted_before_sign_in(question) || 
+      <% if @answers_by_question_id[question.id] == answer.title &&
+            (!voted_before_sign_in(question) ||
              question.poll.voted_in_booth?(current_user)) %>
         <span class="button answered"
               title="<%= t("poll_questions.show.voted", answer: answer.title)%>">

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -50,10 +50,10 @@
             <%= t("polls.show.already_voted_in_web") %>
           </div>
         <% end %>
+      <% end %>
 
-        <% @questions.each do |question| %>
-          <%= render 'polls/questions/question', question: question, token: @token %>
-        <% end %>
+      <% @questions.each do |question| %>
+        <%= render 'polls/questions/question', question: question, token: @token %>
       <% end %>
     </div>
   </div>

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -319,10 +319,14 @@ feature 'Polls' do
       visit poll_path(poll)
 
       expect(page).to have_content "You have already participated in a physical booth. You can not participate again."
-      expect(page).to have_content('Han Solo')
-      expect(page).to have_content('Chewbacca')
-      expect(page).to_not have_link('Han Solo')
-      expect(page).to_not have_link('Chewbacca')
+
+      within("#poll_question_#{question.id}_answers") do
+        expect(page).to have_content('Han Solo')
+        expect(page).to have_content('Chewbacca')
+
+        expect(page).to_not have_link('Han Solo')
+        expect(page).to_not have_link('Chewbacca')
+      end
     end
 
   end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2000
* **Related PR's:** https://github.com/consul/consul/pull/2007

What
====
If the user votes in a booth, it can see the poll and answers but can't see what he/she voted and the answers are inactive (no link, inactive UI style).

Screenshots
===========
![localhost-3000-polls-11](https://user-images.githubusercontent.com/2141690/31309394-e3e3cd78-ab85-11e7-9899-bbfd0cba76c2.png)

Test
====
As usual.

Deployment
==========
As usual.
