### PR TITLE
Create a Video concern

### DIFF
--- a/app/helpers/embed_videos_helper.rb
+++ b/app/helpers/embed_videos_helper.rb
@@ -1,8 +1,5 @@
 module EmbedVideosHelper
 
-  VIMEO_REGEX = /vimeo.*(staffpicks\/|channels\/|videos\/|video\/|\/)([^#\&\?]*).*/
-  YOUTUBE_REGEX = /youtu.*(be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
-
   def embedded_video_code
     link = @proposal.video_url
     title = t('proposals.show.embed_video_title', proposal: @proposal.title)
@@ -13,10 +10,10 @@ module EmbedVideosHelper
     end
 
     if server == "Vimeo"
-      reg_exp = VIMEO_REGEX
+      reg_exp = Videable::VIMEO_REGEX
       src = "https://player.vimeo.com/video/"
     elsif server == "YouTube"
-      reg_exp = YOUTUBE_REGEX
+      reg_exp = Videable::YOUTUBE_REGEX
       src = "https://www.youtube.com/embed/"
     end
 
@@ -30,12 +27,5 @@ module EmbedVideosHelper
       ''
     end
   end
-
-  #  def valid_video_url?
-  #    return if video_url.blank?
-  #    return if video_url.match(VIMEO_REGEX)
-  #    return if video_url.match(YOUTUBE_REGEX)
-  #    errors.add(:video_url, :invalid)
-  #  end
 
 end

--- a/app/helpers/embed_videos_helper.rb
+++ b/app/helpers/embed_videos_helper.rb
@@ -31,11 +31,11 @@ module EmbedVideosHelper
     end
   end
 
-  def valid_video_url?
-    return if video_url.blank?
-    return if video_url.match(VIMEO_REGEX)
-    return if video_url.match(YOUTUBE_REGEX)
-    errors.add(:video_url, :invalid)
-  end
+  #  def valid_video_url?
+  #    return if video_url.blank?
+  #    return if video_url.match(VIMEO_REGEX)
+  #    return if video_url.match(YOUTUBE_REGEX)
+  #    errors.add(:video_url, :invalid)
+  #  end
 
 end

--- a/app/models/concerns/videable.rb
+++ b/app/models/concerns/videable.rb
@@ -1,0 +1,18 @@
+module Videable
+  extend ActiveSupport::Concern
+
+  VIMEO_REGEX = /vimeo.*(staffpicks\/|channels\/|videos\/|video\/|\/)([^#\&\?]*).*/
+  YOUTUBE_REGEX = /youtu.*(be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
+
+  included do
+    validate :valid_video_url?
+  end
+
+  def valid_video_url?
+    return if video_url.blank?
+    return if video_url.match(VIMEO_REGEX)
+    return if video_url.match(YOUTUBE_REGEX)
+    errors.add(:video_url, :invalid)
+  end
+
+end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -18,7 +18,6 @@ class Proposal < ActiveRecord::Base
   documentable max_documents_allowed: 3,
                max_file_size: 3.megabytes,
                accepted_content_types: [ "application/pdf" ]
-  # include EmbedVideosHelper
   include Relationable
   include Videable
 
@@ -46,8 +45,6 @@ class Proposal < ActiveRecord::Base
   validates :retired_reason, inclusion: { in: RETIRE_OPTIONS, allow_nil: true }
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
-
-  # validate :valid_video_url?
 
   before_validation :set_responsible_name
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -18,8 +18,9 @@ class Proposal < ActiveRecord::Base
   documentable max_documents_allowed: 3,
                max_file_size: 3.megabytes,
                accepted_content_types: [ "application/pdf" ]
-  include EmbedVideosHelper
+  # include EmbedVideosHelper
   include Relationable
+  include Videable
 
   acts_as_votable
   acts_as_paranoid column: :hidden_at
@@ -46,7 +47,7 @@ class Proposal < ActiveRecord::Base
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
 
-  validate :valid_video_url?
+  # validate :valid_video_url?
 
   before_validation :set_responsible_name
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -241,6 +241,26 @@ feature 'Proposals' do
     expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)
   end
 
+  scenario "Create with wrong video url" do
+    author = create(:user)
+    login_as(author)
+
+    visit new_proposal_path
+    fill_in 'proposal_title', with: 'Help refugees'
+    fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
+    fill_in 'proposal_summary', with: 'In summary, what we want is...'
+    fill_in 'proposal_description', with: 'This is very important because...'
+    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
+    fill_in 'proposal_video_url', with: 'https://www.google.com'
+    fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
+    fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
+    check 'proposal_terms_of_service'
+
+    click_button 'Create proposal'
+
+    expect(page).to have_content "1 error prevented this Proposal from being saved"
+  end
+
   scenario 'Create with proposal improvement info link' do
     Setting['proposal_improvement_path'] = '/more-information/proposal-improvement'
     author = create(:user)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1865 
This PR closes #1865 

What
====
Create a concern for all the things related to video_urls so that the management of this logic would be easier to maintain.

How
===
- I created a concern called `Videable` where I put the regex to check video origins and the `valid_video_url?` method.
- I moved all that code from the `EmbedVideosHelper`, and used the regex from Videable in the function `embedded_video_code`. 

Screenshots
===========
There is nothing to show

Test
====
Tests were added to check that the functions moved to `Videable` concern continue working.

Deployment
==========
Nothing to apply.

Warnings
========
This issue was mentioned in #1989 PR. Some of the code added there should be moved to this concern.
