### PR TITLE
Iagirre heading population restriction validation

### DIFF
--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -10,6 +10,7 @@ class Budget
     validates :name, presence: true, uniqueness: { if: :name_exists_in_budget_headings }
     validates :price, presence: true
     validates :slug, presence: true, format: /\A[a-z0-9\-_]+\z/
+    validates :population, numericality: { greater_than: 0 }, allow_nil: true
 
     delegate :budget, :budget_id, to: :group, allow_nil: true
 

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -49,10 +49,17 @@
           <div class="row">
             <div class="small-12 medium-6 column">
               <label><%= t("admin.budgets.form.population") %></label>
-              <%= f.text_field :population,
+              <%= f.number_field :population,
                                 label: false,
                                 maxlength: 8,
-                                placeholder: t("admin.budgets.form.population") %>
+                                min: 1,
+                                placeholder: t("admin.budgets.form.population"),
+                                data: {toggle_focus: "population-info"} %>
+            </div>
+            <div class="small-12 medium-6 column " >
+              <div id="population-info" class="is-hidden" data-toggler="is-hidden">
+                <%= t("admin.budgets.form.population_info") %>
+              </div>
             </div>
           </div>
 

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -105,6 +105,7 @@ en:
         table_heading: Heading
         table_amount: Amount
         table_population: Population
+        population_info: "Budget Heading population field is used for Statistic purposes at the end of the Budget to show for each Heading that represents an area with population what percentage voted. The field is optional so you can leave it empty if it doesn't apply."
       winners:
         calculate: Calculate Winner Investments
         calculated: Winners being calculated, it may take a minute.

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -105,6 +105,7 @@ es:
         table_heading: Partida
         table_amount: Cantidad
         table_population: Población
+        population_info: "El campo población de las partidas presupuestarias se usa con fines estadísticos únicamente, con el objetivo de mostrar el porcentaje de votos habidos en cada partida que represente un área con población. Es un campo opcional, así que puedes dejarlo en blanco si no aplica."
       winners:
         calculate: Calcular propuestas ganadoras
         calculated: Calculando ganadoras, puede tardar un minuto.

--- a/spec/models/budget/heading_spec.rb
+++ b/spec/models/budget/heading_spec.rb
@@ -26,17 +26,22 @@ describe Budget::Heading do
   end
 
   describe "Save population" do
-    it "Allows nil for population" do
-      expect(create(:budget_heading, group: group, name: 'Population is nil')).to be_valid
+    it "Allows population == nil" do
+      expect(create(:budget_heading, group: group, name: 'Population is nil', population: nil)).to be_valid
     end
 
-    it "Doesn't allow 0 for population" do
-      expect(create(:budget_heading, group: group, name: 'Population is 0', population: 0)).not_to be_valid
-    end
-
-    it "Allows value > 0 for population" do
-      expect(create(:budget_heading, group: group, name: 'Population is 10', population: 10)).to be_valid
-    end    
+    it "Doesn't allow population <= 0" do
+      heading = create(:budget_heading, group: group, name: 'Population is > 0')
+      
+      heading.population = 0
+      expect(heading).not_to be_valid
+      
+      heading.population = -10
+      expect(heading).not_to be_valid
+      
+      heading.population = 10
+      expect(heading).to be_valid
+    end 
   end
 
 end

--- a/spec/models/budget/heading_spec.rb
+++ b/spec/models/budget/heading_spec.rb
@@ -25,4 +25,18 @@ describe Budget::Heading do
     end
   end
 
+  describe "Save population" do
+    it "Allows nil for population" do
+      expect(create(:budget_heading, group: group, name: 'Population is nil')).to be_valid
+    end
+
+    it "Doesn't allow 0 for population" do
+      expect(create(:budget_heading, group: group, name: 'Population is 0', population: 0)).not_to be_valid
+    end
+
+    it "Allows value > 0 for population" do
+      expect(create(:budget_heading, group: group, name: 'Population is 10', population: 10)).to be_valid
+    end    
+  end
+
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1710 

What
====
Add validations to avoid the admins to insert a value of 0 in the population field. Only nil or > 0 are valid.

How
===
- I added a validator in the headings model to check the two conditions.
- I added a validator in the form that avoids the user to post the form if population value is less than 1.
- I added an explanation test for that field when the focus is on the field.

Screenshots
===========
![population01](https://user-images.githubusercontent.com/31625251/32231325-8e943280-be55-11e7-8464-f424693d3e2f.png)
![population02](https://user-images.githubusercontent.com/31625251/32231328-93c60c60-be55-11e7-81ec-053b6e600a1e.png)

Test
====
I added tests to check the validations in the model.

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.
