### PR TITLE
Remove all link to additional documentation on Budget::Investment and Proposal and appends it on description

### DIFF
--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -52,7 +52,7 @@ class Management::Budgets::InvestmentsController < Management::BaseController
     end
 
     def investment_params
-      params.require(:budget_investment).permit(:title, :description, :external_url, :heading_id, :tag_list, :organization_name, :location)
+      params.require(:budget_investment).permit(:title, :description, :heading_id, :tag_list, :organization_name, :location)
     end
 
     def only_verified_users

--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -36,7 +36,7 @@ class Management::ProposalsController < Management::BaseController
     end
 
     def proposal_params
-      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
+      params.require(:proposal).permit(:title, :question, :summary, :description, :video_url,
                                        :responsible_name, :tag_list, :terms_of_service, :geozone_id)
     end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -91,7 +91,7 @@ class ProposalsController < ApplicationController
   private
 
     def proposal_params
-      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
+      params.require(:proposal).permit(:title, :question, :summary, :description, :video_url,
                                        :responsible_name, :tag_list, :terms_of_service, :geozone_id, :skip_map,
                                        image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                                        documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],

--- a/app/views/admin/budget_investments/_written_by_author.html.erb
+++ b/app/views/admin/budget_investments/_written_by_author.html.erb
@@ -54,12 +54,6 @@
   </div>
 </div>
 
-<% if @investment.external_url.present? %>
-  <p>
-    <%= text_with_links @investment.external_url %>&nbsp;<span class="icon-external small"></span>
-  </p>
-<% end %>
-
 <%= safe_html_with_links @investment.description %>
 
 <p>

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -26,13 +26,9 @@
     </div>
 
     <div class="small-12 column">
-      <div class="small-12 medium-6">
-        <%= f.text_field :external_url %>
-      </div>
 
-      <div class="small-12 medium-6">
-        <%= f.select :heading_id, budget_heading_select_options(@budget), include_blank: t("admin.budget_investments.edit.select_heading") %>
-      </div>
+      <%= f.select :heading_id, budget_heading_select_options(@budget), include_blank: t("admin.budget_investments.edit.select_heading") %>
+
     </div>
   </div>
 

--- a/app/views/admin/proposals/index.html.erb
+++ b/app/views/admin/proposals/index.html.erb
@@ -22,9 +22,6 @@
           <div class="moderation-description">
             <p><small><%= proposal.summary %></small></p>
             <%= proposal.description %>
-            <% if proposal.external_url.present? %>
-              <p><%= text_with_links proposal.external_url %></p>
-            <% end %>
             <% if proposal.video_url.present? %>
               <p><%= text_with_links proposal.video_url %></p>
             <% end %>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -68,12 +68,6 @@
 
         <%= render 'shared/tags', taggable: investment %>
 
-        <% if investment.external_url.present? %>
-          <div class="document-link">
-            <%= text_with_links investment.external_url %>
-          </div>
-        <% end %>
-
         <% if investment.should_show_unfeasibility_explanation? %>
           <h2><%= t('budgets.investments.show.unfeasibility_explanation') %></h2>
           <p><%= investment.unfeasibility_explanation %></p>

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -57,16 +57,6 @@
 
         <%= safe_html_with_links @proposal.description %>
 
-        <% if @proposal.external_url.present? %>
-          <div class="document-link">
-            <p>
-              <span class="icon-document"></span>&nbsp;
-              <strong><%= t('proposals.show.title_external_url') %></strong>
-            </p>
-              <%= text_with_links @proposal.external_url %>
-          </div>
-        <% end %>
-
         <% if @proposal.video_url.present? %>
           <div class="video-link">
             <p>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -41,11 +41,6 @@
                                    aria: {describedby: "video-url-help-text"} %>
     </div>
 
-    <div class="small-12 column">
-      <%= f.label :external_url, t("proposals.form.proposal_external_url") %>
-      <%= f.text_field :external_url, placeholder: t("proposals.form.proposal_external_url"), label: false %>
-    </div>
-
     <% if feature?(:allow_images) %>
       <div class="images small-12 column">
         <%= render 'images/nested_image', imageable: @proposal, f: f %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -81,16 +81,6 @@
           </div>
         <% end %>
 
-        <% if @proposal.external_url.present? %>
-          <div class="document-link">
-            <p>
-              <span class="icon-document"></span>&nbsp;
-              <strong><%= t('proposals.show.title_external_url') %></strong>
-            </p>
-              <%= text_with_links @proposal.external_url %>
-          </div>
-        <% end %>
-
         <% if @proposal.video_url.present? %>
           <div class="video-link">
             <p>

--- a/app/views/valuation/budget_investments/show.html.erb
+++ b/app/views/valuation/budget_investments/show.html.erb
@@ -5,10 +5,6 @@
 
 <%= safe_html_with_links @investment.description %>
 
-<% if @investment.external_url.present? %>
-  <p><%= text_with_links @investment.external_url %></p>
-<% end %>
-
 <h2><%= t("valuation.budget_investments.show.info") %></h2>
 
 <p><strong><%= t("valuation.budget_investments.show.by") %>:</strong>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -320,7 +320,6 @@ en:
       other: Other
     form:
       geozone: Scope of operation
-      proposal_external_url: Link to additional documentation
       proposal_question: Proposal question
       proposal_question_example_html: "Must be summarised in one question with a Yes or No answer"
       proposal_responsible_name: Full name of the person submitting the proposal

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1279,6 +1279,12 @@ ActiveRecord::Schema.define(version: 20180718115545) do
   add_index "votes", ["votable_id", "votable_type", "vote_scope"], name: "index_votes_on_votable_id_and_votable_type_and_vote_scope", using: :btree
   add_index "votes", ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope", using: :btree
 
+  create_table "web_sections", force: :cascade do |t|
+    t.text     "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "widget_cards", force: :cascade do |t|
     t.string   "title"
     t.text     "description"
@@ -1295,12 +1301,6 @@ ActiveRecord::Schema.define(version: 20180718115545) do
     t.integer  "limit",      default: 3
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
-  end
-
-  create_table "web_sections", force: :cascade do |t|
-    t.text     "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "administrators", "users"

--- a/lib/tasks/external_url.rake
+++ b/lib/tasks/external_url.rake
@@ -1,0 +1,25 @@
+namespace :external_url do
+
+  desc "Copy external url to description on Proposals"
+  task proposals: :environment do
+
+    Proposal.where('external_url is not null').all.each do |proposal|
+      proposal.description += "\r\n\r\n<p><strong>Additional documentation: </strong><a>#{proposal.external_url}</a></p>".html_safe
+      proposal.external_url = nil
+      proposal.save!
+    end
+
+  end
+
+  desc "Copy external url to description on Budget::Investments"
+  task investments: :environment do
+
+    Budget::Investment.where('external_url is not null').all.each do |investment|
+      investment.description += "\r\n\r\n<p><strong>Additional documentation: </strong><a>#{investment.external_url}</a></p>".html_safe
+      investment.external_url = nil
+      investment.save!
+    end
+
+  end
+
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -165,7 +165,6 @@ FactoryBot.define do
     sequence(:summary)   { |n| "In summary, what we want is... #{n}" }
     description          'Proposal description'
     question             'Proposal question'
-    external_url         'http://external_documention.es'
     video_url            'https://youtu.be/nhuNb0XtRhQ'
     responsible_name     'John Snow'
     terms_of_service     '1'

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -25,7 +25,6 @@ feature 'Admin proposals' do
     expect(page).to have_content(proposal.summary)
     expect(page).to have_content(proposal.description)
     expect(page).to have_content(proposal.question)
-    expect(page).to have_content(proposal.external_url)
     expect(page).to have_content(proposal.video_url)
   end
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1094,7 +1094,7 @@ feature 'Budget Investments' do
                         unfeasibility_explanation: 'Local government is not competent in this matter')
 
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
-
+save_and_open_page
     expect(page).not_to have_content("Unfeasibility explanation")
     expect(page).not_to have_content("Local government is not competent in this matter")
   end

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -25,7 +25,6 @@ feature 'Proposals' do
       fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
       fill_in 'proposal_summary', with: 'In summary, what we want is...'
       fill_in 'proposal_description', with: 'This is very important because...'
-      fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yRYFKcMa_Ek'
       check 'proposal_terms_of_service'
 
@@ -37,7 +36,6 @@ feature 'Proposals' do
       expect(page).to have_content '¿Would you like to give assistance to war refugees?'
       expect(page).to have_content 'In summary, what we want is...'
       expect(page).to have_content 'This is very important because...'
-      expect(page).to have_content 'http://rescue.org/refugees'
       expect(page).to have_content 'https://www.youtube.com/watch?v=yRYFKcMa_Ek'
       expect(page).to have_content user.name
       expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -121,7 +121,6 @@ feature 'Proposals' do
     expect(page).to have_content proposal.code
     expect(page).to have_content "Proposal question"
     expect(page).to have_content "Proposal description"
-    expect(page).to have_content "http://external_documention.es"
     expect(page).to have_content proposal.author.name
     expect(page).to have_content I18n.l(proposal.created_at.to_date)
     expect(page).to have_selector(avatar(proposal.author.name))
@@ -215,7 +214,6 @@ feature 'Proposals' do
     fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_description', with: 'This is very important because...'
-    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yPQfcG-eimk'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
@@ -233,7 +231,6 @@ feature 'Proposals' do
     expect(page).to have_content '¿Would you like to give assistance to war refugees?'
     expect(page).to have_content 'In summary, what we want is...'
     expect(page).to have_content 'This is very important because...'
-    expect(page).to have_content 'http://rescue.org/refugees'
     expect(page).to have_content 'https://www.youtube.com/watch?v=yPQfcG-eimk'
     expect(page).to have_content author.name
     expect(page).to have_content 'Refugees'
@@ -251,7 +248,6 @@ feature 'Proposals' do
     fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_description', with: 'This is very important because...'
-    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yPQfcG-eimk'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
@@ -279,7 +275,6 @@ feature 'Proposals' do
     fill_in 'proposal_question', with: 'This is a question'
     fill_in 'proposal_summary', with: 'This is the summary'
     fill_in 'proposal_description', with: 'This is the description'
-    fill_in 'proposal_external_url', with: 'http://google.com/robots.txt'
     fill_in 'proposal_responsible_name', with: 'Some other robot'
     check 'proposal_terms_of_service'
 
@@ -301,7 +296,6 @@ feature 'Proposals' do
     fill_in 'proposal_question', with: 'This is a question'
     fill_in 'proposal_summary', with: 'This is the summary'
     fill_in 'proposal_description', with: 'This is the description'
-    fill_in 'proposal_external_url', with: 'http://google.com/robots.txt'
     fill_in 'proposal_responsible_name', with: 'Some other robot'
     check 'proposal_terms_of_service'
 
@@ -321,7 +315,6 @@ feature 'Proposals' do
     fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_description', with: 'This is very important because...'
-    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
@@ -346,7 +339,6 @@ feature 'Proposals' do
     fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_description', with: 'This is very important because...'
-    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     check 'proposal_terms_of_service'
 
     click_button 'Create proposal'
@@ -376,7 +368,6 @@ feature 'Proposals' do
     fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_description', with: '<p>This is <script>alert("an attack");</script></p>'
-    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 
@@ -457,7 +448,6 @@ feature 'Proposals' do
       fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
       fill_in 'proposal_summary', with: 'In summary, what we want is...'
       fill_in 'proposal_description', with: 'This is very important because...'
-      fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yPQfcG-eimk'
       fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
       check 'proposal_terms_of_service'
@@ -485,7 +475,6 @@ feature 'Proposals' do
       fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
       fill_in 'proposal_summary', with: 'In summary, what we want is...'
       fill_in 'proposal_description', with: 'This is very important because...'
-      fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yPQfcG-eimk'
       fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
       check 'proposal_terms_of_service'
@@ -636,7 +625,6 @@ feature 'Proposals' do
     fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'Basically...'
     fill_in 'proposal_description', with: "Let's do something to end child poverty"
-    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
 
     click_button "Save changes"

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1819,7 +1819,6 @@ feature 'Successful proposals' do
       fill_in 'proposal_summary', with: 'In summary what we want is...'
       fill_in 'proposal_question', with: 'Would you like to?'
       fill_in 'proposal_description', with: 'This is very important because...'
-      fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yPQfcG-eimk'
       fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
       check 'proposal_terms_of_service'

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -100,7 +100,6 @@ feature 'Tags' do
     fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in_ckeditor 'proposal_description', with: 'A description with enough characters'
-    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=Ae6gQmhaMn4'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
@@ -145,7 +144,6 @@ feature 'Tags' do
     fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_description', with: 'A description suitable for this test'
-    fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     check 'proposal_terms_of_service'
 

--- a/spec/lib/tasks/external_url_spec.rb
+++ b/spec/lib/tasks/external_url_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'rake external_url:investments' do
+
+  before do
+    @investment = create(:budget_investment, external_url: "http://www.url.com")
+
+    Rake.application.rake_require "tasks/external_url"
+    Rake::Task.define_task(:environment)
+  end
+
+  it 'remove content from external_url an insert into description' do
+    expected_text = "\r\n\r\n<p><strong>Additional documentation: </strong>#{@investment.external_url}</p>".html_safe
+    Rake::Task["external_url:investments"].invoke
+
+    expect(Budget::Investment.all.map(&:external_url).compact).to eq []
+    expect(Budget::Investment.last.description).to include expected_text
+  end
+
+end
+
+describe 'rake external_url:proposals' do
+
+  before do
+    @proposal = create(:proposal, external_url: "http://www.url.com")
+
+    Rake.application.rake_require "tasks/external_url"
+    Rake::Task.define_task(:environment)
+  end
+
+  it 'remove content from external_url an insert into description' do
+    expected_text = "\r\n\r\n<p><strong>Additional documentation: </strong>#{@proposal.external_url}</p>".html_safe
+    Rake::Task["external_url:proposals"].invoke
+
+    expect(Proposal.all.map(&:external_url).compact).to eq []
+    expect(Proposal.last.description).to include expected_text
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2204 

What
====
- Eliminate any appearance of the external_url attribute in any Budget::Investment and any Proposal.
Also add at the end of the description of each of the contents of external_url. This PR does not remove the external_url attribute

How
===
- Removed the attribute of the code and added rake tasks that copies the content at the end of the description, converting it into a link

Screenshots
===========
- Before
![screenshot from 2018-01-31 09 42 49](https://user-images.githubusercontent.com/33748390/35616402-67f190d8-0675-11e8-8b03-351cc90e8a7c.png)
-------------------------------------
![screenshot from 2018-01-31 09 49 18](https://user-images.githubusercontent.com/33748390/35616403-6813cfb8-0675-11e8-99f4-d48e0e195751.png)
- After
![screenshot from 2018-01-31 10 12 48](https://user-images.githubusercontent.com/33748390/35616389-601873d6-0675-11e8-8ebf-5e4eab6dc63f.png)
-------------------------------------
![screenshot from 2018-01-31 10 13 11](https://user-images.githubusercontent.com/33748390/35616390-60332cc6-0675-11e8-81bd-348442a46813.png)

Test
====
- Created a new file to test the rake tasks

Deployment
==========
- Remember to run the rake tasks :)

Warnings
========
- None
