### PR TITLE
Add intermediate page to choose between creating a proposal or an investment

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -9,6 +9,7 @@
 // 07. Proposals successful
 // 08. Polls
 // 09. Polls results and stats
+// 10. Guides
 //
 
 // 01. Votes and supports
@@ -1941,5 +1942,96 @@
     font-size: rem-calc(60);
     font-weight: bold;
     line-height: rem-calc(60);
+  }
+}
+
+// 10. Guides
+// ----------------------
+
+.guides {
+
+  h2 {
+    margin: $line-height 0 $line-height * 2;
+  }
+
+  .guide-budget,
+  .guide-proposal {
+    border-radius: rem-calc(3);
+    margin: $line-height 0;
+    padding: $line-height;
+    position: relative;
+
+    .button {
+      color: $text;
+      font-weight: bold;
+    }
+
+    &::before {
+      border-radius: 100%;
+      color: #fff;
+      font-family: "icons" !important;
+      height: rem-calc(80);
+      left: 50%;
+      line-height: rem-calc(80);
+      margin-left: rem-calc(-40);
+      position: absolute;
+      text-align: center;
+      top: -40px;
+      width: rem-calc(80);
+      z-index: 99;
+    }
+  }
+
+  .guide-budget {
+    border: 1px solid $budget;
+
+    &::before {
+      background: $budget;
+      content: '\53';
+      font-size: rem-calc(40);
+    }
+
+    .button {
+      background: #f8f5f9;
+      border: 1px solid $budget;
+    }
+  }
+
+  .guide-proposal {
+    border: 1px solid $proposals;
+
+    &::before {
+      background: $proposals;
+      content: '\68';
+      font-size: rem-calc(40);
+    }
+
+    .button {
+      background: #fffaf4;
+      border: 1px solid $proposals;
+    }
+  }
+
+  ul {
+
+    @include breakpoint(medium) {
+      min-height: $line-height * 14;
+    }
+
+    li {
+      margin-bottom: $line-height;
+      padding-left: $line-height;
+      position: relative;
+
+      &::before {
+        color: #37af65;
+        content: '\56';
+        font-family: "icons" !important;
+        font-size: $small-font-size;
+        left: 0;
+        position: absolute;
+        top: 1px;
+      }
+    }
   }
 }

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -1,0 +1,8 @@
+class GuidesController < ApplicationController
+
+  skip_authorization_check
+
+  def new
+  end
+
+end

--- a/app/helpers/guides_helper.rb
+++ b/app/helpers/guides_helper.rb
@@ -1,0 +1,19 @@
+module GuidesHelper
+
+  def new_proposal_guide
+    if feature?("guides")
+      new_guide_path
+    else
+      new_proposal_path
+    end
+  end
+
+  def new_budget_investment_guide
+    if feature?("guides")
+      new_guide_path
+    else
+      new_budget_investment_path(current_budget)
+    end
+  end
+
+end

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -27,7 +27,7 @@
           <% if current_user %>
             <% if current_user.level_two_or_three_verified? %>
               <%= link_to t("budgets.investments.index.sidebar.create"),
-                          new_budget_investment_path(@budget),
+                          new_budget_investment_guide,
                           class: "button margin-top expanded" %>
             <% else %>
               <div class="callout warning margin-top">

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -1,0 +1,11 @@
+<% if current_budget %>
+  <div>
+    <%= link_to t("guides.new_budget_investment"), 
+                new_budget_investment_path(current_budget) %>
+  </div>
+<% end %>
+
+<div>
+  <%= link_to t("guides.new_proposal"), 
+              new_proposal_path %>
+</div>

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -1,11 +1,58 @@
-<% if current_budget %>
-  <div>
-    <%= link_to t("guides.new_budget_investment"), 
-                new_budget_investment_path(current_budget) %>
+<div class="guides">
+  <div class="row margin">
+    <div class="small-12 column text-center">
+      <h1><%= t("guides.title", org: setting['org_name']) %></h1>
+      <p class="lead"><%= t("guides.subtitle") %></p>
+    </div>
   </div>
-<% end %>
 
-<div>
-  <%= link_to t("guides.new_proposal"), 
-              new_proposal_path %>
+  <div class="row" data-equalizer data-equalize-on="medium">
+
+    <div class="small-12 medium-5 medium-offset-1 column">
+      <div class="guide-budget" data-equalizer-watch>
+        <h2 class="text-center">
+          <%= t("guides.budget_investment.title") %>
+        </h2>
+
+        <ul class="no-bullet">
+          <li><%= t("guides.budget_investment.feature_1_html") %></li>
+          <li><%= t("guides.budget_investment.feature_2_html") %></li>
+          <li><%= t("guides.budget_investment.feature_3_html") %></li>
+          <li><%= t("guides.budget_investment.feature_4_html") %></li>
+        </ul>
+        <% if current_budget %>
+          <div class="small-12 medium-9 small-centered">
+            <%= link_to t("guides.budget_investment.new_button"),
+                        new_budget_investment_path(current_budget),
+                        class: "button expanded" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="small-12 medium-5 column end">
+      <div class="guide-proposal" data-equalizer-watch>
+        <h2 class="text-center">
+          <%= t("guides.proposal.title") %>
+        </h2>
+
+        <ul class="no-bullet">
+          <li><%= t("guides.proposal.feature_1_html") %></li>
+          <li>
+            <%= t("guides.proposal.feature_2_html",
+                  votes: setting["votes_for_proposal_success"],
+                  org: setting['org_name']) %>
+          </li>
+          <li><%= t("guides.proposal.feature_3_html") %></li>
+          <li><%= t("guides.proposal.feature_4_html") %></li>
+        </ul>
+
+        <div class="small-12 medium-9 small-centered">
+          <%= link_to t("guides.proposal.new_button"),
+                      new_proposal_path,
+                      class: "button expanded" %>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -63,7 +63,9 @@
 
       <% if @proposals.any? %>
         <div class="show-for-small-only">
-          <%= link_to t("proposals.index.start_proposal"), new_proposal_path, class: 'button expanded' %>
+          <%= link_to t("proposals.index.start_proposal"), 
+                      new_proposal_guide, 
+                      class: 'button expanded' %>
         </div>
       <% end %>
 
@@ -92,7 +94,9 @@
 
     <div class="small-12 medium-3 column">
       <aside class="margin-bottom">
-        <%= link_to t("proposals.index.start_proposal"), new_proposal_path, class: 'button expanded' %>
+        <%= link_to t("proposals.index.start_proposal"), 
+                    new_proposal_guide, 
+                    class: 'button expanded' %>
         <% if params[:retired].blank? %>
           <%= render 'categories' %>
           <%= render "shared/tag_cloud", taggable: 'proposal' %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -41,6 +41,7 @@ data:
     - config/locales/%{locale}/community.yml
     - config/locales/%{locale}/documents.yml
     - config/locales/%{locale}/images.yml
+    - config/locales/%{locale}/guides.yml
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -95,7 +95,7 @@ en:
           zero: You have not voted any investment project in this group.
           verified_only: "To create a new budget investment %{verify}."
           verify_account: "verify your account"
-          create: "Create budget investment"
+          create: "Create a budget investment"
           not_logged_in: "To create a new budget investment you must %{sign_in} or %{sign_up}."
           sign_in: "sign in"
           sign_up: "sign up"

--- a/config/locales/en/guides.yml
+++ b/config/locales/en/guides.yml
@@ -1,0 +1,4 @@
+en:
+  guides:
+    new_proposal: I want to create a proposal
+    new_budget_investment: I want to create a budget investment

--- a/config/locales/en/guides.yml
+++ b/config/locales/en/guides.yml
@@ -1,4 +1,18 @@
 en:
   guides:
-    new_proposal: I want to create a proposal
-    new_budget_investment: I want to create a budget investment
+    title: "Do you have an idea for %{org}?"
+    subtitle: "Choose what you want to create"
+    budget_investment:
+      title: "An investment project"
+      feature_1_html: "Ideas of how to spend part of the municipal budget"
+      feature_2_html: "Investment projects are accepted between January and March"
+      feature_3_html: "If it receives supports, it's viable and municipal competence, it goes to voting phase"
+      feature_4_html: "If the citizens approve the projects, they become a reality"
+      new_button: I want to create a budget investment
+    proposal:
+      title: "A citizen proposal"
+      feature_1_html: "Ideas about any action the City Council can take"
+      feature_2_html: "Need <strong>%{votes} supports</strong> in %{org} for go to voting"
+      feature_3_html: "Activate at any time, you have a year to get the supports"
+      feature_4_html: "If approved in a vote, the City Council accepts the proposal"
+      new_button: I want to create a proposal

--- a/config/locales/en/guides.yml
+++ b/config/locales/en/guides.yml
@@ -4,8 +4,8 @@ en:
     subtitle: "Choose what you want to create"
     budget_investment:
       title: "An investment project"
-      feature_1_html: "Ideas of how to spend part of the municipal budget"
-      feature_2_html: "Investment projects are accepted between January and March"
+      feature_1_html: "Ideas of how to spend part of the <strong>municipal budget</strong>"
+      feature_2_html: "Investment projects are accepted <strong>between January and March</strong>"
       feature_3_html: "If it receives supports, it's viable and municipal competence, it goes to voting phase"
       feature_4_html: "If the citizens approve the projects, they become a reality"
       new_button: I want to create a budget investment
@@ -13,6 +13,6 @@ en:
       title: "A citizen proposal"
       feature_1_html: "Ideas about any action the City Council can take"
       feature_2_html: "Need <strong>%{votes} supports</strong> in %{org} for go to voting"
-      feature_3_html: "Activate at any time, you have a year to get the supports"
+      feature_3_html: "Activate at any time, you have <strong>a year</strong> to get the supports"
       feature_4_html: "If approved in a vote, the City Council accepts the proposal"
       new_button: I want to create a proposal

--- a/config/locales/en/management.yml
+++ b/config/locales/en/management.yml
@@ -83,7 +83,7 @@ en:
     budget_investments:
       alert:
         unverified_user: User is not verified
-      create: Create budget investment
+      create: Create a budget investment
       filters:
         heading: Concepto
         unfeasible: Unfeasible investment

--- a/config/locales/es/guides.yml
+++ b/config/locales/es/guides.yml
@@ -4,8 +4,8 @@ es:
     subtitle: "Elige qué quieres crear"
     budget_investment:
       title: "Un proyecto de gasto"
-      feature_1_html: "Son ideas de cómo gastar parte del presupuesto municipal"
-      feature_2_html: "Los proyectos de gasto se plantean entre enero y marzo"
+      feature_1_html: "Son ideas de cómo gastar parte del <strong>presupuesto municipal</strong>"
+      feature_2_html: "Los proyectos de gasto se plantean <strong>entre enero y marzo</strong>"
       feature_3_html: "Si recibe apoyos, es viable y competencia municipal, pasa a votación"
       feature_4_html: "Si la ciudadanía aprueba los proyectos, se hacen realidad"
       new_button: Quiero crear un proyecto de gasto
@@ -13,6 +13,6 @@ es:
       title: "Una propuesta ciudadana"
       feature_1_html: "Son ideas sobre cualquier acción que pueda realizar el Ayuntamiento"
       feature_2_html: "Necesitan <strong>%{votes} apoyos</strong> en %{org} para pasar a votación"
-      feature_3_html: "Se activan en cualquier momento; tienes un año para reunir los apoyos"
+      feature_3_html: "Se activan en cualquier momento; tienes <strong>un año</strong> para reunir los apoyos"
       feature_4_html: "De aprobarse en votación, el Ayuntamiento asume la propuesta"
       new_button: Quiero crear una propuesta

--- a/config/locales/es/guides.yml
+++ b/config/locales/es/guides.yml
@@ -1,0 +1,4 @@
+es:
+  guides:
+    new_proposal: Quiero crear una propuesta
+    new_budget_investment: Quiero crear un nuevo proyecto de gasto

--- a/config/locales/es/guides.yml
+++ b/config/locales/es/guides.yml
@@ -1,4 +1,18 @@
 es:
   guides:
-    new_proposal: Quiero crear una propuesta
-    new_budget_investment: Quiero crear un nuevo proyecto de gasto
+    title: "¿Tienes una idea para %{org}?"
+    subtitle: "Elige qué quieres crear"
+    budget_investment:
+      title: "Un proyecto de gasto"
+      feature_1_html: "Son ideas de cómo gastar parte del presupuesto municipal"
+      feature_2_html: "Los proyectos de gasto se plantean entre enero y marzo"
+      feature_3_html: "Si recibe apoyos, es viable y competencia municipal, pasa a votación"
+      feature_4_html: "Si la ciudadanía aprueba los proyectos, se hacen realidad"
+      new_button: Quiero crear un proyecto de gasto
+    proposal:
+      title: "Una propuesta ciudadana"
+      feature_1_html: "Son ideas sobre cualquier acción que pueda realizar el Ayuntamiento"
+      feature_2_html: "Necesitan <strong>%{votes} apoyos</strong> en %{org} para pasar a votación"
+      feature_3_html: "Se activan en cualquier momento; tienes un año para reunir los apoyos"
+      feature_4_html: "De aprobarse en votación, el Ayuntamiento asume la propuesta"
+      new_button: Quiero crear una propuesta

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   draw :direct_upload
   draw :document
   draw :graphql
+  draw :guide
   draw :legislation
   draw :management
   draw :moderation

--- a/config/routes/guide.rb
+++ b/config/routes/guide.rb
@@ -1,0 +1,1 @@
+resources :guides, only: :new

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -37,6 +37,7 @@ section "Creating Settings" do
   Setting.create(key: 'url', value: 'http://localhost:3000')
   Setting.create(key: 'org_name', value: 'CONSUL')
   Setting.create(key: 'place_name', value: 'City')
+
   Setting.create(key: 'feature.debates', value: "true")
   Setting.create(key: 'feature.proposals', value: "true")
   Setting.create(key: 'feature.polls', value: "true")
@@ -53,6 +54,8 @@ section "Creating Settings" do
   Setting.create(key: 'feature.map', value: "true")
   Setting.create(key: 'feature.allow_images', value: "true")
   Setting.create(key: 'feature.public_stats', value: "true")
+  Setting.create(key: 'feature.guides', value: nil)
+
   Setting.create(key: 'per_page_code_head', value: "")
   Setting.create(key: 'per_page_code_body', value: "")
   Setting.create(key: 'comments_body_max_length', value: '1000')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -85,6 +85,7 @@ Setting['feature.user.recommendations'] = true
 Setting['feature.community'] = true
 Setting['feature.map'] = nil
 Setting['feature.allow_images'] = true
+Setting['feature.guides'] = nil
 
 # Spending proposals feature flags
 Setting['feature.spending_proposal_features.voting_allowed'] = nil

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -228,7 +228,7 @@ feature 'Budgets' do
 
         visit budget_path(budget)
 
-        expect(page).to have_link "Create budget investment"
+        expect(page).to have_link "Create a budget investment"
       end
 
       scenario "Unverified user" do

--- a/spec/features/guides_spec.rb
+++ b/spec/features/guides_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+feature 'Guide the user to create the correct resource' do
+
+  let(:user) { create(:user, :verified)}
+  let!(:budget) { create(:budget, :accepting) }
+
+  background do
+    Setting['feature.guides'] = true
+  end
+
+  after do
+    Setting['feature.guides'] = nil
+  end
+
+  scenario "Proposal" do
+    login_as(user)
+    visit proposals_path
+
+    click_link "Create a proposal"
+    click_link "I want to create a proposal"
+
+    expect(page).to have_current_path(new_proposal_path)
+  end
+
+  scenario "Budget Investment" do
+    login_as(user)
+    visit budgets_path
+
+    click_link "Create a budget investment"
+    click_link "I want to create a budget investment"
+
+    expect(page).to have_current_path(new_budget_investment_path(budget))
+  end
+
+  scenario "Feature deactivated" do
+    Setting['feature.guides'] = nil
+
+    login_as(user)
+
+    visit proposals_path
+    click_link "Create a proposal"
+
+    expect(page).to_not have_link "I want to create a proposal"
+    expect(page).to have_current_path(new_proposal_path)
+
+    visit budgets_path
+    click_link "Create a budget investment"
+
+    expect(page).to_not have_link "I want to create a new budget investment"
+    expect(page).to have_current_path(new_budget_investment_path(budget))
+  end
+
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2310

What
====
- Add intermediate page to choose between creating a proposal or an investment 
- Add confirmation feature to activate or deactivate this functionality
- Add seeds and dev seeds

Screenshots
===========
![guide](https://user-images.githubusercontent.com/631897/35115265-e80318fc-fc87-11e7-98c6-64801a220c3a.png)

Test
===
- Added guide specs for proposals and budget investments

Deployment
==========
- As usual

Warnings
========
- None

Release Notes
===
To activate this funcionality run this command from the rails console:
`Setting["feature.guides"] = true`
