### PR TITLE
adds poll comments to API

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -30,9 +30,11 @@ class Comment < ActiveRecord::Base
   scope :sort_by_flags, -> { order(flags_count: :desc, updated_at: :desc) }
   scope :public_for_api, -> do
     where(%{(comments.commentable_type = 'Debate' and comments.commentable_id in (?)) or
-            (comments.commentable_type = 'Proposal' and comments.commentable_id in (?))},
+            (comments.commentable_type = 'Proposal' and comments.commentable_id in (?)) or
+            (comments.commentable_type = 'Poll' and comments.commentable_id in (?))},
           Debate.public_for_api.pluck(:id),
-          Proposal.public_for_api.pluck(:id))
+          Proposal.public_for_api.pluck(:id),
+          Poll.public_for_api.pluck(:id))
   end
 
   scope :sort_by_most_voted, -> { order(confidence_score: :desc, created_at: :desc) }

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -28,6 +28,7 @@ class Poll < ActiveRecord::Base
   scope :recounting, -> { Poll.where(ends_at: (Date.current.beginning_of_day - RECOUNT_DURATION)..Date.current.beginning_of_day) }
   scope :published, -> { where('published = ?', true) }
   scope :by_geozone_id, ->(geozone_id) { where(geozones: {id: geozone_id}.joins(:geozones)) }
+  scope :public_for_api, -> { all }
 
   scope :sort_for_list, -> { order(:geozone_restricted, :starts_at, :name) }
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2122 

What
====
- This PR adds polls' comments to the graphql API

How
===
- As stated in the [original issue](https://github.com/consul/consul/issues/2122) only the comments are exposed, the Poll model is not included in the API interface.

Test
====
- Specs updated

Deployment
==========
- none

Warnings
========
- none
