### PR TITLE
Fix: Admin investments table not showing up properly

### DIFF
--- a/app/views/admin/budget_investments/index.html.erb
+++ b/app/views/admin/budget_investments/index.html.erb
@@ -27,15 +27,14 @@
                      class: "js-submit-on-change" } %>
   </div>
 
-    <div class="small-12 medium-3 column">
-      <%= select_tag :tag_name,
-                     options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
-                     { prompt: t("admin.budget_investments.index.tags_filter_all"),
-                       label: false,
-                       class: "js-submit-on-change" } %>
-    </div>
-  <% end %>
-</div>
+  <div class="small-12 medium-3 column">
+    <%= select_tag :tag_name,
+                   options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
+                   { prompt: t("admin.budget_investments.index.tags_filter_all"),
+                     label: false,
+                     class: "js-submit-on-change" } %>
+  </div>
+<% end %>
 
 <%= render "advanced_filters", i18n_namespace: "admin.budget_investments.index" %>
 


### PR DESCRIPTION
What
====
* Fixed `Admin::BudgetInvestments#index` table not showing up properly

How
===
* Removed extra `div` HTML tag that was breaking the UI

Screenshots
===========
* Before:
![screenshot_2018-01-29_18-21-57](https://user-images.githubusercontent.com/9470839/35538226-7680b2d0-0523-11e8-8536-5eae5d34be37.png)

* After:
![screenshot_2018-01-29_18-33-19](https://user-images.githubusercontent.com/9470839/35538247-7f99cac8-0523-11e8-8158-a6ab12b3aed4.png)

Warnings
========
* Merge ASAP to resume work on all Budget-related issues
