### PR TITLE
Topic notifications

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -29,6 +29,8 @@ class NotificationsController < ApplicationController
       case notification.linkable_resource.class.name
       when "Budget::Investment"
         budget_investment_path @notification.linkable_resource.budget, @notification.linkable_resource
+      when "Topic"
+        community_topic_path @notification.linkable_resource.community, @notification.linkable_resource
       else
         url_for @notification.linkable_resource
       end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -14,6 +14,12 @@ feature "Notifications" do
   let(:legislation_question) { create(:legislation_question, process: process, author: administrator) }
   let(:legislation_annotation) { create(:legislation_annotation, author: author) }
 
+  let(:topic) {
+    proposal = create(:proposal)
+    community = proposal.community
+    create(:topic, community: community, author: author)
+  }
+
   scenario "User commented on my debate", :js do
     create(:notification, notifiable: debate, user: author)
     login_as author
@@ -30,6 +36,19 @@ feature "Notifications" do
   scenario "User commented on my legislation question", :js do
     create(:notification, notifiable: legislation_question, user: administrator)
     login_as administrator
+    visit root_path
+
+    find(".icon-notification").click
+
+    expect(page).to have_css ".notification", count: 1
+
+    expect(page).to have_content "Someone commented on"
+    expect(page).to have_xpath "//a[@href='#{notification_path(Notification.last)}']"
+  end
+
+  scenario "User commented on my topic", :js do
+    create(:notification, notifiable: topic, user: author)
+    login_as author
     visit root_path
 
     find(".icon-notification").click


### PR DESCRIPTION
Where
=====
* **Related Issue:** Comments on proposals topic #2078

What
====
- Fixes notification link error when someone commented a Topic. Reported by @ortegacmanuel on #2078 (I borrow his gif) 

![peek 20-10-2017 13-19](https://user-images.githubusercontent.com/413133/31818792-ebd45142-b599-11e7-9d26-8bab5e4e4e39.gif)

How
===
- Adds case when Topic on notifications controller.
- Adds specs when someone commented on Topic.

