### PR TITLE
Design

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -21,6 +21,7 @@
 // 19. Recommended Section Home
 // 20. Documents
 // 21. Related content
+// 22. Images
 //
 
 // 01. Global styles
@@ -2444,4 +2445,11 @@ table {
   .flag {
     margin-top: $line-height / 2;
   }
+}
+
+// 22. Images
+// -----------------
+
+.images .button {
+  margin-top: $line-height / 2;
 }

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -482,6 +482,10 @@
     .icon-video {
       color: #cc181e;
     }
+
+    p {
+      margin-bottom: 0;
+    }
   }
 
   .supports {

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -14,7 +14,7 @@
       <%= render "shared/errors", resource: @account %>
 
       <div class="row">
-        <div class="small-12 medium-6 column">
+        <div class="small-12 medium-7 column">
 
           <h2><%= t("account.show.personal")%></h2>
 
@@ -112,10 +112,10 @@
             </div>
           <% end %>
 
-          <%= f.submit t("account.show.save_changes_submit"), class: "button" %>
+          <%= f.submit t("account.show.save_changes_submit"), class: "button margin-top" %>
         </div>
 
-        <div class="user-permissions small-12 medium-6 column">
+        <div class="user-permissions small-12 medium-5 column">
           <h2><%= t("account.show.user_permission_title") %></h2>
 
           <p><%= t("account.show.user_permission_info") %></p>
@@ -143,7 +143,8 @@
 
           <p>
             <span><%= t("account.show.user_permission_verify_info") %></span>
-            <br>
+          </p>
+          <p>
             <%= t("account.show.user_permission_verify") %>
           </p>
 

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -2,13 +2,14 @@
 
   <%= f.hidden_field :title, value: l(Time.current, format: :datetime), maxlength: Budget::Investment::Milestone.title_max_length %>
   <%= f.text_area :description, rows: 5 %>
+  <%= f.label :publication_date, t("admin.milestones.new.date") %>
   <%= f.text_field :publication_date,
                    value: @milestone.publication_date.present? ? l(@milestone.publication_date.to_date) : nil,
+                   label: false,
                    class: "js-calendar-full" %>
 
   <%= render 'images/admin_image', imageable: @milestone, f: f %>
 
-  <hr>
   <div class="documents">
     <%= render 'documents/nested_documents', documentable: @milestone, f: f %>
   </div>

--- a/app/views/admin/budget_investments/_milestones.html.erb
+++ b/app/views/admin/budget_investments/_milestones.html.erb
@@ -14,17 +14,17 @@
     <tbody>
       <% @investment.milestones.each do |milestone| %>
         <tr id="<%= dom_id(milestone) %>" class="milestone">
-          <td><%= milestone.id %></td>
+          <td class="text-center"><%= milestone.id %></td>
           <td>
             <%= link_to milestone.title,
                         edit_admin_budget_budget_investment_budget_investment_milestone_path(@investment.budget,
                                                                                              @investment,
                                                                                              milestone) %>
           </td>
-          <td class="small"><%= milestone.description %></td>
-          <% if milestone.publication_date.present? %>
-            <td class="small"><%= l(milestone.publication_date.to_date) %></td>
-          <% end %>
+          <td class="small small-5"><%= milestone.description %></td>
+          <td class="small">
+            <%= l(milestone.publication_date.to_date) if milestone.publication_date.present? %>
+          </td>
           <td class="small">
             <%= link_to t("admin.milestones.index.show_image"),
                         milestone.image_url(:large),
@@ -40,7 +40,7 @@
               <% end %>
             <% end %>
           </td>
-          <td>
+          <td class="small-2">
             <%= link_to t("admin.milestones.index.delete"),
                         admin_budget_budget_investment_budget_investment_milestone_path(@investment.budget,
                                                                                         @investment,

--- a/app/views/admin/budget_investments/show.html.erb
+++ b/app/views/admin/budget_investments/show.html.erb
@@ -54,5 +54,7 @@
 <%= render 'admin/budget_investments/milestones' %>
 
 <p>
-  <%= link_to t("admin.budget_investments.show.new_milestone"), new_admin_budget_budget_investment_budget_investment_milestone_path(@budget, @investment) %>
+  <%= link_to t("admin.budget_investments.show.new_milestone"),
+              new_admin_budget_budget_investment_budget_investment_milestone_path(@budget, @investment),
+              class: "button hollow" %>
 </p>

--- a/app/views/admin/poll/polls/_form.html.erb
+++ b/app/views/admin/poll/polls/_form.html.erb
@@ -32,7 +32,9 @@
   </div>
 
   <div class="row">
-    <%= render 'images/admin_image', imageable: @poll, f: f %>
+    <div class="small-12 column">
+      <%= render 'images/admin_image', imageable: @poll, f: f %>
+    </div>
   </div>
 
   <div class="row">

--- a/app/views/budgets/investments/_milestones.html.erb
+++ b/app/views/budgets/investments/_milestones.html.erb
@@ -23,7 +23,7 @@
                   <div class="document-link text-center">
                     <p>
                       <span class="icon-document"></span>&nbsp;
-                      <strong><%= t('proposals.show.title_external_url') %></strong>
+                      <strong><%= t("shared.documentation") %></strong>
                     </p>
                     <% milestone.documents.each do |document| %>
                       <%= link_to document.title,

--- a/app/views/images/_admin_image.html.erb
+++ b/app/views/images/_admin_image.html.erb
@@ -1,7 +1,7 @@
-<div class="images small-12 column">
+<div class="images">
     <div>
       <%= f.label :image, t("images.form.admin_title") %>
-      
+
       <%= link_to_add_association t('images.form.add_new_image'), f, :image,
                             force_non_association_create: true,
                             partial: "images/image_fields",
@@ -14,12 +14,12 @@
                               association_insertion_node: "#nested-image",
                               association_insertion_method: "append"
                             } %>
-      
+
       <%= render_image(f.object.image, :thumb, false) if f.object.image %>
 
       <div id="nested-image">
         <%= f.fields_for :image do |image_builder| %>
-        
+
           <div id="<%= dom_id(image_builder.object) %>" class="image direct-upload nested-fields">
             <%= image_builder.hidden_field :id %>
             <%= image_builder.hidden_field :user_id, value: current_user.id %>
@@ -33,7 +33,7 @@
               </div>
             </div>
           </div>
-        
+
         <% end %>
       </div>
     </div>

--- a/app/views/images/_image_fields.html.erb
+++ b/app/views/images/_image_fields.html.erb
@@ -3,7 +3,7 @@
   <%= f.hidden_field :user_id, value: current_user.id %>
   <%= f.hidden_field :cached_attachment %>
 
-  <div class="small-12 column title">
+  <div class="small-12 margin-top title">
     <%= f.text_field :title, placeholder: t("images.form.title_placeholder") %>
   </div>
 

--- a/app/views/welcome/_recommended_carousel.html.erb
+++ b/app/views/welcome/_recommended_carousel.html.erb
@@ -1,7 +1,7 @@
 <div class="small-12 medium-4 large-4 <%= carousel_size %> column text-center <%= key %> ">
   <div class="card small-centered <%= key %>-inner">
 
-    <h4><%= t("welcome.recommended.#{key.underscore}.title") %></h4>
+    <h3><%= t("welcome.recommended.#{key.underscore}.title") %></h3>
 
     <div class="orbit" role="region" data-orbit data-use-m-u-i="false">
       <div class="orbit-wrapper">
@@ -14,9 +14,9 @@
                 <%= render_recommendation_image(recommended, image_default) %>
                 <div class="card-section">
                   <%= link_to recommended_path(recommended) do %>
-                    <h5 class="truncate-horizontal-text"><%= recommended.title %></h5>
+                    <h4 class="truncate-horizontal-text"><%= recommended.title %></h4>
                   <% end %>
-                  <p><%= recommended.description %></p>
+                  <%= recommended.description %>
                 </div>
               </div>
             </li>
@@ -27,13 +27,13 @@
 
       </div>
 
-      <nav class="orbit-bullets">
+      <div class="orbit-bullets">
         <% recommendeds.each_with_index do |recommended, index| %>
           <button data-slide="<%= index %>" class="<%= active_class(index) %>">
             <span class="show-for-sr">Second slide details.</span>
           </button>
         <% end %>
-      </nav>
+      </div>
 
     </div>
 

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -202,6 +202,7 @@ en:
         documents: "Documents"
       new:
         creating: Create milestone
+        date: Date
       edit:
         title: Edit milestone
       create:

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -12,7 +12,7 @@ en:
       personal: Personal details
       phone_number_label: Phone number
       public_activity_label: Keep my list of activities public
-      public_interests_label: Keep my interests public
+      public_interests_label: Keep the labels of the elements I follow public
       public_interests_my_title_list: Tags of elements you follow
       public_interests_user_title_list: Tags of elements this user follows
       save_changes_submit: Save changes

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -620,6 +620,7 @@ en:
     orbit:
       previous_slide: Previous Slide
       next_slide: Next Slide
+    documentation: Additional documentation
   social:
     blog: "%{org} Blog"
     facebook: "%{org} Facebook"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -282,7 +282,8 @@ en:
       sign_up: Sign up with Facebook
       name: Facebook
     finish_signup:
-      title: Add your email address
+      title: "Additional details"
+      username_warning: "Due to a change in the way we interact with social networks, it is possible that your username now appears as 'already in use'. If that is your case, please choose a different username."
     google_oauth2:
       sign_in: Sign in with Google
       sign_up: Sign up with Google
@@ -294,9 +295,6 @@ en:
     info_sign_in: "Sign in with:"
     info_sign_up: "Sign up with:"
     or_fill: "Or fill the following form:"
-    finish_signup:
-      title: "Additional details"
-      username_warning: "Due to a change in the way we interact with social networks, it is possible that your username now appears as 'already in use'. If that is your case, please choose a different username."
   proposals:
     create:
       form:

--- a/config/locales/en/images.yml
+++ b/config/locales/en/images.yml
@@ -9,7 +9,7 @@ en:
       note: "You can upload one image of following content types: %{accepted_content_types}, up to %{max_file_size} MB."
       add_new_image: Add image
       title_placeholder: Add a descriptive title for the image
-      admin_title: "Main image of the poll"
+      admin_title: "Image"
       admin_alt_text: "Alternative text for the image"
     actions:
       destroy:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -202,6 +202,7 @@ es:
         documents: "Documentos"
       new:
         creating: Crear hito
+        date: Fecha
       edit:
         title: Editar hito
       create:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -619,6 +619,7 @@ es:
     orbit:
       previous_slide: Imagen anterior
       next_slide: Siguiente imagen
+    documentation: Documentación adicional
   social:
     blog: "Blog de %{org}"
     facebook: "Facebook de %{org}"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -12,7 +12,7 @@ es:
       personal: Datos personales
       phone_number_label: Teléfono
       public_activity_label: Mostrar públicamente mi lista de actividades
-      public_interests_label: Mostrar públicamente mis intereses
+      public_interests_label: Mostrar públicamente las etiquetas de los elementos que sigo
       public_interests_my_title_list: Etiquetas de los elementos que sigues
       public_interests_user_title_list: Etiquetas de los elementos que sigue este usuario
       save_changes_submit: Guardar cambios

--- a/config/locales/es/images.yml
+++ b/config/locales/es/images.yml
@@ -8,7 +8,7 @@ es:
       delete_button: Eliminar imagen
       note: 'Puedes subir una imagen en los formatos: %{accepted_content_types}, y de hasta %{max_file_size} MB por archivo.'
       add_new_image: Añadir imagen
-      admin_title: "Imagen principal de la votación"
+      admin_title: "Imagen"
       admin_alt_text: "Texto alternativo para la imagen"
     actions:
       destroy:


### PR DESCRIPTION
What
====
Minor design/front UI improvements:

- Removes duplicated i18n key `finish_signup.title` (en)
- Changes public interest label and improves account show layout: changes "Keep my interests public" to "Keep the labels of the elements I follow public".
- Changes image admin title label and improves image fields layout: changes "Main image of the poll" to "Image"
- Changes milestones date label: changes "Publication date" to "Date".
- Fixes milestone table and improve button: the table was show broken if there wasn't documents
- Improves admin image partial: removes some margin/paddings.
- Adds documentation text shared i18n key: Now for "Additional Documentation" you can use `t("shared.documentation")`
- Improves document-link styles: removes margin between title and link.
- Improves html markup for recommended carousel partial: fixes headings structure and removes unnecessary `<p>` tag for descriptions.