### PR TITLE
Refactor documents and document view partials

### DIFF
--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,20 +1,24 @@
-<tr id="<%= dom_id(document)%>">
-  <td class="document-link">
-    <%= document.title %>
-  </td>
-  <td class="text-center">
-    <%= link_to t('documents.buttons.download_document'),
-                document.attachment.url,
-                target: "_blank",
-                rel: "nofollow",
-                class: 'button hollow' %>
-  </td>
-  <td class="text-center">
-    <% if can? :destroy, Document %>
-      <%= link_to t('documents.buttons.destroy_document'),
-                    document_path(document, from: request.url), method: :delete,
-                    data: { confirm: t('documents.actions.destroy.confirm') },
-                    class: 'button hollow alert' %>
-    <% end %>
-  </td>
-</tr>
+<table>
+  <tbody>
+    <tr id="<%= dom_id(document)%>">
+      <td class="document-link">
+        <%= document.title %>
+      </td>
+      <td class="text-center">
+        <%= link_to t('documents.buttons.download_document'),
+                    document.attachment.url,
+                    target: "_blank",
+                    rel: "nofollow",
+                    class: 'button hollow' %>
+      </td>
+      <td class="text-center">
+        <% if can? :destroy, Document %>
+          <%= link_to t('documents.buttons.destroy_document'),
+                        document_path(document, from: request.url), method: :delete,
+                        data: { confirm: t('documents.actions.destroy.confirm') },
+                        class: 'button hollow alert' %>
+        <% end %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/documents/_documents.html.erb
+++ b/app/views/documents/_documents.html.erb
@@ -1,33 +1,11 @@
-<% if documents.any? %>
-
-  <% if documents.size == max_documents_allowed && can?(:destroy, Document) %>
-    <div class="row documents-list">
-      <div class="small-12 column">
-        <div class="callout warning text-center">
-          <%= t "documents.max_documents_allowed_reached_html" %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
-  <div class="row documents-list">
-    <div class="small-12 column">
-      <table>
-        <tbody>
-          <%= render partial: "documents/document", collection: documents %>
-        </tbody>
-      </table>
-    </div>
-  </div>
-
-<% else %>
-
-  <div class="row">
-    <div class="small-12 column">
+<div class="row <% 'documents-list' if documents.any? %>">
+  <div class="small-12 column">
+    <% if documents.any? %>
+      <%= render partial: "documents/document", collection: documents %>
+    <% else %>
       <div class="callout primary text-center">
         <%= t('documents.no_documents') %>
       </div>
-    </div>
+    <% end %>
   </div>
-
-<% end %>
+</div>

--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -18,25 +18,6 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
 
     let!(:document) { create(:document, documentable: documentable, user: documentable.author)}
 
-    scenario "Should not display maximum number of documents alert when reached for users without document creation permission" do
-      create_list(:document, 2, documentable: documentable)
-      visit send(documentable_path, arguments)
-
-      within "#tab-documents" do
-        expect(page).not_to have_content "You have reached the maximum number of documents allowed! You have to delete one before you can upload another."
-      end
-    end
-
-    scenario "Should display maximum number of documents alert when reached and when current user has document creation permission" do
-      login_as documentable.author
-      create_list(:document, 2, documentable: documentable)
-      visit send(documentable_path, arguments)
-
-      within "#tab-documents" do
-        expect(page).to have_content "You have reached the maximum number of documents allowed! You have to delete one before you can upload another."
-      end
-    end
-
     scenario "Download action should be able to anyone" do
       visit send(documentable_path, arguments)
 


### PR DESCRIPTION
What
====
Make documentable partials easier to read, by reducing the amount of lines and removing unneeded max docs alert.

How
===
- Removing unnecesary max docs alert (user can't edit document list after creating resource)
- Moving the table tags on to the document partial
- Making if-else logic simpler

Screenshots
===========
We were showing the max documents number alert on the resource show view, even though the user can't edit the resource neither upload more documents after creating the resource:
![screen shot 2018-01-02 at 13 29 03](https://user-images.githubusercontent.com/983242/34483791-0a345efa-efc1-11e7-8b31-a143ff7df911.jpg)

That alert has been removed.

Test
====
Removed no longer needed spec scenarios

Deployment
==========
As usual

Warnings
========
If in the future editing a resource with documents becomes available again, the alert should return.