### PR TITLE
Allow destroying budgets without investments

### DIFF
--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -42,6 +42,15 @@ class Admin::BudgetsController < Admin::BaseController
     end
   end
 
+  def destroy
+    if @budget.investments.any?
+      redirect_to admin_budgets_path, alert: t('admin.budgets.destroy.unable_notice')
+    else
+      @budget.destroy
+      redirect_to admin_budgets_path, notice: t('admin.budgets.destroy.success_notice')
+    end
+  end
+
   private
 
     def budget_params

--- a/app/views/admin/budgets/edit.html.erb
+++ b/app/views/admin/budgets/edit.html.erb
@@ -1,5 +1,7 @@
 <%= back_link_to admin_budgets_path %>
 
+<%= button_to t("admin.budgets.edit.delete"), admin_budget_path(@budget), method: :delete, class: "button hollow alert float-right small" %>
+
 <h2><%= t("admin.budgets.edit.title") %></h2>
 
 <%= render '/admin/budgets/form' %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -84,6 +84,10 @@ en:
         notice: Participatory budget updated successfully
       edit:
         title: Edit Participatory budget
+        delete: Delete budget
+      destroy:
+        success_notice: Budget deleted successfully
+        unable_notice: You cannot destroy a Budget that has associated investments
       new:
         title: New participatory budget
       show:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -84,6 +84,11 @@ es:
         notice: Campaña de presupuestos participativos actualizada
       edit:
         title: Editar campaña de presupuestos participativos
+        delete: Borrar campaña
+      destroy:
+        success_notice: Campaña eliminada correctamente
+        unable_notice: No se pueden eliminar campañas con presupuestos asociados
+
       new:
         title: Nuevo presupuesto ciudadano
       show:

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -109,6 +109,33 @@ feature 'Admin budgets' do
 
   end
 
+  context 'Destroy' do
+
+    let!(:budget) { create(:budget) }
+    let(:heading) { create(:budget_heading, group: create(:budget_group, budget: budget)) }
+
+    scenario 'Destroy a budget without investments' do
+      visit admin_budgets_path
+      click_link 'Edit budget'
+      click_button 'Delete budget'
+
+      expect(page).to have_content('Budget deleted successfully')
+      expect(page).to have_content('participatory budgets cannot be found')
+    end
+
+    scenario 'Try to destroy a budget with investments' do
+      create(:budget_investment, heading: heading)
+
+      visit admin_budgets_path
+      click_link 'Edit budget'
+      click_button 'Delete budget'
+
+      expect(page).to have_content('You cannot destroy a Budget that has associated investments')
+      expect(page).to have_content('There is 1 participatory budget')
+    end
+
+  end
+
   context "Calculate Budget's Winner Investments" do
 
     scenario 'For a Budget in reviewing balloting' do


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2275 (closes #2275)

What
====
Allowing admins to destroy budgets that have no associated investments from the Edit form.

How
===
- Adding a destroy button consistent with others in the admin sections
- Checking the Budget has no associated investments before destroy, showing an error notice explaining the reason behind if so.

Screenshots
===========

## When the Budget has no investments
![budget_destroy_success](https://user-images.githubusercontent.com/983242/34682510-60ef2cd8-f49f-11e7-972b-3c28d43dea4c.gif)

## When the Budget does have investments
![budget_destroy_unable](https://user-images.githubusercontent.com/983242/34682533-6b60c2c6-f49f-11e7-9ced-324db461e14d.gif)

Test
====
Extended existent admin budget feature spec adding a "Destroy" scenario that checks both a budget without investments and budget with investments destroyal.

Deployment
==========
As usual

Warnings
========
None