### PR TITLE
Added officing tests for officers logged in at the same time

### DIFF
--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -108,10 +108,17 @@ feature 'Poll Officing' do
   end
 
   scenario 'Officing dashboard available for multiple sessions' do
+    poll = create(:poll)
+    booth = create(:poll_booth)
+    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+
     user1 = create(:user)
     user2 = create(:user)
     officer1 = create(:poll_officer, user: user1)
     officer2 = create(:poll_officer, user: user2)
+
+    officer_assignment_1 = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer1)
+    officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer2)
 
     in_browser(:one) do
       login_as user1

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sessions_helper'
 
 feature 'Poll Officing' do
   let(:user) { create(:user) }
@@ -106,4 +107,40 @@ feature 'Poll Officing' do
     expect(page).to_not have_css('#moderation_menu')
   end
 
+  scenario 'Officing dashboard available for multiple sessions' do
+    user1 = create(:user)
+    user2 = create(:user)
+    officer1 = create(:poll_officer, user: user1)
+    officer2 = create(:poll_officer, user: user2)
+
+    in_browser(:one) do
+      login_as user1
+      visit officing_root_path
+    end
+
+    in_browser(:two) do
+      login_as user2
+      visit officing_root_path
+    end
+
+    in_browser(:one) do
+      page.should have_content("Here you can validate user documents and store voting results")
+
+      visit new_officing_residence_path
+      page.should have_content("Validate document")
+
+      visit final_officing_polls_path
+      page.should have_content("Polls ready for final recounting")
+    end
+
+    in_browser(:two) do
+      page.should have_content("Here you can validate user documents and store voting results")
+
+      visit new_officing_residence_path
+      page.should have_content("Validate document")
+
+      visit final_officing_polls_path
+      page.should have_content("Polls ready for final recounting")
+    end
+  end
 end

--- a/spec/sessions_helper.rb
+++ b/spec/sessions_helper.rb
@@ -1,0 +1,8 @@
+def in_browser(name)
+  old_session = Capybara.session_name
+
+  Capybara.session_name = name
+  yield
+
+  Capybara.session_name = old_session
+end


### PR DESCRIPTION
Where
====
* **Closes:** #2032 

What
====
Added new tests to officing section to ensure that  multiple sessions (different users) can be initialized at the same time without crashing.

How
===
- Make sure this bug is not currently happening.
- Added tests to avoid having the same problem in the future.

Test
====
As usual.

Deployment
==========
As usual.