### PR TITLE
Hidden comments

### DIFF
--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -18,7 +18,7 @@
           <% if comment.commentable.hidden? %>
             (<%= t("admin.comments.index.hidden_#{comment.commentable_type.downcase}") %>: <%= comment.commentable.title %>)
           <% else %>
-            <%= link_to comment.commentable.title, comment.commentable %>
+            <%= link_to comment.commentable.title, commentable_path(comment) %>
           <% end %>
         </td>
         <td>

--- a/app/views/moderation/comments/index.html.erb
+++ b/app/views/moderation/comments/index.html.erb
@@ -34,7 +34,7 @@
       <tr id="comment_<%= comment.id %>">
         <td>
           <%= comment.commentable_type.constantize.model_name.human %> -
-          <%= link_to comment.commentable.title, comment.commentable %>
+           <%= link_to comment.commentable.title, commentable_path(comment) %>
           <br>
           <span class="date"><%= l comment.updated_at.to_date %></span>
           <span class="bullet">&nbsp;&bull;&nbsp;</span>

--- a/spec/features/admin/comments_spec.rb
+++ b/spec/features/admin/comments_spec.rb
@@ -26,6 +26,45 @@ feature 'Admin comments' do
     expect(page).not_to have_content("Good Proposal!")
   end
 
+  scenario "Visit items with hidden comments" do
+    debate = create(:debate, title: "Debate with spam comment")
+    proposal = create(:proposal, title: "Proposal with spam comment")
+    create(:comment, :hidden, commentable: debate, body: "This is SPAM comment on debate")
+    create(:comment, :hidden, commentable: proposal, body: "This is SPAM comment on proposal")
+
+    visit admin_comments_path
+
+    expect(page).to have_content("Debate with spam comment")
+    expect(page).to have_content("Proposal with spam comment")
+    expect(page).to have_content("This is SPAM comment on debate")
+    expect(page).to have_content("This is SPAM comment on proposal")
+
+    click_link "Debate with spam comment"
+    expect(page).to have_content("Debate with spam comment")
+    expect(page).not_to have_content("This is SPAM comment on debate")
+
+    visit admin_comments_path
+
+    click_link "Proposal with spam comment"
+    expect(page).to have_content("Proposal with spam comment")
+    expect(page).not_to have_content("This is SPAM comment on proposal")
+  end
+
+  scenario "Don't show link on hidden items" do
+    debate = create(:debate, :hidden, title: "Hidden debate title")
+    proposal = create(:proposal, :hidden, title: "Hidden proposal title")
+    create(:comment, :hidden, commentable: debate, body: "This is SPAM comment on debate")
+    create(:comment, :hidden, commentable: proposal, body: "This is SPAM comment on proposal")
+
+    visit admin_comments_path
+
+    expect(page).to have_content("(Hidden proposal: Hidden proposal title)")
+    expect(page).to have_content("(Hidden debate: Hidden debate title)")
+
+    expect(page).not_to have_link("This is SPAM comment on debate")
+    expect(page).not_to have_link("This is SPAM comment on proposal")
+  end
+
   scenario "Restore" do
     comment = create(:comment, :hidden, body: 'Not really SPAM')
     visit admin_comments_path

--- a/spec/features/moderation/comments_spec.rb
+++ b/spec/features/moderation/comments_spec.rb
@@ -37,6 +37,32 @@ feature 'Moderate comments' do
     end
   end
 
+  scenario "Visit items with flagged comments" do
+    moderator = create(:moderator)
+    debate = create(:debate, title: "Debate with spam comment")
+    proposal = create(:proposal, title: "Proposal with spam comment")
+    create(:comment, commentable: debate, body: "This is SPAM comment on debate", flags_count: 2)
+    create(:comment, commentable: proposal, body: "This is SPAM comment on proposal", flags_count: 2)
+
+    login_as(moderator.user)
+    visit moderation_comments_path
+
+    expect(page).to have_content("Debate with spam comment")
+    expect(page).to have_content("Proposal with spam comment")
+    expect(page).to have_content("This is SPAM comment on debate")
+    expect(page).to have_content("This is SPAM comment on proposal")
+
+    click_link "Debate with spam comment"
+    expect(page).to have_content("Debate with spam comment")
+    expect(page).to have_content("This is SPAM comment on debate")
+
+    visit moderation_comments_path
+
+    click_link "Proposal with spam comment"
+    expect(page).to have_content("Proposal with spam comment")
+    expect(page).to have_content("This is SPAM comment on proposal")
+  end
+
   feature '/moderation/ screen' do
 
     background do


### PR DESCRIPTION
Where
=====
This PR continue the work of @sergiochtf on https://github.com/consul/consul/pull/1610 and https://github.com/consul/consul/pull/1611/

What
====
- Changes hidden comments links on admin and moderation panel using `commentable_path` helper.

- Add specs for admin:
  - Visit items with hidden comments
  - Don't show link on hidden items

- Add specs for moderation:
  - Visit items with flagged comments
