### PR TITLE
Skip map on dev seeds

### DIFF
--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -227,6 +227,7 @@ section "Creating Proposals" do
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(','),
                                 geozone: Geozone.all.sample,
+                                skip_map: "1",
                                 terms_of_service: "1")
   end
 end
@@ -245,6 +246,7 @@ section "Creating Archived Proposals" do
                                 description: description,
                                 tag_list: tags.sample(3).join(','),
                                 geozone: Geozone.all.sample,
+                                skip_map: "1",
                                 terms_of_service: "1",
                                 created_at: Setting["months_to_archive_proposals"].to_i.months.ago)
   end
@@ -265,6 +267,7 @@ section "Creating Successful Proposals" do
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(','),
                                 geozone: Geozone.all.sample,
+                                skip_map: "1",
                                 terms_of_service: "1",
                                 cached_votes_up: Setting["votes_for_proposal_success"])
   end
@@ -283,6 +286,7 @@ section "Creating Successful Proposals" do
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(','),
                                 geozone: Geozone.all.sample,
+                                skip_map: "1",
                                 terms_of_service: "1")
   end
 end
@@ -441,6 +445,7 @@ section "Creating Investments" do
       valuation_finished: [false, true].sample,
       tag_list: tags.sample(3).join(','),
       price: rand(1..100) * 100000,
+      skip_map: "1",
       terms_of_service: "1"
     )
   end
@@ -469,6 +474,7 @@ section "Winner Investments" do
       valuation_finished: true,
       selected: true,
       price: rand(10000..heading.price),
+      skip_map: "1",
       terms_of_service: "1"
     )
   end


### PR DESCRIPTION
What
====
Now some elements have a map. This field it's mandatory (marker on map or select checkbox if the map is not necessary).

How
===
- Adds `skip_map: "1"` to `dev_seeds.rb` to prevent `rake db:dev_seed` error 🎉 

Notes
===

This is a temporary change to avoid the error. It would be nice some elements include a map on seeds (see issue https://github.com/consul/consul/issues/2209)

