### PR TITLE
Added setting on admin to skip user verification

### DIFF
--- a/app/models/concerns/verification.rb
+++ b/app/models/concerns/verification.rb
@@ -10,31 +10,42 @@ module Verification
     scope :incomplete_verification, -> { where("(users.residence_verified_at IS NULL AND users.failed_census_calls_count > ?) OR (users.residence_verified_at IS NOT NULL AND (users.unconfirmed_phone IS NULL OR users.confirmed_phone IS NULL))", 0) }
   end
 
+  def skip_verification?
+    Setting["feature.user.skip_verification"].present?
+  end
+
   def verification_email_sent?
+    return true if skip_verification?
     email_verification_token.present?
   end
 
   def verification_sms_sent?
+    return true if skip_verification?
     unconfirmed_phone.present? && sms_confirmation_code.present?
   end
 
   def verification_letter_sent?
+    return true if skip_verification?
     letter_requested_at.present? && letter_verification_code.present?
   end
 
   def residence_verified?
+    return true if skip_verification?
     residence_verified_at.present?
   end
 
   def sms_verified?
+    return true if skip_verification?
     confirmed_phone.present?
   end
 
   def level_two_verified?
+    return true if skip_verification?
     level_two_verified_at.present? || (residence_verified? && sms_verified?)
   end
 
   def level_three_verified?
+    return true if skip_verification?
     verified_at.present?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -247,7 +247,8 @@ class User < ActiveRecord::Base
   end
 
   def show_welcome_screen?
-    sign_in_count == 1 && unverified? && !organization && !administrator?
+    verification = Setting["feature.user.skip_verification"].present? ? true : unverified?
+    sign_in_count == 1 && verification && !organization && !administrator?
   end
 
   def password_required?

--- a/app/views/welcome/welcome.html.erb
+++ b/app/views/welcome/welcome.html.erb
@@ -7,8 +7,22 @@
   <ul>
     <li><span class="icon-check"></span>&nbsp;<%= t("welcome.welcome.user_permission_debates") %></li>
     <li><span class="icon-check"></span>&nbsp;<%= t("welcome.welcome.user_permission_proposal") %></li>
-    <li><span class="icon-x"></span>&nbsp;<%= t("welcome.welcome.user_permission_support_proposal") %></li>
-    <li><span class="icon-x"></span>&nbsp;<%= t("welcome.welcome.user_permission_votes") %></li>
+    <li>
+      <% if current_user.level_two_or_three_verified? %>
+        <span class="icon-check"></span>
+      <% else %>
+        <span class="icon-x"></span>
+      <% end %>
+      <%= t("welcome.welcome.user_permission_support_proposal") %>
+    </li>
+    <li>
+      <% if current_user.level_three_verified? %>
+        <span class="icon-check"></span>
+      <% else %>
+        <span class="icon-x"></span>
+      <% end %>
+      <%= t("welcome.welcome.user_permission_votes") %>
+    </li>
   </ul>
 
   <p>
@@ -19,7 +33,14 @@
     <%= t("welcome.welcome.user_permission_verify") %>
   </p>
 
-  <%= link_to(t("welcome.welcome.user_permission_verify_my_account"), verification_path, class: "button success radius expand") %>
+  <% if current_user.level_three_verified? %>
+    <p class="already-verified">
+      <span class="icon-check"></span>
+      <%= t("account.show.verified_account") %>
+    </p>
+  <% else %>
+    <%= link_to(t("welcome.welcome.user_permission_verify_my_account"), verification_path, class: "button success radius expand") %>
+  <% end %>
 
   <p class="text-center">
     <%= link_to t("welcome.welcome.go_to_index"), proposals_path %>

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -42,6 +42,7 @@ en:
       legislation: Legislation
       user:
         recommendations: Recommendeds
+        skip_verification: Skip user verification
       community: Community on proposals and investments
       map: Proposals and budget investments geolocation
       allow_images: Allow upload and show images

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -42,6 +42,7 @@ es:
       legislation: Legislación
       user:
         recommendations: Recomendaciones
+        skip_verification: Omitir verificación de usuarios
       community: Comunidad en propuestas y proyectos de gasto
       map: Geolocalización de propuestas y proyectos de gasto
       allow_images: Permitir subir y mostrar imágenes

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -46,6 +46,7 @@ section "Creating Settings" do
   Setting.create(key: 'feature.allow_attached_documents', value: "true")
   Setting.create(key: 'feature.public_stats', value: "true")
   Setting.create(key: 'feature.guides', value: nil)
+  Setting.create(key: 'feature.user.skip_verification', value: "true")
 
   Setting.create(key: 'per_page_code_head', value: "")
   Setting.create(key: 'per_page_code_body', value: "")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -123,3 +123,5 @@ Setting['map_zoom'] = 10
 
 # Related content
 Setting['related_content_score_threshold'] = -0.3
+
+Setting["feature.user.skip_verification"] = 'true'

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -89,4 +89,36 @@ feature 'Admin settings' do
 
   end
 
+  describe "Skip verification" do
+
+    scenario "deactivate skip verification", :js do
+      Setting["feature.user.skip_verification"] = 'true'
+      setting = Setting.where(key: "feature.user.skip_verification").first
+
+      visit admin_settings_path
+
+      accept_alert do
+        find("#edit_setting_#{setting.id} .button").click
+      end
+
+      expect(page).to have_content 'Value updated'
+    end
+
+    scenario "activate skip verification", :js do
+      Setting["feature.user.skip_verification"] = nil
+      setting = Setting.where(key: "feature.user.skip_verification").first
+
+      visit admin_settings_path
+
+      accept_alert do
+        find("#edit_setting_#{setting.id} .button").click
+      end
+
+      expect(page).to have_content 'Value updated'
+
+      Setting["feature.user.skip_verification"] = nil
+    end
+
+  end
+
 end

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -68,4 +68,22 @@ feature "Welcome screen" do
     expect(page).to have_current_path(root_path)
   end
 
+  scenario 'a regular users sees it the first time he logs in, with all options active
+            if the setting skip_verification is activated' do
+
+    Setting["feature.user.skip_verification"] = 'true'
+
+    user = create(:user)
+
+    login_through_form_as(user)
+
+    4.times do |i|
+      expect(page).to have_css ".user-permissions > ul:nth-child(2) >
+                                li:nth-child(#{i + 1}) > span:nth-child(1)"
+    end
+
+    Setting["feature.user.skip_verification"] = nil
+  end
+
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     I18n.locale = :en
     load Rails.root.join('db', 'seeds.rb').to_s
+    Setting["feature.user.skip_verification"] = nil
   end
 
   config.before(:each, type: :feature) do

--- a/spec/support/verifiable.rb
+++ b/spec/support/verifiable.rb
@@ -179,4 +179,79 @@ shared_examples_for "verifiable" do
     end
   end
 
+  describe "methods modified by Setting user.skip_verification" do
+
+    let(:user) {create(:user)}
+
+    before do
+      Setting["feature.user.skip_verification"] = 'true'
+    end
+
+    after do
+      Setting["feature.user.skip_verification"] = nil
+    end
+
+    describe "#residence_verified?" do
+      it "is true if skipped" do
+        expect(user.residence_verified?).to eq(true)
+      end
+    end
+
+    describe "#sms_verified?" do
+      it "is true if skipped" do
+        expect(user.sms_verified?).to eq(true)
+      end
+    end
+
+    describe "#level_two_verified?" do
+      it "is true if skipped" do
+        expect(user.level_two_verified?).to eq(true)
+
+        user.update(residence_verified_at: Time.current)
+        expect(user.level_two_verified?).to eq(true)
+
+        user.update(confirmed_phone: "123456789", residence_verified_at: false)
+        expect(user.level_two_verified?).to eq(true)
+      end
+    end
+
+    describe "#level_three_verified?" do
+      it "is true if skipped" do
+        expect(user.level_three_verified?).to eq(true)
+      end
+    end
+
+    describe "#verification_email_sent?" do
+      it "is true if skipped" do
+        expect(user.verification_email_sent?).to eq(true)
+      end
+    end
+
+    describe "#verification_sms_sent?" do
+      it "is true  if skipped" do
+        user.update(unconfirmed_phone: nil, sms_confirmation_code: "666")
+        expect(user.verification_sms_sent?).to eq(true)
+
+        user.update(unconfirmed_phone: "666666666", sms_confirmation_code: nil)
+        expect(user.verification_sms_sent?).to eq(true)
+
+        user.update(unconfirmed_phone: nil, sms_confirmation_code: nil)
+        expect(user.verification_sms_sent?).to eq(true)
+      end
+    end
+
+    describe "#verification_letter_sent?" do
+      it "is true if skipped" do
+        user.update(letter_requested_at: nil, letter_verification_code: "666")
+        expect(user.verification_letter_sent?).to eq(true)
+
+        user.update(letter_requested_at: Time.current, letter_verification_code: nil)
+        expect(user.verification_letter_sent?).to eq(true)
+
+        user.update(letter_requested_at: nil, letter_verification_code: nil)
+        expect(user.verification_letter_sent?).to eq(true)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2291

What
====
- It allows to ignore the user verification (postal mail, sms, telephone, email and census, all appear verified) using a new setting. If activated, any user will be considered verified and see the welcome page only in his first login. 

- Using seeds on a new installation sets this setting active (on seeds and dev_seeds)

How
===
- Added a new option to settings (skip_validation) which makes to returns true any methods from models/concerns/validation.rb wich involves any kind of validation

- Also added conditions to force the user to go to welcome_path only in his first login

Screenshots
===========
- As you can see after the activation of the new setting a unverified user can login, with all participation options active and see the welcome page only once

![peek 2018-04-13 11-13](https://user-images.githubusercontent.com/33748390/38726895-c4cedf9e-3f0b-11e8-92e9-ae836471c4f7.gif)

Test
====
- Added test to verify the correct activation of the setting
- Added test for any verification method skipped
- Added test to ensure that welcome view is showed one time to any user on his first login if the setting is active and shows correctly the four green checks about active users

Deployment
==========
- No

Warnings
========
- No
