### PR TITLE
Add spec for 'rake db:dev_seed' task

### DIFF
--- a/spec/lib/tasks/dev_seed_spec.rb
+++ b/spec/lib/tasks/dev_seed_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'rake db:dev_seed' do
+  before do
+    Rake.application.rake_require('tasks/db')
+    Rake::Task.define_task(:environment)
+  end
+
+  let :run_rake_task do
+    Rake::Task['db:dev_seed'].reenable
+    Rake.application.invoke_task('db:dev_seed')
+  end
+
+  it 'seeds the database without errors' do
+    expect { run_rake_task }.to_not raise_error
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2194

What
====
* Adds a spec for `rake db:dev_seed` to make sure the DB is properly seeded (useful when a table attribute is removed/deprecated)

How
===
* Wrote a rake task spec under `spec/lib/tasks`

Test
====
* Increased coverage for the aforementioned spec
