### PR TITLE
Fix milestones order

### DIFF
--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -14,6 +14,9 @@ class Budget
       validates :investment, presence: true
       validates :publication_date, presence: true
 
+
+      scope :order_by_publication_date, -> { order(publication_date: :asc) }
+
       def self.title_max_length
         80
       end

--- a/app/views/admin/budget_investments/_milestones.html.erb
+++ b/app/views/admin/budget_investments/_milestones.html.erb
@@ -12,7 +12,7 @@
       </tr>
     </thead>
     <tbody>
-      <% @investment.milestones.each do |milestone| %>
+      <% @investment.milestones.order_by_publication_date.each do |milestone| %>
         <tr id="<%= dom_id(milestone) %>" class="milestone">
           <td class="text-center"><%= milestone.id %></td>
           <td>

--- a/app/views/budgets/investments/_milestones.html.erb
+++ b/app/views/budgets/investments/_milestones.html.erb
@@ -8,7 +8,7 @@
       <% end %>
       <section class="timeline">
         <ul class="no-bullet">
-          <% @investment.milestones.each do |milestone| %>
+          <% @investment.milestones.order_by_publication_date.each do |milestone| %>
             <li>
               <div class="milestone-content">
                 <% if milestone.publication_date.present? %>

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -910,9 +910,14 @@ feature 'Budget Investments' do
   scenario "Show milestones", :js do
     user = create(:user)
     investment = create(:budget_investment)
-    milestone = create(:budget_investment_milestone, investment: investment, title: "New text to show")
-    image = create(:image, imageable: milestone)
-    document = create(:document, documentable: milestone)
+    create(:budget_investment_milestone, investment: investment,
+                                         description: "Last milestone",
+                                         publication_date: Date.tomorrow)
+    first_milestone = create(:budget_investment_milestone, investment: investment,
+                                                           description: "First milestone",
+                                                           publication_date: Date.yesterday)
+    image = create(:image, imageable: first_milestone)
+    document = create(:document, documentable: first_milestone)
 
     login_as(user)
     visit budget_investment_path(budget_id: investment.budget.id, id: investment.id)
@@ -920,10 +925,12 @@ feature 'Budget Investments' do
     find("#tab-milestones-label").trigger('click')
 
     within("#tab-milestones") do
-      expect(page).to have_content(milestone.description)
-      expect(page).to have_content(Date.current)
-      expect(page.find("#image_#{milestone.id}")['alt']).to have_content image.title
-      expect(page).to have_link document.title
+      expect(first_milestone.description).to appear_before('Last milestone')
+      expect(page).to have_content(Date.tomorrow)
+      expect(page).to have_content(Date.yesterday)
+      expect(page).not_to have_content(Date.current)
+      expect(page.find("#image_#{first_milestone.id}")['alt']).to have_content(image.title)
+      expect(page).to have_link(document.title)
     end
   end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2429

What
====
Milestones should be ordered by publication date! Not by creation date

How
===
Adding a default order scope https://github.com/consul/consul/commit/0664d339f46bba2c776a66fb22b4d0c3fbb784bf

Screenshots
===========
## Before:

![screen shot 2018-02-03 at 18 48 52](https://user-images.githubusercontent.com/983242/35769933-455945de-0913-11e8-8bcc-a8d83faddb39.jpg)

## After:

![screen shot 2018-02-03 at 18 48 33](https://user-images.githubusercontent.com/983242/35769937-4a8f2cf8-0913-11e8-88f2-4856114a20e5.jpg)

Test
====
Scenario was incomplete even for description checking, added it as well as order check https://github.com/consul/consul/commit/67663804c5db63588fd74a70ff90bfba934397c6

Deployment
==========
As usual

Warnings
========
None. But don't ever use or think about default_scopes ever-never-forever =)