### PR TITLE
Polls - Admin booth results

### DIFF
--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -19,6 +19,7 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
                                                          officer_assignments: [officer: [:user]]).find(params[:id])
     @voters_by_date = @booth_assignment.voters.group_by {|v| v.created_at.to_date}
     @partial_results = @booth_assignment.partial_results
+    @recounts = @booth_assignment.recounts
   end
 
   def create

--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -18,6 +18,7 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
     @booth_assignment = @poll.booth_assignments.includes(:recounts, :voters,
                                                          officer_assignments: [officer: [:user]]).find(params[:id])
     @voters_by_date = @booth_assignment.voters.group_by {|v| v.created_at.to_date}
+    @partial_results = @booth_assignment.partial_results
   end
 
   def create

--- a/app/views/admin/poll/booth_assignments/_results.html.erb
+++ b/app/views/admin/poll/booth_assignments/_results.html.erb
@@ -6,7 +6,7 @@
       <%= t("admin.results.index.no_results") %>
     </div>
   <% else %>
-  	<%= render "admin/poll/results/recount", resource: @booth_assignment %>
+    <%= render "admin/poll/results/recount", resource: @booth_assignment %>
     <%= render "admin/poll/results/result" %>
   <% end %>
 </div>

--- a/app/views/admin/poll/booth_assignments/_results.html.erb
+++ b/app/views/admin/poll/booth_assignments/_results.html.erb
@@ -1,0 +1,11 @@
+<div id="poll-resources">
+  <h3><%= t("admin.results.index.title") %></h3>
+
+  <% if @partial_results.empty? %>
+    <div class="callout primary margin-top">
+      <%= t("admin.results.index.no_results") %>
+    </div>
+  <% else %>
+    <%= render "admin/poll/results/result" %>
+  <% end %>
+</div>

--- a/app/views/admin/poll/booth_assignments/_results.html.erb
+++ b/app/views/admin/poll/booth_assignments/_results.html.erb
@@ -6,6 +6,7 @@
       <%= t("admin.results.index.no_results") %>
     </div>
   <% else %>
+  	<%= render "admin/poll/results/recount", resource: @booth_assignment %>
     <%= render "admin/poll/results/result" %>
   <% end %>
 </div>

--- a/app/views/admin/poll/booth_assignments/show.html.erb
+++ b/app/views/admin/poll/booth_assignments/show.html.erb
@@ -17,8 +17,11 @@
     <li class="tabs-title">
       <%= link_to t("admin.poll_booth_assignments.show.officers"), "#tab-officers" %>
     </li>
-    <li class="tabs-title is-active">
+    <li class="tabs-title">
       <%= link_to t("admin.poll_booth_assignments.show.recounts"), "#tab-recounts" %>
+    </li>
+    <li class="tabs-title">
+      <%= link_to "Results", "#tab-results" %>
     </li>
   </ul>
 
@@ -43,7 +46,7 @@
     <% end %>
   </div>
 
-  <div class="tabs-panel is-active" id="tab-recounts">
+  <div class="tabs-panel" id="tab-recounts">
     <h3><%= t("admin.poll_booth_assignments.show.recounts_list") %></h3>
 
     <table id="totals">
@@ -55,8 +58,12 @@
       </thead>
       <tbody>
         <tr>
-          <td class="text-center" id="total_final"><%= total_recounts_by_booth(@booth_assignment) || '-'  %></td>
-          <td class="text-center" id="total_system"><%= @booth_assignment.voters.count %></td>
+          <td class="text-center" id="total_final">
+            <%= total_recounts_by_booth(@booth_assignment) || '-'  %>
+          </td>
+          <td class="text-center" id="total_system">
+            <%= @booth_assignment.voters.count %>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -78,5 +85,8 @@
       <% end %>
       </tbody>
     </table>
+  </div>
+  <div class="tabs-panel is-active" id="tab-results">
+    <%= render "results" %>
   </div>
 </div>

--- a/app/views/admin/poll/booth_assignments/show.html.erb
+++ b/app/views/admin/poll/booth_assignments/show.html.erb
@@ -21,7 +21,7 @@
       <%= link_to t("admin.poll_booth_assignments.show.recounts"), "#tab-recounts" %>
     </li>
     <li class="tabs-title">
-      <%= link_to "Results", "#tab-results" %>
+      <%= link_to t("admin.poll_booth_assignments.show.results"), "#tab-results" %>
     </li>
   </ul>
 

--- a/app/views/admin/poll/booth_assignments/show.html.erb
+++ b/app/views/admin/poll/booth_assignments/show.html.erb
@@ -20,7 +20,7 @@
     <li class="tabs-title">
       <%= link_to t("admin.poll_booth_assignments.show.recounts"), "#tab-recounts" %>
     </li>
-    <li class="tabs-title">
+    <li class="tabs-title is-active">
       <%= link_to t("admin.poll_booth_assignments.show.results"), "#tab-results" %>
     </li>
   </ul>

--- a/app/views/admin/poll/results/_recount.html.erb
+++ b/app/views/admin/poll/results/_recount.html.erb
@@ -1,0 +1,14 @@
+<table class="margin">
+  <thead>
+    <th><%= t("admin.results.result.table_whites") %></th>
+    <th><%= t("admin.results.result.table_nulls") %></th>
+    <th><%= t("admin.results.result.table_total") %></th>
+  </thead>
+  <tbody>
+    <tr>
+      <td id="white_results"><%= resource.recounts.sum(:white_amount) %></td>
+      <td id="null_results"><%= resource.recounts.sum(:null_amount) %></td>
+      <td id="total_results"><%= resource.recounts.sum(:total_amount) %></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/admin/poll/results/_result.html.erb
+++ b/app/views/admin/poll/results/_result.html.erb
@@ -1,8 +1,8 @@
 <table class="margin">
   <thead>
-    <th><%= t("admin.results.index.table_whites") %></th>
-    <th><%= t("admin.results.index.table_nulls") %></th>
-    <th><%= t("admin.results.index.table_total") %></th>
+    <th><%= t("admin.results.result.table_whites") %></th>
+    <th><%= t("admin.results.result.table_nulls") %></th>
+    <th><%= t("admin.results.result.table_total") %></th>
   </thead>
   <tbody>
     <tr>
@@ -20,8 +20,8 @@
   <table class="margin">
     <thead>
       <tr>
-        <th><%= t("admin.results.index.table_answer") %></th>
-        <th class="text-center"><%= t("admin.results.index.table_votes") %></th>
+        <th><%= t("admin.results.result.table_answer") %></th>
+        <th class="text-center"><%= t("admin.results.result.table_votes") %></th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/admin/poll/results/_result.html.erb
+++ b/app/views/admin/poll/results/_result.html.erb
@@ -1,19 +1,3 @@
-<table class="margin">
-  <thead>
-    <th><%= t("admin.results.result.table_whites") %></th>
-    <th><%= t("admin.results.result.table_nulls") %></th>
-    <th><%= t("admin.results.result.table_total") %></th>
-  </thead>
-  <tbody>
-    <tr>
-      <td id="white_results"><%= @poll.recounts.sum(:white_amount) %></td>
-      <td id="null_results"><%= @poll.recounts.sum(:null_amount) %></td>
-      <td id="total_results"><%= @poll.recounts.sum(:total_amount) %></td>
-    </tr>
-  </tbody>
-</table>
-
-
 <% by_question = @partial_results.group_by(&:question_id) %>
 <% @poll.questions.each do |question| %>
   <h3><%= question.title %></h3>

--- a/app/views/admin/poll/results/_result.html.erb
+++ b/app/views/admin/poll/results/_result.html.erb
@@ -1,0 +1,37 @@
+<table class="margin">
+  <thead>
+    <th><%= t("admin.results.index.table_whites") %></th>
+    <th><%= t("admin.results.index.table_nulls") %></th>
+    <th><%= t("admin.results.index.table_total") %></th>
+  </thead>
+  <tbody>
+    <tr>
+      <td id="white_results"><%= @poll.recounts.sum(:white_amount) %></td>
+      <td id="null_results"><%= @poll.recounts.sum(:null_amount) %></td>
+      <td id="total_results"><%= @poll.recounts.sum(:total_amount) %></td>
+    </tr>
+  </tbody>
+</table>
+
+
+<% by_question = @partial_results.group_by(&:question_id) %>
+<% @poll.questions.each do |question| %>
+  <h3><%= question.title %></h3>
+  <table class="margin">
+    <thead>
+      <tr>
+        <th><%= t("admin.results.index.table_answer") %></th>
+        <th class="text-center"><%= t("admin.results.index.table_votes") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% question.question_answers.each_with_index do |answer, i| %>
+        <% by_answer = by_question[question.id].present? ? by_question[question.id].group_by(&:answer) : {} %>
+        <tr id="question_<%= question.id %>_<%= i %>_result">
+          <td><%= answer.title %></td>
+          <td class="text-center"><%= by_answer[answer.title].present? ? by_answer[answer.title].sum(&:amount) : 0 %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/admin/poll/results/_results_by_booth.html.erb
+++ b/app/views/admin/poll/results/_results_by_booth.html.erb
@@ -1,0 +1,19 @@
+<table class="margin" id="booth_assignment_results">
+  <thead>
+    <tr>
+      <th>Urna</th>
+      <th class="text-center">Resultados</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @poll.booth_assignments.each do |booth_assignment| %>
+      <tr id="booth_assignment_<%= booth_assignment.id %>_result">
+        <td><%= booth_assignment.booth.name %></td>
+        <td class="text-center">
+          <%= link_to "See results", 
+                			admin_poll_booth_assignment_path(@poll, booth_assignment, anchor: "tab-results") %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/poll/results/_results_by_booth.html.erb
+++ b/app/views/admin/poll/results/_results_by_booth.html.erb
@@ -11,9 +11,8 @@
       <tr id="booth_assignment_<%= booth_assignment.id %>_result">
         <td><%= booth_assignment.booth.name %></td>
         <td class="text-center">
-          <%= link_to t("admin.results.results_by_booth.see_results"), 
-                			admin_poll_booth_assignment_path(@poll, booth_assignment, 
-                																			 anchor: "tab-results") %>
+          <%= link_to t("admin.results.results_by_booth.see_results"),
+                      admin_poll_booth_assignment_path(@poll, booth_assignment, anchor: "tab-results") %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/poll/results/_results_by_booth.html.erb
+++ b/app/views/admin/poll/results/_results_by_booth.html.erb
@@ -6,7 +6,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @poll.booth_assignments.each do |booth_assignment| %>
+    <% @poll.booth_assignments.sort_by {|ba| ba.booth.name }.each do |booth_assignment| %>
       <tr id="booth_assignment_<%= booth_assignment.id %>_result">
         <td><%= booth_assignment.booth.name %></td>
         <td class="text-center">

--- a/app/views/admin/poll/results/_results_by_booth.html.erb
+++ b/app/views/admin/poll/results/_results_by_booth.html.erb
@@ -1,4 +1,5 @@
-<table class="margin" id="booth_assignment_results">
+<h3><%= t("admin.results.results_by_booth.title") %></h3>
+  <table class="margin" id="booth_assignment_results">
   <thead>
     <tr>
       <th><%= t("admin.results.results_by_booth.booth") %></th>

--- a/app/views/admin/poll/results/_results_by_booth.html.erb
+++ b/app/views/admin/poll/results/_results_by_booth.html.erb
@@ -1,8 +1,8 @@
 <table class="margin" id="booth_assignment_results">
   <thead>
     <tr>
-      <th>Urna</th>
-      <th class="text-center">Resultados</th>
+      <th><%= t("admin.results.results_by_booth.booth") %></th>
+      <th class="text-center"><%= t("admin.results.results_by_booth.results") %></th>
     </tr>
   </thead>
   <tbody>
@@ -10,8 +10,9 @@
       <tr id="booth_assignment_<%= booth_assignment.id %>_result">
         <td><%= booth_assignment.booth.name %></td>
         <td class="text-center">
-          <%= link_to "See results", 
-                			admin_poll_booth_assignment_path(@poll, booth_assignment, anchor: "tab-results") %>
+          <%= link_to t("admin.results.results_by_booth.see_results"), 
+                			admin_poll_booth_assignment_path(@poll, booth_assignment, 
+                																			 anchor: "tab-results") %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/poll/results/index.html.erb
+++ b/app/views/admin/poll/results/index.html.erb
@@ -9,6 +9,7 @@
       <%= t("admin.results.index.no_results") %>
     </div>
   <% else %>
+    <%= render "recount", resource: @poll %>
     <%= render "result" %>
     <%= render "results_by_booth" %>
   <% end %>

--- a/app/views/admin/poll/results/index.html.erb
+++ b/app/views/admin/poll/results/index.html.erb
@@ -9,44 +9,6 @@
       <%= t("admin.results.index.no_results") %>
     </div>
   <% else %>
-
-    <table class="margin">
-      <thead>
-        <th><%= t("admin.results.index.table_whites") %></th>
-        <th><%= t("admin.results.index.table_nulls") %></th>
-        <th><%= t("admin.results.index.table_total") %></th>
-      </thead>
-      <tbody>
-        <tr>
-          <td id="white_results"><%= @poll.recounts.sum(:white_amount) %></td>
-          <td id="null_results"><%= @poll.recounts.sum(:null_amount) %></td>
-          <td id="total_results"><%= @poll.recounts.sum(:total_amount) %></td>
-        </tr>
-      </tbody>
-    </table>
-
-
-    <% by_question = @partial_results.group_by(&:question_id) %>
-    <% @poll.questions.each do |question| %>
-      <h3><%= question.title %></h3>
-      <table class="margin">
-        <thead>
-          <tr>
-            <th><%= t("admin.results.index.table_answer") %></th>
-            <th class="text-center"><%= t("admin.results.index.table_votes") %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% question.question_answers.each_with_index do |answer, i| %>
-            <% by_answer = by_question[question.id].present? ? by_question[question.id].group_by(&:answer) : {} %>
-            <tr id="question_<%= question.id %>_<%= i %>_result">
-              <td><%= answer.title %></td>
-              <td class="text-center"><%= by_answer[answer.title].present? ? by_answer[answer.title].sum(&:amount) : 0 %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    <% end %>
-
+    <%= render "result" %>
   <% end %>
 </div>

--- a/app/views/admin/poll/results/index.html.erb
+++ b/app/views/admin/poll/results/index.html.erb
@@ -10,5 +10,6 @@
     </div>
   <% else %>
     <%= render "result" %>
+    <%= render "results_by_booth" %>
   <% end %>
 </div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -658,6 +658,7 @@ en:
         booth: Booth
         results: Results
         see_results: See results
+        title: "Results by booth"
     booths:
       index:
         title: "List of booths"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -537,6 +537,7 @@ en:
         no_officers: "There are no officers for this booth"
         recounts: "Recounts"
         recounts_list: "Recount list for this booth"
+        results: "Results"
         date: "Date"
         count_final: "Final recount (by officer)"
         count_by_system:  "Votes (automatic)"
@@ -647,11 +648,16 @@ en:
       index:
         title: "Results"
         no_results: "There are no results"
+      result:
         table_whites: "Totally blank ballots"
         table_nulls: "Invalid ballots"
         table_total: "Total ballots"
         table_answer: Answer
         table_votes: Votes
+      results_by_booth:
+        booth: Booth
+        results: Results
+        see_results: See results
     booths:
       index:
         title: "List of booths"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -537,6 +537,7 @@ es:
         no_officers: "No hay presidentes de mesa para esta urna"
         recounts: "Recuentos"
         recounts_list: "Lista de recuentos de esta urna"
+        results: "Resultados"
         date: "Fecha"
         count_final: "Recuento final (presidente de mesa)"
         count_by_system:  "Votos (automático)"
@@ -649,11 +650,16 @@ es:
       index:
         title: "Resultados"
         no_results: "No hay resultados"
+      result:
         table_whites: Papeletas totalmente en blanco
         table_nulls: Papeletas nulas
         table_total: Papeletas totales
         table_answer: Respuesta
         table_votes: Votos
+      results_by_booth:
+        booth: Urna
+        results: Resultados
+        see_results: Ver resultados
     booths:
       index:
         title: "Lista de urnas"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -660,6 +660,7 @@ es:
         booth: Urna
         results: Resultados
         see_results: Ver resultados
+        title: "Resultados por urna"
     booths:
       index:
         title: "Lista de urnas"

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -641,6 +641,49 @@ print "Creating Poll Voters"
 end
 
 puts " ✅"
+print "Creating Poll Recounts"
+
+Poll.all.each do |poll|
+  poll.booth_assignments.each do |booth_assignment|
+    officer_assignment = poll.officer_assignments.first
+    author = Poll::Officer.first.user
+
+    Poll::Recount.create!(officer_assignment: officer_assignment,
+                          booth_assignment: booth_assignment,
+                          author: author,
+                          date: poll.ends_at,
+                          white_amount: rand(0..10),
+                          null_amount: rand(0..10),
+                          total_amount: rand(100..9999),
+                          origin: "booth")
+  end
+end
+
+puts " ✅"
+print "Creating Poll Results"
+
+Poll.all.each do |poll|
+  poll.booth_assignments.each do |booth_assignment|
+    officer_assignment = poll.officer_assignments.first
+    author = Poll::Officer.first.user
+
+    poll.questions.each do |question|
+      question.question_answers.each do |answer|
+        Poll::PartialResult.create!(officer_assignment: officer_assignment,
+                                    booth_assignment: booth_assignment,
+                                    date: Date.current,
+                                    question: question,
+                                    answer: answer.title,
+                                    author: author,
+                                    amount: rand(999),
+                                    origin: "booth")
+      end
+    end
+  end
+
+end
+
+puts " ✅"
 print "Creating legislation processes"
 
 5.times do

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -126,5 +126,91 @@ feature 'Admin booths assignments' do
       end
     end
 
+    scenario 'Results' do
+      poll = create(:poll)
+      booth_assignment = create(:poll_booth_assignment, poll: poll)
+
+      question_1 = create(:poll_question, poll: poll)
+      create(:poll_question_answer, title: 'Yes', question: question_1)
+      create(:poll_question_answer, title: 'No', question: question_1)
+
+      question_2 = create(:poll_question, poll: poll)
+      create(:poll_question_answer, title: 'Today', question: question_2)
+      create(:poll_question_answer, title: 'Tomorrow', question: question_2)
+
+      create(:poll_partial_result,
+              booth_assignment: booth_assignment,
+              question: question_1,
+              answer: 'Yes',
+              amount: 11)
+
+      create(:poll_partial_result,
+              booth_assignment: booth_assignment,
+              question: question_1,
+              answer: 'No',
+              amount: 4)
+
+      create(:poll_partial_result,
+              booth_assignment: booth_assignment,
+              question: question_2,
+              answer: 'Today',
+              amount: 5)
+
+      create(:poll_partial_result,
+              booth_assignment: booth_assignment,
+              question: question_2,
+              answer: 'Tomorrow',
+              amount: 6)
+
+      create(:poll_recount,
+             booth_assignment: booth_assignment,
+             white_amount: 21,
+             null_amount: 44,
+             total_amount: 66)
+
+      visit admin_poll_booth_assignment_path(poll, booth_assignment)
+
+      click_link 'Results'
+
+      expect(page).to have_content(question_1.title)
+
+      within("#question_#{question_1.id}_0_result") do
+        expect(page).to have_content("Yes")
+        expect(page).to have_content(11)
+      end
+
+      within("#question_#{question_1.id}_1_result") do
+        expect(page).to have_content("No")
+        expect(page).to have_content(4)
+      end
+
+      expect(page).to have_content(question_2.title)
+
+      within("#question_#{question_2.id}_0_result") do
+        expect(page).to have_content("Today")
+        expect(page).to have_content(5)
+      end
+
+      within("#question_#{question_2.id}_1_result") do
+        expect(page).to have_content("Tomorrow")
+        expect(page).to have_content(6)
+      end
+
+      within('#white_results') { expect(page).to have_content('21') }
+      within('#null_results') { expect(page).to have_content('44') }
+      within('#total_results') { expect(page).to have_content('66') }
+    end
+
+    scenario "No results" do
+      poll = create(:poll)
+      booth_assignment = create(:poll_booth_assignment, poll: poll)
+
+      visit admin_poll_booth_assignment_path(poll, booth_assignment)
+
+      click_link "Results"
+
+      expect(page).to have_content "There are no results"
+    end
+
   end
 end

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -126,9 +126,10 @@ feature 'Admin booths assignments' do
       end
     end
 
-    scenario 'Results' do
+    scenario 'Results for a booth assignment' do
       poll = create(:poll)
       booth_assignment = create(:poll_booth_assignment, poll: poll)
+      other_booth_assignment = create(:poll_booth_assignment, poll: poll)
 
       question_1 = create(:poll_question, poll: poll)
       create(:poll_question_answer, title: 'Yes', question: question_1)
@@ -162,11 +163,23 @@ feature 'Admin booths assignments' do
               answer: 'Tomorrow',
               amount: 6)
 
+      create(:poll_partial_result,
+              booth_assignment: other_booth_assignment,
+              question: question_1,
+              answer: 'Yes',
+              amount: 9999)
+
       create(:poll_recount,
              booth_assignment: booth_assignment,
              white_amount: 21,
              null_amount: 44,
              total_amount: 66)
+
+      create(:poll_recount,
+             booth_assignment: other_booth_assignment,
+             white_amount: 999,
+             null_amount: 999,
+             total_amount: 999)
 
       visit admin_poll_booth_assignment_path(poll, booth_assignment)
 

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -311,6 +311,43 @@ feature 'Admin polls' do
         within('#null_results') { expect(page).to have_content('44') }
         within('#total_results') { expect(page).to have_content('66') }
       end
+
+      scenario "Link to results by booth" do
+        poll = create(:poll)
+        booth_assignment1 = create(:poll_booth_assignment, poll: poll)
+        booth_assignment2 = create(:poll_booth_assignment, poll: poll)
+
+        question = create(:poll_question, poll: poll)
+        create(:poll_question_answer, title: 'Yes', question: question)
+        create(:poll_question_answer, title: 'No', question: question)
+
+        create(:poll_partial_result,
+               booth_assignment: booth_assignment1,
+               question: question,
+               answer: 'Yes',
+               amount: 5)
+
+        create(:poll_partial_result,
+               booth_assignment: booth_assignment2,
+               question: question,
+               answer: 'Yes',
+               amount: 6)
+
+        visit admin_poll_path(poll)
+
+        click_link "Results"
+
+        expect(page).to have_link("See results", count: 2)
+
+        within("#booth_assignment_#{booth_assignment1.id}_result") do
+          click_link "See results"
+        end
+
+        expect(page).to have_content booth_assignment1.booth.name
+        expect(page).to have_content "Results"
+        expect(page).to have_content "Yes"
+        expect(page).to have_content "5"
+      end
     end
   end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2044

What
====
- Displays admin results for a booth
- Links all booth results for a poll
- Adds dev seeds for poll's recounts and results

How
===
- Reusing logic from poll's results

Screenshots
===========
- Booth results

![booth results](https://user-images.githubusercontent.com/4169/31737085-ba2f84a8-b446-11e7-90a3-c4b628c5202f.png)

- Link to booth results from a poll

![link to booth results](https://user-images.githubusercontent.com/4169/31737090-bce96d3a-b446-11e7-8b9e-b41184d5f34a.png)

Test
====
- Manual testing can be done after running `rake db:dev_seeds`

Deployment
==========
- As usual

Warnings
========
- The default tab for a booth, is now results. We can make it be recounts once again.
For that we would need some helpers to dynamically highlight the correct tab when:
  - Loading the page the first time
  - Linking to a specific tab from another page
