### PR TITLE
Fix for test suite deprecations warnings

### DIFF
--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -12,7 +12,7 @@ feature 'Account' do
 
     click_link "My account"
 
-    expect(page).to have_current_path(account_path, only_path: true)
+    expect(page).to have_current_path(account_path, ignore_query: true)
 
     expect(page).to have_selector("input[value='Manuela Colau']")
     expect(page).to have_selector(avatar('Manuela Colau'), count: 1)
@@ -116,7 +116,7 @@ feature 'Account' do
 
     click_link 'My account'
 
-    expect(page).to have_current_path(account_path, only_path: true)
+    expect(page).to have_current_path(account_path, ignore_query: true)
 
     expect(page).to have_link('Change my credentials')
     click_link 'Change my credentials'

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -670,8 +670,8 @@ feature 'Admin budget investments' do
                                                           filter: :valuation_finished)
 
       header = page.response_headers['Content-Disposition']
-      header.should match(/^attachment/)
-      header.should match(/filename="budget_investments.csv"$/)
+      expect(header).to match(/^attachment/)
+      expect(header).to match(/filename="budget_investments.csv"$/)
 
       expect(page).to have_content investment2.title
       expect(page).to_not have_content investment1.title

--- a/spec/features/admin/officials_spec.rb
+++ b/spec/features/admin/officials_spec.rb
@@ -46,7 +46,7 @@ feature 'Admin officials' do
     fill_in 'name_or_email', with: @citizen.email
     click_button 'Search'
 
-    expect(page).to have_current_path(search_admin_officials_path, only_path: true)
+    expect(page).to have_current_path(search_admin_officials_path, ignore_query: true)
     expect(page).not_to have_content @official.name
 
     click_link @citizen.name
@@ -71,7 +71,7 @@ feature 'Admin officials' do
     click_link "Remove 'Official' status"
 
     expect(page).to have_content 'Details saved: the user is no longer an official'
-    expect(page).to have_current_path(admin_officials_path, only_path: true)
+    expect(page).to have_current_path(admin_officials_path, ignore_query: true)
     expect(page).not_to have_content @citizen.name
     expect(page).not_to have_content @official.name
   end

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -40,7 +40,7 @@ feature 'Admin::Organizations' do
       fill_in "term", with: "      "
       click_button "Search"
 
-      expect(page).to have_current_path(search_admin_organizations_path, only_path: true)
+      expect(page).to have_current_path(search_admin_organizations_path, ignore_query: true)
       within("#search-results") do
         expect(page).not_to have_content("Get up, Stand up")
       end
@@ -88,13 +88,13 @@ feature 'Admin::Organizations' do
 
     visit admin_organizations_path
     within("#organization_#{organization.id}") do
-      expect(page).to have_current_path(admin_organizations_path, only_path: true)
+      expect(page).to have_current_path(admin_organizations_path, ignore_query: true)
       expect(page).to have_link('Verify')
       expect(page).to have_link('Reject')
 
       click_on 'Verify'
     end
-    expect(page).to have_current_path(admin_organizations_path, only_path: true)
+    expect(page).to have_current_path(admin_organizations_path, ignore_query: true)
     expect(page).to have_content 'Verified'
 
     expect(organization.reload.verified?).to eq(true)
@@ -114,7 +114,7 @@ feature 'Admin::Organizations' do
 
       click_on 'Reject'
     end
-    expect(page).to have_current_path(admin_organizations_path, only_path: true)
+    expect(page).to have_current_path(admin_organizations_path, ignore_query: true)
     expect(page).not_to have_content organization.name
 
     click_on 'Rejected'
@@ -136,7 +136,7 @@ feature 'Admin::Organizations' do
 
       click_on 'Verify'
     end
-    expect(page).to have_current_path(admin_organizations_path, only_path: true)
+    expect(page).to have_current_path(admin_organizations_path, ignore_query: true)
     expect(page).not_to have_content organization.name
     click_on('Verified')
 

--- a/spec/features/admin/poll/questions_spec.rb
+++ b/spec/features/admin/poll/questions_spec.rb
@@ -58,7 +58,7 @@ feature 'Admin poll questions' do
     visit proposals_path
     click_link "Create question"
 
-    expect(page).to have_current_path(new_admin_question_path, only_path: true)
+    expect(page).to have_current_path(new_admin_question_path, ignore_query: true)
     expect(page).to have_field('poll_question_title', with: proposal.title)
 
     select 'Proposals', from: 'poll_question_poll_id'

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -310,7 +310,7 @@ feature 'Ballots' do
       click_link group.name
       # No need to click on the heading name
       expect(page).to have_content("Investment projects with scope: #{heading.name}")
-      expect(page).to have_current_path(budget_investments_path(budget), only_path: true)
+      expect(page).to have_current_path(budget_investments_path(budget), ignore_query: true)
     end
 
     scenario 'Displaying the correct group, heading, count & amount' do

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -95,7 +95,7 @@ feature 'Proposals' do
     fill_in "search", with: "what you got"
     click_button "Search"
 
-    expect(page).to have_current_path(management_proposals_path, only_path: true)
+    expect(page).to have_current_path(management_proposals_path, ignore_query: true)
 
     within(".proposals-list") do
       expect(page).to have_css('.proposal', count: 1)

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -149,7 +149,7 @@ feature 'Poll Officing' do
     end
 
     in_browser(:one) do
-      page.should have_content("Here you can validate user documents and store voting results")
+      expect(page).to have_content("Here you can validate user documents and store voting results")
 
       visit new_officing_residence_path
       select 'DNI', from: 'residence_document_type'
@@ -162,11 +162,11 @@ feature 'Poll Officing' do
       expect(Poll::Voter.where(document_number: '12345678Z', poll_id: poll, origin: 'booth', officer_id: officer1).count).to be(1)
 
       visit final_officing_polls_path
-      page.should have_content("Polls ready for final recounting")
+      expect(page).to have_content("Polls ready for final recounting")
     end
 
     in_browser(:two) do
-      page.should have_content("Here you can validate user documents and store voting results")
+      expect(page).to have_content("Here you can validate user documents and store voting results")
 
       visit new_officing_residence_path
       select 'DNI', from: 'residence_document_type'
@@ -179,7 +179,7 @@ feature 'Poll Officing' do
       expect(Poll::Voter.where(document_number: '12345678Y', poll_id: poll, origin: 'booth', officer_id: officer2).count).to be(1)
 
       visit final_officing_polls_path
-      page.should have_content("Polls ready for final recounting")
+      expect(page).to have_content("Polls ready for final recounting")
     end
   end
 end

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -29,7 +29,7 @@ feature "Voter" do
         expect(page).not_to have_link(answer_yes.title)
       end
 
-      find(:css, ".js-token-message").should be_visible
+      expect(find(:css, ".js-token-message")).to be_visible
       token = find(:css, ".js-question-answer")[:href].gsub(/.+?(?=token)/, '').gsub('token=', '')
 
       expect(page).to have_content "You can write down this vote identifier, to check your vote on the final results: #{token}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,6 +105,8 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  config.expect_with(:rspec) { |c| c.syntax = :expect }
 end
 
 # Parallel build helper configuration for travis


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2287 (This PR closes #2287 once merged)

What
====
* Fixed deprecations warnings related to the old `rspec should` syntax

How
===
* Replaced all occurrences with the new `expect` syntax
* Added a new setting to `spec_helper` to enforce `expect` syntax usage

Test
====
* All green without warnings

Warnings
====
* Tests will fail if `should` syntax is used
* ~~`only_path` deprecation warnings are now taking placing during the test suite. `rspec` dictates it should be replaced with `ignore_query` but doing so breaks several specs.~~
  