### PR TITLE
Adds spec for user voting in booth and then verifying account

### DIFF
--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -126,8 +126,34 @@ feature "Voter" do
           expect(page).to have_link('Yes')
           expect(page).to have_link('No')
         end
-
       end
+    end
+
+    scenario "Voting in poll and then verifiying account", :js do
+      user = create(:user)
+
+      question = create(:poll_question, poll: poll)
+      answer1 = create(:poll_question_answer, question: question, title: 'Yes')
+      answer2 = create(:poll_question_answer, question: question, title: 'No')
+
+      login_through_form_as_officer(officer.user)
+      vote_for_poll_via_booth
+
+      visit root_path
+      click_link "Sign out"
+
+      login_as user
+      visit account_path
+      click_link 'Verify my account'
+
+      verify_residence
+      confirm_phone(user)
+
+      visit poll_path(poll)
+
+      expect(page).to_not have_link('Yes')
+      expect(page).to have_content "You have already participated in a physical booth. You can not participate again."
+      expect(Poll::Voter.count).to eq(1)
     end
 
   end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -163,14 +163,15 @@ module CommonActions
     expect(page).to have_content 'Document verified with Census'
   end
 
-  def confirm_phone
+  def confirm_phone(user=nil)
+    user ||= User.last
+
     fill_in 'sms_phone', with: "611111111"
     click_button 'Send'
 
     expect(page).to have_content 'Enter the confirmation code sent to you by text message'
 
-    user = User.last.reload
-    fill_in 'sms_confirmation_code', with: user.sms_confirmation_code
+    fill_in 'sms_confirmation_code', with: user.reload.sms_confirmation_code
     click_button 'Send'
 
     expect(page).to have_content 'Code correct'


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2033 

What
====
- Adds spec for when a user votes in a booth and then verifies the account

Why
===
- To make sure that he/she can not vote in a booth and then in web with the same document number

Note
===
- Not explicitly specifying a document number in the test, because we only have one valid document number in the test environment "12345678Z". Which is used in the test helpers for [voting in a booth](https://github.com/consul/consul/blob/master/spec/support/common_actions.rb#L156) and [verifing an account](https://github.com/consul/consul/blob/master/spec/support/common_actions.rb#L145)
