### PR TITLE
Adds model validations for legislation proposals

### DIFF
--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -27,6 +27,7 @@ class Legislation::Proposal < ActiveRecord::Base
   validates :title, presence: true
   validates :summary, presence: true
   validates :author, presence: true
+  validates :process, presence: true
 
   validates :title, length: { in: 4..Legislation::Proposal.title_max_length }
   validates :description, length: { maximum: Legislation::Proposal.description_max_length }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -816,6 +816,14 @@ LOREM_IPSUM
     user
   end
 
+  factory :legislation_proposal, class: 'Legislation::Proposal' do
+    title "Example proposal for a legislation"
+    summary "This law should include..."
+    terms_of_service '1'
+    process factory: :legislation_process
+    author factory: :user
+  end
+
   factory :site_customization_page, class: 'SiteCustomization::Page' do
     slug "example-page"
     title "Example page"

--- a/spec/models/legislation/proposal_spec.rb
+++ b/spec/models/legislation/proposal_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe Legislation::Proposal do
+  let(:proposal) { build(:legislation_proposal) }
+
+  it "should be valid" do
+    expect(proposal).to be_valid
+  end
+
+  it "should not be valid without a process" do
+    proposal.process = nil
+    expect(proposal).to_not be_valid
+  end
+
+  it "should not be valid without an author" do
+    proposal.author = nil
+    expect(proposal).to_not be_valid
+  end
+
+  it "should not be valid without a title" do
+    proposal.title = nil
+    expect(proposal).to_not be_valid
+  end
+
+  it "should not be valid without a summary" do
+    proposal.summary = nil
+    expect(proposal).to_not be_valid
+  end
+
+end


### PR DESCRIPTION
What
====
- Adds validation model specs for legislation proposals

Why
===
- Always good to add some tests
- Needed for an upcoming PR which requires having the spec file present

Deployment
==========
- As usual

Warnings
========
- None
