### PR TITLE
Dropdown menus

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1139,8 +1139,13 @@ form {
     color: #ecf00b;
     font-size: rem-calc(10);
     position: absolute;
-    right: 8px;
+    left: 12px;
     top: 6px;
+
+    @include breakpoint(medium) {
+      left: auto;
+      right: 8px;
+    }
   }
 }
 

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -12,7 +12,7 @@
 
 #print_link { display: none !important; }
 
-#responsive-menu { display: none !important; }
+#responsive_menu { display: none !important; }
 
 .admin-sidebar { display: none !important; }
 

--- a/app/views/devise/menu/_login_items.html.erb
+++ b/app/views/devise/menu/_login_items.html.erb
@@ -6,8 +6,14 @@
         <span class="icon-circle" aria-hidden="true"></span>
         <span class="icon-notification" aria-hidden="true" title="<%= t('layouts.header.new_notifications', count: current_user.notifications_count).html_safe %>">
         </span>
+        <small class="show-for-small-only">
+          <%= t('layouts.header.new_notifications', count: current_user.notifications_count).html_safe %>
+        </small>
       <% else %>
         <span class="icon-no-notification" aria-hidden="true" title="<%= t('layouts.header.no_notifications') %>"></span>
+        <small class="show-for-small-only">
+          <%= t('layouts.header.no_notifications') %>
+        </small>
       <% end %>
     <% end %>
   </li>

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -8,7 +8,7 @@
   <div class="expanded row">
     <div class="top-bar">
 
-      <span data-responsive-toggle="responsive-menu" data-hide-for="medium" class="float-right">
+      <span data-responsive-toggle="responsive_menu" data-hide-for="medium" class="float-right">
         <span class="menu-icon dark" data-toggle></span>
         <%= t("application.menu")%>
       </span>
@@ -22,7 +22,7 @@
             <% end %>
           </h1>
         </div>
-        <div id="responsive-menu">
+        <div id="responsive_menu">
 
         <div class="top-bar-right">
           <ul class="dropdown menu" data-dropdown-menu>

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -25,7 +25,7 @@
         <div id="responsive_menu">
 
         <div class="top-bar-right">
-          <ul class="dropdown menu" data-dropdown-menu>
+          <ul class="menu" data-responsive-menu="medium-dropdown">
             <%= render "admin/shared/admin_shortcuts" %>
             <%= render "shared/admin_login_items" %>
             <%= render "devise/menu/login_items" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -28,7 +28,7 @@
         </div>
 
         <div class="top-bar-right">
-          <ul class="dropdown menu" data-dropdown-menu>
+          <ul class="menu" data-responsive-menu="medium-dropdown">
             <%= render "shared/admin_login_items" %>
             <%= render "devise/menu/login_items" %>
           </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -14,12 +14,12 @@
 
       <%= link_to setting['org_name'], root_path, class: "logo show-for-small-only" %>
 
-      <span data-responsive-toggle="responsive-menu" data-hide-for="medium" class="float-right">
+      <span data-responsive-toggle="responsive_menu" data-hide-for="medium" class="float-right">
         <span class="menu-icon dark" data-toggle></span>
         <%= t("application.menu")%>
       </span>
 
-      <div id="responsive-menu">
+      <div id="responsive_menu">
         <div class="top-bar-title">
           <%= link_to root_path, class: "hide-for-small-only", accesskey: "0" do %>
             <%= image_tag(image_path_for('logo_header.png'), class: 'hide-for-small-only float-left', size: '80x80', alt: t("layouts.header.logo")) %>

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -15,30 +15,25 @@
   </head>
 
   <body class="admin">
-    <header>
-      <section class="top-links">
+    <header class="header">
+      <div class="top-links">
         <div class="expanded row">
           <%= render 'shared/locale_switcher' %>
         </div>
-      </section>
+      </div>
 
       <div class="expanded row">
         <div class="top-bar">
 
           <%= link_to setting['org_name'], management_root_path, class: "logo show-for-small-only" %>
 
-          <span data-responsive-toggle="responsive-menu" data-hide-for="medium" class="float-right">
-            <span class="menu-icon dark" data-toggle></span>
-            <%= t("application.menu")%>
-          </span>
-
-          <div id="responsive-menu">
             <div class="top-bar-title">
-              <%= link_to management_root_path, class: "hide-for-small-only" do %>
-                <%= image_tag(image_path_for('logo_header.png'), class: 'hide-for-small-only float-left', size: '80x80', alt: t("layouts.header.logo")) %>
-                <%= setting['org_name'] %>
-                &nbsp;|&nbsp;<%= t("management.dashboard.index.title") %>
-              <% end %>
+              <h1>
+                <%= link_to management_root_path do %>
+                  <%= setting['org_name'] %>
+                  <br><small><%= t("management.dashboard.index.title") %></small>
+                <% end %>
+              </h1>
             </div>
           </div>
         </div>

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -1,6 +1,6 @@
 <% if show_admin_menu? %>
   <li>
-    <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow" %>
+    <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
     <ul class="menu">
       <% if current_user.administrator? %>
         <li>


### PR DESCRIPTION
What
====
- Fixes dropdown menus on mobile size.

How
===

- Fixes admin login items menu on mobile size (avoid dropdown)
- Include text for notification menu on mobile size (easier to clic on it)
- Uses underscore for ids names to normalize format.
- Fixes header on management panel (the logo was broken)
- Fixes admin login items menu on mobile size for admin panel (same as front users)

Screenshots
===========
**Admin menu (front) BEFORE**
<img width="399" alt="small_menu_before" src="https://user-images.githubusercontent.com/631897/31662948-b6d14db6-b340-11e7-8487-e8547acfe78c.png">

**Admin menu (front) AFTER**
<img width="402" alt="small_menu_after" src="https://user-images.githubusercontent.com/631897/31662951-b9948f5e-b340-11e7-8c71-d00bfa1175fa.png">

**Management header BEFORE**
<img width="583" alt="management_before" src="https://user-images.githubusercontent.com/631897/31662953-bbc16810-b340-11e7-9097-c1333dbce615.png">

**Management header AFTER**
<img width="604" alt="management_after" src="https://user-images.githubusercontent.com/631897/31662954-bd9d9794-b340-11e7-976f-76a68836a5f1.png">

**Admin menu (Admin) BEFORE**
<img width="396" alt="menu_admin_before" src="https://user-images.githubusercontent.com/631897/31662957-c03e3cf6-b340-11e7-8521-704b44f114eb.png">

**Admin menu (Admin) AFTER**
<img width="397" alt="menu_admin_after" src="https://user-images.githubusercontent.com/631897/31662964-c51949aa-b340-11e7-8668-89f01e62e413.png">


Test
====
- No needed, only visual styles changed.

Deployment
==========
- As usual.

Warnings
========
- There is a little "bug" documented on Foundation when resizing, but it's a weird case of use. If you open the page in a large size, resize to small and clic on "Menu" the admin section doesn't appear. You need to refresh the page, really it's a weird case because the users use the site on same device each time and don't resize the screens. Moreover this only happens on admin menu, not for regular users.
