### PR TITLE
Date of birth on management verification email

### DIFF
--- a/app/controllers/management/email_verifications_controller.rb
+++ b/app/controllers/management/email_verifications_controller.rb
@@ -13,11 +13,24 @@ class Management::EmailVerificationsController < Management::BaseController
       render :new
     end
   end
+  
+  def date_of_birth    
+  end
+  
+  def save_date_of_birth
+    user = User.where(email_verification_token: params[:email_verification_token]).first
+    user.date_of_birth = date_of_birth
+  end
 
   private
 
     def email_verification_params
       params.require(:email_verification).permit(:document_type, :document_number, :email)
+    end    
+    
+    def date_of_birth
+      date_params = params.require(:date).permit(:day, :month, :year)
+      DateTime.new(date_params[:year], date_params[:month], date_params[:day])
     end
 
 end

--- a/app/controllers/management/email_verifications_controller.rb
+++ b/app/controllers/management/email_verifications_controller.rb
@@ -13,24 +13,11 @@ class Management::EmailVerificationsController < Management::BaseController
       render :new
     end
   end
-  
-  def date_of_birth    
-  end
-  
-  def save_date_of_birth
-    user = User.where(email_verification_token: params[:email_verification_token]).first
-    user.date_of_birth = date_of_birth
-  end
 
   private
 
     def email_verification_params
       params.require(:email_verification).permit(:document_type, :document_number, :email)
-    end    
-    
-    def date_of_birth
-      date_params = params.require(:date).permit(:day, :month, :year)
-      DateTime.new(date_params[:year], date_params[:month], date_params[:day])
     end
 
 end

--- a/app/controllers/verification/email_controller.rb
+++ b/app/controllers/verification/email_controller.rb
@@ -12,8 +12,16 @@ class Verification::EmailController < ApplicationController
       redirect_to verified_user_path, alert: t('verification.email.show.alert.failure')
     end
   end
-  
-  def new    
+
+  def date_of_birth
+    @user = current_user
+  end
+
+  def save_date_of_birth
+    user = User.where(id: params[:id]).first
+    user.date_of_birth = Date.new(date_of_birth_params[:year].to_i, date_of_birth_params[:month].to_i, date_of_birth_params[:day].to_i)
+    user.save
+    redirect_to email_path(email_verification_token: params[:email_verification_token])
   end
 
   def create
@@ -41,8 +49,8 @@ class Verification::EmailController < ApplicationController
     def verified_user_params
       params.require(:verified_user).permit(:id)
     end
-    
-    def date_of_birth
+
+    def date_of_birth_params
       params.require(:date).permit(:day, :month, :year)
     end
 end

--- a/app/controllers/verification/email_controller.rb
+++ b/app/controllers/verification/email_controller.rb
@@ -12,6 +12,9 @@ class Verification::EmailController < ApplicationController
       redirect_to verified_user_path, alert: t('verification.email.show.alert.failure')
     end
   end
+  
+  def new    
+  end
 
   def create
     @email = Verification::Email.new(@verified_user)
@@ -32,9 +35,14 @@ class Verification::EmailController < ApplicationController
 
     def set_verified_user
       @verified_user = VerifiedUser.by_user(current_user).where(id: verified_user_params[:id]).first
+      @verified_user.set_date_of_birth(date_of_birth)
     end
 
     def verified_user_params
       params.require(:verified_user).permit(:id)
+    end
+    
+    def date_of_birth
+      params.require(:date).permit(:day, :month, :year)
     end
 end

--- a/app/controllers/verification/email_controller.rb
+++ b/app/controllers/verification/email_controller.rb
@@ -43,7 +43,6 @@ class Verification::EmailController < ApplicationController
 
     def set_verified_user
       @verified_user = VerifiedUser.by_user(current_user).where(id: verified_user_params[:id]).first
-      @verified_user.set_date_of_birth(date_of_birth)
     end
 
     def verified_user_params

--- a/app/controllers/verification/email_controller.rb
+++ b/app/controllers/verification/email_controller.rb
@@ -19,9 +19,13 @@ class Verification::EmailController < ApplicationController
 
   def save_date_of_birth
     user = User.where(id: params[:id]).first
-    user.date_of_birth = Date.new(date_of_birth_params[:year].to_i, date_of_birth_params[:month].to_i, date_of_birth_params[:day].to_i)
-    user.save
-    redirect_to email_path(email_verification_token: params[:email_verification_token])
+    if correct_date?
+      user.date_of_birth = Date.new(date_of_birth_params[:year].to_i, date_of_birth_params[:month].to_i, date_of_birth_params[:day].to_i)
+      user.save
+      redirect_to email_path(email_verification_token: params[:email_verification_token])
+    else
+      redirect_to date_of_birth_email_path(email_verification_token: params[:email_verification_token], id: params[:id]), flash: { error: t('verification.email.date.error') }
+    end
   end
 
   def create
@@ -51,5 +55,9 @@ class Verification::EmailController < ApplicationController
 
     def date_of_birth_params
       params.require(:date).permit(:day, :month, :year)
+    end
+
+    def correct_date?
+      date_of_birth_params[:year].to_i.positive? && date_of_birth_params[:month].to_i.positive? && date_of_birth_params[:day].to_i.positive?
     end
 end

--- a/app/views/mailer/email_verification.html.erb
+++ b/app/views/mailer/email_verification.html.erb
@@ -7,7 +7,7 @@
   <%= t("mailers.email_verification.instructions_html",
         verification_link: link_to(
           t('mailers.email_verification.click_here_to_verify'),
-          date_of_birth_management_email_verification_url(email_verification_token: @token))) %> <!-- new_email_url -->
+          date_of_birth_email_url(email_verification_token: @token, id: @user.id))) %>
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">

--- a/app/views/mailer/email_verification.html.erb
+++ b/app/views/mailer/email_verification.html.erb
@@ -7,7 +7,7 @@
   <%= t("mailers.email_verification.instructions_html",
         verification_link: link_to(
           t('mailers.email_verification.click_here_to_verify'),
-          email_url(email_verification_token: @token))) %>
+          date_of_birth_management_email_verification_url(email_verification_token: @token))) %> <!-- new_email_url -->
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">

--- a/app/views/verification/email/date_of_birth.html.erb
+++ b/app/views/verification/email/date_of_birth.html.erb
@@ -1,0 +1,28 @@
+<div class="row">
+  <div class="small-12 medium-6 column">
+    <h1>
+      <%= t("mailers.email_verification.title") %>
+    </h1>
+    <p>
+      Por favor, introduce tu fecha de nacimiento para verificar tu cuenta
+    </p>  
+    <div class="row">
+      <%= form_tag(save_date_of_birth_management_email_verification_path) do %>  
+        <%= hidden_field_tag :email_verification_token, params[:email_verification_token] %>
+        <div class="small-4 column">
+           <%=select_day nil, prompt: 'Día'%>
+        </div>
+        <div class="small-4 column">
+           <%=select_month nil, prompt: 'Mes'%>
+        </div>
+        <div class="small-4 column">
+           <%=select_year nil, prompt: 'Año'%>
+        </div>
+      
+        <div class="small-12 column">
+          <%= submit_tag "Verificar mi cuenta" %>
+        </div>
+      <% end %>
+    </div>  
+  </div>
+</div>

--- a/app/views/verification/email/date_of_birth.html.erb
+++ b/app/views/verification/email/date_of_birth.html.erb
@@ -11,17 +11,17 @@
         <%= hidden_field_tag :email_verification_token, params[:email_verification_token] %>
         <%= hidden_field_tag :id, @user.id %>
         <div class="small-4 column">
-           <%=  select_day nil, prompt: t("verification.email.date.day"), required: true %>
+           <%= select_day nil, prompt: true %>
         </div>
         <div class="small-4 column">
-           <%=  select_month nil, prompt: t("verification.email.date.month"), required: true %>
+           <%= select_month nil, prompt: true %>
         </div>
         <div class="small-4 column">
-           <%=  select_year nil, prompt: t("verification.email.date.year"), required: true %>
+           <%= select_year nil, prompt: true, start_year: 1900, end_year: 16.years.ago.year %>
         </div>
       
         <div class="small-12 column">
-          <%= submit_tag t("verification.email.date.submit") %>
+          <%= submit_tag t("verification.email.date.submit"), class: 'button' %>
         </div>
       <% end %>
     </div>  

--- a/app/views/verification/email/date_of_birth.html.erb
+++ b/app/views/verification/email/date_of_birth.html.erb
@@ -7,8 +7,9 @@
       Por favor, introduce tu fecha de nacimiento para verificar tu cuenta
     </p>  
     <div class="row">
-      <%= form_tag(save_date_of_birth_management_email_verification_path) do %>  
+      <%= form_tag(save_date_of_birth_email_path) do %>  
         <%= hidden_field_tag :email_verification_token, params[:email_verification_token] %>
+        <%= hidden_field_tag :id, @user.id %>
         <div class="small-4 column">
            <%=select_day nil, prompt: 'Día'%>
         </div>

--- a/app/views/verification/email/date_of_birth.html.erb
+++ b/app/views/verification/email/date_of_birth.html.erb
@@ -1,27 +1,27 @@
 <div class="row">
   <div class="small-12 medium-6 column">
     <h1>
-      <%= t("mailers.email_verification.title") %>
+      <%= t("verification.email.date.title") %>
     </h1>
     <p>
-      Por favor, introduce tu fecha de nacimiento para verificar tu cuenta
+      <%= t("verification.email.date.explanation") %>
     </p>  
     <div class="row">
       <%= form_tag(save_date_of_birth_email_path) do %>  
         <%= hidden_field_tag :email_verification_token, params[:email_verification_token] %>
         <%= hidden_field_tag :id, @user.id %>
         <div class="small-4 column">
-           <%=select_day nil, prompt: 'Día'%>
+           <%=  select_day nil, prompt: t("verification.email.date.day"), required: true %>
         </div>
         <div class="small-4 column">
-           <%=select_month nil, prompt: 'Mes'%>
+           <%=  select_month nil, prompt: t("verification.email.date.month"), required: true %>
         </div>
         <div class="small-4 column">
-           <%=select_year nil, prompt: 'Año'%>
+           <%=  select_year nil, prompt: t("verification.email.date.year"), required: true %>
         </div>
       
         <div class="small-12 column">
-          <%= submit_tag "Verificar mi cuenta" %>
+          <%= submit_tag t("verification.email.date.submit") %>
         </div>
       <% end %>
     </div>  

--- a/config/locales/en/verification.yml
+++ b/config/locales/en/verification.yml
@@ -14,6 +14,13 @@ en:
           failure: Verification code incorrect
         flash:
           success: You are a verified user
+      date:
+        title: Confirm your account
+        explanation: Please, select your date of birth to confirm the account
+        day: Day
+        month: Month
+        year: Year
+        submit: Confirm my account
     letter:
       alert:
         unconfirmed_code: You have not yet entered the confirmation code

--- a/config/locales/en/verification.yml
+++ b/config/locales/en/verification.yml
@@ -17,10 +17,8 @@ en:
       date:
         title: Confirm your account
         explanation: Please, select your date of birth to confirm the account
-        day: Day
-        month: Month
-        year: Year
         submit: Confirm my account
+        error: Date cannot be blank
     letter:
       alert:
         unconfirmed_code: You have not yet entered the confirmation code

--- a/config/locales/es/verification.yml
+++ b/config/locales/es/verification.yml
@@ -17,10 +17,8 @@ es:
       date:
         title: Verifica tu cuenta
         explanation: Por favor, introduce tu fecha de nacimiento para verificar la cuenta
-        day: Día
-        month: Mes
-        year: Año
         submit: Verificar mi cuenta
+        error: La fecha no puede estar en blanco
     letter:
       alert:
         unconfirmed_code: Todavía no has introducido el código de confirmación

--- a/config/locales/es/verification.yml
+++ b/config/locales/es/verification.yml
@@ -14,6 +14,13 @@ es:
           failure: Código de verificación incorrecto
         flash:
           success: Eres un usuario verificado
+      date:
+        title: Verifica tu cuenta
+        explanation: Por favor, introduce tu fecha de nacimiento para verificar la cuenta
+        day: Día
+        month: Mes
+        year: Año
+        submit: Verificar mi cuenta
     letter:
       alert:
         unconfirmed_code: Todavía no has introducido el código de confirmación

--- a/config/routes/management.rb
+++ b/config/routes/management.rb
@@ -5,10 +5,7 @@ namespace :management do
     post :check, on: :collection
   end
 
-  resources :email_verifications, only: [:new, :create] do
-    get :date_of_birth
-    post :save_date_of_birth
-  end
+  resources :email_verifications, only: [:new, :create]
 
   resources :user_invites, only: [:new, :create]
 

--- a/config/routes/management.rb
+++ b/config/routes/management.rb
@@ -5,7 +5,11 @@ namespace :management do
     post :check, on: :collection
   end
 
-  resources :email_verifications, only: [:new, :create]
+  resources :email_verifications, only: [:new, :create] do
+    get :date_of_birth
+    post :save_date_of_birth
+  end
+
   resources :user_invites, only: [:new, :create]
 
   resources :users, only: [:new, :create] do

--- a/config/routes/verification.rb
+++ b/config/routes/verification.rb
@@ -2,8 +2,13 @@ scope module: :verification do
   resource :residence, controller: "residence", only: [:new, :create]
   resource :sms, controller: "sms", only: [:new, :create, :edit, :update]
   resource :verified_user, controller: "verified_user", only: [:show]
-  resource :email, controller: "email", only: [:new, :show, :create]
   resource :letter, controller: "letter", only: [:new, :create, :show, :edit, :update]
+
+  resource :email, controller: "email", only: [:new, :show, :create] do
+    get :date_of_birth
+    post :save_date_of_birth
+  end
+
 end
 
 resource :verification, controller: "verification", only: [:show]

--- a/spec/features/management/email_verifications_spec.rb
+++ b/spec/features/management/email_verifications_spec.rb
@@ -21,20 +21,18 @@ feature 'EmailVerifications' do
     user.reload
 
     login_as(user)
-    
+
     sent_token = /.*email_verification_token=(.*)&amp;.*".*/.match(ActionMailer::Base.deliveries.last.body.to_s)[1]
-        
+
     visit date_of_birth_email_path(email_verification_token: sent_token, id: user.id)
-    
+
     expect(page).to have_content "Confirm your account"
 
-    page.find_by_id('date_day').find("option[value='1']").select_option
-    page.find_by_id('date_month').find("option[value='1']").select_option
-    page.find_by_id('date_year').find("option[value='#{16.years.ago.year}']").select_option
-    
+    page.find_by(id: 'date_day').find("option[value='1']").select_option
+    page.find_by(id: 'date_month').find("option[value='1']").select_option
+    page.find_by(id: 'date_year').find("option[value='#{16.years.ago.year}']").select_option
+
     click_button "Confirm my account"
-    
-#    visit email_path(email_verification_token: sent_token)
 
     expect(page).to have_content "You are a verified user"
 

--- a/spec/features/management/email_verifications_spec.rb
+++ b/spec/features/management/email_verifications_spec.rb
@@ -28,9 +28,17 @@ feature 'EmailVerifications' do
 
     expect(page).to have_content "Confirm your account"
 
-    page.find_by(id: 'date_day').find("option[value='1']").select_option
-    page.find_by(id: 'date_month').find("option[value='1']").select_option
-    page.find_by(id: 'date_year').find("option[value='#{16.years.ago.year}']").select_option
+    within('#date_day') do
+      find("option[value='1']").select_option
+    end
+    
+    within('#date_month') do
+      find("option[value='1']").select_option
+    end
+    
+    within('#date_year') do
+      find("option[value='#{16.years.ago.year}']").select_option
+    end
 
     click_button "Confirm my account"
 

--- a/spec/features/management/email_verifications_spec.rb
+++ b/spec/features/management/email_verifications_spec.rb
@@ -21,9 +21,20 @@ feature 'EmailVerifications' do
     user.reload
 
     login_as(user)
+    
+    sent_token = /.*email_verification_token=(.*)&amp;.*".*/.match(ActionMailer::Base.deliveries.last.body.to_s)[1]
+        
+    visit date_of_birth_email_path(email_verification_token: sent_token, id: user.id)
+    
+    expect(page).to have_content "Confirm your account"
 
-    sent_token = /.*email_verification_token=(.*)".*/.match(ActionMailer::Base.deliveries.last.body.to_s)[1]
-    visit email_path(email_verification_token: sent_token)
+    page.find_by_id('date_day').find("option[value='1']").select_option
+    page.find_by_id('date_month').find("option[value='1']").select_option
+    page.find_by_id('date_year').find("option[value='2012']").select_option
+    
+    click_button "Confirm my account"
+    
+#    visit email_path(email_verification_token: sent_token)
 
     expect(page).to have_content "You are a verified user"
 
@@ -32,6 +43,7 @@ feature 'EmailVerifications' do
 
     expect(user.reload.document_number).to eq('12345678Z')
     expect(user).to be_level_three_verified
+    expect(user.date_of_birth.to_date).to eq(DateTime.new(2012, 1, 1, 0, 0, 0).in_time_zone.to_date)
   end
 
 end

--- a/spec/features/management/email_verifications_spec.rb
+++ b/spec/features/management/email_verifications_spec.rb
@@ -30,7 +30,7 @@ feature 'EmailVerifications' do
 
     page.find_by_id('date_day').find("option[value='1']").select_option
     page.find_by_id('date_month').find("option[value='1']").select_option
-    page.find_by_id('date_year').find("option[value='2012']").select_option
+    page.find_by_id('date_year').find("option[value='#{16.years.ago.year}']").select_option
     
     click_button "Confirm my account"
     
@@ -43,7 +43,7 @@ feature 'EmailVerifications' do
 
     expect(user.reload.document_number).to eq('12345678Z')
     expect(user).to be_level_three_verified
-    expect(user.date_of_birth.to_date).to eq(DateTime.new(2012, 1, 1, 0, 0, 0).in_time_zone.to_date)
+    expect(user.date_of_birth.to_date).to eq(DateTime.new(16.years.ago.year, 1, 1, 0, 0, 0).in_time_zone.to_date)
   end
 
 end

--- a/spec/features/verification/email_spec.rb
+++ b/spec/features/verification/email_spec.rb
@@ -24,7 +24,7 @@ feature 'Verify email' do
 
     expect(page).to have_content 'We have sent a confirmation email to your account: rock@example.com'
 
-    sent_token = /.*email_verification_token=(.*)".*/.match(ActionMailer::Base.deliveries.last.body.to_s)[1]
+    sent_token = /.*email_verification_token=(.*)&amp;.*".*/.match(ActionMailer::Base.deliveries.last.body.to_s)[1]
     visit email_path(email_verification_token: sent_token)
 
     expect(page).to have_content "You are a verified user"

--- a/spec/features/verification/level_three_verification_spec.rb
+++ b/spec/features/verification/level_three_verification_spec.rb
@@ -55,7 +55,7 @@ feature 'Level three verification' do
 
     expect(page).to have_content 'We have sent a confirmation email to your account: rock@example.com'
 
-    sent_token = /.*email_verification_token=(.*)".*/.match(ActionMailer::Base.deliveries.last.body.to_s)[1]
+    sent_token = /.*email_verification_token=(.*)&amp;.*".*/.match(ActionMailer::Base.deliveries.last.body.to_s)[1]
     visit email_path(email_verification_token: sent_token)
 
     expect(page).to have_content "You are a verified user"


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1452
This PR close #1452 

What
====
When a user receives a verification email from the admin, the page should ask their date of birth before verifying the account.

How
===
I modified the flow of how a verification is done from an email. The link sent  to the user has been changed, and now it points to a URL where the date of birth is asked. When the user selects its date of birth and sends the information the page verifies the account. If the user tries to send a nil date the page asks for it again.

Screenshots
===========
![birth01](https://user-images.githubusercontent.com/31625251/32440265-b93bf3be-c2f2-11e7-8ca6-6da1e2d05466.png)

![birth02](https://user-images.githubusercontent.com/31625251/32440270-bec67746-c2f2-11e7-95db-516e04aac430.png)

Test
====
I added/modified the tests that check the verification via email. For the test that checks the verification flow modified, I added the selection of the date. For the other two, I modified the regex that takes the token from the email link.

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.
