### PR TITLE
Only change budget slugs if its on draft phase

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -180,6 +180,10 @@ class Budget < ActiveRecord::Base
       )
     end
   end
+
+  def generate_slug?
+    slug.nil? || drafting?
+  end
 end
 
 

--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -13,5 +13,11 @@ class Budget
     def single_heading_group?
       headings.count == 1
     end
+
+    private
+
+    def generate_slug?
+      slug.nil? || budget.drafting?
+    end
   end
 end

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -28,5 +28,11 @@ class Budget
       investments.empty?
     end
 
+    private
+
+    def generate_slug?
+      slug.nil? || budget.drafting?
+    end
+
   end
 end

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -2,7 +2,7 @@ module Sluggable
   extend ActiveSupport::Concern
 
   included do
-    before_validation :generate_slug
+    before_validation :generate_slug, if: :generate_slug?
   end
 
   def generate_slug

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -220,7 +220,7 @@ FactoryBot.define do
   end
 
   factory :budget do
-    sequence(:name) { |n| "Budget #{n}" }
+    sequence(:name) { |n| "#{Faker::Lorem.word} #{n}" }
     currency_symbol "€"
     phase 'accepting'
     description_drafting  "This budget is drafting"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -278,6 +278,10 @@ FactoryBot.define do
   factory :budget_group, class: 'Budget::Group' do
     budget
     sequence(:name) { |n| "Group #{n}" }
+
+    trait :drafting_budget do
+      association :budget, factory: [:budget, :drafting]
+    end
   end
 
   factory :budget_heading, class: 'Budget::Heading' do
@@ -285,6 +289,10 @@ FactoryBot.define do
     sequence(:name) { |n| "Heading #{n}" }
     price 1000000
     population 1234
+
+    trait :drafting_budget do
+      association :group, factory: [:budget_group, :drafting_budget]
+    end
   end
 
   factory :budget_investment, class: 'Budget::Investment' do

--- a/spec/models/budget/group_spec.rb
+++ b/spec/models/budget/group_spec.rb
@@ -4,7 +4,7 @@ describe Budget::Group do
 
   let(:budget) { create(:budget) }
 
-  it_behaves_like "sluggable"
+  it_behaves_like "sluggable", updatable_slug_trait: :drafting_budget
 
   describe "name" do
     before do

--- a/spec/models/budget/heading_spec.rb
+++ b/spec/models/budget/heading_spec.rb
@@ -5,7 +5,7 @@ describe Budget::Heading do
   let(:budget) { create(:budget) }
   let(:group) { create(:budget_group, budget: budget) }
 
-  it_behaves_like "sluggable"
+  it_behaves_like "sluggable", updatable_slug_trait: :drafting_budget
 
   describe "name" do
     before do

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -4,7 +4,7 @@ describe Budget do
 
   let(:budget) { create(:budget) }
 
-  it_behaves_like "sluggable"
+  it_behaves_like "sluggable", updatable_slug_trait: :drafting
 
   describe "name" do
     before do

--- a/spec/models/concerns/sluggable.rb
+++ b/spec/models/concerns/sluggable.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-shared_examples_for 'sluggable' do
+shared_examples_for 'sluggable' do |updatable_slug_trait:|
 
   describe 'generate_slug' do
     let(:factory_name) { described_class.name.parameterize('_').to_sym }
@@ -9,6 +9,21 @@ shared_examples_for 'sluggable' do
     context "when a new sluggable is created" do
       it "gets a slug string" do
         expect(sluggable.slug).to eq("marlo-branido-carlo")
+      end
+    end
+
+    context "slug updating condition is true" do
+      it "slug is updated" do
+        updatable = create(factory_name, updatable_slug_trait, name: 'Old Name')
+        expect{updatable.update_attributes(name: 'New Name')}
+          .to change{ updatable.slug }.from('old-name').to('new-name')
+      end
+    end
+
+    context "slug updating condition is false" do
+      it "slug isn't updated" do
+        expect{sluggable.update_attributes(name: 'New Name')}
+          .not_to (change{ sluggable.slug })
       end
     end
   end

--- a/spec/models/concerns/sluggable.rb
+++ b/spec/models/concerns/sluggable.rb
@@ -3,13 +3,12 @@ require 'spec_helper'
 shared_examples_for 'sluggable' do
 
   describe 'generate_slug' do
-    before do
-      create(described_class.name.parameterize.tr('-', '_').to_sym, name: "Marlo Brañido Carlo")
-    end
+    let(:factory_name) { described_class.name.parameterize('_').to_sym }
+    let(:sluggable) { create(factory_name, name: "Marló Brañido Carlo") }
 
     context "when a new sluggable is created" do
       it "gets a slug string" do
-        expect(described_class.last.slug).to eq("marlo-branido-carlo")
+        expect(sluggable.slug).to eq("marlo-branido-carlo")
       end
     end
   end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #2419

What
====
If a Budget is not on Drafting phase, the public urls for the Budget/Budget::Headings/Budget::Groups/Budget::Investments should not change as if those are published online/offline they will send users to 404 errors.

How
===
Only set a slug value if its not present or conditions are met (budget must be drafting) e0871e5dc6cbbe792b1ce29e381aceb6a3f5a47f

Screenshots
===========
No need, backend only feature. See tests

Test
====
- First a small [refactor of sluggable concern spec](2eab6a476ea8ec9cedf199147f29b68308dc18eb) and [changed Budget factory name value](8f7297234490df70d15698764c0a52c08dca1a81)  to avoid collisions
- Created factory traits to have Budget::Heading and Budget::Group with a drafting budget at 
8e6e360fc8086f208cabe7e870608ee327e2ff64
- Increased sluggable concern spec to require a factory trait that should allow slug to be updated, and created scenarios for both "should" and "shouldn't" slug be udpdated 198ff0cd1f7e2e5e68b7a810166b0b8fbdff5a71

Deployment
==========
As usual

Warnings
========
This new behaviour may be as unintuitive for the admin as the current one... we're not showing the budget/budget group/budget heading slugs anywhere at the admin panel/forms... neither communicating when slugs are changed. I've created an issue to allow slug view/change (with clear & big disclaimers & warnings) here https://github.com/consul/consul/issues/2433
