### PR TITLE
Redirect admin to budget lists after edit

### DIFF
--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -27,7 +27,7 @@ class Admin::BudgetsController < Admin::BaseController
 
   def update
     if @budget.update(budget_params)
-      redirect_to admin_budget_path(@budget), notice: t('admin.budgets.update.notice')
+      redirect_to admin_budgets_path, notice: t('admin.budgets.update.notice')
     else
       render :edit
     end

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -109,6 +109,25 @@ feature 'Admin budgets' do
 
   end
 
+  context 'Update' do
+
+    background do
+      create(:budget)
+    end
+
+    scenario 'Update budget' do
+      visit admin_budgets_path
+      click_link 'Edit budget'
+
+      fill_in 'budget_name', with: 'More trees on the streets'
+      click_button 'Update Participatory budget'
+
+      expect(page).to have_content('More trees on the streets')
+      expect(page).to have_current_path(admin_budgets_path)
+    end
+
+  end
+
   context "Calculate Budget's Winner Investments" do
 
     scenario 'For a Budget in reviewing balloting' do


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2276 (closes #2276)

What
====
Redirect the admin to the Admin Budget list after editing a Budget to make the experience better

How
===
Just changing the redirect destination path to admin budgets list https://github.com/consul/consul/commit/03e1481fb1e51ff021fa126b75f9c5cb446d5b6e

Screenshots
===========
## After editing the admin sees the budgets list
![edit_budget_home](https://user-images.githubusercontent.com/983242/34684249-c751ed80-f4a4-11e7-9ade-39db684b3cca.gif)

Test
====
Added an "Update" scenario that checks the new redirection as well as updating the title https://github.com/consul/consul/commit/53842ba919dc4d8ff9487798d9b391f4f15653a8

Deployment
==========
As usual

Warnings
========
None 