### PR TITLE
Exclude vendor folder from Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -32,3 +32,4 @@ exclude_paths:
 - files/
 - public/
 - tmp/
+- vendor/


### PR DESCRIPTION
What
====
- Excludes vendor folder and all its javascript files from Code Climate

How
===
- Adding the clause to codeclimate.yml

Why
===
- These are libraries that should not be modified and thus should not be included in the code quality of CONSUL

Deployment
==========
- As usual

Warnings
========
- None
