### PR TITLE
Add alert message when a user deletes an investment project from "My activity"

### DIFF
--- a/app/views/users/_budget_investment.html.erb
+++ b/app/views/users/_budget_investment.html.erb
@@ -5,7 +5,8 @@
   <td>
     <% if can? :destroy, budget_investment %>
       <%= link_to t('shared.delete'), budget_investment_path(budget_investment.budget, budget_investment),
-                  method: :delete, class: "button hollow alert expanded" %>
+                  method: :delete, class: "button hollow alert expanded",
+                  data: {confirm: "#{t('users.show.delete_alert')}"} %>
     <% end %>
   </td>
 </tr>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -740,6 +740,7 @@ en:
       no_private_messages: "This user doesn't accept private messages."
       private_activity: This user decided to keep the activity list private.
       send_private_message: "Send private message"
+      delete_alert: "Are you sure you want to delete your investment project? This action can't be undone"
     proposals:
       send_notification: "Send notification"
       retire: "Retire"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -739,6 +739,7 @@ es:
       no_private_messages: "Este usuario no acepta mensajes privados."
       private_activity: Este usuario ha decidido mantener en privado su lista de actividades.
       send_private_message: "Enviar un mensaje privado"
+      delete_alert: "¿Estás seguro de que deseas borrar tu proyecto de gasto? Esta acción no se puede deshacer"
     proposals:
       send_notification: "Enviar notificación"
       retire: "Retirar"

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -114,6 +114,29 @@ feature 'Users' do
       end
     end
 
+    scenario "Show alert when user wants to delete a budget investment", :js do
+      user = create(:user, :level_two)
+      budget = create(:budget, phase: 'accepting')
+      budget_investment = create(:budget_investment, author_id: user.id, budget: budget)
+
+      login_as(user)
+      visit user_path(user)
+
+      expect(page).to have_link budget_investment.title
+
+      within("#budget_investment_#{budget_investment.id}") do
+        page.driver.browser.dismiss_confirm
+        click_link 'Delete'
+      end
+      expect(page).to have_link budget_investment.title
+
+      within("#budget_investment_#{budget_investment.id}") do
+        page.driver.browser.accept_confirm
+        click_link 'Delete'
+      end
+      expect(page).not_to have_link budget_investment.title
+    end
+
   end
 
   feature 'Public activity' do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2363 (this PR closes #2363)

What
====
Add an alert message when the user clicks delete (a budget_investment) to avoid to removing them accidentally.

How
===
Add a confirm data attribute to the link to lauch the alert dialog.

Screenshots
===========
![investment01](https://user-images.githubusercontent.com/31625251/35400591-7ac9840e-01f7-11e8-8dd0-ba51d18279a4.gif)

Test
====
A new scenario was created to test if the dialog works. If the user dismisses the dialog the investment is not delted; if it accepts, it's deleted.

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.
