### PR TITLE
Tabs deep links

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -74,6 +74,7 @@
 //= require polls
 //= require sortable
 //= require table_sortable
+//= require tabs
 
 var initialize_modules = function() {
   App.Comments.initialize();
@@ -115,6 +116,7 @@ var initialize_modules = function() {
   App.Polls.initialize();
   App.Sortable.initialize();
   App.TableSortable.initialize();
+  App.Tabs.initialize();
 };
 
 $(function(){

--- a/app/assets/javascripts/tabs.js.coffee
+++ b/app/assets/javascripts/tabs.js.coffee
@@ -1,0 +1,25 @@
+App.Tabs =
+
+  tabDeepLink: (selector) ->
+    $(selector).each ->
+      $tabs = $(this)
+      # match page load anchor
+      anchor = window.location.hash
+      if anchor.length and $tabs.find('[href="' + anchor + '"]').length
+        $tabs.foundation 'selectTab', $(anchor)
+        # roll up a little to show the header
+        offset = $tabs.offset()
+        $(window).load ->
+          $('html, body').animate { scrollTop: offset.top }, 300
+          return
+      # append the hash on click
+      $tabs.on 'change.zf.tabs', ->
+        `var anchor`
+        anchor = $tabs.find('.tabs-title.is-active a').attr('href')
+        history.pushState {}, '', anchor
+        return
+      return
+    return
+
+  initialize: ->
+    App.Tabs.tabDeepLink('.tabs');

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -420,6 +420,14 @@ feature 'Budget Investments' do
     end
   end
 
+  scenario 'Selected tab in URL anchor active', :js do
+    investment = create(:budget_investment, heading: heading)
+
+    visit budget_investment_path(budget_id: budget.id, id: investment.id, anchor: 'tab-milestones')
+
+    expect(page.first('ul.tabs li.is-active a').text).to eq('Milestones (0)')
+  end
+
   scenario 'Can access the community' do
     Setting['feature.community'] = true
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -105,6 +105,14 @@ feature 'Proposals' do
     end
   end
 
+  scenario 'Selected tab in URL anchor active', :js do
+    proposal = create(:proposal)
+
+    visit proposal_path(proposal, anchor: 'tab-notifications')
+
+    expect(page.first('ul.tabs li.is-active a').text).to eq('Notifications (0)')
+  end
+
   context "Show" do
     scenario 'When path matches the friendly url' do
       proposal = create(:proposal)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2210 (this PR closes #2210)

What
====
- When a user visits a proposal or a budget investment with a hash `#tab-x` in the URL, the page should activate the mentioned tab.
- When the user clicks on a tab, the URL should change and add the `#tab-x` hash to the end.

How
===
As said in the issue, the foundation-rails version that is been used doesn't have the deep-link functionality implemented. I was able to make it work (as explained in [foundation's docs](https://foundation.zurb.com/sites/docs/tabs.html)) updating the gem, but that's not something trivial, so, for the moment, I added a JS solution provided in [this GitHub issue](https://github.com/zurb/foundation-sites/issues/7652), that works as foundation deep-link.

Screenshots
===========
### Changing the URL when clicking the tabs

![deep-links01](https://user-images.githubusercontent.com/31625251/34675591-5d614570-f48a-11e7-85de-74c0b5c55f91.gif)

### Activating the tab and scroll to it when accessing from a link

![deep-links03](https://user-images.githubusercontent.com/31625251/34675653-98af522a-f48a-11e7-9d1a-3b5b8ffaa5e7.gif)

Test
====
Add some featuer specs to test that, when a user access a link with an anchor to a tab, the selected tab is the one activated.

Deployment
==========
Nothing.

Warnings
========
- This is only a patch to get the functionality. The best solution is to update the gem, but, as said, this is not a as trivial as desired.
- Because it's not developed using the `data-deep-link="true"` option, it works for all the tabs.