### PR TITLE
Show error message when relating content to itself

### DIFF
--- a/app/controllers/related_contents_controller.rb
+++ b/app/controllers/related_contents_controller.rb
@@ -5,13 +5,18 @@ class RelatedContentsController < ApplicationController
 
   def create
     if relationable_object && related_object
-      RelatedContent.create(parent_relationable: @relationable, child_relationable: @related, author: current_user)
 
-      flash[:success] = t('related_content.success')
+      if relationable_object.url != related_object.url
+        RelatedContent.create(parent_relationable: @relationable, child_relationable: @related, author: current_user)
+
+        flash[:success] = t('related_content.success')
+      else
+        flash[:error] = t('related_content.error_itself')
+      end
+
     else
       flash[:error] = t('related_content.error', url: Setting['url'])
     end
-
     redirect_to @relationable.url
   end
 

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -821,6 +821,7 @@ en:
     help: "You can add links of %{models} inside of %{org}."
     submit: "Add"
     error: "Link not valid. Remember to start with %{url}."
+    error_itself: "Link not valid. You cannot relate a content to itself."
     success: "You added a new related content"
     is_related: "¿Is it related content?"
     score_positive: "Yes"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -820,6 +820,7 @@ es:
     help: "Puedes introducir cualquier enlace de %{models} que esté dentro de %{org}."
     submit: "Añadir"
     error: "Enlace no válido. Recuerda que debe empezar por %{url}."
+    error_itself: "Enlace no válido. No se puede relacionar un contenido consigo mismo."
     success: "Has añadido un nuevo contenido relacionado"
     is_related: "¿Es contenido relacionado?"
     score_positive: "Sí"

--- a/config/locales/val/general.yml
+++ b/config/locales/val/general.yml
@@ -819,6 +819,7 @@ val:
     help: "Pots afegir enllaços de %{models} en %{org}."
     submit: "Afegir"
     error: "Enllaç no vàlid. Recorda iniciar amb %{url}."
+    error_itself: "Enllaç no vàlid. No es pot relacionar un contingut aconseguisc mateix"
     success: "Has afegit nou contingut relacionat"
     is_related: "Es contingut relacionat?"
     score_positive: "Sí"

--- a/spec/shared/features/relationable.rb
+++ b/spec/shared/features/relationable.rb
@@ -71,6 +71,20 @@ shared_examples "relationable" do |relationable_model_name|
     expect(page).to have_content("Link not valid. Remember to start with #{Setting[:url]}.")
   end
 
+  scenario 'returns error when relating content URL to itself' do
+    login_as(user)
+    visit relationable.url
+
+    click_on("Add related content")
+
+    within("#related_content") do
+      fill_in 'url', with: Setting[:url] + relationable.url.to_s
+      click_button "Add"
+    end
+
+    expect(page).to have_content("Link not valid. You cannot relate a content to itself")
+  end
+
   scenario 'related content can be scored positively', :js do
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2402

What
====
- To receive an error when you try to relate an investment error with itself.

How
===
- Check in the controller the URL of the object to be related is the same one in which it is.
- Display an error message with the specific error. 

Screenshots
===========
![c_issue_2402](https://user-images.githubusercontent.com/34024463/35728066-9c6e9e8c-080a-11e8-8f26-54ea9be2549c.gif)

Test
====
- Test added by placing the same URL as the current investment. Verified the error message to pass the test.

Deployment
==========
- N/A

