### PR TITLE
Prevent edition of investments if budget is in the final phase

### DIFF
--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -55,28 +55,24 @@
         <%= investment.valuation_finished? ? t('shared.yes'): t('shared.no') %>
       </td>
       <td class="small">
-        <% unless investment.budget.finished? %>
-          <% if investment.selected? %>
-            <%= link_to toggle_selection_admin_budget_budget_investment_path(@budget,
-                                                                             investment,
-                                                                             filter: params[:filter],
-                                                                             page: params[:page]),
-                        method: :patch,
-                        remote: true,
-                        class: "button small expanded" do %>
-              <%= t("admin.budget_investments.index.selected") %>
-            <% end %>
-          <% elsif investment.feasible? && investment.valuation_finished? %>
-            <%= link_to toggle_selection_admin_budget_budget_investment_path(@budget,
-                                                                             investment,
-                                                                             filter: params[:filter],
-                                                                             page: params[:page]),
-                        method: :patch,
-                        remote: true,
-                        class: "button small hollow expanded" do %>
-              <%= t("admin.budget_investments.index.select") %>
-            <% end %>
-          <% end %>
+        <% if investment.selected? %>
+          <%= link_to_unless investment.budget.finished?, t("admin.budget_investments.index.selected"),
+                                                          toggle_selection_admin_budget_budget_investment_path(@budget,
+                                                                           investment,
+                                                                           filter: params[:filter],
+                                                                           page: params[:page]),
+                      method: :patch,
+                      remote: true,
+                      class: "button small expanded" %>
+        <% elsif investment.feasible? && investment.valuation_finished? %>
+          <%= link_to_unless investment.budget.finished?, t("admin.budget_investments.index.select"),
+                                                          toggle_selection_admin_budget_budget_investment_path(@budget,
+                                                                           investment,
+                                                                           filter: params[:filter],
+                                                                           page: params[:page]),
+                      method: :patch,
+                      remote: true,
+                      class: "button small hollow expanded" %>
         <% end %>
       </td>
       <% if params[:filter] == 'selected' %>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -55,25 +55,27 @@
         <%= investment.valuation_finished? ? t('shared.yes'): t('shared.no') %>
       </td>
       <td class="small">
-        <% if investment.selected? %>
-          <%= link_to toggle_selection_admin_budget_budget_investment_path(@budget,
-                                                                           investment,
-                                                                           filter: params[:filter],
-                                                                           page: params[:page]),
-                      method: :patch,
-                      remote: true,
-                      class: "button small expanded" do %>
-            <%= t("admin.budget_investments.index.selected") %>
-          <% end %>
-        <% elsif investment.feasible? && investment.valuation_finished? %>
-          <%= link_to toggle_selection_admin_budget_budget_investment_path(@budget,
-                                                                           investment,
-                                                                           filter: params[:filter],
-                                                                           page: params[:page]),
-                      method: :patch,
-                      remote: true,
-                      class: "button small hollow expanded" do %>
-            <%= t("admin.budget_investments.index.select") %>
+        <% unless investment.budget.finished? %>
+          <% if investment.selected? %>
+            <%= link_to toggle_selection_admin_budget_budget_investment_path(@budget,
+                                                                             investment,
+                                                                             filter: params[:filter],
+                                                                             page: params[:page]),
+                        method: :patch,
+                        remote: true,
+                        class: "button small expanded" do %>
+              <%= t("admin.budget_investments.index.selected") %>
+            <% end %>
+          <% elsif investment.feasible? && investment.valuation_finished? %>
+            <%= link_to toggle_selection_admin_budget_budget_investment_path(@budget,
+                                                                             investment,
+                                                                             filter: params[:filter],
+                                                                             page: params[:page]),
+                        method: :patch,
+                        remote: true,
+                        class: "button small hollow expanded" do %>
+              <%= t("admin.budget_investments.index.select") %>
+            <% end %>
           <% end %>
         <% end %>
       </td>

--- a/app/views/admin/budget_investments/show.html.erb
+++ b/app/views/admin/budget_investments/show.html.erb
@@ -6,7 +6,7 @@
 
 <%= link_to t("admin.budget_investments.show.edit"),
             edit_admin_budget_budget_investment_path(@budget, @investment,
-                                                Budget::Investment.filter_params(params)) %>
+                                                Budget::Investment.filter_params(params)) unless @budget.finished? %>
 
 <hr>
 
@@ -34,7 +34,7 @@
 <p>
   <%= link_to t("admin.budget_investments.show.edit_classification"),
                 edit_admin_budget_budget_investment_path(@budget, @investment,
-                                                  {anchor: 'classification'}.merge(Budget::Investment.filter_params(params))) %>
+                                                  {anchor: 'classification'}.merge(Budget::Investment.filter_params(params))) unless @budget.finished? %>
 </p>
 
 <hr>
@@ -44,7 +44,7 @@
 <%= render 'valuation/budget_investments/written_by_valuators' %>
 
 <p>
-  <%= link_to t("admin.budget_investments.show.edit_dossier"), edit_valuation_budget_budget_investment_path(@budget, @investment) %>
+  <%= link_to t("admin.budget_investments.show.edit_dossier"), edit_valuation_budget_budget_investment_path(@budget, @investment) unless @budget.finished? %>
 </p>
 
 <hr>


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2159
This PR closes #2159 

What
====
If the budget is in the final phase, prevent any changes in their investments except the milestones, which can be managed as always.

How
===
- "Selected" link is conditional, so if the budget is finished it appears like text (to see if it is selected or not).
- All the "Edit" links are removed if the budget is finished, only the milestones section is enabled.

Screenshots
===========
### "Selected" link
![selected01](https://user-images.githubusercontent.com/31625251/34386264-1a834c96-eb28-11e7-89c2-9ab7d46c74b4.jpg)

### "Edit" links
![selected02](https://user-images.githubusercontent.com/31625251/34386267-1e966dc2-eb28-11e7-8013-221875c7d255.jpg)

Test
====
Feature spects to test that the "Selected" and "Edit" links are not appearing.

Deployment
==========
Nothing.

Warnings
========
Nothing.
