### PR TITLE
Show only current budget tags in admin budget

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -52,8 +52,8 @@ module BudgetsHelper
     Budget::Ballot.where(user: current_user, budget: @budget).first
   end
 
-  def investment_tags_select_options
-    Budget::Investment.tags_on(:valuation).order(:name).select(:name).distinct
+  def investment_tags_select_options(budget)
+    Budget::Investment.where(budget_id: budget).tags_on(:valuation).order(:name).select(:name).distinct
   end
 
   def budget_published?(budget)

--- a/app/views/admin/budget_investments/index.html.erb
+++ b/app/views/admin/budget_investments/index.html.erb
@@ -25,14 +25,15 @@
                      class: "js-submit-on-change" } %>
   </div>
 
-  <div class="small-12 medium-3 column">
-    <%= select_tag :tag_name,
-                   options_for_select(investment_tags_select_options, params[:tag_name]),
-                   { prompt: t("admin.budget_investments.index.tags_filter_all"),
-                     label: false,
-                     class: "js-submit-on-change" } %>
-  </div>
-<% end %>
+    <div class="small-12 medium-3 column">
+      <%= select_tag :tag_name,
+                     options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
+                     { prompt: t("admin.budget_investments.index.tags_filter_all"),
+                       label: false,
+                       class: "js-submit-on-change" } %>
+    </div>
+  <% end %>
+</div>
 
 <%= render "advanced_filters", i18n_namespace: "admin.budget_investments.index" %>
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -281,6 +281,23 @@ feature 'Admin budget investments' do
       expect(page).to have_select("tag_name", options: ["All tags", "Hospitals", "Teachers"])
     end
 
+    scenario "Filtering by tag, display only valuation tags of the current budget" do
+      new_budget = create(:budget)
+      investment1 = create(:budget_investment, budget: @budget, tag_list: 'Roads')
+      investment2 = create(:budget_investment, budget: new_budget, tag_list: 'Accessibility')
+
+      investment1.set_tag_list_on(:valuation, 'Roads')
+      investment2.set_tag_list_on(:valuation, 'Accessibility')
+
+      investment1.save
+      investment2.save
+
+      visit admin_budget_budget_investments_path(budget_id: @budget.id)
+
+      expect(page).to have_select("tag_name", options: ["All tags", "Roads"])
+      expect(page).not_to have_select("tag_name", options: ["All tags", "Accessibility"])
+    end
+
     scenario "Limiting by max number of investments per heading", :js do
       group_1 = create(:budget_group, budget: @budget)
       group_2 = create(:budget_group, budget: @budget)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2368 

What
====
- Show only the tags of the current budget in the admin budget page

How
===
- In the  tag's search modify the method to only find the tags of the current budget.

Screenshots
===========
-  No changes have been added to the interface.

Test
====
- Added a test with two different budgets and different tags. And verify that only the current budget tags are displayed.

Deployment
==========
-N/A
