### PR TITLE
Improve heading names at select boxes

### DIFF
--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -10,5 +10,8 @@ class Budget
     validates :name, presence: true, uniqueness: { scope: :budget }
     validates :slug, presence: true, format: /\A[a-z0-9\-_]+\z/
 
+    def single_heading_group?
+      headings.count == 1
+    end
   end
 end

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -17,7 +17,7 @@ class Budget
     scope :order_by_group_name, -> { includes(:group).order('budget_groups.name', 'budget_headings.name') }
 
     def name_scoped_by_group
-      "#{group.name}: #{name}"
+      group.single_heading_group? ? name : "#{group.name}: #{name}"
     end
 
     def name_exists_in_budget_headings

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -60,7 +60,7 @@
         <% @budget.groups.each do |group| %>
           <tr>
             <td>
-              <% if group.headings.count == 1 %>
+              <% if group.single_heading_group? %>
                 <%= link_to group.name,
                             budget_investments_path(@budget,
                               heading_id: group.headings.first.id,

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -101,7 +101,7 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Change name")
       expect(page).to have_link("Plant trees")
 
-      select "Parks: Central Park", from: "heading_id"
+      select "Central Park", from: "heading_id"
 
       expect(page).not_to have_link("Realocate visitors")
       expect(page).not_to have_link("Change name")

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -609,7 +609,7 @@ feature 'Budget Investments' do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
-      select  'Health: More hospitals', from: 'budget_investment_heading_id'
+      select  heading.name, from: 'budget_investment_heading_id'
       fill_in 'budget_investment_title', with: 'I am a bot'
       fill_in 'budget_investment_subtitle', with: 'This is the honeypot'
       fill_in 'budget_investment_description', with: 'This is the description'
@@ -628,7 +628,7 @@ feature 'Budget Investments' do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
-      select  'Health: More hospitals', from: 'budget_investment_heading_id'
+      select  heading.name, from: 'budget_investment_heading_id'
       fill_in 'budget_investment_title', with: 'I am a bot'
       fill_in 'budget_investment_description', with: 'This is the description'
       check   'budget_investment_terms_of_service'
@@ -644,7 +644,7 @@ feature 'Budget Investments' do
 
       visit new_budget_investment_path(budget_id: budget.id)
 
-      select  'Health: More hospitals', from: 'budget_investment_heading_id'
+      select  heading.name, from: 'budget_investment_heading_id'
       fill_in 'budget_investment_title', with: 'Build a skyscraper'
       fill_in 'budget_investment_description', with: 'I want to live in a high tower over the clouds'
       fill_in 'budget_investment_location', with: 'City center'
@@ -734,6 +734,22 @@ feature 'Budget Investments' do
       within('#sidebar') do
         expect(page).not_to have_content('My ballot')
       end
+    end
+
+    scenario "Heading options are correctly ordered" do
+      city_group = create(:budget_group, name: "Toda la ciudad", budget: budget)
+      create(:budget_heading, name: "Toda la ciudad", price: 333333, group: city_group)
+      create(:budget_heading, name: "More health professionals", price: 999999, group: group)
+
+      login_as(author)
+
+      visit new_budget_investment_path(budget_id: budget.id)
+
+      select_options = find('#budget_investment_heading_id').all('option').collect(&:text)
+      expect(select_options.first).to eq('')
+      expect(select_options.second).to eq('Health: More health professionals')
+      expect(select_options.third).to eq('Health: More hospitals')
+      expect(select_options.fourth).to eq('Toda la ciudad')
     end
   end
 

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -366,7 +366,7 @@ feature 'Emails' do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
-      select  "#{group.name}: #{heading.name}", from: 'budget_investment_heading_id'
+      select  heading.name, from: 'budget_investment_heading_id'
       fill_in 'budget_investment_title', with: 'Build a hospital'
       fill_in 'budget_investment_description', with: 'We have lots of people that require medical attention'
       check   'budget_investment_terms_of_service'

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -29,7 +29,7 @@ feature 'Budget Investments' do
         expect(page).to have_content user.document_number
       end
 
-      select "Whole city: Health", from: 'budget_investment_heading_id'
+      select "Health", from: 'budget_investment_heading_id'
       fill_in 'budget_investment_title', with: 'Build a park in my neighborhood'
       fill_in 'budget_investment_description', with: 'There is no parks here...'
       fill_in 'budget_investment_location', with: 'City center'

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -65,7 +65,7 @@ feature 'Tags' do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  "#{group.name}: #{heading.name}", from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in 'budget_investment_description', with: 'I want to live in a high tower over the clouds'
     check   'budget_investment_terms_of_service'
@@ -84,7 +84,7 @@ feature 'Tags' do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  "#{group.name}: #{heading.name}", from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in_ckeditor 'budget_investment_description', with: 'If I had a gym near my place I could go do Zumba'
     check 'budget_investment_terms_of_service'
@@ -100,12 +100,62 @@ feature 'Tags' do
     end
   end
 
+  scenario "Turbolinks sanity check from budget's show", :js do
+    login_as(author)
+
+    education = create(:tag, name: 'Education', kind: 'category')
+    health    = create(:tag, name: 'Health',    kind: 'category')
+
+    visit budget_path(budget)
+    click_link "Create a budget investment"
+
+    select  heading.name, from: 'budget_investment_heading_id'
+    fill_in 'budget_investment_title', with: 'Build a skyscraper'
+    fill_in_ckeditor 'budget_investment_description', with: 'If I had a gym near my place I could go do Zumba'
+    check   'budget_investment_terms_of_service'
+
+    find('.js-add-tag-link', text: 'Education').click
+    click_button 'Create Investment'
+
+    expect(page).to have_content 'Investment created successfully.'
+
+    within "#tags_budget_investment_#{Budget::Investment.last.id}" do
+      expect(page).to have_content 'Education'
+      expect(page).not_to have_content 'Health'
+    end
+  end
+
+  scenario "Turbolinks sanity check from budget heading's show", :js do
+    login_as(author)
+
+    education = create(:tag, name: 'Education', kind: 'category')
+    health    = create(:tag, name: 'Health',    kind: 'category')
+
+    visit budget_investments_path(budget, heading_id: heading.id)
+    click_link "Create a budget investment"
+
+    select  heading.name, from: 'budget_investment_heading_id'
+    fill_in 'budget_investment_title', with: 'Build a skyscraper'
+    fill_in_ckeditor 'budget_investment_description', with: 'If I had a gym near my place I could go do Zumba'
+    check   'budget_investment_terms_of_service'
+
+    find('.js-add-tag-link', text: 'Education').click
+    click_button 'Create Investment'
+
+    expect(page).to have_content 'Investment created successfully.'
+
+    within "#tags_budget_investment_#{Budget::Investment.last.id}" do
+      expect(page).to have_content 'Education'
+      expect(page).not_to have_content 'Health'
+    end
+  end
+
   scenario 'Create with too many tags' do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  "#{group.name}: #{heading.name}", from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in 'budget_investment_description', with: 'I want to live in a high tower over the clouds'
     check   'budget_investment_terms_of_service'
@@ -123,7 +173,7 @@ feature 'Tags' do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  "#{group.name}: #{heading.name}", from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in 'budget_investment_description', with: 'I want to live in a high tower over the clouds'
     check   'budget_investment_terms_of_service'


### PR DESCRIPTION
Where
=====
* **Related PR's:** https://github.com/AyuntamientoMadrid/consul/pull/1138

What
====
*This is a Backport* from madrid's fork, taking only the improvements that may also apply to consul:
- Not showing the Group name along the Heading name when there's only one Heading for that Group (at the dropdown list)
- Moving to Group model the logic to check if it has only one heading 

How
===
Cherrypicking and editing relevant commits, check the original PR for more context.

Screenshots
===========
![screen shot 2018-01-22 at 19 49 47](https://user-images.githubusercontent.com/983242/35238334-6b4f8876-ffad-11e7-83b3-99f0825585fe.jpg)

Test
====
Updated to reflect new Heading options naming rules

Deployment
==========
As usual

Warnings
========
None