### PR TITLE
Budget investments related content

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -41,6 +41,7 @@ module Budgets
     def show
       @commentable = @investment
       @comment_tree = CommentTree.new(@commentable, params[:page], @current_order)
+      @related_contents = Kaminari.paginate_array(@investment.relationed_contents).page(params[:page]).per(5)
       set_comment_flags(@comment_tree.comments)
       load_investment_votes(@investment)
       @investment_ids = [@investment.id]

--- a/app/controllers/related_contents_controller.rb
+++ b/app/controllers/related_contents_controller.rb
@@ -12,7 +12,7 @@ class RelatedContentsController < ApplicationController
       flash[:error] = t('related_content.error', url: Setting['url'])
     end
 
-    redirect_to @relationable
+    redirect_to @relationable.url
   end
 
   def score_positive
@@ -44,8 +44,9 @@ class RelatedContentsController < ApplicationController
       if valid_url?
         url = params[:url]
 
-        related_klass = url.match(/\/(#{RelatedContent::RELATIONABLE_MODELS.join("|")})\//)[0].delete("/")
-        related_id = url.match(/\/[0-9]+/)[0].delete("/")
+        related_klass = url.scan(/\/(#{RelatedContent::RELATIONABLE_MODELS.join("|")})\//)
+                           .flatten.map { |i| i.to_s.singularize.camelize }.join("::")
+        related_id = url.match(/\/(\d+)(?!.*\/\d)/)[1]
 
         @related = related_klass.singularize.camelize.constantize.find_by(id: related_id)
       end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,6 +1,7 @@
 class Budget
   class Investment < ActiveRecord::Base
     require 'csv'
+    include Rails.application.routes.url_helpers
     include Measurable
     include Sanitizable
     include Taggable
@@ -78,6 +79,10 @@ class Budget
     after_save :recalculate_heading_winners if :incompatible_changed?
     before_validation :set_responsible_name
     before_validation :set_denormalized_ids
+
+    def url
+      budget_investment_path(budget, self)
+    end
 
     def self.filter_params(params)
       params.select{|x, _| %w{heading_id group_id administrator_id tag_name valuator_id}.include? x.to_s }

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -1,5 +1,6 @@
 require 'numeric'
 class Debate < ActiveRecord::Base
+  include Rails.application.routes.url_helpers
   include Flaggable
   include Taggable
   include Conflictable
@@ -48,6 +49,10 @@ class Debate < ActiveRecord::Base
   visitable # Ahoy will automatically assign visit_id on create
 
   attr_accessor :link_required
+
+  def url
+    debate_path(self)
+  end
 
   def self.recommendations(user)
     tagged_with(user.interests, any: true)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -1,4 +1,5 @@
 class Proposal < ActiveRecord::Base
+  include Rails.application.routes.url_helpers
   include Flaggable
   include Taggable
   include Conflictable
@@ -70,6 +71,10 @@ class Proposal < ActiveRecord::Base
   scope :unsuccessful,             -> { where("cached_votes_up < ?", Proposal.votes_needed_for_success) }
   scope :public_for_api,           -> { all }
   scope :not_supported_by_user,    ->(user) { where.not(id: user.find_voted_items(votable_type: "Proposal").compact.map(&:id)) }
+
+  def url
+    proposal_path(self)
+  end
 
   def self.recommendations(user)
     tagged_with(user.interests, any: true)

--- a/app/models/related_content.rb
+++ b/app/models/related_content.rb
@@ -1,6 +1,6 @@
 class RelatedContent < ActiveRecord::Base
   RELATED_CONTENT_SCORE_THRESHOLD = Setting['related_content_score_threshold'].to_f
-  RELATIONABLE_MODELS = %w{proposals debates}.freeze
+  RELATIONABLE_MODELS = %w{proposals debates budgets investments}.freeze
 
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -76,6 +76,7 @@
         <p><%= investment.price_explanation %></p>
       <% end %>
 
+      <%= render 'relationable/related_content', relationable: @investment %>
     </div>
 
     <aside class="small-12 medium-3 column">

--- a/app/views/relationable/_related_list.html.erb
+++ b/app/views/relationable/_related_list.html.erb
@@ -7,10 +7,9 @@
           <%= render 'relationable/score', related: related_content %>
         </span>
       <% end %>
-
-      <span class="related-content-title"><%= t("related_content.content_title.#{related.class.name.downcase}") %></span><br>
+      <span class="related-content-title"><%= t("related_content.content_title.#{related.model_name.singular}") %></span><br>
       <h3 class="inline-block">
-        <%= link_to related.title, eval("#{related.class.name.downcase}_path(related)") %>
+        <%= link_to related.title, related.url %>
       </h3>
     </li>
   <% end %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -826,3 +826,4 @@ en:
     content_title:
       proposal: "Proposal"
       debate: "Debate"
+      budget_investment: "Budget investment"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -825,3 +825,4 @@ es:
     content_title:
       proposal: "Propuesta"
       debate: "Debate"
+      budget_investment: "Propuesta de inversión"

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -20,6 +20,7 @@ feature 'Budget Investments' do
 
   context "Concerns" do
     it_behaves_like 'notifiable in-app', Budget::Investment
+    it_behaves_like 'relationable', Budget::Investment
   end
 
   scenario 'Index' do

--- a/spec/shared/features/relationable.rb
+++ b/spec/shared/features/relationable.rb
@@ -1,39 +1,39 @@
 shared_examples "relationable" do |relationable_model_name|
 
-  let(:relationable) { create(relationable_model_name.name.downcase.to_sym) }
-  let(:related1) { create([:proposal, :debate].sample) }
-  let(:related2) { create([:proposal, :debate].sample) }
+  let(:relationable) { create(relationable_model_name.name.parameterize('_').to_sym) }
+  let(:related1) { create([:proposal, :debate, :budget_investment].sample) }
+  let(:related2) { create([:proposal, :debate, :budget_investment].sample) }
   let(:user) { create(:user) }
 
   scenario 'related contents are listed' do
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
-    visit send("#{relationable.class.name.downcase}_path", relationable)
+    visit relationable.url
     within("#related-content-list") do
       expect(page).to have_content(related1.title)
     end
 
-    visit send("#{related1.class.name.downcase}_path", related1)
+    visit related1.url
     within("#related-content-list") do
       expect(page).to have_content(relationable.title)
     end
   end
 
   scenario 'related contents list is not rendered if there are no relations' do
-    visit send("#{relationable.class.name.downcase}_path", relationable)
+    visit relationable.url
     expect(page).not_to have_css("#related-content-list")
   end
 
   scenario 'related contents can be added' do
     login_as(user)
-    visit send("#{relationable.class.name.downcase}_path", relationable)
+    visit relationable.url
 
     expect(page).to have_selector('#related_content', visible: false)
     click_on("Add related content")
     expect(page).to have_selector('#related_content', visible: true)
 
     within("#related_content") do
-      fill_in 'url', with: "#{Setting['url']}/#{related1.class.name.downcase.pluralize}/#{related1.to_param}"
+      fill_in 'url', with: "#{Setting['url'] + related1.url}"
       click_button "Add"
     end
 
@@ -41,14 +41,14 @@ shared_examples "relationable" do |relationable_model_name|
       expect(page).to have_content(related1.title)
     end
 
-    visit send("#{related1.class.name.downcase}_path", related1)
+    visit related1.url
 
     within("#related-content-list") do
       expect(page).to have_content(relationable.title)
     end
 
     within("#related_content") do
-      fill_in 'url', with: "#{Setting['url']}/#{related2.class.name.downcase.pluralize}/#{related2.to_param}"
+      fill_in 'url', with: "#{Setting['url'] + related2.url}"
       click_button "Add"
     end
 
@@ -59,7 +59,7 @@ shared_examples "relationable" do |relationable_model_name|
 
   scenario 'if related content URL is invalid returns error' do
     login_as(user)
-    visit send("#{relationable.class.name.downcase}_path", relationable)
+    visit relationable.url
 
     click_on("Add related content")
 
@@ -75,7 +75,7 @@ shared_examples "relationable" do |relationable_model_name|
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     login_as(user)
-    visit send("#{relationable.class.name.downcase}_path", relationable)
+    visit relationable.url
 
     within("#related-content-list") do
       find("#related-content-#{related_content.opposite_related_content.id}").hover
@@ -92,7 +92,7 @@ shared_examples "relationable" do |relationable_model_name|
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     login_as(user)
-    visit send("#{relationable.class.name.downcase}_path", relationable)
+    visit relationable.url
 
     within("#related-content-list") do
       find("#related-content-#{related_content.opposite_related_content.id}").hover
@@ -117,7 +117,7 @@ shared_examples "relationable" do |relationable_model_name|
 
     login_as(user)
 
-    visit send("#{relationable.class.name.downcase}_path", relationable)
+    visit relationable.url
 
     expect(page).not_to have_css("#related-content-list")
   end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2299

What
====
- Added related contents feature to Budget Investments.
- Adapted the related contents feature to handle namespaced model names (`Budget::Investment`) and simple ones (`Proposal`), and its paths structure.

Screenshots
===========
![localhost_3000_budgets_5_investments_27 laptop with mdpi screen](https://user-images.githubusercontent.com/2141690/34885252-a7991036-f7bf-11e7-851b-b85d1243de52.png)

Tests
======
As usual.