### PR TITLE
Fixes exception when sending a poll comment's email

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -27,6 +27,10 @@ class Poll < ActiveRecord::Base
 
   scope :sort_for_list, -> { order(:geozone_restricted, :starts_at, :name) }
 
+  def title
+    name
+  end
+
   def current?(timestamp = Date.current.beginning_of_day)
     starts_at <= timestamp && timestamp <= ends_at
   end


### PR DESCRIPTION
Where
=====
* **Related PR's:** #1961
* **Related Exceptions:** 1267, 1268

What
====
- Fixes exception when sending an email about a comment reply on a poll
- Adds spec for the scenario where a user creates a root comment on poll (not replying to a previous comment).

How
===
- Adding an alias `title` for a poll's `name`

Deployment
==========
- As usual

Warnings
========
- None
