### PR TITLE
Add feature setting to enable/disable API (admins)

### DIFF
--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -75,6 +75,7 @@ en:
     verification_offices_url: Verification offices URL
     proposal_improvement_path: Proposal improvement info internal link
     feature:
+      api: "API"
       budgets: "Participatory budgeting"
       budgets_description: "With participatory budgets, citizens decide which projects presented by their neighbours will receive a part of the municipal budget"
       twitter_login: "Twitter login"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -75,6 +75,7 @@ es:
     verification_offices_url: URL oficinas verificación
     proposal_improvement_path: Link a información para mejorar propuestas
     feature:
+      api: "API"
       budgets: "Presupuestos participativos"
       budgets_description: "Con los presupuestos participativos la ciudadanía decide a qué proyectos presentados por los vecinos y vecinas va destinada una parte del presupuesto municipal"
       twitter_login: "Registro con Twitter"

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -28,6 +28,7 @@ section "Creating Settings" do
   Setting.create(key: 'org_name', value: 'CONSUL')
   Setting.create(key: 'place_name', value: 'City')
 
+  Setting.create(key: 'feature.api', value: "true")
   Setting.create(key: 'feature.debates', value: "true")
   Setting.create(key: 'feature.proposals', value: "true")
   Setting.create(key: 'feature.polls', value: "true")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 # Default admin user (change password after first deploy to a server!)
 if Administrator.count == 0 && !Rails.env.test?
   admin = User.create!(username: 'admin', email: 'admin@consul.dev', password: '12345678', password_confirmation: '12345678', confirmed_at: Time.current, terms_of_service: "1")
@@ -89,6 +90,7 @@ Setting['feature.map'] = nil
 Setting['feature.allow_images'] = true
 Setting['feature.allow_attached_documents'] = true
 Setting['feature.guides'] = nil
+Setting['feature.api'] = true
 
 # Spending proposals feature flags
 Setting['feature.spending_proposal_features.voting_allowed'] = nil

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -20,4 +20,9 @@ namespace :settings do
     Setting['feature.user.recommendations_on_proposals'] = true
   end
 
+  desc "Add setting for enabling/disabling the API"
+  task add_feature_api: :environment do
+    Settings['feature.api'] = true
+  end
+
 end

--- a/spec/controllers/graphql_controller_spec.rb
+++ b/spec/controllers/graphql_controller_spec.rb
@@ -88,4 +88,24 @@ describe GraphqlController, type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "handles enabled/disabled API correctly" do
+    let(:query_string) { "{ proposal(id: #{proposal.id}) { title } }" }
+
+    it "retrieves data if API is enabled" do
+      get '/graphql', query: query_string
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['data']['proposal']['title']).to eq(proposal.title)
+    end
+
+    it "shows message if API is disabled" do
+      Setting['feature.api'] = nil
+
+      get '/graphql', query: query_string
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['message']).to eq("The API has been disabled")
+    end
+  end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1592 
This PR close #1592 

What
====
Add a feature setting to let the admins enable or disable the API.

How
===
- I added a setting to the DB that determines if the API is enabled or disabled. Checking this, the app will show a message alerting that the API has been disabled (if it was). If the API is enabled it will work normally.
- I also edited the `dev_seeds` and `seeds` to include that feature in the settings. There is also a `rake task` to insert only that feature.

Screenshots
===========
- API Enabled
![api01](https://user-images.githubusercontent.com/31625251/33072233-ee1d73d2-cebe-11e7-91dd-e6fecdb71dc1.png)
![api02](https://user-images.githubusercontent.com/31625251/33072239-f1b6b9cc-cebe-11e7-82eb-28453d1dc3e7.png)

- API Disabled
![api03](https://user-images.githubusercontent.com/31625251/33072244-f5dce896-cebe-11e7-946d-d0afd56fa8bb.png)
![api04](https://user-images.githubusercontent.com/31625251/33072248-fa04ca56-cebe-11e7-98f2-c8d19a7f88e3.png)

Test
====
I added some tests to check if the disabled API works and return the message.

Deployment
==========
In order to make this work, a rake task must be run: `rake settings:add_feature_api`

Warnings
========
Nothing to apply.
