### PR TITLE
Add Images to Milestones

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -315,7 +315,8 @@
 .poll-question-form,
 .legislation-process-new,
 .legislation-process-edit,
-.milestone-new {
+.milestone-new,
+.milestone-edit {
   @include direct-uploads;
 }
 

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -314,7 +314,8 @@
 .polls-form,
 .poll-question-form,
 .legislation-process-new,
-.legislation-process-edit {
+.legislation-process-edit,
+.milestone-new {
   @include direct-uploads;
 }
 

--- a/app/controllers/admin/budget_investment_milestones_controller.rb
+++ b/app/controllers/admin/budget_investment_milestones_controller.rb
@@ -40,7 +40,8 @@ class Admin::BudgetInvestmentMilestonesController < Admin::BaseController
 
   def milestone_params
     params.require(:budget_investment_milestone)
-          .permit(:title, :description, :budget_investment_id)
+          .permit(:title, :description, :budget_investment_id,
+                  image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy])
   end
 
   def load_budget_investment

--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -1,6 +1,8 @@
 class Budget
   class Investment
     class Milestone < ActiveRecord::Base
+      include Imageable
+
       belongs_to :investment
 
       validates :title, presence: true

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -2,6 +2,7 @@
 
   <%= f.text_field :title, maxlength: Budget::Investment::Milestone.title_max_length %>
   <%= f.text_area :description, rows: 5 %>
+  <%= render 'images/admin_image', imageable: @milestone, f: f %>
 
   <%= f.submit nil, class: "button success" %>
 <% end %>

--- a/app/views/admin/budget_investment_milestones/edit.html.erb
+++ b/app/views/admin/budget_investment_milestones/edit.html.erb
@@ -2,4 +2,6 @@
 
 <h2><%= t("admin.milestones.edit.title") %></h2>
 
-<%= render '/admin/budget_investment_milestones/form' %>
+<div class="milestone-edit">
+  <%= render '/admin/budget_investment_milestones/form' %>
+</div>

--- a/app/views/admin/budget_investments/_milestones.html.erb
+++ b/app/views/admin/budget_investments/_milestones.html.erb
@@ -5,6 +5,7 @@
         <th><%= t("admin.milestones.index.table_id") %></th>
         <th><%= t("admin.milestones.index.table_title") %></th>
         <th><%= t("admin.milestones.index.table_description") %></th>
+        <th><%= t("admin.milestones.index.image") %></th>
         <th><%= t("admin.milestones.index.table_actions") %></th>
       </tr>
     </thead>
@@ -19,6 +20,9 @@
           </td>
           <td class="small">
             <%= milestone.description %>
+          </td>
+          <td class="small">
+            <%= link_to 'Ver imagen', milestone.image_url(:large), target: :_blank if milestone.image.present? %>
           </td>
           <td>
             <%= link_to t("admin.milestones.index.delete"), admin_budget_budget_investment_budget_investment_milestone_path(@investment.budget, @investment, milestone),

--- a/app/views/admin/budget_investments/_milestones.html.erb
+++ b/app/views/admin/budget_investments/_milestones.html.erb
@@ -22,7 +22,7 @@
             <%= milestone.description %>
           </td>
           <td class="small">
-            <%= link_to 'Ver imagen', milestone.image_url(:large), target: :_blank if milestone.image.present? %>
+            <%= link_to t("admin.milestones.index.show_image"), milestone.image_url(:large), target: :_blank if milestone.image.present? %>
           </td>
           <td>
             <%= link_to t("admin.milestones.index.delete"), admin_budget_budget_investment_budget_investment_milestone_path(@investment.budget, @investment, milestone),

--- a/app/views/budgets/investments/_milestones.html.erb
+++ b/app/views/budgets/investments/_milestones.html.erb
@@ -16,6 +16,7 @@
                   <strong><%= t("budgets.investments.show.milestone_publish_date", publish_date: l(milestone.created_at.to_date)) %></strong>
                 </span>
                 <p><%= milestone.description %></p>
+                <%= image_tag milestone.image_url(:large) if milestone.image.present? %>
               </div>
             </li>
           <% end %>

--- a/app/views/budgets/investments/_milestones.html.erb
+++ b/app/views/budgets/investments/_milestones.html.erb
@@ -15,8 +15,8 @@
                 <span class="milestone-date">
                   <strong><%= t("budgets.investments.show.milestone_publish_date", publish_date: l(milestone.created_at.to_date)) %></strong>
                 </span>
+                <%= image_tag(milestone.image_url(:large), {alt: milestone.image.title, class: "margin", id: "image_#{milestone.id}"}) if milestone.image.present? %>
                 <p><%= milestone.description %></p>
-                <%= image_tag milestone.image_url(:large) if milestone.image.present? %>
               </div>
             </li>
           <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -196,6 +196,7 @@ en:
         table_actions: "Actions"
         delete: "Delete milestone"
         no_milestones: "Don't have defined milestones"
+        image: "Image"
         show_image: "Show image"
       new:
         creating: Create milestone

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -196,6 +196,7 @@ en:
         table_actions: "Actions"
         delete: "Delete milestone"
         no_milestones: "Don't have defined milestones"
+        show_image: "Show image"
       new:
         creating: Create milestone
       edit:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -196,6 +196,7 @@ es:
         table_actions: "Acciones"
         delete: "Eliminar hito"
         no_milestones: "No hay hitos definidos"
+        show_image: "Ver imagen"
       new:
         creating: Crear hito
       edit:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -196,6 +196,7 @@ es:
         table_actions: "Acciones"
         delete: "Eliminar hito"
         no_milestones: "No hay hitos definidos"
+        image: "Imagen"
         show_image: "Ver imagen"
       new:
         creating: Crear hito

--- a/spec/features/admin/budget_investment_milestones_spec.rb
+++ b/spec/features/admin/budget_investment_milestones_spec.rb
@@ -62,10 +62,13 @@ feature 'Admin budget investment milestones' do
   context "Edit" do
     scenario "Change title and description" do
       milestone = create(:budget_investment_milestone, investment: @investment)
+      create(:image, imageable: milestone)
 
       visit admin_budget_budget_investment_path(@investment.budget, @investment)
 
       click_link milestone.title
+
+      expect(page).to have_css("img[alt='#{milestone.image.title}']")
 
       fill_in 'budget_investment_milestone_title', with: 'Changed title'
       fill_in 'budget_investment_milestone_description', with: 'Changed description'
@@ -74,6 +77,7 @@ feature 'Admin budget investment milestones' do
 
       expect(page).to have_content 'Changed title'
       expect(page).to have_content 'Changed description'
+      expect(page).to have_link 'Show image'
     end
   end
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -495,6 +495,7 @@ feature 'Budget Investments' do
     investment = create(:budget_investment)
     milestone = create(:budget_investment_milestone, investment: investment, title: "New text to show",
                                                      created_at: DateTime.new(2015, 9, 19).utc)
+    image = create(:image, imageable: milestone)
 
     login_as(user)
     visit budget_investment_path(budget_id: investment.budget.id, id: investment.id)
@@ -505,6 +506,7 @@ feature 'Budget Investments' do
       expect(page).to have_content(milestone.title)
       expect(page).to have_content(milestone.description)
       expect(page).to have_content("Published 2015-09-19")
+      expect(page.find("#image_#{milestone.id}")['alt']).to have_content image.title
     end
   end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2173

What
====
Add images to milestones, so that admins can add them when creating milestones and users can see them when viewing milestones.

How
===
- Make the Budget::Investment::Milestone imageable.
- Add an image uploader field to the milestones form.
- Add a column to milestones list with a link to the image, if it exists. If it doesn't, the table column is empty.
- The milestones' images are shown in the public investment view.

Screenshots
===========
![milestones01](https://user-images.githubusercontent.com/31625251/33945245-c80f9348-e01e-11e7-808d-7673e36e37d8.png)

![milestones02](https://user-images.githubusercontent.com/31625251/33945253-cc56653a-e01e-11e7-8e31-92bba96999fd.png)

![milestones03](https://user-images.githubusercontent.com/31625251/33945259-cf41d234-e01e-11e7-91d3-8a715dbd5a01.png)

Test
====
- Feature specs to test the admin form.
- Feature specs to test if the images are shown for the user.

Deployment
==========
Nothing.

Warnings
========
Nothing.
