### PR TITLE
Budgets phases front

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1472,6 +1472,63 @@
   }
 }
 
+.budget-timeline {
+  border-left: 3px solid $budget;
+  margin-left: $line-height / 2;
+  padding: $line-height $line-height / 2;
+
+  h3,
+  span,
+  p {
+    padding: 0 $line-height / 4;
+  }
+
+  h3 {
+    margin-bottom: 0;
+  }
+
+  span {
+    color: $text-medium;
+    display: block;
+    font-size: $small-font-size;
+    margin-bottom: $line-height / 2;
+  }
+
+  .phase {
+    position: relative;
+
+    &:not(:first-child) {
+      margin-top: $line-height * 1.5;
+    }
+
+    &::before {
+      background-color: #fff;
+      border: 4px solid $budget;
+      border-radius: 100%;
+      content: '';
+      height: 16px;
+      left: -22px;
+      position: absolute;
+      top: 6px;
+      width: 16px;
+      z-index: 99;
+    }
+
+    &.active {
+
+      h3 {
+        background: $budget;
+        color: white;
+        display: inline-block;
+      }
+
+      &::before {
+        background-color: $budget;
+      }
+    }
+  }
+}
+
 // 07. Proposals successful
 // -------------------------
 

--- a/app/helpers/text_with_links_helper.rb
+++ b/app/helpers/text_with_links_helper.rb
@@ -7,6 +7,7 @@ module TextWithLinksHelper
   end
 
   def safe_html_with_links(html)
+    return if html.nil?
     return html.html_safe unless html.html_safe?
     Rinku.auto_link(html, :all, 'target="_blank" rel="nofollow"').html_safe
   end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -41,7 +41,7 @@ class Budget < ActiveRecord::Base
   end
 
   def published_phases
-    phases.published
+    phases.published.order(:id)
   end
 
   def description

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -56,7 +56,7 @@ class Budget
     end
 
     def step_number
-      budget.published_phases.order(:id).index(self) + 1 || 0
+      budget.published_phases.index(self) + 1 || 0
     end
 
     private

--- a/app/views/budgets/_phases.html.erb
+++ b/app/views/budgets/_phases.html.erb
@@ -1,15 +1,11 @@
 <ul class="no-bullet budget-timeline">
-  <% @budget.phases.published.each do |phase| %>
+  <% @budget.published_phases.each do |phase| %>
     <li class="phase <%= 'active' if phase == @budget.current_phase %>">
       <h3><%= t("budgets.phase.#{phase.kind}") %></h3>
       <span>
-        <% if phase.starts_at.to_date.present? %>
-          <%= format_date(phase.starts_at) %>
-        <% end %>
+        <%= format_date(phase.starts_at) if phase.starts_at.present? %>
         -
-        <% if phase.ends_at.to_date.present? %>
-          <%= format_date(phase.ends_at) %>
-        <% end %>
+        <%= format_date(phase.ends_at - 1.day) if phase.ends_at.present? %>
       </span>
       <p><%= phase.summary %></p>
     </li>

--- a/app/views/budgets/_phases.html.erb
+++ b/app/views/budgets/_phases.html.erb
@@ -1,0 +1,17 @@
+<ul class="no-bullet budget-timeline">
+  <% @budget.phases.published.each do |phase| %>
+    <li class="phase <%= 'active' if phase == @budget.current_phase %>">
+      <h3><%= t("budgets.phase.#{phase.kind}") %></h3>
+      <span>
+        <% if phase.starts_at.to_date.present? %>
+          <%= format_date(phase.starts_at) %>
+        <% end %>
+        -
+        <% if phase.ends_at.to_date.present? %>
+          <%= format_date(phase.ends_at) %>
+        <% end %>
+      </span>
+      <p><%= phase.summary %></p>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -121,7 +121,7 @@
                 <div class="row" data-equalizer data-equalizer-on="medium">
                   <div class="small-12 medium-9 column" data-equalizer-watch>
                     <h3><%= budget.name %></h3>
-                    <%= budget.description %>
+                    <%= safe_html_with_links(budget.description) %>
                   </div>
                   <div class="small-12 medium-3 column table" data-equalizer-watch>
                     <div class="table-cell align-middle">

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -10,7 +10,9 @@
         <h1><%= @budget.name %></h1>
 
         <%= safe_html_with_links(@budget.description) %>
-        <%= link_to t("budgets.index.section_header.help"), "#section_help" %>
+        <p>
+          <%= link_to t("budgets.index.section_header.help"), "#section_help" %>
+        </p>
       </div>
       <div class="small-12 medium-3 column info padding" data-equalizer-watch>
         <p>
@@ -94,10 +96,7 @@
 
       <div id="all_phases">
         <h2><%= t("budgets.index.all_phases") %></h2>
-        <!--
-          Pending to include here the list of phases from
-          https://github.com/consul/consul/issues/2289
-        -->
+        <%= render "phases" %>
       </div>
     </div>
   </div>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -119,11 +119,11 @@
             <div class="budget-investment clear">
               <div class="panel">
                 <div class="row" data-equalizer data-equalizer-on="medium">
-                  <div class="small-9 column" data-equalizer-watch>
+                  <div class="small-12 medium-9 column" data-equalizer-watch>
                     <h3><%= budget.name %></h3>
                     <%= budget.description %>
                   </div>
-                  <div class="small-3 column table" data-equalizer-watch>
+                  <div class="small-12 medium-3 column table" data-equalizer-watch>
                     <div class="table-cell align-middle">
                       <%= link_to t("budgets.index.see_results"),
                                   budget_results_path(budget.id),

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -16,8 +16,8 @@
       </div>
       <div class="small-12 medium-3 column info padding" data-equalizer-watch>
         <p>
-          <% steps_progress = "(#{current_phase.step_number}/#{@budget.published_phases.count})" %>
-          <strong><%= t('budgets.show.phase') %> <%= steps_progress %></strong>
+          <% steps = "(#{@budget.current_phase.step_number}/#{@budget.published_phases.count})" %>
+          <strong><%= t('budgets.show.phase') %> <%= steps %></strong>
         </p>
         <h2><%= t("budgets.phase.#{@budget.phase}") %></h2>
 

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -99,13 +99,13 @@ feature 'Budgets' do
     expect(page).not_to have_content "11 Mar 2018 - 20 Mar 2018'"
 
     expect(page).to have_content "This is the summary for accepting phase"
-    expect(page).to have_content "01 Jan 2018 - 21 Jan 2018"
+    expect(page).to have_content "01 Jan 2018 - 20 Jan 2018"
     expect(page).to have_content "This is the summary for selecting phase"
-    expect(page).to have_content "21 Jan 2018 - 02 Mar 2018"
+    expect(page).to have_content "21 Jan 2018 - 01 Mar 2018"
     expect(page).to have_content "This is the summary for balloting phase"
-    expect(page).to have_content "02 Mar 2018 - 21 Mar 2018"
+    expect(page).to have_content "02 Mar 2018 - 20 Mar 2018"
     expect(page).to have_content "This is the summary for finished phase"
-    expect(page).to have_content "21 Mar 2018 - 30 Mar 2018"
+    expect(page).to have_content "21 Mar 2018 - 29 Mar 2018"
 
     expect(page).to have_css(".phase.active", count: 1)
   end

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -45,6 +45,71 @@ feature 'Budgets' do
     end
   end
 
+  scenario 'Index shows only published phases' do
+
+    budget.update(phase: :finished)
+
+    budget.phases.drafting.update(starts_at: '30-12-2017', ends_at: '31-12-2017', enabled: true,
+                                  description: 'Description of drafting phase',
+                                  summary: 'This is the summary for drafting phase')
+
+    budget.phases.accepting.update(starts_at: '01-01-2018', ends_at: '10-01-2018', enabled: true,
+                                   description: 'Description of accepting phase',
+                                   summary: 'This is the summary for accepting phase')
+
+    budget.phases.reviewing.update(starts_at: '11-01-2018', ends_at: '20-01-2018', enabled: false,
+                                   description: 'Description of reviewing phase',
+                                   summary: 'This is the summary for reviewing phase')
+
+    budget.phases.selecting.update(starts_at: '21-01-2018', ends_at: '01-02-2018', enabled: true,
+                                   description: 'Description of selecting phase',
+                                   summary: 'This is the summary for selecting phase')
+
+    budget.phases.valuating.update(starts_at: '10-02-2018', ends_at: '20-02-2018', enabled: false,
+                                   description: 'Description of valuating phase',
+                                   summary: 'This is the summary for valuating phase')
+
+    budget.phases.publishing_prices.update(starts_at: '21-02-2018', ends_at: '01-03-2018', enabled: false,
+                                           description: 'Description of publishing prices phase',
+                                           summary: 'This is the summary for publishing_prices phase')
+
+    budget.phases.balloting.update(starts_at: '02-03-2018', ends_at: '10-03-2018', enabled: true,
+                                   description: 'Description of balloting phase',
+                                   summary: 'This is the summary for balloting phase')
+
+    budget.phases.reviewing_ballots.update(starts_at: '11-03-2018', ends_at: '20-03-2018', enabled: false,
+                                           description: 'Description of reviewing ballots phase',
+                                           summary: 'This is the summary for reviewing_ballots phase')
+
+    budget.phases.finished.update(starts_at: '21-03-2018', ends_at: '30-03-2018', enabled: true,
+                                  description: 'Description of finished phase',
+                                  summary: 'This is the summary for finished phase')
+
+    visit budgets_path
+
+    expect(page).not_to have_content "This is the summary for drafting phase"
+    expect(page).not_to have_content "30 Dec 2017 - 31 Dec 2017"
+    expect(page).not_to have_content "This is the summary for reviewing phase"
+    expect(page).not_to have_content "11 Jan 2018 - 20 Jan 2018"
+    expect(page).not_to have_content "This is the summary for valuating phase"
+    expect(page).not_to have_content "10 Feb 2018 - 20 Feb 2018"
+    expect(page).not_to have_content "This is the summary for publishing_prices phase"
+    expect(page).not_to have_content "21 Feb 2018 - 01 Mar 2018"
+    expect(page).not_to have_content "This is the summary for reviewing_ballots phase"
+    expect(page).not_to have_content "11 Mar 2018 - 20 Mar 2018'"
+
+    expect(page).to have_content "This is the summary for accepting phase"
+    expect(page).to have_content "01 Jan 2018 - 21 Jan 2018"
+    expect(page).to have_content "This is the summary for selecting phase"
+    expect(page).to have_content "21 Jan 2018 - 02 Mar 2018"
+    expect(page).to have_content "This is the summary for balloting phase"
+    expect(page).to have_content "02 Mar 2018 - 21 Mar 2018"
+    expect(page).to have_content "This is the summary for finished phase"
+    expect(page).to have_content "21 Mar 2018 - 30 Mar 2018"
+
+    expect(page).to have_css(".phase.active", count: 1)
+  end
+
   context 'Show' do
 
     scenario "List all groups" do


### PR DESCRIPTION
Where
=====
This PR closes https://github.com/consul/consul/issues/2289

What
====
- Include a new `_phases` partial on `budgets/index` page to show the info text of each enabled phase.

Screenshots
===========
![screen shot 2018-01-18 at 17 20 02](https://user-images.githubusercontent.com/983242/35108437-de048fa2-fc73-11e7-82c4-766e8417fc4e.jpg)
