### PR TITLE
Fix map location update

### DIFF
--- a/app/models/map_location.rb
+++ b/app/models/map_location.rb
@@ -1,7 +1,7 @@
 class MapLocation < ActiveRecord::Base
 
-  belongs_to :proposal
-  belongs_to :investment, class_name: Budget::Investment
+  belongs_to :proposal, touch: true
+  belongs_to :investment, class_name: Budget::Investment, touch: true
 
   def available?
     latitude.present? && longitude.present? && zoom.present?

--- a/spec/shared/models/map_validations.rb
+++ b/spec/shared/models/map_validations.rb
@@ -2,7 +2,7 @@ shared_examples "map validations" do
 
 	let(:mappable) { build(model_name(described_class)) }
 
-	describe "map" do
+  describe "validations" do
 
 		before(:each) do
 			Setting["feature.map"] = true
@@ -49,5 +49,17 @@ shared_examples "map validations" do
 		end
 
 	end
+  describe "cache" do
+
+    it "should expire cache when the map is updated" do
+      map_location = create(:map_location)
+      mappable.map_location = map_location
+      mappable.save
+
+      expect { map_location.update(latitude: 12.34) }
+      .to change { mappable.reload.updated_at }
+    end
+
+  end
 
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2176

What
====
- Expires mappable's cache after updating its map location

Why
===
- When editing the map of a proposal or investment(the mappable) the
`updated_at` attribute of the mappable was not been updated and so the
map still displayed the old location after updating it

Screenshots
===========
- Not necessary

Deployment
==========
- As usual

Warnings
========
- None
