### PR TITLE
Knapsack Pro gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - bundle exec rake db:setup
 script:
   - "bundle exec rake assets:precompile RAILS_ENV=test"
-  - "bundle exec rake knapsack_pro:rspec"
+  - "bundle exec rake knapsack_pro:queue:rspec"
 env:
   global:
     - KNAPSACK_PRO_CI_NODE_TOTAL=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ before_script:
   - bundle exec rake db:setup
 script:
   - "bundle exec rake assets:precompile RAILS_ENV=test"
-  - "bundle exec rake knapsack:rspec"
+  - "bundle exec rake knapsack_pro:rspec"
 env:
   global:
-    - CI_NODE_TOTAL=2
+    - KNAPSACK_PRO_CI_NODE_TOTAL=2
   matrix:
-    - CI_NODE_INDEX=0
-    - CI_NODE_INDEX=1
+    - KNAPSACK_PRO_CI_NODE_INDEX=0
+    - KNAPSACK_PRO_CI_NODE_INDEX=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - bundle exec rake db:setup
 script:
   - "bundle exec rake assets:precompile RAILS_ENV=test"
-  - "bundle exec rake knapsack_pro:queue:rspec"
+  - "bin/knapsack_pro_rspec"
 env:
   global:
     - KNAPSACK_PRO_CI_NODE_TOTAL=2

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :development, :test do
   gem 'factory_girl_rails', '~> 4.8.0'
   gem 'faker', '~> 1.7.3'
   gem 'i18n-tasks', '~> 0.9.15'
-  gem 'knapsack_pro', '~> 0.52.0'
+  gem 'knapsack_pro', '~> 0.53.0'
   gem 'launchy', '~> 2.4.3'
   gem 'letter_opener_web', '~> 1.3.1'
   gem 'quiet_assets', '~> 1.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :development, :test do
   gem 'factory_girl_rails', '~> 4.8.0'
   gem 'faker', '~> 1.7.3'
   gem 'i18n-tasks', '~> 0.9.15'
-  gem 'knapsack', '~> 1.13.3'
+  gem 'knapsack_pro', '~> 0.52.0'
   gem 'launchy', '~> 2.4.3'
   gem 'letter_opener_web', '~> 1.3.1'
   gem 'quiet_assets', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
     kgio (2.11.0)
-    knapsack_pro (0.52.0)
+    knapsack_pro (0.53.0)
       rake
     kramdown (1.14.0)
     launchy (2.4.3)
@@ -529,7 +529,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3.1)
   jquery-ui-rails (~> 6.0.1)
   kaminari (~> 1.0.1)
-  knapsack_pro (~> 0.52.0)
+  knapsack_pro (~> 0.53.0)
   launchy (~> 2.4.3)
   letter_opener_web (~> 1.3.1)
   mdl (~> 0.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,9 +229,8 @@ GEM
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
     kgio (2.11.0)
-    knapsack (1.13.3)
+    knapsack_pro (0.52.0)
       rake
-      timecop (>= 0.1.0)
     kramdown (1.14.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -451,7 +450,6 @@ GEM
     thread (0.2.2)
     thread_safe (0.3.6)
     tilt (2.0.7)
-    timecop (0.9.1)
     tins (1.15.0)
     turbolinks (2.5.3)
       coffee-rails
@@ -531,7 +529,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3.1)
   jquery-ui-rails (~> 6.0.1)
   kaminari (~> 1.0.1)
-  knapsack (~> 1.13.3)
+  knapsack_pro (~> 0.52.0)
   launchy (~> 2.4.3)
   letter_opener_web (~> 1.3.1)
   mdl (~> 0.4.0)
@@ -573,4 +571,4 @@ DEPENDENCIES
   whenever (~> 0.9.7)
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,4 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
-Knapsack.load_tasks if defined?(Knapsack)
+KnapsackPro.load_tasks if defined?(KnapsackPro)

--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
+  KNAPSACK_PRO_ENDPOINT=https://api-disabled-for-fork.knapsackpro.com \
+    KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
+    bundle exec rake knapsack_pro:rspec # use Regular Mode here always
+else
+  # Queue Mode - dynamic tests allocation across CI nodes
+  bundle exec rake knapsack_pro:queue:rspec
+fi

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,8 @@ require 'factory_girl_rails'
 require 'database_cleaner'
 require 'email_spec'
 require 'devise'
-require 'knapsack'
+require 'knapsack_pro'
+
 Dir["./spec/models/concerns/*.rb"].each { |f| require f }
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 Dir["./spec/shared/**/*.rb"].sort.each { |f| require f }
@@ -107,4 +108,4 @@ RSpec.configure do |config|
 end
 
 # Parallel build helper configuration for travis
-Knapsack::Adapters::RSpecAdapter.bind
+KnapsackPro::Adapters::RSpecAdapter.bind

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,6 +106,3 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
-
-# Parallel build helper configuration for travis
-KnapsackPro::Adapters::RSpecAdapter.bind

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,3 +106,6 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+# Parallel build helper configuration for travis
+KnapsackPro::Adapters::RSpecAdapter.bind


### PR DESCRIPTION
Where
=====
* travis.yml configuration

What
====
* added knapsack_pro gem https://knapsackpro.com and configure it to use Queue Mode which allocates tests across CI nodes in a dynamic way to save time execution for each CI build.
* The forked version of the https://github.com/consul/consul repo can still run tests without exposing the secret API key `KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC` thanks to fallback mode as described here: https://github.com/KnapsackPro/knapsack_pro-ruby#how-to-make-knapsack_pro-works-for-forked-repositories-of-my-project

How
===
* added `bin/knapsack_pro_rspec` that can handle forked version repo. Based on https://github.com/KnapsackPro/knapsack_pro-ruby#how-to-make-knapsack_pro-works-for-forked-repositories-of-my-project

Test
====
- ensure the CI build is green (I rebased my branch with the current master which was red, unfortunately)



