### PR TITLE
Fixed link back from moderation dashboard to root_path

### DIFF
--- a/app/views/moderation/dashboard/index.html.erb
+++ b/app/views/moderation/dashboard/index.html.erb
@@ -1,4 +1,4 @@
-<%= link_to t("admin.dashboard.index.back") + " " + setting['org_name'], root_path, class: "button float-right" %>
+<%= link_to t("admin.dashboard.index.back", org: setting['org_name']), root_path, class: "button float-right" %>
 
 <h2 class="inline-block"><%= t("moderation.dashboard.index.title") %></h2>
 


### PR DESCRIPTION
Where
=====
Just a little fix not related with a open issue

What
====
- Fixes link back from moderation dashboard to root_path

How
===
- Passing the organization name to the locale yml file

Test
====
- No needed. Just a little change in a view
