### PR TITLE
Fixed already voted message in poll show

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -65,6 +65,10 @@ class Poll < ActiveRecord::Base
     Poll::Voter.where(poll: self, user: user, origin: "booth").exists?
   end
 
+  def voted_in_web?(user)
+    Poll::Voter.where(poll: self, user: user, origin: "web").exists?
+  end
+
   def date_range
     unless starts_at.present? && ends_at.present? && starts_at <= ends_at
       errors.add(:starts_at, I18n.t('errors.messages.invalid_date_range'))

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -39,7 +39,7 @@
         </div>
       <% else %>
 
-        <% if current_user && @poll.votable_by?(current_user) %>
+        <% unless current_user && @poll.votable_by?(current_user) %>
           <div class="callout warning">
             <%= t("polls.show.already_voted_in_web") %>
           </div>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -39,7 +39,7 @@
         </div>
       <% else %>
 
-        <% if current_user && !@poll.votable_by?(current_user) %>
+        <% if current_user && @poll.votable_by?(current_user) %>
           <div class="callout warning">
             <%= t("polls.show.already_voted_in_web") %>
           </div>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -39,7 +39,7 @@
         </div>
       <% else %>
 
-        <% unless current_user && @poll.votable_by?(current_user) %>
+        <% if current_user && @poll.voted_in_web?(current_user) %>
           <div class="callout warning">
             <%= t("polls.show.already_voted_in_web") %>
           </div>

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -54,8 +54,8 @@ feature "Voter" do
       visit poll_path(poll)
 
       within("#poll_question_#{question.id}_answers") do
-        expect(page).to_not have_link('Yes')
-        expect(page).to_not have_link('No')
+        expect(page).to_not have_link('Yes', href: "/questions/#{question.id}/answer?answer=Yes&token=")
+        expect(page).to_not have_link('No', href: "/questions/#{question.id}/answer?answer=No&token=")
       end
 
       expect(page).to have_content("You must verify your account in order to answer")

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -41,6 +41,27 @@ feature "Voter" do
       expect(Poll::Voter.first.origin).to eq("web")
     end
 
+    scenario "Voting via web as unverified user", :js do
+      poll = create(:poll)
+
+      question = create(:poll_question, poll: poll)
+      answer1 = create(:poll_question_answer, question: question, title: 'Yes')
+      answer2 = create(:poll_question_answer, question: question, title: 'No')
+
+      user = create(:user, :incomplete_verification)
+
+      login_as user
+      visit poll_path(poll)
+
+      within("#poll_question_#{question.id}_answers") do
+        expect(page).to_not have_link('Yes')
+        expect(page).to_not have_link('No')
+      end
+
+      expect(page).to have_content("You must verify your account in order to answer")
+      expect(page).to_not have_content("You have already participated in this poll. If you vote again it will be overwritten")
+    end
+
     scenario "Voting in booth", :js do
       user = create(:user, :in_census)
 


### PR DESCRIPTION
What
====
Fixed logic to properly show the message “you already voted” in a Poll show view. As it was before these changes, if an unverified user goes to the Poll show view, it could see this message, which doesn’t make sense unless a user has the ability to vote and has already voted that poll.

Tests
====
As usual.

Deploy
=====
As usual.