### PR TITLE
Add a previous question link to debates

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -203,29 +203,38 @@
       }
     }
 
-    .quiz-next,
-    .quiz-previous {
+    %quiz {
       background: #ccdbe5;
       color: $brand;
       font-size: $small-font-size;
       font-weight: bold;
-      text-align: right;
       text-transform: uppercase;
       transition: background 0.25s ease-out, background 0.25s ease-out;
-
-      .icon-angle-right {
-        vertical-align: middle;
-      }
-
-      .icon-angle-left {
-        vertical-align: middle;
-      }
 
       &:hover,
       &:active {
         background: $brand;
         color: #fff;
         text-decoration: none;
+      }
+    }
+
+    .quiz-next {
+      @extend %quiz;
+      text-align: right;
+
+      .icon-angle-right {
+        vertical-align: middle;
+      }
+    }
+
+    .quiz-previous {
+      @extend %quiz;
+      text-align: left;
+
+      .icon-angle-left {
+        vertical-align: middle;
+        color: $brand;
       }
     }
   }

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -165,7 +165,8 @@
     margin-bottom: $line-height;
 
     .quiz-title,
-    .quiz-next {
+    .quiz-next,
+    .quiz-previous {
       padding: $line-height;
 
       @include breakpoint(medium) {
@@ -192,7 +193,8 @@
       }
     }
 
-    .quiz-next-link {
+    .quiz-next-link,
+    .quiz-previous-link {
       display: block;
 
       &:hover,
@@ -201,7 +203,8 @@
       }
     }
 
-    .quiz-next {
+    .quiz-next,
+    .quiz-previous {
       background: #ccdbe5;
       color: $brand;
       font-size: $small-font-size;
@@ -211,6 +214,10 @@
       transition: background 0.25s ease-out, background 0.25s ease-out;
 
       .icon-angle-right {
+        vertical-align: middle;
+      }
+
+      .icon-angle-left {
         vertical-align: middle;
       }
 

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -25,6 +25,14 @@ class Legislation::Question < ActiveRecord::Base
   def first_question_id
     @first_question_id ||= process.questions.sorted.limit(1).pluck(:id).first
   end
+  
+  def previous_question_id
+    @previous_question_id ||= process.questions.where("id < ?", id).sorted.limit(1).pluck(:id).first    
+  end
+  
+  def last_question_id
+    @last_question_id ||= process.questions.sorted.limit(1).pluck(:id).last    
+  end
 
   def answer_for_user(user)
     answers.where(user: user).first

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -17,6 +17,7 @@ class Legislation::Question < ActiveRecord::Base
   validates :title, presence: true
 
   scope :sorted, -> { order('id ASC') }
+  scope :reverse_sorted, -> { reorder('id DESC') }
 
   def next_question_id
     @next_question_id ||= process.questions.where("id > ?", id).sorted.limit(1).pluck(:id).first
@@ -25,13 +26,13 @@ class Legislation::Question < ActiveRecord::Base
   def first_question_id
     @first_question_id ||= process.questions.sorted.limit(1).pluck(:id).first
   end
-  
+
   def previous_question_id
-    @previous_question_id ||= process.questions.where("id < ?", id).sorted.limit(1).pluck(:id).first    
+    @previous_question_id ||= process.questions.where("id < ?", id).sorted.limit(1).pluck(:id).first
   end
-  
+
   def last_question_id
-    @last_question_id ||= process.questions.sorted.limit(1).pluck(:id).last    
+    @last_question_id ||= process.questions.reverse_sorted.limit(1).pluck(:id).last
   end
 
   def answer_for_user(user)

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -28,7 +28,7 @@ class Legislation::Question < ActiveRecord::Base
   end
 
   def previous_question_id
-    @previous_question_id ||= process.questions.where("id < ?", id).sorted.limit(1).pluck(:id).first
+    @previous_question_id ||= process.questions.where("id < ?", id).reverse_sorted.limit(1).pluck(:id).first
   end
 
   def last_question_id

--- a/app/views/legislation/questions/show.html.erb
+++ b/app/views/legislation/questions/show.html.erb
@@ -6,15 +6,15 @@
       <% if @question.previous_question_id %>
         <%= link_to legislation_process_question_path(@process, @question.previous_question_id), class: "quiz-previous-link" do %>
           <%= content_tag :div, class: "quiz-previous" do %>
+            <%= t('.previous_question') %>
             <span class="icon-angle-left" aria-hidden="true">
-            <%= t('.next_question') %>
           <% end %>
         <% end %>
       <% elsif @question.last_question_id %>
         <%= link_to legislation_process_question_path(@process, @question.last_question_id), class: "quiz-previous-link" do %>
-          <%= content_tag :div, class: "quiz-next" do %>
+          <%= content_tag :div, class: "quiz-previous" do %>
+            <%= t('.last_question') %>
             <span class="icon-angle-left" aria-hidden="true">
-            <%= t('.next_question') %>
           <% end %>
         <% end %>     
       <% end %>

--- a/app/views/legislation/questions/show.html.erb
+++ b/app/views/legislation/questions/show.html.erb
@@ -2,7 +2,24 @@
 
 <section class="debate-questions">
   <div class="quiz-header row small-collapse">
-    <div class="small-12 medium-9 column">
+    <div class="small-12 medium-3 column">
+      <% if @question.previous_question_id %>
+        <%= link_to legislation_process_question_path(@process, @question.previous_question_id), class: "quiz-previous-link" do %>
+          <%= content_tag :div, class: "quiz-previous" do %>
+            <span class="icon-angle-left" aria-hidden="true">
+            <%= t('.next_question') %>
+          <% end %>
+        <% end %>
+      <% elsif @question.last_question_id %>
+        <%= link_to legislation_process_question_path(@process, @question.last_question_id), class: "quiz-previous-link" do %>
+          <%= content_tag :div, class: "quiz-next" do %>
+            <span class="icon-angle-left" aria-hidden="true">
+            <%= t('.next_question') %>
+          <% end %>
+        <% end %>     
+      <% end %>
+    </div>
+    <div class="small-12 medium-6 column">
       <div class="quiz-title">
         <p class="quiz-header-title"><%= t('.title') %></p>
         <h4><%= link_to @process.title, @process %></h4>
@@ -37,7 +54,7 @@
 
     <aside class="small-12 medium-3 column">
       <div id="social-share" class="sidebar-divider"></div>
-      <h3><%= t('.share') %></h3>
+      <p class="sidebar-title"><%= t('.share') %></p>
       <%= render '/shared/social_share', title: @question.title, url: legislation_process_question_url(@question.process, @question) %>
     </aside>
   </div>

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -101,7 +101,9 @@ en:
       show:
         answer_question: Submit answer
         next_question: Next question
+        previous_question: Previous question
         first_question: First question
+        last_question: Last question
         share: Share
         title: Collaborative legislation process
       participation:

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -101,7 +101,9 @@ es:
       show:
         answer_question: Enviar respuesta
         next_question: Siguiente pregunta
+        previous_question: Pregunta anterior
         first_question: Primera pregunta
+        last_question: Última pregunta
         share: Compartir
         title: Proceso de legislación colaborativa
       participation:

--- a/spec/features/legislation/questions_spec.rb
+++ b/spec/features/legislation/questions_spec.rb
@@ -22,16 +22,31 @@ feature 'Legislation' do
 
       expect(page).to have_content("Question 1")
       expect(page).to have_content("Next question")
+      expect(page).not_to have_content("Previous question")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 2")
       expect(page).to have_content("Next question")
+      expect(page).to have_content("Previous question")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 3")
       expect(page).not_to have_content("Next question")
+      expect(page).to have_content("Previous question")
+
+      click_link "Previous question"
+
+      expect(page).to have_content("Question 2")
+      expect(page).to have_content("Next question")
+      expect(page).to have_content("Previous question")
+
+      click_link "Previous question"
+
+      expect(page).to have_content("Question 1")
+      expect(page).to have_content("Next question")
+      expect(page).not_to have_content("Previous question")
     end
 
     scenario 'shows question page' do
@@ -56,6 +71,23 @@ feature 'Legislation' do
 
       expect(page).to have_content("Question 3")
       expect(page).not_to have_content("Next question")
+    end
+
+    scenario 'shows previous question link in question page' do
+      visit legislation_process_question_path(@process, @process.questions.first)
+
+      expect(page).to have_content("Question 1")
+      expect(page).to_not have_content("Previous question")
+
+      click_link "Next question"
+
+      expect(page).to have_content("Question 2")
+      expect(page).to have_content("Previous question")
+
+      click_link "Next question"
+
+      expect(page).to have_content("Question 3")
+      expect(page).to have_content("Previous question")
     end
 
     scenario 'answer question' do

--- a/spec/models/legislation/question_spec.rb
+++ b/spec/models/legislation/question_spec.rb
@@ -54,6 +54,20 @@ describe Legislation::Question do
     end
   end
 
+  describe "#previous_question_id" do
+    let!(:question1) { create(:legislation_question) }
+    let!(:question2) { create(:legislation_question, legislation_process_id: question1.legislation_process_id) }
+    let!(:question3) { create(:legislation_question, legislation_process_id: question1.legislation_process_id) }
+
+    it "should return the previous question" do
+      expect(question3.previous_question_id).to eq(question2.id)
+    end
+
+    it "should return nil" do
+      expect(question1.previous_question_id).to be_nil
+    end
+  end
+
   describe "#first_question_id" do
     let!(:question1) { create(:legislation_question) }
     let!(:question2) { create(:legislation_question, legislation_process_id: question1.legislation_process_id) }
@@ -68,4 +82,15 @@ describe Legislation::Question do
     it_behaves_like 'notifiable'
   end
 
+  describe "#last_question_id" do
+    let!(:question1) { create(:legislation_question) }
+    let!(:question2) { create(:legislation_question, legislation_process_id: question1.legislation_process_id) }
+    let!(:question3) { create(:legislation_question, legislation_process_id: question1.legislation_process_id) }
+
+    it "should return the last question" do
+      expect(question1.last_question_id).to eq(question3.id)
+      expect(question2.last_question_id).to eq(question3.id)
+      expect(question3.last_question_id).to eq(question3.id)
+    end
+  end
 end


### PR DESCRIPTION
Where
=====
This PR close #1589 

What
====
- Add a "Previous question" link in the legislation debate's header.
- Change the "Share" `h3` to `p` in order to match the styles.

How
===
I added the HTML needed for rendering the button and the functions in the model to get the correct ids. When the first question is reached, the link changes to "Last question", as happens when the last question is reached (the link goes to the first question).

Screenshots
===========
![back_question01](https://user-images.githubusercontent.com/31625251/32889606-d43aa5b2-cacb-11e7-8bab-cde31894200d.png)
![back_question02](https://user-images.githubusercontent.com/31625251/32889607-d7323258-cacb-11e7-8abb-14e55937ef82.png)


Test
====
Test coverage increased to check:
- the UI navigation through questions.
- the functions that get the previous and last question id.

Deployment
==========
Nothing to apply.

Warnings
========
There is some kind of conflic with the `icon-angle-left` class that makes the arrow icon invisible on hover.
![back_question03_warning](https://user-images.githubusercontent.com/31625251/32889797-8b852efe-cacc-11e7-9f5d-eb13a49f33f1.png)
The conflict comes from the `layout.scss`, where the icon class is styled:
```
.back,
.icon-angle-left {
  clear: both;
  color: $text-medium;
  float: left;
}
```
