### PR TITLE
Email specs for commentable models

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -17,6 +17,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   end
 
   def create
+    @poll = Poll.new(poll_params.merge(author: current_user))
     if @poll.save
       redirect_to [:admin, @poll], notice: t("flash.actions.create.poll")
     else

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -3,6 +3,7 @@ module MailerHelper
   def commentable_url(commentable)
     return debate_url(commentable) if commentable.is_a?(Debate)
     return proposal_url(commentable) if commentable.is_a?(Proposal)
+    return community_topic_url(commentable.community_id, commentable) if commentable.is_a?(Topic)
     return budget_investment_url(commentable.budget_id, commentable) if commentable.is_a?(Budget::Investment)
   end
 

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,6 +1,7 @@
 module MailerHelper
 
   def commentable_url(commentable)
+    return poll_url(commentable) if commentable.is_a?(Poll)
     return debate_url(commentable) if commentable.is_a?(Debate)
     return proposal_url(commentable) if commentable.is_a?(Proposal)
     return community_topic_url(commentable.community_id, commentable) if commentable.is_a?(Topic)

--- a/app/models/comment_notifier.rb
+++ b/app/models/comment_notifier.rb
@@ -22,7 +22,6 @@ class CommentNotifier
   end
 
   def email_on_comment?
-    return false if @comment.commentable.is_a?(Poll)
     commentable_author = @comment.commentable.author
     commentable_author != @author && commentable_author.email_on_comment?
   end

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -91,6 +91,9 @@ en:
       topic:
         one: "Topic"
         other: "Topics"
+      poll:
+        one: "Poll"
+        other: "Polls"
     attributes:
       budget:
         name: "Name"

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -88,6 +88,9 @@ en:
       images:
         one: "Image"
         other: "Images"
+      topic:
+        one: "Topic"
+        other: "Topics"
     attributes:
       budget:
         name: "Name"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -88,6 +88,9 @@ es:
       images:
         one: "Imagen"
         other: "Imágenes"
+      topic:
+        one: "Tema"
+        other: "Temas"
     attributes:
       budget:
         name: "Nombre"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -91,6 +91,9 @@ es:
       topic:
         one: "Tema"
         other: "Temas"
+      poll:
+        one: "Votación"
+        other: "Votaciones"
     attributes:
       budget:
         name: "Nombre"

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -3,7 +3,7 @@ include ActionView::Helpers::DateHelper
 
 feature 'Commenting polls' do
   let(:user) { create :user }
-  let(:poll) { create :poll }
+  let(:poll) { create(:poll, author: create(:user)) }
 
   scenario 'Index' do
     3.times { create(:comment, commentable: poll) }

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -84,6 +84,37 @@ feature 'Emails' do
     end
   end
 
+  context 'Budget investments comments' do
+    scenario 'Send email on budget investment comment', :js do
+      user = create(:user, email_on_comment: true)
+      investment = create(:budget_investment, author: user, budget: create(:budget))
+      comment_on(investment)
+
+      email = open_last_email
+      expect(email).to have_subject('Someone has commented on your investment')
+      expect(email).to deliver_to(investment.author)
+      expect(email).to have_body_text(budget_investment_path(investment, budget_id: investment.budget_id))
+      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
+      expect(email).to have_body_text(account_path)
+    end
+
+    scenario 'Do not send email about own budget investments comments', :js do
+      user = create(:user, email_on_comment: true)
+      investment = create(:budget_investment, author: user, budget: create(:budget))
+      comment_on(investment, user)
+
+      expect { open_last_email }.to raise_error 'No email has been sent!'
+    end
+
+    scenario 'Do not send email about budget investment comment unless set in preferences', :js do
+      user = create(:user, email_on_comment: false)
+      investment = create(:budget_investment, author: user, budget: create(:budget))
+      comment_on(investment)
+
+      expect { open_last_email }.to raise_error 'No email has been sent!'
+    end
+  end
+
   context 'Comment replies' do
     scenario "Send email on comment reply", :js do
       user = create(:user, email_on_comment_reply: true)

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -77,10 +77,16 @@ module CommonActions
     user ||= create(:user)
 
     login_as(user)
-    commentable_path = commentable.is_a?(Proposal) ? proposal_path(commentable) : debate_path(commentable)
+    commentable_path = if commentable.is_a?(Proposal)
+                         proposal_path(commentable)
+                       elsif commentable.is_a?(Debate)
+                         debate_path(commentable)
+                       else
+                         budget_investment_path(commentable, budget_id: commentable.budget_id)
+                       end
     visit commentable_path
 
-    fill_in "comment-body-#{commentable.class.name.underscore}_#{commentable.id}", with: 'Have you thought about...?'
+    fill_in "comment-body-#{commentable.class.name.gsub(/::/, '_').downcase}_#{commentable.id}", with: 'Have you thought about...?'
     click_button 'Publish comment'
 
     expect(page).to have_content 'Have you thought about...?'

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -83,6 +83,8 @@ module CommonActions
                          debate_path(commentable)
                        elsif commentable.is_a?(Topic)
                          community_topic_path(commentable, community_id: commentable.community_id)
+                       elsif commentable.is_a?(Poll)
+                         poll_path(commentable)
                        else
                          budget_investment_path(commentable, budget_id: commentable.budget_id)
                        end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -81,6 +81,8 @@ module CommonActions
                          proposal_path(commentable)
                        elsif commentable.is_a?(Debate)
                          debate_path(commentable)
+                       elsif commentable.is_a?(Topic)
+                         community_topic_path(commentable, community_id: commentable.community_id)
                        else
                          budget_investment_path(commentable, budget_id: commentable.budget_id)
                        end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1241

What
====
* Add specs for `Budget::Investment`, `Topic` and `Poll` models for email notifications when commented

How
===
* Wrote the necessary tests for the aforementioned models
* Adapted spec helper `comment_on` to fit the models mentioned above
* Adapted related specs to fit the new requirements
* Adapted mailer helper to include commentable models
* Adapted `PollsController` to include `current_user` as `author` when creating a new Poll to fit the specs
* Added missing English/Spanish translations

Test
====
* Increased coverage

Notes
====
* Removed [this spec](https://github.com/consul/consul/blob/master/spec/features/emails_spec.rb#L376) as [this one](https://github.com/wairbut-m2c/consul/blob/aperez-email-specs-for-commentables/spec/features/emails_spec.rb#L167) covers the same scenario.