### PR TITLE
Remove deprecated on hold from Budget phase context

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -5,7 +5,6 @@ class Budget < ActiveRecord::Base
 
   PHASES = %w(drafting accepting reviewing selecting valuating publishing_prices
               balloting reviewing_ballots finished).freeze
-  ON_HOLD_PHASES = %w(reviewing valuating publishing_prices reviewing_ballots).freeze
   PUBLISHED_PRICES_PHASES = %w(publishing_prices balloting reviewing_ballots finished).freeze
 
   CURRENCY_SYMBOLS = %w(€ $ £ ¥).freeze
@@ -22,7 +21,6 @@ class Budget < ActiveRecord::Base
 
   before_validation :sanitize_descriptions
 
-  scope :on_hold, -> { where(phase: ON_HOLD_PHASES) }
   scope :drafting, -> { where(phase: "drafting") }
   scope :accepting, -> { where(phase: "accepting") }
   scope :reviewing, -> { where(phase: "reviewing") }
@@ -93,10 +91,6 @@ class Budget < ActiveRecord::Base
 
   def balloting_or_later?
     balloting_process? || finished?
-  end
-
-  def on_hold?
-    ON_HOLD_PHASES.include?(phase)
   end
 
   def current?

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -551,7 +551,7 @@ describe Budget::Investment do
       end
 
       it "rejects selections when selecting is not allowed (via admin setting)" do
-        budget.phase = "on_hold"
+        budget.phase = "reviewing"
         expect(district_sp.reason_for_not_being_selectable_by(user)).to eq(:no_selecting_allowed)
       end
 

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -68,35 +68,6 @@ describe Budget do
       expect(budget).to be_finished
     end
 
-    it "on_hold?" do
-      budget.phase = "drafting"
-      expect(budget).not_to be_on_hold
-
-      budget.phase = "accepting"
-      expect(budget).not_to be_on_hold
-
-      budget.phase = "reviewing"
-      expect(budget).to be_on_hold
-
-      budget.phase = "selecting"
-      expect(budget).not_to be_on_hold
-
-      budget.phase = "valuating"
-      expect(budget).to be_on_hold
-
-      budget.phase = "publishing_prices"
-      expect(budget).to be_on_hold
-
-      budget.phase = "balloting"
-      expect(budget).not_to be_on_hold
-
-      budget.phase = "reviewing_ballots"
-      expect(budget).to be_on_hold
-
-      budget.phase = "finished"
-      expect(budget).not_to be_on_hold
-    end
-
     it "balloting_or_later?" do
       budget.phase = "drafting"
       expect(budget).not_to be_balloting_or_later


### PR DESCRIPTION
What
====
On hold was a Budget phase kind that got deprecated from `on_hold` to a group of possible phase kinds. There is no existing use of the `on_hold` scope or `on_hold?` Budget method.

How
===
Just removing the scope, method and class constant, as well as associated specs.

Screenshots
===========
No need

Test
====
Removed the on_hold check from budget model spec, as well as fixed the budget investment  model spec to use a valid phase kind.

Deployment
==========
As usual

Warnings
========
None