### PR TITLE
[FROZEN] Hide/Unhide Poll comments 

### DIFF
--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -128,14 +128,33 @@
         </div>
       <% end %>
     </div>
-    
+
   </div>
 </div>
 
-<div class="tabs-content" data-tabs-content="proposals-tabs" role="tablist">
-  <%= render "filter_subnav" %>
+<div class="row margin-top">
+  <div class="small-12 medium-6 large-4 column small-centered text-center">
+    <a id="show_comments_<%= @poll.id %>"
+       class="button expanded"
+       data-toggle="comments_<%= @poll.id %> hide_comments_<%= @poll.id %> show_comments_<%= @poll.id %>"
+       data-toggler="hide">
+      <%= t("polls.show.show_comments") %>
+    </a>
+    <a id="hide_comments_<%= @poll.id %>"
+       class="button expanded hide"
+       data-toggle="comments_<%= @poll.id %> hide_comments_<%= @poll.id %> show_comments_<%= @poll.id %>"
+       data-toggler="hide">
+      <%= t("polls.show.hide_comments") %>
+    </a>
+  </div>
+</div>
 
-  <div class="tabs-panel is-active" id="tab-comments">
-    <%= render "comments" %>
+<div id="comments_<%= @poll.id %>" class="hide" data-toggler="hide">
+  <div class="tabs-content" data-tabs-content="polls-tabs" role="tablist">
+    <%= render "filter_subnav" %>
+
+    <div class="tabs-panel is-active" id="tab-comments">
+      <%= render "comments" %>
+    </div>
   </div>
 </div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -497,6 +497,8 @@ en:
       read_more: "Read more about %{answer}"
       read_less: "Read less about %{answer}"
       participate_in_other_polls: Participate in other polls
+      show_comments: Show comments
+      hide_comments: Hide comments
   poll_questions:
     create_question: "Create question"
     default_valid_answers: "Yes, No"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -497,6 +497,8 @@ es:
       read_more: "Leer más sobre %{answer}"
       read_less: "Leer menos sobre %{answer}"
       participate_in_other_polls: Participar en otras votaciones
+      show_comments: Mostrar comentarios
+      hide_comments: Ocultar comentarios
   poll_questions:
     create_question: "Crear pregunta para votación"
     default_valid_answers: "Sí, No"


### PR DESCRIPTION
Where
=====

* **Related PR's:** https://github.com/consul/consul/pull/1961

What
====
- Cleanup and improvements of previous PR.

How
===
- Adds **show/hide comments buttons** on polls/show.

Screenshots
===========
<img width="1318" alt="show_comments" src="https://user-images.githubusercontent.com/631897/31383381-23326d86-adbb-11e7-8533-9ff2694472d7.png">

<img width="1251" alt="hide_comments" src="https://user-images.githubusercontent.com/631897/31383382-234a627e-adbb-11e7-8215-74f96b7dec24.png">

# WARNING‼️
⚠️⚠️⚠️ The  associated issue hasn't yet been accepted. This is just stashed work to be used if needed