### PR TITLE
Budget new "Information" phase

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1239,7 +1239,8 @@
       text-decoration: none;
     }
 
-    a {
+    a,
+    div {
       display: block;
       padding: $line-height / 2;
 

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -1,5 +1,12 @@
 module BudgetsHelper
 
+  def heading_name_and_price_html(heading, budget)
+    content_tag :div do
+      concat(heading.name + ' ')
+      concat(content_tag(:span, budget.formatted_heading_price(heading)))
+    end
+  end
+
   def csv_params
     csv_params = params.clone.merge(format: :csv).symbolize_keys
     csv_params.delete(:page)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -21,6 +21,7 @@ class Budget < ActiveRecord::Base
   after_create :generate_phases
 
   scope :drafting, -> { where(phase: "drafting") }
+  scope :informing, -> { where(phase: "informing") }
   scope :accepting, -> { where(phase: "accepting") }
   scope :reviewing, -> { where(phase: "reviewing") }
   scope :selecting, -> { where(phase: "selecting") }
@@ -62,6 +63,10 @@ class Budget < ActiveRecord::Base
 
   def drafting?
     phase == "drafting"
+  end
+
+  def informing?
+    phase == "informing"
   end
 
   def accepting?

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -1,6 +1,6 @@
 class Budget
   class Phase < ActiveRecord::Base
-    PHASE_KINDS = %w(drafting accepting reviewing selecting valuating publishing_prices balloting
+    PHASE_KINDS = %w(drafting informing accepting reviewing selecting valuating publishing_prices balloting
                 reviewing_ballots finished).freeze
     PUBLISHED_PRICES_PHASES = %w(publishing_prices balloting reviewing_ballots finished).freeze
     SUMMARY_MAX_LENGTH = 1000
@@ -26,6 +26,7 @@ class Budget
     scope :enabled,           -> { where(enabled: true) }
     scope :published,         -> { enabled.where.not(kind: 'drafting') }
     scope :drafting,          -> { find_by_kind('drafting') }
+    scope :informing,       -> { find_by_kind('informing') }
     scope :accepting,         -> { find_by_kind('accepting')}
     scope :reviewing,         -> { find_by_kind('reviewing')}
     scope :selecting,         -> { find_by_kind('selecting')}

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -26,7 +26,7 @@ class Budget
     scope :enabled,           -> { where(enabled: true) }
     scope :published,         -> { enabled.where.not(kind: 'drafting') }
     scope :drafting,          -> { find_by_kind('drafting') }
-    scope :informing,       -> { find_by_kind('informing') }
+    scope :informing,         -> { find_by_kind('informing') }
     scope :accepting,         -> { find_by_kind('accepting')}
     scope :reviewing,         -> { find_by_kind('reviewing')}
     scope :selecting,         -> { find_by_kind('selecting')}

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -69,13 +69,11 @@
               <li class="heading small-12 medium-4 large-2">
                 <% unless @budget.informing? %>
                   <%= link_to budget_investments_path(@budget.id, heading_id: heading.id) do %>
-                    <%= heading.name %>
-                    <span><%= @budget.formatted_heading_price(heading) %></span>
+                    <%= heading_name_and_price_html(heading, @budget) %>
                   <% end %>
                 <% else %>
                   <div>
-                    <%= heading.name %>
-                    <span><%= @budget.formatted_heading_price(heading) %></span>
+                    <%= heading_name_and_price_html(heading, @budget) %>
                   </div>
                 <% end %>
               </li>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -67,9 +67,16 @@
           <ul class="no-bullet">
             <% group.headings.each do |heading| %>
               <li class="heading small-12 medium-4 large-2">
-                <%= link_to budget_investments_path(@budget.id, heading_id: heading.id) do %>
-                  <%= heading.name %>
-                  <span><%= @budget.formatted_heading_price(heading) %></span>
+                <% unless @budget.informing? %>
+                  <%= link_to budget_investments_path(@budget.id, heading_id: heading.id) do %>
+                    <%= heading.name %>
+                    <span><%= @budget.formatted_heading_price(heading) %></span>
+                  <% end %>
+                <% else %>
+                  <div>
+                    <%= heading.name %>
+                    <span><%= @budget.formatted_heading_price(heading) %></span>
+                  </div>
                 <% end %>
               </li>
             <% end %>
@@ -77,22 +84,24 @@
         <% end %>
       </div>
 
-      <div id="map">
-        <h3><%= t("budgets.index.map") %></h3>
-        <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
-      </div>
+      <% unless @budget.informing? %>
+        <div id="map">
+          <h3><%= t("budgets.index.map") %></h3>
+          <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
+        </div>
 
-      <p>
-        <%= link_to budget_investments_path(@budget.id) do %>
-          <small><%= t("budgets.index.investment_proyects") %></small>
-        <% end %><br>
-        <%= link_to budget_investments_path(budget_id: @budget.id, filter: 'unfeasible') do %>
-          <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
-        <% end %><br>
-        <%= link_to budget_investments_path(budget_id: @budget.id, filter: 'unselected') do %>
-          <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
-        <% end %>
-      </p>
+        <p>
+          <%= link_to budget_investments_path(@budget.id) do %>
+            <small><%= t("budgets.index.investment_proyects") %></small>
+          <% end %><br>
+          <%= link_to budget_investments_path(budget_id: @budget.id, filter: 'unfeasible') do %>
+            <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
+          <% end %><br>
+          <%= link_to budget_investments_path(budget_id: @budget.id, filter: 'unselected') do %>
+            <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
+          <% end %>
+        </p>
+      <% end %>
 
       <div id="all_phases">
         <h2><%= t("budgets.index.all_phases") %></h2>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -30,7 +30,7 @@ en:
         unselected: See investments not selected for balloting phase
     phase:
       drafting: Draft (Not visible to the public)
-      informing: Informating
+      informing: Informing
       accepting: Accepting projects
       reviewing: Reviewing projects
       selecting: Selecting projects

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -30,6 +30,7 @@ en:
         unselected: See investments not selected for balloting phase
     phase:
       drafting: Draft (Not visible to the public)
+      informing: Informating
       accepting: Accepting projects
       reviewing: Reviewing projects
       selecting: Selecting projects

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -30,6 +30,7 @@ es:
         unselected: Ver las propuestas no seleccionadas para la votación final
     phase:
       drafting: Borrador (No visible para el público)
+      informing: Información
       accepting: Presentación de proyectos
       reviewing: Revisión inicial de proyectos
       selecting: Fase de apoyos

--- a/db/migrate/20180119073228_add_description_informing_to_budgets.rb
+++ b/db/migrate/20180119073228_add_description_informing_to_budgets.rb
@@ -1,0 +1,5 @@
+class AddDescriptionInformingToBudgets < ActiveRecord::Migration
+  def change
+    add_column :budgets, :description_informing, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180112123641) do
+ActiveRecord::Schema.define(version: 20180119073228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -219,6 +219,7 @@ ActiveRecord::Schema.define(version: 20180112123641) do
     t.string   "slug"
     t.text     "description_drafting"
     t.text     "description_publishing_prices"
+    t.text     "description_informing"
   end
 
   create_table "campaigns", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -224,6 +224,7 @@ FactoryBot.define do
     currency_symbol "€"
     phase 'accepting'
     description_drafting  "This budget is drafting"
+    description_informing "This budget is informing"
     description_accepting "This budget is accepting"
     description_reviewing "This budget is reviewing"
     description_selecting "This budget is selecting"
@@ -235,6 +236,10 @@ FactoryBot.define do
 
     trait :drafting do
       phase 'drafting'
+    end
+
+    trait :informing do
+      phase 'informing'
     end
 
     trait :accepting do

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -16,22 +16,26 @@ feature 'Budgets' do
       heading1 = create(:budget_heading, group: group1)
       heading2 = create(:budget_heading, group: group2)
 
+      last_budget.update_attributes(phase: 'informing')
+
       visit budgets_path
+
 
       within("#budget_heading") do
         expect(page).to have_content(last_budget.name)
         expect(page).to have_content(last_budget.description)
-        expect(page).to have_content("Actual phase (2/9)")
-        expect(page).to have_content("Accepting projects")
+        expect(page).to have_content(I18n.t('budgets.phase.informing'))
         expect(page).to have_link 'Help about participatory budgets'
         expect(page).to have_link 'See all phases'
       end
+
+      expect(page).to have_content("Accepting projects")
 
       last_budget.update_attributes(phase: 'publishing_prices')
       visit budgets_path
 
       within("#budget_heading") do
-        expect(page).to have_content("Actual phase (6/9)")
+        expect(page).to have_content(I18n.t('budgets.phase.publishing_prices'))
       end
 
       within('#budget_info') do

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -5,43 +5,65 @@ feature 'Budgets' do
   let(:budget) { create(:budget) }
   let(:level_two_user) { create(:user, :level_two) }
 
-  scenario 'Index' do
-    budgets = create_list(:budget, 3)
-    last_budget = budgets.last
-    group1 = create(:budget_group, budget: last_budget)
-    group2 = create(:budget_group, budget: last_budget)
+  context 'Index' do
+    let(:budgets) { create_list(:budget, 3) }
+    let(:last_budget) { budgets.last }
 
-    heading1 = create(:budget_heading, group: group1)
-    heading2 = create(:budget_heading, group: group2)
+    scenario 'Show normal index with links' do
+      group1 = create(:budget_group, budget: last_budget)
+      group2 = create(:budget_group, budget: last_budget)
 
-    visit budgets_path
+      heading1 = create(:budget_heading, group: group1)
+      heading2 = create(:budget_heading, group: group2)
 
-    within("#budget_heading") do
-      expect(page).to have_content(last_budget.name)
-      expect(page).to have_content(last_budget.description)
-      expect(page).to have_content("Actual phase")
-      expect(page).to have_content("Accepting projects")
-      expect(page).to have_link 'Help with participatory budgets'
-      expect(page).to have_link 'See all phases'
+      visit budgets_path
+
+      within("#budget_heading") do
+        expect(page).to have_content(last_budget.name)
+        expect(page).to have_content(last_budget.description)
+        expect(page).to have_content("Actual phase (2/9)")
+        expect(page).to have_content("Accepting projects")
+        expect(page).to have_link 'Help about participatory budgets'
+        expect(page).to have_link 'See all phases'
+      end
+
+      last_budget.update_attributes(phase: 'publishing_prices')
+      visit budgets_path
+
+      within("#budget_heading") do
+        expect(page).to have_content("Actual phase (6/9)")
+      end
+
+      within('#budget_info') do
+        expect(page).to have_content group1.name
+        expect(page).to have_content group2.name
+        expect(page).to have_content heading1.name
+        expect(page).to have_content last_budget.formatted_heading_price(heading1)
+        expect(page).to have_content heading2.name
+        expect(page).to have_content last_budget.formatted_heading_price(heading2)
+
+        expect(page).to have_content budgets.first.name
+        expect(page).to have_content budgets[2].name
+      end
     end
 
-    last_budget.update_attributes(phase: 'publishing_prices')
-    visit budgets_path
+    scenario 'Show informing index without links' do
+      last_budget.update_attributes(phase: 'informing')
+      group = create(:budget_group, budget: last_budget)
+      heading = create(:budget_heading, group: group)
 
-    within("#budget_heading") do
-      expect(page).to have_content("Actual phase")
-    end
+      visit budgets_path
 
-    within('#budget_info') do
-      expect(page).to have_content group1.name
-      expect(page).to have_content group2.name
-      expect(page).to have_content heading1.name
-      expect(page).to have_content last_budget.formatted_heading_price(heading1)
-      expect(page).to have_content heading2.name
-      expect(page).to have_content last_budget.formatted_heading_price(heading2)
+      within('#budget_info') do
+        expect(page).not_to have_link "#{heading.name} €1,000,000"
+        expect(page).to have_content "#{heading.name} €1,000,000"
 
-      expect(page).to have_content budgets.first.name
-      expect(page).to have_content budgets[2].name
+        expect(page).not_to have_link "List of all investment projects"
+        expect(page).not_to have_link "List of all unfeasible investment projects"
+        expect(page).not_to have_link "List of all investment projects not selected for balloting"
+
+        expect(page).not_to have_css('div#map')
+      end
     end
   end
 

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -25,7 +25,7 @@ feature 'Budgets' do
         expect(page).to have_content(last_budget.name)
         expect(page).to have_content(last_budget.description)
         expect(page).to have_content(I18n.t('budgets.phase.informing'))
-        expect(page).to have_link 'Help about participatory budgets'
+        expect(page).to have_link 'Help with participatory budgets'
         expect(page).to have_link 'See all phases'
       end
 

--- a/spec/models/budget/phase_spec.rb
+++ b/spec/models/budget/phase_spec.rb
@@ -4,16 +4,18 @@ describe Budget::Phase do
 
   let(:budget)       { create(:budget) }
   let(:first_phase)  { budget.phases.drafting }
-  let(:second_phase) { budget.phases.accepting }
-  let(:third_phase)  { budget.phases.reviewing }
-  let(:fourth_phase) { budget.phases.selecting }
-  let(:final_phase)  { budget.phases.finished}
+  let(:second_phase)  { budget.phases.informing }
+  let(:third_phase) { budget.phases.accepting }
+  let(:fourth_phase)  { budget.phases.reviewing }
+  let(:fifth_phase) { budget.phases.selecting }
+  let(:final_phase) { budget.phases.finished}
 
   before do
     first_phase.update_attributes(starts_at: Date.current - 3.days, ends_at: Date.current - 1.day)
     second_phase.update_attributes(starts_at: Date.current - 1.days, ends_at: Date.current + 1.day)
     third_phase.update_attributes(starts_at: Date.current + 1.days, ends_at: Date.current + 3.day)
     fourth_phase.update_attributes(starts_at: Date.current + 3.days, ends_at: Date.current + 5.day)
+    fifth_phase.update_attributes(starts_at: Date.current + 5.days, ends_at: Date.current + 7.day)
   end
 
   describe "validates" do
@@ -90,7 +92,7 @@ describe Budget::Phase do
 
     describe "#next_phase_dates_valid?" do
       let(:error) do
-        "End date must be earlier than the end date of the next enabled phase (Reviewing projects)"
+        "End date must be earlier than the end date of the next enabled phase (Accepting projects)"
       end
 
       it "is invalid when end date is same as next enabled phase end date" do

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -192,6 +192,7 @@ describe Budget do
 
   describe "#generate_phases" do
     let(:drafting_phase)          { budget.phases.drafting }
+    let(:informing_phase)       { budget.phases.informing }
     let(:accepting_phase)         { budget.phases.accepting }
     let(:reviewing_phase)         { budget.phases.reviewing }
     let(:selecting_phase)         { budget.phases.selecting }
@@ -204,7 +205,8 @@ describe Budget do
     it "generates all phases linked in correct order" do
       expect(budget.phases.count).to eq(Budget::Phase::PHASE_KINDS.count)
 
-      expect(drafting_phase.next_phase).to eq(accepting_phase)
+      expect(drafting_phase.next_phase).to eq(informing_phase)
+      expect(informing_phase.next_phase).to eq(accepting_phase)
       expect(accepting_phase.next_phase).to eq(reviewing_phase)
       expect(reviewing_phase.next_phase).to eq(selecting_phase)
       expect(selecting_phase.next_phase).to eq(valuating_phase)
@@ -215,7 +217,8 @@ describe Budget do
       expect(finished_phase.next_phase).to eq(nil)
 
       expect(drafting_phase.prev_phase).to eq(nil)
-      expect(accepting_phase.prev_phase).to eq(drafting_phase)
+      expect(informing_phase.prev_phase).to eq(drafting_phase)
+      expect(accepting_phase.prev_phase).to eq(informing_phase)
       expect(reviewing_phase.prev_phase).to eq(accepting_phase)
       expect(selecting_phase.prev_phase).to eq(reviewing_phase)
       expect(valuating_phase.prev_phase).to eq(selecting_phase)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2303 (this PR closes #2303)

What
====
Add a new phase called "Information", between "Drafting" and "Accepting" phases. This new phase will not have any link, just the information about the money and the dates.

How
===
- Add a new phase "informating" to `PHASE_KINDS` (it's called "informating", not "information", to follow the same structure of other phases).
- Add a new scope for that phase to budget and phase models, and functions to check if the budget is in the phase or not.
- If the budget is in informating phase, do not show the heading as links, but as simple text. The map and the heading list links below it have been removed for this phase.

Screenshots
===========
![information01](https://user-images.githubusercontent.com/31625251/35152893-84029c72-fd24-11e7-9879-7a4f3cfaff34.png)

Test
====
- Add `trait :informating` to budgets factory.
- Add a new scenario to the budgets index context, where the index wihout links is tested.
- `budget` and `phase` model specs have been modified to include the new "Information" phase.

Deployment
==========
There is a migration (explanation in 'Warnings' section).

Warnings
========
I added a migration to add the column `description_informating` to budgets (even if it will be deprecated soon) because in this version of master they are being used when creating a new `budget` and when running `dev_seed`.
