### PR TITLE
Admin officer menu

### DIFF
--- a/app/controllers/officing/base_controller.rb
+++ b/app/controllers/officing/base_controller.rb
@@ -7,6 +7,6 @@ class Officing::BaseController < ApplicationController
   skip_authorization_check
 
   def verify_officer
-    raise CanCan::AccessDenied unless current_user.try(:poll_officer?) || current_user.try(:administrator?)
+    raise CanCan::AccessDenied unless current_user.try(:poll_officer?)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -52,12 +52,8 @@ module UsersHelper
     current_user && current_user.manager?
   end
 
-  def current_poll_officer?
-    current_user && current_user.poll_officer?
-  end
-
   def show_admin_menu?
-    current_administrator? || current_moderator? || current_valuator? || current_manager? || current_poll_officer?
+    current_administrator? || current_moderator? || current_valuator? || current_manager?
   end
 
   def interests_title_text(user)

--- a/app/views/admin/shared/_admin_shortcuts.html.erb
+++ b/app/views/admin/shared/_admin_shortcuts.html.erb
@@ -1,10 +1,12 @@
-<li>
-  <%= link_to admin_stats_path, title: t("admin.menu.stats") do %>
-    <span class="icon-stats"></span>
-  <% end %>
-</li>
-<li>
-  <%= link_to admin_settings_path, title: t("admin.menu.settings") do %>
-    <span class="icon-settings"></span>
-  <% end %>
-</li>
+<% if current_user.administrator? %>
+  <li>
+    <%= link_to admin_stats_path, title: t("admin.menu.stats") do %>
+      <span class="icon-stats"></span>
+    <% end %>
+  </li>
+  <li>
+    <%= link_to admin_settings_path, title: t("admin.menu.settings") do %>
+      <span class="icon-settings"></span>
+    <% end %>
+  </li>
+<% end %>

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -26,12 +26,11 @@
           <%= link_to t("layouts.header.management"), management_sign_in_path %>
         </li>
       <% end %>
-
-      <% if current_user.administrator? || current_user.poll_officer? %>
-        <li>
-          <%= link_to t("layouts.header.officing"), officing_root_path %>
-        </li>
-      <% end %>
     </ul>
+  </li>
+<% end %>
+<% if current_user && current_user.poll_officer? %>
+  <li>
+    <%= link_to t("layouts.header.officing"), officing_root_path %>
   </li>
 <% end %>

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -55,7 +55,22 @@ feature 'Poll Officing' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as an poll officer is authorized' do
+  scenario 'Access as an administrator is not authorized' do
+    create(:administrator, user: user)
+    create(:poll)
+    login_as(user)
+    visit root_path
+
+    expect(page).to_not have_link("Polling officers")
+    visit officing_root_path
+
+    expect(current_path).not_to eq(officing_root_path)
+    expect(current_path).to eq(root_path)
+    expect(page).to have_content "You do not have permission to access this page"
+  end
+
+  scenario 'Access as an administrator with poll officer role is authorized' do
+    create(:administrator, user: user)
     create(:poll_officer, user: user)
     create(:poll)
     login_as(user)
@@ -68,8 +83,8 @@ feature 'Poll Officing' do
     expect(page).to_not have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as an administrator is authorized' do
-    create(:administrator, user: user)
+  scenario 'Access as an poll officer is authorized' do
+    create(:poll_officer, user: user)
     create(:poll)
     login_as(user)
     visit root_path


### PR DESCRIPTION
Where
=====
* **Related Issue:** Remove Admins from login on officing panel #2097

What
====
- Avoids admin access to officing panel.

How
===
- Deletes administrator from `/officing/base_controller.rb`
- Moves officing menu outside of admin dropdown (this also makes that officers don't see the "Admin" dropdown, less confuse)
- Once in officing panel show admin shortcuts (settings and stats) only to admins.

- Specs added:
  - Access as an administrator is not authorized.
  - Access as an administrator with poll officer role is authorized.

Screenshots
===========
**Admin front**
<img width="499" alt="admin_front" src="https://user-images.githubusercontent.com/631897/31853344-37c982c8-b687-11e7-8583-71df8cea3a17.png">

**Admin & Officer front**
<img width="545" alt="admin_and_officer_front" src="https://user-images.githubusercontent.com/631897/31853345-37e07c4e-b687-11e7-8e84-8f4292d961bc.png">

**Admin & Officer back**
<img width="643" alt="admin_and_officer_back" src="https://user-images.githubusercontent.com/631897/31853346-380ce81a-b687-11e7-8d9b-800dcee287a3.png">

**Officer front**
<img width="475" alt="officer_front" src="https://user-images.githubusercontent.com/631897/31853348-3a05da8c-b687-11e7-8e50-b5d897c282c2.png">

**Officer back**
<img width="455" alt="officer_back" src="https://user-images.githubusercontent.com/631897/31853347-39efb18a-b687-11e7-910c-61bc96e2f476.png">

Test
====
- Specs added. Also you can try UI with:
  - Admin: shows admin dropdown.
  - Officer: shows officing link.
  - Admin with officer role: shows admin dropdown and officing link.
  - Regular user: don't shows admin dropdown neither officing link.

Deployment
==========
- As usual.

Warnings
========
- None.
