### PR TITLE
Officing tests improvements

### DIFF
--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -17,8 +17,6 @@ class Officing::VotersController < Officing::BaseController
                              origin: "booth",
                              officer: current_user.poll_officer)
     @voter.save!
-
-    render 'create.js'
   end
 
   private

--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -17,6 +17,8 @@ class Officing::VotersController < Officing::BaseController
                              origin: "booth",
                              officer: current_user.poll_officer)
     @voter.save!
+
+    render 'create.js'
   end
 
   private

--- a/lib/census_api.rb
+++ b/lib/census_api.rb
@@ -84,7 +84,7 @@ class CensusApi
     end
 
     def stubbed_response(document_type, document_number)
-      if document_number == "12345678Z" && document_type == "1"
+      if (document_number == "12345678Z" || document_number == "12345678Y") && document_type == "1"
         stubbed_valid_response
       else
         stubbed_invalid_response

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -156,7 +156,6 @@ feature 'Poll Officing' do
       page.should have_content("Here you can validate user documents and store voting results")
 
       visit new_officing_residence_path
-      page.should have_content("Validate document")
       within("#side_menu") do
         click_link "Validate document"
       end

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -148,6 +148,8 @@ feature 'Poll Officing' do
       click_button "Confirm vote"
       expect(page).to have_content "Vote introduced!"
 
+      expect(Poll::Voter.where(document_number: '12345678Z').count).to be(1)
+
       visit final_officing_polls_path
       page.should have_content("Polls ready for final recounting")
     end
@@ -166,6 +168,8 @@ feature 'Poll Officing' do
       expect(page).to have_content 'Document verified with Census'
       click_button "Confirm vote"
       expect(page).to have_content "Vote introduced!"
+
+      expect(Poll::Voter.where(document_number: '12345678Y').count).to be(1)
 
       visit final_officing_polls_path
       page.should have_content("Polls ready for final recounting")

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -144,8 +144,7 @@ feature 'Poll Officing' do
       expect(page).to have_content 'Document verified with Census'
       click_button "Confirm vote"
       expect(page).to have_content "Vote introduced!"
-
-      expect(Poll::Voter.where(document_number: '12345678Z').count).to be(1)
+      expect(Poll::Voter.where(document_number: '12345678Z', poll_id: poll, origin: 'booth', officer_id: officer1).count).to be(1)
 
       visit final_officing_polls_path
       page.should have_content("Polls ready for final recounting")
@@ -162,8 +161,7 @@ feature 'Poll Officing' do
       expect(page).to have_content 'Document verified with Census'
       click_button "Confirm vote"
       expect(page).to have_content "Vote introduced!"
-
-      expect(Poll::Voter.where(document_number: '12345678Y').count).to be(1)
+      expect(Poll::Voter.where(document_number: '12345678Y', poll_id: poll, origin: 'booth', officer_id: officer2).count).to be(1)
 
       visit final_officing_polls_path
       page.should have_content("Polls ready for final recounting")

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -107,7 +107,7 @@ feature 'Poll Officing' do
     expect(page).to_not have_css('#moderation_menu')
   end
 
-  scenario 'Officing dashboard available for multiple sessions' do
+  scenario 'Officing dashboard available for multiple sessions', :js do
     poll = create(:poll)
     booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
@@ -137,9 +137,6 @@ feature 'Poll Officing' do
       page.should have_content("Here you can validate user documents and store voting results")
 
       visit new_officing_residence_path
-      within("#side_menu") do
-        click_link "Validate document"
-      end
       select 'DNI', from: 'residence_document_type'
       fill_in 'residence_document_number', with: "12345678Z"
       fill_in 'residence_year_of_birth', with: '1980'
@@ -158,9 +155,6 @@ feature 'Poll Officing' do
       page.should have_content("Here you can validate user documents and store voting results")
 
       visit new_officing_residence_path
-      within("#side_menu") do
-        click_link "Validate document"
-      end
       select 'DNI', from: 'residence_document_type'
       fill_in 'residence_document_number', with: "12345678Y"
       fill_in 'residence_year_of_birth', with: '1980'

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -117,6 +117,9 @@ feature 'Poll Officing' do
     officer1 = create(:poll_officer, user: user1)
     officer2 = create(:poll_officer, user: user2)
 
+    create(:poll_shift, officer: officer1, booth: booth, date: Date.current, task: :vote_collection)
+    create(:poll_shift, officer: officer2, booth: booth, date: Date.current, task: :vote_collection)
+
     officer_assignment_1 = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer1)
     officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer2)
 
@@ -134,7 +137,16 @@ feature 'Poll Officing' do
       page.should have_content("Here you can validate user documents and store voting results")
 
       visit new_officing_residence_path
-      page.should have_content("Validate document")
+      within("#side_menu") do
+        click_link "Validate document"
+      end
+      select 'DNI', from: 'residence_document_type'
+      fill_in 'residence_document_number', with: "12345678Z"
+      fill_in 'residence_year_of_birth', with: '1980'
+      click_button 'Validate document'
+      expect(page).to have_content 'Document verified with Census'
+      click_button "Confirm vote"
+      expect(page).to have_content "Vote introduced!"
 
       visit final_officing_polls_path
       page.should have_content("Polls ready for final recounting")
@@ -145,6 +157,16 @@ feature 'Poll Officing' do
 
       visit new_officing_residence_path
       page.should have_content("Validate document")
+      within("#side_menu") do
+        click_link "Validate document"
+      end
+      select 'DNI', from: 'residence_document_type'
+      fill_in 'residence_document_number', with: "12345678Y"
+      fill_in 'residence_year_of_birth', with: '1980'
+      click_button 'Validate document'
+      expect(page).to have_content 'Document verified with Census'
+      click_button "Confirm vote"
+      expect(page).to have_content "Vote introduced!"
 
       visit final_officing_polls_path
       page.should have_content("Polls ready for final recounting")


### PR DESCRIPTION
Where
=====
* **Related PR's:** https://github.com/consul/consul/pull/2063

What
====
Extended officing tests to ensure two officers assigned to the same booth at the same date can register votes simultaneously without problems.

Introduced a couple of changes in `officing/voters_controller.rb` and `census_api.rb`:
- First one to solve a problem with tests that couldn't find the correct path to a view as its extension is `.js`.
- Second one, added a new default document number to be able to register two _dummy_ votes.

Test
====
As usual.

Deployment
==========
As usual.
