### PR TITLE
Design improvements

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2043,36 +2043,6 @@ table {
 
 .activity {
 
-  .accordion li {
-    margin-bottom: $line-height / 2;
-
-    .accordion-title {
-      border-bottom: 1px solid $border;
-      background: #f8f9fb;
-      font-size: $small-font-size;
-      padding: $line-height / 2;
-    }
-
-    .accordion-content {
-      padding: 0;
-    }
-  }
-
-  .accordion .title {
-    display: block;
-    line-height: $line-height;
-  }
-
-  .accordion .icon {
-    font-size: rem-calc(20);
-    float: left;
-    margin-right: $line-height / 3;
-
-    &.icon-debates {
-      margin-top: rem-calc(3);
-    }
-  }
-
   .retired {
     text-decoration: line-through;
   }
@@ -2082,6 +2052,45 @@ table {
 
   li {
     margin-right: $line-height / 4;
+
+    span {
+      background: none;
+      border: 1px solid #ececec;
+    }
+  }
+}
+
+.following {
+
+  .follow-list {
+    list-style-type: circle;
+    padding: $line-height / 2;
+
+    li {
+      margin-bottom: $line-height / 2;
+      margin-left: $line-height;
+    }
+  }
+
+  h3 {
+    font-size: rem-calc(24);
+    margin-top: $line-height;
+    padding-left: rem-calc(30);
+    position: relative;
+
+    span {
+      left: 0;
+      position: absolute;
+      top: 2px;
+    }
+  }
+
+  .interests {
+
+    @include breakpoint(medium) {
+      border-left: 1px solid #ececec;
+      padding-left: $line-height;
+    }
   }
 }
 

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -655,41 +655,12 @@
 .budget-investments-list .budget-investment,
 .proposals-list .proposal {
 
-  .no-image {
-    background: $brand;
-  }
-}
-
-.budget-investments-list .budget-investment,
-.proposals-list .proposal {
-
-  @include breakpoint(small) {
-
-    .no-image {
-      width: 100%;
-      max-width: rem-calc(300);
-      margin: 0 auto;
-
-      &::before {
-        content: '';
-        display: block;
-        padding-top: 100%;
-      }
-    }
-  }
-
   @include breakpoint(medium) {
 
     .panel {
 
       &.with-image {
         padding: 0 $line-height / 2 0 0;
-      }
-
-      .no-image {
-        height: 100%;
-        min-height: rem-calc(245);
-        width: rem-calc(140);
       }
     }
 

--- a/app/helpers/followables_helper.rb
+++ b/app/helpers/followables_helper.rb
@@ -13,7 +13,7 @@ module FollowablesHelper
 
   def render_follow(follow)
     followable = follow.followable
-    partial = followable_class_name(followable)
+    partial = followable_class_name(followable) + "_follow"
     locals = {followable_class_name(followable).to_sym => followable}
 
     render partial, locals

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -64,12 +64,4 @@ module UsersHelper
     end
   end
 
-  def empty_interests_message_text(user)
-    if current_user == user
-      t('account.show.public_interests_my_empty_list')
-    else
-      t('account.show.public_interests_user_empty_list')
-    end
-  end
-
 end

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -21,9 +21,11 @@
       <%= f.text_field :external_url %>
     </div>
 
-    <div class="images small-12 column">
-      <%= render 'images/nested_image', imageable: @investment, f: f %>
-    </div>
+    <% if feature?(:allow_images) %>
+      <div class="images small-12 column">
+        <%= render 'images/nested_image', imageable: @investment, f: f %>
+      </div>
+    <% end %>
 
     <div class="documents small-12 column">
       <%= render 'documents/nested_documents', documentable: @investment, f: f %>

--- a/app/views/budgets/investments/_investment.html.erb
+++ b/app/views/budgets/investments/_investment.html.erb
@@ -1,18 +1,20 @@
 <div id="<%= dom_id(investment) %>" class="budget-investment clear">
-  <div class="panel with-image">
+  <div class="panel <%= ('with-image' if feature?(:allow_images) && investment.image.present?) %>">
+
+    <% if feature?(:allow_images) && investment.image.present? %>
     <div class="row" data-equalizer>
 
       <div class="small-12 medium-3 large-2 column text-center">
         <div data-equalizer-watch>
-          <% if investment.image.present? %>
-            <%= image_tag investment.image_url(:thumb), alt: investment.image.title %>
-          <% else %>
-            <div class="no-image"></div>
-          <% end %>
+          <%= image_tag investment.image_url(:thumb), alt: investment.image.title %>
         </div>
       </div>
 
       <div class="small-12 medium-6 large-7 column">
+    <% else %>
+      <div class="row">
+        <div class="small-12 medium-9 column">
+    <% end %>
         <div class="budget-investment-content">
 
           <% cache [locale_and_user_status(investment), 'index', investment, investment.author] do %>
@@ -55,7 +57,8 @@
 
         <% if investment.should_show_votes? %>
           <div id="<%= dom_id(investment) %>_votes"
-               class="small-12 medium-3 column text-center" data-equalizer-watch>
+               class="small-12 medium-3 column text-center"
+               <%= 'data-equalizer-watch' if feature?(:allow_images) && investment.image.present? %>>
                <%= render partial: '/budgets/investments/votes', locals: {
                  investment: investment,
                  investment_votes: investment_votes,
@@ -64,7 +67,8 @@
           </div>
         <% elsif investment.should_show_vote_count? %>
           <div id="<%= dom_id(investment) %>_votes"
-               class="small-12 medium-3 column text-center" data-equalizer-watch>
+               class="small-12 medium-3 column text-center"
+               <%= 'data-equalizer-watch' if feature?(:allow_images) && investment.image.present? %>>
             <div class="supports js-participation">
               <span class="total-supports no-button">
                 <%= t("budgets.investments.investment.supports",
@@ -74,7 +78,8 @@
           </div>
         <% elsif investment.should_show_ballots? %>
           <div id="<%= dom_id(investment) %>_ballot"
-                class="small-12 medium-3 column text-center" data-equalizer-watch>
+                class="small-12 medium-3 column text-center"
+                <%= 'data-equalizer-watch' if feature?(:allow_images) && investment.image.present? %>>
                 <%= render partial: '/budgets/investments/ballot', locals: {
                   investment: investment,
                   investment_ids: investment_ids,
@@ -83,13 +88,14 @@
           </div>
         <% elsif investment.should_show_price? %>
           <div id="<%= dom_id(investment) %>_price"
-               class="supports small-12 medium-3 column text-center" data-equalizer-watch>
+               class="supports small-12 medium-3 column text-center"
+               <%= 'data-equalizer-watch' if feature?(:allow_images) && investment.image.present? %>>
             <p class="investment-project-amount margin-top">
               <%= investment.formatted_price %>
             </p>
           </div>
         <% else %>
-          <div data-equalizer-watch></div>
+          <div <%= 'data-equalizer-watch' if feature?(:allow_images) && investment.image.present? %>></div>
         <% end %>
 
       <% end %>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -46,7 +46,9 @@
       <%= safe_html_with_links investment.description.html_safe %>
 
       <% if feature?(:map) && map_location_available?(@investment.map_location) %>
-        <%= render_map(@investment.map_location, "budget_investment", false, nil) %>
+        <div class="margin">
+          <%= render_map(@investment.map_location, "budget_investment", false, nil) %>
+        </div>
       <% end %>
 
       <% if investment.external_url.present? %>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -131,6 +131,9 @@
       } %>
 
       <% if current_user %>
+        <div class="sidebar-divider"></div>
+        <p class="sidebar-title"><%= t("shared.follow") %></p>
+
         <%= render 'follows/follow_button', follow: find_or_build_follow(current_user, investment) %>
       <% end %>
 

--- a/app/views/follows/_follow_button.html.erb
+++ b/app/views/follows/_follow_button.html.erb
@@ -1,24 +1,19 @@
-<span class="js-follow">
+<div class="js-follow">
   <span class="followable-content">
-
     <% if follow.followable.followed_by?(current_user) %>
-
-      <%= link_to t('shared.unfollow'),
+      <%= link_to t('shared.following'),
                   follow_path(follow),
                   method: :delete, remote: true,
                   title: unfollow_text(follow.followable),
-                  class: 'button hollow' %>
+                  class: 'button expanded' %>
 
     <% else %>
-
-      <%= link_to t('shared.follow'),
+      <%= link_to follow_text(follow.followable),
                   follows_path(followable_id: follow.followable.id,
                                followable_type: follow.followable.class.name),
                   method: :post, remote: true,
                   title: follow_text(follow.followable),
-                  class: 'button hollow' %>
-
+                  class: 'button hollow expanded' %>
     <% end %>
-
   </span>
-</span>
+</div>

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -10,8 +10,6 @@
         <div class="image-container" data-equalizer-watch>
           <% if poll.image.present? %>
             <%= image_tag poll.image_url(:large), alt: poll.image.title %>
-          <% else %>
-            <div class="no-image"></div>
           <% end %>
         </div>
       </div>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -46,9 +46,11 @@
       <%= f.text_field :external_url, placeholder: t("proposals.form.proposal_external_url"), label: false %>
     </div>
 
-    <div class="images small-12 column">
-      <%= render 'images/nested_image', imageable: @proposal, f: f %>
-    </div>
+    <% if feature?(:allow_images) %>
+      <div class="images small-12 column">
+        <%= render 'images/nested_image', imageable: @proposal, f: f %>
+      </div>
+    <% end %>
 
     <div class="documents small-12 column">
       <%= render 'documents/nested_documents', documentable: @proposal, f: f %>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -1,21 +1,23 @@
 <div id="<%= dom_id(proposal) %>"
      class="proposal clear <%= ("successful" if proposal.total_votes > Proposal.votes_needed_for_success) %>"
      data-type="proposal">
-  <div class="panel with-image">
+  <div class="panel <%= ('with-image' if feature?(:allow_images) && proposal.image.present?) %>">
     <div class="icon-successful"></div>
-    <div class="row" data-equalizer>
 
-      <div class="small-12 medium-3 large-2 column text-center">
-        <div data-equalizer-watch>
-          <% if proposal.image.present? %>
+    <% if feature?(:allow_images) && proposal.image.present? %>
+      <div class="row" data-equalizer>
+
+        <div class="small-12 medium-3 large-2 column text-center">
+          <div data-equalizer-watch>
             <%= image_tag proposal.image_url(:thumb), alt: proposal.image.title %>
-          <% else %>
-            <div class="no-image"></div>
-          <% end %>
+          </div>
         </div>
-      </div>
 
-      <div class="small-12 medium-6 large-7 column">
+        <div class="small-12 medium-6 large-7 column">
+    <% else %>
+      <div class="row">
+        <div class="small-12 medium-9 column">
+      <% end %>
         <div class="proposal-content">
           <% cache [locale_and_user_status(proposal), 'index', proposal, proposal.author] do %>
             <h3><%= link_to proposal.title, namespaced_proposal_path(proposal) %></h3>
@@ -60,7 +62,9 @@
         </div>
       </div>
 
-      <div id="<%= dom_id(proposal) %>_votes" class="small-12 medium-3 column supports-container" data-equalizer-watch>
+      <div id="<%= dom_id(proposal) %>_votes"
+           class="small-12 medium-3 column supports-container"
+           <%= 'data-equalizer-watch' if feature?(:allow_images) && proposal.image.present? %>>
         <% if proposal.successful? %>
           <div class="padding text-center">
 

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -69,7 +69,9 @@
         <%= safe_html_with_links @proposal.description %>
 
         <% if feature?(:map) && map_location_available?(@proposal.map_location) %>
-          <%= render_map(@proposal.map_location, "proposal", false, nil) %>
+          <div class="margin">
+            <%= render_map(@proposal.map_location, "proposal", false, nil) %>
+          </div>
         <% end %>
 
         <% if @proposal.external_url.present? %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -182,6 +182,9 @@
         } %>
 
         <% if current_user %>
+          <div class="sidebar-divider"></div>
+          <p class="sidebar-title"><%= t("shared.follow") %></p>
+
           <%= render 'follows/follow_button', follow: find_or_build_follow(current_user, @proposal)  %>
         <% end %>
 

--- a/app/views/users/_budget_investment_follow.html.erb
+++ b/app/views/users/_budget_investment_follow.html.erb
@@ -1,0 +1,3 @@
+<li id="budget_investment_<%= budget_investment.id %>">
+  <%= link_to budget_investment.title, budget_investment_path(budget_investment.budget, budget_investment) %>
+</li>

--- a/app/views/users/_following.html.erb
+++ b/app/views/users/_following.html.erb
@@ -1,30 +1,27 @@
-<ul class="accordion" data-accordion data-allow-all-closed="true">
+<div class="row following margin-top" data-equalizer data-equalize-on="medium" >
+  <div class="small-12 medium-8 column" data-equalizer-watch>
+    <ul class="menu simple clear">
+      <% @follows.each do |followable_type, follows| %>
+        <li><%= link_to followable_type_title(followable_type), "##{followable_type_title(followable_type).parameterize.underscore}" %></li>
+      <% end %>
+    </ul>
 
-  <% @follows.each do |followable_type, follows| %>
+    <% @follows.each do |followable_type, follows| %>
 
-    <li class="accordion-item" data-accordion-item>
+      <h3 id="<%= followable_type_title(followable_type).parameterize.underscore %>">
+        <span class="icon-<%= followable_icon(followable_type) %>"></span>
+        <%= followable_type_title(followable_type) %>
+      </h3>
 
-      <a href="#" class="accordion-title">
-        <span class="icon">
-          <i class="icon icon-<%= followable_icon(followable_type) %>"></i>
-        </span>
-        <span class="title">
-          <strong><%= followable_type_title(followable_type) %></strong>
-        </span>
-      </a>
+      <ul class="follow-list">
+        <% follows.each do |follow| %>
+          <%= render_follow(follow) %>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
 
-      <div class="accordion-content" data-tab-content>
-        <table>
-          <tbody>
-            <% follows.each do |follow| %>
-              <%= render_follow(follow) %>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-
-    </li>
-
-  <% end %>
-
-</ul>
+  <div class="small-12 medium-4 column interests" data-equalizer-watch>
+    <%= render 'interests', user: @user if valid_interests_access? %>
+  </div>
+</div>

--- a/app/views/users/_interests.html.erb
+++ b/app/views/users/_interests.html.erb
@@ -2,18 +2,10 @@
   <h4><%= interests_title_text(user) %></h4>
 
   <% if user.interests.any? %>
-
     <ul class="no-bullet tags">
       <% user.interests.each do |interest| %>
         <li class="inline-block"><span><%= interest %></span></li>
       <% end %>
     </ul>
-
-  <% else %>
-
-    <div class="callout primary">
-      <%= empty_interests_message_text(user) %>
-    </div>
-
   <% end %>
 </div>

--- a/app/views/users/_proposal_follow.html.erb
+++ b/app/views/users/_proposal_follow.html.erb
@@ -1,0 +1,6 @@
+<li id="proposal_<%= proposal.id %>">
+  <%= link_to proposal.title, proposal, proposal.retired? ? { class: 'retired' } : {} %>
+  <% if proposal.retired? %>
+    <span class="label alert"><%= t('users.proposals.retired') %></span>
+  <% end %>
+</li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -48,8 +48,6 @@
         </div>
       <% end %>
 
-      <%= render 'interests', user: @user if valid_interests_access? %>
-
     </div>
   </div>
 </main>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -38,8 +38,13 @@
               <% end %>
             <% end %>
           <% end %>
-          <%= t("users.show.no_activity") if @activity_counts.values.inject(&:+) == 0 %>
         </ul>
+
+        <% if @activity_counts.values.inject(&:+) == 0 %>
+          <div class="callout primary">
+            <%= t("users.show.no_activity") %>
+          </div>
+        <% end %>
 
         <%= render "activity_page" %>
       <% else %>
@@ -47,7 +52,6 @@
           <%= t('users.show.private_activity') %>
         </div>
       <% end %>
-
     </div>
   </div>
 </main>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -15,8 +15,6 @@ en:
       public_interests_label: Keep my interests public
       public_interests_my_title_list: Tags of elements you follow
       public_interests_user_title_list: Tags of elements this user follows
-      public_interests_my_empty_list: You do not follow any elements yet.
-      public_interests_user_empty_list: This user does not follow any elements yet.
       save_changes_submit: Save changes
       subscription_to_website_newsletter_label: Receive by email website relevant information
       email_on_direct_message_label: Receive emails about direct messages

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -13,8 +13,8 @@ en:
       phone_number_label: Phone number
       public_activity_label: Keep my list of activities public
       public_interests_label: Keep my interests public
-      public_interests_my_title_list: List of interests (tags of elements you follow)
-      public_interests_user_title_list: List of interests (tags of elements this user follows)
+      public_interests_my_title_list: Tags of elements you follow
+      public_interests_user_title_list: Tags of elements this user follows
       public_interests_my_empty_list: You do not follow any elements yet.
       public_interests_user_empty_list: This user does not follow any elements yet.
       save_changes_submit: Save changes

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -569,6 +569,7 @@ en:
     collective: Collective
     flag: Flag as inappropriate
     follow: "Follow"
+    following: "Following"
     follow_entity: "Follow %{entity}"
     followable:
       budget_investment:

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -614,7 +614,6 @@ en:
     target_blank_html: " (link opens in new window)"
     you_are_in: "You are in"
     unflag: Unflag
-    unfollow: "Unfollow"
     unfollow_entity: "Unfollow %{entity}"
     outline:
       budget: Participatory budget

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -43,6 +43,7 @@ en:
         recommendations: Recommendeds
       community: Community on proposals and investments
       map: Proposals and budget investments geolocation
+      allow_images: Allow upload and show images
     map_latitude: Latitude
     map_longitude: Longitude
     map_zoom: Zoom

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -566,6 +566,7 @@ es:
     collective: Colectivo
     flag: Denunciar como inapropiado
     follow: "Seguir"
+    following: "Siguiendo"
     follow_entity: "Seguir %{entity}"
     followable:
       budget_investment:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -611,7 +611,6 @@ es:
     target_blank_html: " (se abre en ventana nueva)"
     you_are_in: "Estás en"
     unflag: Deshacer denuncia
-    unfollow: "Dejar de seguir"
     unfollow_entity: "Dejar de seguir %{entity}"
     outline:
       budget: Presupuestos participativos

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -15,8 +15,6 @@ es:
       public_interests_label: Mostrar públicamente mis intereses
       public_interests_my_title_list: Etiquetas de los elementos que sigues
       public_interests_user_title_list: Etiquetas de los elementos que sigue este usuario
-      public_interests_my_empty_list: Aún no sigues ningún elemento.
-      public_interests_user_empty_list: Este usuario no sigue ningún elemento todavía.
       save_changes_submit: Guardar cambios
       subscription_to_website_newsletter_label: Recibir emails con información interesante sobre la web
       email_on_direct_message_label: Recibir emails con mensajes privados

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -13,8 +13,8 @@ es:
       phone_number_label: Teléfono
       public_activity_label: Mostrar públicamente mi lista de actividades
       public_interests_label: Mostrar públicamente mis intereses
-      public_interests_my_title_list: Lista de intereses (etiquetas de los elementos que sigues)
-      public_interests_user_title_list: Lista de intereses (etiquetas de los elementos seguidos este usuario)
+      public_interests_my_title_list: Etiquetas de los elementos que sigues
+      public_interests_user_title_list: Etiquetas de los elementos que sigue este usuario
       public_interests_my_empty_list: Aún no sigues ningún elemento.
       public_interests_user_empty_list: Este usuario no sigue ningún elemento todavía.
       save_changes_submit: Guardar cambios

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -43,6 +43,7 @@ es:
         recommendations: Recomendaciones
       community: Comunidad en propuestas y proyectos de inversión
       map: Geolocalización de propuestas y proyectos de inversión
+      allow_images: Permitir subir y mostrar imágenes
     map_latitude: Latitud
     map_longitude: Longitud
     map_zoom: Zoom

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -50,6 +50,7 @@ section "Creating Settings" do
   Setting.create(key: 'feature.user.recommendations', value: "true")
   Setting.create(key: 'feature.community', value: "true")
   Setting.create(key: 'feature.map', value: "true")
+  Setting.create(key: 'feature.allow_images', value: "true")
   Setting.create(key: 'feature.public_stats', value: "true")
   Setting.create(key: 'per_page_code_head', value: "")
   Setting.create(key: 'per_page_code_body', value: "")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,6 +83,7 @@ Setting['feature.legislation'] = true
 Setting['feature.user.recommendations'] = true
 Setting['feature.community'] = true
 Setting['feature.map'] = nil
+Setting['feature.allow_images'] = true
 
 # Spending proposals feature flags
 Setting['feature.spending_proposal_features.voting_allowed'] = nil

--- a/spec/controllers/installation_controller_spec.rb
+++ b/spec/controllers/installation_controller_spec.rb
@@ -18,7 +18,8 @@ describe InstallationController, type: :request do
         'user.recommendations' => nil,
         'community' => nil,
         'map' => 't',
-        'spending_proposal_features.voting_allowed' => 't'
+        'spending_proposal_features.voting_allowed' => 't',
+        'allow_images' => 't'
       }
     end
 
@@ -41,6 +42,7 @@ describe InstallationController, type: :request do
       Setting['feature.community'] = true
       Setting['feature.map'] = nil
       Setting['feature.spending_proposal_features.voting_allowed'] = nil
+      Setting['feature.allow_images'] = true
     end
 
     specify "with query string inside query params" do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -9,6 +9,14 @@ feature 'Budget Investments' do
   let(:group) { create(:budget_group, name: "Health", budget: budget) }
   let!(:heading) { create(:budget_heading, name: "More hospitals", group: group) }
 
+  before do
+    Setting['feature.allow_images'] = true
+  end
+
+  after do
+    Setting['feature.allow_images'] = nil
+  end
+
   scenario 'Index' do
     investments = [create(:budget_investment, heading: heading),
                    create(:budget_investment, heading: heading),
@@ -37,7 +45,7 @@ feature 'Budget Investments' do
     visit budget_investments_path(budget, heading_id: heading.id)
 
     within("#budget_investment_#{investment.id}") do
-      expect(page).to have_css("div.no-image")
+      expect(page).to_not have_css("div.with-image")
     end
     within("#budget_investment_#{investment_with_image.id}") do
       expect(page).to have_css("img[alt='#{investment_with_image.image.title}']")

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -4,6 +4,15 @@ require 'rails_helper'
 feature 'Proposals' do
 
   context 'Index' do
+
+    before do
+      Setting['feature.allow_images'] = true
+    end
+
+    after do
+      Setting['feature.allow_images'] = nil
+    end
+
     scenario 'Lists featured and regular proposals' do
       featured_proposals = create_featured_proposals
       proposals = [create(:proposal), create(:proposal), create(:proposal)]
@@ -55,7 +64,7 @@ feature 'Proposals' do
       visit proposals_path(proposal)
 
       within("#proposal_#{proposal.id}") do
-        expect(page).to have_css("div.no-image")
+        expect(page).to_not have_css("div.with-image")
       end
       within("#proposal_#{proposal_with_image.id}") do
         expect(page).to have_css("img[alt='#{proposal_with_image.image.title}']")

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -259,6 +259,9 @@ feature 'Users' do
     end
 
     scenario 'User can display public page' do
+      proposal = create(:proposal, tag_list: "Sport")
+      create(:follow, :followed_proposal, followable: proposal, user: @user)
+
       login_as(@user)
       visit account_path
 
@@ -267,22 +270,29 @@ feature 'Users' do
 
       logout
 
-      visit user_path(@user)
+      visit user_path(@user, filter: 'follows', page: '1')
+
       expect(page).to have_css('#public_interests')
     end
 
     scenario 'Is always visible for the owner' do
+      proposal = create(:proposal, tag_list: "Sport")
+      create(:follow, :followed_proposal, followable: proposal, user: @user)
+
       login_as(@user)
       visit account_path
 
       uncheck 'account_public_interests'
       click_button 'Save changes'
 
-      visit user_path(@user)
+      visit user_path(@user, filter: 'follows', page: '1')
       expect(page).to have_css('#public_interests')
     end
 
     scenario 'Is always visible for admins' do
+      proposal = create(:proposal, tag_list: "Sport")
+      create(:follow, :followed_proposal, followable: proposal, user: @user)
+
       login_as(@user)
       visit account_path
 
@@ -292,11 +302,14 @@ feature 'Users' do
       logout
 
       login_as(create(:administrator).user)
-      visit user_path(@user)
+      visit user_path(@user, filter: 'follows', page: '1')
       expect(page).to have_css('#public_interests')
     end
 
     scenario 'Is always visible for moderators' do
+      proposal = create(:proposal, tag_list: "Sport")
+      create(:follow, :followed_proposal, followable: proposal, user: @user)
+
       login_as(@user)
       visit account_path
 
@@ -306,38 +319,29 @@ feature 'Users' do
       logout
 
       login_as(create(:moderator).user)
-      visit user_path(@user)
+      visit user_path(@user, filter: 'follows', page: '1')
       expect(page).to have_css('#public_interests')
     end
 
     scenario 'Should display generic interests title' do
+      proposal = create(:proposal, tag_list: "Sport")
+      create(:follow, :followed_proposal, followable: proposal, user: @user)
+
       @user.update(public_interests: true)
-      visit user_path(@user)
+      visit user_path(@user, filter: 'follows', page: '1')
 
       expect(page).to have_content("Tags of elements this user follows")
     end
 
     scenario 'Should display custom interests title when user is visiting own user page' do
+      proposal = create(:proposal, tag_list: "Sport")
+      create(:follow, :followed_proposal, followable: proposal, user: @user)
+
       @user.update(public_interests: true)
       login_as(@user)
-      visit user_path(@user)
+      visit user_path(@user, filter: 'follows', page: '1')
 
       expect(page).to have_content("Tags of elements you follow")
-    end
-
-    scenario 'Should display generic empty interests list message when visited user has not interests defined' do
-      @user.update(public_interests: true)
-      visit user_path(@user)
-
-      expect(page).to have_content("This user does not follow any elements yet.")
-    end
-
-    scenario 'Should display custom empty interests list message when user has not interests defined and user is visiting own user page' do
-      @user.update(public_interests: true)
-      login_as(@user)
-      visit user_path(@user)
-
-      expect(page).to have_content("You do not follow any elements yet.")
     end
   end
 
@@ -418,22 +422,22 @@ feature 'Users' do
         expect(page).to have_content('1 Following')
       end
 
-      scenario 'Display accordion proposal tab when user is following one proposal at least' do
+      scenario 'Display proposal tab when user is following one proposal at least' do
         proposal = create(:proposal)
         create(:follow, followable: proposal, user: @user)
 
         visit user_path(@user, filter: "follows")
 
-        expect(page).to have_link('Citizen proposals', href: "#")
+        expect(page).to have_link('Citizen proposals', href: "#citizen_proposals")
       end
 
-      scenario 'Not display accordion proposal tab when user is not following any proposal' do
+      scenario 'Not display proposal tab when user is not following any proposal' do
         visit user_path(@user, filter: "follows")
 
-        expect(page).not_to have_link('Citizen proposals', href: "#")
+        expect(page).not_to have_link('Citizen proposals', href: "#citizen_proposals")
       end
 
-      scenario 'Display proposal with action buttons inside accordion proposal tab when current user is proposal author', :js do
+      scenario 'Display proposals with link to proposal' do
         proposal = create(:proposal, author: @user)
         create(:follow, followable: proposal, user: @user)
         login_as @user
@@ -442,35 +446,7 @@ feature 'Users' do
         click_link 'Citizen proposals'
 
         expect(page).to have_content proposal.title
-        expect(page).to have_link "Send notification"
-        expect(page).to have_link "Retire"
       end
-
-      scenario 'Display proposal with action buttons inside accordion proposal tab when there is no logged user', :js do
-        proposal = create(:proposal, author: @user)
-        create(:follow, followable: proposal, user: @user)
-
-        visit user_path(@user, filter: "follows")
-        click_link 'Citizen proposals'
-
-        expect(page).to have_content proposal.title
-        expect(page).not_to have_link "Send notification"
-        expect(page).not_to have_link "Retire"
-      end
-
-      scenario 'Display proposal without action buttons inside accordion proposal tab when current user is not proposal author', :js do
-        proposal = create(:proposal)
-        create(:follow, followable: proposal, user: @user)
-        login_as @user
-
-        visit user_path(@user, filter: "follows")
-        click_link 'Citizen proposals'
-
-        expect(page).to have_content proposal.title
-        expect(page).not_to have_link "Send notification"
-        expect(page).not_to have_link "Retire"
-      end
-
     end
 
     describe 'Budget Investments' do
@@ -484,35 +460,22 @@ feature 'Users' do
         expect(page).to have_content('1 Following')
       end
 
-      scenario 'Display accordion budget investment tab when user is following one budget investment at least' do
+      scenario 'Display budget investment tab when user is following one budget investment at least' do
         budget_investment = create(:budget_investment)
         create(:follow, followable: budget_investment, user: @user)
 
-        visit user_path(@user, filter: "follow")
+        visit user_path(@user, filter: "follows")
 
-        expect(page).to have_link('Investments', href: "#")
+        expect(page).to have_link('Investments', href: "#investments")
       end
 
-      scenario 'Not display accordion budget investment tab when user is not following any budget investment' do
-        visit user_path(@user, filter: "follow")
+      scenario 'Not display budget investment tab when user is not following any budget investment' do
+        visit user_path(@user, filter: "follows")
 
-        expect(page).not_to have_link('Investments', href: "#")
+        expect(page).not_to have_link('Investments', href: "#investments")
       end
 
-      scenario 'Display budget investment with action buttons inside accordion budget investment tab when current user is a verified user and author', :js do
-        user = create(:user, :level_two)
-        budget_investment = create(:budget_investment, author: user)
-        create(:follow, followable: budget_investment, user: user)
-        login_as user
-
-        visit user_path(user, filter: "follows")
-        click_link 'Investments'
-
-        expect(page).to have_link budget_investment.title
-        expect(page).to have_link "Delete"
-      end
-
-      scenario 'Display budget investment with action buttons inside accordion budget investment tab when there is no logged user', :js do
+      scenario 'Display budget investment with link to budget investment' do
         user = create(:user, :level_two)
         budget_investment = create(:budget_investment, author: user)
         create(:follow, followable: budget_investment, user: user)
@@ -521,22 +484,7 @@ feature 'Users' do
         click_link 'Investments'
 
         expect(page).to have_link budget_investment.title
-        expect(page).not_to have_link "Delete"
       end
-
-      scenario 'Display budget investment without action buttons inside accordion budget investment tab when current user is not budget investment author', :js do
-        user = create(:user, :level_two)
-        budget_investment = create(:budget_investment)
-        create(:follow, followable: budget_investment, user: user)
-        login_as user
-
-        visit user_path(user, filter: "follows")
-        click_link 'Investments'
-
-        expect(page).to have_link budget_investment.title
-        expect(page).not_to have_link "Delete"
-      end
-
     end
 
   end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -314,7 +314,7 @@ feature 'Users' do
       @user.update(public_interests: true)
       visit user_path(@user)
 
-      expect(page).to have_content("List of interests (tags of elements this user follows)")
+      expect(page).to have_content("Tags of elements this user follows")
     end
 
     scenario 'Should display custom interests title when user is visiting own user page' do
@@ -322,7 +322,7 @@ feature 'Users' do
       login_as(@user)
       visit user_path(@user)
 
-      expect(page).to have_content("List of interests (tags of elements you follow)")
+      expect(page).to have_content("Tags of elements you follow")
     end
 
     scenario 'Should display generic empty interests list message when visited user has not interests defined' do

--- a/spec/shared/features/followable.rb
+++ b/spec/shared/features/followable.rb
@@ -48,8 +48,8 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       within "##{dom_id(followable)}" do
         click_link("Follow #{followable.model_name.human.downcase}")
 
-        expect(page).not_to have_link "Follow"
-        expect(page).to have_link "Unfollow"
+        expect(page).not_to have_link("Follow")
+        expect(page).to have_link("Following")
       end
     end
 
@@ -72,7 +72,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
 
-      expect(page).to have_link("Unfollow")
+      expect(page).to have_link("Following")
     end
 
     scenario "Should update follow button and show destroy notice after user clicks on unfollow button", :js do
@@ -84,7 +84,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       within "##{dom_id(followable)}" do
         click_link("Unfollow #{followable.model_name.human.downcase}")
 
-        expect(page).not_to have_link "Unfollow"
+        expect(page).not_to have_link("Unfollow")
         expect(page).to have_link("Follow #{followable.model_name.human.downcase}")
       end
     end

--- a/spec/shared/features/followable.rb
+++ b/spec/shared/features/followable.rb
@@ -28,7 +28,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       visit send(followable_path, arguments)
 
       within "##{dom_id(followable)}" do
-        expect(page).to have_link("Follow")
+        expect(page).to have_link("Follow #{followable.model_name.human.downcase}")
       end
     end
 
@@ -37,8 +37,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       login_as(user)
 
       visit send(followable_path, arguments)
-
-      expect(page).to have_link("Follow")
+      expect(page).to have_link("Follow #{followable.model_name.human.downcase}")
     end
 
     scenario "Should display unfollow after user clicks on follow button", :js do
@@ -47,7 +46,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
       within "##{dom_id(followable)}" do
-        click_link "Follow"
+        click_link("Follow #{followable.model_name.human.downcase}")
 
         expect(page).not_to have_link "Follow"
         expect(page).to have_link "Unfollow"
@@ -60,7 +59,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
       within "##{dom_id(followable)}" do
-        click_link "Follow"
+        click_link("Follow #{followable.model_name.human.downcase}")
       end
 
       expect(page).to have_content strip_tags(t("shared.followable.#{followable_class_name}.create.notice_html"))
@@ -83,10 +82,10 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
       within "##{dom_id(followable)}" do
-        click_link "Unfollow"
+        click_link("Unfollow #{followable.model_name.human.downcase}")
 
         expect(page).not_to have_link "Unfollow"
-        expect(page).to have_link "Follow"
+        expect(page).to have_link("Follow #{followable.model_name.human.downcase}")
       end
     end
 
@@ -97,7 +96,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
       visit send(followable_path, arguments)
       within "##{dom_id(followable)}" do
-        click_link "Unfollow"
+        click_link("Unfollow #{followable.model_name.human.downcase}")
       end
 
       expect(page).to have_content strip_tags(t("shared.followable.#{followable_class_name}.destroy.notice_html"))

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -9,11 +9,18 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
   let!(:imageable)           { create(imageable_factory_name) }
 
   before do
+
+    Setting['feature.allow_images'] = true
+
     imageable_path_arguments&.each do |argument_name, path_to_value|
         arguments.merge!("#{argument_name}": imageable.send(path_to_value))
     end
 
     imageable.update(author: user) if imageable.respond_to?(:author)
+  end
+
+  after do
+    Setting['feature.allow_images'] = nil
   end
 
   describe "at #{path}" do


### PR DESCRIPTION
What
====
- Some minor improvements of design.

How
===
- Adds margin to maps on proposal and budget investment show views.
- Changes title text for public interests list.
- Adds setting `Setting['feature.allow_images']` to allow images for proposals and budget investment projects.
- Improves layout for proposals and budget investment with images on index view.
- Improves styles and texts for `Follow` button.
- Improves following page on my activity, shows public interest (tags) only in this view.
- Removes some unused i18n keys.

Screenshots
===========
## Margin on maps
![margin_map](https://user-images.githubusercontent.com/631897/33825095-c93d1aca-de60-11e7-8075-25df247252f4.png)

## Index with images
![proposals_images](https://user-images.githubusercontent.com/631897/33825197-2eac0b14-de61-11e7-9de4-5f80d2ff0118.png)

## Follow button
![follow_button](https://user-images.githubusercontent.com/631897/33825207-38db3196-de61-11e7-8dbc-41f86148aa85.png)

## Mi activity/follow (before)
![follow_before](https://user-images.githubusercontent.com/631897/33825229-4da0b0ec-de61-11e7-82d1-d13740fcd49b.png)

## Mi activity/follow (after)
![follow_after](https://user-images.githubusercontent.com/631897/33825242-56549730-de61-11e7-8aba-d276c57d2a48.png)

Test
====
Increased

Warnings
========
- The `Setting['feature.allow_images']` allow upload and show images for both (proposals and budget investment projects).
