### PR TITLE
Use 'image_url' properties to improve SEO for proposals & investments

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -1,3 +1,12 @@
+<% provide :social_media_meta_tags do %>
+<%= render "shared/social_media_meta_tags",
+            social_url: budget_investments_path(investment),
+            social_title: investment.title,
+            social_description: investment.description,
+            twitter_image_url: (investment.image.present? ? investment.image_url(:thumb) : nil),
+            og_image_url: (investment.image.present? ? investment.image_url(:thumb) : nil) %>
+<% end %>
+
 <section class="budget-investment-show" id="<%= dom_id(investment) %>">
 
   <div class="row">

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -4,7 +4,9 @@
 <%= render "shared/social_media_meta_tags",
             social_url: proposal_url(@proposal),
             social_title: @proposal.title,
-            social_description: @proposal.summary %>
+            social_description: @proposal.summary,
+            twitter_image_url: (@proposal.image.present? ? @proposal.image_url(:thumb) : nil),
+            og_image_url: (@proposal.image.present? ? @proposal.image_url(:thumb) : nil) %>
 <% end %>
 <% content_for :canonical do %>
   <%= render "shared/canonical", href: proposal_url(@proposal) %>


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2197

This PR closes #2197 once merged

What
====
* Add `twitter_image_url` and `og_image_url` properties on Proposal and Budget::Investment `show` views to improve SEO

How
===
* Added `twitter_image_url` and `og_image_url` properties when an image for the associated record is present. Otherwise, use the default image
