### PR TITLE
Make Milestones description required, hide title usage

### DIFF
--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -10,12 +10,14 @@ class Budget
       belongs_to :investment
 
       validates :title, presence: true
+      validates :description, presence: true
       validates :investment, presence: true
       validates :publication_date, presence: true
 
       def self.title_max_length
         80
       end
+
     end
   end
 end

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for [:admin, @investment.budget, @investment, @milestone] do |f| %>
 
-  <%= f.text_field :title, maxlength: Budget::Investment::Milestone.title_max_length %>
+  <%= f.hidden_field :title, value: l(Time.current, format: :datetime), maxlength: Budget::Investment::Milestone.title_max_length %>
   <%= f.text_area :description, rows: 5 %>
   <%= f.text_field :publication_date,
                    value: @milestone.publication_date.present? ? l(@milestone.publication_date.to_date) : nil,

--- a/app/views/budgets/investments/_milestones.html.erb
+++ b/app/views/budgets/investments/_milestones.html.erb
@@ -11,7 +11,6 @@
           <% @investment.milestones.each do |milestone| %>
             <li>
               <div class="milestone-content">
-                <h3><%= milestone.title %></h3>
                 <% if milestone.publication_date.present? %>
                   <span class="milestone-date">
                     <strong><%= t("budgets.investments.show.milestone_publication_date",

--- a/spec/features/admin/budget_investment_milestones_spec.rb
+++ b/spec/features/admin/budget_investment_milestones_spec.rb
@@ -39,15 +39,13 @@ feature 'Admin budget investment milestones' do
 
       click_link 'Create new milestone'
 
-      fill_in 'budget_investment_milestone_title', with: 'New title milestone'
       fill_in 'budget_investment_milestone_description', with: 'New description milestone'
-      fill_in 'budget_investment_milestone_publication_date', with: Time.zone.today.to_date
+      fill_in 'budget_investment_milestone_publication_date', with: Time.zone.today
 
       click_button 'Create milestone'
 
-      expect(page).to have_content 'New title milestone'
       expect(page).to have_content 'New description milestone'
-      expect(page).to have_content Time.zone.today.to_date
+      expect(page).to have_content Time.zone.today
     end
 
     scenario "Show validation errors on milestone form" do
@@ -60,7 +58,7 @@ feature 'Admin budget investment milestones' do
       click_button 'Create milestone'
 
       within "#new_budget_investment_milestone" do
-        expect(page).to have_content "can't be blank", count: 2
+        expect(page).to have_content "can't be blank", count: 1
         expect(page).to have_content 'New description milestone'
       end
     end
@@ -79,14 +77,12 @@ feature 'Admin budget investment milestones' do
 
       expect(page).to have_css("img[alt='#{milestone.image.title}']")
 
-      fill_in 'budget_investment_milestone_title', with: 'Changed title'
       fill_in 'budget_investment_milestone_description', with: 'Changed description'
       fill_in 'budget_investment_milestone_publication_date', with: Time.zone.today.to_date
       fill_in 'budget_investment_milestone_documents_attributes_0_title', with: 'New document title'
 
       click_button 'Update milestone'
 
-      expect(page).to have_content 'Changed title'
       expect(page).to have_content 'Changed description'
       expect(page).to have_content Time.zone.today.to_date
       expect(page).to have_link 'Show image'

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -515,7 +515,6 @@ feature 'Budget Investments' do
     find("#tab-milestones-label").trigger('click')
 
     within("#tab-milestones") do
-      expect(page).to have_content(milestone.title)
       expect(page).to have_content(milestone.description)
       expect(page).to have_content(Time.zone.today.to_date)
       expect(page.find("#image_#{milestone.id}")['alt']).to have_content image.title

--- a/spec/models/budget/investment/milestone_spec.rb
+++ b/spec/models/budget/investment/milestone_spec.rb
@@ -14,6 +14,11 @@ describe "Budget::Investment::Milestone" do
       expect(milestone).to_not be_valid
     end
 
+    it "Should not be valid without a description" do
+      milestone.description = nil
+      expect(milestone).to_not be_valid
+    end
+
     it "Should not be valid without an investment" do
       milestone.investment_id = nil
       expect(milestone).to_not be_valid


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2189

What
====
Milestone's seem to need a description but not always a title.

How
===
- Making description attribute a required field
- Hiding the title input in the milestone form (but still giving it a valid value to be future-compatible with possible changes around this, and also allow forks to keep this feature in a different way with the less amount of changes)

Screenshots
===========

### Admin's Milestone form with title input hidden:
![screen shot 2017-12-15 at 16 42 55](https://user-images.githubusercontent.com/983242/34049268-12b0fea2-e1b7-11e7-9c78-2bf670c878f9.jpg)

### Admin's Milestone list with default value for titles
![screen shot 2017-12-15 at 16 43 17](https://user-images.githubusercontent.com/983242/34049269-12d82694-e1b7-11e7-8fff-86bb8005f779.jpg)

Test
====
Increased to cover description presence validation and fixed to cover title hiding

Deployment
==========
As usual, check warnings section

Warnings
========
The presence validation of milestone's description shouldn't affect existing milestones for showing but it will for editing (requiring a description to complete the form submission). A rake task to fill with an empty description text doesn't seem like a great option. I think it's on each fork situation to decide what's best: fill with default value, remove the presence validation, or if there are existing milestones that won't be edited ... just do nothing.

