### PR TITLE
Admin layout

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -372,6 +372,10 @@ a {
   display: table-cell;
 }
 
+.off-canvas-content {
+  box-shadow: none;
+}
+
 // 02. Header
 // ----------
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -18,10 +18,6 @@
       <div class="off-canvas-wrapper-inner" data-off-canvas-wrapper>
         <div class="off-canvas position-left" id="offCanvas" data-off-canvas>
 
-          <button class="close-button" aria-label="Close menu" type="button" data-close>
-            <span aria-hidden="true">&times;</span>
-          </button>
-
           <div class="show-for-small-only">
             <%= side_menu %>
           </div>


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/1914

What
====
- In some parts of admin section the content seems overflow.

How
===
- This PR only patch the error. There is an issue with the load elements order, the problem is Foundation `data-equalizer` calculates the height before all the layout is loaded. There is a lot of reported issues on Foundation and foundation-rails repositories, but:

  1. There is some "js hacks" to fix it, but I think is add unnecessary code, since it only happens in a few admin pages.

  2. On Chrome the menu get the correct height if you resize de windows browser.

  3. I hope is fixed on future versions of foundation-rails gem. 
  
  4. I just remove the `box-shadow` of content to patch this "error".

Also in this PR I removed the (unnecessary) `close-button` for admin menu (on mobile version), this button overlays the main menu, and the menu can closes clicking on right side of the screen. Moreover very few users use admin panel from mobile.

Screenshots
===========
**Removed box-shadow**
<img width="1678" alt="no box shadow" src="https://user-images.githubusercontent.com/631897/31626743-2e2589ea-b2ab-11e7-9d96-80c4e944b480.png">

**Removed close-button**
<img width="242" alt="close button" src="https://user-images.githubusercontent.com/631897/31626756-37bf0a4e-b2ab-11e7-83c1-533816197912.png">


Test
====
- No needed.

Deployment
==========
- As usual.

Warnings
========
- None!
