### PR TITLE
Excluded officer shift dates from each task date range

### DIFF
--- a/app/helpers/shifts_helper.rb
+++ b/app/helpers/shifts_helper.rb
@@ -1,15 +1,15 @@
 module ShiftsHelper
 
   def shift_vote_collection_dates(polls)
-    date_options((start_date(polls)..end_date(polls)))
+    date_options((start_date(polls)..end_date(polls)), 0)
   end
 
   def shift_recount_scrutiny_dates(polls)
-    date_options(polls.map(&:ends_at).map(&:to_date).sort.inject([]) { |total, date| total << (date..date + 1.week).to_a }.flatten.uniq)
+    date_options(polls.map(&:ends_at).map(&:to_date).sort.inject([]) { |total, date| total << (date..date + 1.week).to_a }.flatten.uniq, 1)
   end
 
-  def date_options(dates)
-    dates.map { |date| [l(date, format: :long), l(date)] }
+  def date_options(dates, task_id)
+    dates.reject { |date| officer_shifts(task_id).include?(date) }.map { |date| [l(date, format: :long), l(date)] }
   end
 
   def start_date(polls)
@@ -24,4 +24,9 @@ module ShiftsHelper
     officers.collect { |officer| [officer.name, officer.id] }
   end
 
+  private
+
+  def officer_shifts(task_id)
+    @officer.shifts.where(task: task_id).map(&:date)
+  end
 end

--- a/app/helpers/shifts_helper.rb
+++ b/app/helpers/shifts_helper.rb
@@ -1,15 +1,19 @@
 module ShiftsHelper
 
   def shift_vote_collection_dates(polls)
-    date_options((start_date(polls)..end_date(polls)), 0)
+    date_options((start_date(polls)..end_date(polls)), Poll::Shift.tasks[:vote_collection])
   end
 
   def shift_recount_scrutiny_dates(polls)
-    date_options(polls.map(&:ends_at).map(&:to_date).sort.inject([]) { |total, date| total << (date..date + 1.week).to_a }.flatten.uniq, 1)
+    date_options(polls.map(&:ends_at).map(&:to_date).sort.inject([]) { |total, date| total << (date..date + 1.week).to_a }.flatten.uniq, Poll::Shift.tasks[:recount_scrutiny])
   end
 
   def date_options(dates, task_id)
-    dates.reject { |date| officer_shifts(task_id).include?(date) }.map { |date| [l(date, format: :long), l(date)] }
+    valid_dates(dates, task_id).map { |date| [l(date, format: :long), l(date)] }
+  end
+
+  def valid_dates(dates, task_id)
+    dates.reject { |date| officer_shifts(task_id).include?(date) }
   end
 
   def start_date(polls)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -531,6 +531,14 @@ FactoryGirl.define do
     association :booth, factory: :poll_booth
     association :officer, factory: :poll_officer
     date Date.current
+
+    trait :vote_collection_task do
+      task 0
+    end
+
+    trait :recount_scrutiny_task do
+      task 1
+    end
   end
 
   factory :poll_voter, class: 'Poll::Voter' do

--- a/spec/features/admin/poll/shifts_spec.rb
+++ b/spec/features/admin/poll/shifts_spec.rb
@@ -91,6 +91,37 @@ feature 'Admin shifts' do
     end
   end
 
+  scenario "Vote Collection Shift and Recount & Scrutiny Shift don't include already assigned dates to officer", :js do
+    poll = create(:poll, :current)
+    booth = create(:poll_booth)
+    assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    officer = create(:poll_officer)
+
+    shift1 = create(:poll_shift, :vote_collection_task, officer: officer, booth: booth, date: Time.zone.today)
+    shift2 = create(:poll_shift, :recount_scrutiny_task, officer: officer, booth: booth, date: Time.zone.tomorrow)
+
+    vote_collection_dates = (poll.starts_at.to_date..poll.ends_at.to_date).to_a
+                              .reject { |date| date == Time.zone.today }
+                              .map { |date| I18n.l(date, format: :long) }
+    recount_scrutiny_dates = (poll.ends_at.to_date..poll.ends_at.to_date + 1.week).to_a
+                              .reject { |date| date == Time.zone.tomorrow }
+                              .map { |date| I18n.l(date, format: :long) }
+
+    visit available_admin_booths_path
+
+    within("#booth_#{booth.id}") do
+      click_link "Manage shifts"
+    end
+
+    fill_in "search", with: officer.email
+    click_button "Search"
+    click_link "Edit shifts"
+
+    expect(page).to have_select('shift_date_vote_collection_date', options: ["Select day", *vote_collection_dates])
+    select "Recount & Scrutiny", from: 'shift_task'
+    expect(page).to have_select('shift_date_recount_scrutiny_date', options: ["Select day", *recount_scrutiny_dates])
+  end
+
   scenario "Error on create", :js do
     poll = create(:poll, :current)
     booth = create(:poll_booth)


### PR DESCRIPTION
Where
=====
* **Closes** #2031

What
====
In the admin `#new` form to assign shifts to officers, excluded from task dates lists **already assigned dates for that officer in the booth** selected.

Screenshots
===========
<img width="1055" alt="screen shot 2017-10-16 at 12 20 50" src="https://user-images.githubusercontent.com/2141690/31607601-3e697d22-b26d-11e7-9e28-2be60610fda5.png">
<img width="770" alt="screen shot 2017-10-16 at 12 20 59" src="https://user-images.githubusercontent.com/2141690/31607602-3e94202c-b26d-11e7-8dbc-168f4fd78d20.png">
<img width="780" alt="screen shot 2017-10-16 at 12 21 11" src="https://user-images.githubusercontent.com/2141690/31607603-3eb27bb2-b26d-11e7-8687-9bc8bd5327b3.png">


Test
====
As usual.

Deployment
==========
As usual.
