### PR TITLE
Add current_budget to management controllers

### DIFF
--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -5,6 +5,7 @@ class Management::BaseController < ActionController::Base
   before_action :set_locale
 
   helper_method :managed_user
+  helper_method :current_user
 
   private
 
@@ -40,4 +41,7 @@ class Management::BaseController < ActionController::Base
       I18n.locale = session[:locale]
     end
 
+    def current_budget
+      Budget.current
+    end
 end

--- a/app/controllers/management/budgets_controller.rb
+++ b/app/controllers/management/budgets_controller.rb
@@ -19,7 +19,7 @@ class Management::BudgetsController < Management::BaseController
   end
 
   def print_investments
-    @budget = Budget.current
+    @budget = current_budget
   end
 
   private

--- a/app/controllers/valuation/budgets_controller.rb
+++ b/app/controllers/valuation/budgets_controller.rb
@@ -5,7 +5,7 @@ class Valuation::BudgetsController < Valuation::BaseController
   load_and_authorize_resource
 
   def index
-    @budget = Budget.current
+    @budget = current_budget
     if @budget.present?
       @investments_with_valuation_open = {}
       @investments_with_valuation_open = @budget.investments

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -33,7 +33,7 @@ class Budget < ActiveRecord::Base
   scope :open, -> { where.not(phase: "finished") }
 
   def self.current
-    where.not(phase: "drafting").last
+    where.not(phase: "drafting").order(:created_at).last
   end
 
   def description


### PR DESCRIPTION
Where
=====
* **Related PR's:** https://github.com/consul/consul/pull/2322

What
====
- Use `current_budget` helper instead of `Budget.current` method in controllers
- Order budgets by `created_at` instead of by `id` in `Budget.current` scope

Why
===
- Using current_budget for consistency throughout controllers and views
- Regarding the ordering by `created_at` instead of by `id`:

It's is a preventive change which will be useful once the rake to
migrate from `spending_proposals` to `budget_investments` is complete

As after running that migration, old `spending_proposal` budgets will
have a newer `id` than the existing budgets. And therefore the last
budget will be one of those migrated from the old `spending_proposal`
model

By ordering by `created_at` and probably updating the `created_at`
attribute in the rake that migrates `spending_proposals` to
`budget_investments`, we will have a coherent order for budgets

How
===
- Duplicating current_budget method in the management_base_controller.
  Seems a little overkill to create reusable concern for just one method

Test
====
- Not needed

Deployment
==========
- As usual

Warnings
========
- If you are an early adopter and have adventured into running the [partially complete rake task](https://github.com/consul/consul/issues/1593) to migrate `spending_proposals` to `budget_investments`, update the `created_at` attribute of the migrated budgets to the real date when the budget started to get the ordering :ok_hand: 
