### PR TITLE
Iagirre budget pagination bug

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -94,7 +94,8 @@ module Budgets
 
       def set_random_seed
         if params[:order] == 'random' || params[:order].blank?
-          params[:random_seed] ||= rand(1..9)
+          seed = rand(10..99) / 10.0
+          params[:random_seed] ||= Float(seed) rescue 0
         else
           params[:random_seed] = nil
         end

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -28,8 +28,8 @@ module Budgets
     respond_to :html, :js
 
     def index
-      @investments = @investments.apply_filters_and_search(@budget, params, @current_filter)
-                                 .send("sort_by_#{@current_order}").page(params[:page]).per(10).for_render
+      @investments = investments.page(params[:page]).per(10).for_render
+
       @investment_ids = @investments.pluck(:id)
       load_investment_votes(@investments)
       @tag_cloud = tag_cloud
@@ -94,9 +94,7 @@ module Budgets
 
       def set_random_seed
         if params[:order] == 'random' || params[:order].blank?
-          params[:random_seed] ||= rand(99) / 100.0
-          seed = Float(params[:random_seed]) rescue 0
-          Budget::Investment.connection.execute("select setseed(#{seed})")
+          params[:random_seed] ||= rand(9)
         else
           params[:random_seed] = nil
         end
@@ -129,6 +127,17 @@ module Budgets
 
       def tag_cloud
         TagCloud.new(Budget::Investment, params[:search])
+      end
+
+      def investments
+        case @current_order
+        when 'random'
+          @investments.apply_filters_and_search(@budget, params, @current_filter)
+                      .send("sort_by_#{@current_order}", params[:random_seed])
+        else
+          @investments.apply_filters_and_search(@budget, params, @current_filter)
+                      .send("sort_by_#{@current_order}")
+        end
       end
 
   end

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -94,7 +94,7 @@ module Budgets
 
       def set_random_seed
         if params[:order] == 'random' || params[:order].blank?
-          params[:random_seed] ||= rand(9)
+          params[:random_seed] ||= rand(1..9)
         else
           params[:random_seed] = nil
         end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -43,7 +43,7 @@ class Budget
     scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc, id: :desc) }
     scope :sort_by_ballots,          -> { reorder(ballot_lines_count: :desc, id: :desc) }
     scope :sort_by_price,            -> { reorder(price: :desc, confidence_score: :desc, id: :desc) }
-    scope :sort_by_random,           -> { reorder("RANDOM()") }
+    scope :sort_by_random,           ->(seed) { reorder("budget_investments.id % #{seed}, budget_investments.id") }
 
     scope :valuation_open,              -> { where(valuation_finished: false) }
     scope :without_admin,               -> { valuation_open.where(administrator_id: nil) }

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -43,7 +43,7 @@ class Budget
     scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc, id: :desc) }
     scope :sort_by_ballots,          -> { reorder(ballot_lines_count: :desc, id: :desc) }
     scope :sort_by_price,            -> { reorder(price: :desc, confidence_score: :desc, id: :desc) }
-    scope :sort_by_random,           ->(seed) { reorder("budget_investments.id % #{seed}, budget_investments.id") }
+    scope :sort_by_random,           ->(seed) { reorder("budget_investments.id % #{seed || 1}, budget_investments.id") }
 
     scope :valuation_open,              -> { where(valuation_finished: false) }
     scope :without_admin,               -> { valuation_open.where(administrator_id: nil) }

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -170,6 +170,25 @@ feature 'Budget Investments' do
       expect(order).to eq(new_order)
     end
 
+    scenario "Investments are not repeated with random order", :js do
+      12.times { create(:budget_investment, heading: heading) }
+      # 12 instead of per_page + 2 because in each page there are 10 (in this case), not 25
+
+      visit budget_investments_path(budget, order: 'random')
+
+      first_page_investments = all(".budget-investment h3").collect {|i| i.text }
+
+      click_link 'Next'
+      expect(page).to have_content "You're on page 2"
+
+      second_page_investments = all(".budget-investment h3").collect {|i| i.text }
+
+      common_values = first_page_investments & second_page_investments
+
+      expect(common_values.length).to eq(0)
+
+    end
+
     scenario 'Proposals are ordered by confidence_score', :js do
       create(:budget_investment, heading: heading, title: 'Best proposal').update_column(:confidence_score, 10)
       create(:budget_investment, heading: heading, title: 'Worst proposal').update_column(:confidence_score, 2)

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -207,7 +207,7 @@ feature 'Budget Investments' do
       expect(current_url).to include('order=confidence_score')
       expect(current_url).to include('page=1')
     end
-    
+
     scenario 'Each user as a different and consistent random budget investment order', :js do
       12.times { create(:budget_investment, heading: heading) }
 
@@ -224,28 +224,26 @@ feature 'Budget Investments' do
       expect(@first_user_investments_order).not_to eq(@second_user_investments_order)
 
       in_browser(:one) do
-        visit budget_investments_path(budget, heading: heading)
-#        click_link 'Next'
-#        expect(page).to have_content "You're on page 2"
-#
-#        click_link 'Previous'
-#        expect(page).to have_content "You're on page 1"        
-#        
+        click_link 'Next'
+        expect(page).to have_content "You're on page 2"
+
+        click_link 'Previous'
+        expect(page).to have_content "You're on page 1"
+
         expect(investments_order).to eq(@first_user_investments_order)
       end
 
       in_browser(:two) do
-        visit budget_investments_path(budget, heading: heading)
-#        click_link 'Next'
-#        expect(page).to have_content "You're on page 2"
-#
-#        click_link 'Previous'
-#        expect(page).to have_content "You're on page 1"   
-#        
+        click_link 'Next'
+        expect(page).to have_content "You're on page 2"
+
+        click_link 'Previous'
+        expect(page).to have_content "You're on page 1"
+
         expect(investments_order).to eq(@second_user_investments_order)
       end
     end
-    
+
     def investments_order
       all(".budget-investment h3").collect {|i| i.text }
     end

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sessions_helper'
 
 feature 'Budget Investments' do
 
@@ -176,12 +177,12 @@ feature 'Budget Investments' do
 
       visit budget_investments_path(budget, order: 'random')
 
-      first_page_investments = all(".budget-investment h3").collect {|i| i.text }
+      first_page_investments = investments_order
 
       click_link 'Next'
       expect(page).to have_content "You're on page 2"
 
-      second_page_investments = all(".budget-investment h3").collect {|i| i.text }
+      second_page_investments = investments_order
 
       common_values = first_page_investments & second_page_investments
 
@@ -205,6 +206,48 @@ feature 'Budget Investments' do
 
       expect(current_url).to include('order=confidence_score')
       expect(current_url).to include('page=1')
+    end
+    
+    scenario 'Each user as a different and consistent random budget investment order', :js do
+      12.times { create(:budget_investment, heading: heading) }
+
+      in_browser(:one) do
+        visit budget_investments_path(budget, heading: heading)
+        @first_user_investments_order = investments_order
+      end
+
+      in_browser(:two) do
+        visit budget_investments_path(budget, heading: heading)
+        @second_user_investments_order = investments_order
+      end
+
+      expect(@first_user_investments_order).not_to eq(@second_user_investments_order)
+
+      in_browser(:one) do
+        visit budget_investments_path(budget, heading: heading)
+#        click_link 'Next'
+#        expect(page).to have_content "You're on page 2"
+#
+#        click_link 'Previous'
+#        expect(page).to have_content "You're on page 1"        
+#        
+        expect(investments_order).to eq(@first_user_investments_order)
+      end
+
+      in_browser(:two) do
+        visit budget_investments_path(budget, heading: heading)
+#        click_link 'Next'
+#        expect(page).to have_content "You're on page 2"
+#
+#        click_link 'Previous'
+#        expect(page).to have_content "You're on page 1"   
+#        
+        expect(investments_order).to eq(@second_user_investments_order)
+      end
+    end
+    
+    def investments_order
+      all(".budget-investment h3").collect {|i| i.text }
     end
 
   end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1612

What
====
There was a bug when a user navigates from one investment page to another. This bug repeated the investmentes between pages, and there where other investments that didn't appear.
e.g. Page 1 contains 4, 7, 2, 8, 3; Page 2 contains 7, 4, 1 -> 5 and 6 are missing, because 4 and 7 are repeated.

How
===
I followed [this Stackoverflow answer](https://stackoverflow.com/a/46527029/1799880) to make a semi-random order (it's not a real random selection, but it makes what we want for this case), because I detected that using `random()` (event if we use PostgreSQL `setseed` to set a seed) is not maintaining the order from the variable we get on controller and the one used in the view (the variable in the `each` loop. [Something](https://stackoverflow.com/a/6590245/1799880) that may be involved). I think that this is the problem with repeating objects between pages.

Screenshots
===========
Nothing to show.

Test
====
- I added some test to check that the objects are not been repeated through pages
- I added another test (taken from Madrid's fork) to check that different users, each one in their browser, get different investment order BUT each one is consistent when they navigate forward and backward through pages.

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply

As a side note
========
I changed the test from Madrid's fork slighly to check the order when the user navigates through pages, instead of visiting the `budget_investments_path` again. As I understood, the order should be maintained when users change the page, not when they revisit it (talking about random order).
