### PR TITLE
Show investment links only on phase balloting or later 

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -1,5 +1,9 @@
 module BudgetsHelper
 
+  def show_links_to_budget_investments(budget)
+    ['reviewing_ballots', 'finished'].include? budget.phase
+  end
+
   def heading_name_and_price_html(heading, budget)
     content_tag :div do
       concat(heading.name + ' ')

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -1,7 +1,7 @@
 module BudgetsHelper
 
   def show_links_to_budget_investments(budget)
-    ['reviewing_ballots', 'finished'].include? budget.phase
+    ['balloting', 'reviewing_ballots', 'finished'].include? budget.phase
   end
 
   def heading_name_and_price_html(heading, budget)

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -89,14 +89,19 @@
         </div>
 
         <p>
-          <%= link_to budget_investments_path(current_budget.id) do %>
-            <small><%= t("budgets.index.investment_proyects") %></small>
-          <% end %><br>
+          <% show_links = show_links_to_budget_investments(current_budget) %>
+          <% if show_links %>
+            <%= link_to budget_investments_path(current_budget.id) do %>
+              <small><%= t("budgets.index.investment_proyects") %></small>
+            <% end %><br>
+          <% end %>
           <%= link_to budget_investments_path(budget_id: current_budget.id, filter: 'unfeasible') do %>
             <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
           <% end %><br>
-          <%= link_to budget_investments_path(budget_id: current_budget.id, filter: 'unselected') do %>
-            <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
+          <% if show_links %>
+            <%= link_to budget_investments_path(budget_id: current_budget.id, filter: 'unselected') do %>
+              <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
+            <% end %>
           <% end %>
         </p>
       <% end %>

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -77,6 +77,46 @@ feature 'Budgets' do
         expect(page).not_to have_css('div#map')
       end
     end
+
+    scenario 'Show investment links only on balloting or later' do
+
+      budget = create(:budget)
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+
+      ['reviewing_ballots', 'finished'].each do |phase|
+        budget.update(phase: phase)
+
+        visit budgets_path
+
+        expect(page).to have_content(I18n.t("budgets.index.investment_proyects"))
+        expect(page).to have_content(I18n.t("budgets.index.unfeasible_investment_proyects"))
+        expect(page).to have_content(I18n.t("budgets.index.not_selected_investment_proyects"))
+      end
+    end
+
+    scenario 'Not show investment links earlier of balloting ' do
+
+      budget = create(:budget)
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+      phases_without_links = ['drafting','informing']
+      allowed_phase_list = ['reviewing_ballots', 'finished']
+      not_allowed_phase_list = Budget::Phase::PHASE_KINDS -
+                               phases_without_links -
+                               allowed_phase_list
+
+      not_allowed_phase_list.each do |phase|
+        budget.update(phase: phase)
+
+        visit budgets_path
+
+        expect(page).not_to have_content(I18n.t("budgets.index.investment_proyects"))
+        expect(page).to have_content(I18n.t("budgets.index.unfeasible_investment_proyects"))
+        expect(page).not_to have_content(I18n.t("budgets.index.not_selected_investment_proyects"))
+      end
+    end
+
   end
 
   scenario 'Index shows only published phases' do

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -4,6 +4,7 @@ feature 'Budgets' do
 
   let(:budget) { create(:budget) }
   let(:level_two_user) { create(:user, :level_two) }
+  let(:allowed_phase_list) { ['balloting', 'reviewing_ballots', 'finished'] }
 
   context 'Index' do
 
@@ -84,7 +85,7 @@ feature 'Budgets' do
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group)
 
-      ['reviewing_ballots', 'finished'].each do |phase|
+      allowed_phase_list.each do |phase|
         budget.update(phase: phase)
 
         visit budgets_path
@@ -101,7 +102,6 @@ feature 'Budgets' do
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group)
       phases_without_links = ['drafting','informing']
-      allowed_phase_list = ['reviewing_ballots', 'finished']
       not_allowed_phase_list = Budget::Phase::PHASE_KINDS -
                                phases_without_links -
                                allowed_phase_list


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2377

What
====
- Restricted links to budget_investments_path(@budget.id) and budget_investments_path(budget_id: @budget.id, filter: 'unselected') only for balloting or later phases on budgets#index

How
===
- Adding a method to budget_helper checking current_buget phase and using the result as condition to draw the links

Screenshots
===========

![screenshot from 2018-01-26 09 39 34](https://user-images.githubusercontent.com/33748390/35431559-3364c106-027d-11e8-85b0-5fc2ac9ffc32.png)

![screenshot from 2018-01-26 09 42 01](https://user-images.githubusercontent.com/33748390/35431560-337bebd8-027d-11e8-8b8c-37d1883a2d04.png)

Test
====
- Increased index budget spec checking the links phase by phase except the first two in which it does not apply

Deployment
==========
- Not needed

Warnings
========
- None
