### PR TITLE
Feature/2278#budget draft phase

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -1,5 +1,6 @@
 class BudgetsController < ApplicationController
   include FeatureFlags
+  include BudgetsHelper
   feature_flag :budgets
 
   load_and_authorize_resource
@@ -9,6 +10,7 @@ class BudgetsController < ApplicationController
   respond_to :html, :js
 
   def show
+    raise ActionController::RoutingError, 'Not Found' unless budget_published?(@budget)
   end
 
   def index

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -42,4 +42,9 @@ module BudgetsHelper
   def investment_tags_select_options
     Budget::Investment.tags_on(:valuation).order(:name).select(:name).distinct
   end
+
+  def budget_published?(budget)
+    !budget.drafting? || current_user&.administrator?
+  end
+
 end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -3,7 +3,8 @@ class Budget < ActiveRecord::Base
   include Measurable
   include Sluggable
 
-  PHASES = %w(accepting reviewing selecting valuating balloting reviewing_ballots finished).freeze
+  PHASES = %w(drafting accepting reviewing selecting valuating balloting
+              reviewing_ballots finished).freeze
   CURRENCY_SYMBOLS = %w(€ $ £ ¥).freeze
 
   validates :name, presence: true, uniqueness: true
@@ -19,6 +20,7 @@ class Budget < ActiveRecord::Base
   before_validation :sanitize_descriptions
 
   scope :on_hold,   -> { where(phase: %w(reviewing valuating reviewing_ballots")) }
+  scope :drafting,  -> { where(phase: "drafting") }
   scope :accepting, -> { where(phase: "accepting") }
   scope :reviewing, -> { where(phase: "reviewing") }
   scope :selecting, -> { where(phase: "selecting") }
@@ -39,6 +41,10 @@ class Budget < ActiveRecord::Base
 
   def self.title_max_length
     80
+  end
+
+  def drafting?
+    phase == "drafting"
   end
 
   def accepting?

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -16,14 +16,16 @@
       </thead>
       <tbody>
       <% @budgets.each do |budget| %>
-        <tr>
-          <td>
-            <%= link_to budget.name, budget %>
-          </td>
-          <td>
-            <%= budget.translated_phase %>
-          </td>
-        </tr>
+        <% if budget_published?(budget) %>
+          <tr>
+            <td>
+              <%= link_to budget.name, budget %>
+            </td>
+            <td>
+              <%= budget.translated_phase %>
+            </td>
+          </tr>
+        <% end %>
       <% end %>
       </tbody>
     </table>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -29,6 +29,7 @@ en:
         unselected_title: Investments not selected for balloting phase
         unselected: See investments not selected for balloting phase
     phase:
+      drafting: Draft (Not visible to the public)
       accepting: Accepting projects
       reviewing: Reviewing projects
       selecting: Selecting projects

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -29,6 +29,7 @@ es:
         unselected_title: Propuestas no seleccionadas para la votación final
         unselected: Ver las propuestas no seleccionadas para la votación final
     phase:
+      drafting: Borrador (No visible para el público)
       accepting: Presentación de proyectos
       reviewing: Revisión interna de proyectos
       selecting: Fase de apoyos

--- a/db/migrate/20180108182839_add_drafting_phase_to_budget.rb
+++ b/db/migrate/20180108182839_add_drafting_phase_to_budget.rb
@@ -1,0 +1,5 @@
+class AddDraftingPhaseToBudget < ActiveRecord::Migration
+  def change
+    add_column :budgets, :description_drafting, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171220010000) do
+ActiveRecord::Schema.define(version: 20180108182839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,6 +201,7 @@ ActiveRecord::Schema.define(version: 20171220010000) do
     t.text     "description_reviewing_ballots"
     t.text     "description_finished"
     t.string   "slug"
+    t.text     "description_drafting"
   end
 
   create_table "campaigns", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -231,6 +231,10 @@ FactoryBot.define do
     description_reviewing_ballots "This budget is reviewing ballots"
     description_finished "This budget is finished"
 
+    trait :drafting do
+      phase 'drafting'
+    end
+
     trait :accepting do
       phase 'accepting'
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -223,6 +223,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Budget #{n}" }
     currency_symbol "€"
     phase 'accepting'
+    description_drafting  "This budget is drafting"
     description_accepting "This budget is accepting"
     description_reviewing "This budget is reviewing"
     description_selecting "This budget is selecting"

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -34,32 +34,32 @@ feature 'Admin budgets' do
     end
 
     scenario 'Filters by phase' do
-      budget1 = create(:budget)
-      budget2 = create(:budget, :accepting)
-      budget3 = create(:budget, :selecting)
-      budget4 = create(:budget, :balloting)
-      budget5 = create(:budget, :finished)
+      drafting_budget  = create(:budget, :drafting)
+      accepting_budget = create(:budget, :accepting)
+      selecting_budget = create(:budget, :selecting)
+      balloting_budget = create(:budget, :balloting)
+      finished_budget  = create(:budget, :finished)
 
       visit admin_budgets_path
-      expect(page).to have_content(budget1.name)
-      expect(page).to have_content(budget2.name)
-      expect(page).to have_content(budget3.name)
-      expect(page).to have_content(budget4.name)
-      expect(page).not_to have_content(budget5.name)
+      expect(page).to have_content(drafting_budget.name)
+      expect(page).to have_content(accepting_budget.name)
+      expect(page).to have_content(selecting_budget.name)
+      expect(page).to have_content(balloting_budget.name)
+      expect(page).not_to have_content(finished_budget.name)
 
       click_link 'Finished'
-      expect(page).not_to have_content(budget1.name)
-      expect(page).not_to have_content(budget2.name)
-      expect(page).not_to have_content(budget3.name)
-      expect(page).not_to have_content(budget4.name)
-      expect(page).to have_content(budget5.name)
+      expect(page).not_to have_content(drafting_budget.name)
+      expect(page).not_to have_content(accepting_budget.name)
+      expect(page).not_to have_content(selecting_budget.name)
+      expect(page).not_to have_content(balloting_budget.name)
+      expect(page).to have_content(finished_budget.name)
 
       click_link 'Open'
-      expect(page).to have_content(budget1.name)
-      expect(page).to have_content(budget2.name)
-      expect(page).to have_content(budget3.name)
-      expect(page).to have_content(budget4.name)
-      expect(page).not_to have_content(budget5.name)
+      expect(page).to have_content(drafting_budget.name)
+      expect(page).to have_content(accepting_budget.name)
+      expect(page).to have_content(selecting_budget.name)
+      expect(page).to have_content(balloting_budget.name)
+      expect(page).not_to have_content(finished_budget.name)
     end
 
     scenario 'Open filter is properly highlighted' do

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 feature 'Budgets' do
 
+  let(:budget) { create(:budget) }
+
   scenario 'Index' do
     budgets = create_list(:budget, 3)
     visit budgets_path
@@ -11,7 +13,6 @@ feature 'Budgets' do
   context 'Show' do
 
     scenario "List all groups" do
-      budget = create(:budget)
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
 
@@ -62,8 +63,6 @@ feature 'Budgets' do
   end
 
   context 'Accepting' do
-
-    let(:budget) { create(:budget) }
 
     background do
       budget.update(phase: 'accepting')

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 feature 'Budgets' do
 
   let(:budget) { create(:budget) }
+  let(:level_two_user) { create(:user, :level_two) }
 
   scenario 'Index' do
     budgets = create_list(:budget, 3)
@@ -71,8 +72,7 @@ feature 'Budgets' do
     context "Permissions" do
 
       scenario "Verified user" do
-        user = create(:user, :level_two)
-        login_as(user)
+        login_as(level_two_user)
 
         visit budget_path(budget)
 

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -63,6 +63,58 @@ feature 'Budgets' do
 
   end
 
+  context "In Drafting phase" do
+
+    let(:admin) { create(:administrator).user }
+
+    background do
+      logout
+      budget.update(phase: 'drafting')
+    end
+
+    context "Listed" do
+      scenario "Not listed to guest users at the public budgets list" do
+        visit budgets_path
+
+        expect(page).not_to have_content(budget.name)
+      end
+
+      scenario "Not listed to logged users at the public budgets list" do
+        login_as(level_two_user)
+        visit budgets_path
+
+        expect(page).not_to have_content(budget.name)
+      end
+
+      scenario "Is listed to admins at the public budgets list" do
+        login_as(admin)
+        visit budgets_path
+
+        expect(page).to have_content(budget.name)
+      end
+    end
+
+    context "Shown" do
+      scenario "Not accesible to guest users" do
+        expect { visit budget_path(budget) }.to raise_error(ActionController::RoutingError)
+      end
+
+      scenario "Not accesible to logged users" do
+        login_as(level_two_user)
+
+        expect { visit budget_path(budget) }.to raise_error(ActionController::RoutingError)
+      end
+
+      scenario "Is accesible to admin users" do
+        login_as(admin)
+        visit budget_path(budget)
+
+        expect(page.status_code).to eq(200)
+      end
+    end
+
+  end
+
   context 'Accepting' do
 
     background do

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -65,7 +65,7 @@ feature 'Results' do
   end
 
   scenario "If budget is in a phase different from finished results can't be accessed" do
-    budget.update phase: (Budget::PHASES - ["finished"]).sample
+    budget.update(phase: (Budget::PHASES - ['drafting', 'finished']).sample)
     visit budget_path(budget)
     expect(page).not_to have_link "See results"
 

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -8,6 +8,7 @@ feature 'Tags' do
   let!(:heading) { create(:budget_heading, name: "More hospitals", group: group) }
   let!(:tag_medio_ambiente) { create(:tag, :category, name: 'Medio Ambiente') }
   let!(:tag_economia) { create(:tag, :category, name: 'Economía') }
+  let(:admin) { create(:administrator).user }
 
   scenario 'Index' do
     earth = create(:budget_investment, heading: heading, tag_list: tag_medio_ambiente.name)
@@ -282,8 +283,7 @@ feature 'Tags' do
       investment.set_tag_list_on(:valuation, 'Education')
       investment.save
 
-      admin = create(:administrator)
-      login_as(admin.user)
+      login_as(admin)
 
       visit admin_budget_budget_investment_path(budget, investment)
       click_link 'Edit classification'

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -186,6 +186,7 @@ feature 'Tags' do
       Budget::PHASES.each do |phase|
         budget.update(phase: phase)
 
+        login_as(admin) if budget.drafting?
         visit budget_investments_path(budget, heading_id: heading.id)
 
         within "#tag-cloud" do
@@ -205,6 +206,7 @@ feature 'Tags' do
           end
         end
 
+        login_as(admin) if budget.drafting?
         visit budget_path(budget)
         click_link group.name
 
@@ -231,6 +233,7 @@ feature 'Tags' do
       Budget::PHASES.each do |phase|
         budget.update(phase: phase)
 
+        login_as(admin) if budget.drafting?
         visit budget_investments_path(budget, heading_id: heading.id)
 
         within "#categories" do
@@ -250,6 +253,7 @@ feature 'Tags' do
           end
         end
 
+        login_as(admin) if budget.drafting?
         visit budget_path(budget)
         click_link group.name
 

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -40,6 +40,9 @@ describe Budget do
     end
 
     it "produces auxiliary methods" do
+      budget.phase = "drafting"
+      expect(budget).to be_drafting
+
       budget.phase = "accepting"
       expect(budget).to be_accepting
 
@@ -63,6 +66,9 @@ describe Budget do
     end
 
     it "on_hold?" do
+      budget.phase = "drafting"
+      expect(budget).not_to be_on_hold
+
       budget.phase = "accepting"
       expect(budget).not_to be_on_hold
 
@@ -86,6 +92,9 @@ describe Budget do
     end
 
     it "balloting_or_later?" do
+      budget.phase = "drafting"
+      expect(budget).not_to be_balloting_or_later
+
       budget.phase = "accepting"
       expect(budget).not_to be_balloting_or_later
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2278 (doesn't close it entirely, just partially)

What
====
Adds "Drafting" phase to Budgets. Budgets in drafting phase can only be listed/viewed by admins.

How
===
- Adding `description_drafting` & drafting phase to Budget model https://github.com/consul/consul/commit/d0937d7022fff307b8733392adcc697240932909 & https://github.com/consul/consul/commit/f9803ce9ca3e8b230477ef335d398c9820e8b381

- Creating a `budget_published?` helper method at BudgetHelper https://github.com/consul/consul/commit/03f4fce2dd13aef6428f65f588f195d54dbc9695 to use it on both BudgetController to raise a 404 error https://github.com/consul/consul/commit/76e05d58b1fe05bde6abdb2f1083852f062fce04 and at public budget lists https://github.com/consul/consul/commit/4916f9a3c313da2d420dfe21276520dbd7e8aa3f to decide if it should be accessible or not by current user.

Screenshots
===========
## A Gif is worth a thousand Screenshots!

In this gif we:
- Create a Drafting Budget & check as admins that its listed & accesible
- Check that its not listed neither accessible as guests or verified users
- Change phase to Accepting and re-check as guests & users its listed & accessible as it should

![drafting_budgets](https://user-images.githubusercontent.com/983242/34695110-e0b92476-f4c9-11e7-8d7e-6b6ddc5554dc.gif)

Test
====
- Created a "Drafting phase" scenario for Budget feature spec that checks guest/verified/admin user listing & accessing a Drafting Budget https://github.com/consul/consul/commit/2026f537e6413916b8f420a60208857ba2134b3a

- Increased both admin budget spec https://github.com/consul/consul/commit/63694b5bae8bcab1f91ae47e3fd79ee137adf44d and budget model spec https://github.com/consul/consul/commit/1f0eb49ddcf8520f39b01bb937335b3789523779 with drafting phase scenarios

Deployment
==========
As usual

Warnings
========
We could have gone with CanCanCan to prevent non-admin's from accessing Budgets in drafting phase but... from my point of view that's a leak of information. Users could know there's an ongoing/drafting Budget by trying different url's until finding one that returns a "You cannot access this Budget" error instead of a 404 error. By imitating the same 404 behaviour as a non-existing budget url we are consistent in the behaviour, although I agree the disadvantage is that the "ability" is not represented in plain sight under `app/model/abilities/*` files :/