### PR TITLE
Exclude development gems from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
 rvm:
  - "2.3.2"
 cache: bundler
+bundler_args: --without development
 before_script:
   - "for i in config/*.example; do cp \"$i\" \"${i/.example}\"; done"
   - bundle exec rake db:setup

--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ group :development, :test do
   gem 'launchy', '~> 2.4.3'
   gem 'letter_opener_web', '~> 1.3.1'
   gem 'quiet_assets', '~> 1.1.0'
-  gem 'rubocop', '~> 0.49.1', require: false
   gem 'spring', '~> 2.0.1'
   gem 'spring-commands-rspec', '~> 1.0.4'
 end
@@ -87,6 +86,7 @@ group :development do
   gem "capistrano-rails", '~> 1.2.3', require: false
   gem 'capistrano3-delayed-job', '~> 1.7.3'
   gem 'mdl', '~> 0.4.0', require: false
+  gem 'rubocop', '~> 0.49.1', require: false
   gem 'rvm1-capistrano3', '~> 1.4.0', require: false
   gem 'scss_lint', '~> 0.54.0', require: false
   gem 'web-console', '~> 3.3.0'


### PR DESCRIPTION
What
====
Speed up travis build a bit by avoiding development group gems from being bundled
Current gems on development only group that you can see being installed on each travis build:
```
  gem 'capistrano', '~> 3.8.1', require: false
  gem 'capistrano-bundler', '~> 1.2', require: false
  gem "capistrano-rails", '~> 1.2.3', require: false
  gem 'capistrano3-delayed-job', '~> 1.7.3'
  gem 'mdl', '~> 0.4.0', require: false
  gem 'rubocop', '~> 0.49.1', require: false
  gem 'rvm1-capistrano3', '~> 1.4.0', require: false
  gem 'scss_lint', '~> 0.54.0', require: false
  gem 'web-console', '~> 3.3.0'
```

How
===
- Following travis docs https://docs.travis-ci.com/user/languages/ruby/ (using `bundler_args: --without development
` at .travis.yml file)
- Moving rubocop from development & test group to just development to exclude it as well from being installed on a travis build

Screenshots
===========
No need

Test
====
Hopefully a bit faster

Deployment
==========
As usual

Warnings
========
None