### PR TITLE
Investment report alert

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -74,6 +74,7 @@
 //= require polls
 //= require sortable
 //= require table_sortable
+//= require investment_report_alert
 
 var initialize_modules = function() {
   App.Comments.initialize();
@@ -115,6 +116,7 @@ var initialize_modules = function() {
   App.Polls.initialize();
   App.Sortable.initialize();
   App.TableSortable.initialize();
+  App.InvestmentReportAlert.initialize();
 };
 
 $(function(){

--- a/app/assets/javascripts/investment_report_alert.js.coffee
+++ b/app/assets/javascripts/investment_report_alert.js.coffee
@@ -1,0 +1,7 @@
+App.InvestmentReportAlert =
+  initialize: ->
+    $('#js-investment-report-alert').on 'click', ->
+      if this.checked && $('#budget_investment_feasibility_unfeasible').is(':checked')
+        confirm(this.dataset.alert + "\n" + this.dataset.notFeasibleAlert);
+      else if this.checked
+        confirm(this.dataset.alert);

--- a/app/views/valuation/budget_investments/edit.html.erb
+++ b/app/views/valuation/budget_investments/edit.html.erb
@@ -79,7 +79,11 @@
   <div class="row">
     <div class="small-12 medium-8 column">
       <%= f.label :valuation_finished do %>
-        <%= f.check_box :valuation_finished, title: t('valuation.budget_investments.edit.valuation_finished'), label: false %>
+        <%= f.check_box :valuation_finished,
+            title: t('valuation.budget_investments.edit.valuation_finished'),
+            label: false, id: 'js-investment-report-alert',
+            "data-alert": t("valuation.budget_investments.edit.valuation_finished_alert"),
+            "data-not-feasible-alert": t("valuation.budget_investments.edit.not_feasible_alert") %>
         <span class="checkbox"><%= t("valuation.budget_investments.edit.valuation_finished") %></span>
       <% end %>
     </div>

--- a/config/locales/en/valuation.yml
+++ b/config/locales/en/valuation.yml
@@ -68,6 +68,8 @@ en:
         undefined_feasible: Pending
         feasible_explanation_html: Feasibility explanation
         valuation_finished: Valuation finished
+        valuation_finished_alert: "Are you sure you want to mark this report as completed? If you do it, it can no longer be modified."
+        not_feasible_alert: "An email will be sent immediately to the author of the project with the report of unfeasibility."
         duration_html: Time scope
         internal_comments_html: Internal comments
         save: Save changes

--- a/config/locales/es/valuation.yml
+++ b/config/locales/es/valuation.yml
@@ -68,6 +68,8 @@ es:
         undefined_feasible: Sin decidir
         feasible_explanation_html: Informe de inviabilidad <small>(en caso de que lo sea, dato público)</small>
         valuation_finished: Informe finalizado
+        valuation_finished_alert: "¿Estás seguro/a de querer marcar este informe como completado? Una vez hecho, no se puede deshacer la acción."
+        not_feasible_alert: "Un email será enviado inmediatamente al autor del proyecto con el informe de inviabilidad."
         duration_html: Plazo de ejecución <small>(opcional, dato no público)</small>
         internal_comments_html: Comentarios y observaciones <small>(para responsables internos, dato no público)</small>
         save: Guardar Cambios

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -508,6 +508,50 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content "Refugees, Solidarity"
     end
 
+    scenario "Shows alert when 'Valuation finished' is checked", :js do
+      budget_investment = create(:budget_investment)
+
+      visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
+      click_link 'Edit dossier'
+
+      expect(page).to have_content 'Valuation finished'
+
+      find_field('budget_investment[valuation_finished]').click
+
+      page.accept_confirm("Are you sure you want to mark this report as completed? If you do it, it can no longer be modified.")
+
+      expect(page).to have_field('budget_investment[valuation_finished]', checked: true)
+    end
+
+    scenario "Shows alert with unfeasible status when 'Valuation finished' is checked", :js do
+      budget_investment = create(:budget_investment)
+
+      visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
+      click_link 'Edit dossier'
+
+      expect(page).to have_content 'Valuation finished'
+
+      find_field('budget_investment_feasibility_unfeasible').click
+      find_field('budget_investment[valuation_finished]').click
+
+      page.accept_confirm("Are you sure you want to mark this report as completed? If you do it, it can no longer be modified.\nAn email will be sent immediately to the author of the project with the report of unfeasibility.")
+
+      expect(page).to have_field('budget_investment[valuation_finished]', checked: true)
+    end
+
+    scenario "Undoes check in 'Valuation finished' if user clicks 'cancel' on alert", :js do
+      budget_investment = create(:budget_investment)
+
+      visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
+      click_link 'Edit dossier'
+
+      dismiss_confirm do
+        find_field('budget_investment[valuation_finished]').click
+      end
+
+      expect(page).to have_field('budget_investment[valuation_finished]', checked: false)
+    end
+
     scenario "Errors on update" do
       budget_investment = create(:budget_investment)
 

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -396,7 +396,7 @@ feature 'Emails' do
 
       choose 'budget_investment_feasibility_unfeasible'
       fill_in 'budget_investment_unfeasibility_explanation', with: 'This is not legal as stated in Article 34.9'
-      check 'budget_investment_valuation_finished'
+      find_field('budget_investment[valuation_finished]').click
       click_button 'Save changes'
 
       expect(page).to have_content "Dossier updated"

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -345,7 +345,7 @@ feature 'Valuation budget investments' do
       visit valuation_budget_budget_investment_path(@budget, @investment)
       click_link 'Edit dossier'
 
-      check 'budget_investment_valuation_finished'
+      find_field('budget_investment[valuation_finished]').click
       click_button 'Save changes'
 
       visit valuation_budget_budget_investments_path(@budget)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2308

What
====
Added browser alerts for a budget evaluators after they check "Valuation finished" in the "Edit dossier" investments' section.

If the user clicks on 'Cancel' in the alert, the checkbox will not be marked as checked.

~Screenshots~ GIF 😎 
===========
![untitled](https://user-images.githubusercontent.com/2141690/34982310-5a0398da-faaa-11e7-81de-fd7735765030.gif)


Test
====
As usual.
