### PR TITLE
Add admin menu in management view (if user is admin)

### DIFF
--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -6,6 +6,7 @@ class Management::BaseController < ActionController::Base
 
   helper_method :managed_user
   helper_method :current_user
+  helper_method :user_signed_in
 
   private
 
@@ -22,7 +23,10 @@ class Management::BaseController < ActionController::Base
     end
 
     def managed_user
-      @managed_user ||= Verification::Management::ManagedUser.find(session[:document_type], session[:document_number])
+      @managed_user ||= Verification::Management::ManagedUser.find(
+        session[:document_type],
+        session[:document_number]
+      )
     end
 
     def check_verified_user(alert_msg)
@@ -49,4 +53,11 @@ class Management::BaseController < ActionController::Base
     def clear_password
       session[:new_password] = nil
     end
+
+    def user_signed_in
+      if current_manager
+        @user_signed_in = User.find(session[:manager]["login"].last(1))
+      end
+    end
+
 end

--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -6,7 +6,7 @@ class Management::BaseController < ActionController::Base
 
   helper_method :managed_user
   helper_method :current_user
-  helper_method :user_signed_in
+  helper_method :manager_logged_in
 
   private
 
@@ -54,9 +54,9 @@ class Management::BaseController < ActionController::Base
       session[:new_password] = nil
     end
 
-    def user_signed_in
+    def manager_logged_in
       if current_manager
-        @user_signed_in = User.find(session[:manager]["login"].last(1))
+        @manager_logged_in = User.find_by(id: session[:manager]["login"].last(1))
       end
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,7 +11,7 @@ class Users::SessionsController < Devise::SessionsController
     end
 
     def after_sign_out_path_for(resource)
-      request.referer.present? ? request.referer : super
+      request.referer.present? && !request.referer.match("management") ? request.referer : super
     end
 
     def verifying_via_email?

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -53,7 +53,7 @@ module UsersHelper
   end
 
   def show_admin_menu?(user = nil)
-    current_administrator? || current_moderator? || current_valuator? || current_manager? || user.administrator?
+    current_administrator? || current_moderator? || current_valuator? || current_manager? || (user && user.administrator?)
   end
 
   def interests_title_text(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -52,8 +52,8 @@ module UsersHelper
     current_user && current_user.manager?
   end
 
-  def show_admin_menu?
-    current_administrator? || current_moderator? || current_valuator? || current_manager?
+  def show_admin_menu?(user = nil)
+    current_administrator? || current_moderator? || current_valuator? || current_manager? || user.administrator?
   end
 
   def interests_title_text(user)

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -29,6 +29,19 @@
               </li>
             </ul>
           </div>
+          <% if current_administrator? %>
+            <div id="responsive_menu">
+
+              <div class="top-bar-right">
+                <ul class="menu" data-responsive-menu="medium-dropdown">
+                  <%= render "admin/shared/admin_shortcuts" %>
+                  <%= render "shared/admin_login_items" %>
+                  <%= render "devise/menu/login_items" %>
+                </ul>
+              </div>
+
+            </div>
+          <% end %>
         </div>
       </div>
     </header>

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -29,14 +29,14 @@
               </li>
             </ul>
           </div>
-          <% if current_administrator? %>
+          <% if user_signed_in.administrator? %>
             <div id="responsive_menu">
 
               <div class="top-bar-right">
                 <ul class="menu" data-responsive-menu="medium-dropdown">
-                  <%= render "admin/shared/admin_shortcuts" %>
-                  <%= render "shared/admin_login_items" %>
-                  <%= render "devise/menu/login_items" %>
+                  <%= render "admin/shared/admin_shortcuts", current_user: user_signed_in %>
+                  <%= render "shared/admin_login_items", current_user: user_signed_in %>
+                  <%= render "devise/menu/login_items", current_user: user_signed_in %>
                 </ul>
               </div>
 

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -29,14 +29,14 @@
               </li>
             </ul>
           </div>
-          <% if user_signed_in.administrator? %>
+          <% if show_admin_menu?(manager_logged_in) %>
             <div id="responsive_menu">
 
               <div class="top-bar-right">
                 <ul class="menu" data-responsive-menu="medium-dropdown">
-                  <%= render "admin/shared/admin_shortcuts", current_user: user_signed_in %>
-                  <%= render "shared/admin_login_items", current_user: user_signed_in %>
-                  <%= render "devise/menu/login_items", current_user: user_signed_in %>
+                  <%= render "admin/shared/admin_shortcuts", current_user: manager_logged_in %>
+                  <%= render "shared/admin_login_items", current_user: manager_logged_in %>
+                  <%= render "devise/menu/login_items", current_user: manager_logged_in %>
                 </ul>
               </div>
 

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -1,4 +1,4 @@
-<% if show_admin_menu? %>
+<% if show_admin_menu?(current_user) %>
   <li class="has-submenu">
     <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
     <ul class="submenu menu vertical" data-submenu>

--- a/spec/features/management_spec.rb
+++ b/spec/features/management_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+feature 'Management' do
+  let(:user) { create(:user) }
+
+  scenario "Should show admin menu if logged user is admin" do
+    create(:administrator, user: user)
+    login_as(user)
+    visit root_path
+
+    expect(page).to have_link("Management")
+
+    click_link "Management"
+
+    expect(page).to have_content("My activity")
+    expect(page).to have_content("My account")
+    expect(page).to have_content("Sign out")
+  end
+
+  scenario "Should not show admin menu if logged user is manager" do
+    create(:manager, user: user)
+    login_as(user)
+    visit root_path
+
+    expect(page).to have_link("Management")
+
+    click_link "Management"
+
+    expect(page).not_to have_content("My activity")
+    expect(page).not_to have_content("My account")
+    expect(page).not_to have_content("Sign out")
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1614 (this PR closes #1614)

What
====
Make the admin menu visible in the management section if the user is an admin.

How
===
I added the menu to the management layout. It is shown only if a condition is fulfilled (logged_in user is an admin). If not, it isn't shown.

Screenshots
===========
Admin management view

![admin_management_menu01](https://user-images.githubusercontent.com/31625251/32950429-9071cfe6-cba6-11e7-91c2-0ac0334a8806.png)

Manager management view

![admin_management_menu02](https://user-images.githubusercontent.com/31625251/32950439-9c38da2c-cba6-11e7-83aa-322fc9b23aa4.png)

Test
====
I added test to check the management UI. If the user is admin it shoult have the menu. If it isn't, no.

Deployment
==========
Nothing to apply

Warnings
========
Nothing to apply.
