### PR TITLE
Add investment user tags admin interface

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -51,7 +51,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
     def budget_investment_params
       params.require(:budget_investment)
-            .permit(:title, :description, :external_url, :heading_id, :administrator_id, :valuation_tag_list, :incompatible,
+            .permit(:title, :description, :external_url, :heading_id, :administrator_id, :tag_list, :valuation_tag_list, :incompatible,
                     :selected, valuator_ids: [])
     end
 

--- a/app/views/admin/budget_investments/_written_by_author.html.erb
+++ b/app/views/admin/budget_investments/_written_by_author.html.erb
@@ -58,6 +58,6 @@
 <%= safe_html_with_links @investment.description %>
 
 <p id="user-tags">
-  <strong><%= t("admin.budget_investments.show.tags") %> del usuario:</strong>
+  <strong><%= t("admin.budget_investments.show.user_tags") %>: </strong>
   <%= @investment.tag_list.sort.join(', ') %>
 </p>

--- a/app/views/admin/budget_investments/_written_by_author.html.erb
+++ b/app/views/admin/budget_investments/_written_by_author.html.erb
@@ -56,3 +56,8 @@
 <% end %>
 
 <%= safe_html_with_links @investment.description %>
+
+<p id="user-tags">
+  <strong><%= t("admin.budget_investments.show.tags") %> del usuario:</strong>
+  <%= @investment.tag_list.sort.join(', ') %>
+</p>

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -19,6 +19,13 @@
     </div>
 
     <div class="small-12 column">
+      <%= f.label :tag_list, t("admin.budget_investments.edit.user_tags") %>
+      <%= f.text_field :tag_list,
+                       value: @investment.tag_list.sort.join(','),
+                       label: false %>
+    </div>
+
+    <div class="small-12 column">
       <%= f.text_field :external_url %>
     </div>
 
@@ -39,7 +46,7 @@
 
 
     <div class="small-12 column">
-      <%= f.label :tag_list, t("admin.budget_investments.edit.tags") %>
+      <%= f.label :valuation_tag_list, t("admin.budget_investments.edit.tags") %>
       <div class="tags">
         <% @tags.each do |tag| %>
           <a class="js-add-tag-link"><%= tag.name %></a>

--- a/app/views/admin/budget_investments/show.html.erb
+++ b/app/views/admin/budget_investments/show.html.erb
@@ -19,7 +19,7 @@
 <p id="tags">
   <strong><%= t("admin.budget_investments.show.tags") %>:</strong>
 
-  <%= @investment.tags_on(:valuation).pluck(:name).join(', ') %>
+  <%= @investment.tags_on(:valuation).pluck(:name).sort.join(', ') %>
 </p>
 
 <p id="assigned_valuators">

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -157,6 +157,7 @@ en:
         dossier: Dossier
         edit_dossier: Edit dossier
         tags: Tags
+        user_tags: User tags
         undefined: Undefined
         milestone: Milestone
         new_milestone: Create new milestone

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -181,6 +181,7 @@ en:
         assigned_valuators: Valuators
         select_heading: Select heading
         submit_button: Update
+        user_tags: User assigned tags
         tags: Tags
         tags_placeholder: "Write the tags you want separated by commas (,)"
         undefined: Undefined

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -157,6 +157,7 @@ es:
         dossier: Informe
         edit_dossier: Editar informe
         tags: Etiquetas
+        user_tags: Etiquetas del usuario
         undefined: Sin definir
         milestone: Seguimiento
         new_milestone: Crear nuevo hito
@@ -181,7 +182,7 @@ es:
         assigned_valuators: Evaluadores
         select_heading: Seleccionar partida
         submit_button: Actualizar
-        user_tags: Etiquetas asignadas por el usuario        
+        user_tags: Etiquetas asignadas por el usuario
         tags: Etiquetas
         tags_placeholder: "Escribe las etiquetas que desees separadas por comas (,)"
         undefined: Sin definir

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -181,6 +181,7 @@ es:
         assigned_valuators: Evaluadores
         select_heading: Seleccionar partida
         submit_button: Actualizar
+        user_tags: Etiquetas asignadas por el usuario        
         tags: Etiquetas
         tags_placeholder: "Escribe las etiquetas que desees separadas por comas (,)"
         undefined: Sin definir

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -421,20 +421,37 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Only displays valuation tags" do
+    scenario "Changes valuation and user generated tags" do
       budget_investment = create(:budget_investment, tag_list: 'Park')
       budget_investment.set_tag_list_on(:valuation, 'Education')
       budget_investment.save
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
 
-      expect(page).to     have_content "Education"
-      expect(page).to_not have_content "Park"
+      within("#user-tags") do
+        expect(page).to_not have_content "Education"
+        expect(page).to have_content "Park"
+      end
 
       click_link 'Edit classification'
 
-      expect(page).to     have_content "Education"
-      expect(page).to_not have_content "Park"
+      fill_in 'budget_investment_tag_list', with: 'Park, Trees'
+      fill_in 'budget_investment_valuation_tag_list', with: 'Education, Environment'
+      click_button 'Update'
+
+      visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
+
+      within("#user-tags") do
+        expect(page).to_not have_content "Education"
+        expect(page).to_not have_content "Environment"
+        expect(page).to have_content "Park, Trees"
+      end
+
+      within("#tags") do
+        expect(page).to have_content "Education, Environment"
+        expect(page).to_not have_content "Park"
+        expect(page).to_not have_content "Trees"
+      end
     end
 
     scenario "Maintains user tags" do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1946

What
====
- Adds investment's user generated tags to admin interface

How
===
- Following the implementation done in [Madrid's fork](http://github.com)

Why
====

There are two kind of tags related to budget investments:

- User tags
- Valuation tags

User tags are the ones added by users when they create an investment.

Valuation tags, are used to internally tag investments.

Case example:

- The Health area of the Government, deals with internal tags for “hospitals and ambulances”
- The Culture area of the Government, deals with internal tags for “theatres and street music”
