### PR TITLE
deletion ensured of the investment_budget

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -68,7 +68,7 @@ module Budgets
     end
 
     def destroy
-      @investment.destroy
+      @investment.really_destroy!
       redirect_to user_path(current_user, filter: 'budget_investments'), notice: t('flash.actions.destroy.budget_investment')
     end
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -37,10 +37,15 @@ class Budget
     has_many :valuator_group_assignments, dependent: :destroy
     has_many :valuator_groups, through: :valuator_group_assignments
 
-    has_many :comments, -> {where(valuation: false)}, as: :commentable, class_name: 'Comment'
-    has_many :valuations, -> {where(valuation: true)}, as: :commentable, class_name: 'Comment'
+    has_many :comments,   -> { where(valuation: false) }, as: :commentable,
+                                                          class_name: 'Comment',
+                                                          dependent: :destroy
 
-    has_many :milestones
+    has_many :valuations, -> { where(valuation: true) },  as: :commentable,
+                                                          class_name: 'Comment',
+                                                          dependent: :destroy
+
+    has_many :milestones, dependent: :destroy
 
     validates :title, presence: true
     validates :author, presence: true

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -178,6 +178,15 @@
             </div>
           <% end %>
         <% end %>
+
+        <% if can? :destroy, investment %>
+          <div class="sidebar-divider"></div>
+          <p class="sidebar-title"><%= t("budgets.investments.show.author") %></p>
+          <%= link_to t('shared.delete'), budget_investment_path(investment.budget, investment),
+                      method: :delete,
+                      class: "button hollow alert expanded" %>
+        <% end %>
+
         <%= render partial: 'shared/social_share', locals: {
           share_title: t("budgets.investments.show.share"),
           title: investment.title,

--- a/config/locales/fr/budgets.yml
+++ b/config/locales/fr/budgets.yml
@@ -90,6 +90,7 @@ fr:
         supports: Soutiens
         votes: Votes
         price: Coût
+        author: Auteur
       wrong_price_format: Nombres entiers uniquement
       investment:
         title: Proposition d'investissement

--- a/config/locales/nl/budgets.yml
+++ b/config/locales/nl/budgets.yml
@@ -83,6 +83,7 @@ nl:
         title: Begrotingsvoorstel
         supports: Steunt
         votes: Stemmen
+        author: Auteur
       wrong_price_format: Alleen hele nummers
       investment:
         title: Begrotingsvoorstel

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1215,6 +1215,7 @@ feature 'Budget Investments' do
     scenario "Author can destroy while on the accepting phase" do
       user = create(:user, :level_two)
       sp1 = create(:budget_investment, heading: heading, price: 10000, author: user)
+      budget_investment_count = Budget::Investment.count
 
       login_as(user)
       visit user_path(user, tab: :budget_investments)
@@ -1225,6 +1226,9 @@ feature 'Budget Investments' do
       end
 
       visit user_path(user, tab: :budget_investments)
+
+      expect(Budget::Investment.count).to eq (budget_investment_count - 1)
+
     end
   end
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1230,6 +1230,74 @@ feature 'Budget Investments' do
       expect(Budget::Investment.count).to eq (budget_investment_count - 1)
 
     end
+
+  end
+
+  context "Check delete links" do
+
+    let(:author)  { create(:user, :level_two) }
+    let(:user)  { create(:user, :level_two) }
+    let(:budget)  { create(:budget) }
+    let(:investment) { create(:budget_investment, author: author, budget: budget) }
+    let(:delete_phases) { ['accepting','reviewing'] }
+
+    scenario 'Check delete links on budget_investment_path' do
+      login_as(author)
+      Budget::Phase::PHASE_KINDS.each do |phase|
+        investment.budget.update(phase: phase)
+
+        visit budget_investment_path(investment.budget, investment)
+
+        if delete_phases.include? phase
+          expect(page).to have_content I18n.t("shared.delete")
+        else
+          expect(page).not_to have_content I18n.t("shared.delete")
+        end
+      end
+    end
+
+    scenario 'Check delete links not showing on not owned public investments on
+              budget_investment_path' do
+      login_as(user)
+
+      Budget::Phase::PHASE_KINDS.each do |phase|
+        investment.budget.update(phase: phase)
+
+        visit budget_investment_path(investment.budget, investment)
+
+        expect(page).not_to have_content I18n.t("shared.delete")
+      end
+    end
+
+    scenario 'Display budget investment with link to delete when its
+              possible on user_path' do
+      login_as(author)
+      Budget::Phase::PHASE_KINDS.each do |phase|
+        investment.budget.update(phase: phase)
+
+        visit user_path(author, filter: "budget_investments")
+
+        if delete_phases.include? phase
+          expect(page).to have_content I18n.t("shared.delete")
+        else
+          expect(page).not_to have_content I18n.t("shared.delete")
+        end
+      end
+
+    end
+
+    scenario 'Check delete links not showing on not owned public investments on
+              user_path' do
+      login_as(user)
+
+      Budget::Phase::PHASE_KINDS.each do |phase|
+        investment.budget.update(phase: phase)
+
+        visit user_path(author, filter: "budget_investments")
+
+        expect(page).not_to have_content I18n.t("shared.delete")
+      end
+    end
   end
 
   context "Selecting Phase" do

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -1123,4 +1123,29 @@ describe Budget::Investment do
     end
 
   end
+
+  describe "Delete" do
+
+    it "correctly destroy all associated objects" do
+      user = create(:user, :level_two)
+      sp1 = create(:budget_investment, price: 10000, author: user)
+
+      sp1.milestones << create(:budget_investment_milestone)
+      sp1.comments << create(:comment)
+      create(:valuator, user: user, description: 'Valuators')
+      Budget::ValuatorAssignment.create(investment_id: sp1.id, valuator_id: user.valuator.id)
+
+      comments_size = Comment.count
+      milestones_size = Budget::Investment::Milestone.count
+      valuator_assignments_size = Budget::ValuatorAssignment.count
+
+      sp1.destroy
+
+      expect(Comment.count).to eq (comments_size - 1)
+      expect(Budget::Investment::Milestone.count).to eq (milestones_size - 1)
+      expect(Budget::ValuatorAssignment.count).to eq (valuator_assignments_size - 1)
+
+    end
+
+  end
 end


### PR DESCRIPTION
## References

* Closes #2301

## Objectives

* Ensure the deletion of an investment_budget and all of its associated objects

## How

* I added dependent: :destroy for comments in the investment model and changed  @investment.destroy to @investment.really_destroy! in the controller (I didn't want to  change act_as_paranoid)

## Visual changes

- ![screenshot from 2018-01-15 09 34 56](https://user-images.githubusercontent.com/33748390/34933512-69b53550-f9d7-11e7-8507-1ced47d880a7.png)

- ![screenshot from 2018-01-15 09 35 09](https://user-images.githubusercontent.com/33748390/34933513-69cfa368-f9d7-11e7-8b30-286fef0016a5.png)