### PR TITLE
Change concept of current budget to account for multiple budgets

### DIFF
--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -2,7 +2,7 @@ class Admin::BudgetsController < Admin::BaseController
   include FeatureFlags
   feature_flag :budgets
 
-  has_filters %w{current finished}, only: :index
+  has_filters %w{open finished}, only: :index
 
   load_and_authorize_resource
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,7 @@ class ApplicationController < ActionController::Base
 
   layout :set_layout
   respond_to :html
+  helper_method :current_budget
 
   private
 
@@ -119,5 +120,9 @@ class ApplicationController < ActionController::Base
       if @budget.try(:balloting?)
         params[:filter] ||= "selected"
       end
+    end
+
+    def current_budget
+      Budget.current
     end
 end

--- a/app/controllers/management/budgets_controller.rb
+++ b/app/controllers/management/budgets_controller.rb
@@ -19,7 +19,7 @@ class Management::BudgetsController < Management::BaseController
   end
 
   def print_investments
-    @budgets = Budget.current.order(created_at: :desc).page(params[:page])
+    @budget = Budget.current
   end
 
   private

--- a/app/controllers/valuation/budgets_controller.rb
+++ b/app/controllers/valuation/budgets_controller.rb
@@ -5,10 +5,10 @@ class Valuation::BudgetsController < Valuation::BaseController
   load_and_authorize_resource
 
   def index
-    @budgets = @budgets.current.order(created_at: :desc).page(params[:page])
-    @investments_with_valuation_open = {}
-    @budgets.each do |b|
-      @investments_with_valuation_open[b.id] = b.investments
+    @budget = Budget.current
+    if @budget.present?
+      @investments_with_valuation_open = {}
+      @investments_with_valuation_open = @budget.investments
                                                 .by_valuator(current_user.valuator.try(:id))
                                                 .valuation_open
                                                 .count

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -31,7 +31,9 @@ class Budget < ActiveRecord::Base
   scope :reviewing_ballots, -> { where(phase: "reviewing_ballots") }
   scope :finished, -> { where(phase: "finished") }
 
-  scope :current, -> { where.not(phase: "finished") }
+  def self.current
+    where.not(phase: "drafting").last
+  end
 
   def description
     send("description_#{phase}").try(:html_safe)
@@ -91,10 +93,6 @@ class Budget < ActiveRecord::Base
 
   def balloting_or_later?
     balloting_process? || finished?
-  end
-
-  def current?
-    !finished?
   end
 
   def heading_price(heading)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -30,6 +30,7 @@ class Budget < ActiveRecord::Base
   scope :balloting, -> { where(phase: "balloting") }
   scope :reviewing_ballots, -> { where(phase: "reviewing_ballots") }
   scope :finished, -> { where(phase: "finished") }
+  scope :open, -> { where.not(phase: "finished") }
 
   def self.current
     where.not(phase: "drafting").last

--- a/app/views/management/budgets/print_investments.html.erb
+++ b/app/views/management/budgets/print_investments.html.erb
@@ -1,12 +1,10 @@
 <table>
-<% @budgets.each do |budget| %>
-  <tr id="<%= dom_id(budget) %>">
-    <td><%= budget.name %></td>
-    <td><%= budget.translated_phase %></td>
+  <tr id="<%= dom_id(@budget) %>">
+    <td><%= @budget.name %></td>
+    <td><%= @budget.translated_phase %></td>
     <td align="right">
       <%= link_to t("management.budgets.print_investments"),
-        print_management_budget_investments_path(budget) %>
+        print_management_budget_investments_path(@budget) %>
     </td>
   </tr>
-<% end %>
 </table>

--- a/app/views/valuation/budgets/index.html.erb
+++ b/app/views/valuation/budgets/index.html.erb
@@ -1,7 +1,5 @@
 <h2 class="inline-block"><%= t("valuation.budgets.index.title") %></h2>
 
-<h3><%= page_entries_info @budgets %></h3>
-
 <table>
   <thead>
     <tr>
@@ -12,25 +10,21 @@
     </tr>
   </thead>
   <tbody>
-    <% @budgets.each do |budget| %>
-      <tr id="<%= dom_id(budget) %>" class="budget">
-        <td>
-          <%= budget.name %>
-        </td>
-        <td>
-          <%= t("budgets.phase.#{budget.phase}") %>
-        </td>
-        <td>
-          <%= @investments_with_valuation_open[budget.id] %>
-        </td>
-        <td>
-          <%= link_to t("valuation.budgets.index.evaluate"),
-                      valuation_budget_budget_investments_path(budget_id: budget.id),
-                      class: "button hollow expanded" %>
-        </td>
-      </tr>
-    <% end %>
+    <tr id="<%= dom_id(@budget) %>" class="budget">
+      <td>
+        <%= @budget.name %>
+      </td>
+      <td>
+        <%= t("budgets.phase.#{@budget.phase}") %>
+      </td>
+      <td>
+        <%= @investments_with_valuation_open %>
+      </td>
+      <td>
+        <%= link_to t("valuation.budgets.index.evaluate"),
+                    valuation_budget_budget_investments_path(budget_id: @budget.id),
+                    class: "button hollow expanded" %>
+      </td>
+    </tr>
   </tbody>
 </table>
-
-<%= paginate @budgets %>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe ApplicationController do
+
+  describe "#current_budget" do
+
+    it "returns the last budget that is not in draft phase" do
+      old_budget      = create(:budget, phase: "finished",  created_at: 2.years.ago)
+      previous_budget = create(:budget, phase: "accepting", created_at: 1.year.ago)
+      current_budget  = create(:budget, phase: "accepting", created_at: 1.month.ago)
+      next_budget     = create(:budget, phase: "drafting",  created_at: 1.week.ago)
+
+      budget = subject.instance_eval{ current_budget }
+      expect(budget).to eq(current_budget)
+    end
+
+  end
+
+end

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -259,9 +259,10 @@ feature 'Budget Investments' do
   context "Printing" do
 
     scenario 'Printing budget investments' do
-      16.times { create(:budget_investment, budget: @budget) }
+      16.times { create(:budget_investment, budget: @budget, heading: @heading) }
 
       click_link "Print Budget Investments"
+
       expect(page).to have_content(@budget.name)
       within "#budget_#{@budget.id}" do
         click_link "Print Budget Investments"
@@ -273,15 +274,17 @@ feature 'Budget Investments' do
 
     scenario "Filtering budget investments by heading to be printed", :js do
       district_9 = create(:budget_heading, group: @group, name: "District Nine")
+      another_heading = create(:budget_heading, group: @group)
       low_investment = create(:budget_investment, budget: @budget, title: 'Nuke district 9', heading: district_9, cached_votes_up: 1)
       mid_investment = create(:budget_investment, budget: @budget, title: 'Change district 9', heading: district_9, cached_votes_up: 10)
       top_investment = create(:budget_investment, budget: @budget, title: 'Destroy district 9', heading: district_9, cached_votes_up: 100)
-      unvoted_investment = create(:budget_investment, budget: @budget, title: 'Add new districts to the city')
+      unvoted_investment = create(:budget_investment, budget: @budget, heading: another_heading, title: 'Add new districts to the city')
 
       user = create(:user, :level_two)
       login_managed_user(user)
 
       click_link "Print Budget Investments"
+
       expect(page).to have_content(@budget.name)
       within "#budget_#{@budget.id}" do
         click_link "Print Budget Investments"

--- a/spec/features/valuation/budgets_spec.rb
+++ b/spec/features/valuation/budgets_spec.rb
@@ -24,18 +24,15 @@ feature 'Valuation budgets' do
     end
 
     scenario 'Filters by phase' do
-      budget1 = create(:budget)
-      budget2 = create(:budget, :accepting)
-      budget3 = create(:budget, :selecting)
-      budget4 = create(:budget, :balloting)
-      budget5 = create(:budget, :finished)
+      budget1 = create(:budget, :finished)
+      budget2 = create(:budget, :finished)
+      budget3 = create(:budget, :accepting)
 
       visit valuation_budgets_path
-      expect(page).to have_content(budget1.name)
-      expect(page).to have_content(budget2.name)
+
+      expect(page).to_not have_content(budget1.name)
+      expect(page).to_not have_content(budget2.name)
       expect(page).to have_content(budget3.name)
-      expect(page).to have_content(budget4.name)
-      expect(page).not_to have_content(budget5.name)
     end
 
   end

--- a/spec/features/valuation_spec.rb
+++ b/spec/features/valuation_spec.rb
@@ -66,6 +66,8 @@ feature 'Valuation' do
 
   scenario 'Access as a valuator is authorized' do
     create(:valuator, user: user)
+    create(:budget)
+
     login_as(user)
     visit root_path
 
@@ -78,6 +80,8 @@ feature 'Valuation' do
 
   scenario 'Access as an administrator is authorized' do
     create(:administrator, user: user)
+    create(:budget)
+
     login_as(user)
     visit root_path
 
@@ -90,6 +94,8 @@ feature 'Valuation' do
 
   scenario "Valuation access links" do
     create(:valuator, user: user)
+    create(:budget)
+
     login_as(user)
     visit root_path
 
@@ -100,6 +106,8 @@ feature 'Valuation' do
 
   scenario 'Valuation dashboard' do
     create(:valuator, user: user)
+    create(:budget)
+
     login_as(user)
     visit root_path
 

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -123,6 +123,18 @@ describe Budget do
 
   end
 
+  describe "#open" do
+
+    it "returns all budgets that are not in the finished phase" do
+      phases = Budget::PHASES - ["finished"]
+      phases.each do |phase|
+        budget = create(:budget, phase: phase)
+        expect(Budget.open).to include(budget)
+      end
+    end
+
+  end
+
   describe "heading_price" do
     let(:budget) { create(:budget) }
     let(:group) { create(:budget_group, budget: budget) }

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -98,6 +98,31 @@ describe Budget do
     end
   end
 
+  describe "#current" do
+
+    it "returns nil if there is only one budget and it is still in drafting phase" do
+      budget = create(:budget, phase: "drafting")
+
+      expect(Budget.current).to eq(nil)
+    end
+
+    it "returns the budget if there is only one and not in drafting phase" do
+      budget = create(:budget, phase: "accepting")
+
+      expect(Budget.current).to eq(budget)
+    end
+
+    it "returns the last budget created that is not in drafting phase" do
+      old_budget      = create(:budget, phase: "finished",  created_at: 2.years.ago)
+      previous_budget = create(:budget, phase: "accepting", created_at: 1.year.ago)
+      current_budget  = create(:budget, phase: "accepting", created_at: 1.month.ago)
+      next_budget     = create(:budget, phase: "drafting",  created_at: 1.week.ago)
+
+      expect(Budget.current).to eq(current_budget)
+    end
+
+  end
+
   describe "heading_price" do
     let(:budget) { create(:budget) }
     let(:group) { create(:budget_group, budget: budget) }


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2317

What
====
- Add `currrent_budget` helper for controllers and views
- The `current_budget` helper takes into account that the current budget is the last budget created
- It also takes into account, that it's possible to have a budget in drafting phase, in which case, the `current_budget` is really the previous budget if it exists or nil otherwise
- Refactor Management and Valuator controllers and views to display only the `current_budget` 
- Add scope `Budget.open` to represent, budgets that are not finished. This substitutes the old `Budget.current` implementation and it's used only in the admin budget's index view, which has two tabs _open budgets_ and _finished_budgets_ (see screenshot)

How
===
- Adding a private method `current_budget` to the ApplicationController and making it accessible to views
- Refactoring existing concept of Budget.current

Screenshots
===========
- Admin budget's index
![admin budget s index](https://user-images.githubusercontent.com/4169/34959110-229e77ae-fa35-11e7-9755-5a56307c7e95.png)


Test
====
- Added unit and controller specs for `current_budget` and `Budget.open`

Deployment
==========
- As usual

Warnings
========
- None
