### PR TITLE
[FROZEN] Remove deprecated Poll::Question valid_answers attribute

### DIFF
--- a/db/migrate/20171017221546_remove_poll_question_valid_answers.rb
+++ b/db/migrate/20171017221546_remove_poll_question_valid_answers.rb
@@ -1,0 +1,5 @@
+class RemovePollQuestionValidAnswers < ActiveRecord::Migration
+  def change
+    remove_column :poll_questions, :valid_answers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171010143623) do
+ActiveRecord::Schema.define(version: 20171017221546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -676,7 +676,6 @@ ActiveRecord::Schema.define(version: 20171010143623) do
     t.integer  "author_id"
     t.string   "author_visible_name"
     t.string   "title"
-    t.string   "valid_answers"
     t.integer  "comments_count"
     t.datetime "hidden_at"
     t.datetime "created_at"


### PR DESCRIPTION
Where
=====
* **Related Issues:** https://github.com/consul/consul/issues/2072
* **Related PR's:** https://github.com/consul/consul/pull/2073

What
====
Remove deprecated column from Poll::Question

How
===
Just a migration

Screenshots
===========
No need

Test
====
No need

Deployment
==========
Remember to check https://github.com/consul/consul/pull/2073 "Deployment" 

Warnings
========
⚠️  This PR needs https://github.com/consul/consul/pull/2073 to be merged before!