### PR TITLE
Booth Assigment management

### DIFF
--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -23,18 +23,24 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
   end
 
   def create
-    @booth_assignment = ::Poll::BoothAssignment.new(poll_id: booth_assignment_params[:poll_id],
-                                                    booth_id: booth_assignment_params[:booth_id])
+    @poll = Poll.find(booth_assignment_params[:poll_id])
+    @booth = Poll::Booth.find(booth_assignment_params[:booth_id])
+    @booth_assignment = ::Poll::BoothAssignment.new(poll: @poll,
+                                                    booth: @booth)
 
     if @booth_assignment.save
       notice = t("admin.poll_booth_assignments.flash.create")
     else
       notice = t("admin.poll_booth_assignments.flash.error_create")
     end
-    redirect_to admin_poll_booth_assignments_path(@booth_assignment.poll_id), notice: notice
+    respond_to do |format|
+      format.js { render layout: false }
+    end
   end
 
   def destroy
+    @poll = Poll.find(booth_assignment_params[:poll_id])
+    @booth = Poll::Booth.find(booth_assignment_params[:booth_id])
     @booth_assignment = ::Poll::BoothAssignment.find(params[:id])
 
     if @booth_assignment.destroy
@@ -42,7 +48,9 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
     else
       notice = t("admin.poll_booth_assignments.flash.error_destroy")
     end
-    redirect_to admin_poll_booth_assignments_path(@booth_assignment.poll_id), notice: notice
+    respond_to do |format|
+      format.js { render layout: false }
+    end
   end
 
   def manage

--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -47,6 +47,7 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
 
   def manage
     @booths = ::Poll::Booth.all
+    @poll = Poll.find(params[:poll_id])
   end
 
   private

--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -45,6 +45,10 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
     redirect_to admin_poll_booth_assignments_path(@booth_assignment.poll_id), notice: notice
   end
 
+  def manage
+    @booths = ::Poll::Booth.all
+  end
+
   private
 
     def load_booth_assignment

--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -47,6 +47,10 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
     redirect_to admin_poll_path(@poll), notice: notice
   end
 
+  def booth_assignments
+    @polls = Poll.current_or_incoming
+  end
+
   private
 
     def load_geozones

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -56,10 +56,10 @@ module Abilities
 
       can [:index, :create, :edit, :update, :destroy], Geozone
 
-      can [:read, :create, :update, :destroy, :add_question, :search_booths, :search_officers], Poll
+      can [:read, :create, :update, :destroy, :add_question, :search_booths, :search_officers, :booth_assignments], Poll
       can [:read, :create, :update, :destroy, :available], Poll::Booth
       can [:search, :create, :index, :destroy], ::Poll::Officer
-      can [:create, :destroy], ::Poll::BoothAssignment
+      can [:create, :destroy, :manage], ::Poll::BoothAssignment
       can [:create, :destroy], ::Poll::OfficerAssignment
       can [:read, :create, :update], Poll::Question
       can :destroy, Poll::Question # , comments_count: 0, votes_up: 0

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -15,5 +15,8 @@ class Poll
       where(polls: { id: Poll.current_or_incoming }).includes(:polls)
     end
 
+    def assignment_on_poll(poll)
+      booth_assignments.where(poll: poll).first
+    end
   end
 end

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -60,7 +60,8 @@
           <strong><%= t("admin.menu.title_polls") %></strong>
         </a>
         <ul id="polls_menu" <%= "class=is-active" if menu_polls? || controller.class.parent == Admin::Poll::Questions::Answers %>>
-          <li <%= "class=active" if ["polls", "officer_assignments", "booth_assignments", "recounts", "results"].include? controller_name %>>
+          <li <%= "class=active" if ["polls", "officer_assignments", "booth_assignments", "recounts", "results"].include? controller_name &&
+                                    action_name != "booth_assignments" %>>
             <%= link_to t('admin.menu.polls'), admin_polls_path %>
           </li>
 
@@ -83,6 +84,10 @@
                                     controller_name == "booths" &&
                                     action_name == "available" %>>
             <%= link_to t('admin.menu.poll_shifts'), available_admin_booths_path %>
+          </li>
+
+          <li <%= "class=active" if (controller_name == "polls" && action_name == "booth_assignments") || (controller_name == "booth_assignments" && action_name == "manage") %>>
+            <%= link_to t('admin.menu.poll_booth_assignments'), booth_assignments_admin_polls_path %>
           </li>
         </ul>
       </li>

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -1,0 +1,17 @@
+<tr id="booth_<%= booth.id %>" class="booth">
+  <td>
+    <%= link_to booth.name, admin_booth_path(booth) %>
+  </td>
+  <td>
+    <%= t("admin.booth_assignments.status.assigned") %>
+    <%= t("admin.booth_assignments.status.unassigned") %>
+  </td>
+  <td class="text-right">
+      <%= link_to t("admin.booth_assignments.manage.assign"),
+                  new_admin_booth_shift_path(booth),
+                  class: "button" %>
+      <%= link_to t("admin.booth_assignments.manage.unassign"),
+                  new_admin_booth_shift_path(booth),
+                  class: "button hollow" %>
+  </td>
+</tr>

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -1,6 +1,9 @@
 <td>
   <%= link_to booth.name, admin_booth_path(booth) %>
 </td>
+<td>
+  <%= booth.location || t("admin.booths.index.no_location") %>
+</td>
 <% if booth_assignment.present? %>
   <td>
     <span class="verified"><%= t("admin.booth_assignments.manage.status.assigned") %></span>

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -1,17 +1,28 @@
-<tr id="booth_<%= booth.id %>" class="booth">
+<td>
+  <%= link_to booth.name, admin_booth_path(booth) %>
+</td>
+<% if booth_assignment.present? %>
   <td>
-    <%= link_to booth.name, admin_booth_path(booth) %>
-  </td>
-  <td>
-    <%= t("admin.booth_assignments.status.assigned") %>
-    <%= t("admin.booth_assignments.status.unassigned") %>
+    <span class="verified"><%= t("admin.booth_assignments.status.assigned") %></span>
   </td>
   <td class="text-right">
-      <%= link_to t("admin.booth_assignments.manage.assign"),
-                  new_admin_booth_shift_path(booth),
-                  class: "button" %>
-      <%= link_to t("admin.booth_assignments.manage.unassign"),
-                  new_admin_booth_shift_path(booth),
-                  class: "button hollow" %>
+    <%= link_to t("admin.booth_assignments.manage.actions.unassign"),
+                admin_poll_booth_assignment_path(@poll, booth_assignment, booth_id: booth.id),
+                method: :delete,
+                remote: true,
+                title: t("admin.booth_assignments.manage.actions.unassign"),
+                class: "button hollow alert" %>
   </td>
-</tr>
+<% else %>
+  <td>
+    <span class="delete"><%= t("admin.booth_assignments.status.unassigned") %></span>
+  </td>
+  <td class="text-right">
+    <%= link_to t("admin.booth_assignments.manage.actions.assign"),
+                admin_poll_booth_assignments_path(@poll, booth_id: booth.id),
+                method: :post,
+                remote: true,
+                title: t("admin.booth_assignments.manage.actions.assign"),
+                class: "button" %>
+  </td>
+<% end %>

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -3,7 +3,7 @@
 </td>
 <% if booth_assignment.present? %>
   <td>
-    <span class="verified"><%= t("admin.booth_assignments.status.assigned") %></span>
+    <span class="verified"><%= t("admin.booth_assignments.manage.status.assigned") %></span>
   </td>
   <td class="text-right">
     <%= link_to t("admin.booth_assignments.manage.actions.unassign"),
@@ -15,7 +15,7 @@
   </td>
 <% else %>
   <td>
-    <span class="delete"><%= t("admin.booth_assignments.status.unassigned") %></span>
+    <span class="delete"><%= t("admin.booth_assignments.manage.status.unassigned") %></span>
   </td>
   <td class="text-right">
     <%= link_to t("admin.booth_assignments.manage.actions.assign"),

--- a/app/views/admin/poll/booth_assignments/_search_booths_results.html.erb
+++ b/app/views/admin/poll/booth_assignments/_search_booths_results.html.erb
@@ -12,7 +12,6 @@
       <tr>
         <th><%= t("admin.poll_booth_assignments.index.table_name") %></th>
         <th><%= t("admin.poll_booth_assignments.index.table_location") %></th>
-        <th class="text-center"><%= t("admin.poll_booth_assignments.index.table_assignment") %></th>
       </tr>
     </thead>
     <tbody>
@@ -23,14 +22,6 @@
         </td>
         <td>
           <%= booth.location %>
-        </td>
-        <td class="text-center">
-          <% unless @poll.booth_ids.include?(booth.id) %>
-            <%= link_to t("admin.poll_booth_assignments.index.add_booth"),
-                          admin_poll_booth_assignments_path(@poll, booth_id: booth.id),
-                          method: :post,
-                          class: "button hollow" %>
-          <% end %>
         </td>
       </tr>
       <% end %>

--- a/app/views/admin/poll/booth_assignments/create.js.erb
+++ b/app/views/admin/poll/booth_assignments/create.js.erb
@@ -1,0 +1,1 @@
+$("#<%= dom_id(@booth) %>").html('<%= j render("booth_assignment", booth: @booth, booth_assignment: @booth.assignment_on_poll(@poll)) %>');

--- a/app/views/admin/poll/booth_assignments/destroy.js.erb
+++ b/app/views/admin/poll/booth_assignments/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#<%= dom_id(@booth) %>").html('<%= j render("booth_assignment", booth: @booth, booth_assignment: @booth.assignment_on_poll(@poll)) %>');

--- a/app/views/admin/poll/booth_assignments/index.html.erb
+++ b/app/views/admin/poll/booth_assignments/index.html.erb
@@ -14,7 +14,6 @@
       <thead>
         <th><%= t("admin.poll_booth_assignments.index.table_name") %></th>
         <th><%= t("admin.poll_booth_assignments.index.table_location") %></th>
-        <th class="text-right"><%= t("admin.poll_booth_assignments.index.table_assignment") %></th>
       </thead>
       <tbody>
         <% @booth_assignments.each do |booth_assignment| %>
@@ -26,12 +25,6 @@
             </td>
             <td>
               <%= booth_assignment.booth.location %>
-            </td>
-            <td class="text-right">
-              <%= link_to t("admin.poll_booth_assignments.index.remove_booth"),
-                          admin_poll_booth_assignment_path(@poll, booth_assignment),
-                          method: :delete,
-                          class: "button hollow alert" %>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/poll/booth_assignments/index.html.erb
+++ b/app/views/admin/poll/booth_assignments/index.html.erb
@@ -1,6 +1,5 @@
 <%= render "/admin/poll/polls/poll_header" %>
 
-
 <div id="poll-resources">
   <%= render "/admin/poll/polls/subnav" %>
   <%= render "search_booths" %>
@@ -30,7 +29,7 @@
               </strong>
             </td>
             <td>
-              <%= booth_assignment.booth.location %>
+              <%= booth_assignment.booth.location || t("admin.booths.index.no_location") %>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/poll/booth_assignments/index.html.erb
+++ b/app/views/admin/poll/booth_assignments/index.html.erb
@@ -1,9 +1,15 @@
 <%= render "/admin/poll/polls/poll_header" %>
+
+
 <div id="poll-resources">
   <%= render "/admin/poll/polls/subnav" %>
   <%= render "search_booths" %>
 
   <h3><%= t("admin.poll_booth_assignments.index.booths_title") %></h3>
+
+  <%= link_to t("admin.booth_assignments.manage_assignments"),
+              manage_admin_poll_booth_assignments_path(@poll),
+              class: "button hollow float-right" %>
 
   <% if @booth_assignments.empty? %>
     <div class="callout primary margin-top">

--- a/app/views/admin/poll/booth_assignments/manage.html.erb
+++ b/app/views/admin/poll/booth_assignments/manage.html.erb
@@ -13,7 +13,7 @@
   <table>
     <thead>
       <th><%= t("admin.booths.index.name") %></th>
-      <th><%= t("admin.booth_assignments.status.assign_status") %></th>
+      <th><%= t("admin.booth_assignments.manage.status.assign_status") %></th>
       <th class="text-right"><%= t("admin.actions.actions") %></th>
     </thead>
     <tbody>

--- a/app/views/admin/poll/booth_assignments/manage.html.erb
+++ b/app/views/admin/poll/booth_assignments/manage.html.erb
@@ -18,7 +18,9 @@
     </thead>
     <tbody>
     <% @booths.each do |booth| %>
-      <%= render partial: "booth_assignment", locals: { booth: booth } %>
+      <tr id="<%= dom_id(booth) %>" class="booth">
+        <%= render partial: "booth_assignment", locals: { booth: booth, booth_assignment: booth.assignment_on_poll(@poll) } %>
+      </tr>
     <% end %>
     </tbody>
   </table>

--- a/app/views/admin/poll/booth_assignments/manage.html.erb
+++ b/app/views/admin/poll/booth_assignments/manage.html.erb
@@ -1,0 +1,25 @@
+<h2 class="inline-block"><%= t("admin.booths.index.title") %></h2>
+
+<% if controller_name == "booths" && action_name != "available" %>
+  <%= link_to t("admin.booths.index.add_booth"), new_admin_booth_path, class: "button success float-right" %>
+<% end %>
+
+<% if @booths.empty? %>
+  <div class="callout primary">
+    <%= t("admin.booths.index.no_booths") %>
+  </div>
+<% end %>
+
+<% if @booths.any? %>
+  <table>
+    <thead>
+      <th><%= t("admin.booths.index.name") %></th>
+      <th class="text-right"><%= t("admin.actions.actions") %></th>
+    </thead>
+    <tbody>
+    <% @booths.each do |booth| %>
+    <% end %>
+    </tbody>
+  </table>
+
+<% end %>

--- a/app/views/admin/poll/booth_assignments/manage.html.erb
+++ b/app/views/admin/poll/booth_assignments/manage.html.erb
@@ -13,6 +13,7 @@
   <table>
     <thead>
       <th><%= t("admin.booths.index.name") %></th>
+      <th><%= t("admin.booths.index.location") %></th>
       <th><%= t("admin.booth_assignments.manage.status.assign_status") %></th>
       <th class="text-right"><%= t("admin.actions.actions") %></th>
     </thead>

--- a/app/views/admin/poll/booth_assignments/manage.html.erb
+++ b/app/views/admin/poll/booth_assignments/manage.html.erb
@@ -1,25 +1,25 @@
-<h2 class="inline-block"><%= t("admin.booths.index.title") %></h2>
-
-<% if controller_name == "booths" && action_name != "available" %>
-  <%= link_to t("admin.booths.index.add_booth"), new_admin_booth_path, class: "button success float-right" %>
+<%= link_to booth_assignments_admin_polls_path do %>
+  <span class="icon-angle-left"></span> <%= t("shared.back") %>
 <% end %>
+<hr>
+
+<h2 class="inline-block"><%= t("admin.booth_assignments.manage.assignments_list", poll: @poll.name) %></h2>
 
 <% if @booths.empty? %>
   <div class="callout primary">
     <%= t("admin.booths.index.no_booths") %>
   </div>
-<% end %>
-
-<% if @booths.any? %>
+<% else %>
   <table>
     <thead>
       <th><%= t("admin.booths.index.name") %></th>
+      <th><%= t("admin.booth_assignments.status.assign_status") %></th>
       <th class="text-right"><%= t("admin.actions.actions") %></th>
     </thead>
     <tbody>
     <% @booths.each do |booth| %>
+      <%= render partial: "booth_assignment", locals: { booth: booth } %>
     <% end %>
     </tbody>
   </table>
-
 <% end %>

--- a/app/views/admin/poll/polls/booth_assignments.html.erb
+++ b/app/views/admin/poll/polls/booth_assignments.html.erb
@@ -1,0 +1,18 @@
+<h2 class="inline-block"><%= t("admin.polls.index.title") %></h2>
+
+<% if @polls.any? %>
+  <table>
+    <thead>
+      <th class="medium-6"><%= t("admin.polls.index.name") %></th>
+      <th><%= t("admin.polls.index.dates") %></th>
+      <th class="text-right"><%= t("admin.actions.actions") %></th>
+    </thead>
+    <tbody>
+      <%= render @polls %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.polls.index.no_polls") %>
+  </div>
+<% end %>

--- a/app/views/admin/poll/polls/booth_assignments.html.erb
+++ b/app/views/admin/poll/polls/booth_assignments.html.erb
@@ -8,7 +8,21 @@
       <th class="text-right"><%= t("admin.actions.actions") %></th>
     </thead>
     <tbody>
-      <%= render @polls %>
+      <% @polls.each do |poll| %>
+        <tr id="<%= dom_id(poll) %>" class="poll">
+          <td>
+            <strong><%= poll.name %></strong>
+          </td>
+          <td>
+            <%= l poll.starts_at.to_date %> - <%= l poll.ends_at.to_date %>
+          </td>
+          <td class="text-right">
+            <%= link_to t("admin.booth_assignments.manage_assignments"),
+                        manage_admin_poll_booth_assignments_path(poll),
+                        class: "button hollow" %>
+          </td>
+        </tr>
+      <% end %>
     </tbody>
   </table>
 <% else %>

--- a/app/views/admin/poll/polls/booth_assignments.html.erb
+++ b/app/views/admin/poll/polls/booth_assignments.html.erb
@@ -11,7 +11,7 @@
       <% @polls.each do |poll| %>
         <tr id="<%= dom_id(poll) %>" class="poll">
           <td>
-            <strong><%= poll.name %></strong>
+            <strong><%= link_to poll.name, admin_poll_path(poll) %></strong>
           </td>
           <td>
             <%= l poll.starts_at.to_date %> - <%= l poll.ends_at.to_date %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -675,6 +675,7 @@ en:
         add_booth: "Add booth"
         name: "Name"
         location: "Location"
+        no_location: "No Location"
       new:
         title: "New booth"
         name: "Name"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -527,6 +527,15 @@ en:
       recount_scrutiny: Recount & Scrutiny
     booth_assignments:
       manage_assignments: Manage assignments
+      manage:
+        assignments_list: "Assignments for poll '%{poll}'"
+        status:
+          assign_status: Assignment
+          assigned: Assigned
+          unassigned: Unassigned
+        actions:
+          assign: Assign booth
+          unassign: Unassign booth
     poll_booth_assignments:
       flash:
         destroy: "Booth not assigned anymore"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -559,8 +559,6 @@ en:
         no_booths: "There are no booths assigned to this poll."
         table_name: "Name"
         table_location: "Location"
-        table_assignment: "Assignment"
-        remove_booth: "Remove booth from poll"
         add_booth: "Assign booth"
     polls:
       index:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -409,6 +409,7 @@ en:
       poll_officers: Poll officers
       polls: Polls
       poll_booths: Booths location
+      poll_booth_assignments: Booths Assignments
       poll_shifts: Manage shifts
       officials: Officials
       organizations: Organisations

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -559,7 +559,6 @@ en:
         no_booths: "There are no booths assigned to this poll."
         table_name: "Name"
         table_location: "Location"
-        add_booth: "Assign booth"
     polls:
       index:
         title: "List of polls"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -525,6 +525,8 @@ en:
         date_missing: "A date must be selected"
       vote_collection: Collect Votes
       recount_scrutiny: Recount & Scrutiny
+    booth_assignments:
+      manage_assignments: Manage assignments
     poll_booth_assignments:
       flash:
         destroy: "Booth not assigned anymore"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -677,6 +677,7 @@ es:
         add_booth: "Añadir urna"
         name: "Nombre"
         location: "Ubicación"
+        no_location: "Sin Ubicación"
       new:
         title: "Nueva urna"
         name: "Nombre"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -525,6 +525,8 @@ es:
         date_missing: "Debe seleccionarse una fecha"
       vote_collection: Recoger Votos
       recount_scrutiny: Recuento & Escrutinio
+    booth_assignments:
+      manage_assignments: Gestionar asignaciones
     poll_booth_assignments:
       flash:
         destroy: "Urna desasignada"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -559,8 +559,6 @@ es:
         no_booths: "No hay urnas asignadas a esta votación."
         table_name: "Nombre"
         table_location: "Ubicación"
-        table_assignment: "Asignación"
-        remove_booth: "Desasignar urna"
         add_booth: "Asignar urna"
     polls:
       index:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -559,7 +559,6 @@ es:
         no_booths: "No hay urnas asignadas a esta votación."
         table_name: "Nombre"
         table_location: "Ubicación"
-        add_booth: "Asignar urna"
     polls:
       index:
         title: "Listado de votaciones"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -420,6 +420,7 @@ es:
       poll_officers: Presidentes de mesa
       polls: Votaciones
       poll_booths: Ubicación de urnas
+      poll_booth_assignments: Asignación de urnas
       poll_shifts: Asignar turnos
       officials: Cargos públicos
       organizations: Organizaciones

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -527,6 +527,15 @@ es:
       recount_scrutiny: Recuento & Escrutinio
     booth_assignments:
       manage_assignments: Gestionar asignaciones
+      manage:
+        assignments_list: "Asignaciones para la votación '%{poll}'"
+        status:
+          assign_status: Asignación
+          assigned: Asignada
+          unassigned: No asignada
+        actions:
+          assign: Assign booth
+          unassign: Unassign booth
     poll_booth_assignments:
       flash:
         destroy: "Urna desasignada"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,7 +111,7 @@ Rails.application.routes.draw do
   resources :annotations do
     get :search, on: :collection
   end
-  
+
   resources :polls, only: [:show, :index] do
     resources :questions, controller: 'polls/questions', shallow: true do
       post :answer, on: :member
@@ -273,10 +273,12 @@ Rails.application.routes.draw do
 
     scope module: :poll do
       resources :polls do
+        get :booth_assignments, on: :collection
         patch :add_question, on: :member
 
         resources :booth_assignments, only: [:index, :show, :create, :destroy] do
           get :search_booths, on: :collection
+          get :manage, on: :collection
         end
 
         resources :officer_assignments, only: [:index, :create, :destroy] do


### PR DESCRIPTION
# Where
Related Issues: #2034

# What
We need to separate the listing of Booths assigned to a Poll from the Booth Assigment manage page:

 - On the Poll details we'll just list Booths assigned to it with a quick access button to Booth Assigment for that Poll. Without "Add booth" or "Remove booth" buttons

 - We need a new Admin > Polls > Booth Assignments menu that:
   **A -** List all current or incoming Polls
   **B -** Selection a Poll we can see all Booths with an "Assign" or "Unassign" ajax button (depending on the existance of a booth assigment for that booth & poll) that changes on click without full page render

# How
- Creating two new routes:
   - `/admin/polls/booth_assignments` for list **A**
  -  `/admin/polls/:id/booth_assignments/manage` for list **B**

- Creating views for each of them (copy&pasting code instead of trying to be smart on current existing views and having `action_name` and `controller_name` conditions all around

- Switching Admin::Poll::BoothAssignmentsController create and destroy methods to work with the ajax buttons to Assign & Unassign booths (creating/destroying a Booth Assigment object)

- Creating a Poll::Booth method `assignment_on_poll(poll)` that returns the existing (or not) booth assignment between that Booth and the poll (check `Warning` section to understand decision before rage kicks in)

# Screenshots
No more screenshots, GIFs!
![mecomaundemonio](https://user-images.githubusercontent.com/983242/31789898-e804b84e-b513-11e7-923a-64619b12d749.gif)

# Tests
Switched from old to new way to manage booth assigments, plus added an scenario to correctly test new Booth Assigment menu poll & booth listing

# Deployment
As usual 

# Warnings
Listing all booths and making a query for each an every one to check the existance of a booth-assigment with the curren poll is not nice with performance if there are a lot of Booths, heck its not even about performance I felt like 💩  doing it  but... we agreed upon this solution to get this working ASAP 

For me best solution would be to:
1. Get a list of booths currently with a booth assigment with the poll `assigned_booths`
2. Get the list of alll booths and substract the assigned booths list resulting in `unassigned_booths`
3. Merging both list (having a boolean flag to distinguish assigned/unassinged) and using that list instead of crappy `@booths = ::Poll::Booth.all` at `Admin::Poll::BoothAssignmentsController#manage`

PR's welcome to fix it if you have read this far!!