### PR TITLE
I18n maintenance

### DIFF
--- a/app/controllers/admin/poll/questions/answers/images_controller.rb
+++ b/app/controllers/admin/poll/questions/answers/images_controller.rb
@@ -14,7 +14,7 @@ class Admin::Poll::Questions::Answers::ImagesController < Admin::Poll::BaseContr
 
     if @answer.save
       redirect_to admin_answer_images_path(@answer),
-               notice: "Image uploaded successfully"
+               notice: t("flash.actions.create.poll_question_answer_image")
     else
       render :new
     end

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -68,7 +68,7 @@ en:
         new_link: Create new budget
         filter: Filter
         filters:
-          current: Open
+          open: Open
           finished: Finished
         budget_investments: See budget investments
         table_name: Name

--- a/config/locales/en/responders.yml
+++ b/config/locales/en/responders.yml
@@ -9,6 +9,7 @@ en:
         poll_booth: "Booth created successfully."
         poll_question_answer: "Answer created successfully"
         poll_question_answer_video: "Video created successfully"
+        poll_question_answer_image: "Image uploaded successfully"
         proposal: "Proposal created successfully."
         proposal_notification: "Your message has been sent correctly."
         spending_proposal: "Spending proposal created successfully. You can access it from %{activity}"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -252,7 +252,7 @@ es:
           without_confirmed_hide: Pendientes
         title: Usuarios bloqueados
         user: Usuario
-        no_hidden_users: No hay uusarios bloqueados.
+        no_hidden_users: No hay usuarios bloqueados.
       show:
         email: 'Email:'
         hidden_at: 'Bloqueado:'

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -68,7 +68,7 @@ es:
         new_link: Crear nuevo presupuesto
         filter: Filtro
         filters:
-          current: Abiertos
+          open: Abiertos
           finished: Terminados
         budget_investments: Ver propuestas de inversión
         table_name: Nombre

--- a/config/locales/es/responders.yml
+++ b/config/locales/es/responders.yml
@@ -9,6 +9,7 @@ es:
         poll_booth: "Urna creada correctamente."
         poll_question_answer: "Respuesta creada correctamente"
         poll_question_answer_video: "Vídeo creado correctamente"
+        poll_question_answer_image: "Imagen cargada correctamente"
         proposal: "Propuesta creada correctamente."
         proposal_notification: "Tu mensaje ha sido enviado correctamente."
         spending_proposal: "Propuesta de inversión creada correctamente. Puedes acceder a ella desde %{activity}"

--- a/config/locales/fr/responders.yml
+++ b/config/locales/fr/responders.yml
@@ -10,6 +10,7 @@ fr:
         poll_booth: "Urne créée avec succès."
         poll_question_answer: "Réponse créée avec succès"
         poll_question_answer_video: "Vidéo créée avec succès"
+        poll_question_answer_image: "Image téléchargée avec succès"
         proposal: "Proposition créée avec succès."
         proposal_notification: "Votre message a correctement été envoyé."
         spending_proposal: "Proposition de dépense créée avec succès. Vous pouvez y accéder depuis %{activity}"


### PR DESCRIPTION
Where
====
* Related PR: #2109

What
====
* Missing I18n translations
* Typos

How
===
* Replaced the hard-coded `Image created successfully` message under `Admin::Poll::Questions::Answers::Images` controller with proper I18n

* Added missing translations in English, Spanish and French

* Fixed typo under `Admin::HiddenUsers` controller views

* Fixed missing key under `Admin::Budget` index action
