### PR TITLE
Notifications for hidden resources

### DIFF
--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,13 +1,23 @@
-<li id="<%= dom_id(notification) %>" class="notification">
-  <%= link_to notification do %>
-    <p>
-      <em>
-        <%= t("notifications.index.#{notification.notifiable_action}",
-              count: notification.counter) %>
-      </em>
-      <strong><%= notification.notifiable_title %></strong>
-    </p>
+<% if notification.notifiable.present? %>
+  <li id="<%= dom_id(notification) %>" class="notification">
+    <%= link_to notification do %>
+      <p>
+        <em>
+          <%= t("notifications.index.#{notification.notifiable_action}",
+                count: notification.counter) %>
+        </em>
+        <strong><%= notification.notifiable_title %></strong>
+      </p>
 
-    <p class="time"><%= l notification.timestamp, format: :datetime %></p>
-  <% end %>
-</li>
+      <p class="time"><%= l notification.timestamp, format: :datetime %></p>
+    <% end %>
+  </li>
+<% else %>
+  <li id="<%= dom_id(notification) %>" class="notification">
+    <p>
+      <strong>
+        <%= t("notifications.index.notifiable_hidden") %>
+      </strong>
+    </p>
+  </li>
+<% end %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,5 +1,5 @@
-<% if notification.notifiable.present? %>
-  <li id="<%= dom_id(notification) %>" class="notification">
+<li id="<%= dom_id(notification) %>" class="notification">
+  <% if notification.notifiable.present? %>
     <%= link_to notification do %>
       <p>
         <em>
@@ -11,13 +11,11 @@
 
       <p class="time"><%= l notification.timestamp, format: :datetime %></p>
     <% end %>
-  </li>
-<% else %>
-  <li id="<%= dom_id(notification) %>" class="notification">
+  <% else %>
     <p>
       <strong>
         <%= t("notifications.index.notifiable_hidden") %>
       </strong>
     </p>
-  </li>
-<% end %>
+  <% end %>
+</li>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -264,6 +264,7 @@ en:
         one: Someone commented on
         other: There are %{count} new comments on
       empty_notifications: You don't have new notifications.
+      notifiable_hidden: This resource is not available anymore.
       mark_all_as_read: Mark all as read
       proposal_notification:
         one: There is one new notification on

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -264,6 +264,7 @@ es:
         one: Hay un nuevo comentario en
         other: Hay %{count} comentarios nuevos en
       empty_notifications: No tienes notificaciones nuevas.
+      notifiable_hidden: Este elemento ya no está disponible.
       mark_all_as_read: Marcar todas como leídas
       proposal_notification:
         one: Hay una nueva notificación en

--- a/spec/controllers/installation_controller_spec.rb
+++ b/spec/controllers/installation_controller_spec.rb
@@ -8,6 +8,7 @@ describe InstallationController, type: :request do
         'debates' => nil,
         'spending_proposals' => 't',
         'polls' => nil,
+        'proposals' => 't',
         'twitter_login' => nil,
         'facebook_login' => nil,
         'google_login' => nil,

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -298,7 +298,6 @@ feature "Notifications" do
     end
 
     pending "group notifications for the same proposal"
-
   end
 
   context "mark as read" do
@@ -332,6 +331,19 @@ feature "Notifications" do
       expect(current_path).to eq(notifications_path)
     end
 
+  end
+
+  scenario "Notifiable hidden", :js do
+    create(:notification, notifiable: debate, user: author)
+    debate.hide
+
+    login_as author
+    visit root_path
+    find(".icon-notification").click
+
+    expect(page).to have_css ".notification", count: 1
+    expect(page).to have_content "This resource is not available anymore"
+    expect(page).to_not have_xpath "//a[@href='#{notification_path(Notification.last)}']"
   end
 
   scenario "no notifications" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -48,33 +48,51 @@ describe Notification do
   end
 
   describe "#notification_action" do
+    it "returns correct text when someone comments on your commentable" do
+      debate = create(:debate)
+      notification = create(:notification, notifiable: debate)
 
-    context "when action was comment on a debate" do
-      it "returns correct text when someone comments on your debate" do
-        debate = create(:debate)
-        notification = create :notification, notifiable: debate
-
-        expect(notification.notifiable_action).to eq "comments_on"
-      end
+      expect(notification.notifiable_action).to eq "comments_on"
     end
 
-    context "when action was comment on a debate" do
-      it "returns correct text when someone replies to your comment" do
-        debate = create(:debate)
-        debate_comment = create :comment, commentable: debate
-        notification = create :notification, notifiable: debate_comment
+    it "returns correct text when someone replies to your comment" do
+      debate = create(:debate)
+      debate_comment = create(:comment, commentable: debate)
+      notification = create(:notification, notifiable: debate_comment)
 
-        expect(notification.notifiable_action).to eq "replies_to"
-      end
+      expect(notification.notifiable_action).to eq "replies_to"
     end
 
-    context "when action was proposal notification" do
-      it "returns correct text when the author created a proposal notification" do
-        proposal_notification = create(:proposal_notification)
-        notification = create :notification, notifiable: proposal_notification
+    it "returns correct text when the author created a proposal notification" do
+      proposal_notification = create(:proposal_notification)
+      notification = create(:notification, notifiable: proposal_notification)
 
-        expect(notification.notifiable_action).to eq "proposal_notification"
-      end
+      expect(notification.notifiable_action).to eq "proposal_notification"
+    end
+  end
+
+  describe "#notification_title" do
+    it "returns the commentable title when it's a root comment" do
+      debate = create(:debate, title: "Save the whales")
+      notification = create(:notification, notifiable: debate)
+
+      expect(notification.notifiable_title).to eq "Save the whales"
+    end
+
+    it "returns the commentable title when it's a reply to a root comment" do
+      debate = create(:debate, title: "Save the whales")
+      debate_comment = create(:comment, commentable: debate)
+      notification = create(:notification, notifiable: debate_comment)
+
+      expect(notification.notifiable_title).to eq "Save the whales"
+    end
+
+    it "returns the commentable title when it's an author's proposals notification" do
+      proposal = create(:proposal, title: "Save the whales")
+      proposal_notification = create(:proposal_notification, proposal: proposal)
+      notification = create(:notification, notifiable: proposal_notification)
+
+      expect(notification.notifiable_title).to eq "Save the whales"
     end
   end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2166

What
====
- Displays an appropriate message when a notification belongs to a resource that has been hidden

How
===
- Checking for the presence of the related resource in the view and displaying this message it if has been hidden. 

Screenshots
===========
![notifications](https://user-images.githubusercontent.com/4169/33830793-e614b79c-de75-11e7-8b5f-31a270780f01.png)

Deployment
==========
- As usual

Warnings
========
- None
