### PR TITLE
Searches for officers assigned to a poll

### DIFF
--- a/app/controllers/admin/poll/officer_assignments_controller.rb
+++ b/app/controllers/admin/poll/officer_assignments_controller.rb
@@ -25,7 +25,9 @@ class Admin::Poll::OfficerAssignmentsController < Admin::Poll::BaseController
 
   def search_officers
     load_search
-    @officers = User.joins(:poll_officer).search(@search).order(username: :asc)
+
+    poll_officers = User.where(id: @poll.officers.pluck(:user_id))
+    @officers = poll_officers.search(@search).order(username: :asc)
 
     respond_to do |format|
       format.js

--- a/app/views/admin/poll/officer_assignments/index.html.erb
+++ b/app/views/admin/poll/officer_assignments/index.html.erb
@@ -11,7 +11,7 @@
       <%= t("admin.poll_officer_assignments.index.no_officers") %>
     </div>
   <% else %>
-    <table class="fixed margin">
+    <table class="fixed margin" id="officer_assignments">
       <thead>
         <th><%= t("admin.poll_officer_assignments.index.table_name") %></th>
         <th><%= t("admin.poll_officer_assignments.index.table_email") %></th>

--- a/spec/features/admin/poll/officer_assignments_spec.rb
+++ b/spec/features/admin/poll/officer_assignments_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+feature 'Officer Assignments' do
+
+  background do
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
+
+  scenario "Index" do
+    poll = create(:poll)
+    booth = create(:poll_booth)
+
+    officer1 = create(:poll_officer)
+    officer2 = create(:poll_officer)
+    officer3 = create(:poll_officer)
+
+    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    officer_assignment = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer1)
+
+    booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
+    officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer2)
+
+    visit admin_poll_path(poll)
+
+    click_link 'Officers (2)'
+
+    within('#officer_assignments') do
+      expect(page).to have_content officer1.name
+      expect(page).to have_content officer2.name
+      expect(page).to_not have_content officer3.name
+    end
+	end
+
+	scenario "Search", :js do
+    poll = create(:poll)
+    booth = create(:poll_booth)
+
+    user1 = create(:user, username: "John Snow")
+    user2 = create(:user, username: "John Silver")
+    user3 = create(:user, username: "John Edwards")
+
+    officer1 = create(:poll_officer, user: user1)
+    officer2 = create(:poll_officer, user: user2)
+    officer3 = create(:poll_officer, user: user3)
+
+    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    officer_assignment = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer1)
+
+    booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
+    officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer2)
+
+    visit admin_poll_path(poll)
+
+    click_link 'Officers (2)'
+
+    fill_in "search-officers", with: "John"
+    click_button "Search"
+
+    within('#search-officers-results') do
+      expect(page).to have_content officer1.name
+      expect(page).to have_content officer2.name
+      expect(page).to_not have_content officer3.name
+    end
+	end
+
+
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2030

What
====
- Searches for officer assigned to a poll
- Does not return officers that have not yet been assigned to that poll
- Adds missing specs for the index of a poll's officers

How
===
- Scoping officers assigned to a poll before searching

Screenshots
===========
- Searching for an officer assigned to a poll
![officer assigned to poll](https://user-images.githubusercontent.com/4169/31556701-589ba9dc-b046-11e7-8132-0854a0ff4057.png)

- Searching for an officer not assigned to a poll
![officer not assigned to poll](https://user-images.githubusercontent.com/4169/31556705-5af58edc-b046-11e7-961f-6e7963d5a511.png)

Deployment
==========
- As usual

Warnings
========
- None
