### PR TITLE
Fixed poll answer document upload redirect

### DIFF
--- a/app/controllers/admin/poll/questions/answers_controller.rb
+++ b/app/controllers/admin/poll/questions/answers_controller.rb
@@ -26,7 +26,7 @@ class Admin::Poll::Questions::AnswersController < Admin::Poll::BaseController
 
   def update
     if @answer.update(answer_params)
-      redirect_to admin_answer_path(@answer),
+      redirect_to admin_question_path(@answer.question),
                notice: t("flash.actions.save_changes.notice")
     else
       redirect_to :back


### PR DESCRIPTION
Changed redirect after answer is updated, now it leads to its question summary page.

Test
====
As usual

Deployment
==========
As usual.
