### PR TITLE
Texts on topics with format

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -19,7 +19,7 @@
                     community_topic_path(@community, @topic, anchor: "comments") %>
       </div>
       <br>
-      <p><%= @topic.description %></p>
+      <p><%= text_with_links(@topic.description).gsub("\n", '<br/>').html_safe %></p>
     </div>
 
     <% if @topic.author == current_user %>

--- a/spec/features/topics_specs.rb
+++ b/spec/features/topics_specs.rb
@@ -125,6 +125,18 @@ feature 'Topics' do
       expect(page).to have_content topic.title
     end
 
+    scenario "Topic description with clickable URL" do
+      proposal = create(:proposal)
+      community = proposal.community
+      topic = create(:topic, community: community, description: "This is a description with a link to https://google.es")
+
+      visit community_topic_path(community, topic)
+
+      expect(page).to have_content community.proposal.title
+      expect(page).to have_content topic.title
+      expect(page).to have_link "https://google.es"
+    end
+
   end
 
   context 'Destroy' do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2211 (This PR closes #2211)

What
====
Make the texts of the topics from communities show the breaklines and links written by users.

How
===
Generate a new helper method that gives the correct format to a text, using `gsub` for breaklines and `auto_links`for links.

Screenshots
===========
### Text in the topic
![topics02](https://user-images.githubusercontent.com/31625251/34417436-d931a7b6-ebf8-11e7-97e4-bb7660a1f523.png)

### Attributes for the link inserted
![topics01](https://user-images.githubusercontent.com/31625251/34417443-dd752a6e-ebf8-11e7-9324-f4dbdbc22179.png)


Test
====
A spec has been created to test that the links are generated in the texts.

Deployment
==========
Nothing.

Warnings
========
Nohting.
