### PR TITLE
Updates spanish translation for polls

### DIFF
--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -557,7 +557,7 @@ es:
           unassigned: No asignada
         actions:
           assign: Asignar urna
-          unassign: Asignar urna
+          unassign: Desasignar urna
     poll_booth_assignments:
       alert:
         shifts: "Hay turnos asignados para esta urna. Si la desasignas, esos turnos se eliminarán. ¿Deseas continuar?"


### PR DESCRIPTION
What
====
- Updates missed translation in Spanish locale

Screenshots
===========
Before PR, the button displays "Assignar urna" when it is already assigned
![assign_booth_typo](https://user-images.githubusercontent.com/4169/33341856-7929d454-d480-11e7-9c7f-59935307ee06.png)

With PR, the button displays "Desasignar urna" when it is already assigned
![unassign_booth](https://user-images.githubusercontent.com/4169/33341881-87ef2354-d480-11e7-83a9-b0f104faa19e.png)

Test
====
- Already [tested in english locale](https://github.com/consul/consul/blob/master/spec/features/admin/poll/booth_assigments_spec.rb#L94)

Deployment
==========
- As usual

Warnings
========
- None
