### PR TITLE
Hide order selectors when only one order available

### DIFF
--- a/app/views/shared/_order_selector.html.erb
+++ b/app/views/shared/_order_selector.html.erb
@@ -1,14 +1,16 @@
-<form class="inline-block">
-  <label for="order-selector-participation" class="show-for-sr"><%= t("#{i18n_namespace}.select_order") %></label>
-  <select class="js-location-changer js-order-selector select-order"
-          data-order="<%= @current_order %>"
-          name="order-selector"
-          id="order-selector-participation">
-     <% @valid_orders.each do |order| %>
-       <option <%= 'selected' if order == @current_order %>
-          value='<%= current_path_with_query_params(order: order, page: 1) %>'>
-         <%= t("#{i18n_namespace}.orders.#{order}") %>
-       </option>
-     <% end %>
-   </select>
-</form>
+<% if @valid_orders.present? && @valid_orders.count > 1 %>
+  <form class="inline-block">
+    <label for="order-selector-participation" class="show-for-sr"><%= t("#{i18n_namespace}.select_order") %></label>
+    <select class="js-location-changer js-order-selector select-order"
+            data-order="<%= @current_order %>"
+            name="order-selector"
+            id="order-selector-participation">
+       <% @valid_orders.each do |order| %>
+         <option <%= 'selected' if order == @current_order %>
+            value='<%= current_path_with_query_params(order: order, page: 1) %>'>
+           <%= t("#{i18n_namespace}.orders.#{order}") %>
+         </option>
+       <% end %>
+     </select>
+  </form>
+<% end %>

--- a/app/views/shared/_wide_order_selector.html.erb
+++ b/app/views/shared/_wide_order_selector.html.erb
@@ -2,25 +2,26 @@
    #
    #   i18n_namespace: for example "moderation.debates.index"
 %>
-
-<div class="wide-order-selector small-12 medium-8">
-  <form>
-    <div class="small-12 medium-6 float-left">
-      <label for="order-selector-participation">
-        <%= t("#{i18n_namespace}.select_order") %>
-      </label>
-    </div>
-    <div class="small-12 medium-6 float-left">
-      <select class="js-location-changer js-order-selector select-order"
-              data-order="<%= @current_order %>" name="order-selector"
-              id="order-selector-participation">
-        <% @valid_orders.each do |order| %>
-          <% value = current_path_with_query_params(order: order, page: 1) %>
-          <option value="<%= value %>" <%= 'selected' if order == @current_order %>>
-            <%= t("#{i18n_namespace}.orders.#{order}") %>
-          </option>
-        <% end %>
-      </select>
-    </div>
-  </form>
-</div>
+<% if @valid_orders.present? && @valid_orders.count > 1 %>
+  <div class="wide-order-selector small-12 medium-8">
+    <form>
+      <div class="small-12 medium-6 float-left">
+        <label for="order-selector-participation">
+          <%= t("#{i18n_namespace}.select_order") %>
+        </label>
+      </div>
+      <div class="small-12 medium-6 float-left">
+        <select class="js-location-changer js-order-selector select-order"
+                data-order="<%= @current_order %>" name="order-selector"
+                id="order-selector-participation">
+          <% @valid_orders.each do |order| %>
+            <% value = current_path_with_query_params(order: order, page: 1) %>
+            <option value="<%= value %>" <%= 'selected' if order == @current_order %>>
+              <%= t("#{i18n_namespace}.orders.#{order}") %>
+            </option>
+          <% end %>
+        </select>
+      </div>
+    </form>
+  </div>
+<% end %>


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2309

What
====
On upcoming internal comments we'll offer only one ordering option (Oldest). But when there's only one option... what's the point of showing the selection box anymore? It'll trick the user into thinking there's more to choose from. I'd rather not see it :) (although I agree that @decabeza may 
think best option here would be to show the current ordering method but in plain text... if that's the case fire your mockup guns 🤗 )

How
===
Simple if statement  checking if valid orders are more than one 

Screenshots
===========
## Before
![screen shot 2018-01-29 at 20 50 28](https://user-images.githubusercontent.com/983242/35531232-ab99e69a-0536-11e8-8e87-db7fefe58adc.jpg)

## After

![screen shot 2018-01-29 at 20 49 36](https://user-images.githubusercontent.com/983242/35531241-b159e2ba-0536-11e8-9a99-7bf1b13dc515.jpg)

Test
====
Instead of doing hacky things on specs to test this, it will be tested at the only place that has only one ordering option for comments: Valuator comments https://github.com/consul/consul/pull/2403

Deployment
==========
As usual

Warnings
========
None but that mention at #What for possible UI/UX improvement 