### PR TITLE
Fix `direct_messages_max_per_day` set to nil

### DIFF
--- a/app/models/direct_message.rb
+++ b/app/models/direct_message.rb
@@ -13,6 +13,7 @@ class DirectMessage < ActiveRecord::Base
   def max_per_day
     return if errors.any?
     max = Setting[:direct_message_max_per_day]
+    return unless max
 
     if sender.direct_messages_sent.today.count >= max.to_i
       errors.add(:title, I18n.t('activerecord.errors.models.direct_message.attributes.max_per_day.invalid'))

--- a/spec/models/direct_message_spec.rb
+++ b/spec/models/direct_message_spec.rb
@@ -4,10 +4,6 @@ describe DirectMessage do
 
   let(:direct_message) { build(:direct_message) }
 
-  before(:each) do
-    Setting[:direct_message_max_per_day] = 3
-  end
-
   it "should be valid" do
     expect(direct_message).to be_valid
   end
@@ -33,32 +29,48 @@ describe DirectMessage do
   end
 
   describe "maximum number of direct messages per day" do
+    context "when set" do
+      before(:each) do
+        Setting[:direct_message_max_per_day] = 3
+      end
 
-    it "should not be valid if above maximum" do
-      sender = create(:user)
-      direct_message1 = create(:direct_message, sender: sender)
-      direct_message2 = create(:direct_message, sender: sender)
-      direct_message3 = create(:direct_message, sender: sender)
+      it "should not be valid if above maximum" do
+        sender = create(:user)
+        direct_message1 = create(:direct_message, sender: sender)
+        direct_message2 = create(:direct_message, sender: sender)
+        direct_message3 = create(:direct_message, sender: sender)
 
-      direct_message4 = build(:direct_message, sender: sender)
-      expect(direct_message4).to_not be_valid
+        direct_message4 = build(:direct_message, sender: sender)
+        expect(direct_message4).to_not be_valid
+      end
+
+      it "should be valid if below maximum" do
+        sender = create(:user)
+        direct_message1 = create(:direct_message, sender: sender)
+        direct_message2 = create(:direct_message, sender: sender)
+
+        direct_message3 = build(:direct_message)
+        expect(direct_message).to be_valid
+      end
+
+      it "should be valid if no direct_messages sent" do
+        direct_message = build(:direct_message)
+
+        expect(direct_message).to be_valid
+      end
     end
 
-    it "should be valid if below maximum" do
-      sender = create(:user)
-      direct_message1 = create(:direct_message, sender: sender)
-      direct_message2 = create(:direct_message, sender: sender)
+    context "when unset" do
+      before(:each) do
+        Setting[:direct_message_max_per_day] = nil
+      end
 
-      direct_message3 = build(:direct_message)
-      expect(direct_message).to be_valid
+      it "should be valid" do
+        direct_message = build(:direct_message)
+
+        expect(direct_message).to be_valid
+      end
     end
-
-    it "should be valid if no direct_messages sent" do
-      direct_message = build(:direct_message)
-
-      expect(direct_message).to be_valid
-    end
-
   end
 
   describe "scopes" do


### PR DESCRIPTION
When set to nil, it should mean not zero, but "infinite".

Where
=====
_None_.

What
====
- Whats the objective of this changes ?

The objective is that there's a way to have unlimited direct messages per day, and also that messages can be sent by default on a development setup, since it currently gives a "max messages per day reached" error that prevents every message from being sent.

How
===
- How you implemented/achieved the objective ?

I checked for the existance of the setting and skip validation in that case. This way we skip the automatic `nil.to_i` (`== 0`) conversion leading to the current behavior. 

Screenshots
===========
_None_.

Test
====
- Is manual test needed or you just increased/fixed coverage?

I added coverage.

Deployment
==========
- Any details to remember when this feature is deployed?

I don't think so.

Warnings
========
- Some caveats or important things to notice?

~Nope~. Well, maybe yes. If some installation is intentionally using this (buggy, in my opinion) behavior, they'll have to start being explicit about it and set `Setting['direct_max_messages_per_day'] = 0`.