### PR TITLE
Updates factory traits

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -709,7 +709,7 @@ FactoryGirl.define do
     start_date Date.current - 5.days
     end_date Date.current + 5.days
     debate_start_date Date.current - 5.days
-    debate_end_date Date.current - 2.days
+    debate_end_date Date.current + 2.days
     draft_publication_date Date.current - 1.day
     allegations_start_date Date.current
     allegations_end_date Date.current + 3.days

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -50,6 +50,7 @@ FactoryGirl.define do
     end
 
     trait :verified do
+      residence_verified_at Time.current
       verified_at Time.current
     end
 


### PR DESCRIPTION
What
====
- Add `residence_verified_at` to the `verified` trait
- Makes a legislation process's debate phase open by default 

Why
===
- In most places we can just use the `verified_at` attribute to know if a user is verified.
  [Other places](https://github.com/consul/consul/blob/master/app/helpers/comments_helper.rb#L80) rely on the residece_verified_at attribute to be set.
- Having all legislation phases open by default makes testing easier

Test
====
- Not needed

Deployment
==========
- As usual

Warnings
========
- None
