### PR TITLE
Add specs to check users permissions to delete images & documents

### DIFF
--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -12,16 +12,16 @@ describe Abilities::Administrator do
 
   let(:debate) { create(:debate) }
   let(:comment) { create(:comment) }
-  let(:proposal) { create(:proposal) }
+  let(:proposal) { create(:proposal, author: user) }
   let(:budget_investment) { create(:budget_investment) }
   let(:legislation_question) { create(:legislation_question) }
   let(:poll_question) { create(:poll_question) }
 
-  let(:proposal_document) { build(:document, documentable: proposal) }
+  let(:proposal_document) { build(:document, documentable: proposal, user: proposal.author) }
   let(:budget_investment_document) { build(:document, documentable: budget_investment) }
   let(:poll_question_document) { build(:document, documentable: poll_question) }
 
-  let(:proposal_image) { build(:image, imageable: proposal) }
+  let(:proposal_image) { build(:image, imageable: proposal, user: proposal.author) }
   let(:budget_investment_image) { build(:image, imageable: budget_investment) }
 
   let(:hidden_debate) { create(:debate, :hidden) }
@@ -82,4 +82,9 @@ describe Abilities::Administrator do
 
   it { should be_able_to(:valuate, create(:budget_investment, budget: create(:budget, phase: 'valuating'))) }
   it { should be_able_to(:valuate, create(:budget_investment, budget: create(:budget, phase: 'finished'))) }
+
+  it { should be_able_to(:destroy, proposal_image) }
+  it { should be_able_to(:destroy, proposal_document) }
+  it { should_not be_able_to(:destroy, budget_investment_image) }
+  it { should_not be_able_to(:destroy, budget_investment_document) }
 end

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -152,6 +152,12 @@ describe Abilities::Common do
     it { should be_able_to(:edit, own_proposal)                  }
     it { should_not be_able_to(:edit, proposal)                  } # Not his
     it { should_not be_able_to(:edit, own_proposal_non_editable) }
+
+    it { should be_able_to(:destroy, own_proposal_image)         }
+    it { should be_able_to(:destroy, own_proposal_document)      }
+
+    it { should_not be_able_to(:destroy, proposal_image)         }
+    it { should_not be_able_to(:destroy, proposal_document)      }
   end
 
   describe "when level 2 verified" do
@@ -218,8 +224,8 @@ describe Abilities::Common do
       it { should_not be_able_to(:create, investment_in_selecting_budget) }
       it { should_not be_able_to(:create, investment_in_balloting_budget) }
 
-      it { should_not be_able_to(:vote, investment_in_accepting_budget) }
       it { should be_able_to(:vote, investment_in_selecting_budget) }
+      it { should_not be_able_to(:vote, investment_in_accepting_budget) }
       it { should_not be_able_to(:vote, investment_in_balloting_budget) }
 
       it { should_not be_able_to(:destroy, investment_in_accepting_budget) }
@@ -232,9 +238,15 @@ describe Abilities::Common do
       it { should_not be_able_to(:destroy, own_investment_in_selecting_budget) }
       it { should_not be_able_to(:destroy, own_investment_in_balloting_budget) }
 
+      it { should be_able_to(:create, ballot_in_balloting_budget) }
       it { should_not be_able_to(:create, ballot_in_accepting_budget) }
       it { should_not be_able_to(:create, ballot_in_selecting_budget) }
-      it { should be_able_to(:create, ballot_in_balloting_budget) }
+
+      it { should be_able_to(:destroy, own_budget_investment_image) }
+      it { should be_able_to(:destroy, own_budget_investment_document) }
+
+      it { should_not be_able_to(:destroy, budget_investment_image) }
+      it { should_not be_able_to(:destroy, budget_investment_document) }
     end
   end
 

--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -60,13 +60,31 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
         end
       end
 
+      scenario "Administrators cannot destroy documentables they have not authored" do
+        login_as(administrator)
+        visit send(documentable_path, arguments)
+
+        within "#tab-documents" do
+          expect(page).not_to have_link("Destroy")
+        end
+      end
+
+      scenario "Users cannot destroy documentables they have not authored" do
+        login_as(create(:user))
+        visit send(documentable_path, arguments)
+
+        within "#tab-documents" do
+          expect(page).not_to have_link("Destroy")
+        end
+      end
+
     end
 
   end
 
   context "Destroy" do
 
-    scenario "Should show success notice after successfull document upload" do
+    scenario "Should show success notice after successful document upload" do
       login_as documentable.author
 
       visit send(documentable_path, arguments)

--- a/spec/shared/features/imageable.rb
+++ b/spec/shared/features/imageable.rb
@@ -44,7 +44,21 @@ shared_examples "imageable" do |imageable_factory_name, imageable_path, imageabl
       create(:image, imageable: imageable, user: imageable.author)
     end
 
-    scenario "Should show success notice after successfull deletion" do
+    scenario "Administrators cannot destroy imageables they have not authored" do
+      login_as(administrator)
+
+      visit send(imageable_path, imageable_arguments)
+      expect(page).not_to have_link "Remove image"
+    end
+
+    scenario "Users cannot destroy imageables they have not authored" do
+      login_as(create(:user))
+
+      visit send(imageable_path, imageable_arguments)
+      expect(page).not_to have_link "Remove image"
+    end
+
+    scenario "Should show success notice after successful deletion" do
       login_as imageable.author
 
       visit send(imageable_path, imageable_arguments)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2375 (This PR closes #2375 once merged)

What
====
* Added specs to make sure neither admins nor users can't delete documentables/imageables they haven't authored

How
===
* Wrote the necessary tests, feature was already implemented

Test
====
* Increased coverage, all green! ✅
