### PR TITLE
Improve user search by email/name

### DIFF
--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -6,7 +6,7 @@ class Admin::AdministratorsController < Admin::BaseController
   end
 
   def search
-    @users = User.search(params[:name_or_email])
+    @users = User.search(params[:name_or_email].strip)
                  .includes(:administrator)
                  .page(params[:page])
                  .for_render

--- a/app/controllers/admin/managers_controller.rb
+++ b/app/controllers/admin/managers_controller.rb
@@ -6,7 +6,7 @@ class Admin::ManagersController < Admin::BaseController
   end
 
   def search
-    @users = User.search(params[:name_or_email])
+    @users = User.search(params[:name_or_email].strip)
                  .includes(:manager)
                  .page(params[:page])
                  .for_render

--- a/app/controllers/admin/moderators_controller.rb
+++ b/app/controllers/admin/moderators_controller.rb
@@ -6,7 +6,7 @@ class Admin::ModeratorsController < Admin::BaseController
   end
 
   def search
-    @users = User.search(params[:name_or_email])
+    @users = User.search(params[:name_or_email].strip)
                  .includes(:moderator)
                  .page(params[:page])
                  .for_render

--- a/app/controllers/admin/officials_controller.rb
+++ b/app/controllers/admin/officials_controller.rb
@@ -5,7 +5,7 @@ class Admin::OfficialsController < Admin::BaseController
   end
 
   def search
-    @users = User.search(params[:name_or_email]).page(params[:page]).for_render
+    @users = User.search(params[:name_or_email].strip).page(params[:page]).for_render
   end
 
   def edit

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,8 +2,12 @@ class Admin::UsersController < Admin::BaseController
   load_and_authorize_resource
 
   def index
-    @users = User.by_username_email_or_document_number(params[:search]) if params[:search]
-    @users = @users.page(params[:page])
+    if params[:search]
+      @users = User.by_username_email_or_document_number(params[:search]).page(params[:page])
+    else
+      @users = @users.page(params[:page])
+    end
+
     respond_to do |format|
       format.html
       format.js

--- a/app/controllers/admin/valuators_controller.rb
+++ b/app/controllers/admin/valuators_controller.rb
@@ -10,7 +10,7 @@ class Admin::ValuatorsController < Admin::BaseController
   end
 
   def search
-    @users = User.search(params[:name_or_email])
+    @users = User.search(params[:name_or_email].strip)
                  .includes(:valuator)
                  .page(params[:page])
                  .for_render

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ActiveRecord::Base
   scope :by_comments,    ->(query, topics_ids) { joins(:comments).where(query, topics_ids).uniq }
   scope :by_authors,     ->(author_ids) { where("users.id IN (?)", author_ids) }
   scope :by_username_email_or_document_number, ->(search_string) do
-    string = "%#{search_string}%"
+    string = "%#{search_string.strip}%"
     where("username ILIKE ? OR email ILIKE ? OR document_number ILIKE ?", string, string, string)
   end
 

--- a/spec/features/admin/administrators_spec.rb
+++ b/spec/features/admin/administrators_spec.rb
@@ -88,6 +88,30 @@ feature 'Admin administrators' do
       expect(page).to have_content(@administrator2.email)
       expect(page).not_to have_content(@administrator1.email)
     end
+
+    scenario 'search by email with space' do
+      expect(page).to have_content(@administrator1.email)
+      expect(page).to have_content(@administrator2.email)
+
+      fill_in 'name_or_email', with: "#{@administrator2.email} "
+      click_button 'Search'
+
+      expect(page).to have_content('Administrators: User search')
+      expect(page).to have_content(@administrator2.email)
+      expect(page).not_to have_content(@administrator1.email)
+    end
+
+    scenario 'search by name with space' do
+      expect(page).to have_content(@administrator1.name)
+      expect(page).to have_content(@administrator2.name)
+
+      fill_in 'name_or_email', with: "#{@administrator2.name} "
+      click_button 'Search'
+
+      expect(page).to have_content('Administrators: User search')
+      expect(page).to have_content(@administrator2.name)
+      expect(page).not_to have_content(@administrator1.name)
+    end
   end
 
 end

--- a/spec/features/admin/managers_spec.rb
+++ b/spec/features/admin/managers_spec.rb
@@ -80,6 +80,30 @@ feature 'Admin managers' do
       expect(page).to have_content(@manager2.email)
       expect(page).not_to have_content(@manager1.email)
     end
+
+    scenario 'search by name with space' do
+      expect(page).to have_content(@manager1.name)
+      expect(page).to have_content(@manager2.name)
+
+      fill_in 'name_or_email', with: 'Taylor '
+      click_button 'Search'
+
+      expect(page).to have_content('Managers: User search')
+      expect(page).to have_content(@manager1.name)
+      expect(page).not_to have_content(@manager2.name)
+    end
+
+    scenario 'search by email with space' do
+      expect(page).to have_content(@manager1.email)
+      expect(page).to have_content(@manager2.email)
+
+      fill_in 'name_or_email', with: "#{@manager2.email} "
+      click_button 'Search'
+
+      expect(page).to have_content('Managers: User search')
+      expect(page).to have_content(@manager2.email)
+      expect(page).not_to have_content(@manager1.email)
+    end
   end
 
 end

--- a/spec/features/admin/moderators_spec.rb
+++ b/spec/features/admin/moderators_spec.rb
@@ -80,6 +80,30 @@ feature 'Admin moderators' do
       expect(page).to have_content(@moderator2.email)
       expect(page).not_to have_content(@moderator1.email)
     end
+
+    scenario 'search by email with space' do
+      expect(page).to have_content(@moderator1.email)
+      expect(page).to have_content(@moderator2.email)
+
+      fill_in 'name_or_email', with: "#{@moderator2.email} "
+      click_button 'Search'
+
+      expect(page).to have_content('Moderators: User search')
+      expect(page).to have_content(@moderator2.email)
+      expect(page).not_to have_content(@moderator1.email)
+    end
+
+    scenario 'search by name with space' do
+      expect(page).to have_content(@moderator1.name)
+      expect(page).to have_content(@moderator2.name)
+
+      fill_in 'name_or_email', with: "#{@moderator2.name} "
+      click_button 'Search'
+
+      expect(page).to have_content('Moderators: User search')
+      expect(page).to have_content(@moderator2.name)
+      expect(page).not_to have_content(@moderator1.name)
+    end
   end
 
 end

--- a/spec/features/admin/officials_spec.rb
+++ b/spec/features/admin/officials_spec.rb
@@ -75,4 +75,36 @@ feature 'Admin officials' do
     expect(page).not_to have_content @citizen.name
     expect(page).not_to have_content @official.name
   end
+
+  context 'Search' do
+
+    background do
+      @official2 = create(:user, official_position: "Mayor", official_level: 5)
+      visit admin_officials_path
+    end
+
+    scenario "search by email with space" do
+      expect(page).to have_content(@official.name)
+      expect(page).to have_content(@official2.name)
+
+      fill_in 'name_or_email', with: "#{@official2.email} "
+      click_button 'Search'
+
+      expect(page).to have_content('Official positions: User search')
+      expect(page).to have_content(@official2.name)
+      expect(page).not_to have_content(@official.name)
+    end
+
+    scenario "search by name with space" do
+      expect(page).to have_content(@official.name)
+      expect(page).to have_content(@official2.name)
+
+      fill_in 'name_or_email', with: "#{@official2.name} "
+      click_button 'Search'
+
+      expect(page).to have_content('Official positions: User search')
+      expect(page).to have_content(@official2.name)
+      expect(page).not_to have_content(@official.name)
+    end
+  end
 end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -17,12 +17,21 @@ feature 'Admin users' do
 
   scenario 'The username links to their public profile' do
     click_link @user.name
-
-    expect(current_path).to eq(user_path(@user))
+    expect(page).to have_current_path(user_path(@user))
   end
 
   scenario 'Search' do
     fill_in :search, with: "Luis"
+    click_button 'Search'
+
+    expect(page).to have_content @user.name
+    expect(page).to have_content @user.email
+    expect(page).not_to have_content @admin.name
+    expect(page).not_to have_content @admin.email
+  end
+
+  scenario 'Search by email with space' do
+    fill_in :search, with: "#{@user.email} "
     click_button 'Search'
 
     expect(page).to have_content @user.name

--- a/spec/features/admin/valuators_spec.rb
+++ b/spec/features/admin/valuators_spec.rb
@@ -101,6 +101,30 @@ feature 'Admin valuators' do
       expect(page).to have_content(@valuator2.email)
       expect(page).not_to have_content(@valuator1.email)
     end
+
+    scenario 'search by name with space' do
+      expect(page).to have_content(@valuator1.name)
+      expect(page).to have_content(@valuator2.name)
+
+      fill_in 'name_or_email', with: 'Foster '
+      click_button 'Search'
+
+      expect(page).to have_content('Valuators: User search')
+      expect(page).to have_content(@valuator1.name)
+      expect(page).not_to have_content(@valuator2.name)
+    end
+
+    scenario 'search by email with space' do
+      expect(page).to have_content(@valuator1.email)
+      expect(page).to have_content(@valuator2.email)
+
+      fill_in 'name_or_email', with: "#{@valuator2.email} "
+      click_button 'Search'
+
+      expect(page).to have_content('Valuators: User search')
+      expect(page).to have_content(@valuator2.email)
+      expect(page).not_to have_content(@valuator1.email)
+    end
   end
 
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2149 
This PR closes #2149

What
====
There was a problem when trying to search by email/name with a blank space before or after the words. The search wasn't being done.

How
===
Add the `strip` function to the searched text so that it is used without blank spaces (even if the user accidentally inserts them). `strip` doesn't affect to the spaces between words (e.g. Ana Perez)

Screenshots
===========
![search01](https://user-images.githubusercontent.com/31625251/33387935-d96bd4bc-d52e-11e7-84c8-60621a64e984.gif)

![search02](https://user-images.githubusercontent.com/31625251/33387945-de2fde30-d52e-11e7-8e08-33ba12b7bab5.gif)

Test
====
Test for searchers involved.

Deployment
==========
Nothing.

Warnings
========
Nothing.
