### PR TITLE
Iagirre booth assignment removal

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -90,8 +90,4 @@ class Poll < ActiveRecord::Base
     end
   end
 
-  def shifts_in_booth(booth_id)
-    officer_assignments.where(booth_assignment_id: booth_assignments.where(booth_id: booth_id).pluck(:id)).pluck(:officer_id).uniq
-  end
-
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -90,4 +90,8 @@ class Poll < ActiveRecord::Base
     end
   end
 
+  def shifts_in_booth(booth_id)
+    officer_assignments.where(booth_assignment_id: booth_assignments.where(booth_id: booth_id).pluck(:id)).pluck(:officer_id).uniq
+  end
+
 end

--- a/app/models/poll/booth_assignment.rb
+++ b/app/models/poll/booth_assignment.rb
@@ -8,5 +8,18 @@ class Poll
     has_many :voters
     has_many :partial_results
     has_many :recounts
+
+    before_destroy :destroy_poll_shifts
+    
+    def has_shifts?
+      
+    end
+
+    private
+
+      def destroy_poll_shifts
+#        officers = poll.officers_in_booth(booth.id)
+#        Poll::Shift.where(officer_id: officers, booth_id: booth.id)
+      end
   end
 end

--- a/app/models/poll/booth_assignment.rb
+++ b/app/models/poll/booth_assignment.rb
@@ -3,23 +3,26 @@ class Poll
     belongs_to :booth
     belongs_to :poll
 
+    before_destroy :destroy_poll_shifts, only: :destroy
+
     has_many :officer_assignments, class_name: "Poll::OfficerAssignment", dependent: :destroy
     has_many :officers, through: :officer_assignments
     has_many :voters
     has_many :partial_results
     has_many :recounts
 
-    before_destroy :destroy_poll_shifts
-    
-    def has_shifts?
-      
+    def shifts?
+      shifts.empty? ? false : true
     end
 
     private
 
+      def shifts
+        Poll::Shift.where(booth_id: booth_id, officer_id: officer_assignments.pluck(:officer_id), date: officer_assignments.pluck(:date))
+      end
+
       def destroy_poll_shifts
-#        officers = poll.officers_in_booth(booth.id)
-#        Poll::Shift.where(officer_id: officers, booth_id: booth.id)
+        shifts.destroy_all
       end
   end
 end

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -14,8 +14,8 @@
                 method: :delete,
                 remote: true,
                 title: t("admin.booth_assignments.manage.actions.unassign"),
-                class: "button hollow alert #{@poll.expired? ? 'disabled' : ''}",
-                data: (booth_assignment.shifts? ? {confirm: "#{t("admin.poll_booth_assignments.alert.shifts")}"} : nil) %>
+                class: "button hollow alert",
+                data: (booth_assignment.shifts? ? {confirm: "#{t("admin.poll_booth_assignments.alert.shifts")}"} : nil) if !@poll.expired? %>
   </td>
 <% else %>
   <td>
@@ -27,6 +27,6 @@
                 method: :post,
                 remote: true,
                 title: t("admin.booth_assignments.manage.actions.assign"),
-                class: "button #{@poll.expired? ? 'disabled' : ''}" %>
+                class: "button" if !@poll.expired? %>
   </td>
 <% end %>

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -15,7 +15,7 @@
                 remote: true,
                 title: t("admin.booth_assignments.manage.actions.unassign"),
                 class: "button hollow alert #{@poll.expired? ? 'disabled' : ''}",
-                data: (booth_assignment.has_shifts? ? {confirm: "Are you sure?"} : nil) %>
+                data: (booth_assignment.shifts? ? {confirm: "#{t("admin.poll_booth_assignments.alert.shifts")}"} : nil) %>
   </td>
 <% else %>
   <td>

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -14,7 +14,7 @@
                 method: :delete,
                 remote: true,
                 title: t("admin.booth_assignments.manage.actions.unassign"),
-                class: "button hollow alert" %>
+                class: "button hollow alert #{@poll.expired? ? 'disabled' : ''}" %>
   </td>
 <% else %>
   <td>
@@ -26,6 +26,6 @@
                 method: :post,
                 remote: true,
                 title: t("admin.booth_assignments.manage.actions.assign"),
-                class: "button" %>
+                class: "button #{@poll.expired? ? 'disabled' : ''}" %>
   </td>
 <% end %>

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -14,7 +14,8 @@
                 method: :delete,
                 remote: true,
                 title: t("admin.booth_assignments.manage.actions.unassign"),
-                class: "button hollow alert #{@poll.expired? ? 'disabled' : ''}" %>
+                class: "button hollow alert #{@poll.expired? ? 'disabled' : ''}",
+                data: (booth_assignment.has_shifts? ? {confirm: "Are you sure?"} : nil) %>
   </td>
 <% else %>
   <td>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -544,6 +544,8 @@ en:
           assign: Assign booth
           unassign: Unassign booth
     poll_booth_assignments:
+      alert:
+        shifts: "There are shifts associated to this booth. If you remove the booth assignment, the shifts will be also deleted. Continue?"
       flash:
         destroy: "Booth not assigned anymore"
         create: "Booth assigned"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -544,6 +544,8 @@ es:
           assign: Assign booth
           unassign: Unassign booth
     poll_booth_assignments:
+      alert:
+        shifts: "Hay turnos asignados para esta urna. Si la desasignas, esos turnos se eliminarán. ¿Deseas continuar?"
       flash:
         destroy: "Urna desasignada"
         create: "Urna asignada"

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -143,7 +143,7 @@ feature 'Admin booths assignments' do
     end
   end
 
-  xfeature 'Show' do
+  feature 'Show' do
     scenario 'Lists all assigned poll officers' do
       poll = create(:poll)
       booth = create(:poll_booth)

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -106,9 +106,44 @@ feature 'Admin booths assignments' do
       expect(page).to have_content 'There are no booths assigned to this poll.'
       expect(page).not_to have_content booth.name
     end
+    
+    scenario 'Unassing booth whith associated shifts', :js do
+      assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+      officer = create(:poll_officer)
+      create(:poll_officer_assignment, officer: officer, booth_assignment: assignment)
+      create(:poll_shift, booth: booth, officer: officer)
+      
+      visit manage_admin_poll_booth_assignments_path(poll)
+      
+      within("#poll_booth_#{booth.id}") do
+        expect(page).to have_content(booth.name)
+        expect(page).to have_content "Assigned"
+
+        click_link 'Unassign booth'
+        
+        expect(page).to have_content "Unassigned"
+        expect(page).not_to have_content "Assigned"
+        expect(page).to have_link "Assign booth"
+      end      
+    end
+      
+    scenario "Cannot unassing booth if poll is expired" do
+      poll_expired = create(:poll, :expired)
+      create(:poll_booth_assignment, poll: poll_expired, booth: booth)
+
+      visit manage_admin_poll_booth_assignments_path(poll_expired)
+      
+      within("#poll_booth_#{booth.id}") do
+        expect(page).to have_content(booth.name)
+        expect(page).to have_content "Assigned"
+
+        expect(page).not_to have_link 'Unassign booth'
+      end
+
+    end
   end
 
-  feature 'Show' do
+  xfeature 'Show' do
     scenario 'Lists all assigned poll officers' do
       poll = create(:poll)
       booth = create(:poll_booth)

--- a/spec/models/poll/booth_assignment_spec.rb
+++ b/spec/models/poll/booth_assignment_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe :booth_assignment do
+  let(:poll){create(:poll)}
+  let(:booth){create(:poll_booth)}
+  let(:booth1){create(:poll_booth)}
+  
+  it "should check if there are shifts" do
+    assignment_with_shifts = create(:poll_booth_assignment, poll: poll, booth: booth)
+    assignment_without_shifts = create(:poll_booth_assignment, poll: poll, booth: booth1)
+    officer = create(:poll_officer)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: assignment_with_shifts)
+    create(:poll_shift, booth: booth, officer: officer)    
+    
+    expect(assignment_with_shifts.shifts?).to eq(true)
+    expect(assignment_without_shifts.shifts?).to eq(false)    
+  end
+  
+  it "should delete shifts associated to booth assignments" do
+    assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    officer = create(:poll_officer)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: assignment)
+    create(:poll_shift, booth: booth, officer: officer)
+    
+    assignment.destroy
+    
+    expect(Poll::Shift.all.count).to eq(0)
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2061 

What
====
Delete the shifts associated to a `booth_assigment` when that booth is unassigned.

How
===
- I make a callback `before_destroy` on the `booth_assignment` model that deletes the shifts related to that `booth_assignment`.
- When there are shifts related to a booth_assignment, an alert is shown before unassinging it so that the user can cancel the action.
- For expired polls there are no links to Assing/Unassing booths (to reach de booth management for an expired poll, the user needs to modify the URL directly, but, just in case it happens, there is no option to change the assignments).

Screenshots
===========
![booth_removal](https://user-images.githubusercontent.com/31625251/32181592-038fa996-bd95-11e7-85d0-a4b7cef53ef5.png)

Test
====
Test added to:
- check that the booth unassings correctly event if there are shifts for it.
- check that there is not link to unassing/assing booths when poll is expired
- test the booth_assignment models `shifts? `and `destroy_shifts` methods.

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.
