### PR TITLE
Consul installation details

### DIFF
--- a/app/controllers/installation_controller.rb
+++ b/app/controllers/installation_controller.rb
@@ -1,0 +1,24 @@
+class InstallationController < ApplicationController
+
+  skip_authorization_check
+
+  def details
+    respond_to do |format|
+      format.any { render json: consul_installation_details.to_json, content_type: 'application/json' }
+    end
+  end
+
+  private
+
+  def consul_installation_details
+   {
+     release: 'v0.11'
+   }.merge(features: settings_feature_flags)
+  end
+
+  def settings_feature_flags
+    Setting.where("key LIKE 'feature.%'").each_with_object({}) { |x, n| n[x.key.remove('feature.')] = x.value }
+  end
+
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
   get '/welcome', to: 'welcome#welcome'
   get '/cuentasegura', to: 'welcome#verification', as: :cuentasegura
 
+  get '/consul.json', to: "installation#details"
+
   resources :debates do
     member do
       post :vote

--- a/spec/controllers/installation_controller_spec.rb
+++ b/spec/controllers/installation_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe InstallationController, type: :request do
+
+  describe "consul.json" do
+    let(:feature_settings) do
+      {
+        'debates' => nil,
+        'spending_proposals' => 't',
+        'polls' => nil,
+        'twitter_login' => nil,
+        'facebook_login' => nil,
+        'google_login' => nil,
+        'public_stats' => nil,
+        'budgets' => nil,
+        'signature_sheets' => nil,
+        'legislation' => nil,
+        'user.recommendations' => nil,
+        'community' => nil,
+        'map' => 't',
+        'spending_proposal_features.voting_allowed' => 't'
+      }
+    end
+
+    before do
+      feature_settings.each { |feature_name, feature_value| Setting["feature.#{feature_name}"] = feature_value }
+    end
+
+    after do
+      Setting['feature.debates'] = true
+      Setting['feature.spending_proposals'] = nil
+      Setting['feature.polls'] = true
+      Setting['feature.twitter_login'] = true
+      Setting['feature.facebook_login'] = true
+      Setting['feature.google_login'] = true
+      Setting['feature.public_stats'] = true
+      Setting['feature.budgets'] = true
+      Setting['feature.signature_sheets'] = true
+      Setting['feature.legislation'] = true
+      Setting['feature.user.recommendations'] = true
+      Setting['feature.community'] = true
+      Setting['feature.map'] = nil
+      Setting['feature.spending_proposal_features.voting_allowed'] = nil
+    end
+
+    specify "with query string inside query params" do
+      get '/consul.json'
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['release']).not_to be_empty
+      expect(JSON.parse(response.body)['features']).to eq(feature_settings)
+    end
+  end
+end


### PR DESCRIPTION
What
====
- Add a way to a future "fork dashboard" app to gather info from version & enabled features from consul installations

How
===
Simple `/consul.json` route that has latest release version number hardcoded and gets from Setting all `feature` flags. Controller was named `installation` as it seemed more descriptive to me, as well as method `details`

```
  | {"release":"v0.11","features":{"debates":"true","polls":"true","spending_proposals":null,"spending_proposal_features.voting_allowed":null,"budgets":"true","twitter_login":"true","facebook_login":"true","google_login":"true","signature_sheets":"true","legislation":"true","user.recommendations":"true","community":"true","map":"true","stats":"t","public_stats":"t"}}
```

Screenshots
===========
![screen shot 2017-12-04 at 18 21 11](https://user-images.githubusercontent.com/983242/33566409-3292c934-d920-11e7-96aa-5359e9e020db.jpg)

Test
====
Added a request test that describes expected response from a GET to `/consul.json` route

Deployment
==========
As usual

Warnings
========
This should be included before the v0.11 release is done