### PR TITLE
Edit booth button

### DIFF
--- a/app/views/admin/poll/booths/_booth.html.erb
+++ b/app/views/admin/poll/booths/_booth.html.erb
@@ -10,7 +10,8 @@
       <%= link_to t("admin.booths.booth.shifts"),
                   new_admin_booth_shift_path(booth),
                   class: "button hollow" %>
-      <%= link_to t("admin.actions.edit"),
+    <% else %>
+      <%= link_to t("admin.booths.booth.edit"),
                   edit_admin_booth_path(booth),
                   class: "button hollow" %>
     <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -664,6 +664,7 @@ en:
         location: "Location"
       booth:
         shifts: "Manage shifts"
+        edit: "Edit booth"
     officials:
       edit:
         destroy: Remove 'Official' status

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -666,6 +666,7 @@ es:
         location: "Ubicación"
       booth:
         shifts: "Asignar turnos"
+        edit: "Editar urna"
     officials:
       edit:
         destroy: Eliminar condición de 'Cargo Público'

--- a/spec/features/admin/poll/booths_spec.rb
+++ b/spec/features/admin/poll/booths_spec.rb
@@ -60,6 +60,7 @@ feature 'Admin booths' do
     expect(page).to have_content booth_for_current_poll.name
     expect(page).to have_content booth_for_incoming_poll.name
     expect(page).to_not have_content booth_for_expired_poll.name
+    expect(page).to_not have_link "Edit booth"
   end
 
   scenario 'Show' do
@@ -91,10 +92,11 @@ feature 'Admin booths' do
     booth = create(:poll_booth)
     assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
 
-    visit available_admin_booths_path
+    visit admin_booths_path
 
     within("#booth_#{booth.id}") do
-      click_link "Edit"
+      expect(page).to_not have_link "Manage shifts"
+      click_link "Edit booth"
     end
 
     fill_in "poll_booth_name", with: "Next booth"


### PR DESCRIPTION
Where
=====
This closes https://github.com/consul/consul/issues/2029

What
====
- In `/admin/booths/available` only shows `Manage shifts` button.
- In `/admin/booths/` only shows `Edit booth` button.

How
===
- Hides edit booth button when available filter on, improve a little edit button text.

Screenshots
===========
### admin/booths
<img width="1246" alt="admin_booths" src="https://user-images.githubusercontent.com/631897/31457344-c5a71376-aebc-11e7-8773-729e6def69fe.png">


### admin/booths/available

<img width="1235" alt="booths_available" src="https://user-images.githubusercontent.com/631897/31457333-c0f6ad6e-aebc-11e7-864e-d85d884d881c.png">
