### PR TITLE
Fix map markers with asterisks

### DIFF
--- a/app/helpers/map_locations_helper.rb
+++ b/app/helpers/map_locations_helper.rb
@@ -60,11 +60,15 @@ module MapLocationsHelper
       latitude_input_selector: "##{map_location_input_id(parent_class, 'latitude')}",
       longitude_input_selector: "##{map_location_input_id(parent_class, 'longitude')}",
       zoom_input_selector: "##{map_location_input_id(parent_class, 'zoom')}",
-      marker_investments_coordinates: investments_coordinates
+      marker_investments_coordinates: clean_coordinates(investments_coordinates)
     }
     options[:marker_latitude] = map_location.latitude if map_location.latitude.present?
     options[:marker_longitude] = map_location.longitude if map_location.longitude.present?
     options
+  end
+
+  def clean_coordinates(coordinates)
+    coordinates.select {|c| [c[:lat], c[:long]].all? {|value| value.is_a? Numeric }}
   end
 
 end

--- a/spec/helpers/map_locations_helper_spec.rb
+++ b/spec/helpers/map_locations_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe MapLocationsHelper do
+
+  describe "#clean_coordinates" do
+
+    it "returns valid coordinates" do
+      coordinates = [lat: 40.3267278, long: -3.6755274]
+      expect(clean_coordinates(coordinates)).to eq([lat: 40.3267278, long: -3.6755274])
+    end
+
+    it "does not return coordinates with an invalid latitude" do
+      coordinates = [lat: "********", long: -3.6755274]
+      expect(clean_coordinates(coordinates)).to eq([])
+    end
+
+    it "does not return coordinates with an invalid longitude" do
+      coordinates = [lat: 40.3267278, long: "********"]
+      expect(clean_coordinates(coordinates)).to eq([])
+    end
+
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2380

What
===
- Skips invalid map locations

Why
===
Sometimes even though the latitude and longitud of a map location is stored correctly in DB it is passed to the map as “********”. This prevents all points in the map from being displayed

We should figure out where are these asterisks are coming from, maybe it’s from one of the map libraries. In the meantime this should reduce the problem

Screenshots
===========
- Map locations with asterisks instead of numbers
<img width="1163" alt="map asterisks" src="https://user-images.githubusercontent.com/4169/35352655-ead7dc36-0144-11e8-88b2-c69360fa8e26.png">


Test
====
- Added map_locations_helper spec to clean coordinates

Deployment
==========
- As usual

Warnings
========
- Some valid map locations might not be displayed. Figure out what is truly happening here.

Update
===
- Tested in production environment. This does not solve the problem.
   It might have to do with the map libraries
