### PR TITLE
New scopes for proposal recommendations

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -28,8 +28,8 @@ class Proposal < ActiveRecord::Base
 
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
   belongs_to :geozone
-  has_many :comments, as: :commentable
-  has_many :proposal_notifications
+  has_many :comments, as: :commentable, dependent: :destroy
+  has_many :proposal_notifications, dependent: :destroy
 
   validates :title, presence: true
   validates :question, presence: true
@@ -41,7 +41,7 @@ class Proposal < ActiveRecord::Base
   validates :description, length: { maximum: Proposal.description_max_length }
   validates :question, length: { in: 10..Proposal.question_max_length }
   validates :responsible_name, length: { in: 6..Proposal.responsible_name_max_length }
-  validates :retired_reason, inclusion: {in: RETIRE_OPTIONS, allow_nil: true}
+  validates :retired_reason, inclusion: { in: RETIRE_OPTIONS, allow_nil: true }
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
 
@@ -51,8 +51,8 @@ class Proposal < ActiveRecord::Base
 
   before_save :calculate_hot_score, :calculate_confidence_score
 
-  scope :for_render, -> { includes(:tags) }
-  scope :sort_by_hot_score, -> { reorder(hot_score: :desc) }
+  scope :for_render,               -> { includes(:tags) }
+  scope :sort_by_hot_score,        -> { reorder(hot_score: :desc) }
   scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc) }
   scope :sort_by_created_at,       -> { reorder(created_at: :desc) }
   scope :sort_by_most_commented,   -> { reorder(comments_count: :desc) }
@@ -69,12 +69,15 @@ class Proposal < ActiveRecord::Base
   scope :successful,               -> { where("cached_votes_up >= ?", Proposal.votes_needed_for_success) }
   scope :unsuccessful,             -> { where("cached_votes_up < ?", Proposal.votes_needed_for_success) }
   scope :public_for_api,           -> { all }
+  scope :not_supported_by_user,    ->(user) { where.not(id: user.find_voted_items(votable_type: "Proposal").compact.map(&:id)) }
 
   def self.recommendations(user)
     tagged_with(user.interests, any: true)
       .where("author_id != ?", user.id)
       .unsuccessful
       .not_followed_by_user(user)
+      .not_archived
+      .not_supported_by_user(user)
   end
 
   def self.not_followed_by_user(user)

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -952,6 +952,29 @@ describe Proposal do
       expect(result).to eq [proposal2]
     end
 
+    it "should not return archived proposals" do
+      proposal1 = create(:proposal, cached_votes_up: 5, tag_list: "Sport")
+      proposal2 = create(:proposal, cached_votes_up: 5, tag_list: "Sport")
+      archived_proposal = create(:proposal, :archived)
+      create(:follow, followable: proposal1, user: user)
+
+      result = Proposal.recommendations(user)
+      expect(result.size).to eq(1)
+      expect(result).to eq([proposal2])
+    end
+
+    it "should not return already supported proposals" do
+      proposal1 = create(:proposal, cached_votes_up: 5, tag_list: "Health")
+      proposal2 = create(:proposal, cached_votes_up: 5, tag_list: "Health")
+      proposal3 = create(:proposal, cached_votes_up: 5, tag_list: "Health")
+      create(:vote, votable: proposal1, voter: user)
+      create(:follow, followable: proposal2, user: user)
+
+      result = Proposal.recommendations(user)
+      expect(result.size).to eq(1)
+      expect(result).to eq([proposal3])
+    end
+
   end
 
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2168 

What
====
* Proposal recommendations for users on `WelcomeController#index` won't include archived or already supported records

How
===
* Usage of chained scopes (A new scope called `not_supported_by_user` was defined)
* Fixed rubocop warnings

Test
====
* Increased coverage to make sure proposals recommendations won't return `archived` or `already supported` records. Also, manual testing was done in order to make sure ActiveRecord was generating the expected SQL query
