### PR TITLE
Booth shifts back link

### DIFF
--- a/app/views/admin/poll/shifts/new.html.erb
+++ b/app/views/admin/poll/shifts/new.html.erb
@@ -1,4 +1,4 @@
-<%= back_link_to admin_booths_path %>
+<%= back_link_to available_admin_booths_path %>
 
 <h2><%= @booth.name %></h2>
 

--- a/spec/features/admin/poll/booths_spec.rb
+++ b/spec/features/admin/poll/booths_spec.rb
@@ -113,4 +113,18 @@ feature 'Admin booths' do
     end
   end
 
+  scenario "Back link go back to available list when manage shifts" do
+    poll = create(:poll, :current)
+    booth = create(:poll_booth)
+    assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+
+    visit available_admin_booths_path
+
+    within("#booth_#{booth.id}") do
+      click_link "Manage shifts"
+    end
+
+    click_link "Go back"
+    expect(current_path).to eq(available_admin_booths_path)
+  end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** This closes #2028 

What
====
- Changes back link to available booths when manage shifts.

