### PR TITLE
 Improve Dev Seeds

### DIFF
--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -524,46 +524,46 @@ end
 
 section "Creating polls" do
 
-@poll_active = Poll.create(name: "Active Poll",
-                           # TODO: Uncomment when Poll get slugs
-                           # slug: "active-poll",
-                           starts_at: 1.month.ago,
-                           ends_at:   1.month.from_now,
-                           geozone_restricted: false)
+  Poll.create(name: "Current Poll",
+              # TODO: Uncomment when Poll get slugs
+              # slug: "current-poll",
+              starts_at: 7.days.ago,
+              ends_at:   7.days.from_now,
+              geozone_restricted: false)
 
-@poll_active_geolocalized = Poll.create(name: "Active Poll Restricted",
-                                        # TODO: Uncomment when Poll get slugs
-                                        # slug: "active-poll-restricted",
-                                        starts_at: 1.month.ago,
-                                        ends_at:   1.month.from_now,
-                                        geozone_restricted: true,
-                                        geozones: Geozone.reorder("RANDOM()").limit(3))
+  Poll.create(name: "Current Poll Geozone Restricted",
+              # TODO: Uncomment when Poll get slugs
+              # slug: "current-poll-geozone-restricted",
+              starts_at: 5.days.ago,
+              ends_at:   5.days.from_now,
+              geozone_restricted: true,
+              geozones: Geozone.reorder("RANDOM()").limit(3))
 
-poll = Poll.create(name: "Upcoming Poll",
-                   # TODO: Uncomment when Poll get slugs
-                   # slug: "upcoming-poll",
-                   starts_at: 1.month.from_now,
-                   ends_at:   2.months.from_now)
+  Poll.create(name: "Incoming Poll",
+              # TODO: Uncomment when Poll get slugs
+              # slug: "incoming-poll",
+              starts_at: 1.month.from_now,
+              ends_at:   2.months.from_now)
 
-poll = Poll.create(name: "Recounting Poll",
-                   # TODO: Uncomment when Poll get slugs
-                   # slug: "recounting-poll",
-                   starts_at: 1.month.ago,
-                   ends_at:   5.days.ago)
+  Poll.create(name: "Recounting Poll",
+              # TODO: Uncomment when Poll get slugs
+              # slug: "recounting-poll",
+              starts_at: 15.days.ago,
+              ends_at:   2.days.ago)
 
-@poll_expired = Poll.create(name: "Expired Poll",
-                            # TODO: Uncomment when Poll get slugs
-                            # slug: "expired-poll",
-                            starts_at: 2.months.ago,
-                            ends_at:   1.month.ago)
+  Poll.create(name: "Expired Poll without Stats & Results",
+              # TODO: Uncomment when Poll get slugs
+              # slug: "expired-poll-without-stats-and-results",
+              starts_at: 2.months.ago,
+              ends_at:   1.month.ago)
 
-poll = Poll.create(name: "Expired Poll with Stats & Results",
-                   # TODO: Uncomment when Poll get slugs
-                   # slug: "expired-poll-with-stats-and-results",
-                   starts_at: 2.months.ago,
-                   ends_at:   1.month.ago,
-                   results_enabled: true,
-                   stats_enabled: true)
+  Poll.create(name: "Expired Poll with Stats & Results",
+              # TODO: Uncomment when Poll get slugs
+              # slug: "expired-poll-with-stats-and-results",
+              starts_at: 2.months.ago,
+              ends_at:   1.month.ago,
+              results_enabled: true,
+              stats_enabled: true)
 end
 
 section "Creating Poll Questions" do

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -581,15 +581,9 @@ section "Creating Poll Questions & Answers" do
   end
 end
 
-section "Creating Poll Booths" do
-  20.times.each_with_index do |i|
-    Poll::Booth.create(name: "Booth #{i}", polls: [Poll.all.sample])
-  end
-end
-
-section "Creating Booth Assignments" do
-  Poll::Booth.all.each do |booth|
-    Poll::BoothAssignment.create(booth: booth, poll: Poll.all.sample)
+section "Creating Poll Booths & BoothAssignments" do
+  20.times do |i|
+    Poll::Booth.create(name: "Booth #{i}", location: Faker::Address.street_address, polls: [Poll.all.sample])
   end
 end
 

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -165,21 +165,21 @@ section "Creating Users" do
 end
 
 section "Creating Tags Categories" do
-  ActsAsTaggableOn::Tag.category.create!(name:  "Asociaciones")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Cultura")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Deportes")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Derechos Sociales")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Economía")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Empleo")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Equidad")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Sostenibilidad")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Participación")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Movilidad")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Medios")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Salud")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Transparencia")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Seguridad y Emergencias")
-  ActsAsTaggableOn::Tag.category.create!(name:  "Medio Ambiente")
+  ActsAsTaggableOn::Tag.category.create!(name: "Asociaciones")
+  ActsAsTaggableOn::Tag.category.create!(name: "Cultura")
+  ActsAsTaggableOn::Tag.category.create!(name: "Deportes")
+  ActsAsTaggableOn::Tag.category.create!(name: "Derechos Sociales")
+  ActsAsTaggableOn::Tag.category.create!(name: "Economía")
+  ActsAsTaggableOn::Tag.category.create!(name: "Empleo")
+  ActsAsTaggableOn::Tag.category.create!(name: "Equidad")
+  ActsAsTaggableOn::Tag.category.create!(name: "Sostenibilidad")
+  ActsAsTaggableOn::Tag.category.create!(name: "Participación")
+  ActsAsTaggableOn::Tag.category.create!(name: "Movilidad")
+  ActsAsTaggableOn::Tag.category.create!(name: "Medios")
+  ActsAsTaggableOn::Tag.category.create!(name: "Salud")
+  ActsAsTaggableOn::Tag.category.create!(name: "Transparencia")
+  ActsAsTaggableOn::Tag.category.create!(name: "Seguridad y Emergencias")
+  ActsAsTaggableOn::Tag.category.create!(name: "Medio Ambiente")
 end
 
 section "Creating Debates" do

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -122,8 +122,8 @@ section "Creating Users" do
   create_user('unverified@consul.dev', 'unverified')
 
   level_2 = create_user('leveltwo@consul.dev', 'level 2')
-  level_2.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_number: unique_document_number,
-                 document_type: "1")
+  level_2.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number,
+                 document_number: unique_document_number, document_type: "1")
 
   verified = create_user('verified@consul.dev', 'verified')
   verified.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -587,32 +587,25 @@ section "Creating Poll Booths & BoothAssignments" do
   end
 end
 
-# section "Creating Poll Officer Assignments" do
-#   (1..15).to_a.sample.times do |i|
-#     Poll::BoothAssignment.all.sample(i).each do |booth_assignment|
-#       Poll::OfficerAssignment.create(officer: poll_officer.poll_officer,
-#                                      booth_assignment: booth_assignment,
-#                                      date: booth_assignment.poll.starts_at)
-#     end
-#   end
-# end
-
 section "Creating Poll Shifts for Poll Officers" do
-  Poll::BoothAssignment.all.each do |booth_assignment|
-    # TODO: Create vote_collection on correct date ranges
-    Poll::Shift.create(booth_id: booth_assignment.booth_id,
-                       officer: Poll::Officer.first,
-                       date: Date.current,
-                       officer_name: Poll::Officer.first.name,
-                       officer_email: Poll::Officer.first.email,
-                       task: :vote_collection)
-    # TODO: Create recount_scrutiny shifts on correct date ranges
-    # Poll::Shift.create(booth_id: booth_assignment.booth_id,
-    #                    officer_id: poll_officer.poll_officer.id,
-    #                    date: Date.current,
-    #                    officer_name: poll_officer.poll_officer.name,
-    #                    officer_email: poll_officer.poll_officer.email,
-    #                    task: 1)
+  Poll.all.each do |poll|
+    Poll::BoothAssignment.where(poll: poll).each do |booth_assignment|
+      Poll::Officer.all.each do |poll_officer|
+        {
+          vote_collection: (poll.starts_at.to_datetime..poll.ends_at.to_datetime),
+          recount_scrutiny: (poll.ends_at.to_datetime..poll.ends_at.to_datetime + Poll::RECOUNT_DURATION)
+        }.each do |task_name, task_dates|
+          task_dates.each do |shift_date|
+            Poll::Shift.create(booth: booth_assignment.booth,
+                               officer: poll_officer,
+                               date: shift_date,
+                               officer_name: poll_officer.name,
+                               officer_email: poll_officer.email,
+                               task: task_name)
+          end
+        end
+      end
+    end
   end
 end
 

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -96,7 +96,7 @@ section "Creating Users" do
   admin = create_user('admin@consul.dev', 'admin')
   admin.create_administrator
   admin.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
-               verified_at: Time.current, document_number: "1111111111")
+               verified_at: Time.current, document_number: unique_document_number)
 
   moderator = create_user('mod@consul.dev', 'mod')
   moderator.create_moderator
@@ -107,27 +107,27 @@ section "Creating Users" do
   @valuator = create_user('valuator@consul.dev', 'valuator')
   @valuator.create_valuator
   @valuator.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
-                   verified_at: Time.current, document_number: "2111111111")
+                  verified_at: Time.current, document_number: unique_document_number)
 
   poll_officer = create_user('poll_officer@consul.dev', 'Paul O. Fisher')
   poll_officer.create_poll_officer
   poll_officer.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
-                      verified_at: Time.current, document_number: "2211111111")
+                      verified_at: Time.current, document_number: unique_document_number)
 
   poll_officer2 = create_user('poll_officer2@consul.dev', 'Pauline M. Espinosa')
   poll_officer2.create_poll_officer
   poll_officer2.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
-                       verified_at: Time.current, document_number: "3311111111")
+                       verified_at: Time.current, document_number: unique_document_number)
 
   create_user('unverified@consul.dev', 'unverified')
 
   level_2 = create_user('leveltwo@consul.dev', 'level 2')
-  level_2.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_number: "2222222222",
+  level_2.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_number: unique_document_number,
                  document_type: "1")
 
   verified = create_user('verified@consul.dev', 'verified')
   verified.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
-                  verified_at: Time.current, document_number: "3333333333")
+                  verified_at: Time.current, document_number: unique_document_number)
 
   (1..10).each do |i|
     org_name = Faker::Company.name
@@ -153,10 +153,10 @@ section "Creating Users" do
     level = [1, 2, 3].sample
     if level >= 2
       user.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number,
-                  document_number: Faker::Number.number(10), document_type: "1", geozone: Geozone.reorder("RANDOM()").first)
+                  document_number: unique_document_number, document_type: "1", geozone: Geozone.reorder("RANDOM()").first)
     end
     if level == 3
-      user.update(verified_at: Time.current, document_number: Faker::Number.number(10))
+      user.update(verified_at: Time.current, document_number: unique_document_number)
     end
   end
 

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -609,32 +609,6 @@ section "Creating Poll Shifts for Poll Officers" do
   end
 end
 
-section "Creating Poll Questions from Proposals" do
-  3.times do
-    proposal = Proposal.all.sample
-    poll = Poll.current.first
-    question = Poll::Question.create(poll: poll)
-    Faker::Lorem.words((2..4).to_a.sample).each do |answer|
-      Poll::Question::Answer.create!(question: question, title: answer.capitalize, description: Faker::ChuckNorris.fact)
-    end
-    question.copy_attributes_from_proposal(proposal)
-    question.save!
-  end
-end
-
-section "Creating Successful Proposals" do
-  10.times do
-    proposal = Proposal.all.sample
-    poll = Poll.current.first
-    question = Poll::Question.create(poll: poll)
-    Faker::Lorem.words((2..4).to_a.sample).each do |answer|
-      Poll::Question::Answer.create!(question: question, title: answer.capitalize, description: Faker::ChuckNorris.fact)
-    end
-    question.copy_attributes_from_proposal(proposal)
-    question.save!
-  end
-end
-
 section "Commenting Poll Questions" do
   30.times do
     author = User.all.sample
@@ -715,6 +689,32 @@ section "Creating Poll Results" do
         end
       end
     end
+  end
+end
+
+section "Creating Poll Questions from Proposals" do
+  3.times do
+    proposal = Proposal.all.sample
+    poll = Poll.current.first
+    question = Poll::Question.create(poll: poll)
+    Faker::Lorem.words((2..4).to_a.sample).each do |answer|
+      Poll::Question::Answer.create!(question: question, title: answer.capitalize, description: Faker::ChuckNorris.fact)
+    end
+    question.copy_attributes_from_proposal(proposal)
+    question.save!
+  end
+end
+
+section "Creating Successful Proposals" do
+  10.times do
+    proposal = Proposal.all.sample
+    poll = Poll.current.first
+    question = Poll::Question.create(poll: poll)
+    Faker::Lorem.words((2..4).to_a.sample).each do |answer|
+      Poll::Question::Answer.create!(question: question, title: answer.capitalize, description: Faker::ChuckNorris.fact)
+    end
+    question.copy_attributes_from_proposal(proposal)
+    question.save!
   end
 end
 

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -159,9 +159,6 @@ section "Creating Users" do
       user.update(verified_at: Time.current, document_number: unique_document_number)
     end
   end
-
-  org_user_ids = User.organizations.pluck(:id)
-  @not_org_users = User.where(['users.id NOT IN(?)', org_user_ids])
 end
 
 section "Creating Tags Categories" do
@@ -321,22 +318,23 @@ section "Commenting Comments" do
 end
 
 section "Voting Debates, Proposals & Comments" do
+  not_org_users = User.where(['users.id NOT IN(?)', User.organizations.pluck(:id)])
   100.times do
-    voter  = @not_org_users.level_two_or_three_verified.reorder("RANDOM()").first
+    voter  = not_org_users.level_two_or_three_verified.reorder("RANDOM()").first
     vote   = [true, false].sample
     debate = Debate.reorder("RANDOM()").first
     debate.vote_by(voter: voter, vote: vote)
   end
 
   100.times do
-    voter  = @not_org_users.reorder("RANDOM()").first
+    voter  = not_org_users.reorder("RANDOM()").first
     vote   = [true, false].sample
     comment = Comment.reorder("RANDOM()").first
     comment.vote_by(voter: voter, vote: vote)
   end
 
   100.times do
-    voter = @not_org_users.level_two_or_three_verified.reorder("RANDOM()").first
+    voter = not_org_users.level_two_or_three_verified.reorder("RANDOM()").first
     proposal = Proposal.reorder("RANDOM()").first
     proposal.vote_by(voter: voter, vote: true)
   end

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -104,9 +104,9 @@ section "Creating Users" do
   manager = create_user('manager@consul.dev', 'manager')
   manager.create_manager
 
-  @valuator = create_user('valuator@consul.dev', 'valuator')
-  @valuator.create_valuator
-  @valuator.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
+  valuator = create_user('valuator@consul.dev', 'valuator')
+  valuator.create_valuator
+  valuator.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
                   verified_at: Time.current, document_number: unique_document_number)
 
   poll_officer = create_user('poll_officer@consul.dev', 'Paul O. Fisher')
@@ -388,7 +388,7 @@ end
 
 section "Creating Valuation Assignments" do
   (1..17).to_a.sample.times do
-    SpendingProposal.reorder("RANDOM()").first.valuators << @valuator.valuator
+    SpendingProposal.reorder("RANDOM()").first.valuators << Valuator.first
   end
 end
 
@@ -476,7 +476,7 @@ end
 
 section "Creating Valuation Assignments" do
   (1..50).to_a.sample.times do
-    Budget::Investment.reorder("RANDOM()").first.valuators << @valuator.valuator
+    Budget::Investment.reorder("RANDOM()").first.valuators << Valuator.first
   end
 end
 

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -651,13 +651,9 @@ section "Creating Poll Voters" do
   (Poll.expired + Poll.current + Poll.recounting).uniq.each do |poll|
     level_two_verified_users = User.level_two_verified
     level_two_verified_users = level_two_verified_users.where(geozone_id: poll.geozone_ids) if poll.geozone_restricted?
-    level_two_verified_users.each_with_index do |user, i|
-      if i.even?
-        vote_poll_on_web(user, poll)
-      else
-        vote_poll_on_booth(user, poll)
-      end
-    end
+    user_groups = level_two_verified_users.in_groups(2)
+    user_groups.first.each { |user| vote_poll_on_booth(user, poll) }
+    user_groups.second.compact.each { |user| vote_poll_on_web(user, poll) }
   end
 end
 

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -566,17 +566,17 @@ section "Creating polls" do
               stats_enabled: true)
 end
 
-section "Creating Poll Questions" do
-  25.times do
-    poll = Poll.reorder("RANDOM()").first
-    author = User.reorder("RANDOM()").first
-    description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
-    open_at = rand(2.months.ago..2.months.from_now)
-    question = Poll::Question.create!(author: author,
-                                      title: Faker::Lorem.sentence(3).truncate(60),
-                                      poll: poll)
-    Faker::Lorem.words((2..4).to_a.sample).each do |answer|
-      Poll::Question::Answer.create!(question: question, title: answer.capitalize, description: Faker::ChuckNorris.fact)
+section "Creating Poll Questions & Answers" do
+  Poll.all.each do |poll|
+    (1..4).to_a.sample.times do
+      question = Poll::Question.create!(author: User.all.sample,
+                                        title: Faker::Lorem.sentence(3).truncate(60) + '?',
+                                        poll: poll)
+      Faker::Lorem.words((2..4).to_a.sample).each do |answer|
+        Poll::Question::Answer.create!(question: question,
+                                       title: answer.capitalize,
+                                       description: "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>")
+      end
     end
   end
 end

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -89,8 +89,8 @@ section "Creating Users" do
 
   def unique_document_number
     @document_number ||= 12345678
-    @document_number = @document_number + 1
-    @document_number.to_s
+    @document_number += 1
+    "#{@document_number}#{[*'A'..'Z'].sample}"
   end
 
   admin = create_user('admin@consul.dev', 'admin')

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -153,7 +153,7 @@ section "Creating Users" do
     level = [1, 2, 3].sample
     if level >= 2
       user.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number,
-                  document_number: unique_document_number, document_type: "1", geozone: Geozone.reorder("RANDOM()").first)
+                  document_number: unique_document_number, document_type: "1", geozone: Geozone.all.sample)
     end
     if level == 3
       user.update(verified_at: Time.current, document_number: unique_document_number)
@@ -182,27 +182,27 @@ end
 section "Creating Debates" do
   tags = Faker::Lorem.words(25)
   30.times do
-    author = User.reorder("RANDOM()").first
+    author = User.all.sample
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     debate = Debate.create!(author: author,
                             title: Faker::Lorem.sentence(3).truncate(60),
                             created_at: rand((Time.current - 1.week)..Time.current),
                             description: description,
                             tag_list: tags.sample(3).join(','),
-                            geozone: Geozone.reorder("RANDOM()").first,
+                            geozone: Geozone.all.sample,
                             terms_of_service: "1")
   end
 
   tags = ActsAsTaggableOn::Tag.where(kind: 'category')
   30.times do
-    author = User.reorder("RANDOM()").first
+    author = User.all.sample
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     debate = Debate.create!(author: author,
                             title: Faker::Lorem.sentence(3).truncate(60),
                             created_at: rand((Time.current - 1.week)..Time.current),
                             description: description,
                             tag_list: tags.sample(3).join(','),
-                            geozone: Geozone.reorder("RANDOM()").first,
+                            geozone: Geozone.all.sample,
                             terms_of_service: "1")
   end
 end
@@ -210,7 +210,7 @@ end
 section "Creating Proposals" do
   tags = Faker::Lorem.words(25)
   30.times do
-    author = User.reorder("RANDOM()").first
+    author = User.all.sample
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.sentence(3).truncate(60),
@@ -221,7 +221,7 @@ section "Creating Proposals" do
                                 description: description,
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(','),
-                                geozone: Geozone.reorder("RANDOM()").first,
+                                geozone: Geozone.all.sample,
                                 terms_of_service: "1")
   end
 end
@@ -229,7 +229,7 @@ end
 section "Creating Archived Proposals" do
   tags = Faker::Lorem.words(25)
   5.times do
-    author = User.reorder("RANDOM()").first
+    author = User.all.sample
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.sentence(3).truncate(60),
@@ -239,7 +239,7 @@ section "Creating Archived Proposals" do
                                 external_url: Faker::Internet.url,
                                 description: description,
                                 tag_list: tags.sample(3).join(','),
-                                geozone: Geozone.reorder("RANDOM()").first,
+                                geozone: Geozone.all.sample,
                                 terms_of_service: "1",
                                 created_at: Setting["months_to_archive_proposals"].to_i.months.ago)
   end
@@ -248,7 +248,7 @@ end
 section "Creating Successful Proposals" do
   tags = Faker::Lorem.words(25)
   10.times do
-    author = User.reorder("RANDOM()").first
+    author = User.all.sample
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.sentence(3).truncate(60),
@@ -259,14 +259,14 @@ section "Creating Successful Proposals" do
                                 description: description,
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(','),
-                                geozone: Geozone.reorder("RANDOM()").first,
+                                geozone: Geozone.all.sample,
                                 terms_of_service: "1",
                                 cached_votes_up: Setting["votes_for_proposal_success"])
   end
 
   tags = ActsAsTaggableOn::Tag.where(kind: 'category')
   30.times do
-    author = User.reorder("RANDOM()").first
+    author = User.all.sample
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.sentence(3).truncate(60),
@@ -277,15 +277,15 @@ section "Creating Successful Proposals" do
                                 description: description,
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(','),
-                                geozone: Geozone.reorder("RANDOM()").first,
+                                geozone: Geozone.all.sample,
                                 terms_of_service: "1")
   end
 end
 
 section "Commenting Debates" do
   100.times do
-    author = User.reorder("RANDOM()").first
-    debate = Debate.reorder("RANDOM()").first
+    author = User.all.sample
+    debate = Debate.all.sample
     Comment.create!(user: author,
                     created_at: rand(debate.created_at..Time.current),
                     commentable: debate,
@@ -295,8 +295,8 @@ end
 
 section "Commenting Proposals" do
   100.times do
-    author = User.reorder("RANDOM()").first
-    proposal = Proposal.reorder("RANDOM()").first
+    author = User.all.sample
+    proposal = Proposal.all.sample
     Comment.create!(user: author,
                     created_at: rand(proposal.created_at..Time.current),
                     commentable: proposal,
@@ -306,8 +306,8 @@ end
 
 section "Commenting Comments" do
   200.times do
-    author = User.reorder("RANDOM()").first
-    parent = Comment.reorder("RANDOM()").first
+    author = User.all.sample
+    parent = Comment.all.sample
     Comment.create!(user: author,
                     created_at: rand(parent.created_at..Time.current),
                     commentable_id: parent.commentable_id,
@@ -320,42 +320,42 @@ end
 section "Voting Debates, Proposals & Comments" do
   not_org_users = User.where(['users.id NOT IN(?)', User.organizations.pluck(:id)])
   100.times do
-    voter  = not_org_users.level_two_or_three_verified.reorder("RANDOM()").first
+    voter  = not_org_users.level_two_or_three_verified.all.sample
     vote   = [true, false].sample
-    debate = Debate.reorder("RANDOM()").first
+    debate = Debate.all.sample
     debate.vote_by(voter: voter, vote: vote)
   end
 
   100.times do
-    voter  = not_org_users.reorder("RANDOM()").first
+    voter  = not_org_users.all.sample
     vote   = [true, false].sample
-    comment = Comment.reorder("RANDOM()").first
+    comment = Comment.all.sample
     comment.vote_by(voter: voter, vote: vote)
   end
 
   100.times do
-    voter = not_org_users.level_two_or_three_verified.reorder("RANDOM()").first
-    proposal = Proposal.reorder("RANDOM()").first
+    voter = not_org_users.level_two_or_three_verified.all.sample
+    proposal = Proposal.all.sample
     proposal.vote_by(voter: voter, vote: true)
   end
 end
 
 section "Flagging Debates & Comments" do
   40.times do
-    debate = Debate.reorder("RANDOM()").first
-    flagger = User.where(["users.id <> ?", debate.author_id]).reorder("RANDOM()").first
+    debate = Debate.all.sample
+    flagger = User.where(["users.id <> ?", debate.author_id]).all.sample
     Flag.flag(flagger, debate)
   end
 
   40.times do
-    comment = Comment.reorder("RANDOM()").first
-    flagger = User.where(["users.id <> ?", comment.user_id]).reorder("RANDOM()").first
+    comment = Comment.all.sample
+    flagger = User.where(["users.id <> ?", comment.user_id]).all.sample
     Flag.flag(flagger, comment)
   end
 
   40.times do
-    proposal = Proposal.reorder("RANDOM()").first
-    flagger = User.where(["users.id <> ?", proposal.author_id]).reorder("RANDOM()").first
+    proposal = Proposal.all.sample
+    flagger = User.where(["users.id <> ?", proposal.author_id]).all.sample
     Flag.flag(flagger, proposal)
   end
 end
@@ -363,8 +363,8 @@ end
 section "Creating Spending Proposals" do
 tags = Faker::Lorem.words(10)
 60.times do
-  geozone = Geozone.reorder("RANDOM()").first
-  author = User.reorder("RANDOM()").first
+  geozone = Geozone.all.sample
+  author = User.all.sample
   description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
   feasible_explanation = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
   valuation_finished = [true, false].sample
@@ -386,7 +386,7 @@ end
 
 section "Creating Valuation Assignments" do
   (1..17).to_a.sample.times do
-    SpendingProposal.reorder("RANDOM()").first.valuators << Valuator.first
+    SpendingProposal.all.sample.valuators << Valuator.first
   end
 end
 
@@ -420,10 +420,10 @@ end
 section "Creating Investments" do
   tags = Faker::Lorem.words(10)
   100.times do
-    heading = Budget::Heading.reorder("RANDOM()").first
+    heading = Budget::Heading.all.sample
 
     investment = Budget::Investment.create!(
-      author: User.reorder("RANDOM()").first,
+      author: User.all.sample,
       heading: heading,
       group: heading.group,
       budget: heading.group.budget,
@@ -450,9 +450,9 @@ end
 section "Winner Investments" do
   budget = Budget.where(phase: "finished").last
   100.times do
-    heading = budget.headings.reorder("RANDOM()").first
+    heading = budget.headings.all.sample
     investment = Budget::Investment.create!(
-      author: User.reorder("RANDOM()").first,
+      author: User.all.sample,
       heading: heading,
       group: heading.group,
       budget: heading.group.budget,
@@ -474,7 +474,7 @@ end
 
 section "Creating Valuation Assignments" do
   (1..50).to_a.sample.times do
-    Budget::Investment.reorder("RANDOM()").first.valuators << Valuator.first
+    Budget::Investment.all.sample.valuators << Valuator.first
   end
 end
 
@@ -517,8 +517,8 @@ section "Creating proposal notifications" do
   100.times do |i|
     ProposalNotification.create!(title: "Proposal notification title #{i}",
                                  body: "Proposal notification body #{i}",
-                                 author: User.reorder("RANDOM()").first,
-                                 proposal: Proposal.reorder("RANDOM()").first)
+                                 author: User.all.sample,
+                                 proposal: Proposal.all.sample)
   end
 end
 
@@ -624,7 +624,7 @@ end
 
 section "Creating Poll Questions from Proposals" do
   3.times do
-    proposal = Proposal.reorder("RANDOM()").first
+    proposal = Proposal.all.sample
     poll = Poll.current.first
     question = Poll::Question.create(poll: poll)
     Faker::Lorem.words((2..4).to_a.sample).each do |answer|
@@ -637,7 +637,7 @@ end
 
 section "Creating Successful Proposals" do
   10.times do
-    proposal = Proposal.reorder("RANDOM()").first
+    proposal = Proposal.all.sample
     poll = Poll.current.first
     question = Poll::Question.create(poll: poll)
     Faker::Lorem.words((2..4).to_a.sample).each do |answer|
@@ -650,8 +650,8 @@ end
 
 section "Commenting Poll Questions" do
   30.times do
-    author = User.reorder("RANDOM()").first
-    question = Poll::Question.reorder("RANDOM()").first
+    author = User.all.sample
+    question = Poll::Question.all.sample
     Comment.create!(user: author,
                     created_at: rand(question.created_at..Time.current),
                     commentable: question,

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -87,6 +87,12 @@ section "Creating Users" do
     )
   end
 
+  def unique_document_number
+    @document_number ||= 12345678
+    @document_number = @document_number + 1
+    @document_number.to_s
+  end
+
   admin = create_user('admin@consul.dev', 'admin')
   admin.create_administrator
   admin.update(residence_verified_at: Time.current, confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",


### PR DESCRIPTION
What
====
Dev Seeds are important to be able to re-create enough database objects when things go wrong and still avoid having to do much manual tasks to test the features. Also its useful for demos and explaining features.

But it needs to be maintained and cleaned up (as well as the ruby syntax)

How
===
- Switching from `puts` & `print` usage to Rails logger usage, with a `section` and `log` method to emulate the same output we had before on the console 
- Fixing various ruby style & grammar details
- Improving Poll Questions creation 
- Creating Poll Booths (with location) & Booth Assignments to Polls in a single go 
- Creating Poll Shifts instead of deprecated OfficerAssignments (that Shifts still create underneath) for both kinds of Shift tasks and on all needed dates not just today 
- Creating Poll Voters for both `web` and `booth` origin correctly.

Screenshots
===========
![screen shot 2017-10-26 at 12 49 04](https://user-images.githubusercontent.com/983242/32049117-1daf9c7e-ba4c-11e7-9bff-abb9335fb9ed.jpg)

## Generated Stats & Results for Poll with both flags enabled
![screen shot 2017-11-09 at 13 41 26](https://user-images.githubusercontent.com/983242/32605954-b8ba91ee-c553-11e7-9952-7c7055575d3a.jpg)
![screen shot 2017-11-09 at 13 41 03](https://user-images.githubusercontent.com/983242/32605956-b900d7da-c553-11e7-82c3-bc961fcc8285.jpg)


Test
====
No need, manual usage and launch local server

Deployment
==========
As usual

Warnings
========
We need moar emojis!