### PR TITLE
Prevent a division by zero bug on sort by random scope

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -94,7 +94,7 @@ module Budgets
 
       def set_random_seed
         if params[:order] == 'random' || params[:order].blank?
-          seed = rand(10..99) / 10.0
+          seed = rand(11..99) / 10.0
           params[:random_seed] ||= Float(seed) rescue 0
         else
           params[:random_seed] = nil

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -43,7 +43,7 @@ class Budget
     scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc, id: :desc) }
     scope :sort_by_ballots,          -> { reorder(ballot_lines_count: :desc, id: :desc) }
     scope :sort_by_price,            -> { reorder(price: :desc, confidence_score: :desc, id: :desc) }
-    scope :sort_by_random,           ->(seed) { reorder("budget_investments.id % #{seed || 1}, budget_investments.id") }
+    scope :sort_by_random,           ->(seed) { reorder("budget_investments.id % #{seed.to_f&.positive? ? seed : 1}, budget_investments.id") }
 
     scope :valuation_open,              -> { where(valuation_finished: false) }
     scope :without_admin,               -> { valuation_open.where(administrator_id: nil) }


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/pull/2131
* **Related Rollbar:** https://rollbar.com/consul/Participacion/items/1320/

What
====
This just happened at rollbar:
```
ActiveRecord::StatementInvalid: PG::DivisionByZero: ERROR: division by zero
: SELECT "budget_investments"."id" FROM "budget_investments" LEFT OUTER JOIN "budget_headings" ON "budget_headings"."id" = "budget_investments"."heading_id" WHERE "budget_investments"."hidden_at" IS NULL AND "budget_investments"."budget_id" = $1 AND ("budget_investments"."feasibility" != $2) AND "budget_investments"."heading_id" = 11 ORDER BY budget_investments.id % 0.0, budget_investments.id LIMIT 10 OFFSET 20
+ 23 non-project frames
24
File "/aytomad/app/participa/participacion/releases/20171128183128/app/controllers/budgets/investments_controller.rb" line 34 in index
```

Because since at https://github.com/consul/consul/pull/2131/files#diff-d11845acbb803124428a561715692f8eR97 the `rand(10..99) / 10.0` can output a `0.0` result... and also at https://github.com/consul/consul/pull/2131/files#diff-8e806f1abf6a06e54748ebcb2ce63d3aR46 the `seed || 1` is not accounting for a zero scenario.

How
===
Preventing both things to go wrong (having a zero on both points)

Screenshots
===========
No need

Test
====
No idea how to force that scenario (the zero) with a test, carefully reading code should be enough

Deployment
==========
As usual

Warnings
========
None