### PR TITLE
Fix i18n texts

### DIFF
--- a/app/views/admin/budget_phases/_form.html.erb
+++ b/app/views/admin/budget_phases/_form.html.erb
@@ -22,21 +22,6 @@
 
     <div class="row margin-top">
       <div class="small-12 medium-12 column">
-        <%= f.label :summary, t("admin.budget_phases.edit.summary") %>
-
-        <p class="help-text" id="phase-summary-help-text">
-          <%= t("admin.budget_phases.edit.summary_help_text") %>
-        </p>
-
-        <%= f.cktext_area :summary,
-                          maxlength: Budget::Phase::SUMMARY_MAX_LENGTH,
-                          ckeditor: { language: I18n.locale },
-                          label: false %>
-      </div>
-    </div>
-
-    <div class="row margin-top">
-      <div class="small-12 medium-12 column">
         <%= f.label :description, t("admin.budget_phases.edit.description") %>
 
         <p class="help-text" id="phase-description-help-text">
@@ -45,6 +30,21 @@
 
         <%= f.cktext_area :description,
                           maxlength: Budget::Phase::DESCRIPTION_MAX_LENGTH,
+                          ckeditor: { language: I18n.locale },
+                          label: false %>
+      </div>
+    </div>
+
+    <div class="row margin-top">
+      <div class="small-12 medium-12 column">
+        <%= f.label :summary, t("admin.budget_phases.edit.summary") %>
+
+        <p class="help-text" id="phase-summary-help-text">
+          <%= t("admin.budget_phases.edit.summary_help_text") %>
+        </p>
+
+        <%= f.cktext_area :summary,
+                          maxlength: Budget::Phase::SUMMARY_MAX_LENGTH,
                           ckeditor: { language: I18n.locale },
                           label: false %>
       </div>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -63,8 +63,8 @@
 
       <% if @proposals.any? %>
         <div class="show-for-small-only">
-          <%= link_to t("proposals.index.start_proposal"), 
-                      new_proposal_guide, 
+          <%= link_to t("proposals.index.start_proposal"),
+                      new_proposal_guide,
                       class: 'button expanded' %>
         </div>
       <% end %>
@@ -85,7 +85,8 @@
             <p><%= t("proposals.index.section_footer.description") %></p>
             <p><%= t("proposals.index.section_footer.help_text_1") %></p>
             <p><%= t("proposals.index.section_footer.help_text_2",
-                      org: link_to(setting['org_name'], new_user_registration_path)).html_safe %></p>
+                      org: link_to(setting['org_name'], new_user_registration_path),
+                      supports: setting["votes_for_proposal_success"]).html_safe %></p>
             <p><%= t("proposals.index.section_footer.help_text_3") %></p>
           </div>
         <% end %>
@@ -94,8 +95,8 @@
 
     <div class="small-12 medium-3 column">
       <aside class="margin-bottom">
-        <%= link_to t("proposals.index.start_proposal"), 
-                    new_proposal_guide, 
+        <%= link_to t("proposals.index.start_proposal"),
+                    new_proposal_guide,
                     class: 'button expanded' %>
         <% if params[:retired].blank? %>
           <%= render 'categories' %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -125,9 +125,9 @@ en:
         start_date: Start date
         end_date: End date
         summary: Summary
-        summary_help_text: This text will appear in the header when the phase is active
+        summary_help_text: This text will inform the user about the phase. To show it even if the phase is not active, select the checkbox below
         description: Description
-        description_help_text: This text will inform the user about the phase. To show it even if the phase is not active, select the checkbox below
+        description_help_text: This text will appear in the header when the phase is active
         enabled: Phase enabled
         enabled_help_text: This phase will be public in the budget's phases timeline, as well as active for any other purpose
         save_changes: Save changes

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -125,9 +125,9 @@ es:
         start_date: Fecha de Inicio
         end_date: Fecha de fin
         summary: Resumen
-        summary_help_text: Este texto aparecerá en la cabecera cuando la fase esté activa
+        summary_help_text: Este texto informará al usuario sobre la fase. Para mostrarlo aunque la fase no esté activa, marca la opción de más abajo.
         description: Descripción
-        description_help_text: Este texto informará al usuario sobre la fase. Para mostrarlo aunque la fase no esté activa, marca la opción de más abajo.
+        description_help_text: Este texto aparecerá en la cabecera cuando la fase esté activa
         enabled: Fase habilitada
         enabled_help_text: Esta fase será pública en el calendario de fases del presupuesto y estará activa para otros propósitos
         save_changes: Guardar cambios

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -16,7 +16,7 @@ es:
         not_logged_in: Necesitas %{signin} o %{signup} para continuar.
         not_verified: Los proyectos de gasto sólo pueden ser apoyados por usuarios verificados, %{verify_account}.
         organization: Las organizaciones no pueden votar.
-        not_selected: No se pueden votar propuestas inviables.
+        not_selected: No se pueden votar proyectos inviables.
         not_enough_money_html: "Ya has asignado el presupuesto disponible.<br><small>Recuerda que puedes %{change_ballot} en cualquier momento</small>"
         no_ballots_allowed: El periodo de votación está cerrado.
         different_heading_assigned: Ya votaste en una sección distinta del presupuesto.
@@ -24,10 +24,10 @@ es:
     groups:
       show:
         title: Selecciona una opción
-        unfeasible_title: Propuestas inviables
-        unfeasible: Ver propuestas inviables
-        unselected_title: Propuestas no seleccionadas para la votación final
-        unselected: Ver las propuestas no seleccionadas para la votación final
+        unfeasible_title: Proyectos inviables
+        unfeasible: Ver proyectos inviables
+        unselected_title: Proyectos no seleccionados para la votación final
+        unselected: Ver los proyectos no seleccionados para la votación final
     phase:
       drafting: Borrador (No visible para el público)
       informing: Información
@@ -86,11 +86,11 @@ es:
         sidebar:
           my_ballot: Mis votos
           voted_html:
-            one: "<strong>Has votado una propuesta por un valor de %{amount_spent}</strong>"
-            other: "<strong>Has votado %{count} propuestas por un valor de %{amount_spent}</strong>"
+            one: "<strong>Has votado un proyecto por un valor de %{amount_spent}</strong>"
+            other: "<strong>Has votado %{count} proyectos por un valor de %{amount_spent}</strong>"
           voted_info: Puedes %{link} en cualquier momento hasta el cierre de esta fase. No hace falta que gastes todo el dinero disponible.
           voted_info_link: cambiar tus votos
-          different_heading_assigned_html: 'Ya apoyaste propuestas de otra sección del presupuesto: %{heading_link}'
+          different_heading_assigned_html: 'Ya apoyaste proyectos de otra sección del presupuesto: %{heading_link}'
           change_ballot: "Si cambias de opinión puedes borrar tus votos en %{check_ballot} y volver a empezar."
           check_ballot_link: "revisar mis votos"
           zero: Todavía no has votado ningún proyecto de gasto en este ámbito del presupuesto.
@@ -104,14 +104,14 @@ es:
           feasible: Ver los proyectos viables
           unfeasible: Ver los proyectos inviables
         orders:
-          random: Aleatorias
-          confidence_score: Mejor valoradas
+          random: Aleatorios
+          confidence_score: Mejor valorados
           price: Por coste
       show:
         author_deleted: Usuario eliminado
         price_explanation: Informe de coste
         unfeasibility_explanation: Informe de inviabilidad
-        code_html: 'Código propuesta de gasto: <strong>%{code}</strong>'
+        code_html: 'Código proyecto de gasto: <strong>%{code}</strong>'
         location_html: 'Ubicación: <strong>%{location}</strong>'
         organization_name_html: 'Propuesto en nombre de: <strong>%{name}</strong>'
         share: Compartir
@@ -138,7 +138,7 @@ es:
         give_support: Apoyar
       header:
         check_ballot: Revisar mis votos
-        different_heading_assigned_html: 'Ya apoyaste propuestas de otra sección del presupuesto: %{heading_link}'
+        different_heading_assigned_html: 'Ya apoyaste proyectos de otra sección del presupuesto: %{heading_link}'
         change_ballot: "Si cambias de opinión puedes borrar tus votos en %{check_ballot} y volver a empezar."
         check_ballot_link: "revisar mis votos"
         price: "Esta partida tiene un presupuesto de"
@@ -148,10 +148,10 @@ es:
     show:
       group: Grupo
       phase: Fase actual
-      unfeasible_title: Propuestas inviables
-      unfeasible: Ver las propuestas inviables
-      unselected_title: Propuestas no seleccionadas para la votación final
-      unselected: Ver las propuestas no seleccionadas para la votación final
+      unfeasible_title: Proyectos inviables
+      unfeasible: Ver las proyectos inviables
+      unselected_title: Proyectos no seleccionados para la votación final
+      unselected: Ver los proyectos no seleccionados para la votación final
       see_results: Ver resultados
     results:
       link: Resultados

--- a/config/locales/es/pages.yml
+++ b/config/locales/es/pages.yml
@@ -25,7 +25,7 @@ es:
         description: "Propón lo que quieres que el Ayuntamiento lleve a cabo y apoya propuestas de otras personas."
         feature_1: "Para crear una propuesta tienes que %{link}, además para apoyarlas debes verificar tu cuenta."
         feature_1_link: "registrarte en %{org_name}"
-        feature_2_html: "Las propuestas que consigan <strong>el apoyo del 1% de la gente</strong> (mayor de 16 años empadronada en Madrid; 27.064 apoyos) pasan a votación."
+        feature_2_html: "Las propuestas que consigan <strong>el apoyo del 1% de la gente</strong> (mayor de 16 años empadronada; %{supports} apoyos) pasan a votación."
         feature_3_html: "Si hay más gente a favor que en contra en la votación, <strong>el Ayuntamiento asume la propuesta y se hace</strong>."
         image_alt: "Botón para apoyar una propuesta"
         figcaption_html: 'Botón para "Apoyar" una propuesta.<br>Cuando alcance el número de apoyos pasará a votación.'
@@ -61,9 +61,9 @@ es:
       how_to_use:
         text: |-
           Utilízalo en tu municipio libremente o ayúdanos a mejorarlo, es software libre.
-          
+
           Este Portal de Gobierno Abierto usa la [aplicación CONSUL](https://github.com/consul/consul 'github consul') que es software libre, con [licencia AGPLv3](http://www.gnu.org/licenses/agpl-3.0.html 'AGPLv3 gnu' ), esto significa en palabras sencillas, que cualquiera puede libremente usar el código, copiarlo, verlo en detalle, modificarlo, y redistribuirlo al mundo con las modificaciones que quiera (manteniendo el que otros puedan a su vez hacer lo mismo). Porque creemos que la cultura es mejor y más rica cuando se libera.
-          
+
           Si eres programador, puedes ver el código y ayudarnos a mejorarlo en [aplicación CONSUL](https://github.com/consul/consul 'github consul').
       titles:
         how_to_use: Utilízalo en tu municipio


### PR DESCRIPTION
What
====
This PR:

- Replaces hardcoded text supports number to `[votes_for_proposal_success]` Setting.

- Fixes textarea and label order on admin budgets phases form (it was upside down)

- Updates Spanish translations of budgets (`propuesta de inversión` to `proyecto de gasto`)

