### PR TITLE
[Backport] Token error

### DIFF
--- a/app/assets/javascripts/polls.js.coffee
+++ b/app/assets/javascripts/polls.js.coffee
@@ -15,16 +15,16 @@ App.Polls =
       if token_param == "token="
         link.href = link.href + @token
 
+  showTokenMessage: ->
+    token_message = $(".js-token-message")
+    if !token_message.is(':visible') && $('.js-marked-answer').length > 0
+      token_message.html(token_message.html() + "<br><strong>" + @token + "</strong>");
+      token_message.show()
+
   initialize: ->
     @token = App.Polls.generateToken()
     App.Polls.replaceToken()
 
-    $(".js-question-answer").on
-      click: =>
-        token_message = $(".js-token-message")
-        if !token_message.is(':visible')
-          token_message.html(token_message.html() + "<br><strong>" + @token + "</strong>");
-          token_message.show()
     false
 
     $(".zoom-link").on "click", (event) ->

--- a/app/controllers/polls/questions_controller.rb
+++ b/app/controllers/polls/questions_controller.rb
@@ -7,17 +7,26 @@ class Polls::QuestionsController < ApplicationController
 
   def answer
     answer = @question.answers.find_or_initialize_by(author: current_user)
-    token = params[:token]
 
     answer.answer = params[:answer]
     answer.touch if answer.persisted?
-    answer.save!
-    answer.record_voter_participation(token)
-    @question.question_answers.where(question_id: @question).each do |question_answer|
-      question_answer.set_most_voted
-    end
 
-    @answers_by_question_id = { @question.id => params[:answer] }
+    voter = Poll::Voter.find_or_initialize_by(
+      user: answer.author,
+      poll: answer.poll,
+      origin: 'web',
+      token: params[:token]
+    )
+
+    if params[:token].present? && answer.valid? && voter.valid?
+      answer.save!
+      voter.save!
+
+      @answers_by_question_id = { @question.id => params[:answer] }
+    else
+      flash.now[:error] = t("poll_questions.show.vote_error")
+      render :error
+    end
   end
 
 end

--- a/app/models/poll/answer.rb
+++ b/app/models/poll/answer.rb
@@ -15,7 +15,4 @@ class Poll::Answer < ActiveRecord::Base
   scope :by_author, ->(author_id) { where(author_id: author_id) }
   scope :by_question, ->(question_id) { where(question_id: question_id) }
 
-  def record_voter_participation(token)
-    Poll::Voter.find_or_create_by(user: author, poll: poll, origin: "web", token: token)
-  end
 end

--- a/app/models/poll/voter.rb
+++ b/app/models/poll/voter.rb
@@ -12,6 +12,7 @@ class Poll
 
     validates :poll_id, presence: true
     validates :user_id, presence: true
+    validates :token, presence: true, if: ->(voter) { voter.origin == 'web' }
 
     validates :document_number, presence: true, uniqueness: { scope: [:poll_id, :document_type], message: :has_voted }
     validates :origin, inclusion: { in: VALID_ORIGINS }

--- a/app/views/polls/questions/_answers.html.erb
+++ b/app/views/polls/questions/_answers.html.erb
@@ -1,10 +1,10 @@
 <div class="poll-question-answers">
   <% if can?(:answer, question) && !question.poll.voted_in_booth?(current_user) %>
     <% question.question_answers.each do |answer| %>
-      <% if @answers_by_question_id[question.id] == answer.title &&
+      <% if @answers_by_question_id && @answers_by_question_id[question.id] == answer.title &&
             (!voted_before_sign_in(question) ||
              question.poll.voted_in_booth?(current_user)) %>
-        <span class="button answered"
+        <span class="button answered js-marked-answer"
               title="<%= t("poll_questions.show.voted", answer: answer.title)%>">
           <%= answer.title %>
         </span>

--- a/app/views/polls/questions/_error.html.erb
+++ b/app/views/polls/questions/_error.html.erb
@@ -1,0 +1,3 @@
+<div class="callout warning js-token-error-message">
+  <%= t("poll_questions.show.vote_error") %>
+</div>

--- a/app/views/polls/questions/answer.js.erb
+++ b/app/views/polls/questions/answer.js.erb
@@ -1,2 +1,3 @@
 <% token = poll_voter_token(@question.poll, current_user) %>
 $("#<%= dom_id(@question) %>_answers").html('<%= j render("polls/questions/answers", question: @question, token: token) %>');
+App.Polls.showTokenMessage()

--- a/app/views/polls/questions/error.js.erb
+++ b/app/views/polls/questions/error.js.erb
@@ -1,0 +1,3 @@
+if ($('.js-token-error-message').length == 0) {
+  $("#questions-container").prepend('<%= j render("polls/questions/error") %>');
+}

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -6,7 +6,7 @@
   <%= render "poll_subnav" %>
 
   <div class="row margin">
-    <div class="small-12 medium-9 column">
+    <div id="questions-container" class="small-12 medium-9 column">
       <%= render "callout" %>
 
       <% if @poll.voted_in_booth?(current_user) %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -520,6 +520,7 @@ en:
       vote_answer: "Vote %{answer}"
       voted: "You have voted %{answer}"
       voted_token: "You can write down this vote identifier, to check your vote on the final results:"
+      vote_error: "Something went wrong and your vote couldn't be registered. Please check if your browser supports Javascript and try again later."
   proposal_notifications:
     new:
       title: "Send message"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -520,6 +520,7 @@ es:
       vote_answer: "Votar %{answer}"
       voted: "Has votado %{answer}"
       voted_token: "Puedes apuntar este identificador de voto, para comprobar tu votación en el resultado final:"
+      vote_error: "Algo ha fallado y tu voto no se ha podido registrar correctamente. Por favor comprueba que tu navegador soporta Javascript y vuelve a intentarlo más tarde."
   proposal_notifications:
     new:
       title: "Enviar mensaje"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -645,6 +645,7 @@ FactoryBot.define do
     association :user, :level_two
     association :officer, factory: :poll_officer
     origin "web"
+    token SecureRandom.hex(32)
 
     trait :from_booth do
       association :booth_assignment, factory: :poll_booth_assignment

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -38,6 +38,30 @@ feature "Voter" do
       expect(Poll::Voter.first.origin).to eq("web")
     end
 
+    scenario "Voting via web failing vote", :js do
+      poll = create(:poll)
+
+      question = create(:poll_question, poll: poll)
+      create(:poll_question_answer, question: question, title: 'Yes')
+      create(:poll_question_answer, question: question, title: 'No')
+
+      user = create(:user, :level_two)
+
+      login_as user
+      visit poll_path(poll)
+
+      remove_token_from_vote_link
+
+      within("#poll_question_#{question.id}_answers") do
+        click_link 'Yes'
+      end
+
+      expect(page).to have_content "Something went wrong and your vote couldn't be registered. Please check if your browser supports Javascript and try again later."
+      expect(page).to_not have_content "You can write down this vote identifier, to check your vote on the final results"
+
+      expect(Poll::Voter.count).to eq(0)
+    end
+
     scenario "Voting via web as unverified user", :js do
       user = create(:user, :incomplete_verification)
 

--- a/spec/models/poll/answer_spec.rb
+++ b/spec/models/poll/answer_spec.rb
@@ -39,40 +39,4 @@ describe Poll::Answer do
     end
   end
 
-  describe "#record_voter_participation" do
-
-    let(:author) { create(:user, :level_two) }
-    let(:poll) { create(:poll) }
-    let(:question) { create(:poll_question, :with_answers, poll: poll) }
-
-    it "creates a poll_voter with user and poll data" do
-      answer = create(:poll_answer, question: question, author: author, answer: "Yes")
-      expect(answer.poll.voters).to be_blank
-
-      answer.record_voter_participation('token')
-      expect(poll.reload.voters.size).to eq(1)
-      voter = poll.voters.first
-
-      expect(voter.document_number).to eq(answer.author.document_number)
-      expect(voter.poll_id).to eq(answer.poll.id)
-      expect(voter.officer_id).to eq(nil)
-    end
-
-    it "updates a poll_voter with user and poll data" do
-      answer = create(:poll_answer, question: question, author: author, answer: "Yes")
-      answer.record_voter_participation('token')
-
-      expect(poll.reload.voters.size).to eq(1)
-
-      answer = create(:poll_answer, question: question, author: author, answer: "No")
-      answer.record_voter_participation('token')
-
-      expect(poll.reload.voters.size).to eq(1)
-
-      voter = poll.voters.first
-      expect(voter.document_number).to eq(answer.author.document_number)
-      expect(voter.poll_id).to eq(answer.poll.id)
-    end
-  end
-
 end

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -94,14 +94,7 @@ describe Poll::Voter do
 
     it "should be valid if token is not present via booth" do
       user = create(:user, :level_two)
-      voter = build(:poll_voter, user: user, poll: poll, officer_assignment: officer_assignment, origin: "booth", token: '')
-
-      expect(voter).to be_valid
-    end
-
-    it "should be valid if token is not present via letter" do
-      user = create(:user, :level_two)
-      voter = build(:poll_voter, user: user, poll: poll, origin: "letter", token: '')
+      voter = build(:poll_voter, user: user, poll: poll, origin: "booth", token: '')
 
       expect(voter).to be_valid
     end

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -76,11 +76,34 @@ describe Poll::Voter do
 
     it "is not valid if the user has voted via web" do
       answer = create(:poll_answer)
-      answer.record_voter_participation('token')
+
+      Poll::Voter.find_or_create_by(user: answer.author, poll: answer.poll, origin: "web", token: 'token')
 
       voter = build(:poll_voter, poll: answer.question.poll, user: answer.author)
       expect(voter).not_to be_valid
       expect(voter.errors.messages[:document_number]).to eq(["User has already voted"])
+    end
+
+    it "should not be valid if token is not present via web" do
+      user = create(:user, :level_two)
+      voter = build(:poll_voter, user: user, poll: poll, origin: "web", token: '')
+
+      expect(voter).to_not be_valid
+      expect(voter.errors.messages[:token]).to eq(["can't be blank"])
+    end
+
+    it "should be valid if token is not present via booth" do
+      user = create(:user, :level_two)
+      voter = build(:poll_voter, user: user, poll: poll, officer_assignment: officer_assignment, origin: "booth", token: '')
+
+      expect(voter).to be_valid
+    end
+
+    it "should be valid if token is not present via letter" do
+      user = create(:user, :level_two)
+      voter = build(:poll_voter, user: user, poll: poll, origin: "letter", token: '')
+
+      expect(voter).to be_valid
     end
 
     context "origin" do

--- a/spec/support/common_actions/polls.rb
+++ b/spec/support/common_actions/polls.rb
@@ -33,4 +33,8 @@ module Polls
 
     expect(page).to have_content 'Code correct'
   end
+
+  def remove_token_from_vote_link
+    page.execute_script("$('.js-question-answer')[0]['href'] = $('.js-question-answer')[0]['href'].match(/.+?(?=token)/)[0] + 'token='")
+  end
 end


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#957 
* Closes #2088 

## Objectives

Backport problems generated when the voter token wasn't received correctly in the client side.

I took the code related to tokens in Madrid's fork and adapted to make it work in consul.

## Visual changes

![iagirre-token-problem-from-madrid](https://user-images.githubusercontent.com/31625251/32053818-aef5b99c-ba5c-11e7-9ee4-5c4529411b76.jpg)

## Notes

- I added the test from Madrid's fork, but some of them needed some modifications because the features they test didn't exist in consul.
- I removed some test code from features/polls/voter_spec.rb which checks the presence of token in postal votes. In consul there isn't postal vote yet (there is an issue about it #1881). Just to be aware of this when doing that issue.
- In Madrid's fork there was a [call to a method](https://github.com/AyuntamientoMadrid/consul/blob/18550eae40bc0e9534e922e80d88dfe004800b04/app/controllers/polls/questions_controller.rb#L20) to log the vote event. That method was part of a concern call [`analytics.rb`](https://github.com/AyuntamientoMadrid/consul/blob/master/app/controllers/concerns/analytics.rb) that doesn't exists in consul, and I'm not sure if it should be in consul repo. I didn't include neither that `log_event` call nor the concern, but I will if it's needed.
- This PR fixes the problem generated when, by some reason, the answer links don't have the token attribute in the `href` property, BUT it doesn't fix the problem generated when the user has the JS disabled from the browser. If that happens, when the user tries to answer, the `link_to` behaves like a GET, not a POST (event though there is an explicit `method: :post`), and there isn't any route GET that fulfills the path, so the app raises a routing error.

> Note that if the user has JavaScript disabled, the request will fall back to using GET.
> https://apidock.com/rails/ActionView/Helpers/UrlHelper/link_to
