### PR TITLE
Budget: move calculate winners button

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -68,4 +68,16 @@ module BudgetsHelper
     return unless current_budget.present?
     MapLocation.where(investment_id: current_budget.investments).map { |l| l.json_data }
   end
+
+  def display_calculate_winners_button?(budget)
+    budget.balloting_or_later?
+  end
+
+  def calculate_winner_button_text(budget)
+    if budget.investments.winners.empty?
+      t("admin.budgets.winners.calculate")
+    else
+      t("admin.budgets.winners.recalculate")
+    end
+  end
 end

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -9,7 +9,23 @@
 
 <%= link_to t("admin.budget_investments.index.download_current_selection"),
             admin_budget_budget_investments_path(csv_params),
-            class: "float-right small" %>
+            class: "float-right small clear" %>
+
+<% if params[:filter] == 'winners' %>
+  <% if display_calculate_winners_button?(@budget) %>
+    <%= link_to calculate_winner_button_text(@budget),
+                calculate_winners_admin_budget_path(@budget),
+                method: :put,
+                class: "button hollow float-right clear" %>
+  <% else %>
+    <span class="button hollow disabled float-right clear">
+      <%= t("admin.budgets.winners.calculate")%>
+    </span>
+    <div class="callout warning clear">
+      <%= t("admin.budget_investments.index.cannot_calculate_winners") %>
+    </div>
+  <% end %>
+<% end %>
 
 <% if @investments.any? %>
   <h3 class="inline-block"><%= page_entries_info @investments %></h3><br>
@@ -134,7 +150,7 @@
 
   <%= paginate @investments %>
 <% else %>
-  <div class="callout primary">
+  <div class="callout primary clear">
     <%= t("admin.budget_investments.index.no_budget_investments") %>
   </div>
 <% end %>

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -68,7 +68,6 @@
                     budget_results_path(@budget),
                     class: "button hollow margin-left" %>
       <% end %>
-
       <% if @budget.persisted? %>
         <%= link_to t("admin.budgets.edit.delete"),
             admin_budget_path(@budget),

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -124,6 +124,7 @@ en:
       winners:
         calculate: Calculate Winner Investments
         calculated: Winners being calculated, it may take a minute.
+        recalculate: Recalculate Winner Investments
     budget_phases:
       edit:
         start_date: Start date
@@ -190,6 +191,7 @@ en:
         table_selection: "Selected"
         table_evaluation: "Show to valuators"
         table_incompatible: "Incompatible"
+        cannot_calculate_winners: The budget has to stay on phase "Balloting projects", "Reviewing Ballots" or "Finished budget" in order to calculate winners projects
       show:
         assigned_admin: Assigned administrator
         assigned_valuators: Assigned valuators

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -124,6 +124,7 @@ es:
       winners:
         calculate: Calcular propuestas ganadoras
         calculated: Calculando ganadoras, puede tardar un minuto.
+        recalculate: Recalcular propuestas ganadoras
     budget_phases:
       edit:
         start_date: Fecha de Inicio
@@ -190,6 +191,7 @@ es:
         table_selection: "Seleccionado"
         table_evaluation: "Mostrar a evaluadores"
         table_incompatible: "Incompatible"
+        cannot_calculate_winners: El presupuesto debe estar en las fases "Votación final", "Votación finalizada" o "Resultados" para poder calcular las propuestas ganadoras
       show:
         assigned_admin: Administrador asignado
         assigned_valuators: Evaluadores asignados

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -366,6 +366,23 @@ feature 'Admin budget investments' do
       expect(page).not_to have_select("tag_name", options: ["All tags", "Accessibility"])
     end
 
+    scenario "Disable 'Calculate winner' button if incorrect phase" do
+      budget.update(phase: 'reviewing_ballots')
+
+      visit admin_budget_budget_investments_path(budget)
+      click_link 'Winners'
+
+      expect(page).to have_link "Calculate Winner Investments"
+
+      budget.update(phase: 'accepting')
+
+      visit admin_budget_budget_investments_path(budget)
+      click_link 'Winners'
+
+      expect(page).not_to have_link "Calculate Winner Investments"
+      expect(page).to have_content 'The budget has to stay on phase "Balloting projects", "Reviewing Ballots" or "Finished budget" in order to calculate winners projects'
+    end
+
     scenario "Limiting by max number of investments per heading", :js do
       group_1 = create(:budget_group, budget: budget)
       group_2 = create(:budget_group, budget: budget)

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -186,7 +186,8 @@ feature 'Admin budgets' do
   end
 
   context "Calculate Budget's Winner Investments" do
-    scenario 'For a Budget in reviewing balloting' do
+
+    scenario 'For a Budget in reviewing balloting', :js do
       budget = create(:budget, phase: 'reviewing_ballots')
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group, price: 4)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2346 (this PR closes #2346)

What
====
- Move the "Calculate Winner Investments" button to the budget_investments index page.
- Change the name of the button if there are investments generated, from "Calculate [...]" to "Recalculate [...]"
- If the budgets is in a phase different from "Balloting projects", "Reviewing Ballots" or "Finished budget", the button is disabled and a message appears informing about the phases.
- Change the column name (in spanish) from "Ganadoras" to "Ganadores".

How
===
- Move the button to the budgets_investments index and put it in the rigth with CSS.
- Generate a helper function to show the button enabled (with the correct name), or the button disabled with the message.
- Add `clear` class name to the blue callout so that the button is not floating under it.

Screenshots
===========
### Without winner investments
![winners01](https://user-images.githubusercontent.com/31625251/35327876-0573de04-00fb-11e8-88f5-101ec3e37aa5.png)

### With existing winner investments
![winners02](https://user-images.githubusercontent.com/31625251/35327884-08ab5386-00fb-11e8-8f02-041c6cb5142c.png)

### In a phase that doesn't let users calculate winners
![winners03](https://user-images.githubusercontent.com/31625251/35327890-0b39ea54-00fb-11e8-930e-c4e4277740ac.png)

Test
====
- The spec which test the creation of the winner investments was modified to match the new situation of the button. It's no longer in the budget edition, but in the budget_investments index.
- A new scenario was added to test if the button is disabled when a budget is in an incorrect phase.

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.
