### PR TITLE
Add option to unassign Valuator role

### DIFF
--- a/app/controllers/admin/valuators_controller.rb
+++ b/app/controllers/admin/valuators_controller.rb
@@ -19,6 +19,11 @@ class Admin::ValuatorsController < Admin::BaseController
     redirect_to admin_valuators_path
   end
 
+  def destroy
+    @valuator.destroy
+    redirect_to admin_valuators_path
+  end
+
   def summary
     @valuators = Valuator.order(spending_proposals_count: :desc)
   end

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -43,7 +43,7 @@ module Abilities
 
       can [:search, :create, :index, :destroy], ::Administrator
       can [:search, :create, :index, :destroy], ::Moderator
-      can [:search, :create, :index, :summary], ::Valuator
+      can [:search, :create, :index, :destroy, :summary], ::Valuator
       can [:search, :create, :index, :destroy], ::Manager
       can [:search, :index], ::User
 

--- a/app/views/admin/valuators/index.html.erb
+++ b/app/views/admin/valuators/index.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t("admin.valuators.index.title") %></h2>
 
-<%= render 'admin/shared/user_search', url: search_admin_valuators_path %>
+<%= render "admin/shared/user_search", url: search_admin_valuators_path %>
 
 <div id="valuators">
   <% if @valuators.any? %>
@@ -11,22 +11,25 @@
         <th scope="col"><%= t("admin.valuators.index.name") %></th>
         <th scope="col"><%= t("admin.valuators.index.email") %></th>
         <th scope="col"><%= t("admin.valuators.index.description") %></th>
+        <th scope="col"><%= t("admin.actions.actions") %></th>
       </thead>
       <tbody>
         <% @valuators.each do |valuator| %>
           <tr>
-            <td>
-              <%= valuator.name %>
-            </td>
-            <td>
-              <%= valuator.email %>
-            </td>
+            <td><%= valuator.name %></td>
+            <td><%= valuator.email %></td>
             <td>
               <% if valuator.description.present? %>
                 <%= valuator.description %>
               <% else %>
                 <%= t("admin.valuators.index.no_description") %>
               <% end %>
+            </td>
+            <td>
+              <%= link_to t("admin.valuators.valuator.delete"),
+                          admin_valuator_path(valuator),
+                          method: :delete,
+                          class: "button hollow alert expanded" %>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/valuators/search.html.erb
+++ b/app/views/admin/valuators/search.html.erb
@@ -29,7 +29,12 @@
                 <%= t("admin.valuators.index.no_description") %>
               <% end %>
             <td>
-              <% unless user.valuator? %>
+              <% if user.valuator? %>
+                <%= link_to t("admin.valuators.valuator.delete"),
+                            admin_valuator_path(user),
+                            method: :delete,
+                            class: "button hollow alert expanded" %>
+              <% else %>
                 <%= form_for Valuator.new(user: user), url: admin_valuators_path do |f| %>
                   <%= f.text_field :description,
                                    label: false,

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -481,6 +481,7 @@ en:
       valuator:
         description_placeholder: 'Description (optional)'
         add: Add to valuators
+        delete: Delete
       search:
         title: 'Valuators: User search'
       summary:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -481,6 +481,7 @@ es:
       valuator:
         description_placeholder: 'Descripción (opcional)'
         add: Añadir como evaluador
+        delete: Borrar
       search:
         title: 'Evaluadores: Búsqueda de usuarios'
       summary:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -272,7 +272,7 @@ Rails.application.routes.draw do
       get :search, on: :collection
     end
 
-    resources :valuators, only: [:index, :create] do
+    resources :valuators, only: [:index, :create, :destroy] do
       get :search, on: :collection
       get :summary, on: :collection
     end

--- a/spec/features/admin/valuators_spec.rb
+++ b/spec/features/admin/valuators_spec.rb
@@ -29,6 +29,14 @@ feature 'Admin valuators' do
     end
   end
 
+  scenario 'Delete Valuator' do
+    click_link 'Delete'
+
+    within('#valuators') do
+      expect(page).to_not have_content(@valuator.name)
+    end
+  end
+
   context 'Search' do
 
     background do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2091

What
====
* Add the option for administrators to unassign Valuators

How
===
* Added 'Delete' button to Valuators `index` and `search` views
* Added English and Spanish locales
* Added `destroy` route for Valuators, `destroy` action in `Admin::ValuatorsController` and appended the `destroy` ability in the `abilities/administrator` model

Test
====
* Increased coverage for the `Destroy Valuator` scenario