### PR TITLE
Admins can search investments by title or ID

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -35,7 +35,9 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
   def update
     set_valuation_tags
     if @investment.update(budget_investment_params)
-      redirect_to admin_budget_budget_investment_path(@budget, @investment, Budget::Investment.filter_params(params)),
+      redirect_to admin_budget_budget_investment_path(@budget,
+                                                      @investment,
+                                                      Budget::Investment.filter_params(params)),
                   notice: t("flash.actions.update.budget_investment")
     else
       load_admins
@@ -62,9 +64,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_investments
-      @investments = if params[:project_title].present?
-                       Budget::Investment.where("title ILIKE ?",
-                                                "%#{params[:project_title].strip}%")
+      @investments = if params[:title_or_id].present?
+                       Budget::Investment.search_by_title_or_id(params)
                      else
                        Budget::Investment.scoped_filter(params, @current_filter)
                                          .order(sort_by(params[:sort_by]))
@@ -74,8 +75,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
     def budget_investment_params
       params.require(:budget_investment)
-            .permit(:title, :description, :external_url, :heading_id, :administrator_id, :tag_list, :valuation_tag_list,
-                    :incompatible, :selected, valuator_ids: [])
+            .permit(:title, :description, :external_url, :heading_id, :administrator_id, :tag_list,
+                    :valuation_tag_list, :incompatible, :selected, valuator_ids: [])
     end
 
     def load_budget

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -102,7 +102,7 @@ class Budget
     end
 
     def self.scoped_filter(params, current_filter)
-      budget  = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+      budget  = Budget.find_by(id: params[:budget_id]) || Budget.find_by(slug: params[:budget_id])
       results = Investment.where(budget_id: budget.id)
 
       results = limit_results(budget, params, results)              if params[:max_per_heading].present?
@@ -136,6 +136,13 @@ class Budget
       end
 
       results.where("budget_investments.id IN (?)", ids)
+    end
+
+    def self.search_by_title_or_id(params)
+      results = Investment.where(budget_id: params[:budget_id])
+
+      return results.where(id: params[:title_or_id]) if params[:title_or_id] =~ /\A[0-9]+\z/
+      results.where("title ILIKE ?", "%#{params[:title_or_id].strip}%")
     end
 
     def searchable_values

--- a/app/views/admin/budget_investments/_search_form.html.erb
+++ b/app/views/admin/budget_investments/_search_form.html.erb
@@ -3,7 +3,7 @@
                                        method: :get,
                                        remote: true) do |f| %>
     <div class="input-group">
-      <%= text_field_tag :project_title, "", placeholder: t("admin.budget_investments.index.placeholder") %>
+      <%= text_field_tag :title_or_id, "", placeholder: t("admin.budget_investments.index.placeholder") %>
       <div class="input-group-button">
         <%= f.submit t("admin.budget_investments.index.buttons.search"), class: "button" %>
       </div>

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -368,11 +368,24 @@ feature 'Admin budget investments' do
       expect(page).to have_content(@investment_1.title)
       expect(page).to have_content(@investment_2.title)
 
-      fill_in 'project_title', with: 'Some investment'
+      fill_in 'title_or_id', with: 'Some investment'
       click_button 'Search'
 
       expect(page).to have_content(@investment_1.title)
       expect(page).not_to have_content(@investment_2.title)
+    end
+
+    scenario 'Search investments by ID' do
+      visit admin_budget_budget_investments_path(@budget)
+
+      expect(page).to have_content(@investment_1.title)
+      expect(page).to have_content(@investment_2.title)
+
+      fill_in 'title_or_id', with: @investment_2.id
+      click_button 'Search'
+
+      expect(page).to have_content(@investment_2.title)
+      expect(page).not_to have_content(@investment_1.title)
     end
   end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2401 (Closes #2401 once merged)
* **Related PR's:** #2378

What
====
* Allow admins to search investments by `title` or `ID`

How
===
* Added a new class method under `Budget::Investment` to allow search by `title` or `ID` —since the latter is less common, the query to the database for this only happens when the parameter matches a RegEx (numbers only)
* **Fixed a bug** where investments from other budgets appeared if they matched the query (introduced by yours truly on #2378)
* Fixed Rubocop warnings

Screenshots
===========
![peek 2018-01-31 10-07](https://user-images.githubusercontent.com/9470839/35627195-8f3b0b58-066e-11e8-8090-80689082328d.gif)

Test
====
* Increased coverage, all green! ✅
