### PR TITLE
Remove valid answers usage

### DIFF
--- a/app/controllers/admin/poll/questions_controller.rb
+++ b/app/controllers/admin/poll/questions_controller.rb
@@ -15,7 +15,6 @@ class Admin::Poll::QuestionsController < Admin::Poll::BaseController
 
   def new
     @polls = Poll.all
-    @question.valid_answers = I18n.t('poll_questions.default_valid_answers')
     proposal = Proposal.find(params[:proposal_id]) if params[:proposal_id].present?
     @question.copy_attributes_from_proposal(proposal)
   end
@@ -56,7 +55,7 @@ class Admin::Poll::QuestionsController < Admin::Poll::BaseController
   private
 
     def question_params
-      params.require(:poll_question).permit(:poll_id, :title, :question, :proposal_id, :valid_answers, :video_url)
+      params.require(:poll_question).permit(:poll_id, :title, :question, :proposal_id, :video_url)
     end
 
     def search_params

--- a/app/controllers/officing/results_controller.rb
+++ b/app/controllers/officing/results_controller.rb
@@ -51,7 +51,7 @@ class Officing::ResultsController < Officing::BaseController
 
         results.each_pair do |answer_index, count|
           next if count.blank?
-          answer = question.valid_answers[answer_index.to_i]
+          answer = question.question_answers.where(given_order: answer_index.to_i + 1).first.title
           go_back_to_new if question.blank?
 
           partial_result = ::Poll::PartialResult.find_or_initialize_by(booth_assignment_id: @officer_assignment.booth_assignment_id,

--- a/app/models/poll/answer.rb
+++ b/app/models/poll/answer.rb
@@ -9,7 +9,8 @@ class Poll::Answer < ActiveRecord::Base
   validates :author, presence: true
   validates :answer, presence: true
 
-  validates :answer, inclusion: { in: ->(a) { a.question.question_answers.pluck(:title) }}
+  validates :answer, inclusion: { in: ->(a) { a.question.question_answers.pluck(:title) }},
+                     unless: ->(a) { a.question.blank? }
 
   scope :by_author, ->(author_id) { where(author_id: author_id) }
   scope :by_question, ->(question_id) { where(question_id: question_id) }

--- a/app/models/poll/answer.rb
+++ b/app/models/poll/answer.rb
@@ -9,9 +9,7 @@ class Poll::Answer < ActiveRecord::Base
   validates :author, presence: true
   validates :answer, presence: true
 
-  # temporary skipping validation, review when removing valid_answers
-  # validates :answer, inclusion: { in: ->(a) { a.question.valid_answers }},
-  #                                unless: ->(a) { a.question.blank? }
+  validates :answer, inclusion: { in: ->(a) { a.question.question_answers.pluck(:title) }}
 
   scope :by_author, ->(author_id) { where(author_id: author_id) }
   scope :by_question, ->(question_id) { where(question_id: question_id) }

--- a/app/models/poll/partial_result.rb
+++ b/app/models/poll/partial_result.rb
@@ -10,7 +10,7 @@ class Poll::PartialResult < ActiveRecord::Base
   validates :question, presence: true
   validates :author, presence: true
   validates :answer, presence: true
-  validates :answer, inclusion: {in: ->(a) { a.question.valid_answers }}
+  validates :answer, inclusion: {in: ->(a) { a.question.question_answers.pluck(:title) }}
   validates :origin, inclusion: {in: VALID_ORIGINS}
 
   scope :by_author, ->(author_id) { where(author_id: author_id) }

--- a/app/models/poll/partial_result.rb
+++ b/app/models/poll/partial_result.rb
@@ -10,8 +10,9 @@ class Poll::PartialResult < ActiveRecord::Base
   validates :question, presence: true
   validates :author, presence: true
   validates :answer, presence: true
-  validates :answer, inclusion: {in: ->(a) { a.question.question_answers.pluck(:title) }}
-  validates :origin, inclusion: {in: VALID_ORIGINS}
+  validates :answer, inclusion: { in: ->(a) { a.question.question_answers.pluck(:title) }},
+                     unless: ->(a) { a.question.blank? }
+  validates :origin, inclusion: { in: VALID_ORIGINS }
 
   scope :by_author, ->(author_id) { where(author_id: author_id) }
   scope :by_question, ->(question_id) { where(question_id: question_id) }

--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -39,17 +39,12 @@ class Poll::Question < ActiveRecord::Base
       author_visible_name   => 'C' }
   end
 
-  def valid_answers
-    (super.try(:split, ',')&.compact || []).map(&:strip)
-  end
-
   def copy_attributes_from_proposal(proposal)
     if proposal.present?
       self.author = proposal.author
       self.author_visible_name = proposal.author.name
       self.proposal_id = proposal.id
       self.title = proposal.title
-      self.valid_answers = I18n.t('poll_questions.default_valid_answers')
     end
   end
 

--- a/app/views/admin/poll/results/index.html.erb
+++ b/app/views/admin/poll/results/index.html.erb
@@ -37,11 +37,11 @@
           </tr>
         </thead>
         <tbody>
-          <% question.valid_answers.each_with_index do |answer, i| %>
+          <% question.question_answers.each_with_index do |answer, i| %>
             <% by_answer = by_question[question.id].present? ? by_question[question.id].group_by(&:answer) : {} %>
             <tr id="question_<%= question.id %>_<%= i %>_result">
-              <td><%= answer %></td>
-              <td class="text-center"><%= by_answer[answer].present? ? by_answer[answer].sum(&:amount) : 0 %></td>
+              <td><%= answer.title %></td>
+              <td class="text-center"><%= by_answer[answer.title].present? ? by_answer[answer.title].sum(&:amount) : 0 %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/officing/results/index.html.erb
+++ b/app/views/officing/results/index.html.erb
@@ -40,11 +40,11 @@
             </tr>
           </thead>
           <tbody>
-            <% question.valid_answers.each_with_index do |answer, i| %>
+            <% question.question_answers.each_with_index do |answer, i| %>
               <% by_answer = by_question[question.id].present? ? by_question[question.id].group_by(&:answer) : {} %>
               <tr id="question_<%= question.id %>_<%= i %>_result">
-                <td><%= answer %></td>
-                <td><%= by_answer[answer].present? ? by_answer[answer].first.amount : 0 %></td>
+                <td><%= answer.title %></td>
+                <td><%= by_answer[answer.title].present? ? by_answer[answer.title].first.amount : 0 %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/officing/results/new.html.erb
+++ b/app/views/officing/results/new.html.erb
@@ -27,9 +27,9 @@
         <div class="small-12 column">
           <h3><%= question.title %></h3>
         </div>
-        <% question.valid_answers.each_with_index do |answer, i| %>
+        <% question.question_answers.each_with_index do |answer, i| %>
           <div class="small-12 medium-6 large-3 column end">
-            <label><%= answer %></label>
+            <label><%= answer.title %></label>
             <%= text_field_tag "questions[#{question.id}][#{i}]", answer_result_value(question.id, i), placeholder: "0" %>
           </div>
         <% end %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -156,7 +156,6 @@ en:
         description: "Description"
       poll/question:
         title: "Question"
-        valid_answers: "Posibles answers"
         summary: "Summary"
         description: "Description"
         external_url: "Link to additional documentation"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -500,7 +500,6 @@ en:
       videos: "External video"
   poll_questions:
     create_question: "Create question"
-    default_valid_answers: "Yes, No"
     show:
       vote_answer: "Vote %{answer}"
       voted: "You have voted %{answer}"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -150,7 +150,6 @@ es:
         description: "Descripción"
       poll/question:
         title: "Pregunta"
-        valid_answers: "Posibles respuestas"
         summary: "Resumen"
         description: "Descripción"
         external_url: "Enlace a documentación adicional"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -500,7 +500,6 @@ es:
       videos: "Vídeo externo"
   poll_questions:
     create_question: "Crear pregunta para votación"
-    default_valid_answers: "Sí, No"
     show:
       vote_answer: "Votar %{answer}"
       voted: "Has votado %{answer}"

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -73,7 +73,7 @@ def create_user(email, username = Faker::Name.name)
     confirmed_at:           Time.current,
     terms_of_service:       "1",
     gender:                 ['Male', 'Female'].sample,
-    date_of_birth:          rand((Time.current - 80.years) .. (Time.current - 16.years)),
+    date_of_birth:          rand((Time.current - 80.years)..(Time.current - 16.years)),
     public_activity:        (rand(1..100) > 30)
   )
 end
@@ -127,7 +127,7 @@ end
   user = create_user("user#{i}@consul.dev")
   level = [1, 2, 3].sample
   if level >= 2
-    user.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_number: Faker::Number.number(10), document_type: "1", geozone:  Geozone.reorder("RANDOM()").first)
+    user.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_number: Faker::Number.number(10), document_type: "1", geozone: Geozone.reorder("RANDOM()").first)
   end
   if level == 3
     user.update(verified_at: Time.current, document_number: Faker::Number.number(10))
@@ -319,7 +319,7 @@ end
 end
 
 100.times do
-  voter  = not_org_users.level_two_or_three_verified.reorder("RANDOM()").first
+  voter = not_org_users.level_two_or_three_verified.reorder("RANDOM()").first
   proposal = Proposal.reorder("RANDOM()").first
   proposal.vote_by(voter: voter, vote: true)
 end
@@ -504,7 +504,7 @@ Proposal.last(3).each do |proposal|
                                   "banner-img banner-img-three"].sample,
                           target_url: Rails.application.routes.url_helpers.proposal_path(proposal),
                           post_started_at: rand((Time.current - 1.week)..(Time.current - 1.day)),
-                          post_ended_at:   rand((Time.current  - 1.day)..(Time.current + 1.week)),
+                          post_ended_at:   rand((Time.current - 1.day)..(Time.current + 1.week)),
                           created_at: rand((Time.current - 1.week)..Time.current))
 end
 
@@ -561,13 +561,11 @@ print "Creating Poll Questions"
   author = User.reorder("RANDOM()").first
   description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
   open_at = rand(2.months.ago..2.months.from_now)
-  answers = Faker::Lorem.words((2..4).to_a.sample).map { |answer| answer.capitalize }
   question = Poll::Question.create!(author: author,
                                     title: Faker::Lorem.sentence(3).truncate(60),
-                                    valid_answers: answers.join(', '),
                                     poll: poll)
-  answers.each do |answer|
-    Poll::Question::Answer.create!(question: question, title: answer, description: Faker::ChuckNorris.fact)
+  Faker::Lorem.words((2..4).to_a.sample).each do |answer|
+    Poll::Question::Answer.create!(question: question, title: answer.capitalize, description: Faker::ChuckNorris.fact)
   end
 end
 
@@ -599,7 +597,10 @@ print "Creating Poll Questions from Proposals"
 3.times do
   proposal = Proposal.reorder("RANDOM()").first
   poll = Poll.current.first
-  question = Poll::Question.create(valid_answers: "Yes, No", poll: poll)
+  question = Poll::Question.create(poll: poll)
+  Faker::Lorem.words((2..4).to_a.sample).each do |answer|
+    Poll::Question::Answer.create!(question: question, title: answer.capitalize, description: Faker::ChuckNorris.fact)
+  end
   question.copy_attributes_from_proposal(proposal)
   question.save!
 end
@@ -610,7 +611,10 @@ print "Creating Successful Proposals"
 10.times do
   proposal = Proposal.reorder("RANDOM()").first
   poll = Poll.current.first
-  question = Poll::Question.create(valid_answers: "Yes, No", poll: poll)
+  question = Poll::Question.create(poll: poll)
+  Faker::Lorem.words((2..4).to_a.sample).each do |answer|
+    Poll::Question::Answer.create!(question: question, title: answer.capitalize, description: Faker::ChuckNorris.fact)
+  end
   question.copy_attributes_from_proposal(proposal)
   question.save!
 end
@@ -656,8 +660,7 @@ print "Creating legislation processes"
                                            allegations_phase_enabled: true,
                                            draft_publication_enabled: true,
                                            result_publication_enabled: true,
-                                           published: true
-  )
+                                           published: true)
 end
 
 ::Legislation::Process.all.each do |process|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -503,7 +503,6 @@ FactoryGirl.define do
     poll
     association :author, factory: :user
     sequence(:title) { |n| "Question title #{n}" }
-    valid_answers { Faker::Lorem.words(3).join(', ') }
   end
 
   factory :poll_question_answer, class: 'Poll::Question::Answer' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -576,14 +576,14 @@ FactoryGirl.define do
   factory :poll_answer, class: 'Poll::Answer' do
     association :question, factory: :poll_question
     association :author, factory: [:user, :level_two]
-    answer { question.valid_answers.sample }
+    answer { question.question_answers.sample.title }
   end
 
   factory :poll_partial_result, class: 'Poll::PartialResult' do
     association :question, factory: :poll_question
     association :author, factory: :user
     origin { 'web' }
-    answer { question.valid_answers.sample }
+    answer { question.question_answers.sample.title }
   end
 
   factory :poll_recount, class: 'Poll::Recount' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -503,6 +503,13 @@ FactoryGirl.define do
     poll
     association :author, factory: :user
     sequence(:title) { |n| "Question title #{n}" }
+
+    trait :with_answers do
+      after(:create) do |question, _evaluator|
+        create(:poll_question_answer, question: question, title: "Yes")
+        create(:poll_question_answer, question: question, title: "No")
+      end
+    end
   end
 
   factory :poll_question_answer, class: 'Poll::Question::Answer' do
@@ -573,13 +580,13 @@ FactoryGirl.define do
   end
 
   factory :poll_answer, class: 'Poll::Answer' do
-    association :question, factory: :poll_question
+    association :question, factory: [:poll_question, :with_answers]
     association :author, factory: [:user, :level_two]
     answer { question.question_answers.sample.title }
   end
 
   factory :poll_partial_result, class: 'Poll::PartialResult' do
-    association :question, factory: :poll_question
+    association :question, factory: [:poll_question, :with_answers]
     association :author, factory: :user
     origin { 'web' }
     answer { question.question_answers.sample.title }

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -279,7 +279,8 @@ feature 'Admin polls' do
         create(:poll_recount,
                booth_assignment: booth_assignment_1,
                white_amount: 21,
-               null_amount: 44)
+               null_amount: 44,
+               total_amount: 66)
 
         visit admin_poll_path(poll)
 
@@ -303,6 +304,7 @@ feature 'Admin polls' do
 
         within('#white_results') { expect(page).to have_content('21') }
         within('#null_results') { expect(page).to have_content('44') }
+        within('#total_results') { expect(page).to have_content('66') }
       end
     end
   end

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -261,8 +261,13 @@ feature 'Admin polls' do
         booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
         booth_assignment_3 = create(:poll_booth_assignment, poll: poll)
 
-        question_1 = create(:poll_question, poll: poll, valid_answers: "Yes,No")
-        question_2 = create(:poll_question, poll: poll, valid_answers: "Today,Tomorrow")
+        question_1 = create(:poll_question, poll: poll)
+        create(:poll_question_answer, title: 'Yes', question: question_1)
+        create(:poll_question_answer, title: 'No', question: question_1)
+
+        question_2 = create(:poll_question, poll: poll)
+        create(:poll_question_answer, title: 'Today', question: question_2)
+        create(:poll_question_answer, title: 'Tomorrow', question: question_2)
 
         [booth_assignment_1, booth_assignment_2, booth_assignment_3].each do |ba|
           create(:poll_partial_result,
@@ -287,17 +292,17 @@ feature 'Admin polls' do
         click_link "Results"
 
         expect(page).to have_content(question_1.title)
-        question_1.valid_answers.each_with_index do |answer, i|
+        question_1.question_answers.each_with_index do |answer, i|
           within("#question_#{question_1.id}_#{i}_result") do
-            expect(page).to have_content(answer)
+            expect(page).to have_content(answer.title)
             expect(page).to have_content([33, 0][i])
           end
         end
 
         expect(page).to have_content(question_2.title)
-        question_2.valid_answers.each_with_index do |answer, i|
+        question_2.question_answers.each_with_index do |answer, i|
           within("#question_#{question_2.id}_#{i}_result") do
-            expect(page).to have_content(answer)
+            expect(page).to have_content(answer.title)
             expect(page).to have_content([0, 15][i])
           end
         end

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -7,8 +7,13 @@ feature 'Officing Results' do
     @officer_assignment = create(:poll_officer_assignment, :final, officer: @poll_officer)
     @poll = @officer_assignment.booth_assignment.poll
     @poll.update(ends_at: 1.day.ago)
-    @question_1 = create(:poll_question, poll: @poll, valid_answers: "Yes,No")
-    @question_2 = create(:poll_question, poll: @poll, valid_answers: "Today,Tomorrow")
+    @question_1 = create(:poll_question, poll: @poll)
+    create(:poll_question_answer, title: 'Yes', question: @question_1)
+    create(:poll_question_answer, title: 'No', question: @question_1)
+    @question_2 = create(:poll_question, poll: @poll)
+    create(:poll_question_answer, title: 'Today', question: @question_2)
+    create(:poll_question_answer, title: 'Tomorrow', question: @question_2)
+
     login_as(@poll_officer.user)
   end
 
@@ -83,7 +88,7 @@ feature 'Officing Results' do
                       booth_assignment: @officer_assignment.booth_assignment,
                       date: @poll.starts_at,
                       question: @question_1,
-                      answer: @question_1.valid_answers[0],
+                      answer: @question_1.question_answers.first.title,
                       author: @poll_officer.user,
                       amount: 7777)
 
@@ -143,13 +148,13 @@ feature 'Officing Results' do
     expect(page).to have_content(@officer_assignment.booth_assignment.booth.name)
 
     expect(page).to have_content(@question_1.title)
-    @question_1.valid_answers.each_with_index do |answer, i|
-      within("#question_#{@question_1.id}_#{i}_result") { expect(page).to have_content(answer) }
+    @question_1.question_answers.each_with_index do |answer, i|
+      within("#question_#{@question_1.id}_#{i}_result") { expect(page).to have_content(answer.title) }
     end
 
     expect(page).to have_content(@question_2.title)
-    @question_2.valid_answers.each_with_index do |answer, i|
-      within("#question_#{@question_2.id}_#{i}_result") { expect(page).to have_content(answer) }
+    @question_2.question_answers.each_with_index do |answer, i|
+      within("#question_#{@question_2.id}_#{i}_result") { expect(page).to have_content(answer.title) }
     end
 
     within('#white_results') { expect(page).to have_content('21') }

--- a/spec/models/poll/answer_spec.rb
+++ b/spec/models/poll/answer_spec.rb
@@ -43,7 +43,7 @@ describe Poll::Answer do
 
     let(:author) { create(:user, :level_two) }
     let(:poll) { create(:poll) }
-    let(:question) { create(:poll_question, poll: poll) }
+    let(:question) { create(:poll_question, :with_answers, poll: poll) }
 
     it "creates a poll_voter with user and poll data" do
       answer = create(:poll_answer, question: question, author: author, answer: "Yes")

--- a/spec/models/poll/answer_spec.rb
+++ b/spec/models/poll/answer_spec.rb
@@ -25,9 +25,12 @@ describe Poll::Answer do
       expect(answer).to_not be_valid
     end
 
-    it "should be valid for answers included in the Poll::Question's list" do
-      skip "review when removing valid_answers"
-      question = create(:poll_question, valid_answers: 'One, Two, Three')
+    it "should be valid for answers included in the Poll::Question's question_answers list" do
+      question = create(:poll_question)
+      create(:poll_question_answer, title: 'One', question: question)
+      create(:poll_question_answer, title: 'Two', question: question)
+      create(:poll_question_answer, title: 'Three', question: question)
+
       expect(build(:poll_answer, question: question, answer: 'One')).to be_valid
       expect(build(:poll_answer, question: question, answer: 'Two')).to be_valid
       expect(build(:poll_answer, question: question, answer: 'Three')).to be_valid
@@ -40,7 +43,7 @@ describe Poll::Answer do
 
     let(:author) { create(:user, :level_two) }
     let(:poll) { create(:poll) }
-    let(:question) { create(:poll_question, poll: poll, valid_answers: "Yes, No") }
+    let(:question) { create(:poll_question, poll: poll) }
 
     it "creates a poll_voter with user and poll data" do
       answer = create(:poll_answer, question: question, author: author, answer: "Yes")

--- a/spec/models/poll/partial_result_spec.rb
+++ b/spec/models/poll/partial_result_spec.rb
@@ -4,12 +4,16 @@ describe Poll::PartialResult do
 
   describe "validations" do
     it "validates that the answers are included in the Poll::Question's list" do
-      q = create(:poll_question, valid_answers: 'One, Two, Three')
-      expect(build(:poll_partial_result, question: q, answer: 'One')).to be_valid
-      expect(build(:poll_partial_result, question: q, answer: 'Two')).to be_valid
-      expect(build(:poll_partial_result, question: q, answer: 'Three')).to be_valid
+      question = create(:poll_question)
+      create(:poll_question_answer, title: 'One', question: question)
+      create(:poll_question_answer, title: 'Two', question: question)
+      create(:poll_question_answer, title: 'Three', question: question)
 
-      expect(build(:poll_partial_result, question: q, answer: 'Four')).to_not be_valid
+      expect(build(:poll_partial_result, question: question, answer: 'One')).to be_valid
+      expect(build(:poll_partial_result, question: question, answer: 'Two')).to be_valid
+      expect(build(:poll_partial_result, question: question, answer: 'Three')).to be_valid
+
+      expect(build(:poll_partial_result, question: question, answer: 'Four')).to_not be_valid
     end
   end
 

--- a/spec/models/poll/question_spec.rb
+++ b/spec/models/poll/question_spec.rb
@@ -3,13 +3,6 @@ require 'rails_helper'
 RSpec.describe Poll::Question, type: :model do
   let(:poll_question) { build(:poll_question) }
 
-  describe "#valid_answers" do
-    it "gets a comma-separated string, but returns an array" do
-      poll_question.valid_answers = "Yes, No"
-      expect(poll_question.valid_answers).to eq(["Yes", "No"])
-    end
-  end
-
   describe "#poll_question_id" do
     it "should be invalid if a poll is not selected" do
       poll_question.poll_id = nil
@@ -27,7 +20,6 @@ RSpec.describe Poll::Question, type: :model do
       create_list(:geozone, 3)
       p = create(:proposal)
       poll_question.copy_attributes_from_proposal(p)
-      expect(poll_question.valid_answers).to eq(['Yes', 'No'])
       expect(poll_question.author).to eq(p.author)
       expect(poll_question.author_visible_name).to eq(p.author.name)
       expect(poll_question.proposal_id).to eq(p.id)


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2072
* **Related PR's:** https://github.com/consul/consul/pull/2074

What
====
- Remove deprecated Poll::Question's `valid_answers` attribute and fix its usage to `Poll::Question::Answer`

How
===
Reviewing all usages, replacing most of them for `.question_answers` and fixing the specs & factories & dev_seeds

Screenshots
===========
No need, underneath changes only.

Test
====
Fixed to use question_answers instead
 
Deployment
==========
⚠️  Need a tmp rake to migrate from existing `valid_answers` to new `Poll::Question::Answer` or https://github.com/consul/consul/pull/2074 will destroy all values before they can be saved

Warnings
========
None