### PR TITLE
Make English the default locale

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module Consul
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    config.i18n.default_locale = :es
+    config.i18n.default_locale = :en
     config.i18n.available_locales = [:en, :es, :fr, :nl, 'pt-BR']
     config.i18n.fallbacks = {'fr' => 'es', 'pt-br' => 'es', 'nl' => 'en'}
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]


### PR DESCRIPTION
What
====
We're only requiring English translations at Consul (at [i18n-tasks config file](https://github.com/consul/consul/blob/change_default_locale_to_en/config/i18n-tasks.yml#L4-L6)) and running [specs with `default_locale = :en`](https://github.com/consul/consul/blob/change_default_locale_to_en/spec/rails_helper.rb#L13)

For me does make sense to make Consul's default language English instead of Spanish.

How
===
Just changing the application config file

Screenshots
===========
No need

Test
====
No changes, all run on english already, and we have 100% English translations.

Deployment
==========
As usual

Warnings
========
None?