### PR TITLE
Admin menu order

### DIFF
--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -60,8 +60,8 @@
           <strong><%= t("admin.menu.title_polls") %></strong>
         </a>
         <ul id="polls_menu" <%= "class=is-active" if menu_polls? || controller.class.parent == Admin::Poll::Questions::Answers %>>
-          <li <%= "class=active" if ["polls", "officer_assignments", "booth_assignments", "recounts", "results"].include? controller_name &&
-                                    action_name != "booth_assignments" %>>
+          <li <%= "class=active" if controller_name == "polls" && action_name != "booth_assignments" ||
+                                    (["booth_assignments", "officer_assignments", "recounts", "results"].include? controller_name) %>>
             <%= link_to t('admin.menu.polls'), admin_polls_path %>
           </li>
 

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -80,14 +80,14 @@
             <%= link_to t('admin.menu.poll_booths'), admin_booths_path %>
           </li>
 
+          <li <%= "class=active" if (controller_name == "polls" && action_name == "booth_assignments") || (controller_name == "booth_assignments" && action_name == "manage") %>>
+            <%= link_to t('admin.menu.poll_booth_assignments'), booth_assignments_admin_polls_path %>
+          </li>
+
           <li <%= "class=active" if controller_name == "shifts" ||
                                     controller_name == "booths" &&
                                     action_name == "available" %>>
             <%= link_to t('admin.menu.poll_shifts'), available_admin_booths_path %>
-          </li>
-
-          <li <%= "class=active" if (controller_name == "polls" && action_name == "booth_assignments") || (controller_name == "booth_assignments" && action_name == "manage") %>>
-            <%= link_to t('admin.menu.poll_booth_assignments'), booth_assignments_admin_polls_path %>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
Where
====

Product team requirement.

What
====

- Changes admin menu order ("Manage shifts" and "Booths Assignments")
- Fixes active class on polls admin menu.

Screenshots
===========
<img width="412" alt="admin_menu" src="https://user-images.githubusercontent.com/631897/31853674-d844d374-b68c-11e7-94af-757dc60aa4ed.png">

Test
====
- No needed, only visual styles and menu order.

Deployment
==========
- As usual.

Warnings
========
- None.
