### PR TITLE
Added reference to event on the .on method('ajax:success',...) 

### DIFF
--- a/app/assets/javascripts/prevent_double_submission.js.coffee
+++ b/app/assets/javascripts/prevent_double_submission.js.coffee
@@ -25,7 +25,7 @@ App.PreventDoubleSubmission =
       unless event.target.id == "new_officing_voter"
         buttons = $(this).find(':button, :submit')
         App.PreventDoubleSubmission.disable_buttons(buttons)
-    ).on('ajax:success', ->
+    ).on('ajax:success', (event) ->
       unless event.target.id == "new_officing_voter"
         buttons = $(this).find(':button, :submit')
         App.PreventDoubleSubmission.reset_buttons(buttons)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2078

What
====
- Solves the problem with the button `Publish comment`. It stayed grey and it was necessary to refresh the page to see the new comment.

How
===
- Adding the missing reference to event on the .on method('ajax:success',...)

Screenshots
===========
![peek 20-10-2017 14-23](https://user-images.githubusercontent.com/413133/31820607-5edb4828-b5a2-11e7-8bde-1291d5d2f155.gif)
