### PR TITLE
Adds timestamps to polls

### DIFF
--- a/db/migrate/20171212193323_add_timestamps_to_polls.rb
+++ b/db/migrate/20171212193323_add_timestamps_to_polls.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToPolls < ActiveRecord::Migration
+  def change
+    add_timestamps :polls, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171127230716) do
+ActiveRecord::Schema.define(version: 20171212193323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -798,6 +798,8 @@ ActiveRecord::Schema.define(version: 20171127230716) do
     t.datetime "hidden_at"
     t.boolean  "results_enabled",    default: false
     t.boolean  "stats_enabled",      default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "polls", ["starts_at", "ends_at"], name: "index_polls_on_starts_at_and_ends_at", using: :btree

--- a/lib/tasks/polls.rake
+++ b/lib/tasks/polls.rake
@@ -1,0 +1,6 @@
+namespace :polls do
+	desc "Adds created_at and updated_at values to existing polls"
+	task initialize_timestamps: :environment do
+		Poll.update_all(created_at: Time.current, updated_at: Time.current)
+	end
+end


### PR DESCRIPTION
What
====
- Adds timestamps to polls

Why
===
- Generally a good practice to have them in every table

Test
====
- Not needed

Deployment
==========
- As usual

Warnings
========
- Existing Polls will still not have a created_at value. 
  A manual update or a rake task would be needed for this.

Update
===
Added rake task for the happiness of forks

Release Notes
===
Run `rake polls:initialize_timestamps ` to initialize attributes `created_at` and `updated_at` with the current time for all existing polls