### PR TITLE
20171011 - Removed author from polls comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,7 +13,7 @@ class CommentsController < ApplicationController
   def create
     if @comment.save
       CommentNotifier.new(comment: @comment).process
-      add_notification @comment
+      add_notification @comment unless @comment.commentable.is_a?(Poll)
     else
       render :new
     end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -97,4 +97,12 @@ module CommentsHelper
     end
   end
 
+  def commentable_author_id_for_polls(comment, commentable)
+    if commentable.class == Poll
+      comment_author_class comment, nil
+    else
+      comment_author_class comment, commentable.author_id
+    end
+  end
+
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -12,7 +12,7 @@ class Mailer < ApplicationMailer
 
     with_user(@commentable.author) do
       subject = t('mailers.comment.subject', commentable: t("activerecord.models.#{@commentable.class.name.underscore}", count: 1).downcase)
-      mail(to: @email_to, subject: subject) if @commentable.present? && @commentable.author.present?
+      mail(to: @email_to, subject: subject) if @commentable.present? && @commentable.author.present? && commentable.class.name != 'Poll'
     end
   end
 

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -12,7 +12,7 @@ class Mailer < ApplicationMailer
 
     with_user(@commentable.author) do
       subject = t('mailers.comment.subject', commentable: t("activerecord.models.#{@commentable.class.name.underscore}", count: 1).downcase)
-      mail(to: @email_to, subject: subject) if @commentable.present? && @commentable.author.present? && commentable.class.name != 'Poll'
+      mail(to: @email_to, subject: subject) if @commentable.present? && @commentable.author.present? && !@commentable.is_a?(Poll)
     end
   end
 

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -16,8 +16,6 @@ class Poll < ActiveRecord::Base
   has_many :comments, as: :commentable
 
   has_and_belongs_to_many :geozones
-  belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
-
   validates :name, presence: true
 
   validate :date_range

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -48,26 +48,19 @@
                 <%= t("shared.collective") %>
               </span>
             <% end %>
-            <% unless comment.commentable.class.name == 'Poll' %>
-              <% if comment.user_id == comment.commentable.author_id %>
-                &nbsp;&bull;&nbsp;
-                <span class="label round is-author">
-                  <%= t("comments.comment.author") %>
-                </span>
-              <% end %>
+            <% comment.commentable.is_a?(Poll) ? nil : if comment.user_id == comment.commentable.author_id %>
+              &nbsp;&bull;&nbsp;
+              <span class="label round is-author">
+                <%= t("comments.comment.author") %>
+              </span>
             <% end %>
           <% end %>
 
           &nbsp;&bull;&nbsp;<span><%= l comment.created_at.to_datetime, format: :datetime %></span>
         </div>
-
         <div class="comment-user
                   <%= user_level_class comment %>
-                  <% if comment.commentable.class.name == 'Poll' %>
-                    <%= comment_author_class comment, nil %>
-                  <% else %>
-                    <%= comment_author_class comment, comment.commentable.author_id %>
-                  <% end %>">
+                  <%= commentable_author_id_for_polls(comment, comment.commentable) %>">
           <%= simple_format text_with_links(comment.body), {}, sanitize: false %>
         </div>
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -48,13 +48,14 @@
                 <%= t("shared.collective") %>
               </span>
             <% end %>
-            <% if comment.user_id == comment.commentable.author_id %>
-              &nbsp;&bull;&nbsp;
-              <span class="label round is-author">
-                <%= t("comments.comment.author") %>
-              </span>
+            <% unless comment.commentable.class.name == 'Poll' %>
+              <% if comment.user_id == comment.commentable.author_id %>
+                &nbsp;&bull;&nbsp;
+                <span class="label round is-author">
+                  <%= t("comments.comment.author") %>
+                </span>
+              <% end %>
             <% end %>
-
           <% end %>
 
           &nbsp;&bull;&nbsp;<span><%= l comment.created_at.to_datetime, format: :datetime %></span>
@@ -62,7 +63,11 @@
 
         <div class="comment-user
                   <%= user_level_class comment %>
-                  <%= comment_author_class comment, comment.commentable.author_id %>">
+                  <% if comment.commentable.class.name == 'Poll' %>
+                    <%= comment_author_class comment, nil %>
+                  <% else %>
+                    <%= comment_author_class comment, comment.commentable.author_id %>
+                  <% end %>">
           <%= simple_format text_with_links(comment.body), {}, sanitize: false %>
         </div>
 

--- a/db/migrate/20171017143852_remove_author_id_from_polls.rb
+++ b/db/migrate/20171017143852_remove_author_id_from_polls.rb
@@ -1,0 +1,5 @@
+class RemoveAuthorIdFromPolls < ActiveRecord::Migration
+  def change
+    remove_column :polls, :author_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171010143623) do
+ActiveRecord::Schema.define(version: 20171017143852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -758,7 +758,6 @@ ActiveRecord::Schema.define(version: 20171010143623) do
     t.text     "summary"
     t.text     "description"
     t.integer  "comments_count",     default: 0
-    t.integer  "author_id"
     t.datetime "hidden_at"
   end
 

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -377,7 +377,8 @@ feature 'Emails' do
       user1 = create(:user, email_on_comment: true)
       user2 = create(:user)
 
-      poll = create(:poll, author: user1)
+      login_as(user1)
+      poll = create(:poll)
       reset_mailer
 
       login_as(user2)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2045 

What
====
- To remove `author_id` from polls and to refactor related views and controllers to respond accordingly

How
===
- By setting several conditions into
  - comments' show view
  - poll and mailer models
  - comments controller

Screenshots
===========
- n/a

Test
====
- As usual.

Deployment
==========
- You might need to run a migration if author_id is still in your poll table.

Warnings
========
- Check if author_id is not present in your schema.
