### PR TITLE
Budgets groups headings order

### DIFF
--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -65,7 +65,7 @@
         <% @budget.groups.each do |group| %>
           <h2><%= group.name %></h2>
           <ul class="no-bullet">
-            <% group.headings.each do |heading| %>
+            <% group.headings.order(name: :asc).each do |heading| %>
               <li class="heading small-12 medium-4 large-2">
                 <%= link_to budget_investments_path(@budget.id, heading_id: heading.id) do %>
                   <%= heading.name %>


### PR DESCRIPTION
What
====
This PR orders budgets groups headings by name `:asc`

Screenshots
===========

<img width="1029" alt="screen shot 2018-01-23 at 13 56 19" src="https://user-images.githubusercontent.com/631897/35276880-3784a0d8-0045-11e8-8331-2ee62e779573.png">
