### PR TITLE
Poll slugs

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,6 +1,8 @@
 class PollsController < ApplicationController
   include PollsHelper
 
+  before_action :load_poll, except: [:index]
+  
   load_and_authorize_resource
 
   has_filters %w{current expired incoming}
@@ -26,5 +28,11 @@ class PollsController < ApplicationController
     @commentable = @poll
     @comment_tree = CommentTree.new(@commentable, params[:page], @current_order)
   end
+  
+  private
+  
+    def load_poll
+      @poll = ::Poll.find_by(slug: params[:id]) || ::Poll.find_by(id: params[:id])
+    end
 
 end

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -2,10 +2,14 @@ module Sluggable
   extend ActiveSupport::Concern
 
   included do
-    before_validation :generate_slug
+    before_validation :generate_slug, if: :update_slug?
   end
 
   def generate_slug
     self.slug = name.to_s.parameterize
+  end
+
+  def update_slug?
+    new_record? || (name_changed? && (name_was.to_s.parameterize == slug))
   end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -1,5 +1,6 @@
 class Poll < ActiveRecord::Base
   include Imageable
+  include Sluggable
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
@@ -19,6 +20,7 @@ class Poll < ActiveRecord::Base
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
 
   validates :name, presence: true
+  validates :slug, presence: true
 
   validate :date_range
 

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -19,11 +19,11 @@
         <div class="dates"></div>
         <% if poll.questions.count == 1 %>
           <% poll.questions.each do |question| %>
-            <h4><%= link_to question.title, poll %></h4>
+            <h4><%= link_to question.title, poll_path(poll.slug) %></h4>
             <%= poll_dates(poll) %>
           <% end %>
         <% else %>
-          <h4><%= link_to poll.name, poll %></h4>
+          <h4><%= link_to poll.name, poll_path(poll.slug) %></h4>
           <%= poll_dates(poll) %>
           <ul class="margin-top">
             <% poll.questions.each do |question| %>
@@ -44,7 +44,7 @@
       </div>
       <div class="small-12 medium-3 column table" data-equalizer-watch>
         <div class="table-cell aling-middle">
-          <%= link_to poll, class: "button hollow expanded" do %>
+          <%= link_to poll_path(poll.slug), class: "button hollow expanded" do %>
             <% if poll.expired? %>
               <%= t("polls.index.participate_button_expired") %>
             <% elsif poll.incoming? %>

--- a/db/migrate/20171018091520_add_slug_to_polls.rb
+++ b/db/migrate/20171018091520_add_slug_to_polls.rb
@@ -1,0 +1,5 @@
+class AddSlugToPolls < ActiveRecord::Migration
+  def change
+    add_column :polls, :slug, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171010143623) do
+ActiveRecord::Schema.define(version: 20171018091520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -760,6 +760,7 @@ ActiveRecord::Schema.define(version: 20171010143623) do
     t.integer  "comments_count",     default: 0
     t.integer  "author_id"
     t.datetime "hidden_at"
+    t.string   "slug"
   end
 
   add_index "polls", ["starts_at", "ends_at"], name: "index_polls_on_starts_at_and_ends_at", using: :btree

--- a/lib/tasks/poll_slugs.rake
+++ b/lib/tasks/poll_slugs.rake
@@ -1,0 +1,18 @@
+namespace :temp do
+
+  desc "Create slugs for polls"
+  task polls_slugs: :environment do
+
+    polls = Poll.all
+
+    polls.each do |poll|
+      poll.update_attributes(slug: poll.name.to_s.parameterize)
+
+      if poll.save
+        print "."
+      else
+        puts poll.errors.first
+      end
+    end
+  end
+end

--- a/lib/tasks/slugs.rake
+++ b/lib/tasks/slugs.rake
@@ -1,7 +1,7 @@
 namespace :slugs do
   desc "Generate slug attribute for objects from classes that use Sluggable concern"
   task generate: :environment do
-    %w(Budget Budget::Heading Budget::Group).each do |class_name|
+    %w(Budget Budget::Heading Budget::Group Poll).each do |class_name|
       class_name.constantize.all.each(&:generate_slug)
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -471,6 +471,8 @@ FactoryGirl.define do
   factory :poll do
     sequence(:name) { |n| "Poll #{SecureRandom.hex}" }
 
+    slug "this-is-a-slug"
+      
     starts_at { 1.month.ago }
     ends_at { 1.month.from_now }
 

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -64,6 +64,20 @@ feature 'Polls' do
   context 'Show' do
     let(:geozone) { create(:geozone) }
     let(:poll) { create(:poll, summary: "Summary", description: "Description") }
+    
+    scenario "Visit path with id" do
+      visit poll_path(poll.id)
+      
+      expect(page).to have_current_path(poll_path(poll.id))
+      expect(page).to have_content(poll.name)
+    end
+ 
+    scenario "Visit path with slug" do
+      visit poll_path(poll.slug)
+      
+      expect(page).to have_current_path(poll_path(poll.slug))
+      expect(page).to have_content(poll.name)
+    end
 
     scenario 'Show answers with videos' do
       question = create(:poll_question, poll: poll)

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -35,7 +35,7 @@ describe UsersHelper do
 
       investment.hide
 
-      expect(comment_commentable_title(comment)).to eq '<del>' + comment.commentable.title + '</del> <span class="small">(This investment has been deleted)</span>'
+      expect(comment_commentable_title(comment)).to eq '<del>' + comment.commentable.title + '</del> <span class="small">(This investment project has been deleted)</span>'
     end
   end
 

--- a/spec/models/concerns/sluggable.rb
+++ b/spec/models/concerns/sluggable.rb
@@ -12,5 +12,20 @@ shared_examples_for 'sluggable' do
         expect(described_class.last.slug).to eq("marlo-branido-carlo")
       end
     end
+
+    context "when a sluggable is updated" do
+      it "updates the slug with the new name" do
+        described_class.last.update(name: "New name")
+        expect(described_class.last.slug).to eq('new-name')
+      end
+
+      it "doesn't update the custom slug with new name" do
+        described_class.last.update(slug: "custom-slug")
+        expect(described_class.last.slug).to eq('custom-slug')
+
+        described_class.last.update(name: "Another new name")
+        expect(described_class.last.slug).to eq('custom-slug')
+      end
+    end
   end
 end

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
-describe :poll do
+describe Poll do
+
+  it_behaves_like "sluggable"
 
   let(:poll) { build(:poll) }
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2019 
This PR closes #2019 

What
====
- Add a slug attribute to polls so that users can navigate to them using the slug instead of the id.
- If this slug was modified from the rails console, it should not be updated when updating the poll.

How
===
- I added the Sluggable concern to polls model to make polls have the slug attribute.
- I modified the Sluggable concern so that it updates the slug only if there wasn't modified by hand (e.g. from rails console). If it was modified, it won't change it anymore.
- I also updated the `rake slugs:generate` task to add `Poll` model.

Screenshots
===========
![iagirre-poll-slug](https://user-images.githubusercontent.com/31625251/31768888-87e3221c-b4d1-11e7-84eb-e470b7c5a78f.png)

Test
====
- I updated the sluggable concern shared_example to test the update of the slug for all the sluggable models.
- I also added specs to test that users can navigate to poll using either the slug or the id.

Deployment
==========
I created a rake task to generate a slug for all the existing polls in the DB, `rake temp:poll_slug`, and it should be run in order to make things work.

Warnings
========
Nothing to apply.
