### PR TITLE
Add documents to milestones

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -334,7 +334,8 @@
 .draft-panels,
 .debate-questions,
 .communities-show,
-.topic-show {
+.topic-show,
+.milestone-content {
 
   p {
     word-wrap: break-word;

--- a/app/controllers/admin/budget_investment_milestones_controller.rb
+++ b/app/controllers/admin/budget_investment_milestones_controller.rb
@@ -41,7 +41,8 @@ class Admin::BudgetInvestmentMilestonesController < Admin::BaseController
   def milestone_params
     params.require(:budget_investment_milestone)
           .permit(:title, :description, :budget_investment_id,
-                  image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy])
+                  image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
+                  documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy])
   end
 
   def load_budget_investment

--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -2,6 +2,10 @@ class Budget
   class Investment
     class Milestone < ActiveRecord::Base
       include Imageable
+      include Documentable
+      documentable max_documents_allowed: 3,
+                   max_file_size: 3.megabytes,
+                   accepted_content_types: [ "application/pdf" ]
 
       belongs_to :investment
 

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -4,5 +4,10 @@
   <%= f.text_area :description, rows: 5 %>
   <%= render 'images/admin_image', imageable: @milestone, f: f %>
 
+  <hr>
+  <div class="documents">
+    <%= render 'documents/nested_documents', documentable: @milestone, f: f %>
+  </div>
+
   <%= f.submit nil, class: "button success" %>
 <% end %>

--- a/app/views/admin/budget_investments/_milestones.html.erb
+++ b/app/views/admin/budget_investments/_milestones.html.erb
@@ -6,6 +6,7 @@
         <th><%= t("admin.milestones.index.table_title") %></th>
         <th><%= t("admin.milestones.index.table_description") %></th>
         <th><%= t("admin.milestones.index.image") %></th>
+        <th><%= t("admin.milestones.index.documents") %></th>
         <th><%= t("admin.milestones.index.table_actions") %></th>
       </tr>
     </thead>
@@ -23,6 +24,16 @@
           </td>
           <td class="small">
             <%= link_to t("admin.milestones.index.show_image"), milestone.image_url(:large), target: :_blank if milestone.image.present? %>
+          </td>
+          <td class="small">
+            <% if milestone.documents.present? %>
+              <% milestone.documents.each do |document| %>
+                <%= link_to document.title,
+                              document.attachment.url,
+                              target: "_blank",
+                              rel: "nofollow" %><br>
+              <% end %>
+            <% end %>
           </td>
           <td>
             <%= link_to t("admin.milestones.index.delete"), admin_budget_budget_investment_budget_investment_milestone_path(@investment.budget, @investment, milestone),

--- a/app/views/budgets/investments/_milestones.html.erb
+++ b/app/views/budgets/investments/_milestones.html.erb
@@ -17,6 +17,20 @@
                 </span>
                 <%= image_tag(milestone.image_url(:large), {alt: milestone.image.title, class: "margin", id: "image_#{milestone.id}"}) if milestone.image.present? %>
                 <p><%= milestone.description %></p>
+                <% if milestone.documents.present? %>
+                  <div class="document-link text-center">
+                    <p>
+                      <span class="icon-document"></span>&nbsp;
+                      <strong><%= t('proposals.show.title_external_url') %></strong>
+                    </p>
+                    <% milestone.documents.each do |document| %>
+                      <%= link_to document.title,
+                              document.attachment.url,
+                              target: "_blank",
+                              rel: "nofollow" %><br>
+                    <% end %>
+                  </div>
+                <% end %>
               </div>
             </li>
           <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -198,6 +198,7 @@ en:
         no_milestones: "Don't have defined milestones"
         image: "Image"
         show_image: "Show image"
+        documents: "Documents"
       new:
         creating: Create milestone
       edit:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -198,6 +198,7 @@ es:
         no_milestones: "No hay hitos definidos"
         image: "Imagen"
         show_image: "Ver imagen"
+        documents: "Documentos"
       new:
         creating: Crear hito
       edit:

--- a/spec/features/admin/budget_investment_milestones_spec.rb
+++ b/spec/features/admin/budget_investment_milestones_spec.rb
@@ -12,12 +12,16 @@ feature 'Admin budget investment milestones' do
   context "Index" do
     scenario 'Displaying milestones' do
       milestone = create(:budget_investment_milestone, investment: @investment)
+      create(:image, imageable: milestone)
+      document = create(:document, documentable: milestone)
 
       visit admin_budget_budget_investment_path(@investment.budget, @investment)
 
       expect(page).to have_content("Milestone")
       expect(page).to have_content(milestone.title)
       expect(page).to have_content(milestone.id)
+      expect(page).to have_link 'Show image'
+      expect(page).to have_link document.title
     end
 
     scenario 'Displaying no_milestones text' do
@@ -60,11 +64,13 @@ feature 'Admin budget investment milestones' do
   end
 
   context "Edit" do
-    scenario "Change title and description" do
+    scenario "Change title, description and document names" do
       milestone = create(:budget_investment_milestone, investment: @investment)
       create(:image, imageable: milestone)
+      document = create(:document, documentable: milestone)
 
       visit admin_budget_budget_investment_path(@investment.budget, @investment)
+      expect(page).to have_link document.title
 
       click_link milestone.title
 
@@ -72,12 +78,14 @@ feature 'Admin budget investment milestones' do
 
       fill_in 'budget_investment_milestone_title', with: 'Changed title'
       fill_in 'budget_investment_milestone_description', with: 'Changed description'
+      fill_in 'budget_investment_milestone_documents_attributes_0_title', with: 'New document title'
 
       click_button 'Update milestone'
 
       expect(page).to have_content 'Changed title'
       expect(page).to have_content 'Changed description'
       expect(page).to have_link 'Show image'
+      expect(page).to have_link 'New document title'
     end
   end
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -496,6 +496,7 @@ feature 'Budget Investments' do
     milestone = create(:budget_investment_milestone, investment: investment, title: "New text to show",
                                                      created_at: DateTime.new(2015, 9, 19).utc)
     image = create(:image, imageable: milestone)
+    document = create(:document, documentable: milestone)
 
     login_as(user)
     visit budget_investment_path(budget_id: investment.budget.id, id: investment.id)
@@ -507,6 +508,7 @@ feature 'Budget Investments' do
       expect(page).to have_content(milestone.description)
       expect(page).to have_content("Published 2015-09-19")
       expect(page.find("#image_#{milestone.id}")['alt']).to have_content image.title
+      expect(page).to have_link document.title
     end
   end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2174

What
====
Add documents to milestones, so that admins can add them when creating milestones and users can see them when viewing milestones.

How
===
- Make the Budget::Investment::Milestone documentable.
- Add a document uploader field to the milestones form that lets admins upload up to 3 docs, pdf format.
- Add a column to milestones list with a link to each document, if there are. If there aren't, the table column is empty.
- The milestones' documents are accessible in the public investment view.

Screenshots
===========
### Milestone with image and document

![milestones01](https://user-images.githubusercontent.com/31625251/33998594-4ef4e592-e0e8-11e7-927e-0df512ceb6b1.png)

### Milestone only with a document

![milestones02](https://user-images.githubusercontent.com/31625251/33998612-5b98b2e2-e0e8-11e7-9bc6-4622dadefc84.png)

### Admin views

![milestones03](https://user-images.githubusercontent.com/31625251/33998623-6483e21e-e0e8-11e7-878b-e862563dd376.png)
![milestones04](https://user-images.githubusercontent.com/31625251/33998629-67b7655a-e0e8-11e7-8ce6-0f4d32029473.png)

Test
====
- Feature specs to test the admin forms.
- Feature specs to test if the documents are accessible for the user.

Deployment
==========
Nothing.

Warnings
========
The documents bug of this issue #2171 also happens.
