### PR TITLE
Remove usage of Investment's internal_comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Deprecated
 - Budget's `description_*` columns will be erased from database in next release. Please run rake task `budgets:phases:generate_missing` to migrate them. Details at Warning section of https://github.com/consul/consul/pull/2323
+- Budget::Investment's `internal_comments` attribute usage was removed, because of https://github.com/consul/consul/pull/2403, run rake task `investments:internal_comments:migrate_to_thread` to migrate existing values to the new internal comments thread. In next release database column will be removed.
 
 ### Removed
 - Spending Proposals urls from sitemap, that model is getting entirely deprecated soon.

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -70,7 +70,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     def valuation_params
       params.require(:budget_investment).permit(:price, :price_first_year, :price_explanation,
                                                 :feasibility, :unfeasibility_explanation,
-                                                :duration, :valuation_finished, :internal_comments)
+                                                :duration, :valuation_finished)
     end
 
     def restrict_access_to_assigned_items

--- a/app/views/valuation/budget_investments/_written_by_valuators.html.erb
+++ b/app/views/valuation/budget_investments/_written_by_valuators.html.erb
@@ -47,7 +47,3 @@
   </p>
 <% end %>
 
-<% if @investment.internal_comments.present? %>
-  <h2><%= t("valuation.budget_investments.show.internal_comments") %></h2>
-  <%= explanation_field @investment.internal_comments %>
-<% end %>

--- a/app/views/valuation/budget_investments/edit.html.erb
+++ b/app/views/valuation/budget_investments/edit.html.erb
@@ -90,13 +90,6 @@
   </div>
 
   <div class="row">
-    <div class="small-12 column">
-      <%= f.label :internal_comments, t("valuation.budget_investments.edit.internal_comments_html") %>
-      <%= f.text_area :internal_comments, label: false, rows: 3 %>
-    </div>
-  </div>
-
-  <div class="row">
     <div class="actions small-12 medium-4 column">
       <%= f.submit(class: "button expanded large", value: t("valuation.budget_investments.edit.save")) %>
     </div>

--- a/config/locales/en/valuation.yml
+++ b/config/locales/en/valuation.yml
@@ -53,7 +53,6 @@ en:
         undefined: Undefined
         valuation_finished: Valuation finished
         duration: Time scope
-        internal_comments: Internal comments
         responsibles: Responsibles
         assigned_admin: Assigned admin
         assigned_valuators: Assigned valuators
@@ -71,7 +70,6 @@ en:
         valuation_finished_alert: "Are you sure you want to mark this report as completed? If you do it, it can no longer be modified."
         not_feasible_alert: "An email will be sent immediately to the author of the project with the report of unfeasibility."
         duration_html: Time scope
-        internal_comments_html: Internal comments
         save: Save changes
       notice:
         valuate: "Dossier updated"

--- a/config/locales/es/valuation.yml
+++ b/config/locales/es/valuation.yml
@@ -53,7 +53,6 @@ es:
         undefined: Sin definir
         valuation_finished: Informe finalizado
         duration: Plazo de ejecución
-        internal_comments: Comentarios internos
         responsibles: Responsables
         assigned_admin: Administrador asignado
         assigned_valuators: Evaluadores asignados
@@ -71,7 +70,6 @@ es:
         valuation_finished_alert: "¿Estás seguro/a de querer marcar este informe como completado? Una vez hecho, no se puede deshacer la acción."
         not_feasible_alert: "Un email será enviado inmediatamente al autor del proyecto con el informe de inviabilidad."
         duration_html: Plazo de ejecución <small>(opcional, dato no público)</small>
-        internal_comments_html: Comentarios y observaciones <small>(para responsables internos, dato no público)</small>
         save: Guardar Cambios
       notice:
         valuate: "Dossier actualizado"

--- a/lib/tasks/investments.rake
+++ b/lib/tasks/investments.rake
@@ -1,0 +1,11 @@
+namespace :investments do
+  namespace :internal_comments do
+    desc "Migrate internal_comments textarea to a first comment on internal thread"
+    task migrate_to_thread: :environment do
+      comments_author = Administrator.first.user
+      Budget::Investment.where.not(internal_comments: [nil, '']).each do |investment|
+        Comment.create(investment, comments_author, investment.internal_comments)
+      end
+    end
+  end
+end

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -235,7 +235,6 @@ feature 'Valuation budget investments' do
       within('#duration') { expect(page).to have_content('Undefined') }
       within('#feasibility') { expect(page).to have_content('Undecided') }
       expect(page).not_to have_content('Valuation finished')
-      expect(page).not_to have_content('Internal comments')
     end
 
     scenario 'Edit dossier' do
@@ -249,7 +248,6 @@ feature 'Valuation budget investments' do
       fill_in 'budget_investment_price_explanation', with: 'Very cheap idea'
       choose  'budget_investment_feasibility_feasible'
       fill_in 'budget_investment_duration', with: '19 months'
-      fill_in 'budget_investment_internal_comments', with: 'Should be double checked by the urbanism area'
       click_button 'Save changes'
 
       expect(page).to have_content "Dossier updated"
@@ -263,8 +261,6 @@ feature 'Valuation budget investments' do
       within('#duration') { expect(page).to have_content('19 months') }
       within('#feasibility') { expect(page).to have_content('Feasible') }
       expect(page).not_to have_content('Valuation finished')
-      expect(page).to have_content('Internal comments')
-      expect(page).to have_content('Should be double checked by the urbanism area')
     end
 
     scenario 'Feasibility can be marked as pending' do
@@ -290,7 +286,7 @@ feature 'Valuation budget investments' do
     scenario 'Feasibility selection makes proper fields visible', :js do
       feasible_fields = ['Price (€)', 'Cost during the first year (€)', 'Price explanation', 'Time scope']
       unfeasible_fields = ['Feasibility explanation']
-      any_feasibility_fields = ['Valuation finished', 'Internal comments']
+      any_feasibility_fields = ['Valuation finished']
       undecided_fields = feasible_fields + unfeasible_fields + any_feasibility_fields
 
       visit edit_valuation_budget_budget_investment_path(@budget, @investment)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2309
* **Related PR's:** https://github.com/consul/consul/pull/2403

What
====
Internal Comments textarea on Budget Investments is deprecated and will be entirely removed on release v0.14, for now we're just removing usage for release v0.13.

Since internal comments have been in use in production environments, we need to preserve them. The most basic option is to just create an initial comment on the new internal comments thread with the entire `internal_comments` text and make the first Admin the author.

How
===
 - Removing usage at  show & edit views under admin/valuations panels
 - Adding a rake task to migrate existing values.

Screenshots
===========
## Before
### Admin Show [Before]
![screen shot 2018-01-29 at 21 18 25](https://user-images.githubusercontent.com/983242/35532312-19d9924c-053a-11e8-87bf-562b2e72b70a.jpg)
### Valuation Form [Before]
![screen shot 2018-01-29 at 21 18 18](https://user-images.githubusercontent.com/983242/35532313-1a083d0e-053a-11e8-8adb-d0ad0af0e437.jpg)
### Valuation Show [Before]
![screen shot 2018-01-29 at 21 18 07](https://user-images.githubusercontent.com/983242/35532314-1a391c76-053a-11e8-99d6-8ef6ae9a2c94.jpg)

## After
### Admin Show [After]
![screen shot 2018-01-29 at 21 18 37](https://user-images.githubusercontent.com/983242/35532350-3e6afc72-053a-11e8-93fa-5b8220417c36.jpg)
### Valuation Form [After]
![screen shot 2018-01-29 at 21 18 47](https://user-images.githubusercontent.com/983242/35532351-3e9124b0-053a-11e8-8d12-4c64d778d471.jpg)
### Valuation Show [After]
![screen shot 2018-01-29 at 21 20 44](https://user-images.githubusercontent.com/983242/35532366-4a33552c-053a-11e8-8ffc-b4545c4ae446.jpg)

Test
====
Updated those scenarios that were expecting the internal_comments textarea usage

Deployment
==========
As usual

Warnings
========
⚠️  This is a DEPRECATION warning! On the v0.14 release the `internal_comments` column will be removed from the database. Please ensure you'll be migrating existing values either with the provided rake task **`rake investments:internal_comments:migrate_to_thread`** or a custom/manual one.