### PR TITLE
Clean up Travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ before_script:
 - for i in config/*.example; do cp "$i" "${i/.example}"; done
 - bundle exec rake db:setup
 script:
-  - "bundle exec rake assets:precompile RAILS_ENV=test > /dev/null 2>&1"
-  - "bin/knapsack_pro_rspec"
+- "bundle exec rake assets:precompile RAILS_ENV=test > /dev/null 2>&1"
+- "bin/knapsack_pro_rspec"
 env:
   global:
   - KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
+  - KNAPSACK_PRO_LOG_LEVEL=info
   - KNAPSACK_PRO_CI_NODE_TOTAL=2
   matrix:
   - KNAPSACK_PRO_CI_NODE_INDEX=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_script:
 - for i in config/*.example; do cp "$i" "${i/.example}"; done
 - bundle exec rake db:setup
 script:
-- bundle exec rake assets:precompile RAILS_ENV=test
-- bin/knapsack_pro_rspec
+  - "bundle exec rake assets:precompile RAILS_ENV=test > /dev/null 2>&1"
+  - "bin/knapsack_pro_rspec"
 env:
   global:
   - KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -29,7 +29,7 @@ feature "Voter" do
         expect(page).not_to have_link(answer_yes.title)
       end
 
-      expect(find(:css, ".js-token-message")).to be_visible
+      expect(page).to have_css(".js-token-message", visible: true)
       token = find(:css, ".js-question-answer")[:href].gsub(/.+?(?=token)/, '').gsub('token=', '')
 
       expect(page).to have_content "You can write down this vote identifier, to check your vote on the final results: #{token}"

--- a/spec/lib/tasks/dev_seed_spec.rb
+++ b/spec/lib/tasks/dev_seed_spec.rb
@@ -2,13 +2,7 @@ require 'rails_helper'
 require 'rake'
 
 describe 'rake db:dev_seed' do
-  before do
-    Rake.application.rake_require('tasks/db')
-    Rake::Task.define_task(:environment)
-  end
-
   let :run_rake_task do
-    Rake::Task['db:dev_seed'].reenable
     Rake.application.invoke_task('db:dev_seed')
   end
 


### PR DESCRIPTION
What
====
- Remove asset precompilation output from travis logs
- Reduce travis' knapsack log level to info
- Fix RSpec's `should` deprecation warning
- Remove duplicate dev_seed execution

Test
====
- Removed duplicate execution of dev seeds in specs

Deployment
==========
- As usual

Warnings
========
- None
