### PR TITLE
added private comments to investments

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -12,6 +12,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
   before_action :load_ballot, only: [:show, :index]
   before_action :load_investments, only: [:index, :toggle_selection]
 
+  has_orders %w{most_voted newest oldest}, only: :show
+
   def index
     respond_to do |format|
       format.html
@@ -23,6 +25,10 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
   end
 
   def show
+    @concealed = true
+    @commentable = @investment
+    @comment_tree = CommentTree.new(@commentable, params[:page], @current_order, @concealed)
+    set_comment_flags(@comment_tree.comments)
   end
 
   def edit

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -44,11 +44,13 @@ class CommentsController < ApplicationController
   private
 
     def comment_params
-      params.require(:comment).permit(:commentable_type, :commentable_id, :parent_id, :body, :as_moderator, :as_administrator)
+      params.require(:comment).permit(:commentable_type, :commentable_id, :parent_id,
+                                      :body, :as_moderator, :as_administrator, :concealed)
     end
 
     def build_comment
-      @comment = Comment.build(@commentable, current_user, comment_params[:body], comment_params[:parent_id].presence)
+      @comment = Comment.build(@commentable, current_user, comment_params[:body],
+                               comment_params[:parent_id].presence, comment_params[:concealed])
       check_for_special_comments
     end
 

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -7,6 +7,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
   before_action :load_investment, only: [:show, :edit, :valuate]
 
   has_filters %w{valuating valuation_finished}, only: :index
+  has_orders %w{most_voted newest oldest}, only: :show
 
   load_and_authorize_resource :investment, class: "Budget::Investment"
 
@@ -19,6 +20,13 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
                    else
                      Budget::Investment.none.page(params[:page])
                    end
+  end
+
+  def show
+    @concealed = true
+    @commentable = @investment
+    @comment_tree = CommentTree.new(@commentable, params[:page], @current_order, @concealed)
+    set_comment_flags(@comment_tree.comments)
   end
 
   def valuate

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -49,11 +49,12 @@ class Comment < ActiveRecord::Base
 
   after_create :call_after_commented
 
-  def self.build(commentable, user, body, p_id = nil)
+  def self.build(commentable, user, body, p_id = nil, concealed = false)
     new commentable: commentable,
         user_id:     user.id,
         body:        body,
-        parent_id:   p_id
+        parent_id:   p_id,
+        concealed:   concealed
   end
 
   def self.find_commentable(c_type, c_id)

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -94,4 +94,4 @@
 <% end %>
 
 <hr>
-<%# render 'valuation/budget_investments/written_by_valuators' %>
+<%= render 'valuation/budget_investments/written_by_valuators' %>

--- a/app/views/budgets/investments/show.html.erb
+++ b/app/views/budgets/investments/show.html.erb
@@ -17,7 +17,8 @@
   <div class="tabs-panel is-active" id="tab-comments">
     <%= render partial: '/comments/comment_tree', locals: { comment_tree: @comment_tree,
                                                             comment_flags: @comment_flags,
-                                                            display_comments_count: false } %>
+                                                            display_comments_count: false,
+                                                            concealed: false } %>
   </div>
 
   <div class="tabs-panel" id="tab-documents">

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,6 @@
 <% comment_flags ||= @comment_flags %>
+<% concealed = local_assigns.fetch(:concealed, false)%>
+
 <% cache [locale_and_user_status(comment), comment, commentable_cache_key(comment.commentable), comment.author, (comment_flags[comment.id] if comment_flags)] do %>
   <ul id="<%= dom_id(comment) %>" class="comment no-bullet small-12">
     <li class="comment-body">
@@ -88,7 +90,7 @@
 
             <%= render 'comments/actions', comment: comment %>
 
-            <%= render 'comments/form', {commentable: comment.commentable, parent_id: comment.id, toggeable: true} %>
+            <%= render 'comments/form', {commentable: comment.commentable, parent_id: comment.id, toggeable: true, concealed: concealed} %>
           <% end %>
         </div>
       <% end %>
@@ -98,7 +100,7 @@
       <ul id="<%= dom_id(comment) %>_children" class="no-bullet comment-children">
         <% child_comments_of(comment).each do |child| %>
           <li>
-            <%= render 'comments/comment', comment: child %>
+            <%= render 'comments/comment', comment: child, concealed: concealed %>
           </li>
         <% end %>
       </ul>

--- a/app/views/comments/_comment_tree.html.erb
+++ b/app/views/comments/_comment_tree.html.erb
@@ -1,4 +1,5 @@
 <% commentable = comment_tree.commentable %>
+<% concealed = local_assigns.fetch(:concealed, false)%>
 
 <% cache [locale_and_user_status, comment_tree.order, commentable_cache_key(commentable), comment_tree.comments, comment_tree.comment_authors, commentable.comments_count, comment_flags] do %>
   <section class="expanded comments">
@@ -25,7 +26,7 @@
               <%= t("comments.verified_only", verify_account: link_to(t("comments.verify_account"), verification_path )).html_safe %>
             </div>
           <% else %>
-            <%= render 'comments/form', {commentable: commentable, parent_id: nil, toggeable: false} %>
+            <%= render 'comments/form', {commentable: commentable, parent_id: nil, toggeable: false, concealed: concealed } %>
           <% end %>
         <% else %>
           <br>
@@ -36,10 +37,10 @@
           </div>
         <% end %>
 
-        <% comment_tree.root_comments.each do |comment| %>
-          <%= render 'comments/comment', {comment: comment, comment_flags: comment_flags} %>
+        <% comment_tree.root_comments(concealed).each do |comment| %>
+          <%= render 'comments/comment', {comment: comment, comment_flags: comment_flags, concealed: concealed} %>
         <% end %>
-        <%= paginate comment_tree.root_comments %>
+        <%= paginate comment_tree.root_comments(concealed) %>
       </div>
     </div>
   </section>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -7,6 +7,7 @@
       <%= f.hidden_field :commentable_type, value: commentable.class.name %>
       <%= f.hidden_field :commentable_id, value: commentable.id %>
       <%= f.hidden_field :parent_id, value: parent_id %>
+      <%= f.hidden_field :concealed, value: local_assigns.fetch(:concealed, false) %>
 
       <%= f.submit comment_button_text(parent_id, commentable), class: "button", id: "publish_comment" %>
 

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,4 +1,4 @@
-var comment_html = "<%= j(render @comment) %>"
+var comment_html = "<%= j(render @comment, concealed: @comment.concealed) %>"
 
 <% if @comment.root? -%>
   var commentable_id = '<%= dom_id(@commentable) %>';

--- a/app/views/valuation/budget_investments/_written_by_valuators.html.erb
+++ b/app/views/valuation/budget_investments/_written_by_valuators.html.erb
@@ -47,7 +47,19 @@
   </p>
 <% end %>
 
-<% if @investment.internal_comments.present? %>
-  <h2><%= t("valuation.budget_investments.show.internal_comments") %></h2>
-  <%= explanation_field @investment.internal_comments %>
-<% end %>
+
+
+<div class="tabs-panel is-active" id="tab-comments">
+  <% if @investment.internal_comments.present? %>
+    <h2><%= t("valuation.budget_investments.show.internal_comments") %></h2>
+      <%= explanation_field @investment.internal_comments %>
+    <hr/>
+    <br/>
+  <% end %>
+  <% unless @comment_tree.nil? %>
+    <%= render partial: '/comments/comment_tree', locals: { comment_tree: @comment_tree,
+                                                            comment_flags: @comment_flags,
+                                                            concealed: @concealed,
+                                                            display_comments_count: false } %>
+  <% end %>
+</div>

--- a/db/migrate/20180116100446_add_private_to_comments.rb
+++ b/db/migrate/20180116100446_add_private_to_comments.rb
@@ -1,0 +1,5 @@
+class AddPrivateToComments < ActiveRecord::Migration
+  def change
+    add_column :comments, :concealed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180112123641) do
+ActiveRecord::Schema.define(version: 20180116100446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -233,7 +233,7 @@ ActiveRecord::Schema.define(version: 20180112123641) do
     t.string   "commentable_type"
     t.text     "body"
     t.string   "subject"
-    t.integer  "user_id",                        null: false
+    t.integer  "user_id",                            null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "hidden_at"
@@ -246,7 +246,8 @@ ActiveRecord::Schema.define(version: 20180112123641) do
     t.integer  "cached_votes_down",  default: 0
     t.datetime "confirmed_hide_at"
     t.string   "ancestry"
-    t.integer  "confidence_score",   default: 0, null: false
+    t.integer  "confidence_score",   default: 0,     null: false
+    t.boolean  "concealed",          default: false
   end
 
   add_index "comments", ["ancestry"], name: "index_comments_on_ancestry", using: :btree

--- a/lib/comment_tree.rb
+++ b/lib/comment_tree.rb
@@ -4,21 +4,25 @@ class CommentTree
 
   attr_accessor :root_comments, :comments, :commentable, :page, :order
 
-  def initialize(commentable, page, order = 'confidence_score')
+  def initialize(commentable, page, order = 'confidence_score', concealed = false)
     @commentable = commentable
     @page = page
     @order = order
 
-    @comments = root_comments + root_descendants
+    @comments = root_comments(concealed) + root_descendants(concealed)
   end
 
-  def root_comments
-    commentable.comments.roots.send("sort_by_#{order}").page(page).per(ROOT_COMMENTS_PER_PAGE).for_render
+  def root_comments(concealed = false)
+    commentable.comments.where(concealed: concealed).
+                roots.send("sort_by_#{order}").page(page).
+                per(ROOT_COMMENTS_PER_PAGE).for_render
   end
 
-  def root_descendants
-    root_comments.each_with_object([]) do |root, array|
-      array.concat(Comment.descendants_of(root).send("sort_descendants_by_#{order}").for_render.to_a)
+  def root_descendants(concealed = false)
+    root_comments(concealed).each_with_object([]) do |root, array|
+      array.concat(Comment.where(concealed: concealed).
+                          descendants_of(root).send("sort_descendants_by_#{order}").
+                          for_render.to_a)
     end
   end
 

--- a/lib/merged_comment_tree.rb
+++ b/lib/merged_comment_tree.rb
@@ -1,17 +1,17 @@
 class MergedCommentTree < CommentTree
   attr_accessor :commentables, :array_order
 
-  def initialize(commentables, page, order = 'confidence_score')
+  def initialize(commentables, page, order = 'confidence_score', concealed = false)
     @commentables = commentables
     @commentable = commentables.first
     @page = page
     @order = order
     @array_order = set_array_order(order)
 
-    @comments = root_comments + root_descendants
+    @comments = root_comments(concealed) + root_descendants(concealed)
   end
 
-  def root_comments
+  def root_comments(concealed = false)
     Kaminari.paginate_array(commentables.flatten.map(&:comments).map(&:roots).flatten.sort_by {|a| a[array_order]}.reverse).
     page(page).per(ROOT_COMMENTS_PER_PAGE)
   end

--- a/lib/tasks/create_private_comments_from_internal_comments.rake
+++ b/lib/tasks/create_private_comments_from_internal_comments.rake
@@ -1,0 +1,17 @@
+namespace :create_private_comments_form_internal_comments do
+
+  desc "Create comments"
+  task create: :environment do
+    admin_id = Administrator.first.user_id
+    Budget::Investment.where('internal_comments is not null').find_each do |investment|
+      unless investment.internal_comments.blank?
+        Comment.create(commentable_id: investment.id, commentable_type: "Budget::Investment",
+                       body: "commentario 1", subject: investment.internal_comments,
+                       user_id: admin_id, concealed: true)
+        investment.internal_comments = nil
+        investment.save!
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2321 (doesn't close it entirely, just partially)

What
====
- Adds standard comments for admins and valuators in budget/investments to discuss it in private

How
===
- Added a new attribute to Comment (concealed) a boolean who makes the comment private, also added views for comments in the show actions of admin/budget/investment and valuation/budget/investment

Screenshots
===========
![screenshot from 2018-01-19 11 32 00](https://user-images.githubusercontent.com/33748390/35146819-7ec408a8-fd0c-11e7-93ca-b9c055586ade.png)
===========
![screenshot from 2018-01-19 11 32 35](https://user-images.githubusercontent.com/33748390/35146820-7edd0c68-fd0c-11e7-8b01-0ccded0b6de9.png)

Test
====
- Added 2 new set of tests for comments for admin/budget/#/buget_investment/# and valuation/budget/#/buget_investment/# also changed test for budget/#/buget_investment/# to ensure none of the private comments are shown

Deployment
==========
- Any details to remember when this feature is deployed?
As usual

Warnings
========
- This PR do not changes the internal_comment attribute yet, I will make another PR hidding this attribute