### PR TITLE
Specs for valid sitemap generation

### DIFF
--- a/spec/lib/tasks/sitemap_spec.rb
+++ b/spec/lib/tasks/sitemap_spec.rb
@@ -1,0 +1,48 @@
+require 'rake'
+require 'rails_helper'
+Rails.application.load_tasks
+Rake::Task.define_task(:environment)
+
+feature 'rake sitemap:create' do
+  before do
+    @file ||= Rails.root.join('public', 'sitemap.xml')
+
+    # To avoid spec failures if file does not exist
+    # Useful on CI environments or if file was created
+    # previous to the specs (to ensure a clean state)
+    File.delete(@file) if File.exist?(@file)
+
+    Rake::Task['sitemap:create'].reenable
+    Rake.application.invoke_task('sitemap:create')
+  end
+
+  it 'generates a sitemap' do
+    expect(@file).to exist
+  end
+
+  it 'generates a valid sitemap' do
+    sitemap = Nokogiri::XML(File.open(@file))
+    expect(sitemap.errors).to be_empty
+  end
+
+  it 'generates a sitemap with expected and valid URLs' do
+    sitemap = File.read(@file)
+
+    # Static pages
+    expect(sitemap).to include(faq_path)
+    expect(sitemap).to include(more_info_path)
+    expect(sitemap).to include(how_to_use_path)
+    expect(sitemap).to include(page_path(id: 'general_terms'))
+
+    # Dynamic URLs
+    expect(sitemap).to include(polls_path)
+    expect(sitemap).to include(budgets_path)
+    expect(sitemap).to include(debates_path)
+    expect(sitemap).to include(proposals_path)
+    expect(sitemap).to include(spending_proposals_path)
+    expect(sitemap).to include(legislation_processes_path)
+
+    expect(sitemap).to have_content('0.7', count: 6)
+    expect(sitemap).to have_content('daily', count: 6)
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2219 (This PR closes #2219 once merged)

What
====
* Add specs to test if sitemap generation is successful, valid and includes expected URLs

How
===
* Wrote a new spec for `rake sitemap:create` task under `spec/lib/tasks`

Test
====
* Increased coverage as requested
