### PR TITLE
Enable rubocop-rspec Capybara/FeatureMethods & fix all offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,7 +47,7 @@ Capybara/CurrentPathExpectation:
   Enabled: true
 
 Capybara/FeatureMethods:
-  Enabled: false
+  Enabled: true
 
 RSpec/ContextWording:
   Enabled: false

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Account' do
+describe 'Account' do
 
-  background do
+  before do
     @user = create(:user, username: "Manuela Colau")
     login_as(@user)
   end
 
-  scenario 'Show' do
+  it 'Show' do
     visit root_path
 
     click_link "My account"
@@ -18,7 +18,7 @@ feature 'Account' do
     expect(page).to have_selector(avatar('Manuela Colau'), count: 1)
   end
 
-  scenario 'Show organization' do
+  it 'Show organization' do
     create(:organization, user: @user, name: "Manuela Corp")
 
     visit account_path
@@ -29,7 +29,7 @@ feature 'Account' do
     expect(page).to have_selector(avatar('Manuela Corp'), count: 1)
   end
 
-  scenario 'Edit' do
+  it 'Edit' do
     visit account_path
 
     fill_in 'account_username', with: 'Larry Bird'
@@ -50,7 +50,7 @@ feature 'Account' do
     expect(find("#account_email_on_direct_message")).not_to be_checked
   end
 
-  scenario 'Edit Organization' do
+  it 'Edit Organization' do
     create(:organization, user: @user, name: "Manuela Corp")
     visit account_path
 
@@ -71,7 +71,7 @@ feature 'Account' do
 
   context "Option to display badge for official position" do
 
-    scenario "Users with official position of level 1" do
+    it "Users with official position of level 1" do
       official_user = create(:user, official_level: 1)
 
       login_as(official_user)
@@ -85,7 +85,7 @@ feature 'Account' do
       expect(find("#account_official_position_badge")).to be_checked
     end
 
-    scenario "Users with official position of level 2 and above" do
+    it "Users with official position of level 2 and above" do
       official_user2 = create(:user, official_level: 2)
       official_user3 = create(:user, official_level: 3)
 
@@ -102,7 +102,7 @@ feature 'Account' do
 
   end
 
-  scenario "Errors on edit" do
+  it "Errors on edit" do
     visit account_path
 
     fill_in 'account_username', with: ''
@@ -111,7 +111,7 @@ feature 'Account' do
     expect(page).to have_content error_message
   end
 
-  scenario 'Errors editing credentials' do
+  it 'Errors editing credentials' do
     visit root_path
 
     click_link 'My account'
@@ -125,7 +125,7 @@ feature 'Account' do
     expect(page).to have_content error_message
   end
 
-  scenario 'Erasing account' do
+  it 'Erasing account' do
     visit account_path
 
     click_link 'Erase my account'

--- a/spec/features/admin/activity_spec.rb
+++ b/spec/features/admin/activity_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-feature 'Admin activity' do
+describe 'Admin activity' do
 
-  background do
+  before do
     @admin = create(:administrator)
     login_as(@admin.user)
   end
 
   context "Proposals" do
-    scenario "Shows moderation activity on proposals", :js do
+    it "Shows moderation activity on proposals", :js do
       proposal = create(:proposal)
 
       visit proposal_path(proposal)
@@ -26,7 +26,7 @@ feature 'Admin activity' do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen" do
+    it "Shows moderation activity from moderation screen" do
       proposal1 = create(:proposal)
       proposal2 = create(:proposal)
       proposal3 = create(:proposal)
@@ -50,7 +50,7 @@ feature 'Admin activity' do
       expect(page).to have_content(proposal3.title)
     end
 
-    scenario "Shows admin restores" do
+    it "Shows admin restores" do
       proposal = create(:proposal, :hidden)
 
       visit admin_proposals_path
@@ -70,7 +70,7 @@ feature 'Admin activity' do
   end
 
   context "Debates" do
-    scenario "Shows moderation activity on debates", :js do
+    it "Shows moderation activity on debates", :js do
       debate = create(:debate)
 
       visit debate_path(debate)
@@ -88,7 +88,7 @@ feature 'Admin activity' do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen" do
+    it "Shows moderation activity from moderation screen" do
       debate1 = create(:debate)
       debate2 = create(:debate)
       debate3 = create(:debate)
@@ -112,7 +112,7 @@ feature 'Admin activity' do
       expect(page).to have_content(debate3.title)
     end
 
-    scenario "Shows admin restores" do
+    it "Shows admin restores" do
       debate = create(:debate, :hidden)
 
       visit admin_debates_path
@@ -132,7 +132,7 @@ feature 'Admin activity' do
   end
 
   context "Comments" do
-    scenario "Shows moderation activity on comments", :js do
+    it "Shows moderation activity on comments", :js do
       debate = create(:debate)
       comment = create(:comment, commentable: debate)
 
@@ -151,7 +151,7 @@ feature 'Admin activity' do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen" do
+    it "Shows moderation activity from moderation screen" do
       comment1 = create(:comment, body: "SPAM")
       comment2 = create(:comment)
       comment3 = create(:comment, body: "Offensive!")
@@ -175,7 +175,7 @@ feature 'Admin activity' do
       expect(page).to have_content(comment3.body)
     end
 
-    scenario "Shows admin restores" do
+    it "Shows admin restores" do
       comment = create(:comment, :hidden)
 
       visit admin_comments_path
@@ -195,7 +195,7 @@ feature 'Admin activity' do
   end
 
   context "User" do
-    scenario "Shows moderation activity on users" do
+    it "Shows moderation activity on users" do
       proposal = create(:proposal)
 
       visit proposal_path(proposal)
@@ -215,7 +215,7 @@ feature 'Admin activity' do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen" do
+    it "Shows moderation activity from moderation screen" do
       user = create(:user)
 
       visit moderation_users_path(name_or_email: user.username)
@@ -233,7 +233,7 @@ feature 'Admin activity' do
       end
     end
 
-    scenario "Shows moderation activity from proposals moderation screen" do
+    it "Shows moderation activity from proposals moderation screen" do
       proposal1 = create(:proposal)
       proposal2 = create(:proposal)
       proposal3 = create(:proposal)
@@ -259,7 +259,7 @@ feature 'Admin activity' do
       expect(page).not_to have_content(proposal2.author.username)
     end
 
-    scenario "Shows moderation activity from debates moderation screen" do
+    it "Shows moderation activity from debates moderation screen" do
       debate1 = create(:debate)
       debate2 = create(:debate)
       debate3 = create(:debate)
@@ -285,7 +285,7 @@ feature 'Admin activity' do
       expect(page).not_to have_content(debate2.author.username)
     end
 
-    scenario "Shows moderation activity from comments moderation screen" do
+    it "Shows moderation activity from comments moderation screen" do
       comment1 = create(:comment, body: "SPAM")
       comment2 = create(:comment)
       comment3 = create(:comment, body: "Offensive!")
@@ -311,7 +311,7 @@ feature 'Admin activity' do
       expect(page).not_to have_content(comment2.author.username)
     end
 
-    scenario "Shows admin restores" do
+    it "Shows admin restores" do
       user = create(:user, :hidden)
 
       visit admin_hidden_users_path

--- a/spec/features/admin/administrators_spec.rb
+++ b/spec/features/admin/administrators_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature 'Admin administrators' do
-  background do
+describe 'Admin administrators' do
+  before do
     @admin = create(:administrator)
     @user  = create(:user, username: 'Jose Luis Balbin')
     @administrator = create(:administrator)
@@ -9,13 +9,13 @@ feature 'Admin administrators' do
     visit admin_administrators_path
   end
 
-  scenario 'Index' do
+  it 'Index' do
     expect(page).to have_content @administrator.name
     expect(page).to have_content @administrator.email
     expect(page).not_to have_content @user.name
   end
 
-  scenario 'Create Administrator', :js do
+  it 'Create Administrator', :js do
     fill_in 'name_or_email', with: @user.email
     click_button 'Search'
 
@@ -26,7 +26,7 @@ feature 'Admin administrators' do
     end
   end
 
-  scenario 'Delete Administrator' do
+  it 'Delete Administrator' do
     find(:xpath, "//tr[contains(.,'#{@administrator.name}')]/td/a", text: 'Delete').click
 
     within("#administrators") do
@@ -34,7 +34,7 @@ feature 'Admin administrators' do
     end
   end
 
-  scenario 'Delete Administrator when its the current user' do
+  it 'Delete Administrator when its the current user' do
     find(:xpath, "//tr[contains(.,'#{@admin.name}')]/td/a", text: 'Delete').click
 
     within("#error") do
@@ -44,7 +44,7 @@ feature 'Admin administrators' do
 
   context 'Search' do
 
-    background do
+    before do
       user  = create(:user, username: 'Bernard Sumner', email: 'bernard@sumner.com')
       user2 = create(:user, username: 'Tony Soprano', email: 'tony@soprano.com')
       @administrator1 = create(:administrator, user: user)
@@ -52,7 +52,7 @@ feature 'Admin administrators' do
       visit admin_administrators_path
     end
 
-    scenario 'returns no results if search term is empty' do
+    it 'returns no results if search term is empty' do
       expect(page).to have_content(@administrator1.name)
       expect(page).to have_content(@administrator2.name)
 
@@ -65,7 +65,7 @@ feature 'Admin administrators' do
       expect(page).not_to have_content(@administrator2.name)
     end
 
-    scenario 'search by name' do
+    it 'search by name' do
       expect(page).to have_content(@administrator1.name)
       expect(page).to have_content(@administrator2.name)
 
@@ -77,7 +77,7 @@ feature 'Admin administrators' do
       expect(page).not_to have_content(@administrator2.name)
     end
 
-    scenario 'search by email' do
+    it 'search by email' do
       expect(page).to have_content(@administrator1.email)
       expect(page).to have_content(@administrator2.email)
 

--- a/spec/features/admin/banners_spec.rb
+++ b/spec/features/admin/banners_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Admin banners magement' do
+describe 'Admin banners magement' do
 
-  background do
+  before do
     login_as(create(:administrator).user)
   end
 
   context "Index" do
-    background do
+    before do
       @banner1 = create(:banner, title: "Banner number one",
                   description:  "This is the text of banner number one and is not active yet",
                   target_url:  "http://www.url.com",
@@ -49,23 +49,23 @@ feature 'Admin banners magement' do
                   post_ended_at:   (DateTime.current + 10.days))
     end
 
-    scenario 'Index show active banners' do
+    it 'Index show active banners' do
       visit admin_banners_path(filter: 'with_active')
       expect(page).to have_content("There are 3 banners")
     end
 
-    scenario 'Index show inactive banners' do
+    it 'Index show inactive banners' do
       visit admin_banners_path(filter: 'with_inactive')
       expect(page).to have_content("There are 2 banners")
     end
 
-    scenario 'Index show all banners' do
+    it 'Index show all banners' do
       visit admin_banners_path
       expect(page).to have_content("There are 5 banners")
     end
   end
 
-  scenario 'Banners publication is listed on admin menu' do
+  it 'Banners publication is listed on admin menu' do
     visit admin_root_path
 
     within('#side_menu') do
@@ -73,7 +73,7 @@ feature 'Admin banners magement' do
     end
   end
 
-  scenario 'Publish a banner' do
+  it 'Publish a banner' do
     visit admin_root_path
 
     within('#side_menu') do
@@ -102,7 +102,7 @@ feature 'Admin banners magement' do
     expect(page).to have_link 'Such banner many text wow link', href: 'https://www.url.com'
   end
 
-  scenario 'Edit banner with live refresh', :js do
+  it 'Edit banner with live refresh', :js do
     banner1 = create(:banner, title: 'Hello',
                               description: 'Wrong text',
                               target_url:  'http://www.url.com',
@@ -140,7 +140,7 @@ feature 'Admin banners magement' do
     expect(page).not_to have_content 'Wrong text'
   end
 
-  scenario 'Delete a banner' do
+  it 'Delete a banner' do
     create(:banner, title: 'Ugly banner',
                     description: 'Bad text',
                     target_url:  'http://www.url.com',

--- a/spec/features/admin/budget_investment_milestones_spec.rb
+++ b/spec/features/admin/budget_investment_milestones_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Admin budget investment milestones' do
+describe 'Admin budget investment milestones' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
 
@@ -10,7 +10,7 @@ feature 'Admin budget investment milestones' do
   end
 
   context "Index" do
-    scenario 'Displaying milestones' do
+    it 'Displaying milestones' do
       milestone = create(:budget_investment_milestone, investment: @investment)
       create(:image, imageable: milestone)
       document = create(:document, documentable: milestone)
@@ -25,7 +25,7 @@ feature 'Admin budget investment milestones' do
       expect(page).to have_link document.title
     end
 
-    scenario 'Displaying no_milestones text' do
+    it 'Displaying no_milestones text' do
       visit admin_budget_budget_investment_path(@investment.budget, @investment)
 
       expect(page).to have_content("Milestone")
@@ -34,7 +34,7 @@ feature 'Admin budget investment milestones' do
   end
 
   context "New" do
-    scenario "Add milestone" do
+    it "Add milestone" do
       visit admin_budget_budget_investment_path(@investment.budget, @investment)
 
       click_link 'Create new milestone'
@@ -48,7 +48,7 @@ feature 'Admin budget investment milestones' do
       expect(page).to have_content Date.current
     end
 
-    scenario "Show validation errors on milestone form" do
+    it "Show validation errors on milestone form" do
       visit admin_budget_budget_investment_path(@investment.budget, @investment)
 
       click_link 'Create new milestone'
@@ -65,7 +65,7 @@ feature 'Admin budget investment milestones' do
   end
 
   context "Edit" do
-    scenario "Change title, description and document names" do
+    it "Change title, description and document names" do
       milestone = create(:budget_investment_milestone, investment: @investment)
       create(:image, imageable: milestone)
       document = create(:document, documentable: milestone)
@@ -91,7 +91,7 @@ feature 'Admin budget investment milestones' do
   end
 
   context "Delete" do
-    scenario "Remove milestone" do
+    it "Remove milestone" do
       milestone = create(:budget_investment_milestone, investment: @investment, title: "Title will it remove")
 
       visit admin_budget_budget_investment_path(@investment.budget, @investment)

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Admin budget investments' do
+describe 'Admin budget investments' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
 
@@ -11,7 +11,7 @@ feature 'Admin budget investments' do
 
   context "Feature flag" do
 
-    background do
+    before do
       Setting['feature.budgets'] = nil
     end
 
@@ -19,7 +19,7 @@ feature 'Admin budget investments' do
       Setting['feature.budgets'] = true
     end
 
-    scenario 'Disabled with a feature flag' do
+    it 'Disabled with a feature flag' do
       expect{ visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 
@@ -27,7 +27,7 @@ feature 'Admin budget investments' do
 
   context "Index" do
 
-    scenario 'Displaying investments' do
+    it 'Displaying investments' do
       budget_investment = create(:budget_investment, budget: @budget, cached_votes_up: 77)
       visit admin_budget_budget_investments_path(budget_id: @budget.id)
       expect(page).to have_content(budget_investment.title)
@@ -36,7 +36,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content(budget_investment.total_votes)
     end
 
-    scenario 'If budget is finished do not show "Selected" button' do
+    it 'If budget is finished do not show "Selected" button' do
       finished_budget = create(:budget, :finished)
       budget_investment = create(:budget_investment, budget: finished_budget, cached_votes_up: 77)
 
@@ -51,7 +51,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario 'Displaying assignments info' do
+    it 'Displaying assignments info' do
       budget_investment1 = create(:budget_investment, budget: @budget)
       budget_investment2 = create(:budget_investment, budget: @budget)
       budget_investment3 = create(:budget_investment, budget: @budget)
@@ -83,7 +83,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Filtering by budget heading", :js do
+    it "Filtering by budget heading", :js do
       group1 = create(:budget_group, name: "Streets", budget: @budget)
       group2 = create(:budget_group, name: "Parks", budget: @budget)
 
@@ -126,7 +126,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_link("Plant trees")
     end
 
-    scenario "Filtering by admin", :js do
+    it "Filtering by admin", :js do
       user = create(:user, username: 'Admin 1')
       administrator = create(:administrator, user: user)
 
@@ -155,7 +155,7 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Realocate visitors")
     end
 
-    scenario "Filtering by valuator", :js do
+    it "Filtering by valuator", :js do
       user = create(:user)
       valuator = create(:valuator, user: user, description: 'Valuator 1')
 
@@ -186,7 +186,7 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Realocate visitors")
     end
 
-    scenario "Current filter is properly highlighted" do
+    it "Current filter is properly highlighted" do
       filters_links = { 'all' => 'All',
                         'without_admin' => 'Without assigned admin',
                         'without_valuator' => 'Without assigned valuator',
@@ -209,7 +209,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Filtering by assignment status" do
+    it "Filtering by assignment status" do
       assigned = create(:budget_investment, title: "Assigned idea", budget: @budget, administrator: create(:administrator))
       valuating = create(:budget_investment, title: "Evaluating...", budget: @budget)
       valuating.valuators.push(create(:valuator))
@@ -225,7 +225,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("Evaluating...")
     end
 
-    scenario "Filtering by valuation status" do
+    it "Filtering by valuation status" do
       valuating = create(:budget_investment, budget: @budget, title: "Ongoing valuation", administrator: create(:administrator))
       valuated = create(:budget_investment, budget: @budget, title: "Old idea", valuation_finished: true)
       valuating.valuators.push(create(:valuator))
@@ -246,7 +246,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content("Old idea")
     end
 
-    scenario "Filtering by tag" do
+    it "Filtering by tag" do
       create(:budget_investment, budget: @budget, title: 'Educate the children', tag_list: 'Education')
       create(:budget_investment, budget: @budget, title: 'More schools',         tag_list: 'Education')
       create(:budget_investment, budget: @budget, title: 'More hospitals',       tag_list: 'Health')
@@ -266,7 +266,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content("More schools")
     end
 
-    scenario "Filtering by tag, display only valuation tags" do
+    it "Filtering by tag, display only valuation tags" do
       investment1 = create(:budget_investment, budget: @budget, tag_list: 'Education')
       investment2 = create(:budget_investment, budget: @budget, tag_list: 'Health')
 
@@ -281,7 +281,7 @@ feature 'Admin budget investments' do
       expect(page).to have_select("tag_name", options: ["All tags", "Hospitals", "Teachers"])
     end
 
-    scenario "Filtering by tag, display only valuation tags of the current budget" do
+    it "Filtering by tag, display only valuation tags of the current budget" do
       new_budget = create(:budget)
       investment1 = create(:budget_investment, budget: @budget, tag_list: 'Roads')
       investment2 = create(:budget_investment, budget: new_budget, tag_list: 'Accessibility')
@@ -298,7 +298,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_select("tag_name", options: ["All tags", "Accessibility"])
     end
 
-    scenario "Limiting by max number of investments per heading", :js do
+    it "Limiting by max number of investments per heading", :js do
       group_1 = create(:budget_group, budget: @budget)
       group_2 = create(:budget_group, budget: @budget)
       parks   = create(:budget_heading, group: group_1)
@@ -356,13 +356,13 @@ feature 'Admin budget investments' do
   end
 
   context 'Search' do
-    background do
+    before do
       @budget = create(:budget)
       @investment_1 = create(:budget_investment, title: "Some investment", budget: @budget)
       @investment_2 = create(:budget_investment, title: "Some other investment", budget: @budget)
     end
 
-    scenario "Search investments by title" do
+    it "Search investments by title" do
       visit admin_budget_budget_investments_path(@budget)
 
       expect(page).to have_content(@investment_1.title)
@@ -375,7 +375,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content(@investment_2.title)
     end
 
-    scenario 'Search investments by ID' do
+    it 'Search investments by ID' do
       visit admin_budget_budget_investments_path(@budget)
 
       expect(page).to have_content(@investment_1.title)
@@ -390,28 +390,28 @@ feature 'Admin budget investments' do
   end
 
   context 'Sorting' do
-    background do
+    before do
       @budget = create(:budget)
       @investment_1 = create(:budget_investment, title: "BBBB", cached_votes_up: 50, budget: @budget)
       @investment_2 = create(:budget_investment, title: "AAAA", cached_votes_up: 25, budget: @budget)
       @investment_3 = create(:budget_investment, title: "CCCC", cached_votes_up: 10, budget: @budget)
     end
 
-    scenario 'Sort by ID' do
+    it 'Sort by ID' do
       visit admin_budget_budget_investments_path(@budget, sort_by: 'id')
 
       expect(@investment_1.title).to appear_before(@investment_2.title)
       expect(@investment_2.title).to appear_before(@investment_3.title)
     end
 
-    scenario 'Sort by title' do
+    it 'Sort by title' do
       visit admin_budget_budget_investments_path(@budget, sort_by: 'title')
 
       expect(@investment_2.title).to appear_before(@investment_1.title)
       expect(@investment_1.title).to appear_before(@investment_3.title)
     end
 
-    scenario 'Sort by supports' do
+    it 'Sort by supports' do
       visit admin_budget_budget_investments_path(@budget, sort_by: 'supports')
 
       expect(@investment_3.title).to appear_before(@investment_2.title)
@@ -420,11 +420,11 @@ feature 'Admin budget investments' do
   end
 
   context 'Show' do
-    background do
+    before do
       @administrator = create(:administrator, user: create(:user, username: 'Ana', email: 'ana@admins.org'))
     end
 
-    scenario 'Show the investment details' do
+    it 'Show the investment details' do
       valuator = create(:valuator, user: create(:user, username: 'Rachel', email: 'rachel@valuators.org'))
       budget_investment = create(:budget_investment,
                                   price: 1234,
@@ -455,7 +455,7 @@ feature 'Admin budget investments' do
       expect(page).to have_button "Publish comment"
     end
 
-    scenario "If budget is finished, investment cannot be edited or valuation comments created" do
+    it "If budget is finished, investment cannot be edited or valuation comments created" do
       # Only milestones can be managed
 
       finished_budget = create(:budget, :finished)
@@ -477,7 +477,7 @@ feature 'Admin budget investments' do
 
   context "Edit" do
 
-    scenario "Change title, incompatible, description or heading" do
+    it "Change title, incompatible, description or heading" do
       budget_investment = create(:budget_investment, :incompatible)
       create(:budget_heading, group: budget_investment.group, name: "Barbate")
 
@@ -499,7 +499,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content 'Selected'
     end
 
-    scenario "Compatible non-winner can't edit incompatibility" do
+    it "Compatible non-winner can't edit incompatibility" do
       budget_investment = create(:budget_investment, :selected)
       create(:budget_heading, group: budget_investment.group, name: "Tetuan")
 
@@ -510,7 +510,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content 'Mark as incompatible'
     end
 
-    scenario "Add administrator" do
+    it "Add administrator" do
       budget_investment = create(:budget_investment)
       administrator = create(:administrator, user: create(:user, username: 'Marta', email: 'marta@admins.org'))
 
@@ -524,7 +524,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content 'Assigned administrator: Marta'
     end
 
-    scenario "Add valuators" do
+    it "Add valuators" do
       budget_investment = create(:budget_investment)
 
       valuator1 = create(:valuator, user: create(:user, username: 'Valentina', email: 'v1@valuators.org'))
@@ -549,7 +549,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Adds existing valuation tags", :js do
+    it "Adds existing valuation tags", :js do
       budget_investment1 = create(:budget_investment)
       budget_investment1.set_tag_list_on(:valuation, 'Education, Health')
       budget_investment1.save
@@ -570,7 +570,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Adds non existent valuation tags" do
+    it "Adds non existent valuation tags" do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -587,7 +587,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Changes valuation and user generated tags" do
+    it "Changes valuation and user generated tags" do
       budget_investment = create(:budget_investment, tag_list: 'Park')
       budget_investment.set_tag_list_on(:valuation, 'Education')
       budget_investment.save
@@ -620,7 +620,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Maintains user tags" do
+    it "Maintains user tags" do
       budget_investment = create(:budget_investment, tag_list: 'Park')
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -637,7 +637,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content "Refugees, Solidarity"
     end
 
-    scenario "Shows alert when 'Valuation finished' is checked", :js do
+    it "Shows alert when 'Valuation finished' is checked", :js do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -652,7 +652,7 @@ feature 'Admin budget investments' do
       expect(page).to have_field('budget_investment[valuation_finished]', checked: true)
     end
 
-    scenario "Shows alert with unfeasible status when 'Valuation finished' is checked", :js do
+    it "Shows alert with unfeasible status when 'Valuation finished' is checked", :js do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -668,7 +668,7 @@ feature 'Admin budget investments' do
       expect(page).to have_field('budget_investment[valuation_finished]', checked: true)
     end
 
-    scenario "Undoes check in 'Valuation finished' if user clicks 'cancel' on alert", :js do
+    it "Undoes check in 'Valuation finished' if user clicks 'cancel' on alert", :js do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -681,7 +681,7 @@ feature 'Admin budget investments' do
       expect(page).to have_field('budget_investment[valuation_finished]', checked: false)
     end
 
-    scenario "Errors on update" do
+    it "Errors on update" do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -705,7 +705,7 @@ feature 'Admin budget investments' do
     let!(:winner_bi)      { create(:budget_investment, :winner, budget: @budget, title: "Winner project") }
     let!(:undecided_bi)   { create(:budget_investment, :undecided, budget: @budget, title: "Undecided project") }
 
-    scenario "Filtering by valuation and selection", :js do
+    it "Filtering by valuation and selection", :js do
       visit admin_budget_budget_investments_path(@budget)
 
       within('#filter-subnav') { click_link 'Valuation finished' }
@@ -743,7 +743,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content(winner_bi.title)
     end
 
-    scenario "Aggregating results", :js do
+    it "Aggregating results", :js do
       visit admin_budget_budget_investments_path(@budget)
 
       click_link 'Advanced filters'
@@ -768,7 +768,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content(feasible_vf_bi.title)
     end
 
-    scenario "Showing the selection buttons", :js do
+    it "Showing the selection buttons", :js do
       visit admin_budget_budget_investments_path(@budget)
 
       within("#budget_investment_#{unfeasible_bi.id}") do
@@ -792,7 +792,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Selecting an investment", :js do
+    it "Selecting an investment", :js do
       visit admin_budget_budget_investments_path(@budget)
 
       within("#budget_investment_#{feasible_vf_bi.id}") do
@@ -810,7 +810,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Unselecting an investment", :js do
+    it "Unselecting an investment", :js do
       visit admin_budget_budget_investments_path(@budget)
       click_link 'Advanced filters'
       within('#advanced_filters') { find(:css, "#advanced_filters_[value='selected']").set(true) }
@@ -836,7 +836,7 @@ feature 'Admin budget investments' do
 
   context "Selecting csv" do
 
-    scenario "Downloading CSV file" do
+    it "Downloading CSV file" do
       investment = create(:budget_investment, :feasible, budget: @budget,
                                                          price: 100)
       valuator = create(:valuator, user: create(:user, username: 'Rachel',
@@ -870,7 +870,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content I18n.t('shared.no')
     end
 
-    scenario "Downloading CSV file with applied filter" do
+    it "Downloading CSV file with applied filter" do
       investment1 = create(:budget_investment, :unfeasible, budget: @budget,
                                                             title: 'compatible')
       investment2 = create(:budget_investment, :finished, budget: @budget,

--- a/spec/features/admin/budget_phases_spec.rb
+++ b/spec/features/admin/budget_phases_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Admin budget phases' do
+describe 'Admin budget phases' do
   let(:budget) { create(:budget) }
 
   context 'Edit' do
@@ -10,7 +10,7 @@ feature 'Admin budget phases' do
       login_as(admin.user)
     end
 
-    scenario 'Update phase' do
+    it 'Update phase' do
       visit edit_admin_budget_budget_phase_path(budget, budget.current_phase)
 
       fill_in 'start_date', with: Date.current + 1.days

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature 'Admin budgets' do
+describe 'Admin budgets' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
   context 'Feature flag' do
 
-    background do
+    before do
       Setting['feature.budgets'] = nil
     end
 
@@ -17,7 +17,7 @@ feature 'Admin budgets' do
       Setting['feature.budgets'] = true
     end
 
-    scenario 'Disabled with a feature flag' do
+    it 'Disabled with a feature flag' do
       expect{ visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 
@@ -25,7 +25,7 @@ feature 'Admin budgets' do
 
   context 'Index' do
 
-    scenario 'Displaying budgets' do
+    it 'Displaying budgets' do
       budget = create(:budget)
       visit admin_budgets_path
 
@@ -33,7 +33,7 @@ feature 'Admin budgets' do
       expect(page).to have_content(translated_phase_name(phase_kind: budget.phase))
     end
 
-    scenario 'Filters by phase' do
+    it 'Filters by phase' do
       drafting_budget  = create(:budget, :drafting)
       accepting_budget = create(:budget, :accepting)
       selecting_budget = create(:budget, :selecting)
@@ -62,7 +62,7 @@ feature 'Admin budgets' do
       expect(page).not_to have_content(finished_budget.name)
     end
 
-    scenario 'Open filter is properly highlighted' do
+    it 'Open filter is properly highlighted' do
       filters_links = {'current' => 'Open', 'finished' => 'Finished'}
 
       visit admin_budgets_path
@@ -85,7 +85,7 @@ feature 'Admin budgets' do
 
   context 'New' do
 
-    scenario 'Create budget' do
+    it 'Create budget' do
       visit admin_budgets_path
       click_link 'Create new budget'
 
@@ -98,7 +98,7 @@ feature 'Admin budgets' do
       expect(page).to have_content 'M30 - Summer campaign'
     end
 
-    scenario 'Name is mandatory' do
+    it 'Name is mandatory' do
       visit new_admin_budget_path
       click_button 'Create Budget'
 
@@ -113,7 +113,7 @@ feature 'Admin budgets' do
     let!(:budget) { create(:budget) }
     let(:heading) { create(:budget_heading, group: create(:budget_group, budget: budget)) }
 
-    scenario 'Destroy a budget without investments' do
+    it 'Destroy a budget without investments' do
       visit admin_budgets_path
       click_link 'Edit budget'
       click_link 'Delete budget'
@@ -122,7 +122,7 @@ feature 'Admin budgets' do
       expect(page).to have_content('budgets cannot be found')
     end
 
-    scenario 'Try to destroy a budget with investments' do
+    it 'Try to destroy a budget with investments' do
       create(:budget_investment, heading: heading)
 
       visit admin_budgets_path
@@ -137,7 +137,7 @@ feature 'Admin budgets' do
   context 'Edit' do
     let!(:budget) { create(:budget) }
 
-    scenario 'Show phases table' do
+    it 'Show phases table' do
       visit admin_budgets_path
       click_link 'Edit budget'
 
@@ -168,11 +168,11 @@ feature 'Admin budgets' do
 
   context 'Update' do
 
-    background do
+    before do
       create(:budget)
     end
 
-    scenario 'Update budget' do
+    it 'Update budget' do
       visit admin_budgets_path
       click_link 'Edit budget'
 
@@ -187,7 +187,7 @@ feature 'Admin budgets' do
 
   context "Calculate Budget's Winner Investments" do
 
-    scenario 'For a Budget in reviewing balloting' do
+    it 'For a Budget in reviewing balloting' do
       budget = create(:budget, phase: 'reviewing_ballots')
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group, price: 4)
@@ -206,7 +206,7 @@ feature 'Admin budgets' do
       expect(page).not_to have_content selected.title
     end
 
-    scenario 'For a finished Budget' do
+    it 'For a finished Budget' do
       budget = create(:budget, phase: 'finished')
 
       visit edit_admin_budget_path(budget)
@@ -217,7 +217,7 @@ feature 'Admin budgets' do
 
   context 'Manage groups and headings' do
 
-    scenario 'Create group', :js do
+    it 'Create group', :js do
       budget = create(:budget, name: 'Yearly budget')
 
       visit admin_budgets_path
@@ -250,7 +250,7 @@ feature 'Admin budgets' do
       expect(page).not_to have_content 'No groups created yet.'
     end
 
-    scenario 'Create heading', :js do
+    it 'Create heading', :js do
       budget = create(:budget, name: 'Yearly budget')
       group  = create(:budget_group, budget: budget, name: 'Districts improvments')
 
@@ -278,7 +278,7 @@ feature 'Admin budgets' do
       end
     end
 
-    scenario 'Update heading', :js do
+    it 'Update heading', :js do
       budget = create(:budget, name: 'Yearly budget')
       group  = create(:budget_group, budget: budget, name: 'Districts improvments')
       heading = create(:budget_heading, group: group, name: "District 1")
@@ -300,7 +300,7 @@ feature 'Admin budgets' do
       expect(page).to have_content '6000'
     end
 
-    scenario 'Delete heading', :js do
+    it 'Delete heading', :js do
       budget = create(:budget, name: 'Yearly budget')
       group  = create(:budget_group, budget: budget, name: 'Districts improvments')
       heading = create(:budget_heading, group: group, name: "District 1")

--- a/spec/features/admin/comments_spec.rb
+++ b/spec/features/admin/comments_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Admin comments' do
+describe 'Admin comments' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario "Do not show comments from blocked users" do
+  it "Do not show comments from blocked users" do
     comment = create(:comment, :hidden, body: "SPAM from SPAMMER")
     proposal = create(:proposal, author: comment.author)
     create(:comment, commentable: proposal, user: comment.author, body: "Good Proposal!")
@@ -26,7 +26,7 @@ feature 'Admin comments' do
     expect(page).not_to have_content("Good Proposal!")
   end
 
-  scenario "Visit items with hidden comments" do
+  it "Visit items with hidden comments" do
     debate = create(:debate, title: "Debate with spam comment")
     proposal = create(:proposal, title: "Proposal with spam comment")
     create(:comment, :hidden, commentable: debate, body: "This is SPAM comment on debate")
@@ -50,7 +50,7 @@ feature 'Admin comments' do
     expect(page).not_to have_content("This is SPAM comment on proposal")
   end
 
-  scenario "Don't show link on hidden items" do
+  it "Don't show link on hidden items" do
     debate = create(:debate, :hidden, title: "Hidden debate title")
     proposal = create(:proposal, :hidden, title: "Hidden proposal title")
     create(:comment, :hidden, commentable: debate, body: "This is SPAM comment on debate")
@@ -65,7 +65,7 @@ feature 'Admin comments' do
     expect(page).not_to have_link("This is SPAM comment on proposal")
   end
 
-  scenario "Restore" do
+  it "Restore" do
     comment = create(:comment, :hidden, body: 'Not really SPAM')
     visit admin_comments_path
 
@@ -77,7 +77,7 @@ feature 'Admin comments' do
     expect(comment).to be_ignored_flag
   end
 
-  scenario "Confirm hide" do
+  it "Confirm hide" do
     comment = create(:comment, :hidden, body: 'SPAM')
     visit admin_comments_path
 
@@ -90,7 +90,7 @@ feature 'Admin comments' do
     expect(comment.reload).to be_confirmed_hide
   end
 
-  scenario "Current filter is properly highlighted" do
+  it "Current filter is properly highlighted" do
     visit admin_comments_path
     expect(page).not_to have_link('Pending')
     expect(page).to have_link('All')
@@ -112,7 +112,7 @@ feature 'Admin comments' do
     expect(page).not_to have_link('Confirmed')
   end
 
-  scenario "Filtering comments" do
+  it "Filtering comments" do
     create(:comment, :hidden, body: "Unconfirmed comment")
     create(:comment, :hidden, :with_confirmed_hide, body: "Confirmed comment")
 
@@ -125,7 +125,7 @@ feature 'Admin comments' do
     expect(page).to have_content('Confirmed comment')
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  it "Action links remember the pagination setting and the filter" do
     per_page = Kaminari.config.default_per_page
     (per_page + 2).times { create(:comment, :hidden, :with_confirmed_hide) }
 

--- a/spec/features/admin/debates_spec.rb
+++ b/spec/features/admin/debates_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Admin debates' do
+describe 'Admin debates' do
 
-  scenario 'Disabled with a feature flag' do
+  it 'Disabled with a feature flag' do
     Setting['feature.debates'] = nil
     admin = create(:administrator)
     login_as(admin.user)
@@ -12,12 +12,12 @@ feature 'Admin debates' do
     Setting['feature.debates'] = true
   end
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario 'Restore' do
+  it 'Restore' do
     debate = create(:debate, :hidden)
     visit admin_debates_path
 
@@ -29,7 +29,7 @@ feature 'Admin debates' do
     expect(debate).to be_ignored_flag
   end
 
-  scenario 'Confirm hide' do
+  it 'Confirm hide' do
     debate = create(:debate, :hidden)
     visit admin_debates_path
 
@@ -42,7 +42,7 @@ feature 'Admin debates' do
     expect(debate.reload).to be_confirmed_hide
   end
 
-  scenario "Current filter is properly highlighted" do
+  it "Current filter is properly highlighted" do
     visit admin_debates_path
     expect(page).not_to have_link('Pending')
     expect(page).to have_link('All')
@@ -64,7 +64,7 @@ feature 'Admin debates' do
     expect(page).not_to have_link('Confirmed')
   end
 
-  scenario "Filtering debates" do
+  it "Filtering debates" do
     create(:debate, :hidden, title: "Unconfirmed debate")
     create(:debate, :hidden, :with_confirmed_hide, title: "Confirmed debate")
 
@@ -81,7 +81,7 @@ feature 'Admin debates' do
     expect(page).to have_content('Confirmed debate')
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  it "Action links remember the pagination setting and the filter" do
     per_page = Kaminari.config.default_per_page
     (per_page + 2).times { create(:debate, :hidden, :with_confirmed_hide) }
 

--- a/spec/features/admin/feature_flags_spec.rb
+++ b/spec/features/admin/feature_flags_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Admin feature flags' do
+describe 'Admin feature flags' do
 
-  background do
+  before do
     Setting['feature.spending_proposals'] = true
     Setting['feature.spending_proposal_features.voting_allowed'] = true
     login_as(create(:administrator).user)
@@ -13,7 +13,7 @@ feature 'Admin feature flags' do
     Setting['feature.spending_proposal_features.voting_allowed'] = nil
   end
 
-  scenario 'Enabled features are listed on menu' do
+  it 'Enabled features are listed on menu' do
     visit admin_root_path
 
     within('#side_menu') do
@@ -22,7 +22,7 @@ feature 'Admin feature flags' do
     end
   end
 
-  scenario 'Disable a feature' do
+  it 'Disable a feature' do
     setting_id = Setting.find_by(key: 'feature.spending_proposals').id
 
     visit admin_settings_path
@@ -44,7 +44,7 @@ feature 'Admin feature flags' do
     expect{ visit admin_spending_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
-  scenario 'Enable a disabled feature' do
+  it 'Enable a disabled feature' do
     Setting['feature.spending_proposals'] = nil
     setting_id = Setting.find_by(key: 'feature.spending_proposals').id
 

--- a/spec/features/admin/geozones_spec.rb
+++ b/spec/features/admin/geozones_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature 'Admin geozones' do
+describe 'Admin geozones' do
 
-  background do
+  before do
     login_as(create(:administrator).user)
   end
 
-  scenario 'Show list of geozones' do
+  it 'Show list of geozones' do
     chamberi = create(:geozone, name: 'Chamberí')
     retiro = create(:geozone, name: 'Retiro')
 
@@ -16,7 +16,7 @@ feature 'Admin geozones' do
     expect(page).to have_content(retiro.name)
   end
 
-  scenario 'Create new geozone' do
+  it 'Create new geozone' do
     visit admin_root_path
 
     within('#side_menu') { click_link 'Manage geozones' }
@@ -36,7 +36,7 @@ feature 'Admin geozones' do
     expect(page).to have_content 'Fancy District'
   end
 
-  scenario 'Edit geozone with no associated elements' do
+  it 'Edit geozone with no associated elements' do
     geozone = create(:geozone, name: 'Edit me!', census_code: '012')
 
     visit admin_geozones_path
@@ -54,7 +54,7 @@ feature 'Admin geozones' do
     end
   end
 
-  scenario 'Edit geozone with associated elements' do
+  it 'Edit geozone with associated elements' do
     geozone = create(:geozone, name: 'Edit me!')
     create(:proposal, title: 'Proposal with geozone', geozone: geozone)
 
@@ -71,7 +71,7 @@ feature 'Admin geozones' do
     end
   end
 
-  scenario 'Delete geozone with no associated elements' do
+  it 'Delete geozone with no associated elements' do
     geozone = create(:geozone, name: 'Delete me!')
 
     visit admin_geozones_path
@@ -83,7 +83,7 @@ feature 'Admin geozones' do
     expect(Geozone.where(id: geozone.id)).to be_empty
   end
 
-  scenario 'Delete geozone with associated element' do
+  it 'Delete geozone with associated element' do
     geozone = create(:geozone, name: 'Delete me!')
     create(:proposal, geozone: geozone)
 

--- a/spec/features/admin/hidden_users_spec.rb
+++ b/spec/features/admin/hidden_users_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Admin hidden users' do
+describe 'Admin hidden users' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario 'Show user activity' do
+  it 'Show user activity' do
     user = create(:user, :hidden)
 
     debate1 = create(:debate, :hidden, author: user)
@@ -23,7 +23,7 @@ feature 'Admin hidden users' do
     expect(page).to have_content(comment2.body)
   end
 
-  scenario 'Restore' do
+  it 'Restore' do
     user = create(:user, :hidden)
     visit admin_hidden_users_path
 
@@ -34,7 +34,7 @@ feature 'Admin hidden users' do
     expect(user.reload).not_to be_hidden
   end
 
-  scenario 'Confirm hide' do
+  it 'Confirm hide' do
     user = create(:user, :hidden)
     visit admin_hidden_users_path
 
@@ -47,7 +47,7 @@ feature 'Admin hidden users' do
     expect(user.reload).to be_confirmed_hide
   end
 
-  scenario "Current filter is properly highlighted" do
+  it "Current filter is properly highlighted" do
     visit admin_hidden_users_path
     expect(page).not_to have_link('Pending')
     expect(page).to have_link('All')
@@ -69,7 +69,7 @@ feature 'Admin hidden users' do
     expect(page).not_to have_link('Confirmed')
   end
 
-  scenario "Filtering users" do
+  it "Filtering users" do
     create(:user, :hidden, username: "Unconfirmed")
     create(:user, :hidden, :with_confirmed_hide, username: "Confirmed user")
 
@@ -82,7 +82,7 @@ feature 'Admin hidden users' do
     expect(page).to have_content('Confirmed user')
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  it "Action links remember the pagination setting and the filter" do
     per_page = Kaminari.config.default_per_page
     (per_page + 2).times { create(:user, :hidden, :with_confirmed_hide) }
 

--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature 'Admin legislation draft versions' do
+describe 'Admin legislation draft versions' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
   context "Feature flag" do
 
-    scenario 'Disabled with a feature flag' do
+    it 'Disabled with a feature flag' do
       Setting['feature.legislation'] = nil
       process = create(:legislation_process)
       expect{ visit admin_legislation_process_draft_versions_path(process) }.to raise_exception(FeatureFlags::FeatureDisabled)
@@ -19,7 +19,7 @@ feature 'Admin legislation draft versions' do
 
   context "Index" do
 
-    scenario 'Displaying legislation process draft versions' do
+    it 'Displaying legislation process draft versions' do
       process = create(:legislation_process, title: 'An example legislation process')
       draft_version = create(:legislation_draft_version, process: process, title: 'Version 1')
 
@@ -35,7 +35,7 @@ feature 'Admin legislation draft versions' do
   end
 
   context 'Create' do
-    scenario 'Valid legislation draft version' do
+    it 'Valid legislation draft version' do
       process = create(:legislation_process, title: 'An example legislation process')
 
       visit admin_root_path
@@ -67,7 +67,7 @@ feature 'Admin legislation draft versions' do
   end
 
   context 'Update' do
-    scenario 'Valid legislation draft version', :js do
+    it 'Valid legislation draft version', :js do
       process = create(:legislation_process, title: 'An example legislation process')
       draft_version = create(:legislation_draft_version, title: 'Version 1', process: process)
 

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature 'Admin legislation processes' do
+describe 'Admin legislation processes' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
   context "Feature flag" do
 
-    scenario 'Disabled with a feature flag' do
+    it 'Disabled with a feature flag' do
       Setting['feature.legislation'] = nil
       expect{ visit admin_legislation_processes_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
@@ -18,7 +18,7 @@ feature 'Admin legislation processes' do
 
   context "Index" do
 
-    scenario 'Displaying legislation processes' do
+    it 'Displaying legislation processes' do
       process = create(:legislation_process)
       visit admin_legislation_processes_path(filter: 'all')
 
@@ -27,7 +27,7 @@ feature 'Admin legislation processes' do
   end
 
   context 'Create' do
-    scenario 'Valid legislation process' do
+    it 'Valid legislation process' do
       visit admin_root_path
 
       within('#side_menu') do
@@ -73,7 +73,7 @@ feature 'Admin legislation processes' do
   end
 
   context 'Update' do
-    scenario 'Remove summary text', js: true do
+    it 'Remove summary text', js: true do
       process = create(:legislation_process,
                        title: 'An example legislation process',
                        summary: 'Summarizing the process',
@@ -100,7 +100,7 @@ feature 'Admin legislation processes' do
       expect(page).to have_content 'Description of the process'
     end
 
-    scenario 'Deactivate draft publication', js: true do
+    it 'Deactivate draft publication', js: true do
       process = create(:legislation_process,
                        title: 'An example legislation process',
                        summary: 'Summarizing the process',

--- a/spec/features/admin/legislation/questions_spec.rb
+++ b/spec/features/admin/legislation/questions_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature 'Admin legislation questions' do
+describe 'Admin legislation questions' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
   context "Feature flag" do
 
-    background do
+    before do
       Setting['feature.legislation'] = nil
     end
 
@@ -17,7 +17,7 @@ feature 'Admin legislation questions' do
       Setting['feature.legislation'] = true
     end
 
-    scenario 'Disabled with a feature flag' do
+    it 'Disabled with a feature flag' do
       process = create(:legislation_process)
       expect{ visit admin_legislation_process_questions_path(process) }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
@@ -26,7 +26,7 @@ feature 'Admin legislation questions' do
 
   context "Index" do
 
-    scenario 'Displaying legislation process questions' do
+    it 'Displaying legislation process questions' do
       process = create(:legislation_process, title: 'An example legislation process')
       question = create(:legislation_question, process: process, title: 'Question 1')
       question = create(:legislation_question, process: process, title: 'Question 2')
@@ -42,7 +42,7 @@ feature 'Admin legislation questions' do
   end
 
   context 'Create' do
-    scenario 'Valid legislation question' do
+    it 'Valid legislation question' do
       process = create(:legislation_process, title: 'An example legislation process')
 
       visit admin_root_path
@@ -68,7 +68,7 @@ feature 'Admin legislation questions' do
   end
 
   context 'Update' do
-    scenario 'Valid legislation question', :js do
+    it 'Valid legislation question', :js do
       process = create(:legislation_process, title: 'An example legislation process')
       question = create(:legislation_question, title: 'Question 2', process: process)
 
@@ -95,7 +95,7 @@ feature 'Admin legislation questions' do
   end
 
   context 'Delete' do
-    scenario 'Legislation question', :js do
+    it 'Legislation question', :js do
       process = create(:legislation_process, title: 'An example legislation process')
       create(:legislation_question, title: 'Question 1', process: process)
       question = create(:legislation_question, title: 'Question 2', process: process)

--- a/spec/features/admin/managers_spec.rb
+++ b/spec/features/admin/managers_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature 'Admin managers' do
-  background do
+describe 'Admin managers' do
+  before do
     @admin = create(:administrator)
     @user  = create(:user)
     @manager = create(:manager)
@@ -9,13 +9,13 @@ feature 'Admin managers' do
     visit admin_managers_path
   end
 
-  scenario 'Index' do
+  it 'Index' do
     expect(page).to have_content @manager.name
     expect(page).to have_content @manager.email
     expect(page).not_to have_content @user.name
   end
 
-  scenario 'Create Manager', :js do
+  it 'Create Manager', :js do
     fill_in 'name_or_email', with: @user.email
     click_button 'Search'
 
@@ -26,7 +26,7 @@ feature 'Admin managers' do
     end
   end
 
-  scenario 'Delete Manager' do
+  it 'Delete Manager' do
     click_link 'Delete'
 
     within("#managers") do
@@ -36,7 +36,7 @@ feature 'Admin managers' do
 
   context 'Search' do
 
-    background do
+    before do
       user  = create(:user, username: 'Taylor Swift', email: 'taylor@swift.com')
       user2 = create(:user, username: 'Stephanie Corneliussen', email: 'steph@mrrobot.com')
       @manager1 = create(:manager, user: user)
@@ -44,7 +44,7 @@ feature 'Admin managers' do
       visit admin_managers_path
     end
 
-    scenario 'returns no results if search term is empty' do
+    it 'returns no results if search term is empty' do
       expect(page).to have_content(@manager1.name)
       expect(page).to have_content(@manager2.name)
 
@@ -57,7 +57,7 @@ feature 'Admin managers' do
       expect(page).not_to have_content(@manager2.name)
     end
 
-    scenario 'search by name' do
+    it 'search by name' do
       expect(page).to have_content(@manager1.name)
       expect(page).to have_content(@manager2.name)
 
@@ -69,7 +69,7 @@ feature 'Admin managers' do
       expect(page).not_to have_content(@manager2.name)
     end
 
-    scenario 'search by email' do
+    it 'search by email' do
       expect(page).to have_content(@manager1.email)
       expect(page).to have_content(@manager2.email)
 

--- a/spec/features/admin/moderators_spec.rb
+++ b/spec/features/admin/moderators_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature 'Admin moderators' do
-  background do
+describe 'Admin moderators' do
+  before do
     @admin = create(:administrator)
     @user  = create(:user, username: 'Jose Luis Balbin')
     @moderator = create(:moderator)
@@ -9,13 +9,13 @@ feature 'Admin moderators' do
     visit admin_moderators_path
   end
 
-  scenario 'Index' do
+  it 'Index' do
     expect(page).to have_content @moderator.name
     expect(page).to have_content @moderator.email
     expect(page).not_to have_content @user.name
   end
 
-  scenario 'Create Moderator', :js do
+  it 'Create Moderator', :js do
     fill_in 'name_or_email', with: @user.email
     click_button 'Search'
 
@@ -26,7 +26,7 @@ feature 'Admin moderators' do
     end
   end
 
-  scenario 'Delete Moderator' do
+  it 'Delete Moderator' do
     click_link 'Delete'
 
     within("#moderators") do
@@ -36,7 +36,7 @@ feature 'Admin moderators' do
 
   context 'Search' do
 
-    background do
+    before do
       user  = create(:user, username: 'Elizabeth Bathory', email: 'elizabeth@bathory.com')
       user2 = create(:user, username: 'Ada Lovelace', email: 'ada@lovelace.com')
       @moderator1 = create(:moderator, user: user)
@@ -44,7 +44,7 @@ feature 'Admin moderators' do
       visit admin_moderators_path
     end
 
-    scenario 'returns no results if search term is empty' do
+    it 'returns no results if search term is empty' do
       expect(page).to have_content(@moderator1.name)
       expect(page).to have_content(@moderator2.name)
 
@@ -57,7 +57,7 @@ feature 'Admin moderators' do
       expect(page).not_to have_content(@moderator2.name)
     end
 
-    scenario 'search by name' do
+    it 'search by name' do
       expect(page).to have_content(@moderator1.name)
       expect(page).to have_content(@moderator2.name)
 
@@ -69,7 +69,7 @@ feature 'Admin moderators' do
       expect(page).not_to have_content(@moderator2.name)
     end
 
-    scenario 'search by email' do
+    it 'search by email' do
       expect(page).to have_content(@moderator1.email)
       expect(page).to have_content(@moderator2.email)
 

--- a/spec/features/admin/newsletters_spec.rb
+++ b/spec/features/admin/newsletters_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-feature 'Admin newsletters emails' do
+describe 'Admin newsletters emails' do
 
   let(:download_button_text) { 'Download zip with users list' }
 
-  background do
+  before do
     @admin = create(:administrator)
     @newsletter_user = create(:user, newsletter: true)
     @non_newsletter_user = create(:user, newsletter: false)
@@ -12,11 +12,11 @@ feature 'Admin newsletters emails' do
     visit admin_newsletters_path
   end
 
-  scenario 'Index' do
+  it 'Index' do
     expect(page).to have_content download_button_text
   end
 
-  scenario 'Download newsletter email zip' do
+  it 'Download newsletter email zip' do
     click_link download_button_text
     downloaded_file_content = Zip::InputStream.open(StringIO.new(page.body)).get_next_entry.get_input_stream {|is| is.read }
     expect(downloaded_file_content).to include(@admin.user.email, @newsletter_user.email)

--- a/spec/features/admin/officials_spec.rb
+++ b/spec/features/admin/officials_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature 'Admin officials' do
+describe 'Admin officials' do
 
-  background do
+  before do
     @citizen = create(:user, username: "Citizen Kane")
     @official = create(:user, official_position: "Mayor", official_level: 5)
     @admin = create(:administrator)
     login_as(@admin.user)
   end
 
-  scenario 'Index' do
+  it 'Index' do
     visit admin_officials_path
 
     expect(page).to have_content @official.name
@@ -18,7 +18,7 @@ feature 'Admin officials' do
     expect(page).to have_content @official.official_level
   end
 
-  scenario 'Edit an official' do
+  it 'Edit an official' do
     visit admin_officials_path
     click_link @official.name
 
@@ -41,7 +41,7 @@ feature 'Admin officials' do
     expect(page).to have_content '3'
   end
 
-  scenario 'Create an official' do
+  it 'Create an official' do
     visit admin_officials_path
     fill_in 'name_or_email', with: @citizen.email
     click_button 'Search'
@@ -65,7 +65,7 @@ feature 'Admin officials' do
     expect(page).to have_content '4'
   end
 
-  scenario 'Destroy' do
+  it 'Destroy' do
     visit edit_admin_official_path(@official)
 
     click_link "Remove 'Official' status"

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Admin::Organizations' do
+describe 'Admin::Organizations' do
 
-  background do
+  before do
     administrator = create(:user)
     create(:administrator, user: administrator)
 
@@ -10,7 +10,7 @@ feature 'Admin::Organizations' do
   end
 
   context "Index" do
-    scenario "shows info on organizations with hidden users" do
+    it "shows info on organizations with hidden users" do
       troll = create(:user, email: "trol@troller.com")
       create(:organization, user: troll, name: "Greentroll")
       org = create(:organization, name: "Human Rights")
@@ -28,12 +28,12 @@ feature 'Admin::Organizations' do
 
   context "Search" do
 
-    background do
+    before do
       @user = create(:user, email: "marley@humanrights.com", phone_number: "6764440002")
       create(:organization, user: @user, name: "Get up, Stand up")
     end
 
-    scenario "returns no results if search term is empty" do
+    it "returns no results if search term is empty" do
       visit admin_organizations_path
       expect(page).to have_content("Get up, Stand up")
 
@@ -46,7 +46,7 @@ feature 'Admin::Organizations' do
       end
     end
 
-    scenario "finds by name" do
+    it "finds by name" do
       visit search_admin_organizations_path
       expect(page).not_to have_content("Get up, Stand up")
 
@@ -58,7 +58,7 @@ feature 'Admin::Organizations' do
       end
     end
 
-    scenario "finds by users email" do
+    it "finds by users email" do
       visit search_admin_organizations_path
       expect(page).not_to have_content("Get up, Stand up")
 
@@ -70,7 +70,7 @@ feature 'Admin::Organizations' do
       end
     end
 
-    scenario "finds by users phone number" do
+    it "finds by users phone number" do
       visit search_admin_organizations_path
       expect(page).not_to have_content("Get up, Stand up")
 
@@ -83,7 +83,7 @@ feature 'Admin::Organizations' do
     end
   end
 
-  scenario "Pending organizations have links to verify and reject" do
+  it "Pending organizations have links to verify and reject" do
     organization = create(:organization)
 
     visit admin_organizations_path
@@ -100,7 +100,7 @@ feature 'Admin::Organizations' do
     expect(organization.reload.verified?).to eq(true)
   end
 
-  scenario "Verified organizations have link to reject" do
+  it "Verified organizations have link to reject" do
     organization = create(:organization, :verified)
 
     visit admin_organizations_path
@@ -124,7 +124,7 @@ feature 'Admin::Organizations' do
     expect(organization.reload.rejected?).to eq(true)
   end
 
-  scenario "Rejected organizations have link to verify" do
+  it "Rejected organizations have link to verify" do
     organization = create(:organization, :rejected)
 
     visit admin_organizations_path
@@ -145,7 +145,7 @@ feature 'Admin::Organizations' do
     expect(organization.reload.verified?).to eq(true)
   end
 
-  scenario "Current filter is properly highlighted" do
+  it "Current filter is properly highlighted" do
     visit admin_organizations_path
     expect(page).not_to have_link('Pending')
     expect(page).to have_link('All')
@@ -177,7 +177,7 @@ feature 'Admin::Organizations' do
     expect(page).not_to have_link('Rejected')
   end
 
-  scenario "Filtering organizations" do
+  it "Filtering organizations" do
     create(:organization, name: "Pending Organization")
     create(:organization, :rejected, name: "Rejected Organization")
     create(:organization, :verified, name: "Verified Organization")
@@ -203,7 +203,7 @@ feature 'Admin::Organizations' do
     expect(page).not_to have_content('Verified Organization')
   end
 
-  scenario "Verifying organization links remember the pagination setting and the filter" do
+  it "Verifying organization links remember the pagination setting and the filter" do
     per_page = Kaminari.config.default_per_page
     (per_page + 2).times { create(:organization) }
 

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 
-feature 'Admin booths assignments' do
+describe 'Admin booths assignments' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  feature 'Admin Booth Assignment management' do
+  describe 'Admin Booth Assignment management' do
 
     let!(:poll) { create(:poll) }
     let!(:booth) { create(:poll_booth) }
 
-    scenario 'List Polls and Booths to manage', :js do
+    it 'List Polls and Booths to manage', :js do
       second_poll = create(:poll)
       second_booth = create(:poll_booth)
 
@@ -31,7 +31,7 @@ feature 'Admin booths assignments' do
       expect(page).to have_content(second_booth.name)
     end
 
-    scenario 'Assign booth to poll', :js do
+    it 'Assign booth to poll', :js do
       visit admin_poll_path(poll)
       within('#poll-resources') do
         click_link 'Booths (0)'
@@ -68,7 +68,7 @@ feature 'Admin booths assignments' do
       expect(page).to have_content booth.name
     end
 
-    scenario 'Unassign booth from poll', :js do
+    it 'Unassign booth from poll', :js do
       assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
 
       visit admin_poll_path(poll)
@@ -107,7 +107,7 @@ feature 'Admin booths assignments' do
       expect(page).not_to have_content booth.name
     end
 
-    scenario 'Unassing booth whith associated shifts', :js do
+    it 'Unassing booth whith associated shifts', :js do
       assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
       officer = create(:poll_officer)
       create(:poll_officer_assignment, officer: officer, booth_assignment: assignment)
@@ -127,7 +127,7 @@ feature 'Admin booths assignments' do
       end
     end
 
-    scenario "Cannot unassing booth if poll is expired" do
+    it "Cannot unassing booth if poll is expired" do
       poll_expired = create(:poll, :expired)
       create(:poll_booth_assignment, poll: poll_expired, booth: booth)
 
@@ -143,8 +143,8 @@ feature 'Admin booths assignments' do
     end
   end
 
-  feature 'Show' do
-    scenario 'Lists all assigned poll officers' do
+  describe 'Show' do
+    it 'Lists all assigned poll officers' do
       poll = create(:poll)
       booth = create(:poll_booth)
       booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
@@ -167,7 +167,7 @@ feature 'Admin booths assignments' do
       end
     end
 
-    scenario 'Lists all recounts for the booth assignment' do
+    it 'Lists all recounts for the booth assignment' do
       poll = create(:poll, starts_at: 2.weeks.ago, ends_at: 1.week.ago)
       booth = create(:poll_booth)
       booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
@@ -204,7 +204,7 @@ feature 'Admin booths assignments' do
       end
     end
 
-    scenario 'Results for a booth assignment' do
+    it 'Results for a booth assignment' do
       poll = create(:poll)
       booth_assignment = create(:poll_booth_assignment, poll: poll)
       other_booth_assignment = create(:poll_booth_assignment, poll: poll)
@@ -292,7 +292,7 @@ feature 'Admin booths assignments' do
       within('#total_results') { expect(page).to have_content('66') }
     end
 
-    scenario "No results" do
+    it "No results" do
       poll = create(:poll)
       booth_assignment = create(:poll_booth_assignment, poll: poll)
 

--- a/spec/features/admin/poll/booths_spec.rb
+++ b/spec/features/admin/poll/booths_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Admin booths' do
+describe 'Admin booths' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario 'Index empty' do
+  it 'Index empty' do
     visit admin_root_path
 
     within('#side_menu') do
@@ -17,7 +17,7 @@ feature 'Admin booths' do
     expect(page).to have_content "There are no booths"
   end
 
-  scenario 'Index' do
+  it 'Index' do
     3.times { create(:poll_booth) }
 
     visit admin_root_path
@@ -36,7 +36,7 @@ feature 'Admin booths' do
     expect(page).not_to have_content "There are no booths"
   end
 
-  scenario "Available" do
+  it "Available" do
     booth_for_current_poll  = create(:poll_booth)
     booth_for_incoming_poll = create(:poll_booth)
     booth_for_expired_poll  = create(:poll_booth)
@@ -63,7 +63,7 @@ feature 'Admin booths' do
     expect(page).not_to have_link "Edit booth"
   end
 
-  scenario 'Show' do
+  it 'Show' do
     booth = create(:poll_booth)
 
     visit admin_booths_path
@@ -72,7 +72,7 @@ feature 'Admin booths' do
     expect(page).to have_content booth.location
   end
 
-  scenario "Create" do
+  it "Create" do
     visit admin_booths_path
     click_link "Add booth"
 
@@ -87,7 +87,7 @@ feature 'Admin booths' do
     expect(page).to have_content "39th Street, number 2, ground floor"
   end
 
-  scenario "Edit" do
+  it "Edit" do
     poll = create(:poll, :current)
     booth = create(:poll_booth)
     assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
@@ -113,7 +113,7 @@ feature 'Admin booths' do
     end
   end
 
-  scenario "Back link go back to available list when manage shifts" do
+  it "Back link go back to available list when manage shifts" do
     poll = create(:poll, :current)
     booth = create(:poll_booth)
     assignment = create(:poll_booth_assignment, poll: poll, booth: booth)

--- a/spec/features/admin/poll/officer_assignments_spec.rb
+++ b/spec/features/admin/poll/officer_assignments_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Officer Assignments' do
+describe 'Officer Assignments' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario "Index" do
+  it "Index" do
     poll = create(:poll)
     booth = create(:poll_booth)
 
@@ -32,7 +32,7 @@ feature 'Officer Assignments' do
     end
   end
 
-  scenario "Search", :js do
+  it "Search", :js do
     poll = create(:poll)
     booth = create(:poll_booth)
 

--- a/spec/features/admin/poll/officers_spec.rb
+++ b/spec/features/admin/poll/officers_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Admin poll officers' do
+describe 'Admin poll officers' do
 
-  background do
+  before do
     @admin = create(:administrator)
     @user  = create(:user, username: 'Pedro Jose Garcia')
     @officer = create(:poll_officer)
@@ -10,13 +10,13 @@ feature 'Admin poll officers' do
     visit admin_officers_path
   end
 
-  scenario 'Index' do
+  it 'Index' do
     expect(page).to have_content @officer.name
     expect(page).to have_content @officer.email
     expect(page).not_to have_content @user.name
   end
 
-  scenario 'Create', :js do
+  it 'Create', :js do
     fill_in 'email', with: @user.email
     click_button 'Search'
 
@@ -27,7 +27,7 @@ feature 'Admin poll officers' do
     end
   end
 
-  scenario 'Delete' do
+  it 'Delete' do
     click_link 'Delete position'
 
     expect(page).not_to have_css '#officers'

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Admin polls' do
+describe 'Admin polls' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario 'Index empty', :js do
+  it 'Index empty', :js do
     visit admin_root_path
 
     click_link "Polls"
@@ -18,7 +18,7 @@ feature 'Admin polls' do
     expect(page).to have_content "There are no polls"
   end
 
-  scenario 'Index', :js do
+  it 'Index', :js do
     3.times { create(:poll) }
 
     visit admin_root_path
@@ -39,7 +39,7 @@ feature 'Admin polls' do
     expect(page).not_to have_content "There are no polls"
   end
 
-  scenario 'Show' do
+  it 'Show' do
     poll = create(:poll)
 
     visit admin_polls_path
@@ -48,7 +48,7 @@ feature 'Admin polls' do
     expect(page).to have_content poll.name
   end
 
-  scenario "Create" do
+  it "Create" do
     visit admin_polls_path
     click_link "Create poll"
 
@@ -72,7 +72,7 @@ feature 'Admin polls' do
     expect(page).to have_content I18n.l(end_date.to_date)
   end
 
-  scenario "Edit" do
+  it "Edit" do
     poll = create(:poll)
     create(:image, imageable: poll)
 
@@ -104,7 +104,7 @@ feature 'Admin polls' do
 
   end
 
-  scenario 'Edit from index' do
+  it 'Edit from index' do
     poll = create(:poll)
     visit admin_polls_path
 
@@ -119,7 +119,7 @@ feature 'Admin polls' do
 
     context "Poll show" do
 
-      scenario "No booths" do
+      it "No booths" do
         poll = create(:poll)
         visit admin_poll_path(poll)
         click_link "Booths (0)"
@@ -127,7 +127,7 @@ feature 'Admin polls' do
         expect(page).to have_content "There are no booths assigned to this poll."
       end
 
-      scenario "Booth list" do
+      it "Booth list" do
         poll = create(:poll)
         3.times { create(:poll_booth, polls: [poll]) }
 
@@ -151,7 +151,7 @@ feature 'Admin polls' do
 
     context "Poll show" do
 
-      scenario "No officers", :js do
+      it "No officers", :js do
         poll = create(:poll)
         visit admin_poll_path(poll)
         click_link "Officers (0)"
@@ -159,7 +159,7 @@ feature 'Admin polls' do
         expect(page).to have_content "There are no officers assigned to this poll"
       end
 
-      scenario "Officer list", :js do
+      it "Officer list", :js do
         poll = create(:poll)
         booth = create(:poll_booth, polls: [poll])
 
@@ -189,7 +189,7 @@ feature 'Admin polls' do
 
     context "Poll show" do
 
-      scenario "Question list", :js do
+      it "Question list", :js do
         poll = create(:poll)
         question = create(:poll_question, poll: poll)
         other_question = create(:poll_question)
@@ -207,7 +207,7 @@ feature 'Admin polls' do
 
   context "Recounting" do
     context "Poll show" do
-      scenario "No recounts", :js do
+      it "No recounts", :js do
         poll = create(:poll)
         visit admin_poll_path(poll)
         click_link "Recounting"
@@ -215,7 +215,7 @@ feature 'Admin polls' do
         expect(page).to have_content "There is nothing to be recounted"
       end
 
-      scenario "Recounts list", :js do
+      it "Recounts list", :js do
         poll = create(:poll)
         booth_assignment = create(:poll_booth_assignment, poll: poll)
         booth_assignment_recounted = create(:poll_booth_assignment, poll: poll)
@@ -262,7 +262,7 @@ feature 'Admin polls' do
 
   context "Results" do
     context "Poll show" do
-      scenario "No results", :js do
+      it "No results", :js do
         poll = create(:poll)
         visit admin_poll_path(poll)
         click_link "Results"
@@ -270,7 +270,7 @@ feature 'Admin polls' do
         expect(page).to have_content "There are no results"
       end
 
-      scenario "Results by answer", :js do
+      it "Results by answer", :js do
         poll = create(:poll)
         booth_assignment_1 = create(:poll_booth_assignment, poll: poll)
         booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
@@ -327,7 +327,7 @@ feature 'Admin polls' do
         within('#total_results') { expect(page).to have_content('66') }
       end
 
-      scenario "Link to results by booth" do
+      it "Link to results by booth" do
         poll = create(:poll)
         booth_assignment1 = create(:poll_booth_assignment, poll: poll)
         booth_assignment2 = create(:poll_booth_assignment, poll: poll)

--- a/spec/features/admin/poll/questions/answers/answers_spec.rb
+++ b/spec/features/admin/poll/questions/answers/answers_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Answers' do
+describe 'Answers' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as admin.user
   end
 
-  scenario 'Create' do
+  it 'Create' do
     question = create(:poll_question)
     title = 'Whatever the question may be, the answer is always 42'
     description = "The Hitchhiker's Guide To The Universe"
@@ -24,7 +24,7 @@ feature 'Answers' do
     expect(page).to have_content(description)
   end
 
-  scenario 'Create second answer and place after the first one' do
+  it 'Create second answer and place after the first one' do
     question = create(:poll_question)
     answer = create(:poll_question_answer, title: 'First', question: question, given_order: 1)
     title = 'Second'
@@ -41,7 +41,7 @@ feature 'Answers' do
     expect(page.body.index('First')).to be < page.body.index('Second')
   end
 
-  scenario 'Update' do
+  it 'Update' do
     question = create(:poll_question)
     answer = create(:poll_question_answer, question: question, title: "Answer title", given_order: 2)
     answer2 = create(:poll_question_answer, question: question, title: "Another title", given_order: 1)

--- a/spec/features/admin/poll/questions/answers/images/images_spec.rb
+++ b/spec/features/admin/poll/questions/answers/images/images_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Images' do
+describe 'Images' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end

--- a/spec/features/admin/poll/questions/answers/videos/videos_spec.rb
+++ b/spec/features/admin/poll/questions/answers/videos/videos_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Videos' do
+describe 'Videos' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario "Create" do
+  it "Create" do
     question = create(:poll_question)
     answer = create(:poll_question_answer, question: question)
     video_title = "'Magical' by Junko Ohashi"

--- a/spec/features/admin/poll/questions_spec.rb
+++ b/spec/features/admin/poll/questions_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature 'Admin poll questions' do
+describe 'Admin poll questions' do
 
-  background do
+  before do
     login_as(create(:administrator).user)
   end
 
-  scenario 'Index' do
+  it 'Index' do
     question1 = create(:poll_question)
     question2 = create(:poll_question)
 
@@ -16,7 +16,7 @@ feature 'Admin poll questions' do
     expect(page).to have_content(question2.title)
   end
 
-  scenario 'Show' do
+  it 'Show' do
     geozone = create(:geozone)
     poll = create(:poll, geozone_restricted: true, geozone_ids: [geozone.id])
     question = create(:poll_question, poll: poll)
@@ -27,7 +27,7 @@ feature 'Admin poll questions' do
     expect(page).to have_content(question.author.name)
   end
 
-  scenario 'Create' do
+  it 'Create' do
     poll = create(:poll, name: 'Movies')
     title = "Star Wars: Episode IV - A New Hope"
     description = %{
@@ -51,7 +51,7 @@ feature 'Admin poll questions' do
     expect(page).to have_content(video_url)
   end
 
-  scenario 'Create from successful proposal index' do
+  it 'Create from successful proposal index' do
     poll = create(:poll, name: 'Proposals')
     proposal = create(:proposal, :successful)
 
@@ -72,7 +72,7 @@ feature 'Admin poll questions' do
 
   pending "Create from successul proposal show"
 
-  scenario 'Update' do
+  it 'Update' do
     question1 = create(:poll_question)
 
     visit admin_questions_path
@@ -95,7 +95,7 @@ feature 'Admin poll questions' do
     expect(page).not_to have_content(old_title)
   end
 
-  scenario 'Destroy' do
+  it 'Destroy' do
     question1 = create(:poll_question)
     question2 = create(:poll_question)
 

--- a/spec/features/admin/poll/shifts_spec.rb
+++ b/spec/features/admin/poll/shifts_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Admin shifts' do
+describe 'Admin shifts' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario "Show" do
+  it "Show" do
     poll = create(:poll)
     officer = create(:poll_officer)
 
@@ -30,7 +30,7 @@ feature 'Admin shifts' do
     expect(page).to have_content officer.name
   end
 
-  scenario "Create Vote Collection Shift and Recount & Scrutiny Shift on same date", :js do
+  it "Create Vote Collection Shift and Recount & Scrutiny Shift on same date", :js do
     create(:poll)
     create(:poll, :incoming)
     poll = create(:poll, :current)
@@ -92,7 +92,7 @@ feature 'Admin shifts' do
     end
   end
 
-  scenario "Vote Collection Shift and Recount & Scrutiny Shift don't include already assigned dates to officer", :js do
+  it "Vote Collection Shift and Recount & Scrutiny Shift don't include already assigned dates to officer", :js do
     poll = create(:poll, :current)
     booth = create(:poll_booth)
     assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
@@ -123,7 +123,7 @@ feature 'Admin shifts' do
     expect(page).to have_select('shift_date_recount_scrutiny_date', options: ["Select day", *recount_scrutiny_dates])
   end
 
-  scenario "Error on create", :js do
+  it "Error on create", :js do
     poll = create(:poll, :current)
     booth = create(:poll_booth)
     assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
@@ -143,7 +143,7 @@ feature 'Admin shifts' do
     expect(page).to have_content "A date must be selected"
   end
 
-  scenario "Destroy" do
+  it "Destroy" do
     poll = create(:poll, :current)
     booth = create(:poll_booth)
     assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
@@ -166,7 +166,7 @@ feature 'Admin shifts' do
     expect(page).to have_css(".shift", count: 0)
   end
 
-  scenario "Destroy an officer" do
+  it "Destroy an officer" do
     poll = create(:poll)
     booth = create(:poll_booth)
     officer = create(:poll_officer)
@@ -180,7 +180,7 @@ feature 'Admin shifts' do
     expect(page).to have_content(officer.name)
   end
 
-  scenario "Empty" do
+  it "Empty" do
     poll = create(:poll)
     booth = create(:poll_booth)
 

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Admin proposals' do
+describe 'Admin proposals' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario 'Disabled with a feature flag' do
+  it 'Disabled with a feature flag' do
     Setting['feature.proposals'] = nil
     admin = create(:administrator)
     login_as(admin.user)
@@ -17,7 +17,7 @@ feature 'Admin proposals' do
     Setting['feature.proposals'] = true
   end
 
-  scenario 'List shows all relevant info' do
+  it 'List shows all relevant info' do
     proposal = create(:proposal, :hidden)
     visit admin_proposals_path
 
@@ -29,7 +29,7 @@ feature 'Admin proposals' do
     expect(page).to have_content(proposal.video_url)
   end
 
-  scenario 'Restore' do
+  it 'Restore' do
     proposal = create(:proposal, :hidden)
     visit admin_proposals_path
 
@@ -41,7 +41,7 @@ feature 'Admin proposals' do
     expect(proposal).to be_ignored_flag
   end
 
-  scenario 'Confirm hide' do
+  it 'Confirm hide' do
     proposal = create(:proposal, :hidden)
     visit admin_proposals_path
 
@@ -54,7 +54,7 @@ feature 'Admin proposals' do
     expect(proposal.reload).to be_confirmed_hide
   end
 
-  scenario "Current filter is properly highlighted" do
+  it "Current filter is properly highlighted" do
     visit admin_proposals_path
     expect(page).not_to have_link('Pending')
     expect(page).to have_link('All')
@@ -76,7 +76,7 @@ feature 'Admin proposals' do
     expect(page).not_to have_link('Confirmed')
   end
 
-  scenario "Filtering proposals" do
+  it "Filtering proposals" do
     create(:proposal, :hidden, title: "Unconfirmed proposal")
     create(:proposal, :hidden, :with_confirmed_hide, title: "Confirmed proposal")
 
@@ -93,7 +93,7 @@ feature 'Admin proposals' do
     expect(page).to have_content('Confirmed proposal')
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  it "Action links remember the pagination setting and the filter" do
     per_page = Kaminari.config.default_per_page
     (per_page + 2).times { create(:proposal, :hidden, :with_confirmed_hide) }
 

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature 'Admin settings' do
+describe 'Admin settings' do
 
-  background do
+  before do
     @setting1 = create(:setting)
     @setting2 = create(:setting)
     @setting3 = create(:setting)
     login_as(create(:administrator).user)
   end
 
-  scenario 'Index' do
+  it 'Index' do
     visit admin_settings_path
 
     expect(page).to have_content @setting1.key
@@ -17,7 +17,7 @@ feature 'Admin settings' do
     expect(page).to have_content @setting3.key
   end
 
-  scenario 'Update' do
+  it 'Update' do
     visit admin_settings_path
 
     within("#edit_setting_#{@setting2.id}") do
@@ -30,7 +30,7 @@ feature 'Admin settings' do
 
   describe "Update map" do
 
-    scenario "Should not be able when map feature deactivated" do
+    it "is not able when map feature deactivated" do
       Setting['feature.map'] = false
       admin = create(:administrator).user
       login_as(admin)
@@ -39,7 +39,7 @@ feature 'Admin settings' do
       expect(page).not_to have_content "Map configuration"
     end
 
-    scenario "Should be able when map feature activated" do
+    it "is able when map feature activated" do
       Setting['feature.map'] = true
       admin = create(:administrator).user
       login_as(admin)
@@ -48,7 +48,7 @@ feature 'Admin settings' do
       expect(page).to have_content "Map configuration"
     end
 
-    scenario "Should show successful notice" do
+    it "shows successful notice" do
       Setting['feature.map'] = true
       admin = create(:administrator).user
       login_as(admin)
@@ -61,7 +61,7 @@ feature 'Admin settings' do
       expect(page).to have_content "Map configuration updated succesfully"
     end
 
-    scenario "Should display marker by default", :js do
+    it "displays marker by default", :js do
       Setting['feature.map'] = true
       admin = create(:administrator).user
       login_as(admin)
@@ -72,7 +72,7 @@ feature 'Admin settings' do
       expect(find("#longitude", visible: false).value).to eq "0.0"
     end
 
-    scenario "Should update marker", :js do
+    it "updates marker", :js do
       Setting['feature.map'] = true
       admin = create(:administrator).user
       login_as(admin)

--- a/spec/features/admin/signature_sheets_spec.rb
+++ b/spec/features/admin/signature_sheets_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Signature sheets' do
+describe 'Signature sheets' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario "Index" do
+  it "Index" do
     3.times { create(:signature_sheet) }
 
     visit admin_signature_sheets_path
@@ -20,7 +20,7 @@ feature 'Signature sheets' do
   end
 
   context 'Create' do
-    scenario 'Proposal' do
+    it 'Proposal' do
       proposal = create(:proposal)
       visit new_admin_signature_sheet_path
 
@@ -36,7 +36,7 @@ feature 'Signature sheets' do
       expect(page).to have_content "1 support"
     end
 
-    scenario 'Budget Investment' do
+    it 'Budget Investment' do
       investment = create(:budget_investment)
       budget = investment.budget
       budget.update(phase: 'selecting')
@@ -57,7 +57,7 @@ feature 'Signature sheets' do
 
   end
 
-  scenario 'Errors on create' do
+  it 'Errors on create' do
     visit new_admin_signature_sheet_path
 
     click_button "Create signature sheet"
@@ -65,7 +65,7 @@ feature 'Signature sheets' do
     expect(page).to have_content error_message
   end
 
-  scenario 'Show' do
+  it 'Show' do
     proposal = create(:proposal)
     user = Administrator.first.user
     signature_sheet = create(:signature_sheet,

--- a/spec/features/admin/site_customization/content_blocks_spec.rb
+++ b/spec/features/admin/site_customization/content_blocks_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature "Admin custom content blocks" do
+describe "Admin custom content blocks" do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario "Index" do
+  it "Index" do
     block = create(:site_customization_content_block)
     visit admin_site_customization_content_blocks_path
 
@@ -16,7 +16,7 @@ feature "Admin custom content blocks" do
   end
 
   context "Create" do
-    scenario "Valid custom block" do
+    it "Valid custom block" do
       visit admin_root_path
 
       within("#side_menu") do
@@ -37,7 +37,7 @@ feature "Admin custom content blocks" do
       expect(page).to have_content "Some custom content"
     end
 
-    scenario "Invalid custom block" do
+    it "Invalid custom block" do
       block = create(:site_customization_content_block)
 
       visit admin_root_path
@@ -62,7 +62,7 @@ feature "Admin custom content blocks" do
   end
 
   context "Update" do
-    scenario "Valid custom block" do
+    it "Valid custom block" do
       block = create(:site_customization_content_block)
       visit admin_root_path
 
@@ -81,7 +81,7 @@ feature "Admin custom content blocks" do
   end
 
   context "Delete" do
-    scenario "From index page" do
+    it "From index page" do
       block = create(:site_customization_content_block)
       visit   admin_site_customization_content_blocks_path
 
@@ -94,7 +94,7 @@ feature "Admin custom content blocks" do
       expect(page).not_to have_content(block.body)
     end
 
-    scenario "From edit page" do
+    it "From edit page" do
       block = create(:site_customization_content_block)
       visit edit_admin_site_customization_content_block_path(block)
 

--- a/spec/features/admin/site_customization/images_spec.rb
+++ b/spec/features/admin/site_customization/images_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature "Admin custom images" do
+describe "Admin custom images" do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario "Upload valid image" do
+  it "Upload valid image" do
     visit admin_root_path
 
     within("#side_menu") do
@@ -23,7 +23,7 @@ feature "Admin custom images" do
     expect(page).to have_css("img[src*='logo_header.png']", count: 1)
   end
 
-  scenario "Upload invalid image" do
+  it "Upload invalid image" do
     visit admin_root_path
 
     within("#side_menu") do
@@ -39,7 +39,7 @@ feature "Admin custom images" do
     expect(page).to have_content("Height must be 240px")
   end
 
-  scenario "Delete image" do
+  it "Delete image" do
     visit admin_root_path
 
     within("#side_menu") do

--- a/spec/features/admin/site_customization/pages_spec.rb
+++ b/spec/features/admin/site_customization/pages_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature "Admin custom pages" do
+describe "Admin custom pages" do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario "Index" do
+  it "Index" do
     custom_page = create(:site_customization_page)
     visit admin_site_customization_pages_path
 
@@ -15,7 +15,7 @@ feature "Admin custom pages" do
   end
 
   context "Create" do
-    scenario "Valid custom page" do
+    it "Valid custom page" do
       visit admin_root_path
 
       within("#side_menu") do
@@ -39,7 +39,7 @@ feature "Admin custom pages" do
   end
 
   context "Update" do
-    scenario "Valid custom page" do
+    it "Valid custom page" do
       create(:site_customization_page, title: "An example custom page")
       visit admin_root_path
 
@@ -59,7 +59,7 @@ feature "Admin custom pages" do
     end
   end
 
-  scenario "Delete" do
+  it "Delete" do
     custom_page = create(:site_customization_page, title: "An example custom page")
     visit edit_admin_site_customization_page_path(custom_page)
 

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Stats' do
+describe 'Stats' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
     visit root_path
@@ -10,7 +10,7 @@ feature 'Stats' do
 
   context 'Summary' do
 
-    scenario 'General' do
+    it 'General' do
       create(:debate)
       2.times { create(:proposal) }
       3.times { create(:comment, commentable: Debate.first) }
@@ -24,7 +24,7 @@ feature 'Stats' do
       expect(page).to have_content "Visits 4"
     end
 
-    scenario 'Votes' do
+    it 'Votes' do
       debate = create(:debate)
       create(:vote, votable: debate)
 
@@ -46,7 +46,7 @@ feature 'Stats' do
 
   context "Users" do
 
-    scenario 'Summary' do
+    it 'Summary' do
       1.times { create(:user, :level_three) }
       2.times { create(:user, :level_two) }
       3.times { create(:user) }
@@ -60,7 +60,7 @@ feature 'Stats' do
       expect(page).to have_content "Total users 7"
     end
 
-    scenario "Do not count erased users" do
+    it "Do not count erased users" do
       1.times { create(:user, :level_three, erased_at: Time.current) }
       2.times { create(:user, :level_two, erased_at: Time.current) }
       3.times { create(:user, erased_at: Time.current) }
@@ -74,7 +74,7 @@ feature 'Stats' do
       expect(page).to have_content "Total users 1"
     end
 
-    scenario "Do not count hidden users" do
+    it "Do not count hidden users" do
       1.times { create(:user, :level_three, hidden_at: Time.current) }
       2.times { create(:user, :level_two, hidden_at: Time.current) }
       3.times { create(:user, hidden_at: Time.current) }
@@ -88,7 +88,7 @@ feature 'Stats' do
       expect(page).to have_content "Total users 1"
     end
 
-    scenario 'Level 2 user Graph' do
+    it 'Level 2 user Graph' do
       create(:geozone)
       visit account_path
       click_link 'Verify my account'
@@ -104,7 +104,7 @@ feature 'Stats' do
 
   context "Proposal notifications" do
 
-    scenario "Summary stats" do
+    it "Summary stats" do
       proposal = create(:proposal)
 
       create(:proposal_notification, proposal: proposal)
@@ -123,7 +123,7 @@ feature 'Stats' do
       end
     end
 
-    scenario "Index" do
+    it "Index" do
       3.times { create(:proposal_notification) }
 
       visit admin_stats_path
@@ -141,7 +141,7 @@ feature 'Stats' do
 
   context "Direct messages" do
 
-    scenario "Summary stats" do
+    it "Summary stats" do
       sender = create(:user, :level_two)
 
       create(:direct_message, sender: sender)
@@ -164,7 +164,7 @@ feature 'Stats' do
 
   context "Polls" do
 
-    scenario "Total participants by origin" do
+    it "Total participants by origin" do
       oa = create(:poll_officer_assignment)
       3.times { create(:poll_voter, origin: "web") }
 
@@ -179,7 +179,7 @@ feature 'Stats' do
       end
     end
 
-    scenario "Total participants" do
+    it "Total participants" do
       user = create(:user, :level_two)
       3.times { create(:poll_voter, user: user) }
       create(:poll_voter)
@@ -195,7 +195,7 @@ feature 'Stats' do
       end
     end
 
-    scenario "Participants by poll" do
+    it "Participants by poll" do
       oa = create(:poll_officer_assignment)
 
       poll1 = create(:poll)
@@ -223,7 +223,7 @@ feature 'Stats' do
       end
     end
 
-    scenario "Participants by poll question" do
+    it "Participants by poll question" do
       user1 = create(:user, :level_two)
       user2 = create(:user, :level_two)
 

--- a/spec/features/admin/tags_spec.rb
+++ b/spec/features/admin/tags_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Admin tags' do
+describe 'Admin tags' do
 
-  background do
+  before do
     @tag1 = create(:tag, :category)
     login_as(create(:administrator).user)
   end
 
-  scenario 'Index' do
+  it 'Index' do
     debate = create(:debate)
     debate.tag_list.add(create(:tag, :category, name: "supertag"))
     visit admin_tags_path
@@ -16,7 +16,7 @@ feature 'Admin tags' do
     expect(page).to have_content 'supertag'
   end
 
-  scenario 'Create' do
+  it 'Create' do
     visit admin_tags_path
 
     expect(page).not_to have_content 'important issues'
@@ -31,7 +31,7 @@ feature 'Admin tags' do
     expect(page).to have_content 'important issues'
   end
 
-  scenario 'Delete' do
+  it 'Delete' do
     tag2 = create(:tag, :category, name: "bad tag")
     create(:debate, tag_list: tag2.name)
     visit admin_tags_path
@@ -48,7 +48,7 @@ feature 'Admin tags' do
     expect(page).not_to have_content tag2.name
   end
 
-  scenario 'Delete tag with hidden taggables' do
+  it 'Delete tag with hidden taggables' do
     tag2 = create(:tag, :category, name: "bad tag")
     debate = create(:debate, tag_list: tag2.name)
     debate.hide
@@ -68,7 +68,7 @@ feature 'Admin tags' do
   end
 
   context "Manage only tags of kind category" do
-    scenario "Index shows only categories" do
+    it "Index shows only categories" do
       not_category_tag = create(:tag, name: "Not a category")
       visit admin_tags_path
 
@@ -76,7 +76,7 @@ feature 'Admin tags' do
       expect(page).not_to have_content "Not a category"
     end
 
-    scenario "Create instanciates tags of correct kind" do
+    it "Create instanciates tags of correct kind" do
       visit admin_tags_path
 
       within("form.new_tag") do

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -1,21 +1,21 @@
 require 'rails_helper'
 
-feature 'Admin users' do
-  background do
+describe 'Admin users' do
+  before do
     @admin = create(:administrator)
     @user  = create(:user, username: 'Jose Luis Balbin')
     login_as(@admin.user)
     visit admin_users_path
   end
 
-  scenario 'Index' do
+  it 'Index' do
     expect(page).to have_content @user.name
     expect(page).to have_content @user.email
     expect(page).to have_content @admin.name
     expect(page).to have_content @admin.email
   end
 
-  scenario 'Search' do
+  it 'Search' do
     fill_in :search, with: "Luis"
     click_button 'Search'
 

--- a/spec/features/admin/valuators_spec.rb
+++ b/spec/features/admin/valuators_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature 'Admin valuators' do
-  background do
+describe 'Admin valuators' do
+  before do
     @admin    = create(:administrator)
     @user     = create(:user, username: 'Jose Luis Balbin')
     @valuator = create(:valuator)
@@ -9,13 +9,13 @@ feature 'Admin valuators' do
     visit admin_valuators_path
   end
 
-  scenario 'Index' do
+  it 'Index' do
     expect(page).to have_content(@valuator.name)
     expect(page).to have_content(@valuator.email)
     expect(page).not_to have_content(@user.name)
   end
 
-  scenario 'Create Valuator', :js do
+  it 'Create Valuator', :js do
     fill_in 'name_or_email', with: @user.email
     click_button 'Search'
 
@@ -29,7 +29,7 @@ feature 'Admin valuators' do
     end
   end
 
-  scenario 'Delete Valuator' do
+  it 'Delete Valuator' do
     click_link 'Delete'
 
     within('#valuators') do
@@ -39,7 +39,7 @@ feature 'Admin valuators' do
 
   context 'Search' do
 
-    background do
+    before do
       user  = create(:user, username: 'David Foster Wallace', email: 'david@wallace.com')
       user2 = create(:user, username: 'Steven Erikson', email: 'steven@erikson.com')
       @valuator1 = create(:valuator, user: user)
@@ -47,7 +47,7 @@ feature 'Admin valuators' do
       visit admin_valuators_path
     end
 
-    scenario 'returns no results if search term is empty' do
+    it 'returns no results if search term is empty' do
       expect(page).to have_content(@valuator1.name)
       expect(page).to have_content(@valuator2.name)
 
@@ -60,7 +60,7 @@ feature 'Admin valuators' do
       expect(page).not_to have_content(@valuator2.name)
     end
 
-    scenario 'search by name' do
+    it 'search by name' do
       expect(page).to have_content(@valuator1.name)
       expect(page).to have_content(@valuator2.name)
 
@@ -72,7 +72,7 @@ feature 'Admin valuators' do
       expect(page).not_to have_content(@valuator2.name)
     end
 
-    scenario 'search by email' do
+    it 'search by email' do
       expect(page).to have_content(@valuator1.email)
       expect(page).to have_content(@valuator2.email)
 

--- a/spec/features/admin/verifications_spec.rb
+++ b/spec/features/admin/verifications_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Incomplete verifications' do
+describe 'Incomplete verifications' do
 
-  background do
+  before do
     admin = create(:administrator)
     login_as(admin.user)
   end
 
-  scenario 'Index' do
+  it 'Index' do
     incompletely_verified_user1 = create(:user, :incomplete_verification)
     incompletely_verified_user2 = create(:user, :incomplete_verification)
     never_tried_to_verify_user = create(:user)
@@ -21,7 +21,7 @@ feature 'Incomplete verifications' do
     expect(page).not_to have_content(verified_user.username)
   end
 
-  scenario 'Search' do
+  it 'Search' do
     verified_user = create(:user, :level_two, username: "Juan Carlos")
     unverified_user = create(:user, :incomplete_verification, username: "Juan_anonymous")
     unverified_user = create(:user, :incomplete_verification, username: "Isabel_anonymous")
@@ -36,7 +36,7 @@ feature 'Incomplete verifications' do
     expect(page).not_to have_content("Isabel_anonymous")
   end
 
-  scenario "Residence unverified" do
+  it "Residence unverified" do
     incompletely_verified_user = create(:user, :incomplete_verification)
 
     visit admin_verifications_path
@@ -49,7 +49,7 @@ feature 'Incomplete verifications' do
     end
   end
 
-  scenario "Phone not given" do
+  it "Phone not given" do
     incompletely_verified_user = create(:user, residence_verified_at: Time.current, unconfirmed_phone: nil)
 
     visit admin_verifications_path
@@ -59,7 +59,7 @@ feature 'Incomplete verifications' do
     end
   end
 
-  scenario "SMS code not confirmed" do
+  it "SMS code not confirmed" do
     incompletely_verified_user = create(:user, residence_verified_at: Time.current,
                                                unconfirmed_phone:     "611111111",
                                                sms_confirmation_code: "1234",

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Admin' do
+describe 'Admin' do
   let(:user) { create(:user) }
   let(:administrator) do
     create(:administrator, user: user)
     user
   end
 
-  scenario 'Access as regular user is not authorized' do
+  it 'Access as regular user is not authorized' do
     login_as(user)
     visit admin_root_path
 
@@ -16,7 +16,7 @@ feature 'Admin' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as moderator is not authorized' do
+  it 'Access as moderator is not authorized' do
     create(:moderator, user: user)
     login_as(user)
     visit admin_root_path
@@ -26,7 +26,7 @@ feature 'Admin' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as valuator is not authorized' do
+  it 'Access as valuator is not authorized' do
     create(:valuator, user: user)
     login_as(user)
     visit admin_root_path
@@ -36,7 +36,7 @@ feature 'Admin' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as manager is not authorized' do
+  it 'Access as manager is not authorized' do
     create(:manager, user: user)
     login_as(user)
     visit admin_root_path
@@ -46,7 +46,7 @@ feature 'Admin' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as poll officer is not authorized' do
+  it 'Access as poll officer is not authorized' do
     create(:poll_officer, user: user)
     login_as(user)
     visit admin_root_path
@@ -56,7 +56,7 @@ feature 'Admin' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as administrator is authorized' do
+  it 'Access as administrator is authorized' do
     login_as(administrator)
     visit admin_root_path
 
@@ -64,7 +64,7 @@ feature 'Admin' do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Admin access links" do
+  it "Admin access links" do
     Setting["feature.spending_proposals"] = true
 
     login_as(administrator)
@@ -78,7 +78,7 @@ feature 'Admin' do
     Setting['feature.spending_proposals'] = nil
   end
 
-  scenario 'Admin dashboard' do
+  it 'Admin dashboard' do
     login_as(administrator)
     visit root_path
 

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Ballots' do
+describe 'Ballots' do
 
   let!(:user)       { create(:user, :level_two) }
   let!(:budget)     { create(:budget, phase: "balloting") }
@@ -10,7 +10,7 @@ feature 'Ballots' do
 
   context "Voting" do
 
-    background do
+    before do
       login_as(user)
       visit budget_path(budget)
     end
@@ -20,14 +20,14 @@ feature 'Ballots' do
 
     context "Group and Heading Navigation" do
 
-      scenario "Groups" do
+      it "Groups" do
         visit budget_path(budget)
 
         expect(page).to have_link "City"
         expect(page).to have_link "Districts"
       end
 
-      scenario "Headings" do
+      it "Headings" do
         city_heading1     = create(:budget_heading, group: city,      name: "Investments Type1")
         city_heading2     = create(:budget_heading, group: city,      name: "Investments Type2")
         district_heading1 = create(:budget_heading, group: districts, name: "District 1")
@@ -47,7 +47,7 @@ feature 'Ballots' do
 
       end
 
-      scenario "Investments" do
+      it "Investments" do
         city_heading1     = create(:budget_heading, group: city,      name: "Investments Type1")
         city_heading2     = create(:budget_heading, group: city,      name: "Investments Type2")
         district_heading1 = create(:budget_heading, group: districts, name: "District 1")
@@ -84,7 +84,7 @@ feature 'Ballots' do
         expect(page).to have_content district2_investment1.title
       end
 
-      scenario "Redirect to first heading if there is only one" do
+      it "Redirect to first heading if there is only one" do
         city_heading      = create(:budget_heading, group: city,      name: "City")
         district_heading1 = create(:budget_heading, group: districts, name: "District 1")
         district_heading2 = create(:budget_heading, group: districts, name: "District 2")
@@ -101,7 +101,7 @@ feature 'Ballots' do
 
     context "Adding and Removing Investments" do
 
-      scenario "Add a investment", :js do
+      it "Add a investment", :js do
         investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000)
         investment2 = create(:budget_investment, :selected, heading: new_york, price: 20000)
 
@@ -130,7 +130,7 @@ feature 'Ballots' do
         end
       end
 
-      scenario "Removing a investment", :js do
+      it "Removing a investment", :js do
         investment = create(:budget_investment, :selected, heading: new_york, price: 10000)
         ballot = create(:budget_ballot, user: user, budget: budget)
         ballot.investments << investment
@@ -166,7 +166,7 @@ feature 'Ballots' do
     #Break up or simplify with helpers
     context "Balloting in multiple headings" do
 
-      scenario "Independent progress bar for headings", :js do
+      it "Independent progress bar for headings", :js do
         city_heading      = create(:budget_heading, group: city,      name: "All city",   price: 10000000)
         district_heading1 = create(:budget_heading, group: districts, name: "District 1", price: 1000000)
         district_heading2 = create(:budget_heading, group: districts, name: "District 2", price: 2000000)
@@ -230,7 +230,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario "Display progress bar after first vote", :js do
+    it "Display progress bar after first vote", :js do
       investment = create(:budget_investment, :selected, heading: new_york, price: 10000)
 
       visit budget_investments_path(budget, heading_id: new_york.id)
@@ -248,9 +248,9 @@ feature 'Ballots' do
 
     let!(:investment) { create(:budget_investment, :selected, heading: california) }
 
-    background { login_as(user) }
+    before { login_as(user) }
 
-    scenario 'Select my heading', :js do
+    it 'Select my heading', :js do
       visit budget_path(budget)
       click_link "States"
       click_link "California"
@@ -264,7 +264,7 @@ feature 'Ballots' do
       expect(page).to have_css("#budget_heading_#{california.id}.active")
     end
 
-    scenario 'Change my heading', :js do
+    it 'Change my heading', :js do
       investment1 = create(:budget_investment, :selected, heading: california)
       investment2 = create(:budget_investment, :selected, heading: new_york)
 
@@ -287,7 +287,7 @@ feature 'Ballots' do
       expect(page).not_to have_css("#budget_heading_#{california.id}.active")
     end
 
-    scenario 'View another heading' do
+    it 'View another heading' do
       investment = create(:budget_investment, :selected, heading: california)
 
       ballot = create(:budget_ballot, user: user, budget: budget)
@@ -303,7 +303,7 @@ feature 'Ballots' do
   end
 
   context 'Showing the ballot' do
-    scenario "Do not display heading name if there is only one heading in the group (example: group city)" do
+    it "Do not display heading name if there is only one heading in the group (example: group city)" do
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group)
       visit budget_path(budget)
@@ -313,7 +313,7 @@ feature 'Ballots' do
       expect(page).to have_current_path(budget_investments_path(budget), ignore_query: true)
     end
 
-    scenario 'Displaying the correct group, heading, count & amount' do
+    it 'Displaying the correct group, heading, count & amount' do
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
 
@@ -350,7 +350,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario 'Display links to vote on groups with no investments voted yet' do
+    it 'Display links to vote on groups with no investments voted yet' do
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, name: "District 1", group: group, price: 100)
 
@@ -364,7 +364,7 @@ feature 'Ballots' do
 
   end
 
-  scenario 'Removing investments from ballot', :js do
+  it 'Removing investments from ballot', :js do
     investment = create(:budget_investment, :selected, price: 10, heading: new_york)
     ballot = create(:budget_ballot, user: user, budget: budget)
     ballot.investments << investment
@@ -382,7 +382,7 @@ feature 'Ballots' do
     expect(page).to have_content("You have voted 0 investments")
   end
 
-  scenario 'Removing investments from ballot (sidebar)', :js do
+  it 'Removing investments from ballot (sidebar)', :js do
     investment1 = create(:budget_investment, :selected, price: 10000, heading: new_york)
     investment2 = create(:budget_investment, :selected, price: 20000, heading: new_york)
 
@@ -419,7 +419,7 @@ feature 'Ballots' do
     end
   end
 
-  scenario 'Back link after removing an investment from Ballot', :js do
+  it 'Back link after removing an investment from Ballot', :js do
     investment = create(:budget_investment, :selected, heading: new_york, price: 10)
 
     login_as(user)
@@ -443,7 +443,7 @@ feature 'Ballots' do
 
   context 'Permissions' do
 
-    scenario 'User not logged in', :js do
+    it 'User not logged in', :js do
       investment = create(:budget_investment, :selected, heading: new_york)
 
       visit budget_investments_path(budget, heading_id: new_york.id)
@@ -455,7 +455,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario 'User not verified', :js do
+    it 'User not verified', :js do
       unverified_user = create(:user)
       investment = create(:budget_investment, :selected, heading: new_york)
 
@@ -469,7 +469,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario 'User is organization', :js do
+    it 'User is organization', :js do
       org = create(:organization)
       investment = create(:budget_investment, :selected, heading: new_york)
 
@@ -482,7 +482,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario 'Unselected investments' do
+    it 'Unselected investments' do
       investment = create(:budget_investment, heading: new_york, title: "WTF asdfasfd")
 
       login_as(user)
@@ -493,7 +493,7 @@ feature 'Ballots' do
       expect(page).not_to have_css("#budget_investment_#{investment.id}")
     end
 
-    scenario 'Investments with feasibility undecided are not shown' do
+    it 'Investments with feasibility undecided are not shown' do
       investment = create(:budget_investment, feasibility: "undecided", heading: new_york)
 
       login_as(user)
@@ -507,7 +507,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario 'Different district', :js do
+    it 'Different district', :js do
       bi1 = create(:budget_investment, :selected, heading: california)
       bi2 = create(:budget_investment, :selected, heading: new_york)
 
@@ -524,7 +524,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario 'Insufficient funds (on page load)', :js do
+    it 'Insufficient funds (on page load)', :js do
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)
       bi2 = create(:budget_investment, :selected, heading: california, price: 500)
 
@@ -541,7 +541,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario 'Insufficient funds (added after create)', :js do
+    it 'Insufficient funds (added after create)', :js do
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)
       bi2 = create(:budget_investment, :selected, heading: california, price: 500)
 
@@ -564,7 +564,7 @@ feature 'Ballots' do
 
     end
 
-    scenario 'Insufficient funds (removed after destroy)', :js do
+    it 'Insufficient funds (removed after destroy)', :js do
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)
       bi2 = create(:budget_investment, :selected, heading: california, price: 500)
 
@@ -592,7 +592,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario 'Insufficient funds (removed after destroying from sidebar)', :js do
+    it 'Insufficient funds (removed after destroying from sidebar)', :js do
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)
       bi2 = create(:budget_investment, :selected, heading: california, price: 500)
 
@@ -621,7 +621,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario "Edge case voting a non-elegible investment", :js do
+    it "Edge case voting a non-elegible investment", :js do
       investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000)
 
       login_as(user)
@@ -644,7 +644,7 @@ feature 'Ballots' do
       end
     end
 
-    scenario "Balloting is disabled when budget isn't in the balotting phase", :js do
+    it "Balloting is disabled when budget isn't in the balotting phase", :js do
       budget.update(phase: 'accepting')
 
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Budgets' do
+describe 'Budgets' do
 
   let(:budget) { create(:budget) }
   let(:level_two_user) { create(:user, :level_two) }
 
   context 'Index' do
 
-    scenario 'Show normal index with links' do
+    it 'Show normal index with links' do
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
       heading1 = create(:budget_heading, group: group1)
@@ -45,7 +45,7 @@ feature 'Budgets' do
       expect(page).not_to have_content("#finished_budgets")
     end
 
-    scenario 'Show finished budgets list' do
+    it 'Show finished budgets list' do
       finished_budget_1 = create(:budget, :finished)
       finished_budget_2 = create(:budget, :finished)
       drafting_budget = create(:budget, :drafting)
@@ -59,7 +59,7 @@ feature 'Budgets' do
       end
     end
 
-    scenario 'Show informing index without links' do
+    it 'Show informing index without links' do
       budget.update_attributes(phase: 'informing')
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group, name: 'Health')
@@ -79,7 +79,7 @@ feature 'Budgets' do
     end
   end
 
-  scenario 'Index shows only published phases' do
+  it 'Index shows only published phases' do
 
     budget.update(phase: :finished)
     phases = budget.phases
@@ -146,7 +146,7 @@ feature 'Budgets' do
 
   context 'Show' do
 
-    scenario "List all groups" do
+    it "List all groups" do
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
 
@@ -155,7 +155,7 @@ feature 'Budgets' do
       budget.groups.each {|group| expect(page).to have_link(group.name)}
     end
 
-    scenario "Links to unfeasible and selected if balloting or later" do
+    it "Links to unfeasible and selected if balloting or later" do
       budget = create(:budget, :selecting)
       group = create(:budget_group, budget: budget)
 
@@ -200,14 +200,14 @@ feature 'Budgets' do
 
     let(:admin) { create(:administrator).user }
 
-    background do
+    before do
       logout
       budget.update(phase: 'drafting')
       create(:budget)
     end
 
     context "Listed" do
-      scenario "Not listed at public budgets list" do
+      it "Not listed at public budgets list" do
         visit budgets_path
 
         expect(page).not_to have_content(budget.name)
@@ -215,17 +215,17 @@ feature 'Budgets' do
     end
 
     context "Shown" do
-      scenario "Not accesible to guest users" do
+      it "Not accesible to guest users" do
         expect { visit budget_path(budget) }.to raise_error(ActionController::RoutingError)
       end
 
-      scenario "Not accesible to logged users" do
+      it "Not accesible to logged users" do
         login_as(level_two_user)
 
         expect { visit budget_path(budget) }.to raise_error(ActionController::RoutingError)
       end
 
-      scenario "Is accesible to admin users" do
+      it "Is accesible to admin users" do
         login_as(admin)
         visit budget_path(budget)
 
@@ -237,13 +237,13 @@ feature 'Budgets' do
 
   context 'Accepting' do
 
-    background do
+    before do
       budget.update(phase: 'accepting')
     end
 
     context "Permissions" do
 
-      scenario "Verified user" do
+      it "Verified user" do
         login_as(level_two_user)
 
         visit budget_path(budget)
@@ -251,7 +251,7 @@ feature 'Budgets' do
 
       end
 
-      scenario "Unverified user" do
+      it "Unverified user" do
         user = create(:user)
         login_as(user)
 
@@ -260,7 +260,7 @@ feature 'Budgets' do
         expect(page).to have_content "To create a new budget investment verify your account."
       end
 
-      scenario "user not logged in" do
+      it "user not logged in" do
         visit budget_path(budget)
 
         expect(page).to have_content "To create a new budget investment you must sign in or sign up"

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'sessions_helper'
 
-feature 'Budget Investments' do
+describe 'Budget Investments' do
 
 
   let(:author)  { create(:user, :level_two, username: 'Isabel') }
@@ -23,7 +23,7 @@ feature 'Budget Investments' do
     it_behaves_like 'relationable', Budget::Investment
   end
 
-  scenario 'Index' do
+  it 'Index' do
     investments = [create(:budget_investment, heading: heading),
                    create(:budget_investment, heading: heading),
                    create(:budget_investment, :feasible, heading: heading)]
@@ -43,7 +43,7 @@ feature 'Budget Investments' do
     end
   end
 
-  scenario 'Index should show investment descriptive image only when is defined' do
+  it 'Index should show investment descriptive image only when is defined' do
     investment = create(:budget_investment, heading: heading)
     investment_with_image = create(:budget_investment, heading: heading)
     image = create(:image, imageable: investment_with_image)
@@ -60,7 +60,7 @@ feature 'Budget Investments' do
 
   context("Search") do
 
-    scenario 'Search by text' do
+    it 'Search by text' do
       investment1 = create(:budget_investment, heading: heading, title: "Get Schwifty")
       investment2 = create(:budget_investment, heading: heading, title: "Schwifty Hello")
       investment3 = create(:budget_investment, heading: heading, title: "Do not show me")
@@ -83,7 +83,7 @@ feature 'Budget Investments' do
 
     context "Advanced search" do
 
-      scenario "Search by text", :js do
+      it "Search by text", :js do
         bdgt_invest1 = create(:budget_investment, heading: heading,title: "Get Schwifty")
         bdgt_invest2 = create(:budget_investment, heading: heading,title: "Schwifty Hello")
         bdgt_invest3 = create(:budget_investment, heading: heading,title: "Do not show me")
@@ -106,7 +106,7 @@ feature 'Budget Investments' do
 
       context "Search by author type" do
 
-        scenario "Public employee", :js do
+        it "Public employee", :js do
           ana = create :user, official_level: 1
           john = create :user, official_level: 2
 
@@ -129,7 +129,7 @@ feature 'Budget Investments' do
           end
         end
 
-        scenario "Municipal Organization", :js do
+        it "Municipal Organization", :js do
           ana = create :user, official_level: 2
           john = create :user, official_level: 3
 
@@ -152,7 +152,7 @@ feature 'Budget Investments' do
           end
         end
 
-        scenario "General director", :js do
+        it "General director", :js do
           ana = create :user, official_level: 3
           john = create :user, official_level: 4
 
@@ -175,7 +175,7 @@ feature 'Budget Investments' do
           end
         end
 
-        scenario "City councillor", :js do
+        it "City councillor", :js do
           ana = create :user, official_level: 4
           john = create :user, official_level: 5
 
@@ -198,7 +198,7 @@ feature 'Budget Investments' do
           end
         end
 
-        scenario "Mayoress", :js do
+        it "Mayoress", :js do
           ana = create :user, official_level: 5
           john = create :user, official_level: 4
 
@@ -227,7 +227,7 @@ feature 'Budget Investments' do
 
         context "Predefined date ranges" do
 
-          scenario "Last day", :js do
+          it "Last day", :js do
             bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 1.minute.ago)
             bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 1.hour.ago)
             bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 2.days.ago)
@@ -247,7 +247,7 @@ feature 'Budget Investments' do
             end
           end
 
-          scenario "Last week", :js do
+          it "Last week", :js do
             bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 1.day.ago)
             bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 5.days.ago)
             bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 8.days.ago)
@@ -267,7 +267,7 @@ feature 'Budget Investments' do
             end
           end
 
-          scenario "Last month", :js do
+          it "Last month", :js do
             bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 10.days.ago)
             bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 20.days.ago)
             bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 33.days.ago)
@@ -287,7 +287,7 @@ feature 'Budget Investments' do
             end
           end
 
-          scenario "Last year", :js do
+          it "Last year", :js do
             bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 300.days.ago)
             bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 350.days.ago)
             bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 370.days.ago)
@@ -309,7 +309,7 @@ feature 'Budget Investments' do
 
         end
 
-        scenario "Search by custom date range", :js do
+        it "Search by custom date range", :js do
           bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 2.days.ago)
           bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 3.days.ago)
           bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 9.days.ago)
@@ -331,7 +331,7 @@ feature 'Budget Investments' do
           end
         end
 
-        scenario "Search by custom invalid date range", :js do
+        it "Search by custom invalid date range", :js do
           bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 2.days.ago)
           bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 3.days.ago)
           bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 9.days.ago)
@@ -353,7 +353,7 @@ feature 'Budget Investments' do
           end
         end
 
-        scenario "Search by multiple filters", :js do
+        it "Search by multiple filters", :js do
           ana  = create :user, official_level: 1
           john = create :user, official_level: 1
 
@@ -377,7 +377,7 @@ feature 'Budget Investments' do
           end
         end
 
-        scenario "Maintain advanced search criteria", :js do
+        it "Maintain advanced search criteria", :js do
           visit budget_investments_path(budget)
           click_link "Advanced search"
 
@@ -396,7 +396,7 @@ feature 'Budget Investments' do
           end
         end
 
-        scenario "Maintain custom date search criteria", :js do
+        it "Maintain custom date search criteria", :js do
           visit budget_investments_path(budget)
           click_link "Advanced search"
 
@@ -420,7 +420,7 @@ feature 'Budget Investments' do
 
   context("Filters") do
 
-    scenario 'by unfeasibility' do
+    it 'by unfeasibility' do
       investment1 = create(:budget_investment, :unfeasible, heading: heading, valuation_finished: true)
       investment2 = create(:budget_investment, :feasible, heading: heading)
       investment3 = create(:budget_investment, heading: heading)
@@ -438,7 +438,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario "by unfeasibilty link for group with one heading" do
+    it "by unfeasibilty link for group with one heading" do
       budget.update(phase: :balloting)
       group   = create(:budget_group,   name: 'All City', budget: budget)
       heading = create(:budget_heading, name: "Madrid",   group: group)
@@ -452,7 +452,7 @@ feature 'Budget Investments' do
       expect(page).to have_current_path(expected_path)
     end
 
-    scenario "by unfeasibilty link for group with many headings" do
+    it "by unfeasibilty link for group with many headings" do
       budget.update(phase: :balloting)
       group = create(:budget_group, name: 'Districts', budget: budget)
       heading1 = create(:budget_heading, name: 'Carabanchel', group: group)
@@ -473,7 +473,7 @@ feature 'Budget Investments' do
   context("Orders") do
     before { budget.update(phase: 'selecting') }
 
-    scenario "Default order is random" do
+    it "Default order is random" do
       per_page = Kaminari.config.default_per_page
       (per_page + 100).times { create(:budget_investment) }
 
@@ -486,7 +486,7 @@ feature 'Budget Investments' do
       expect(order).not_to eq(new_order)
     end
 
-    scenario "Random order after another order" do
+    it "Random order after another order" do
       per_page = Kaminari.config.default_per_page
       (per_page + 2).times { create(:budget_investment) }
 
@@ -502,7 +502,7 @@ feature 'Budget Investments' do
       expect(order).not_to eq(new_order)
     end
 
-    scenario 'Random order maintained with pagination', :js do
+    it 'Random order maintained with pagination', :js do
       per_page = Kaminari.config.default_per_page
       (per_page + 2).times { create(:budget_investment, heading: heading) }
 
@@ -520,7 +520,7 @@ feature 'Budget Investments' do
       expect(order).to eq(new_order)
     end
 
-    scenario "Investments are not repeated with random order", :js do
+    it "Investments are not repeated with random order", :js do
       12.times { create(:budget_investment, heading: heading) }
       # 12 instead of per_page + 2 because in each page there are 10 (in this case), not 25
 
@@ -539,7 +539,7 @@ feature 'Budget Investments' do
 
     end
 
-    scenario 'Proposals are ordered by confidence_score', :js do
+    it 'Proposals are ordered by confidence_score', :js do
       best_proposal = create(:budget_investment, heading: heading, title: 'Best proposal')
       best_proposal.update_column(:confidence_score, 10)
       worst_proposal = create(:budget_investment, heading: heading, title: 'Worst proposal')
@@ -560,7 +560,7 @@ feature 'Budget Investments' do
       expect(current_url).to include('page=1')
     end
 
-    scenario 'Each user as a different and consistent random budget investment order', :js do
+    it 'Each user as a different and consistent random budget investment order', :js do
       (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
       in_browser(:one) do
@@ -605,7 +605,7 @@ feature 'Budget Investments' do
   context 'Phase I - Accepting' do
     before { budget.update(phase: 'accepting') }
 
-    scenario 'Create with invisible_captcha honeypot field' do
+    it 'Create with invisible_captcha honeypot field' do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
@@ -622,7 +622,7 @@ feature 'Budget Investments' do
       expect(page).to have_current_path(budget_investments_path(budget_id: budget.id))
     end
 
-    scenario 'Create budget investment too fast' do
+    it 'Create budget investment too fast' do
       allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
 
       login_as(author)
@@ -639,7 +639,7 @@ feature 'Budget Investments' do
       expect(page).to have_current_path(new_budget_investment_path(budget_id: budget.id))
     end
 
-    scenario 'Create' do
+    it 'Create' do
       login_as(author)
 
       visit new_budget_investment_path(budget_id: budget.id)
@@ -666,7 +666,7 @@ feature 'Budget Investments' do
       expect(page).to have_content 'Build a skyscraper'
     end
 
-    scenario 'Errors on create' do
+    it 'Errors on create' do
       login_as(author)
 
       visit new_budget_investment_path(budget_id: budget.id)
@@ -677,7 +677,7 @@ feature 'Budget Investments' do
     context 'Suggest' do
       factory = :budget_investment
 
-      scenario 'Show up to 5 suggestions', :js do
+      it 'Show up to 5 suggestions', :js do
         login_as(author)
 
         %w(first second third fourth fifth sixth).each do |ordinal|
@@ -693,7 +693,7 @@ feature 'Budget Investments' do
         end
       end
 
-      scenario 'No found suggestions', :js do
+      it 'No found suggestions', :js do
         login_as(author)
 
         %w(first second third fourth fifth sixth).each do |ordinal|
@@ -708,7 +708,7 @@ feature 'Budget Investments' do
         end
       end
 
-      scenario "Don't show suggestions from a different budget", :js do
+      it "Don't show suggestions from a different budget", :js do
         login_as(author)
 
         %w(first second third fourth fifth sixth).each do |ordinal|
@@ -724,7 +724,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario 'Ballot is not visible' do
+    it 'Ballot is not visible' do
       login_as(author)
 
       visit budget_investments_path(budget, heading_id: heading.id)
@@ -736,7 +736,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario "Heading options are correctly ordered" do
+    it "Heading options are correctly ordered" do
       city_group = create(:budget_group, name: "Toda la ciudad", budget: budget)
       create(:budget_heading, name: "Toda la ciudad", price: 333333, group: city_group)
       create(:budget_heading, name: "More health professionals", price: 999999, group: group)
@@ -753,7 +753,7 @@ feature 'Budget Investments' do
     end
   end
 
-  scenario "Show" do
+  it "Show" do
     user = create(:user)
     login_as(user)
 
@@ -776,7 +776,7 @@ feature 'Budget Investments' do
 
     context "When investment with price is selected" do
 
-      scenario "Price & explanation is shown when Budget is on published prices phase" do
+      it "Price & explanation is shown when Budget is on published prices phase" do
         Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
           budget.update(phase: phase)
           visit budget_investment_path(budget_id: budget.id, id: investment.id)
@@ -790,7 +790,7 @@ feature 'Budget Investments' do
         end
       end
 
-      scenario "Price & explanation isn't shown when Budget is not on published prices phase" do
+      it "Price & explanation isn't shown when Budget is not on published prices phase" do
         (Budget::Phase::PHASE_KINDS - Budget::Phase::PUBLISHED_PRICES_PHASES).each do |phase|
           budget.update(phase: phase)
           visit budget_investment_path(budget_id: budget.id, id: investment.id)
@@ -807,11 +807,11 @@ feature 'Budget Investments' do
 
     context "When investment with price is unselected" do
 
-      background do
+      before do
         investment.update(selected: false)
       end
 
-      scenario "Price & explanation isn't shown for any Budget's phase" do
+      it "Price & explanation isn't shown for any Budget's phase" do
         Budget::Phase::PHASE_KINDS.each do |phase|
           budget.update(phase: phase)
           visit budget_investment_path(budget_id: budget.id, id: investment.id)
@@ -828,7 +828,7 @@ feature 'Budget Investments' do
 
   end
 
-  scenario 'Can access the community' do
+  it 'Can access the community' do
     Setting['feature.community'] = true
 
     investment = create(:budget_investment, heading: heading)
@@ -838,7 +838,7 @@ feature 'Budget Investments' do
     Setting['feature.community'] = false
   end
 
-  scenario 'Can not access the community' do
+  it 'Can not access the community' do
     Setting['feature.community'] = false
 
     investment = create(:budget_investment, heading: heading)
@@ -846,7 +846,7 @@ feature 'Budget Investments' do
     expect(page).not_to have_content "Access the community"
   end
 
-  scenario "Don't display flaggable buttons" do
+  it "Don't display flaggable buttons" do
     investment = create(:budget_investment, heading: heading)
 
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
@@ -854,7 +854,7 @@ feature 'Budget Investments' do
     expect(page).not_to have_selector ".js-follow"
   end
 
-  scenario "Show back link contains heading id" do
+  it "Show back link contains heading id" do
     investment = create(:budget_investment, heading: heading)
     visit budget_investment_path(budget, investment)
 
@@ -873,12 +873,12 @@ feature 'Budget Investments' do
              price_explanation: 'Every wheel is 4 euros, so total is 16')
     end
 
-    background do
+    before do
       user = create(:user)
       login_as(user)
     end
 
-    scenario "Budget in selecting phase" do
+    it "Budget in selecting phase" do
       budget.update(phase: "selecting")
       visit budget_investment_path(budget_id: budget.id, id: investment.id)
 
@@ -889,7 +889,7 @@ feature 'Budget Investments' do
 
   end
 
-  scenario "Show (unfeasible budget investment)" do
+  it "Show (unfeasible budget investment)" do
     user = create(:user)
     login_as(user)
 
@@ -907,7 +907,7 @@ feature 'Budget Investments' do
     expect(page).to have_content(investment.unfeasibility_explanation)
   end
 
-  scenario "Show milestones", :js do
+  it "Show milestones", :js do
     user = create(:user)
     investment = create(:budget_investment)
     create(:budget_investment_milestone, investment: investment,
@@ -934,7 +934,7 @@ feature 'Budget Investments' do
     end
   end
 
-  scenario "Show no_milestones text", :js do
+  it "Show no_milestones text", :js do
     user = create(:user)
     investment = create(:budget_investment)
 
@@ -981,7 +981,7 @@ feature 'Budget Investments' do
 
   context "Destroy" do
 
-    scenario "Admin cannot destroy budget investments" do
+    it "Admin cannot destroy budget investments" do
       admin = create(:administrator)
       user = create(:user, :level_two)
       investment = create(:budget_investment, heading: heading, author: user)
@@ -994,7 +994,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario "Author can destroy while on the accepting phase" do
+    it "Author can destroy while on the accepting phase" do
       user = create(:user, :level_two)
       sp1 = create(:budget_investment, heading: heading, price: 10000, author: user)
 
@@ -1012,13 +1012,13 @@ feature 'Budget Investments' do
 
   context "Selecting Phase" do
 
-    background do
+    before do
       budget.update(phase: "selecting")
     end
 
     context "Popup alert to vote only in one heading per group" do
 
-      scenario "When supporting in the first heading group", :js do
+      it "When supporting in the first heading group", :js do
         carabanchel = create(:budget_heading, group: group)
         salamanca   = create(:budget_heading, group: group)
 
@@ -1032,7 +1032,7 @@ feature 'Budget Investments' do
         end
       end
 
-      scenario "When already supported in the group", :js do
+      it "When already supported in the group", :js do
         carabanchel = create(:budget_heading, group: group)
         salamanca   = create(:budget_heading, group: group)
 
@@ -1049,7 +1049,7 @@ feature 'Budget Investments' do
         end
       end
 
-      scenario "When supporting in another group", :js do
+      it "When supporting in another group", :js do
         carabanchel     = create(:budget_heading, group: group)
         another_heading = create(:budget_heading, group: create(:budget_group, budget: budget))
 
@@ -1067,7 +1067,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario "Sidebar in show should display support text" do
+    it "Sidebar in show should display support text" do
       investment = create(:budget_investment, budget: budget)
       visit budget_investment_path(budget, investment)
 
@@ -1080,11 +1080,11 @@ feature 'Budget Investments' do
 
   context "Evaluating Phase" do
 
-    background do
+    before do
       budget.update(phase: "valuating")
     end
 
-    scenario "Sidebar in show should display support text and count" do
+    it "Sidebar in show should display support text and count" do
       investment = create(:budget_investment, :selected, budget: budget)
       create(:vote, votable: investment)
 
@@ -1096,7 +1096,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario "Index should display support count" do
+    it "Index should display support count" do
       investment = create(:budget_investment, budget: budget, heading: heading)
       create(:vote, votable: investment)
 
@@ -1107,7 +1107,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario "Show should display support text and count" do
+    it "Show should display support text and count" do
       investment = create(:budget_investment, budget: budget, heading: heading)
       create(:vote, votable: investment)
 
@@ -1123,11 +1123,11 @@ feature 'Budget Investments' do
 
   context "Balloting Phase" do
 
-    background do
+    before do
       budget.update(phase: "balloting")
     end
 
-    scenario "Index" do
+    it "Index" do
       user = create(:user, :level_two)
       sp1 = create(:budget_investment, :selected, heading: heading, price: 10000)
       sp2 = create(:budget_investment, :selected, heading: heading, price: 20000)
@@ -1150,7 +1150,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario 'Order by cost (only when balloting)' do
+    it 'Order by cost (only when balloting)' do
       mid_investment = create(:budget_investment, :selected, heading: heading, title: 'Build a nice house', price: 1000)
       mid_investment.update_column(:confidence_score, 10)
       low_investment = create(:budget_investment, :selected, heading: heading, title: 'Build an ugly house', price: 1000)
@@ -1171,7 +1171,7 @@ feature 'Budget Investments' do
       expect(current_url).to include('page=1')
     end
 
-    scenario "Show" do
+    it "Show" do
       user = create(:user, :level_two)
       sp1 = create(:budget_investment, :selected, heading: heading, price: 10000)
 
@@ -1183,7 +1183,7 @@ feature 'Budget Investments' do
       expect(page).to have_content "€10,000"
     end
 
-    scenario "Sidebar in show should display vote text" do
+    it "Sidebar in show should display vote text" do
       investment = create(:budget_investment, :selected, budget: budget)
       visit budget_investment_path(budget, investment)
 
@@ -1192,7 +1192,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario "Confirm", :js do
+    it "Confirm", :js do
       budget.update(phase: 'balloting')
       user = create(:user, :level_two)
 
@@ -1254,7 +1254,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario 'Ballot is visible' do
+    it 'Ballot is visible' do
       login_as(author)
 
       visit budget_investments_path(budget, heading_id: heading.id)
@@ -1266,7 +1266,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario 'Show unselected budget investments' do
+    it 'Show unselected budget investments' do
       investment1 = create(:budget_investment, :unselected, :feasible, heading: heading, valuation_finished: true)
       investment2 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
       investment3 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
@@ -1284,7 +1284,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario "Shows unselected link for group with one heading" do
+    it "Shows unselected link for group with one heading" do
       group   = create(:budget_group,   name: 'All City', budget: budget)
       heading = create(:budget_heading, name: "Madrid",   group: group)
 
@@ -1297,7 +1297,7 @@ feature 'Budget Investments' do
       expect(page).to have_current_path(expected_path)
     end
 
-    scenario "Shows unselected link for group with many headings" do
+    it "Shows unselected link for group with many headings" do
       group = create(:budget_group, name: 'Districts', budget: budget)
       heading1 = create(:budget_heading, name: 'Carabanchel', group: group)
       heading2 = create(:budget_heading, name: 'Barajas',     group: group)
@@ -1313,7 +1313,7 @@ feature 'Budget Investments' do
       expect(page).to have_current_path(expected_path)
     end
 
-    scenario "Do not display vote button for unselected investments in index" do
+    it "Do not display vote button for unselected investments in index" do
       investment = create(:budget_investment, :unselected, heading: heading)
 
       visit budget_investments_path(budget_id: budget.id, heading_id: heading.id, filter: "unselected")
@@ -1322,7 +1322,7 @@ feature 'Budget Investments' do
       expect(page).not_to have_link("Vote")
     end
 
-    scenario "Do not display vote button for unselected investments in show" do
+    it "Do not display vote button for unselected investments in show" do
       investment = create(:budget_investment, :unselected, heading: heading)
 
       visit budget_investment_path(budget, investment)
@@ -1331,9 +1331,9 @@ feature 'Budget Investments' do
       expect(page).not_to have_link("Vote")
     end
 
-    feature "Reclassification" do
+    describe "Reclassification" do
 
-      scenario "Due to heading change" do
+      it "Due to heading change" do
         user = create(:user, :level_two)
         investment = create(:budget_investment, :selected, heading: heading)
         heading2 = create(:budget_heading, group: group)
@@ -1354,7 +1354,7 @@ feature 'Budget Investments' do
         expect(page).to have_content("You have voted 0 investment")
       end
 
-      scenario "Due to being unfeasible" do
+      it "Due to being unfeasible" do
         user = create(:user, :level_two)
         investment = create(:budget_investment, :selected, heading: heading)
         heading2 = create(:budget_heading, group: group)

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Results' do
+describe 'Results' do
 
   let(:budget)  { create(:budget, phase: "finished") }
   let(:group)   { create(:budget_group, budget: budget) }
@@ -11,11 +11,11 @@ feature 'Results' do
   let!(:investment3) { create(:budget_investment, :incompatible, heading: heading, price: 500, ballot_lines_count: 700) }
   let!(:investment4) { create(:budget_investment, :selected, heading: heading, price: 600, ballot_lines_count: 600) }
 
-  background do
+  before do
     Budget::Result.new(budget, heading).calculate_winners
   end
 
-  scenario "Diplays winner investments" do
+  it "Diplays winner investments" do
     create(:budget_heading, group: group)
 
     visit budget_path(budget)
@@ -33,7 +33,7 @@ feature 'Results' do
     end
   end
 
-  scenario "Show non winner & incomaptible investments", :js do
+  it "Show non winner & incomaptible investments", :js do
     visit budget_path(budget)
     click_link "See results"
     click_link "Show all"
@@ -52,7 +52,7 @@ feature 'Results' do
     end
   end
 
-  scenario "Load first budget heading if not specified" do
+  it "Load first budget heading if not specified" do
     other_heading = create(:budget_heading, group: group)
     other_investment = create(:budget_investment, :winner, heading: other_heading)
 
@@ -64,7 +64,7 @@ feature 'Results' do
     end
   end
 
-  scenario "If budget is in a phase different from finished results can't be accessed" do
+  it "If budget is in a phase different from finished results can't be accessed" do
     budget.update(phase: (Budget::Phase::PHASE_KINDS - ['drafting', 'finished']).sample)
     visit budget_path(budget)
     expect(page).not_to have_link "See results"
@@ -73,7 +73,7 @@ feature 'Results' do
     expect(page).to have_content "You do not have permission to carry out the action"
   end
 
-  scenario "No incompatible investments", :js do
+  it "No incompatible investments", :js do
     investment3.incompatible = false
     investment3.save
 

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -1,22 +1,22 @@
 require 'rails_helper'
 
-feature 'Votes' do
+describe 'Votes' do
 
-  background do
+  before do
     @manuela = create(:user, verified_at: Time.current)
   end
 
-  feature 'Investments' do
+  describe 'Investments' do
 
     let(:budget)  { create(:budget, phase: "selecting") }
     let(:group)   { create(:budget_group, budget: budget) }
     let(:heading) { create(:budget_heading, group: group) }
 
-    background { login_as(@manuela) }
+    before { login_as(@manuela) }
 
-    feature 'Index' do
+    describe 'Index' do
 
-      scenario "Index shows user votes on proposals" do
+      it "Index shows user votes on proposals" do
         investment1 = create(:budget_investment, heading: heading)
         investment2 = create(:budget_investment, heading: heading)
         investment3 = create(:budget_investment, heading: heading)
@@ -39,7 +39,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Create from spending proposal index', :js do
+      it 'Create from spending proposal index', :js do
         investment = create(:budget_investment, heading: heading, budget: budget)
 
         visit budget_investments_path(budget, heading_id: heading.id)
@@ -53,17 +53,17 @@ feature 'Votes' do
       end
     end
 
-    feature 'Single spending proposal' do
-      background do
+    describe 'Single spending proposal' do
+      before do
         @investment = create(:budget_investment, budget: budget, heading: heading)
       end
 
-      scenario 'Show no votes' do
+      it 'Show no votes' do
         visit budget_investment_path(budget, @investment)
         expect(page).to have_content "No supports"
       end
 
-      scenario 'Trying to vote multiple times', :js do
+      it 'Trying to vote multiple times', :js do
         visit budget_investment_path(budget, @investment)
 
         within('.supports') do
@@ -74,7 +74,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Create from proposal show', :js do
+      it 'Create from proposal show', :js do
         visit budget_investment_path(budget, @investment)
 
         within('.supports') do
@@ -86,7 +86,7 @@ feature 'Votes' do
       end
     end
 
-    scenario 'Disable voting on spending proposals', :js do
+    it 'Disable voting on spending proposals', :js do
       login_as(@manuela)
       budget.update(phase: "reviewing")
       investment = create(:budget_investment, budget: budget, heading: heading)

--- a/spec/features/campaigns_spec.rb
+++ b/spec/features/campaigns_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Email campaigns' do
+describe 'Email campaigns' do
 
-  background do
+  before do
     @campaign1 = create(:campaign)
     @campaign2 = create(:campaign)
 
@@ -10,7 +10,7 @@ feature 'Email campaigns' do
     login_as(admin.user)
   end
 
-  scenario "Track email templates" do
+  it "Track email templates" do
     3.times { visit root_url(track_id: @campaign1.track_id) }
     5.times { visit root_url(track_id: @campaign2.track_id) }
 
@@ -20,7 +20,7 @@ feature 'Email campaigns' do
     expect(page).to have_content "#{@campaign2.name} (5)"
   end
 
-  scenario "Do not track erroneous track_ids" do
+  it "Do not track erroneous track_ids" do
     visit root_url(track_id: @campaign1.track_id)
     visit root_url(track_id: "999")
 

--- a/spec/features/ckeditor_spec.rb
+++ b/spec/features/ckeditor_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'CKEditor' do
+describe 'CKEditor' do
 
-  scenario 'is present before & after turbolinks update page', :js do
+  it 'is present before & after turbolinks update page', :js do
     author = create(:user)
     login_as(author)
 

--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
-feature 'Commenting Budget::Investments' do
+describe 'Commenting Budget::Investments' do
   let(:user) { create :user }
   let(:investment) { create :budget_investment }
 
-  scenario 'Index' do
+  it 'Index' do
     3.times { create(:comment, commentable: investment) }
     valuation_comment = create(:comment, :valuation, commentable: investment, subject: 'Not viable')
 
@@ -23,7 +23,7 @@ feature 'Commenting Budget::Investments' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     parent_comment = create(:comment, commentable: investment)
     first_child    = create(:comment, commentable: investment, parent: parent_comment)
     second_child   = create(:comment, commentable: investment, parent: parent_comment)
@@ -44,7 +44,7 @@ feature 'Commenting Budget::Investments' do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
-  scenario 'Collapsable comments', :js do
+  it 'Collapsable comments', :js do
     parent_comment = create(:comment, body: "Main comment", commentable: investment)
     child_comment  = create(:comment, body: "First subcomment", commentable: investment, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: investment, parent: child_comment)
@@ -70,7 +70,7 @@ feature 'Commenting Budget::Investments' do
     expect(page).not_to have_content grandchild_comment.body
   end
 
-  scenario 'Comment order' do
+  it 'Comment order' do
     c1 = create(:comment, :with_confidence_score, commentable: investment, cached_votes_up: 100,
                                                   cached_votes_total: 120, created_at: Time.current - 2)
     c2 = create(:comment, :with_confidence_score, commentable: investment, cached_votes_up: 10,
@@ -94,7 +94,7 @@ feature 'Commenting Budget::Investments' do
     expect(c2.body).to appear_before(c3.body)
   end
 
-  scenario 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
+  it 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
    old_root = create(:comment, commentable: investment, created_at: Time.current - 10)
    new_root = create(:comment, commentable: investment, created_at: Time.current)
    old_child = create(:comment, commentable: investment, parent_id: new_root.id, created_at: Time.current - 10)
@@ -116,7 +116,7 @@ feature 'Commenting Budget::Investments' do
    expect(old_child.body).to appear_before(new_child.body)
   end
 
-  scenario 'Turns links into html links' do
+  it 'Turns links into html links' do
     create :comment, commentable: investment, body: 'Built with http://rubyonrails.org/'
 
     visit budget_investment_path(investment.budget, investment)
@@ -129,7 +129,7 @@ feature 'Commenting Budget::Investments' do
     end
   end
 
-  scenario 'Sanitizes comment body for security' do
+  it 'Sanitizes comment body for security' do
     create :comment, commentable: investment,
                      body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
@@ -142,7 +142,7 @@ feature 'Commenting Budget::Investments' do
     end
   end
 
-  scenario 'Paginated comments' do
+  it 'Paginated comments' do
     per_page = 10
     (per_page + 2).times { create(:comment, commentable: investment)}
 
@@ -159,8 +159,8 @@ feature 'Commenting Budget::Investments' do
     expect(page).to have_css('.comment', count: 2)
   end
 
-  feature 'Not logged user' do
-    scenario 'can not see comments forms' do
+  describe 'Not logged user' do
+    it 'can not see comments forms' do
       create(:comment, commentable: investment)
       visit budget_investment_path(investment.budget, investment)
 
@@ -172,7 +172,7 @@ feature 'Commenting Budget::Investments' do
     end
   end
 
-  scenario 'Create', :js do
+  it 'Create', :js do
     login_as(user)
     visit budget_investment_path(investment.budget, investment)
 
@@ -188,7 +188,7 @@ feature 'Commenting Budget::Investments' do
     end
   end
 
-  scenario 'Errors on create', :js do
+  it 'Errors on create', :js do
     login_as(user)
     visit budget_investment_path(investment.budget, investment)
 
@@ -197,7 +197,7 @@ feature 'Commenting Budget::Investments' do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario 'Reply', :js do
+  it 'Reply', :js do
     citizen = create(:user, username: 'Ana')
     manuela = create(:user, username: 'Manuela')
     comment = create(:comment, commentable: investment, user: citizen)
@@ -219,7 +219,7 @@ feature 'Commenting Budget::Investments' do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
-  scenario 'Errors on reply', :js do
+  it 'Errors on reply', :js do
     comment = create(:comment, commentable: investment, user: user)
 
     login_as(user)
@@ -234,7 +234,7 @@ feature 'Commenting Budget::Investments' do
 
   end
 
-  scenario "N replies", :js do
+  it "N replies", :js do
     parent = create(:comment, commentable: investment)
 
     7.times do
@@ -246,7 +246,7 @@ feature 'Commenting Budget::Investments' do
     expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
   end
 
-  scenario "Flagging as inappropriate", :js do
+  it "Flagging as inappropriate", :js do
     comment = create(:comment, commentable: investment)
 
     login_as(user)
@@ -262,7 +262,7 @@ feature 'Commenting Budget::Investments' do
     expect(Flag.flagged?(user, comment)).to be
   end
 
-  scenario "Undoing flagging as inappropriate", :js do
+  it "Undoing flagging as inappropriate", :js do
     comment = create(:comment, commentable: investment)
     Flag.flag(user, comment)
 
@@ -279,7 +279,7 @@ feature 'Commenting Budget::Investments' do
     expect(Flag.flagged?(user, comment)).not_to be
   end
 
-  scenario "Flagging turbolinks sanity check", :js do
+  it "Flagging turbolinks sanity check", :js do
     investment = create(:budget_investment, title: "Should we change the world?")
     comment = create(:comment, commentable: investment)
 
@@ -293,7 +293,7 @@ feature 'Commenting Budget::Investments' do
     end
   end
 
-  scenario "Erasing a comment's author" do
+  it "Erasing a comment's author" do
     investment = create(:budget_investment)
     comment = create(:comment, commentable: investment, body: "this should be visible")
     comment.user.erase
@@ -305,8 +305,8 @@ feature 'Commenting Budget::Investments' do
     end
   end
 
-  feature "Moderators" do
-    scenario "can create comment as a moderator", :js do
+  describe "Moderators" do
+    it "can create comment as a moderator", :js do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -324,7 +324,7 @@ feature 'Commenting Budget::Investments' do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    it "can create reply as a moderator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -351,7 +351,7 @@ feature 'Commenting Budget::Investments' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as an administrator" do
+    it "can not comment as an administrator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -361,8 +361,8 @@ feature 'Commenting Budget::Investments' do
     end
   end
 
-  feature "Administrators" do
-    scenario "can create comment as an administrator", :js do
+  describe "Administrators" do
+    it "can create comment as an administrator", :js do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -380,7 +380,7 @@ feature 'Commenting Budget::Investments' do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    it "can create reply as an administrator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       admin   = create(:administrator, user: manuela)
@@ -407,7 +407,7 @@ feature 'Commenting Budget::Investments' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as a moderator" do
+    it "can not comment as a moderator" do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -417,9 +417,9 @@ feature 'Commenting Budget::Investments' do
     end
   end
 
-  feature 'Voting comments' do
+  describe 'Voting comments' do
 
-    background do
+    before do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @investment = create(:budget_investment)
@@ -429,7 +429,7 @@ feature 'Commenting Budget::Investments' do
       login_as(@manuela)
     end
 
-    scenario 'Show' do
+    it 'Show' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
@@ -448,7 +448,7 @@ feature 'Commenting Budget::Investments' do
       end
     end
 
-    scenario 'Create', :js do
+    it 'Create', :js do
       visit budget_investment_path(@budget, @investment)
 
       within("#comment_#{@comment.id}_votes") do
@@ -466,7 +466,7 @@ feature 'Commenting Budget::Investments' do
       end
     end
 
-    scenario 'Update', :js do
+    it 'Update', :js do
       visit budget_investment_path(@budget, @investment)
 
       within("#comment_#{@comment.id}_votes") do
@@ -485,7 +485,7 @@ feature 'Commenting Budget::Investments' do
       end
     end
 
-    scenario 'Trying to vote multiple times', :js do
+    it 'Trying to vote multiple times', :js do
       visit budget_investment_path(@budget, @investment)
 
       within("#comment_#{@comment.id}_votes") do

--- a/spec/features/comments/budget_investments_valuation_spec.rb
+++ b/spec/features/comments/budget_investments_valuation_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Internal valuation comments on Budget::Investments' do
+describe 'Internal valuation comments on Budget::Investments' do
   let(:user) { create(:user) }
   let(:valuator_user) { create(:valuator).user }
   let(:admin_user) { create(:administrator).user }
   let(:budget) { create(:budget, :valuating) }
   let(:investment) { create(:budget_investment, budget: budget) }
 
-  background do
+  before do
     Setting['feature.budgets'] = true
     investment.valuators << valuator_user.valuator
     login_as(valuator_user)
@@ -19,7 +19,7 @@ feature 'Internal valuation comments on Budget::Investments' do
 
   context 'Show valuation comments' do
     context 'Show valuation comments without public comments' do
-      background do
+      before do
         public_comment = create(:comment, commentable: investment, body: 'Public comment')
         create(:comment, commentable: investment, author: valuator_user,
                          body: 'Public valuator comment')
@@ -37,7 +37,7 @@ feature 'Internal valuation comments on Budget::Investments' do
                                      body: 'Valuator Valuation response', parent: admin_response)
       end
 
-      scenario 'Valuation Show page without public comments' do
+      it 'Valuation Show page without public comments' do
         visit valuation_budget_budget_investment_path(budget, investment)
 
         expect(page).not_to have_content('Comment as admin')
@@ -50,7 +50,7 @@ feature 'Internal valuation comments on Budget::Investments' do
         expect(page).to     have_content('Valuator Valuation response')
       end
 
-      scenario 'Valuation Edit page without public comments' do
+      it 'Valuation Edit page without public comments' do
         visit edit_valuation_budget_budget_investment_path(budget, investment)
 
         expect(page).not_to have_content('Comment as admin')
@@ -64,7 +64,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       end
     end
 
-    scenario 'Collapsable comments', :js do
+    it 'Collapsable comments', :js do
       parent_comment = create(:comment, :valuation, author: valuator_user, body: "Main comment",
                                                     commentable: investment)
       child_comment  = create(:comment, :valuation, author: valuator_user, body: "First child",
@@ -95,7 +95,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       expect(page).not_to have_content grandchild_comment.body
     end
 
-    scenario 'Comment order' do
+    it 'Comment order' do
       create(:comment, :valuation, commentable: investment,
                                    author: valuator_user,
                                    body: 'Valuator Valuation',
@@ -110,7 +110,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       expect(admin_valuation.body).to appear_before('Valuator Valuation')
     end
 
-    scenario 'Turns links into html links' do
+    it 'Turns links into html links' do
       create(:comment, :valuation, author: admin_user, commentable: investment,
                                    body: 'Check http://rubyonrails.org/')
 
@@ -124,7 +124,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       end
     end
 
-    scenario 'Sanitizes comment body for security' do
+    it 'Sanitizes comment body for security' do
       comment_with_js = "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">"\
                         "click me<a/> http://www.url.com"
       create(:comment, :valuation, author: admin_user, commentable: investment,
@@ -139,7 +139,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       end
     end
 
-    scenario 'Paginated comments' do
+    it 'Paginated comments' do
       per_page = 10
       (per_page + 2).times do
         create(:comment, :valuation, commentable: investment, author: valuator_user)
@@ -160,7 +160,7 @@ feature 'Internal valuation comments on Budget::Investments' do
   end
 
   context 'Valuation comment creation' do
-    scenario 'Normal users cannot create valuation comments altering public comments form', :js do
+    it 'Normal users cannot create valuation comments altering public comments form', :js do
       logout
       login_as(user)
       visit budget_investment_path(investment.budget, investment)
@@ -176,7 +176,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       expect(page).not_to have_content('HACKERMAN IS HERE')
     end
 
-    scenario 'Create comment', :js do
+    it 'Create comment', :js do
       visit valuation_budget_budget_investment_path(budget, investment)
 
       fill_in "comment-body-budget_investment_#{investment.id}", with: 'Have you thought about...?'
@@ -190,7 +190,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       expect(page).not_to have_content('Have you thought about...?')
     end
 
-    scenario 'Errors on create without comment text', :js do
+    it 'Errors on create without comment text', :js do
       visit valuation_budget_budget_investment_path(budget, investment)
 
       click_button 'Publish comment'
@@ -198,7 +198,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       expect(page).to have_content "Can't be blank"
     end
 
-    scenario 'Reply to existing valuation', :js do
+    it 'Reply to existing valuation', :js do
       comment = create(:comment, :valuation, author: admin_user, commentable: investment)
 
       login_as(valuator_user)
@@ -221,7 +221,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       expect(page).not_to have_content('It will be done next week.')
     end
 
-    scenario 'Errors on reply without comment text', :js do
+    it 'Errors on reply without comment text', :js do
       comment = create(:comment, :valuation, author: admin_user, commentable: investment)
 
       visit valuation_budget_budget_investment_path(budget, investment)
@@ -235,7 +235,7 @@ feature 'Internal valuation comments on Budget::Investments' do
 
     end
 
-    scenario "Multiple nested replies", :js do
+    it "Multiple nested replies", :js do
       parent = create(:comment, :valuation, author: valuator_user, commentable: investment)
 
       7.times do
@@ -252,7 +252,7 @@ feature 'Internal valuation comments on Budget::Investments' do
     end
   end
 
-  scenario "Erasing a comment's author" do
+  it "Erasing a comment's author" do
     comment = create(:comment, :valuation, author: valuator_user, commentable: investment,
                                            body: "this should be visible")
     comment.user.erase
@@ -264,8 +264,8 @@ feature 'Internal valuation comments on Budget::Investments' do
     end
   end
 
-  feature "Administrators" do
-    scenario "can create valuation comment as an administrator", :js do
+  describe "Administrators" do
+    it "can create valuation comment as an administrator", :js do
       login_as(admin_user)
       visit valuation_budget_budget_investment_path(budget, investment)
 
@@ -281,7 +281,7 @@ feature 'Internal valuation comments on Budget::Investments' do
       end
     end
 
-    scenario "can create valuation reply as an administrator", :js do
+    it "can create valuation reply as an administrator", :js do
       comment = create(:comment, :valuation, author: valuator_user, commentable: investment)
 
       login_as(admin_user)

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
-feature 'Commenting debates' do
+describe 'Commenting debates' do
   let(:user)   { create :user }
   let(:debate) { create :debate }
 
-  scenario 'Index' do
+  it 'Index' do
     3.times { create(:comment, commentable: debate) }
 
     visit debate_path(debate)
@@ -20,7 +20,7 @@ feature 'Commenting debates' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     parent_comment = create(:comment, commentable: debate)
     first_child    = create(:comment, commentable: debate, parent: parent_comment)
     second_child   = create(:comment, commentable: debate, parent: parent_comment)
@@ -39,7 +39,7 @@ feature 'Commenting debates' do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
-  scenario 'Collapsable comments', :js do
+  it 'Collapsable comments', :js do
     parent_comment = create(:comment, body: "Main comment", commentable: debate)
     child_comment  = create(:comment, body: "First subcomment", commentable: debate, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: debate, parent: child_comment)
@@ -65,7 +65,7 @@ feature 'Commenting debates' do
     expect(page).not_to have_content grandchild_comment.body
   end
 
-  scenario 'Comment order' do
+  it 'Comment order' do
     c1 = create(:comment, :with_confidence_score, commentable: debate, cached_votes_up: 100,
                                                   cached_votes_total: 120, created_at: Time.current - 2)
     c2 = create(:comment, :with_confidence_score, commentable: debate, cached_votes_up: 10,
@@ -89,7 +89,7 @@ feature 'Commenting debates' do
     expect(c2.body).to appear_before(c3.body)
   end
 
-  scenario 'Creation date works differently in roots and in child comments, even when sorting by confidence_score' do
+  it 'Creation date works differently in roots and in child comments, even when sorting by confidence_score' do
     old_root = create(:comment, commentable: debate, created_at: Time.current - 10)
     new_root = create(:comment, commentable: debate, created_at: Time.current)
     old_child = create(:comment, commentable: debate, parent_id: new_root.id, created_at: Time.current - 10)
@@ -111,7 +111,7 @@ feature 'Commenting debates' do
     expect(old_child.body).to appear_before(new_child.body)
   end
 
-  scenario 'Turns links into html links' do
+  it 'Turns links into html links' do
     create :comment, commentable: debate, body: 'Built with http://rubyonrails.org/'
 
     visit debate_path(debate)
@@ -124,7 +124,7 @@ feature 'Commenting debates' do
     end
   end
 
-  scenario 'Sanitizes comment body for security' do
+  it 'Sanitizes comment body for security' do
     create :comment, commentable: debate,
                      body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
@@ -137,7 +137,7 @@ feature 'Commenting debates' do
     end
   end
 
-  scenario 'Paginated comments' do
+  it 'Paginated comments' do
     per_page = 10
     (per_page + 2).times { create(:comment, commentable: debate)}
 
@@ -154,8 +154,8 @@ feature 'Commenting debates' do
     expect(page).to have_css('.comment', count: 2)
   end
 
-  feature 'Not logged user' do
-    scenario 'can not see comments forms' do
+  describe 'Not logged user' do
+    it 'can not see comments forms' do
       create(:comment, commentable: debate)
       visit debate_path(debate)
 
@@ -167,7 +167,7 @@ feature 'Commenting debates' do
     end
   end
 
-  scenario 'Create', :js do
+  it 'Create', :js do
     login_as(user)
     visit debate_path(debate)
 
@@ -180,7 +180,7 @@ feature 'Commenting debates' do
     end
   end
 
-  scenario 'Errors on create', :js do
+  it 'Errors on create', :js do
     login_as(user)
     visit debate_path(debate)
 
@@ -189,7 +189,7 @@ feature 'Commenting debates' do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario 'Reply', :js do
+  it 'Reply', :js do
     citizen = create(:user, username: 'Ana')
     manuela = create(:user, username: 'Manuela')
     comment = create(:comment, commentable: debate, user: citizen)
@@ -211,7 +211,7 @@ feature 'Commenting debates' do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
-  scenario 'Errors on reply', :js do
+  it 'Errors on reply', :js do
     comment = create(:comment, commentable: debate, user: user)
 
     login_as(user)
@@ -226,7 +226,7 @@ feature 'Commenting debates' do
 
   end
 
-  scenario "N replies", :js do
+  it "N replies", :js do
     parent = create(:comment, commentable: debate)
 
     7.times do
@@ -238,7 +238,7 @@ feature 'Commenting debates' do
     expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
   end
 
-  scenario "Flagging as inappropriate", :js do
+  it "Flagging as inappropriate", :js do
     comment = create(:comment, commentable: debate)
 
     login_as(user)
@@ -254,7 +254,7 @@ feature 'Commenting debates' do
     expect(Flag.flagged?(user, comment)).to be
   end
 
-  scenario "Undoing flagging as inappropriate", :js do
+  it "Undoing flagging as inappropriate", :js do
     comment = create(:comment, commentable: debate)
     Flag.flag(user, comment)
 
@@ -271,7 +271,7 @@ feature 'Commenting debates' do
     expect(Flag.flagged?(user, comment)).not_to be
   end
 
-  scenario "Flagging turbolinks sanity check", :js do
+  it "Flagging turbolinks sanity check", :js do
     debate = create(:debate, title: "Should we change the world?")
     comment = create(:comment, commentable: debate)
 
@@ -285,7 +285,7 @@ feature 'Commenting debates' do
     end
   end
 
-  scenario "Erasing a comment's author" do
+  it "Erasing a comment's author" do
     debate = create(:debate)
     comment = create(:comment, commentable: debate, body: 'this should be visible')
     comment.user.erase
@@ -297,7 +297,7 @@ feature 'Commenting debates' do
     end
   end
 
-  scenario 'Submit button is disabled after clicking', :js do
+  it 'Submit button is disabled after clicking', :js do
     debate = create(:debate)
     login_as(user)
     visit debate_path(debate)
@@ -312,8 +312,8 @@ feature 'Commenting debates' do
     expect(page).to have_content('Testing submit button!')
   end
 
-  feature "Moderators" do
-    scenario "can create comment as a moderator", :js do
+  describe "Moderators" do
+    it "can create comment as a moderator", :js do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -331,7 +331,7 @@ feature 'Commenting debates' do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    it "can create reply as a moderator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -358,7 +358,7 @@ feature 'Commenting debates' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as an administrator" do
+    it "can not comment as an administrator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -368,8 +368,8 @@ feature 'Commenting debates' do
     end
   end
 
-  feature "Administrators" do
-    scenario "can create comment as an administrator", :js do
+  describe "Administrators" do
+    it "can create comment as an administrator", :js do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -387,7 +387,7 @@ feature 'Commenting debates' do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    it "can create reply as an administrator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       admin   = create(:administrator, user: manuela)
@@ -414,7 +414,7 @@ feature 'Commenting debates' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as a moderator" do
+    it "can not comment as a moderator" do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -424,8 +424,8 @@ feature 'Commenting debates' do
     end
   end
 
-  feature 'Voting comments' do
-    background do
+  describe 'Voting comments' do
+    before do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @debate = create(:debate)
@@ -434,7 +434,7 @@ feature 'Commenting debates' do
       login_as(@manuela)
     end
 
-    scenario 'Show' do
+    it 'Show' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
@@ -453,7 +453,7 @@ feature 'Commenting debates' do
       end
     end
 
-    scenario 'Create', :js do
+    it 'Create', :js do
       visit debate_path(@debate)
 
       within("#comment_#{@comment.id}_votes") do
@@ -471,7 +471,7 @@ feature 'Commenting debates' do
       end
     end
 
-    scenario 'Update', :js do
+    it 'Update', :js do
       visit debate_path(@debate)
 
       within("#comment_#{@comment.id}_votes") do
@@ -490,7 +490,7 @@ feature 'Commenting debates' do
       end
     end
 
-    xscenario 'Trying to vote multiple times', :js do
+    xit 'Trying to vote multiple times', :js do
       visit debate_path(@debate)
 
       within("#comment_#{@comment.id}_votes") do

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
-feature 'Commenting legislation questions' do
+describe 'Commenting legislation questions' do
   let(:user) { create :user }
   let(:legislation_annotation) { create :legislation_annotation, author: user }
 
-  scenario 'Index' do
+  it 'Index' do
     3.times { create(:comment, commentable: legislation_annotation) }
 
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
@@ -22,7 +22,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     parent_comment = create(:comment, commentable: legislation_annotation)
     first_child    = create(:comment, commentable: legislation_annotation, parent: parent_comment)
     second_child   = create(:comment, commentable: legislation_annotation, parent: parent_comment)
@@ -44,7 +44,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
-  scenario 'Collapsable comments', :js do
+  it 'Collapsable comments', :js do
     parent_comment = legislation_annotation.comments.first
     child_comment  = create(:comment, body: "First subcomment", commentable: legislation_annotation, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: legislation_annotation, parent: child_comment)
@@ -72,7 +72,7 @@ feature 'Commenting legislation questions' do
     expect(page).not_to have_content grandchild_comment.body
   end
 
-  scenario 'Comment order' do
+  it 'Comment order' do
     c1 = create(:comment, :with_confidence_score, commentable: legislation_annotation, cached_votes_up: 100,
                                                   cached_votes_total: 120, created_at: Time.current - 2)
     c2 = create(:comment, :with_confidence_score, commentable: legislation_annotation, cached_votes_up: 10,
@@ -105,7 +105,7 @@ feature 'Commenting legislation questions' do
     expect(c2.body).to appear_before(c3.body)
   end
 
-  xscenario 'Creation date works differently in roots and in child comments, even when sorting by confidence_score' do
+  xit 'Creation date works differently in roots and in child comments, even when sorting by confidence_score' do
     old_root = create(:comment, commentable: legislation_annotation, created_at: Time.current - 10)
     new_root = create(:comment, commentable: legislation_annotation, created_at: Time.current)
     old_child = create(:comment, commentable: legislation_annotation, parent_id: new_root.id, created_at: Time.current - 10)
@@ -136,7 +136,7 @@ feature 'Commenting legislation questions' do
     expect(old_child.body).to appear_before(new_child.body)
   end
 
-  scenario 'Turns links into html links' do
+  it 'Turns links into html links' do
     create :comment, commentable: legislation_annotation, body: 'Built with http://rubyonrails.org/'
 
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
@@ -151,7 +151,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Sanitizes comment body for security' do
+  it 'Sanitizes comment body for security' do
     create :comment, commentable: legislation_annotation,
                      body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
@@ -166,7 +166,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Paginated comments' do
+  it 'Paginated comments' do
     per_page = 10
     (per_page + 2).times { create(:comment, commentable: legislation_annotation)}
 
@@ -185,8 +185,8 @@ feature 'Commenting legislation questions' do
     expect(page).to have_css('.comment', count: 3)
   end
 
-  feature 'Not logged user' do
-    scenario 'can not see comments forms' do
+  describe 'Not logged user' do
+    it 'can not see comments forms' do
       create(:comment, commentable: legislation_annotation)
       visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
                                                               legislation_annotation.draft_version,
@@ -200,7 +200,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Create', :js do
+  it 'Create', :js do
     login_as(user)
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
                                                             legislation_annotation.draft_version,
@@ -215,7 +215,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Errors on create', :js do
+  it 'Errors on create', :js do
     login_as(user)
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
                                                             legislation_annotation.draft_version,
@@ -226,7 +226,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario 'Reply', :js do
+  it 'Reply', :js do
     citizen = create(:user, username: 'Ana')
     manuela = create(:user, username: 'Manuela')
     legislation_annotation = create(:legislation_annotation, author: citizen)
@@ -251,7 +251,7 @@ feature 'Commenting legislation questions' do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
-  scenario 'Errors on reply', :js do
+  it 'Errors on reply', :js do
     comment = legislation_annotation.comments.first
 
     login_as(user)
@@ -268,7 +268,7 @@ feature 'Commenting legislation questions' do
 
   end
 
-  scenario "N replies", :js do
+  it "N replies", :js do
     parent = create(:comment, commentable: legislation_annotation)
 
     7.times do
@@ -283,7 +283,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
   end
 
-  scenario "Flagging as inappropriate", :js do
+  it "Flagging as inappropriate", :js do
     comment = create(:comment, commentable: legislation_annotation)
 
     login_as(user)
@@ -301,7 +301,7 @@ feature 'Commenting legislation questions' do
     expect(Flag.flagged?(user, comment)).to be
   end
 
-  scenario "Undoing flagging as inappropriate", :js do
+  it "Undoing flagging as inappropriate", :js do
     comment = create(:comment, commentable: legislation_annotation)
     Flag.flag(user, comment)
 
@@ -320,7 +320,7 @@ feature 'Commenting legislation questions' do
     expect(Flag.flagged?(user, comment)).not_to be
   end
 
-  scenario "Flagging turbolinks sanity check", :js do
+  it "Flagging turbolinks sanity check", :js do
     legislation_annotation = create(:legislation_annotation, text: "Should we change the world?")
     comment = create(:comment, commentable: legislation_annotation)
 
@@ -335,7 +335,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario "Erasing a comment's author" do
+  it "Erasing a comment's author" do
     legislation_annotation = create(:legislation_annotation)
     comment = create(:comment, commentable: legislation_annotation, body: 'this should be visible')
     comment.user.erase
@@ -350,7 +350,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Submit button is disabled after clicking', :js do
+  it 'Submit button is disabled after clicking', :js do
     legislation_annotation = create(:legislation_annotation)
     login_as(user)
 
@@ -368,8 +368,8 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content('Testing submit button!')
   end
 
-  feature "Moderators" do
-    scenario "can create comment as a moderator", :js do
+  describe "Moderators" do
+    it "can create comment as a moderator", :js do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -389,7 +389,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    it "can create reply as a moderator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -419,7 +419,7 @@ feature 'Commenting legislation questions' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as an administrator" do
+    it "can not comment as an administrator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -431,8 +431,8 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  feature "Administrators" do
-    scenario "can create comment as an administrator", :js do
+  describe "Administrators" do
+    it "can create comment as an administrator", :js do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -452,7 +452,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    it "can create reply as an administrator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       admin   = create(:administrator, user: manuela)
@@ -482,7 +482,7 @@ feature 'Commenting legislation questions' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as a moderator" do
+    it "can not comment as a moderator" do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -494,8 +494,8 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  feature 'Voting comments' do
-    background do
+  describe 'Voting comments' do
+    before do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @legislation_annotation = create(:legislation_annotation)
@@ -504,7 +504,7 @@ feature 'Commenting legislation questions' do
       login_as(@manuela)
     end
 
-    scenario 'Show' do
+    it 'Show' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
@@ -525,7 +525,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    scenario 'Create', :js do
+    it 'Create', :js do
       visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process,
                                                               @legislation_annotation.draft_version,
                                                               @legislation_annotation)
@@ -545,7 +545,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    scenario 'Update', :js do
+    it 'Update', :js do
       visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process,
                                                               @legislation_annotation.draft_version,
                                                               @legislation_annotation)
@@ -566,7 +566,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    xscenario 'Trying to vote multiple times', :js do
+    xit 'Trying to vote multiple times', :js do
       visit legislation_process_draft_version_annotation_path(@legislation_annotation.draft_version.process,
                                                               @legislation_annotation.draft_version,
                                                               @legislation_annotation)
@@ -592,7 +592,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  feature "Merged comment threads", :js do
+  describe "Merged comment threads", :js do
     let!(:draft_version) { create(:legislation_draft_version, :published) }
     let!(:annotation1) do
       create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
@@ -603,7 +603,7 @@ feature 'Commenting legislation questions' do
                                       ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10}])
     end
 
-    background do
+    before do
       login_as user
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
@@ -617,7 +617,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    scenario 'View comments of annotations in an included range' do
+    it 'View comments of annotations in an included range' do
       within("#annotation-link") do
         first(:css, "a").trigger('click')
       end
@@ -627,7 +627,7 @@ feature 'Commenting legislation questions' do
       expect(page).to have_content("my other annotation")
     end
 
-    scenario "Reply on a single annotation thread and display it in the merged annotation thread" do
+    it "Reply on a single annotation thread and display it in the merged annotation thread" do
       within(".comment-box #annotation-#{annotation1.id}-comments") do
         first(:link, "0 replies").click
       end
@@ -664,7 +664,7 @@ feature 'Commenting legislation questions' do
       expect(page).to have_content("replying in single annotation thread")
     end
 
-    scenario "Reply on a multiple annotation thread and display it in the single annotation thread" do
+    it "Reply on a multiple annotation thread and display it in the single annotation thread" do
       within("#annotation-link") do
         first(:css, "a").trigger('click')
       end

--- a/spec/features/comments/legislation_questions_spec.rb
+++ b/spec/features/comments/legislation_questions_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
-feature 'Commenting legislation questions' do
+describe 'Commenting legislation questions' do
 
   let(:user) { create :user, :level_two }
   let(:process) { create :legislation_process, :in_debate_phase }
@@ -11,7 +11,7 @@ feature 'Commenting legislation questions' do
     it_behaves_like 'notifiable in-app', Legislation::Question
   end
 
-  scenario 'Index' do
+  it 'Index' do
     3.times { create(:comment, commentable: legislation_question) }
 
     visit legislation_process_question_path(legislation_question.process, legislation_question)
@@ -26,7 +26,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     parent_comment = create(:comment, commentable: legislation_question)
     first_child    = create(:comment, commentable: legislation_question, parent: parent_comment)
     second_child   = create(:comment, commentable: legislation_question, parent: parent_comment)
@@ -46,7 +46,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
-  scenario 'Collapsable comments', :js do
+  it 'Collapsable comments', :js do
     parent_comment = create(:comment, body: "Main comment", commentable: legislation_question)
     child_comment  = create(:comment, body: "First subcomment", commentable: legislation_question, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: legislation_question, parent: child_comment)
@@ -72,7 +72,7 @@ feature 'Commenting legislation questions' do
     expect(page).not_to have_content grandchild_comment.body
   end
 
-  scenario 'Comment order' do
+  it 'Comment order' do
     c1 = create(:comment, :with_confidence_score, commentable: legislation_question, cached_votes_up: 100,
                                                   cached_votes_total: 120, created_at: Time.current - 2)
     c2 = create(:comment, :with_confidence_score, commentable: legislation_question, cached_votes_up: 10,
@@ -96,7 +96,7 @@ feature 'Commenting legislation questions' do
     expect(c2.body).to appear_before(c3.body)
   end
 
-  scenario 'Creation date works differently in roots and in child comments, even when sorting by confidence_score' do
+  it 'Creation date works differently in roots and in child comments, even when sorting by confidence_score' do
     old_root = create(:comment, commentable: legislation_question, created_at: Time.current - 10)
     new_root = create(:comment, commentable: legislation_question, created_at: Time.current)
     old_child = create(:comment, commentable: legislation_question, parent_id: new_root.id, created_at: Time.current - 10)
@@ -118,7 +118,7 @@ feature 'Commenting legislation questions' do
     expect(old_child.body).to appear_before(new_child.body)
   end
 
-  scenario 'Turns links into html links' do
+  it 'Turns links into html links' do
     create :comment, commentable: legislation_question, body: 'Built with http://rubyonrails.org/'
 
     visit legislation_process_question_path(legislation_question.process, legislation_question)
@@ -131,7 +131,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Sanitizes comment body for security' do
+  it 'Sanitizes comment body for security' do
     create :comment, commentable: legislation_question,
                      body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
@@ -144,7 +144,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Paginated comments' do
+  it 'Paginated comments' do
     per_page = 10
     (per_page + 2).times { create(:comment, commentable: legislation_question)}
 
@@ -161,8 +161,8 @@ feature 'Commenting legislation questions' do
     expect(page).to have_css('.comment', count: 2)
   end
 
-  feature 'Not logged user' do
-    scenario 'can not see comments forms' do
+  describe 'Not logged user' do
+    it 'can not see comments forms' do
       create(:comment, commentable: legislation_question)
       visit legislation_process_question_path(legislation_question.process, legislation_question)
 
@@ -174,7 +174,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Create', :js do
+  it 'Create', :js do
     login_as(user)
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 
@@ -187,7 +187,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Errors on create', :js do
+  it 'Errors on create', :js do
     login_as(user)
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 
@@ -196,7 +196,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario "Unverified user can't create comments", :js do
+  it "Unverified user can't create comments", :js do
     unverified_user = create :user
     login_as(unverified_user)
 
@@ -205,7 +205,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content "To participate verify your account"
   end
 
-  scenario "Can't create comments if debate phase is not open", :js do
+  it "Can't create comments if debate phase is not open", :js do
     process.update_attributes(debate_start_date: Date.current - 2.days, debate_end_date: Date.current - 1.day)
     login_as(user)
 
@@ -214,7 +214,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content "Closed phase"
   end
 
-  scenario 'Reply', :js do
+  it 'Reply', :js do
     citizen = create(:user, username: 'Ana')
     manuela = create(:user, :level_two, username: 'Manuela')
     comment = create(:comment, commentable: legislation_question, user: citizen)
@@ -236,7 +236,7 @@ feature 'Commenting legislation questions' do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
-  scenario 'Errors on reply', :js do
+  it 'Errors on reply', :js do
     comment = create(:comment, commentable: legislation_question, user: user)
 
     login_as(user)
@@ -251,7 +251,7 @@ feature 'Commenting legislation questions' do
 
   end
 
-  scenario "N replies", :js do
+  it "N replies", :js do
     parent = create(:comment, commentable: legislation_question)
 
     7.times do
@@ -263,7 +263,7 @@ feature 'Commenting legislation questions' do
     expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
   end
 
-  scenario "Flagging as inappropriate", :js do
+  it "Flagging as inappropriate", :js do
     comment = create(:comment, commentable: legislation_question)
 
     login_as(user)
@@ -279,7 +279,7 @@ feature 'Commenting legislation questions' do
     expect(Flag.flagged?(user, comment)).to be
   end
 
-  scenario "Undoing flagging as inappropriate", :js do
+  it "Undoing flagging as inappropriate", :js do
     comment = create(:comment, commentable: legislation_question)
     Flag.flag(user, comment)
 
@@ -296,7 +296,7 @@ feature 'Commenting legislation questions' do
     expect(Flag.flagged?(user, comment)).not_to be
   end
 
-  scenario "Flagging turbolinks sanity check", :js do
+  it "Flagging turbolinks sanity check", :js do
     legislation_question = create(:legislation_question, process: process, title: "Should we change the world?")
     comment = create(:comment, commentable: legislation_question)
 
@@ -310,7 +310,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario "Erasing a comment's author" do
+  it "Erasing a comment's author" do
     comment = create(:comment, commentable: legislation_question, body: 'this should be visible')
     comment.user.erase
 
@@ -321,7 +321,7 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  scenario 'Submit button is disabled after clicking', :js do
+  it 'Submit button is disabled after clicking', :js do
     login_as(user)
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 
@@ -335,8 +335,8 @@ feature 'Commenting legislation questions' do
     expect(page).to have_content('Testing submit button!')
   end
 
-  feature "Moderators" do
-    scenario "can create comment as a moderator", :js do
+  describe "Moderators" do
+    it "can create comment as a moderator", :js do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -354,7 +354,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    it "can create reply as a moderator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -381,7 +381,7 @@ feature 'Commenting legislation questions' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as an administrator" do
+    it "can not comment as an administrator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -391,8 +391,8 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  feature "Administrators" do
-    scenario "can create comment as an administrator", :js do
+  describe "Administrators" do
+    it "can create comment as an administrator", :js do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -410,7 +410,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    it "can create reply as an administrator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       admin   = create(:administrator, user: manuela)
@@ -437,7 +437,7 @@ feature 'Commenting legislation questions' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as a moderator" do
+    it "can not comment as a moderator" do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -447,8 +447,8 @@ feature 'Commenting legislation questions' do
     end
   end
 
-  feature 'Voting comments' do
-    background do
+  describe 'Voting comments' do
+    before do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @legislation_question = create(:legislation_question)
@@ -457,7 +457,7 @@ feature 'Commenting legislation questions' do
       login_as(@manuela)
     end
 
-    scenario 'Show' do
+    it 'Show' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
@@ -476,7 +476,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    scenario 'Create', :js do
+    it 'Create', :js do
       visit legislation_process_question_path(@legislation_question.process, @legislation_question)
 
       within("#comment_#{@comment.id}_votes") do
@@ -494,7 +494,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    scenario 'Update', :js do
+    it 'Update', :js do
       visit legislation_process_question_path(@legislation_question.process, @legislation_question)
 
       within("#comment_#{@comment.id}_votes") do
@@ -513,7 +513,7 @@ feature 'Commenting legislation questions' do
       end
     end
 
-    xscenario 'Trying to vote multiple times', :js do
+    xit 'Trying to vote multiple times', :js do
       visit legislation_process_question_path(@legislation_question.process, @legislation_question)
 
       within("#comment_#{@comment.id}_votes") do

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
-feature 'Commenting polls' do
+describe 'Commenting polls' do
   let(:user) { create :user }
   let(:poll) { create(:poll, author: create(:user)) }
 
-  scenario 'Index' do
+  it 'Index' do
     3.times { create(:comment, commentable: poll) }
 
     visit poll_path(poll)
@@ -20,7 +20,7 @@ feature 'Commenting polls' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     skip "Feature not implemented yet, review soon"
 
     parent_comment = create(:comment, commentable: poll)
@@ -40,7 +40,7 @@ feature 'Commenting polls' do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
-  scenario 'Collapsable comments', :js do
+  it 'Collapsable comments', :js do
     parent_comment = create(:comment, body: "Main comment", commentable: poll)
     child_comment  = create(:comment, body: "First subcomment", commentable: poll, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: poll, parent: child_comment)
@@ -66,7 +66,7 @@ feature 'Commenting polls' do
     expect(page).not_to have_content grandchild_comment.body
   end
 
-  scenario 'Comment order' do
+  it 'Comment order' do
     c1 = create(:comment, :with_confidence_score, commentable: poll, cached_votes_up: 100,
                                                   cached_votes_total: 120, created_at: Time.current - 2)
     c2 = create(:comment, :with_confidence_score, commentable: poll, cached_votes_up: 10,
@@ -90,7 +90,7 @@ feature 'Commenting polls' do
     expect(c2.body).to appear_before(c3.body)
   end
 
-  scenario 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
+  it 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
    old_root = create(:comment, commentable: poll, created_at: Time.current - 10)
    new_root = create(:comment, commentable: poll, created_at: Time.current)
    old_child = create(:comment, commentable: poll, parent_id: new_root.id, created_at: Time.current - 10)
@@ -112,7 +112,7 @@ feature 'Commenting polls' do
    expect(old_child.body).to appear_before(new_child.body)
   end
 
-  scenario 'Turns links into html links' do
+  it 'Turns links into html links' do
     create :comment, commentable: poll, body: 'Built with http://rubyonrails.org/'
 
     visit poll_path(poll)
@@ -125,7 +125,7 @@ feature 'Commenting polls' do
     end
   end
 
-  scenario 'Sanitizes comment body for security' do
+  it 'Sanitizes comment body for security' do
     create :comment, commentable: poll,
                      body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
@@ -138,7 +138,7 @@ feature 'Commenting polls' do
     end
   end
 
-  scenario 'Paginated comments' do
+  it 'Paginated comments' do
     per_page = 10
     (per_page + 2).times { create(:comment, commentable: poll)}
 
@@ -155,8 +155,8 @@ feature 'Commenting polls' do
     expect(page).to have_css('.comment', count: 2)
   end
 
-  feature 'Not logged user' do
-    scenario 'can not see comments forms' do
+  describe 'Not logged user' do
+    it 'can not see comments forms' do
       create(:comment, commentable: poll)
       visit poll_path(poll)
 
@@ -168,7 +168,7 @@ feature 'Commenting polls' do
     end
   end
 
-  scenario 'Create', :js do
+  it 'Create', :js do
     login_as(user)
     visit poll_path(poll)
 
@@ -184,7 +184,7 @@ feature 'Commenting polls' do
     end
   end
 
-  scenario 'Errors on create', :js do
+  it 'Errors on create', :js do
     login_as(user)
     visit poll_path(poll)
 
@@ -193,7 +193,7 @@ feature 'Commenting polls' do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario 'Reply', :js do
+  it 'Reply', :js do
     citizen = create(:user, username: 'Ana')
     manuela = create(:user, username: 'Manuela')
     comment = create(:comment, commentable: poll, user: citizen)
@@ -215,7 +215,7 @@ feature 'Commenting polls' do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
-  scenario 'Errors on reply', :js do
+  it 'Errors on reply', :js do
     comment = create(:comment, commentable: poll, user: user)
 
     login_as(user)
@@ -230,7 +230,7 @@ feature 'Commenting polls' do
 
   end
 
-  scenario "N replies", :js do
+  it "N replies", :js do
     parent = create(:comment, commentable: poll)
 
     7.times do
@@ -242,7 +242,7 @@ feature 'Commenting polls' do
     expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
   end
 
-  scenario "Flagging as inappropriate", :js do
+  it "Flagging as inappropriate", :js do
     skip "Feature not implemented yet, review soon"
 
     comment = create(:comment, commentable: poll)
@@ -260,7 +260,7 @@ feature 'Commenting polls' do
     expect(Flag.flagged?(user, comment)).to be
   end
 
-  scenario "Undoing flagging as inappropriate", :js do
+  it "Undoing flagging as inappropriate", :js do
     skip "Feature not implemented yet, review soon"
 
     comment = create(:comment, commentable: poll)
@@ -279,7 +279,7 @@ feature 'Commenting polls' do
     expect(Flag.flagged?(user, comment)).not_to be
   end
 
-  scenario "Flagging turbolinks sanity check", :js do
+  it "Flagging turbolinks sanity check", :js do
     skip "Feature not implemented yet, review soon"
 
     poll = create(:poll, title: "Should we change the world?")
@@ -295,7 +295,7 @@ feature 'Commenting polls' do
     end
   end
 
-  scenario "Erasing a comment's author" do
+  it "Erasing a comment's author" do
     poll = create(:poll)
     comment = create(:comment, commentable: poll, body: "this should be visible")
     comment.user.erase
@@ -307,9 +307,9 @@ feature 'Commenting polls' do
     end
   end
 
-  feature "Moderators" do
+  describe "Moderators" do
 
-    scenario "can create comment as a moderator", :js do
+    it "can create comment as a moderator", :js do
       skip "Feature not implemented yet, review soon"
 
       moderator = create(:moderator)
@@ -329,7 +329,7 @@ feature 'Commenting polls' do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    it "can create reply as a moderator", :js do
       skip "Feature not implemented yet, review soon"
 
       citizen = create(:user, username: "Ana")
@@ -358,7 +358,7 @@ feature 'Commenting polls' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as an administrator" do
+    it "can not comment as an administrator" do
       skip "Feature not implemented yet, review soon"
 
       moderator = create(:moderator)
@@ -370,8 +370,8 @@ feature 'Commenting polls' do
     end
   end
 
-  feature "Administrators" do
-    scenario "can create comment as an administrator", :js do
+  describe "Administrators" do
+    it "can create comment as an administrator", :js do
       skip "Feature not implemented yet, review soon"
 
       admin = create(:administrator)
@@ -391,7 +391,7 @@ feature 'Commenting polls' do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    it "can create reply as an administrator", :js do
       skip "Feature not implemented yet, review soon"
 
       citizen = create(:user, username: "Ana")
@@ -420,7 +420,7 @@ feature 'Commenting polls' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as a moderator" do
+    it "can not comment as a moderator" do
       skip "Feature not implemented yet, review soon"
 
       admin = create(:administrator)
@@ -432,9 +432,9 @@ feature 'Commenting polls' do
     end
   end
 
-  feature 'Voting comments' do
+  describe 'Voting comments' do
 
-    background do
+    before do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @poll = create(:poll)
@@ -443,7 +443,7 @@ feature 'Commenting polls' do
       login_as(@manuela)
     end
 
-    scenario 'Show' do
+    it 'Show' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
@@ -462,7 +462,7 @@ feature 'Commenting polls' do
       end
     end
 
-    scenario 'Create', :js do
+    it 'Create', :js do
       visit poll_path(@poll)
 
       within("#comment_#{@comment.id}_votes") do
@@ -480,7 +480,7 @@ feature 'Commenting polls' do
       end
     end
 
-    scenario 'Update', :js do
+    it 'Update', :js do
       visit poll_path(@poll)
 
       within("#comment_#{@comment.id}_votes") do
@@ -499,7 +499,7 @@ feature 'Commenting polls' do
       end
     end
 
-    scenario 'Trying to vote multiple times', :js do
+    it 'Trying to vote multiple times', :js do
       visit poll_path(@poll)
 
       within("#comment_#{@comment.id}_votes") do

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
-feature 'Commenting proposals' do
+describe 'Commenting proposals' do
   let(:user) { create :user }
   let(:proposal) { create :proposal }
 
-  scenario 'Index' do
+  it 'Index' do
     3.times { create(:comment, commentable: proposal) }
 
     visit proposal_path(proposal)
@@ -20,7 +20,7 @@ feature 'Commenting proposals' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     parent_comment = create(:comment, commentable: proposal)
     first_child    = create(:comment, commentable: proposal, parent: parent_comment)
     second_child   = create(:comment, commentable: proposal, parent: parent_comment)
@@ -38,7 +38,7 @@ feature 'Commenting proposals' do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
-  scenario 'Collapsable comments', :js do
+  it 'Collapsable comments', :js do
     parent_comment = create(:comment, body: "Main comment", commentable: proposal)
     child_comment  = create(:comment, body: "First subcomment", commentable: proposal, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: proposal, parent: child_comment)
@@ -64,7 +64,7 @@ feature 'Commenting proposals' do
     expect(page).not_to have_content grandchild_comment.body
   end
 
-  scenario 'Comment order' do
+  it 'Comment order' do
     c1 = create(:comment, :with_confidence_score, commentable: proposal, cached_votes_up: 100,
                                                   cached_votes_total: 120, created_at: Time.current - 2)
     c2 = create(:comment, :with_confidence_score, commentable: proposal, cached_votes_up: 10,
@@ -88,7 +88,7 @@ feature 'Commenting proposals' do
     expect(c2.body).to appear_before(c3.body)
   end
 
-  scenario 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
+  it 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
    old_root = create(:comment, commentable: proposal, created_at: Time.current - 10)
    new_root = create(:comment, commentable: proposal, created_at: Time.current)
    old_child = create(:comment, commentable: proposal, parent_id: new_root.id, created_at: Time.current - 10)
@@ -110,7 +110,7 @@ feature 'Commenting proposals' do
    expect(old_child.body).to appear_before(new_child.body)
   end
 
-  scenario 'Turns links into html links' do
+  it 'Turns links into html links' do
     create :comment, commentable: proposal, body: 'Built with http://rubyonrails.org/'
 
     visit proposal_path(proposal)
@@ -123,7 +123,7 @@ feature 'Commenting proposals' do
     end
   end
 
-  scenario 'Sanitizes comment body for security' do
+  it 'Sanitizes comment body for security' do
     create :comment, commentable: proposal,
                      body: "<script>alert('hola')</script> <a href=\"javascript:alert('sorpresa!')\">click me<a/> http://www.url.com"
 
@@ -136,7 +136,7 @@ feature 'Commenting proposals' do
     end
   end
 
-  scenario 'Paginated comments' do
+  it 'Paginated comments' do
     per_page = 10
     (per_page + 2).times { create(:comment, commentable: proposal)}
 
@@ -153,8 +153,8 @@ feature 'Commenting proposals' do
     expect(page).to have_css('.comment', count: 2)
   end
 
-  feature 'Not logged user' do
-    scenario 'can not see comments forms' do
+  describe 'Not logged user' do
+    it 'can not see comments forms' do
       create(:comment, commentable: proposal)
       visit proposal_path(proposal)
 
@@ -166,7 +166,7 @@ feature 'Commenting proposals' do
     end
   end
 
-  scenario 'Create', :js do
+  it 'Create', :js do
     login_as(user)
     visit proposal_path(proposal)
 
@@ -182,7 +182,7 @@ feature 'Commenting proposals' do
     end
   end
 
-  scenario 'Errors on create', :js do
+  it 'Errors on create', :js do
     login_as(user)
     visit proposal_path(proposal)
 
@@ -191,7 +191,7 @@ feature 'Commenting proposals' do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario 'Reply', :js do
+  it 'Reply', :js do
     citizen = create(:user, username: 'Ana')
     manuela = create(:user, username: 'Manuela')
     comment = create(:comment, commentable: proposal, user: citizen)
@@ -213,7 +213,7 @@ feature 'Commenting proposals' do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
-  scenario 'Errors on reply', :js do
+  it 'Errors on reply', :js do
     comment = create(:comment, commentable: proposal, user: user)
 
     login_as(user)
@@ -228,7 +228,7 @@ feature 'Commenting proposals' do
 
   end
 
-  scenario "N replies", :js do
+  it "N replies", :js do
     parent = create(:comment, commentable: proposal)
 
     7.times do
@@ -240,7 +240,7 @@ feature 'Commenting proposals' do
     expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
   end
 
-  scenario "Flagging as inappropriate", :js do
+  it "Flagging as inappropriate", :js do
     comment = create(:comment, commentable: proposal)
 
     login_as(user)
@@ -256,7 +256,7 @@ feature 'Commenting proposals' do
     expect(Flag.flagged?(user, comment)).to be
   end
 
-  scenario "Undoing flagging as inappropriate", :js do
+  it "Undoing flagging as inappropriate", :js do
     comment = create(:comment, commentable: proposal)
     Flag.flag(user, comment)
 
@@ -273,7 +273,7 @@ feature 'Commenting proposals' do
     expect(Flag.flagged?(user, comment)).not_to be
   end
 
-  scenario "Flagging turbolinks sanity check", :js do
+  it "Flagging turbolinks sanity check", :js do
     proposal = create(:proposal, title: "Should we change the world?")
     comment = create(:comment, commentable: proposal)
 
@@ -287,7 +287,7 @@ feature 'Commenting proposals' do
     end
   end
 
-  scenario "Erasing a comment's author" do
+  it "Erasing a comment's author" do
     proposal = create(:proposal)
     comment = create(:comment, commentable: proposal, body: "this should be visible")
     comment.user.erase
@@ -299,8 +299,8 @@ feature 'Commenting proposals' do
     end
   end
 
-  feature "Moderators" do
-    scenario "can create comment as a moderator", :js do
+  describe "Moderators" do
+    it "can create comment as a moderator", :js do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -318,7 +318,7 @@ feature 'Commenting proposals' do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    it "can create reply as a moderator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -345,7 +345,7 @@ feature 'Commenting proposals' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as an administrator" do
+    it "can not comment as an administrator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -355,8 +355,8 @@ feature 'Commenting proposals' do
     end
   end
 
-  feature "Administrators" do
-    scenario "can create comment as an administrator", :js do
+  describe "Administrators" do
+    it "can create comment as an administrator", :js do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -374,7 +374,7 @@ feature 'Commenting proposals' do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    it "can create reply as an administrator", :js do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       admin   = create(:administrator, user: manuela)
@@ -401,7 +401,7 @@ feature 'Commenting proposals' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as a moderator" do
+    it "can not comment as a moderator" do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -411,9 +411,9 @@ feature 'Commenting proposals' do
     end
   end
 
-  feature 'Voting comments' do
+  describe 'Voting comments' do
 
-    background do
+    before do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @proposal = create(:proposal)
@@ -422,7 +422,7 @@ feature 'Commenting proposals' do
       login_as(@manuela)
     end
 
-    scenario 'Show' do
+    it 'Show' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
@@ -441,7 +441,7 @@ feature 'Commenting proposals' do
       end
     end
 
-    scenario 'Create', :js do
+    it 'Create', :js do
       visit proposal_path(@proposal)
 
       within("#comment_#{@comment.id}_votes") do
@@ -459,7 +459,7 @@ feature 'Commenting proposals' do
       end
     end
 
-    scenario 'Update', :js do
+    it 'Update', :js do
       visit proposal_path(@proposal)
 
       within("#comment_#{@comment.id}_votes") do
@@ -478,7 +478,7 @@ feature 'Commenting proposals' do
       end
     end
 
-    scenario 'Trying to vote multiple times', :js do
+    it 'Trying to vote multiple times', :js do
       visit proposal_path(@proposal)
 
       within("#comment_#{@comment.id}_votes") do

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
-feature 'Commenting topics from proposals' do
+describe 'Commenting topics from proposals' do
   let(:user) { create :user }
   let(:proposal) { create :proposal }
 
-  scenario 'Index', :js do
+  it 'Index', :js do
 
     community = proposal.community
     topic = create(:topic, community: community)
@@ -23,7 +23,7 @@ feature 'Commenting topics from proposals' do
     end
   end
 
-  scenario 'Show', :js do
+  it 'Show', :js do
     community = proposal.community
     topic = create(:topic, community: community)
     parent_comment = create(:comment, commentable: topic)
@@ -40,7 +40,7 @@ feature 'Commenting topics from proposals' do
     expect(page).to have_link "Go back to #{topic.title}", href: community_topic_path(community, topic)
   end
 
-  scenario 'Collapsable comments', :js do
+  it 'Collapsable comments', :js do
     community = proposal.community
     topic = create(:topic, community: community)
     parent_comment = create(:comment, body: "Main comment", commentable: topic)
@@ -68,7 +68,7 @@ feature 'Commenting topics from proposals' do
     expect(page).not_to have_content grandchild_comment.body
   end
 
-  scenario 'Comment order' do
+  it 'Comment order' do
     community = proposal.community
     topic = create(:topic, community: community)
     c1 = create(:comment, :with_confidence_score, commentable: topic, cached_votes_up: 100,
@@ -94,7 +94,7 @@ feature 'Commenting topics from proposals' do
     expect(c2.body).to appear_before(c3.body)
   end
 
-  scenario 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
+  it 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
     community = proposal.community
     topic = create(:topic, community: community)
     old_root = create(:comment, commentable: topic, created_at: Time.current - 10)
@@ -118,7 +118,7 @@ feature 'Commenting topics from proposals' do
     expect(old_child.body).to appear_before(new_child.body)
   end
 
-  scenario 'Turns links into html links' do
+  it 'Turns links into html links' do
     community = proposal.community
     topic = create(:topic, community: community)
     create :comment, commentable: topic, body: 'Built with http://rubyonrails.org/'
@@ -133,7 +133,7 @@ feature 'Commenting topics from proposals' do
     end
   end
 
-  scenario 'Sanitizes comment body for security' do
+  it 'Sanitizes comment body for security' do
     community = proposal.community
     topic = create(:topic, community: community)
     create :comment, commentable: topic,
@@ -148,7 +148,7 @@ feature 'Commenting topics from proposals' do
     end
   end
 
-  scenario 'Paginated comments' do
+  it 'Paginated comments' do
     community = proposal.community
     topic = create(:topic, community: community)
     per_page = 10
@@ -167,8 +167,8 @@ feature 'Commenting topics from proposals' do
     expect(page).to have_css('.comment', count: 2)
   end
 
-  feature 'Not logged user' do
-    scenario 'can not see comments forms' do
+  describe 'Not logged user' do
+    it 'can not see comments forms' do
       community = proposal.community
       topic = create(:topic, community: community)
       create(:comment, commentable: topic)
@@ -183,7 +183,7 @@ feature 'Commenting topics from proposals' do
     end
   end
 
-  scenario 'Create', :js do
+  it 'Create', :js do
     login_as(user)
     community = proposal.community
     topic = create(:topic, community: community)
@@ -201,7 +201,7 @@ feature 'Commenting topics from proposals' do
     end
   end
 
-  scenario 'Errors on create', :js do
+  it 'Errors on create', :js do
     login_as(user)
     community = proposal.community
     topic = create(:topic, community: community)
@@ -212,7 +212,7 @@ feature 'Commenting topics from proposals' do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario 'Reply', :js do
+  it 'Reply', :js do
     community = proposal.community
     topic = create(:topic, community: community)
     citizen = create(:user, username: 'Ana')
@@ -236,7 +236,7 @@ feature 'Commenting topics from proposals' do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
-  scenario 'Errors on reply', :js do
+  it 'Errors on reply', :js do
     community = proposal.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic, user: user)
@@ -253,7 +253,7 @@ feature 'Commenting topics from proposals' do
 
   end
 
-  scenario "N replies", :js do
+  it "N replies", :js do
     community = proposal.community
     topic = create(:topic, community: community)
     parent = create(:comment, commentable: topic)
@@ -267,7 +267,7 @@ feature 'Commenting topics from proposals' do
     expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
   end
 
-  scenario "Flagging as inappropriate", :js do
+  it "Flagging as inappropriate", :js do
     community = proposal.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic)
@@ -285,7 +285,7 @@ feature 'Commenting topics from proposals' do
     expect(Flag.flagged?(user, comment)).to be
   end
 
-  scenario "Undoing flagging as inappropriate", :js do
+  it "Undoing flagging as inappropriate", :js do
     community = proposal.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic)
@@ -304,7 +304,7 @@ feature 'Commenting topics from proposals' do
     expect(Flag.flagged?(user, comment)).not_to be
   end
 
-  scenario "Flagging turbolinks sanity check", :js do
+  it "Flagging turbolinks sanity check", :js do
     Setting['feature.community'] = true
 
     community = proposal.community
@@ -323,7 +323,7 @@ feature 'Commenting topics from proposals' do
     Setting['feature.community'] = nil
   end
 
-  scenario "Erasing a comment's author" do
+  it "Erasing a comment's author" do
     community = proposal.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic, body: "this should be visible")
@@ -337,8 +337,8 @@ feature 'Commenting topics from proposals' do
     end
   end
 
-  feature "Moderators" do
-    scenario "can create comment as a moderator", :js do
+  describe "Moderators" do
+    it "can create comment as a moderator", :js do
       community = proposal.community
       topic = create(:topic, community: community)
       moderator = create(:moderator)
@@ -358,7 +358,7 @@ feature 'Commenting topics from proposals' do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    it "can create reply as a moderator", :js do
       community = proposal.community
       topic = create(:topic, community: community)
       citizen = create(:user, username: "Ana")
@@ -387,7 +387,7 @@ feature 'Commenting topics from proposals' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as an administrator" do
+    it "can not comment as an administrator" do
       community = proposal.community
       topic = create(:topic, community: community)
       moderator = create(:moderator)
@@ -399,8 +399,8 @@ feature 'Commenting topics from proposals' do
     end
   end
 
-  feature "Administrators" do
-    scenario "can create comment as an administrator", :js do
+  describe "Administrators" do
+    it "can create comment as an administrator", :js do
       community = proposal.community
       topic = create(:topic, community: community)
       admin = create(:administrator)
@@ -420,7 +420,7 @@ feature 'Commenting topics from proposals' do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    it "can create reply as an administrator", :js do
       community = proposal.community
       topic = create(:topic, community: community)
       citizen = create(:user, username: "Ana")
@@ -449,7 +449,7 @@ feature 'Commenting topics from proposals' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as a moderator" do
+    it "can not comment as a moderator" do
       community = proposal.community
       topic = create(:topic, community: community)
       admin = create(:administrator)
@@ -461,9 +461,9 @@ feature 'Commenting topics from proposals' do
     end
   end
 
-  feature 'Voting comments' do
+  describe 'Voting comments' do
 
-    background do
+    before do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @proposal = create(:proposal)
@@ -473,7 +473,7 @@ feature 'Commenting topics from proposals' do
       login_as(@manuela)
     end
 
-    scenario 'Show' do
+    it 'Show' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
@@ -492,7 +492,7 @@ feature 'Commenting topics from proposals' do
       end
     end
 
-    scenario 'Create', :js do
+    it 'Create', :js do
       visit community_topic_path(@proposal.community, @topic)
 
       within("#comment_#{@comment.id}_votes") do
@@ -510,7 +510,7 @@ feature 'Commenting topics from proposals' do
       end
     end
 
-    scenario 'Update', :js do
+    it 'Update', :js do
       visit community_topic_path(@proposal.community, @topic)
 
       within("#comment_#{@comment.id}_votes") do
@@ -529,7 +529,7 @@ feature 'Commenting topics from proposals' do
       end
     end
 
-    scenario 'Trying to vote multiple times', :js do
+    it 'Trying to vote multiple times', :js do
       visit community_topic_path(@proposal.community, @topic)
 
       within("#comment_#{@comment.id}_votes") do
@@ -551,11 +551,11 @@ feature 'Commenting topics from proposals' do
 
 end
 
-feature 'Commenting topics from budget investments' do
+describe 'Commenting topics from budget investments' do
   let(:user) { create :user }
   let(:investment) { create :budget_investment }
 
-  scenario 'Index', :js do
+  it 'Index', :js do
 
     community = investment.community
     topic = create(:topic, community: community)
@@ -573,7 +573,7 @@ feature 'Commenting topics from budget investments' do
     end
   end
 
-  scenario 'Show', :js do
+  it 'Show', :js do
     community = investment.community
     topic = create(:topic, community: community)
     parent_comment = create(:comment, commentable: topic)
@@ -590,7 +590,7 @@ feature 'Commenting topics from budget investments' do
     expect(page).to have_link "Go back to #{topic.title}", href: community_topic_path(community, topic)
   end
 
-  scenario 'Collapsable comments', :js do
+  it 'Collapsable comments', :js do
     community = investment.community
     topic = create(:topic, community: community)
     parent_comment = create(:comment, body: "Main comment", commentable: topic)
@@ -618,7 +618,7 @@ feature 'Commenting topics from budget investments' do
     expect(page).not_to have_content grandchild_comment.body
   end
 
-  scenario 'Comment order' do
+  it 'Comment order' do
     community = investment.community
     topic = create(:topic, community: community)
     c1 = create(:comment, :with_confidence_score, commentable: topic, cached_votes_up: 100,
@@ -644,7 +644,7 @@ feature 'Commenting topics from budget investments' do
     expect(c2.body).to appear_before(c3.body)
   end
 
-  scenario 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
+  it 'Creation date works differently in roots and in child comments, when sorting by confidence_score' do
     community = investment.community
     topic = create(:topic, community: community)
     old_root = create(:comment, commentable: topic, created_at: Time.current - 10)
@@ -668,7 +668,7 @@ feature 'Commenting topics from budget investments' do
     expect(old_child.body).to appear_before(new_child.body)
   end
 
-  scenario 'Turns links into html links' do
+  it 'Turns links into html links' do
     community = investment.community
     topic = create(:topic, community: community)
     create :comment, commentable: topic, body: 'Built with http://rubyonrails.org/'
@@ -683,7 +683,7 @@ feature 'Commenting topics from budget investments' do
     end
   end
 
-  scenario 'Sanitizes comment body for security' do
+  it 'Sanitizes comment body for security' do
     community = investment.community
     topic = create(:topic, community: community)
     create :comment, commentable: topic,
@@ -698,7 +698,7 @@ feature 'Commenting topics from budget investments' do
     end
   end
 
-  scenario 'Paginated comments' do
+  it 'Paginated comments' do
     community = investment.community
     topic = create(:topic, community: community)
     per_page = 10
@@ -717,8 +717,8 @@ feature 'Commenting topics from budget investments' do
     expect(page).to have_css('.comment', count: 2)
   end
 
-  feature 'Not logged user' do
-    scenario 'can not see comments forms' do
+  describe 'Not logged user' do
+    it 'can not see comments forms' do
       community = investment.community
       topic = create(:topic, community: community)
       create(:comment, commentable: topic)
@@ -733,7 +733,7 @@ feature 'Commenting topics from budget investments' do
     end
   end
 
-  scenario 'Create', :js do
+  it 'Create', :js do
     login_as(user)
     community = investment.community
     topic = create(:topic, community: community)
@@ -751,7 +751,7 @@ feature 'Commenting topics from budget investments' do
     end
   end
 
-  scenario 'Errors on create', :js do
+  it 'Errors on create', :js do
     login_as(user)
     community = investment.community
     topic = create(:topic, community: community)
@@ -762,7 +762,7 @@ feature 'Commenting topics from budget investments' do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario 'Reply', :js do
+  it 'Reply', :js do
     community = investment.community
     topic = create(:topic, community: community)
     citizen = create(:user, username: 'Ana')
@@ -786,7 +786,7 @@ feature 'Commenting topics from budget investments' do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
-  scenario 'Errors on reply', :js do
+  it 'Errors on reply', :js do
     community = investment.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic, user: user)
@@ -803,7 +803,7 @@ feature 'Commenting topics from budget investments' do
 
   end
 
-  scenario "N replies", :js do
+  it "N replies", :js do
     community = investment.community
     topic = create(:topic, community: community)
     parent = create(:comment, commentable: topic)
@@ -817,7 +817,7 @@ feature 'Commenting topics from budget investments' do
     expect(page).to have_css(".comment.comment.comment.comment.comment.comment.comment.comment")
   end
 
-  scenario "Flagging as inappropriate", :js do
+  it "Flagging as inappropriate", :js do
     community = investment.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic)
@@ -835,7 +835,7 @@ feature 'Commenting topics from budget investments' do
     expect(Flag.flagged?(user, comment)).to be
   end
 
-  scenario "Undoing flagging as inappropriate", :js do
+  it "Undoing flagging as inappropriate", :js do
     community = investment.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic)
@@ -854,7 +854,7 @@ feature 'Commenting topics from budget investments' do
     expect(Flag.flagged?(user, comment)).not_to be
   end
 
-  scenario "Flagging turbolinks sanity check", :js do
+  it "Flagging turbolinks sanity check", :js do
     Setting['feature.community'] = true
 
     community = investment.community
@@ -873,7 +873,7 @@ feature 'Commenting topics from budget investments' do
     Setting['feature.community'] = nil
   end
 
-  scenario "Erasing a comment's author" do
+  it "Erasing a comment's author" do
     community = investment.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic, body: "this should be visible")
@@ -887,8 +887,8 @@ feature 'Commenting topics from budget investments' do
     end
   end
 
-  feature "Moderators" do
-    scenario "can create comment as a moderator", :js do
+  describe "Moderators" do
+    it "can create comment as a moderator", :js do
       community = investment.community
       topic = create(:topic, community: community)
       moderator = create(:moderator)
@@ -908,7 +908,7 @@ feature 'Commenting topics from budget investments' do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    it "can create reply as a moderator", :js do
       community = investment.community
       topic = create(:topic, community: community)
       citizen = create(:user, username: "Ana")
@@ -937,7 +937,7 @@ feature 'Commenting topics from budget investments' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as an administrator" do
+    it "can not comment as an administrator" do
       community = investment.community
       topic = create(:topic, community: community)
       moderator = create(:moderator)
@@ -949,8 +949,8 @@ feature 'Commenting topics from budget investments' do
     end
   end
 
-  feature "Administrators" do
-    scenario "can create comment as an administrator", :js do
+  describe "Administrators" do
+    it "can create comment as an administrator", :js do
       community = investment.community
       topic = create(:topic, community: community)
       admin = create(:administrator)
@@ -970,7 +970,7 @@ feature 'Commenting topics from budget investments' do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    it "can create reply as an administrator", :js do
       community = investment.community
       topic = create(:topic, community: community)
       citizen = create(:user, username: "Ana")
@@ -999,7 +999,7 @@ feature 'Commenting topics from budget investments' do
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
 
-    scenario "can not comment as a moderator" do
+    it "can not comment as a moderator" do
       community = investment.community
       topic = create(:topic, community: community)
       admin = create(:administrator)
@@ -1011,9 +1011,9 @@ feature 'Commenting topics from budget investments' do
     end
   end
 
-  feature 'Voting comments' do
+  describe 'Voting comments' do
 
-    background do
+    before do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @investment = create(:budget_investment)
@@ -1023,7 +1023,7 @@ feature 'Commenting topics from budget investments' do
       login_as(@manuela)
     end
 
-    scenario 'Show' do
+    it 'Show' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
@@ -1042,7 +1042,7 @@ feature 'Commenting topics from budget investments' do
       end
     end
 
-    scenario 'Create', :js do
+    it 'Create', :js do
       visit community_topic_path(@investment.community, @topic)
 
       within("#comment_#{@comment.id}_votes") do
@@ -1060,7 +1060,7 @@ feature 'Commenting topics from budget investments' do
       end
     end
 
-    scenario 'Update', :js do
+    it 'Update', :js do
       visit community_topic_path(@investment.community, @topic)
 
       within("#comment_#{@comment.id}_votes") do
@@ -1079,7 +1079,7 @@ feature 'Commenting topics from budget investments' do
       end
     end
 
-    scenario 'Trying to vote multiple times', :js do
+    it 'Trying to vote multiple times', :js do
       visit community_topic_path(@investment.community, @topic)
 
       within("#comment_#{@comment.id}_votes") do

--- a/spec/features/communities_spec.rb
+++ b/spec/features/communities_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Communities' do
+describe 'Communities' do
 
-  background do
+  before do
     Setting['feature.community'] = true
   end
 
@@ -12,7 +12,7 @@ feature 'Communities' do
 
   context 'Show' do
 
-    scenario 'Should display default content' do
+    it 'displays default content' do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -26,7 +26,7 @@ feature 'Communities' do
       expect(page).to have_link("Create topic", href: new_community_topic_path(community))
     end
 
-    scenario 'Should display without_topics_text and participants when there are not topics' do
+    it 'displays without_topics_text and participants when there are not topics' do
       proposal = create(:proposal)
       community = proposal.community
 
@@ -36,7 +36,7 @@ feature 'Communities' do
       expect(page).to have_content "Participants (1)"
     end
 
-    scenario 'Should display order selector and topic content when there are topics' do
+    it 'displays order selector and topic content when there are topics' do
       proposal = create(:proposal)
       community = proposal.community
       topic = create(:topic, community: community)
@@ -53,7 +53,7 @@ feature 'Communities' do
       end
     end
 
-    scenario "Topic order" do
+    it "Topic order" do
       proposal = create(:proposal)
       community = proposal.community
       topic1 = create(:topic, community: community)
@@ -79,7 +79,7 @@ feature 'Communities' do
       expect(topic2.title).to appear_before(topic1.title)
     end
 
-    scenario "Should order by newest when order param is invalid" do
+    it "orders by newest when order param is invalid" do
       proposal = create(:proposal)
       community = proposal.community
       topic1 = create(:topic, community: community)
@@ -90,7 +90,7 @@ feature 'Communities' do
       expect(topic2.title).to appear_before(topic1.title)
     end
 
-    scenario 'Should display topic edit button on topic show when author is logged' do
+    it 'displays topic edit button on topic show when author is logged' do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -105,7 +105,7 @@ feature 'Communities' do
       expect(page).not_to have_link("Edit topic", href: edit_community_topic_path(community, topic2))
     end
 
-    scenario 'Should display participant when there is topics' do
+    it 'displays participant when there is topics' do
       proposal = create(:proposal)
       community = proposal.community
       topic = create(:topic, community: community)
@@ -119,7 +119,7 @@ feature 'Communities' do
       end
     end
 
-    scenario 'Should display participants when there are topics and comments' do
+    it 'displays participants when there are topics and comments' do
       proposal = create(:proposal)
       community = proposal.community
       topic = create(:topic, community: community)
@@ -135,7 +135,7 @@ feature 'Communities' do
       end
     end
 
-    scenario 'Should redirect root path when communities are disabled' do
+    it 'redirects root path when communities are disabled' do
       Setting['feature.community'] = nil
       proposal = create(:proposal)
       community = proposal.community
@@ -145,7 +145,7 @@ feature 'Communities' do
       expect(page).to have_current_path(root_path)
     end
 
-    scenario "Accesing a community without associated communitable" do
+    it "Accesing a community without associated communitable" do
       proposal = create(:proposal)
       community = proposal.community
       proposal.really_destroy!

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -1,9 +1,9 @@
 # coding: utf-8
 require 'rails_helper'
 
-feature 'Debates' do
+describe 'Debates' do
 
-  scenario 'Disabled with a feature flag' do
+  it 'Disabled with a feature flag' do
     Setting['feature.debates'] = nil
     expect{ visit debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     Setting['feature.debates'] = true
@@ -14,7 +14,7 @@ feature 'Debates' do
     it_behaves_like 'relationable', Debate
   end
 
-  scenario 'Index' do
+  it 'Index' do
     debates = [create(:debate), create(:debate), create(:debate)]
 
     visit debates_path
@@ -29,7 +29,7 @@ feature 'Debates' do
     end
   end
 
-  scenario 'Paginated Index' do
+  it 'Paginated Index' do
     per_page = Kaminari.config.default_per_page
     (per_page + 2).times { create(:debate) }
 
@@ -47,7 +47,7 @@ feature 'Debates' do
     expect(page).to have_selector('#debates .debate', count: 2)
   end
 
-  scenario 'Show' do
+  it 'Show' do
     debate = create(:debate)
 
     visit debate_path(debate)
@@ -64,7 +64,7 @@ feature 'Debates' do
     end
   end
 
-  scenario 'Show: "Back" link directs to previous page', :js do
+  it 'Show: "Back" link directs to previous page', :js do
     debate = create(:debate, title: 'Test Debate 1')
 
     visit debates_path(order: :hot_score, page: 1)
@@ -75,7 +75,7 @@ feature 'Debates' do
   end
 
   context "Show" do
-    scenario 'When path matches the friendly url' do
+    it 'When path matches the friendly url' do
       debate = create(:debate)
 
       right_path = debate_path(debate)
@@ -84,7 +84,7 @@ feature 'Debates' do
       expect(page).to have_current_path(right_path)
     end
 
-    scenario 'When path does not match the friendly url' do
+    it 'When path does not match the friendly url' do
       debate = create(:debate)
 
       right_path = debate_path(debate)
@@ -96,7 +96,7 @@ feature 'Debates' do
     end
   end
 
-  scenario 'Create' do
+  it 'Create' do
     author = create(:user)
     login_as(author)
 
@@ -114,7 +114,7 @@ feature 'Debates' do
     expect(page).to have_content I18n.l(Debate.last.created_at.to_date)
   end
 
-  scenario 'Create with invisible_captcha honeypot field' do
+  it 'Create with invisible_captcha honeypot field' do
     author = create(:user)
     login_as(author)
 
@@ -131,7 +131,7 @@ feature 'Debates' do
     expect(page).to have_current_path(debates_path)
   end
 
-  scenario 'Create debate too fast' do
+  it 'Create debate too fast' do
     allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
 
     author = create(:user)
@@ -149,7 +149,7 @@ feature 'Debates' do
     expect(page).to have_current_path(new_debate_path)
   end
 
-  scenario 'Errors on create' do
+  it 'Errors on create' do
     author = create(:user)
     login_as(author)
 
@@ -158,7 +158,7 @@ feature 'Debates' do
     expect(page).to have_content error_message
   end
 
-  scenario 'JS injection is prevented but safe html is respected' do
+  it 'JS injection is prevented but safe html is respected' do
     author = create(:user)
     login_as(author)
 
@@ -176,7 +176,7 @@ feature 'Debates' do
     expect(page.html).not_to include '&lt;p&gt;This is'
   end
 
-  scenario 'Autolinking is applied to description' do
+  it 'Autolinking is applied to description' do
     author = create(:user)
     login_as(author)
 
@@ -192,7 +192,7 @@ feature 'Debates' do
     expect(page).to have_link('www.example.org', href: 'http://www.example.org')
   end
 
-  scenario 'JS injection is prevented but autolinking is respected' do
+  it 'JS injection is prevented but autolinking is respected' do
     author = create(:user)
     js_injection_string = "<script>alert('hey')</script> <a href=\"javascript:alert('surprise!')\">click me<a/> http://example.org"
     login_as(author)
@@ -217,7 +217,7 @@ feature 'Debates' do
     expect(page.html).not_to include "<script>alert('hey')</script>"
   end
 
-  scenario 'Update should not be posible if logged user is not the author' do
+  it 'Update should not be posible if logged user is not the author' do
     debate = create(:debate)
     expect(debate).to be_editable
     login_as(create(:user))
@@ -228,7 +228,7 @@ feature 'Debates' do
     expect(page).to have_content "You do not have permission to carry out the action 'edit' on debate."
   end
 
-  scenario 'Update should not be posible if debate is not editable' do
+  it 'Update should not be posible if debate is not editable' do
     debate = create(:debate)
     Setting["max_votes_for_debate_edit"] = 2
     3.times { create(:vote, votable: debate) }
@@ -243,7 +243,7 @@ feature 'Debates' do
     expect(page).to have_content 'You do not have permission to'
   end
 
-  scenario 'Update should be posible for the author of an editable debate' do
+  it 'Update should be posible for the author of an editable debate' do
     debate = create(:debate)
     login_as(debate.author)
 
@@ -260,7 +260,7 @@ feature 'Debates' do
     expect(page).to have_content "Let's do something to end child poverty"
   end
 
-  scenario 'Errors on update' do
+  it 'Errors on update' do
     debate = create(:debate)
     login_as(debate.author)
 
@@ -271,7 +271,7 @@ feature 'Debates' do
     expect(page).to have_content error_message
   end
 
-  scenario "Flagging", :js do
+  it "Flagging", :js do
     user = create(:user)
     debate = create(:debate)
 
@@ -288,7 +288,7 @@ feature 'Debates' do
     expect(Flag.flagged?(user, debate)).to be
   end
 
-  scenario "Unflagging", :js do
+  it "Unflagging", :js do
     user = create(:user)
     debate = create(:debate)
     Flag.flag(user, debate)
@@ -306,9 +306,9 @@ feature 'Debates' do
     expect(Flag.flagged?(user, debate)).not_to be
   end
 
-  feature 'Debate index order filters' do
+  describe 'Debate index order filters' do
 
-    scenario 'Default order is hot_score', :js do
+    it 'Default order is hot_score', :js do
       best_debate = create(:debate, title: 'Best')
       best_debate.update_column(:hot_score, 10)
       worst_debate = create(:debate, title: 'Worst')
@@ -322,7 +322,7 @@ feature 'Debates' do
       expect(medium_debate.title).to appear_before(worst_debate.title)
     end
 
-    scenario 'Debates are ordered by confidence_score', :js do
+    it 'Debates are ordered by confidence_score', :js do
       best_debate = create(:debate, title: 'Best')
       best_debate.update_column(:confidence_score, 10)
       worst_debate = create(:debate, title: 'Worst')
@@ -344,7 +344,7 @@ feature 'Debates' do
       expect(current_url).to include('page=1')
     end
 
-    scenario 'Debates are ordered by newest', :js do
+    it 'Debates are ordered by newest', :js do
       best_debate = create(:debate, title: 'Best', created_at: Time.current)
       medium_debate = create(:debate, title: 'Medium', created_at: Time.current - 1.hour)
       worst_debate = create(:debate, title: 'Worst', created_at: Time.current - 1.day)
@@ -369,7 +369,7 @@ feature 'Debates' do
       let!(:medium_debate) { create(:debate, title: 'Medium', cached_votes_total: 5, tag_list: "Sport") }
       let!(:worst_debate) { create(:debate, title: 'Worst', cached_votes_total: 1, tag_list: "Sport") }
 
-      background do
+      before do
         Setting['feature.user.recommendations'] = true
       end
 
@@ -377,13 +377,13 @@ feature 'Debates' do
         Setting['feature.user.recommendations'] = nil
       end
 
-      scenario 'Debates can not ordered by recommendations when there is not an user logged', :js do
+      it 'Debates can not ordered by recommendations when there is not an user logged', :js do
         visit debates_path
 
         expect(page).not_to have_selector('a', text: 'recommendations')
       end
 
-      scenario 'Should display text when there are not recommendeds results', :js do
+      it 'displays text when there are not recommendeds results', :js do
         user = create(:user)
         proposal = create(:proposal, tag_list: "Distinct_to_sport")
         create(:follow, followable: proposal, user: user)
@@ -395,7 +395,7 @@ feature 'Debates' do
         expect(page).to have_content "There are not debates related to your interests"
       end
 
-      scenario 'Should display text when user has not related interests', :js do
+      it 'displays text when user has not related interests', :js do
         user = create(:user)
         login_as(user)
         visit debates_path
@@ -405,7 +405,7 @@ feature 'Debates' do
         expect(page).to have_content "Follow proposals so we can give you recommendations"
       end
 
-      scenario 'Debates are ordered by recommendations when there is a user logged', :js do
+      it 'Debates are ordered by recommendations when there is a user logged', :js do
         proposal = create(:proposal, tag_list: "Sport")
         user = create(:user)
         create(:follow, followable: proposal, user: user)
@@ -432,7 +432,7 @@ feature 'Debates' do
 
     context "Basic search" do
 
-      scenario 'Search by text' do
+      it 'Search by text' do
         debate1 = create(:debate, title: "Get Schwifty")
         debate2 = create(:debate, title: "Schwifty Hello")
         debate3 = create(:debate, title: "Do not show me")
@@ -453,7 +453,7 @@ feature 'Debates' do
         end
       end
 
-      scenario "Maintain search criteria" do
+      it "Maintain search criteria" do
         visit debates_path
 
         within(".expanded #search_form") do
@@ -468,7 +468,7 @@ feature 'Debates' do
 
     context "Advanced search" do
 
-      scenario "Search by text", :js do
+      it "Search by text", :js do
         debate1 = create(:debate, title: "Get Schwifty")
         debate2 = create(:debate, title: "Schwifty Hello")
         debate3 = create(:debate, title: "Do not show me")
@@ -490,7 +490,7 @@ feature 'Debates' do
 
       context "Search by author type" do
 
-        scenario "Public employee", :js do
+        it "Public employee", :js do
           ana = create :user, official_level: 1
           john = create :user, official_level: 2
 
@@ -513,7 +513,7 @@ feature 'Debates' do
           end
         end
 
-        scenario "Municipal Organization", :js do
+        it "Municipal Organization", :js do
           ana = create :user, official_level: 2
           john = create :user, official_level: 3
 
@@ -536,7 +536,7 @@ feature 'Debates' do
           end
         end
 
-        scenario "General director", :js do
+        it "General director", :js do
           ana = create :user, official_level: 3
           john = create :user, official_level: 4
 
@@ -559,7 +559,7 @@ feature 'Debates' do
           end
         end
 
-        scenario "City councillor", :js do
+        it "City councillor", :js do
           ana = create :user, official_level: 4
           john = create :user, official_level: 5
 
@@ -582,7 +582,7 @@ feature 'Debates' do
           end
         end
 
-        scenario "Mayoress", :js do
+        it "Mayoress", :js do
           ana = create :user, official_level: 5
           john = create :user, official_level: 4
 
@@ -611,7 +611,7 @@ feature 'Debates' do
 
         context "Predefined date ranges" do
 
-          scenario "Last day", :js do
+          it "Last day", :js do
             debate1 = create(:debate, created_at: 1.minute.ago)
             debate2 = create(:debate, created_at: 1.hour.ago)
             debate3 = create(:debate, created_at: 2.days.ago)
@@ -631,7 +631,7 @@ feature 'Debates' do
             end
           end
 
-          scenario "Last week", :js do
+          it "Last week", :js do
             debate1 = create(:debate, created_at: 1.day.ago)
             debate2 = create(:debate, created_at: 5.days.ago)
             debate3 = create(:debate, created_at: 8.days.ago)
@@ -651,7 +651,7 @@ feature 'Debates' do
             end
           end
 
-          scenario "Last month", :js do
+          it "Last month", :js do
             debate1 = create(:debate, created_at: 10.days.ago)
             debate2 = create(:debate, created_at: 20.days.ago)
             debate3 = create(:debate, created_at: 33.days.ago)
@@ -671,7 +671,7 @@ feature 'Debates' do
             end
           end
 
-          scenario "Last year", :js do
+          it "Last year", :js do
             debate1 = create(:debate, created_at: 300.days.ago)
             debate2 = create(:debate, created_at: 350.days.ago)
             debate3 = create(:debate, created_at: 370.days.ago)
@@ -693,7 +693,7 @@ feature 'Debates' do
 
         end
 
-        scenario "Search by custom date range", :js do
+        it "Search by custom date range", :js do
           debate1 = create(:debate, created_at: 2.days.ago)
           debate2 = create(:debate, created_at: 3.days.ago)
           debate3 = create(:debate, created_at: 9.days.ago)
@@ -715,7 +715,7 @@ feature 'Debates' do
           end
         end
 
-        scenario "Search by custom invalid date range", :js do
+        it "Search by custom invalid date range", :js do
           debate1 = create(:debate, created_at: 2.years.ago)
           debate2 = create(:debate, created_at: 3.days.ago)
           debate3 = create(:debate, created_at: 9.days.ago)
@@ -737,7 +737,7 @@ feature 'Debates' do
           end
         end
 
-        scenario "Search by multiple filters", :js do
+        it "Search by multiple filters", :js do
           ana  = create :user, official_level: 1
           john = create :user, official_level: 1
 
@@ -760,7 +760,7 @@ feature 'Debates' do
           end
         end
 
-        scenario "Maintain advanced search criteria", :js do
+        it "Maintain advanced search criteria", :js do
           visit debates_path
           click_link "Advanced search"
 
@@ -777,7 +777,7 @@ feature 'Debates' do
           end
         end
 
-        scenario "Maintain custom date search criteria", :js do
+        it "Maintain custom date search criteria", :js do
           visit debates_path
           click_link "Advanced search"
 
@@ -796,7 +796,7 @@ feature 'Debates' do
       end
     end
 
-    scenario "Order by relevance by default", :js do
+    it "Order by relevance by default", :js do
       debate1 = create(:debate, title: "Show you got",      cached_votes_up: 10)
       debate2 = create(:debate, title: "Show what you got", cached_votes_up: 1)
       debate3 = create(:debate, title: "Show you got",      cached_votes_up: 100)
@@ -814,7 +814,7 @@ feature 'Debates' do
       end
     end
 
-    scenario "Reorder results maintaing search", :js do
+    it "Reorder results maintaing search", :js do
       debate1 = create(:debate, title: "Show you got",      cached_votes_up: 10,  created_at: 1.week.ago)
       debate2 = create(:debate, title: "Show what you got", cached_votes_up: 1,   created_at: 1.month.ago)
       debate3 = create(:debate, title: "Show you got",      cached_votes_up: 100, created_at: Time.current)
@@ -834,7 +834,7 @@ feature 'Debates' do
       end
     end
 
-    scenario "Reorder by recommendations results maintaing search", :js do
+    it "Reorder by recommendations results maintaing search", :js do
       Setting['feature.user.recommendations'] = true
       user = create(:user)
       login_as(user)
@@ -860,7 +860,7 @@ feature 'Debates' do
       Setting['feature.user.recommendations'] = nil
     end
 
-    scenario 'After a search do not show featured debates' do
+    it 'After a search do not show featured debates' do
       featured_debates = create_featured_debates
       debate = create(:debate, title: "Abcdefghi")
 
@@ -876,7 +876,7 @@ feature 'Debates' do
 
   end
 
-  scenario 'Conflictive' do
+  it 'Conflictive' do
     good_debate = create(:debate)
     conflictive_debate = create(:debate, :conflictive)
 
@@ -887,7 +887,7 @@ feature 'Debates' do
     expect(page).not_to have_content "This debate has been flagged as inappropriate by several users."
   end
 
-  scenario 'Erased author' do
+  it 'Erased author' do
     user = create(:user)
     debate = create(:debate, author: user)
     user.erase
@@ -903,7 +903,7 @@ feature 'Debates' do
 
     context "By geozone" do
 
-      background do
+      before do
         @california = Geozone.create(name: "California")
         @new_york   = Geozone.create(name: "New York")
 
@@ -963,7 +963,7 @@ feature 'Debates' do
   end
 
   context 'Suggesting debates' do
-    scenario 'Shows up to 5 suggestions', :js do
+    it 'Shows up to 5 suggestions', :js do
       author = create(:user)
       login_as(author)
 
@@ -984,7 +984,7 @@ feature 'Debates' do
       end
     end
 
-    scenario 'No found suggestions', :js do
+    it 'No found suggestions', :js do
       author = create(:user)
       login_as(author)
 
@@ -1001,7 +1001,7 @@ feature 'Debates' do
     end
   end
 
-  scenario 'Mark/Unmark a debate as featured' do
+  it 'Mark/Unmark a debate as featured' do
     admin = create(:administrator)
     login_as(admin.user)
 
@@ -1034,7 +1034,7 @@ feature 'Debates' do
     end
   end
 
-  scenario 'Index include featured debates' do
+  it 'Index include featured debates' do
     admin = create(:administrator)
     login_as(admin.user)
 
@@ -1047,7 +1047,7 @@ feature 'Debates' do
     end
   end
 
-  scenario 'Index do not show featured debates if none is marked as featured' do
+  it 'Index do not show featured debates if none is marked as featured' do
     admin = create(:administrator)
     login_as(admin.user)
 

--- a/spec/features/direct_messages_spec.rb
+++ b/spec/features/direct_messages_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature 'Direct messages' do
+describe 'Direct messages' do
 
-  background do
+  before do
     Setting[:direct_message_max_per_day] = 3
   end
 
-  scenario "Create" do
+  it "Create" do
     sender   = create(:user, :level_two)
     receiver = create(:user, :level_two)
 
@@ -28,7 +28,7 @@ feature 'Direct messages' do
 
   context "Permissions" do
 
-    scenario "Do not display link to send message to myself" do
+    it "Do not display link to send message to myself" do
       sender = create(:user, :level_two)
 
       login_as(sender)
@@ -37,7 +37,7 @@ feature 'Direct messages' do
       expect(page).not_to have_link "Send private message"
     end
 
-    scenario "Do not display link if direct message for user not allowed" do
+    it "Do not display link if direct message for user not allowed" do
       sender   = create(:user, :level_two)
       receiver = create(:user, :level_two, email_on_direct_message: false)
 
@@ -48,7 +48,7 @@ feature 'Direct messages' do
       expect(page).not_to have_link "Send private message"
     end
 
-    scenario "Unverified user" do
+    it "Unverified user" do
       sender = create(:user)
       receiver = create(:user)
 
@@ -59,7 +59,7 @@ feature 'Direct messages' do
       expect(page).not_to have_link "Send private message"
     end
 
-    scenario "User not logged in" do
+    it "User not logged in" do
       sender = create(:user)
       receiver = create(:user)
 
@@ -69,7 +69,7 @@ feature 'Direct messages' do
       expect(page).not_to have_link "Send private message"
     end
 
-    scenario "Accessing form directly" do
+    it "Accessing form directly" do
       sender   = create(:user, :level_two)
       receiver = create(:user, :level_two, email_on_direct_message: false)
 
@@ -82,7 +82,7 @@ feature 'Direct messages' do
 
   end
 
-  scenario "Error messages" do
+  it "Error messages" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -96,7 +96,7 @@ feature 'Direct messages' do
 
   context "Limits" do
 
-    scenario "Can only send a maximum number of direct messages per day" do
+    it "Can only send a maximum number of direct messages per day" do
       sender   = create(:user, :level_two)
       receiver = create(:user, :level_two)
 

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature 'Emails' do
+describe 'Emails' do
 
-  background do
+  before do
     reset_mailer
   end
 
-  scenario "Signup Email" do
+  it "Signup Email" do
     sign_up
 
     email = open_last_email
@@ -15,7 +15,7 @@ feature 'Emails' do
     expect(email).to have_body_text(user_confirmation_path)
   end
 
-  scenario "Reset password" do
+  it "Reset password" do
     reset_password
 
     email = open_last_email
@@ -25,7 +25,7 @@ feature 'Emails' do
   end
 
   context 'Proposal comments' do
-    scenario "Send email on proposal comment", :js do
+    it "Send email on proposal comment", :js do
       user = create(:user, email_on_comment: true)
       proposal = create(:proposal, author: user)
       comment_on(proposal)
@@ -36,7 +36,7 @@ feature 'Emails' do
       expect(email).to have_body_text(proposal_path(proposal))
     end
 
-    scenario 'Do not send email about own proposal comments', :js do
+    it 'Do not send email about own proposal comments', :js do
       user = create(:user, email_on_comment: true)
       proposal = create(:proposal, author: user)
       comment_on(proposal, user)
@@ -44,7 +44,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error "No email has been sent!"
     end
 
-    scenario 'Do not send email about proposal comment unless set in preferences', :js do
+    it 'Do not send email about proposal comment unless set in preferences', :js do
       user = create(:user, email_on_comment: false)
       proposal = create(:proposal, author: user)
       comment_on(proposal)
@@ -54,7 +54,7 @@ feature 'Emails' do
   end
 
   context 'Debate comments' do
-    scenario "Send email on debate comment", :js do
+    it "Send email on debate comment", :js do
       user = create(:user, email_on_comment: true)
       debate = create(:debate, author: user)
       comment_on(debate)
@@ -67,7 +67,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own debate comments', :js do
+    it 'Do not send email about own debate comments', :js do
       user = create(:user, email_on_comment: true)
       debate = create(:debate, author: user)
       comment_on(debate, user)
@@ -75,7 +75,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error "No email has been sent!"
     end
 
-    scenario 'Do not send email about debate comment unless set in preferences', :js do
+    it 'Do not send email about debate comment unless set in preferences', :js do
       user = create(:user, email_on_comment: false)
       debate = create(:debate, author: user)
       comment_on(debate)
@@ -85,7 +85,7 @@ feature 'Emails' do
   end
 
   context 'Budget investments comments' do
-    scenario 'Send email on budget investment comment', :js do
+    it 'Send email on budget investment comment', :js do
       user = create(:user, email_on_comment: true)
       investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment)
@@ -98,7 +98,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own budget investments comments', :js do
+    it 'Do not send email about own budget investments comments', :js do
       user = create(:user, email_on_comment: true)
       investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment, user)
@@ -106,7 +106,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error 'No email has been sent!'
     end
 
-    scenario 'Do not send email about budget investment comment unless set in preferences', :js do
+    it 'Do not send email about budget investment comment unless set in preferences', :js do
       user = create(:user, email_on_comment: false)
       investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment)
@@ -120,7 +120,7 @@ feature 'Emails' do
       @proposal = create(:proposal)
     end
 
-    scenario 'Send email on topic comment', :js do
+    it 'Send email on topic comment', :js do
       user = create(:user, email_on_comment: true)
       topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic)
@@ -133,7 +133,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own topic comments', :js do
+    it 'Do not send email about own topic comments', :js do
       user = create(:user, email_on_comment: true)
       topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic, user)
@@ -141,7 +141,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error 'No email has been sent!'
     end
 
-    scenario 'Do not send email about topic comment unless set in preferences', :js do
+    it 'Do not send email about topic comment unless set in preferences', :js do
       user = create(:user, email_on_comment: false)
       topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic)
@@ -151,7 +151,7 @@ feature 'Emails' do
   end
 
   context 'Poll comments' do
-    scenario 'Send email on poll comment', :js do
+    it 'Send email on poll comment', :js do
       user = create(:user, email_on_comment: true)
       poll = create(:poll, author: user)
       comment_on(poll)
@@ -164,7 +164,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own poll comments', :js do
+    it 'Do not send email about own poll comments', :js do
       user = create(:user, email_on_comment: true)
       poll = create(:poll, author: user)
       comment_on(poll, user)
@@ -172,7 +172,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error 'No email has been sent!'
     end
 
-    scenario 'Do not send email about poll question comment unless set in preferences', :js do
+    it 'Do not send email about poll question comment unless set in preferences', :js do
       user = create(:user, email_on_comment: false)
       poll = create(:poll, author: user)
       comment_on(poll)
@@ -182,7 +182,7 @@ feature 'Emails' do
   end
 
   context 'Comment replies' do
-    scenario "Send email on comment reply", :js do
+    it "Send email on comment reply", :js do
       user = create(:user, email_on_comment_reply: true)
       reply_to(user)
 
@@ -195,14 +195,14 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario "Do not send email about own replies to own comments", :js do
+    it "Do not send email about own replies to own comments", :js do
       user = create(:user, email_on_comment_reply: true)
       reply_to(user, user)
 
       expect { open_last_email }.to raise_error "No email has been sent!"
     end
 
-    scenario "Do not send email about comment reply unless set in preferences", :js do
+    it "Do not send email about comment reply unless set in preferences", :js do
       user = create(:user, email_on_comment_reply: false)
       reply_to(user)
 
@@ -210,7 +210,7 @@ feature 'Emails' do
     end
   end
 
-  scenario "Email on unfeasible spending proposal" do
+  it "Email on unfeasible spending proposal" do
     Setting["feature.spending_proposals"] = true
 
     spending_proposal = create(:spending_proposal)
@@ -242,7 +242,7 @@ feature 'Emails' do
 
   context "Direct Message" do
 
-    scenario "Receiver email" do
+    it "Receiver email" do
       sender   = create(:user, :level_two)
       receiver = create(:user, :level_two)
 
@@ -257,7 +257,7 @@ feature 'Emails' do
       expect(email).to have_body_text(/#{user_path(direct_message.sender_id)}/)
     end
 
-    scenario "Sender email" do
+    it "Sender email" do
       sender   = create(:user, :level_two)
       receiver = create(:user, :level_two)
 
@@ -277,7 +277,7 @@ feature 'Emails' do
 
   context "Proposal notification digest" do
 
-    scenario "notifications for proposals that I have supported" do
+    it "notifications for proposals that I have supported" do
       user = create(:user, email_digest: true)
 
       proposal1 = create(:proposal)
@@ -331,7 +331,7 @@ feature 'Emails' do
 
   context "User invites" do
 
-    scenario "Send an invitation" do
+    it "Send an invitation" do
       login_as_manager
       visit new_management_user_invite_path
 
@@ -353,7 +353,7 @@ feature 'Emails' do
 
   context "Budgets" do
 
-    background do
+    before do
       Setting["feature.budgets"] = true
     end
 
@@ -362,7 +362,7 @@ feature 'Emails' do
     let(:group)    { create(:budget_group, name: "Health", budget: budget) }
     let!(:heading) { create(:budget_heading, name: "More hospitals", group: group) }
 
-    scenario "Investment created" do
+    it "Investment created" do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
@@ -385,7 +385,7 @@ feature 'Emails' do
       expect(email).to have_body_text(budget_path(budget))
     end
 
-    scenario "Unfeasible investment" do
+    it "Unfeasible investment" do
       investment = create(:budget_investment, author: author, budget: budget)
 
       valuator = create(:valuator)
@@ -410,7 +410,7 @@ feature 'Emails' do
       expect(email).to have_body_text(investment.unfeasibility_explanation)
     end
 
-    scenario "Selected investment" do
+    it "Selected investment" do
       author1 = create(:user)
       author2 = create(:user)
       author3 = create(:user)
@@ -433,7 +433,7 @@ feature 'Emails' do
       expect(email).to have_body_text(investment.title)
     end
 
-    scenario "Unselected investment" do
+    it "Unselected investment" do
       author1 = create(:user)
       author2 = create(:user)
       author3 = create(:user)
@@ -460,7 +460,7 @@ feature 'Emails' do
 
   context "Polls" do
 
-    scenario "Send email on poll comment reply", :js do
+    it "Send email on poll comment reply", :js do
       user1 = create(:user, email_on_comment_reply: true)
       user2 = create(:user)
       poll = create(:poll, author: create(:user))
@@ -492,7 +492,7 @@ feature 'Emails' do
   end
 
   context "Users without email" do
-    scenario "should not receive emails", :js do
+    it "does not receive emails", :js do
       user = create(:user, :verified, email_on_comment: true)
       proposal = create(:proposal, author: user)
       user.update(email: nil)

--- a/spec/features/guides_spec.rb
+++ b/spec/features/guides_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-feature 'Guide the user to create the correct resource' do
+describe 'Guide the user to create the correct resource' do
 
   let(:user) { create(:user, :verified)}
   let!(:budget) { create(:budget, :accepting) }
 
-  background do
+  before do
     Setting['feature.guides'] = true
   end
 
@@ -13,7 +13,7 @@ feature 'Guide the user to create the correct resource' do
     Setting['feature.guides'] = nil
   end
 
-  scenario "Proposal" do
+  it "Proposal" do
     login_as(user)
     visit proposals_path
 
@@ -23,7 +23,7 @@ feature 'Guide the user to create the correct resource' do
     expect(page).to have_current_path(new_proposal_path)
   end
 
-  scenario "Budget Investment" do
+  it "Budget Investment" do
     login_as(user)
     visit budgets_path
 
@@ -33,7 +33,7 @@ feature 'Guide the user to create the correct resource' do
     expect(page).to have_current_path(new_budget_investment_path(budget))
   end
 
-  scenario "Feature deactivated" do
+  it "Feature deactivated" do
     Setting['feature.guides'] = nil
 
     login_as(user)

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-feature "Home" do
+describe "Home" do
 
-  feature "For not logged users" do
+  describe "For not logged users" do
 
-    scenario 'Welcome message' do
+    it 'Welcome message' do
       visit root_path
 
       expect(page).to have_content "Love the city, and it will become a city you love"
     end
 
-    scenario 'Not display recommended section' do
+    it 'Not display recommended section' do
       debate = create(:debate)
 
       visit root_path
@@ -20,11 +20,11 @@ feature "Home" do
 
   end
 
-  feature "For signed in users" do
+  describe "For signed in users" do
 
-    feature "Recommended" do
+    describe "Recommended" do
 
-      background do
+      before do
         Setting['feature.user.recommendations'] = true
         user = create(:user)
         proposal = create(:proposal, tag_list: "Sport")
@@ -36,13 +36,13 @@ feature "Home" do
         Setting['feature.user.recommendations'] = nil
       end
 
-      scenario 'Display recommended section when feature flag recommended is active' do
+      it 'Display recommended section when feature flag recommended is active' do
         debate = create(:debate, tag_list: "Sport")
         visit root_path
         expect(page).to have_content "Recommendations that may interest you"
       end
 
-      scenario 'Not display recommended section when feature flag recommended is not active' do
+      it 'Not display recommended section when feature flag recommended is not active' do
         debate = create(:debate, tag_list: "Sport")
         Setting['feature.user.recommendations'] = false
 
@@ -51,7 +51,7 @@ feature "Home" do
         expect(page).not_to have_content "Recommendations that may interest you"
       end
 
-      scenario 'Display debates' do
+      it 'Display debates' do
         debate = create(:debate, tag_list: "Sport")
 
         visit root_path
@@ -60,13 +60,13 @@ feature "Home" do
         expect(page).to have_content debate.description
       end
 
-      scenario 'Display all recommended debates link' do
+      it 'Display all recommended debates link' do
         debate = create(:debate, tag_list: "Sport")
         visit root_path
         expect(page).to have_link("All recommended debates", href: debates_path(order: "recommendations"))
       end
 
-      scenario 'Display proposal' do
+      it 'Display proposal' do
         proposal = create(:proposal, tag_list: "Sport")
 
         visit root_path
@@ -75,13 +75,13 @@ feature "Home" do
         expect(page).to have_content proposal.description
       end
 
-      scenario 'Display all recommended proposals link' do
+      it 'Display all recommended proposals link' do
         debate = create(:proposal, tag_list: "Sport")
         visit root_path
         expect(page).to have_link("All recommended proposals", href: proposals_path(order: "recommendations"))
       end
 
-      scenario 'Display orbit carrousel' do
+      it 'Display orbit carrousel' do
         create_list(:debate, 3, tag_list: "Sport")
 
         visit root_path
@@ -91,7 +91,7 @@ feature "Home" do
         expect(page).to have_selector('li[data-slide="2"]', visible: false)
       end
 
-      scenario 'Display recommended show when click on carousel' do
+      it 'Display recommended show when click on carousel' do
         debate = create(:debate, tag_list: "Sport")
 
         visit root_path
@@ -100,20 +100,20 @@ feature "Home" do
         expect(page).to have_current_path(debate_path(debate))
       end
 
-      scenario 'Do not display recommended section when there are not debates and proposals' do
+      it 'Do not display recommended section when there are not debates and proposals' do
         visit root_path
         expect(page).not_to have_content "Recommendations that may interest you"
       end
 
-      feature 'Carousel size' do
+      describe 'Carousel size' do
 
-        scenario 'Display debates centered when there are no proposals' do
+        it 'Display debates centered when there are no proposals' do
           debate = create(:debate, tag_list: "Sport")
           visit root_path
           expect(page).to have_selector('.medium-centered.large-centered')
         end
 
-        scenario 'Correct display debates and proposals' do
+        it 'Correct display debates and proposals' do
           proposal = create(:proposal, tag_list: "Sport")
           debates = create(:debate, tag_list: "Sport")
 
@@ -131,8 +131,8 @@ feature "Home" do
 
   end
 
-  feature 'IE alert' do
-    scenario 'IE visitors are presented with an alert until they close it', :js do
+  describe 'IE alert' do
+    it 'IE visitors are presented with an alert until they close it', :js do
       page.driver.headers = { "User-Agent" => "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)" }
 
       visit root_path
@@ -148,7 +148,7 @@ feature "Home" do
       expect(page.driver.cookies["ie_alert_closed"].value).to eq('true')
     end
 
-    scenario 'non-IE visitors are not bothered with IE alerts', :js do
+    it 'non-IE visitors are not bothered with IE alerts', :js do
       visit root_path
       expect(page).not_to have_xpath(ie_alert_box_xpath, visible: false)
       expect(page.driver.cookies['ie_alert_closed']).to be_nil

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Legislation Draft Versions' do
+describe 'Legislation Draft Versions' do
   let(:user) { create(:user) }
   let(:administrator) do
     create(:administrator, user: user)
@@ -141,9 +141,9 @@ feature 'Legislation Draft Versions' do
   context 'Annotations', :js do
     let(:user) { create(:user) }
 
-    background { login_as user }
+    before { login_as user }
 
-    scenario 'Visit as anonymous' do
+    it 'Visit as anonymous' do
       logout
       draft_version = create(:legislation_draft_version, :published)
 
@@ -155,7 +155,7 @@ feature 'Legislation Draft Versions' do
       expect(page).to have_content "You must Sign in or Sign up to leave a comment."
     end
 
-    scenario 'Create' do
+    it 'Create' do
       draft_version = create(:legislation_draft_version, :published)
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
@@ -179,7 +179,7 @@ feature 'Legislation Draft Versions' do
       expect(page).to have_content "this is my annotation"
     end
 
-    scenario 'View annotations and comments' do
+    it 'View annotations and comments' do
       draft_version = create(:legislation_draft_version, :published)
       annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
                                                     ranges: [{"start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10}])
@@ -198,7 +198,7 @@ feature 'Legislation Draft Versions' do
       expect(page).to have_content "my other annotation"
     end
 
-    scenario "Publish new comment for an annotation from comments box" do
+    it "Publish new comment for an annotation from comments box" do
       draft_version = create(:legislation_draft_version, :published)
       annotation = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
                                                    ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
@@ -220,9 +220,9 @@ feature 'Legislation Draft Versions' do
 
     let(:user) { create(:user) }
 
-    background { login_as user }
+    before { login_as user }
 
-    scenario 'View annotations and comments in an included range' do
+    it 'View annotations and comments in an included range' do
       draft_version = create(:legislation_draft_version, :published)
       annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
                                                     ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5}])
@@ -244,7 +244,7 @@ feature 'Legislation Draft Versions' do
   end
 
   context "Annotations page" do
-    background do
+    before do
       @draft_version = create(:legislation_draft_version, :published)
       create(:legislation_annotation, draft_version: @draft_version, text: "my annotation",       quote: "ipsum",
                                       ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
@@ -252,7 +252,7 @@ feature 'Legislation Draft Versions' do
                                       ranges: [{"start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}])
     end
 
-    scenario "See all annotations for a draft version" do
+    it "See all annotations for a draft version" do
       visit legislation_process_draft_version_annotations_path(@draft_version.process, @draft_version)
 
       expect(page).to have_content "ipsum"
@@ -260,7 +260,7 @@ feature 'Legislation Draft Versions' do
     end
 
     context "switching versions" do
-      background do
+      before do
         @process = create(:legislation_process)
         @draft_version_1 = create(:legislation_draft_version, :published, process: @process,
                                                                           title: "Version 1", body: "Text with quote for version 1")
@@ -272,7 +272,7 @@ feature 'Legislation Draft Versions' do
                                         ranges: [{"start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30}])
       end
 
-      scenario "without js" do
+      it "without js" do
         visit legislation_process_draft_version_annotations_path(@process, @draft_version_1)
         expect(page).to have_content("quote for version 1")
 
@@ -283,7 +283,7 @@ feature 'Legislation Draft Versions' do
         expect(page).to have_content("quote for version 2")
       end
 
-      scenario "with js", :js do
+      it "with js", :js do
         visit legislation_process_draft_version_annotations_path(@process, @draft_version_1)
         expect(page).to have_content("quote for version 1")
 
@@ -296,7 +296,7 @@ feature 'Legislation Draft Versions' do
   end
 
   context "Annotation comments page" do
-    background do
+    before do
       @draft_version = create(:legislation_draft_version, :published)
       create(:legislation_annotation, draft_version: @draft_version, text: "my annotation", quote: "ipsum",
                                       ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
@@ -304,7 +304,7 @@ feature 'Legislation Draft Versions' do
                                                     ranges: [{"start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}])
     end
 
-    scenario "See one annotation with replies for a draft version" do
+    it "See one annotation with replies for a draft version" do
       visit legislation_process_draft_version_annotation_path(@draft_version.process, @draft_version, @annotation)
 
       expect(page).not_to have_content "ipsum"

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Legislation' do
+describe 'Legislation' do
 
   let!(:administrator) { create(:administrator).user }
 
@@ -26,7 +26,7 @@ feature 'Legislation' do
 
   context 'processes home page' do
 
-    scenario 'No processes to be listed' do
+    it 'No processes to be listed' do
       visit legislation_processes_path
       expect(page).to have_text "There aren't open processes"
 
@@ -37,7 +37,7 @@ feature 'Legislation' do
       expect(page).to have_text "There aren't past processes"
     end
 
-    scenario 'Processes can be listed' do
+    it 'Processes can be listed' do
       processes = create_list(:legislation_process, 3)
 
       visit legislation_processes_path
@@ -47,7 +47,7 @@ feature 'Legislation' do
       end
     end
 
-    scenario 'Filtering processes' do
+    it 'Filtering processes' do
       create(:legislation_process, title: "Process open")
       create(:legislation_process, :next, title: "Process next")
       create(:legislation_process, :past, title: "Process past")
@@ -117,7 +117,7 @@ feature 'Legislation' do
     context "show" do
       include_examples "not published permissions", :legislation_process_path
 
-      scenario '#show view has document present' do
+      it '#show view has document present' do
         process = create(:legislation_process)
         document = create(:document, documentable: process)
         visit legislation_process_path(process)
@@ -127,7 +127,7 @@ feature 'Legislation' do
     end
 
     context 'debate phase' do
-      scenario 'not open' do
+      it 'not open' do
         process = create(:legislation_process, debate_start_date: Date.current + 1.day, debate_end_date: Date.current + 2.days)
 
         visit legislation_process_path(process)
@@ -135,7 +135,7 @@ feature 'Legislation' do
         expect(page).to have_content("This phase is not open yet")
       end
 
-      scenario 'open' do
+      it 'open' do
         process = create(:legislation_process, debate_start_date: Date.current - 1.day, debate_end_date: Date.current + 2.days)
 
         visit legislation_process_path(process)
@@ -147,7 +147,7 @@ feature 'Legislation' do
     end
 
     context 'draft publication phase' do
-      scenario 'not open' do
+      it 'not open' do
         process = create(:legislation_process, draft_publication_date: Date.current + 1.day)
 
         visit draft_publication_legislation_process_path(process)
@@ -155,7 +155,7 @@ feature 'Legislation' do
         expect(page).to have_content("This phase is not open yet")
       end
 
-      scenario 'open' do
+      it 'open' do
         process = create(:legislation_process, draft_publication_date: Date.current)
 
         visit draft_publication_legislation_process_path(process)
@@ -167,7 +167,7 @@ feature 'Legislation' do
     end
 
     context 'allegations phase' do
-      scenario 'not open' do
+      it 'not open' do
         process = create(:legislation_process, allegations_start_date: Date.current + 1.day, allegations_end_date: Date.current + 2.days)
 
         visit allegations_legislation_process_path(process)
@@ -175,7 +175,7 @@ feature 'Legislation' do
         expect(page).to have_content("This phase is not open yet")
       end
 
-      scenario 'open' do
+      it 'open' do
         process = create(:legislation_process, allegations_start_date: Date.current - 1.day, allegations_end_date: Date.current + 2.days)
 
         visit allegations_legislation_process_path(process)
@@ -187,7 +187,7 @@ feature 'Legislation' do
     end
 
     context 'final version publication phase' do
-      scenario 'not open' do
+      it 'not open' do
         process = create(:legislation_process, result_publication_date: Date.current + 1.day)
 
         visit result_publication_legislation_process_path(process)
@@ -195,7 +195,7 @@ feature 'Legislation' do
         expect(page).to have_content("This phase is not open yet")
       end
 
-      scenario 'open' do
+      it 'open' do
         process = create(:legislation_process, result_publication_date: Date.current)
 
         visit result_publication_legislation_process_path(process)

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Legislation Proposals' do
+describe 'Legislation Proposals' do
 
   context "Concerns" do
     it_behaves_like 'notifiable in-app', Legislation::Proposal

--- a/spec/features/legislation/questions_spec.rb
+++ b/spec/features/legislation/questions_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Legislation' do
+describe 'Legislation' do
   context 'process debate page' do
     before do
       @process = create(:legislation_process, debate_start_date: Date.current - 3.days, debate_end_date: Date.current + 2.days)
@@ -9,7 +9,7 @@ feature 'Legislation' do
       create(:legislation_question, process: @process, title: "Question 3")
     end
 
-    scenario 'shows question list' do
+    it 'shows question list' do
       visit legislation_process_path(@process)
 
       expect(page).to have_content("Participate in the debate")
@@ -34,14 +34,14 @@ feature 'Legislation' do
       expect(page).not_to have_content("Next question")
     end
 
-    scenario 'shows question page' do
+    it 'shows question page' do
       visit legislation_process_question_path(@process, @process.questions.first)
 
       expect(page).to have_content("Question 1")
       expect(page).to have_content("Open answers (0)")
     end
 
-    scenario 'shows next question link in question page' do
+    it 'shows next question link in question page' do
       visit legislation_process_question_path(@process, @process.questions.first)
 
       expect(page).to have_content("Question 1")
@@ -58,7 +58,7 @@ feature 'Legislation' do
       expect(page).not_to have_content("Next question")
     end
 
-    scenario 'answer question' do
+    it 'answer question' do
       question = @process.questions.first
       create(:legislation_question_option, question: question, value: "Yes")
       create(:legislation_question_option, question: question, value: "No")
@@ -88,7 +88,7 @@ feature 'Legislation' do
       expect(option.reload.answers_count).to eq(1)
     end
 
-    scenario 'cannot answer question when phase not open' do
+    it 'cannot answer question when phase not open' do
       @process.update_attribute(:debate_end_date, Date.current - 1.day)
       question = @process.questions.first
       create(:legislation_question_option, question: question, value: "Yes")

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature 'Localization' do
+describe 'Localization' do
 
-  scenario 'Wrong locale' do
+  it 'Wrong locale' do
     visit root_path(locale: :es)
     visit root_path(locale: :klingon)
 
     expect(page).to have_text('La ciudad que quieres será la ciudad que quieras')
   end
 
-  scenario 'Available locales appear in the locale switcher' do
+  it 'Available locales appear in the locale switcher' do
     visit '/'
 
     within('.locale-form .js-location-changer') do
@@ -18,12 +18,12 @@ feature 'Localization' do
     end
   end
 
-  scenario 'The current locale is selected' do
+  it 'The current locale is selected' do
     visit '/'
     expect(page).to have_select('locale-switcher', selected: 'English')
   end
 
-  scenario 'Changing the locale', :js do
+  it 'Changing the locale', :js do
     visit '/'
     expect(page).to have_content('Language')
 
@@ -33,7 +33,7 @@ feature 'Localization' do
     expect(page).to have_select('locale-switcher', selected: 'Español')
   end
 
-  scenario 'Locale switcher not present if only one locale' do
+  it 'Locale switcher not present if only one locale' do
     allow(I18n).to receive(:available_locales).and_return([:en])
 
     visit '/'

--- a/spec/features/management/account_spec.rb
+++ b/spec/features/management/account_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature 'Account' do
+describe 'Account' do
 
-  background do
+  before do
     login_as_manager
   end
 
-  scenario "Should not allow unverified users to create spending proposals" do
+  it "does not allow unverified users to create spending proposals" do
     user = create(:user)
     login_managed_user(user)
 
@@ -15,7 +15,7 @@ feature 'Account' do
     expect(page).to have_content "No verified user logged in yet"
   end
 
-  scenario 'Delete a user account', :js do
+  it 'Delete a user account', :js do
     user = create(:user, :level_two)
     login_managed_user(user)
 

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Budget Investments' do
+describe 'Budget Investments' do
 
-  background do
+  before do
     login_as_manager
     @budget = create(:budget, phase: 'selecting', name: "2033")
     @group = create(:budget_group, budget: @budget, name: 'Whole city')
@@ -12,7 +12,7 @@ feature 'Budget Investments' do
   context "Create" do
     before { @budget.update(phase: 'accepting') }
 
-    scenario 'Creating budget investments on behalf of someone, selecting a budget' do
+    it 'Creating budget investments on behalf of someone, selecting a budget' do
       user = create(:user, :level_two)
 
       login_managed_user(user)
@@ -50,7 +50,7 @@ feature 'Budget Investments' do
       expect(page).to have_content I18n.l(@budget.created_at.to_date)
     end
 
-    scenario "Should not allow unverified users to create budget investments" do
+    it "does not allow unverified users to create budget investments" do
       user = create(:user)
       login_managed_user(user)
 
@@ -62,7 +62,7 @@ feature 'Budget Investments' do
 
   context "Searching" do
 
-    scenario "by title" do
+    it "by title" do
       budget_investment1 = create(:budget_investment, budget: @budget, title: "Show me what you got")
       budget_investment2 = create(:budget_investment, budget: @budget, title: "Get Schwifty")
 
@@ -87,7 +87,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario "by heading" do
+    it "by heading" do
       budget_investment1 = create(:budget_investment, budget: @budget, title: "Hey ho",
                                                       heading: create(:budget_heading, name: "District 9"))
       budget_investment2 = create(:budget_investment, budget: @budget, title: "Let's go",
@@ -115,7 +115,7 @@ feature 'Budget Investments' do
     end
   end
 
-  scenario "Listing" do
+  it "Listing" do
     budget_investment1 = create(:budget_investment, budget: @budget, title: "Show me what you got")
     budget_investment2 = create(:budget_investment, budget: @budget, title: "Get Schwifty")
 
@@ -144,7 +144,7 @@ feature 'Budget Investments' do
     end
   end
 
-  scenario "Listing - managers can see budgets in accepting phase" do
+  it "Listing - managers can see budgets in accepting phase" do
     accepting_budget = create(:budget, phase: "accepting")
     reviewing_budget = create(:budget, phase: "reviewing")
     selecting_budget = create(:budget, phase: "selecting")
@@ -168,7 +168,7 @@ feature 'Budget Investments' do
     expect(page).not_to have_content(finished.name)
   end
 
-  scenario "Listing - admins can see budgets in accepting, reviewing and selecting phases" do
+  it "Listing - admins can see budgets in accepting, reviewing and selecting phases" do
     accepting_budget = create(:budget, phase: "accepting")
     reviewing_budget = create(:budget, phase: "reviewing")
     selecting_budget = create(:budget, phase: "selecting")
@@ -201,7 +201,7 @@ feature 'Budget Investments' do
 
   context "Supporting" do
 
-    scenario 'Supporting budget investments on behalf of someone in index view', :js do
+    it 'Supporting budget investments on behalf of someone in index view', :js do
       budget_investment = create(:budget_investment, budget: @budget, heading: @heading)
 
       user = create(:user, :level_two)
@@ -223,7 +223,7 @@ feature 'Budget Investments' do
     end
 
     # This tests passes ok locally but fails on the last two lines in Travis
-    xscenario 'Supporting budget investments on behalf of someone in show view', :js do
+    xit 'Supporting budget investments on behalf of someone in show view', :js do
       budget_investment = create(:budget_investment, budget: @budget)
 
       user = create(:user, :level_two)
@@ -244,7 +244,7 @@ feature 'Budget Investments' do
       expect(page).to have_content "You have already supported this. Share it!"
     end
 
-    scenario "Should not allow unverified users to vote proposals" do
+    it "does not allow unverified users to vote proposals" do
       budget_investment = create(:budget_investment, budget: @budget)
 
       user = create(:user)
@@ -258,7 +258,7 @@ feature 'Budget Investments' do
 
   context "Printing" do
 
-    scenario 'Printing budget investments' do
+    it 'Printing budget investments' do
       16.times { create(:budget_investment, budget: @budget, heading: @heading) }
 
       click_link "Print Budget Investments"
@@ -272,7 +272,7 @@ feature 'Budget Investments' do
       expect(page).to have_css("a[href='javascript:window.print();']", text: 'Print')
     end
 
-    scenario "Filtering budget investments by heading to be printed", :js do
+    it "Filtering budget investments by heading to be printed", :js do
       district_9 = create(:budget_heading, group: @group, name: "District Nine")
       another_heading = create(:budget_heading, group: @group)
       low_investment = create(:budget_investment, budget: @budget, title: 'Nuke district 9', heading: district_9, cached_votes_up: 1)

--- a/spec/features/management/document_verifications_spec.rb
+++ b/spec/features/management/document_verifications_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature 'DocumentVerifications' do
+describe 'DocumentVerifications' do
 
-  background do
+  before do
     login_as_manager
   end
 
-  scenario 'Verifying a level 3 user shows an "already verified" page' do
+  it 'Verifying a level 3 user shows an "already verified" page' do
     user = create(:user, :level_three)
 
     visit management_document_verifications_path
@@ -16,7 +16,7 @@ feature 'DocumentVerifications' do
     expect(page).to have_content "already verified"
   end
 
-  scenario 'Verifying a level 2 user displays the verification form' do
+  it 'Verifying a level 2 user displays the verification form' do
 
     user = create(:user, :level_two)
 
@@ -33,7 +33,7 @@ feature 'DocumentVerifications' do
     expect(user.reload).to be_level_three_verified
   end
 
-  scenario 'Verifying a user which does not exist and is not in the census shows an error' do
+  it 'Verifying a user which does not exist and is not in the census shows an error' do
 
     expect_any_instance_of(Verification::Management::Document).to receive(:in_census?).and_return(false)
 
@@ -44,7 +44,7 @@ feature 'DocumentVerifications' do
     expect(page).to have_content "This document is not registered"
   end
 
-  scenario 'Verifying a user which does exists in the census but not in the db redirects allows sending an email' do
+  it 'Verifying a user which does exists in the census but not in the db redirects allows sending an email' do
 
     visit management_document_verifications_path
     fill_in 'document_verification_document_number', with: '12345678Z'
@@ -53,7 +53,7 @@ feature 'DocumentVerifications' do
     expect(page).to have_content "Please introduce the email used on the account"
   end
 
-  scenario 'Document number is format-standarized' do
+  it 'Document number is format-standarized' do
 
     visit management_document_verifications_path
     fill_in 'document_verification_document_number', with: '12345 - h'
@@ -62,7 +62,7 @@ feature 'DocumentVerifications' do
     expect(page).to have_content "Document number: 12345H"
   end
 
-  scenario 'User age is checked' do
+  it 'User age is checked' do
     expect_any_instance_of(Verification::Management::Document).to receive(:under_age?).and_return(true)
 
     visit management_document_verifications_path

--- a/spec/features/management/email_verifications_spec.rb
+++ b/spec/features/management/email_verifications_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'EmailVerifications' do
+describe 'EmailVerifications' do
 
-  scenario 'Verifying a level 1 user via email' do
+  it 'Verifying a level 1 user via email' do
     login_as_manager
 
     user = create(:user)

--- a/spec/features/management/localization_spec.rb
+++ b/spec/features/management/localization_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
-feature 'Localization' do
+describe 'Localization' do
 
-  background do
+  before do
     login_as_manager
   end
 
-  scenario 'Wrong locale' do
+  it 'Wrong locale' do
     visit management_root_path(locale: :es)
     visit management_root_path(locale: :klingon)
 
     expect(page).to have_text('Gestión')
   end
 
-  scenario 'Available locales appear in the locale switcher' do
+  it 'Available locales appear in the locale switcher' do
     visit management_root_path
 
     within('.locale-form .js-location-changer') do
@@ -22,13 +22,13 @@ feature 'Localization' do
     end
   end
 
-  scenario 'The current locale is selected' do
+  it 'The current locale is selected' do
     visit management_root_path
     expect(page).to have_select('locale-switcher', selected: 'English')
     expect(page).to have_text('Management')
   end
 
-  scenario 'Changing the locale', :js do
+  it 'Changing the locale', :js do
     visit management_root_path
     expect(page).to have_content('Language')
 
@@ -38,7 +38,7 @@ feature 'Localization' do
     expect(page).to have_select('locale-switcher', selected: 'Español')
   end
 
-  scenario 'Locale switcher not present if only one locale' do
+  it 'Locale switcher not present if only one locale' do
     allow(I18n).to receive(:available_locales).and_return([:en])
 
     visit management_root_path

--- a/spec/features/management/managed_users_spec.rb
+++ b/spec/features/management/managed_users_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
-feature 'Managed User' do
+describe 'Managed User' do
 
-  background do
+  before do
     login_as_manager
   end
 
   context "Currently managed user" do
 
-    scenario "No managed user" do
+    it "No managed user" do
       visit management_document_verifications_path
       expect(page).not_to have_css ".account-info"
     end
 
-    scenario "User is already level three verified" do
+    it "User is already level three verified" do
       user = create(:user, :level_three)
 
       visit management_document_verifications_path
@@ -30,7 +30,7 @@ feature 'Managed User' do
       end
     end
 
-    scenario "User becomes verified as level three" do
+    it "User becomes verified as level three" do
       user = create(:user, :level_two)
 
       visit management_document_verifications_path
@@ -51,7 +51,7 @@ feature 'Managed User' do
       end
     end
 
-    scenario "User becomes verified as level two (pending email confirmation for level three)" do
+    it "User becomes verified as level two (pending email confirmation for level three)" do
       login_as_manager
 
       user = create(:user)
@@ -84,7 +84,7 @@ feature 'Managed User' do
       end
     end
 
-    scenario "User is created with email as level three from scratch" do
+    it "User is created with email as level three from scratch" do
       login_as_manager
 
       visit management_document_verifications_path
@@ -112,7 +112,7 @@ feature 'Managed User' do
       end
     end
 
-    scenario "User is created without email as level three from scratch" do
+    it "User is created without email as level three from scratch" do
       login_as_manager
 
       visit management_document_verifications_path
@@ -140,7 +140,7 @@ feature 'Managed User' do
     end
   end
 
-  scenario "Close the currently managed user session" do
+  it "Close the currently managed user session" do
     user = create(:user, :level_three)
 
     visit management_document_verifications_path

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-feature 'Proposals' do
+describe 'Proposals' do
 
-  background do
+  before do
     login_as_manager
   end
 
   context "Create" do
 
-    scenario 'Creating proposals on behalf of someone' do
+    it 'Creating proposals on behalf of someone' do
       user = create(:user, :level_two)
       login_managed_user(user)
 
@@ -45,7 +45,7 @@ feature 'Proposals' do
       expect(page).to have_current_path(management_proposal_path(Proposal.last))
     end
 
-    scenario "Should not allow unverified users to create proposals" do
+    it "does not allow unverified users to create proposals" do
       user = create(:user)
       login_managed_user(user)
 
@@ -56,7 +56,7 @@ feature 'Proposals' do
   end
 
   context "Show" do
-    scenario 'When path matches the friendly url' do
+    it 'When path matches the friendly url' do
       proposal = create(:proposal)
 
       user = create(:user, :level_two)
@@ -68,7 +68,7 @@ feature 'Proposals' do
       expect(page).to have_current_path(right_path)
     end
 
-    scenario 'When path does not match the friendly url' do
+    it 'When path does not match the friendly url' do
       proposal = create(:proposal)
 
       user = create(:user, :level_two)
@@ -83,7 +83,7 @@ feature 'Proposals' do
     end
   end
 
-  scenario "Searching" do
+  it "Searching" do
     proposal1 = create(:proposal, title: "Show me what you got")
     proposal2 = create(:proposal, title: "Get Schwifty")
 
@@ -106,7 +106,7 @@ feature 'Proposals' do
     end
   end
 
-  scenario "Listing" do
+  it "Listing" do
     proposal1 = create(:proposal, title: "Show me what you got")
     proposal2 = create(:proposal, title: "Get Schwifty")
 
@@ -135,7 +135,7 @@ feature 'Proposals' do
 
   context "Voting" do
 
-    scenario 'Voting proposals on behalf of someone in index view', :js do
+    it 'Voting proposals on behalf of someone in index view', :js do
       proposal = create(:proposal)
 
       user = create(:user, :level_two)
@@ -152,7 +152,7 @@ feature 'Proposals' do
       expect(page).to have_current_path(management_proposals_path)
     end
 
-    scenario 'Voting proposals on behalf of someone in show view', :js do
+    it 'Voting proposals on behalf of someone in show view', :js do
       proposal = create(:proposal)
 
       user = create(:user, :level_two)
@@ -170,7 +170,7 @@ feature 'Proposals' do
       expect(page).to have_current_path(management_proposal_path(proposal))
     end
 
-    scenario "Should not allow unverified users to vote proposals" do
+    it "does not allow unverified users to vote proposals" do
       proposal = create(:proposal)
 
       user = create(:user)
@@ -184,7 +184,7 @@ feature 'Proposals' do
 
   context "Printing" do
 
-    scenario 'Printing proposals' do
+    it 'Printing proposals' do
       6.times { create(:proposal) }
 
       click_link "Print proposals"
@@ -193,7 +193,7 @@ feature 'Proposals' do
       expect(page).to have_css("a[href='javascript:window.print();']", text: 'Print')
     end
 
-    scenario "Filtering proposals to be printed", :js do
+    it "Filtering proposals to be printed", :js do
       worst_proposal = create(:proposal, title: 'Worst proposal')
       worst_proposal.update_column(:confidence_score, 2)
       best_proposal = create(:proposal, title: 'Best proposal')

--- a/spec/features/management/users_spec.rb
+++ b/spec/features/management/users_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature 'Users' do
+describe 'Users' do
 
-  background do
+  before do
     login_as_manager
   end
 
-  scenario 'Create a level 3 user with email from scratch' do
+  it 'Create a level 3 user with email from scratch' do
     visit management_document_verifications_path
     fill_in 'document_verification_document_number', with: '12345678Z'
     click_button 'Check'
@@ -46,7 +46,7 @@ feature 'Users' do
     expect(page).to have_content "Your account has been confirmed."
   end
 
-  scenario 'Create a level 3 user without email from scratch' do
+  it 'Create a level 3 user without email from scratch' do
     visit management_document_verifications_path
     fill_in 'document_verification_document_number', with: '12345678Z'
     click_button 'Check'
@@ -72,7 +72,7 @@ feature 'Users' do
     expect(user.date_of_birth).to have_content Date.new(1980, 12, 31)
   end
 
-  scenario 'Delete a level 2 user account from document verification page', :js do
+  it 'Delete a level 2 user account from document verification page', :js do
     level_2_user = create(:user, :level_two, document_number: "12345678Z")
 
     visit management_document_verifications_path

--- a/spec/features/moderation/comments_spec.rb
+++ b/spec/features/moderation/comments_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Moderate comments' do
+describe 'Moderate comments' do
 
-  scenario 'Hide', :js do
+  it 'Hide', :js do
     citizen = create(:user)
     moderator = create(:moderator)
 
@@ -24,7 +24,7 @@ feature 'Moderate comments' do
     expect(page).not_to have_content('SPAM')
   end
 
-  scenario 'Can not hide own comment' do
+  it 'Can not hide own comment' do
     moderator = create(:moderator)
     comment = create(:comment, user: moderator.user)
 
@@ -37,7 +37,7 @@ feature 'Moderate comments' do
     end
   end
 
-  scenario "Visit items with flagged comments" do
+  it "Visit items with flagged comments" do
     moderator = create(:moderator)
     debate = create(:debate, title: "Debate with spam comment")
     proposal = create(:proposal, title: "Proposal with spam comment")
@@ -63,16 +63,16 @@ feature 'Moderate comments' do
     expect(page).to have_content("This is SPAM comment on proposal")
   end
 
-  feature '/moderation/ screen' do
+  describe '/moderation/ screen' do
 
-    background do
+    before do
       moderator = create(:moderator)
       login_as(moderator.user)
     end
 
-    feature 'moderate in bulk' do
-      feature "When a comment has been selected for moderation" do
-        background do
+    describe 'moderate in bulk' do
+      describe "When a comment has been selected for moderation" do
+        before do
           @comment = create(:comment)
           visit moderation_comments_path
           within('.menu.simple') do
@@ -86,21 +86,21 @@ feature 'Moderate comments' do
           expect(page).not_to have_css("comment_#{@comment.id}")
         end
 
-        scenario 'Hide the comment' do
+        it 'Hide the comment' do
           click_on "Hide comments"
           expect(page).not_to have_css("comment_#{@comment.id}")
           expect(@comment.reload).to be_hidden
           expect(@comment.user).not_to be_hidden
         end
 
-        scenario 'Block the user' do
+        it 'Block the user' do
           click_on "Block authors"
           expect(page).not_to have_css("comment_#{@comment.id}")
           expect(@comment.reload).to be_hidden
           expect(@comment.user).to be_hidden
         end
 
-        scenario 'Ignore the comment' do
+        it 'Ignore the comment' do
           click_on "Mark as viewed"
           expect(page).not_to have_css("comment_#{@comment.id}")
           expect(@comment.reload).to be_ignored_flag
@@ -109,7 +109,7 @@ feature 'Moderate comments' do
         end
       end
 
-      scenario "select all/none", :js do
+      it "select all/none", :js do
         create_list(:comment, 2)
 
         visit moderation_comments_path
@@ -125,7 +125,7 @@ feature 'Moderate comments' do
         end
       end
 
-      scenario "remembering page, filter and order" do
+      it "remembering page, filter and order" do
         create_list(:comment, 52)
 
         visit moderation_comments_path(filter: 'all', page: '2', order: 'newest')
@@ -140,7 +140,7 @@ feature 'Moderate comments' do
       end
     end
 
-    scenario "Current filter is properly highlighted" do
+    it "Current filter is properly highlighted" do
       visit moderation_comments_path
       expect(page).not_to have_link('Pending')
       expect(page).to have_link('All')
@@ -168,7 +168,7 @@ feature 'Moderate comments' do
       end
     end
 
-    scenario "Filtering comments" do
+    it "Filtering comments" do
       create(:comment, body: "Regular comment")
       create(:comment, :flagged, body: "Pending comment")
       create(:comment, :hidden, body: "Hidden comment")
@@ -193,7 +193,7 @@ feature 'Moderate comments' do
       expect(page).to have_content('Ignored comment')
     end
 
-    scenario "sorting comments" do
+    it "sorting comments" do
       flagged_comment = create(:comment, body: "Flagged comment", created_at: Time.current - 1.day, flags_count: 5)
       flagged_new_comment = create(:comment, body: "Flagged new comment", created_at: Time.current - 12.hours, flags_count: 3)
       newer_comment = create(:comment, body: "Newer comment", created_at: Time.current)

--- a/spec/features/moderation/debates_spec.rb
+++ b/spec/features/moderation/debates_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Moderate debates' do
+describe 'Moderate debates' do
 
-  scenario 'Disabled with a feature flag' do
+  it 'Disabled with a feature flag' do
     Setting['feature.debates'] = nil
     moderator = create(:moderator)
     login_as(moderator.user)
@@ -12,7 +12,7 @@ feature 'Moderate debates' do
     Setting['feature.debates'] = true
   end
 
-  scenario 'Hide', :js do
+  it 'Hide', :js do
     citizen = create(:user)
     moderator = create(:moderator)
 
@@ -33,7 +33,7 @@ feature 'Moderate debates' do
     expect(page).to have_css('.debate', count: 0)
   end
 
-  scenario 'Can not hide own debate' do
+  it 'Can not hide own debate' do
     moderator = create(:moderator)
     debate = create(:debate, author: moderator.user)
 
@@ -46,16 +46,16 @@ feature 'Moderate debates' do
     end
   end
 
-  feature '/moderation/ screen' do
+  describe '/moderation/ screen' do
 
-    background do
+    before do
       moderator = create(:moderator)
       login_as(moderator.user)
     end
 
-    feature 'moderate in bulk' do
-      feature "When a debate has been selected for moderation" do
-        background do
+    describe 'moderate in bulk' do
+      describe "When a debate has been selected for moderation" do
+        before do
           @debate = create(:debate)
           visit moderation_debates_path
           within('.menu.simple') do
@@ -69,21 +69,21 @@ feature 'Moderate debates' do
           expect(page).not_to have_css("debate_#{@debate.id}")
         end
 
-        scenario 'Hide the debate' do
+        it 'Hide the debate' do
           click_on "Hide debates"
           expect(page).not_to have_css("debate_#{@debate.id}")
           expect(@debate.reload).to be_hidden
           expect(@debate.author).not_to be_hidden
         end
 
-        scenario 'Block the author' do
+        it 'Block the author' do
           click_on "Block authors"
           expect(page).not_to have_css("debate_#{@debate.id}")
           expect(@debate.reload).to be_hidden
           expect(@debate.author).to be_hidden
         end
 
-        scenario 'Ignore the debate' do
+        it 'Ignore the debate' do
           click_on "Mark as viewed"
           expect(page).not_to have_css("debate_#{@debate.id}")
           expect(@debate.reload).to be_ignored_flag
@@ -92,7 +92,7 @@ feature 'Moderate debates' do
         end
       end
 
-      scenario "select all/none", :js do
+      it "select all/none", :js do
         create_list(:debate, 2)
 
         visit moderation_debates_path
@@ -108,7 +108,7 @@ feature 'Moderate debates' do
         end
       end
 
-      scenario "remembering page, filter and order" do
+      it "remembering page, filter and order" do
         create_list(:debate, 52)
 
         visit moderation_debates_path(filter: 'all', page: '2', order: 'created_at')
@@ -123,7 +123,7 @@ feature 'Moderate debates' do
       end
     end
 
-    scenario "Current filter is properly highlighted" do
+    it "Current filter is properly highlighted" do
       visit moderation_debates_path
       expect(page).not_to have_link('Pending')
       expect(page).to have_link('All')
@@ -151,7 +151,7 @@ feature 'Moderate debates' do
       end
     end
 
-    scenario "Filtering debates" do
+    it "Filtering debates" do
       create(:debate, title: "Regular debate")
       create(:debate, :flagged, title: "Pending debate")
       create(:debate, :hidden, title: "Hidden debate")
@@ -176,7 +176,7 @@ feature 'Moderate debates' do
       expect(page).to have_content('Ignored debate')
     end
 
-    scenario "sorting debates" do
+    it "sorting debates" do
       flagged_debate = create(:debate, title: "Flagged debate", created_at: Time.current - 1.day, flags_count: 5)
       flagged_new_debate = create(:debate, title: "Flagged new debate", created_at: Time.current - 12.hours, flags_count: 3)
       newer_debate = create(:debate, title: "Newer debate", created_at: Time.current)

--- a/spec/features/moderation/proposals_spec.rb
+++ b/spec/features/moderation/proposals_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Moderate proposals' do
+describe 'Moderate proposals' do
 
-  scenario 'Disabled with a feature flag' do
+  it 'Disabled with a feature flag' do
     Setting['feature.proposals'] = nil
     moderator = create(:moderator)
     login_as(moderator.user)
@@ -12,7 +12,7 @@ feature 'Moderate proposals' do
     Setting['feature.proposals'] = true
   end
 
-  scenario 'Hide', :js do
+  it 'Hide', :js do
     citizen = create(:user)
     moderator = create(:moderator)
 
@@ -33,7 +33,7 @@ feature 'Moderate proposals' do
     expect(page).to have_css('.proposal', count: 0)
   end
 
-  scenario 'Can not hide own proposal' do
+  it 'Can not hide own proposal' do
     moderator = create(:moderator)
     proposal = create(:proposal, author: moderator.user)
 
@@ -46,16 +46,16 @@ feature 'Moderate proposals' do
     end
   end
 
-  feature '/moderation/ screen' do
+  describe '/moderation/ screen' do
 
-    background do
+    before do
       moderator = create(:moderator)
       login_as(moderator.user)
     end
 
-    feature 'moderate in bulk' do
-      feature "When a proposal has been selected for moderation" do
-        background do
+    describe 'moderate in bulk' do
+      describe "When a proposal has been selected for moderation" do
+        before do
           @proposal = create(:proposal)
           visit moderation_proposals_path
           within('.menu.simple') do
@@ -69,21 +69,21 @@ feature 'Moderate proposals' do
           expect(page).not_to have_css("proposal_#{@proposal.id}")
         end
 
-        scenario 'Hide the proposal' do
+        it 'Hide the proposal' do
           click_on "Hide proposals"
           expect(page).not_to have_css("proposal_#{@proposal.id}")
           expect(@proposal.reload).to be_hidden
           expect(@proposal.author).not_to be_hidden
         end
 
-        scenario 'Block the author' do
+        it 'Block the author' do
           click_on "Block authors"
           expect(page).not_to have_css("proposal_#{@proposal.id}")
           expect(@proposal.reload).to be_hidden
           expect(@proposal.author).to be_hidden
         end
 
-        scenario 'Ignore the proposal' do
+        it 'Ignore the proposal' do
           click_button "Mark as viewed"
           expect(page).not_to have_css("proposal_#{@proposal.id}")
           expect(@proposal.reload).to be_ignored_flag
@@ -92,7 +92,7 @@ feature 'Moderate proposals' do
         end
       end
 
-      scenario "select all/none", :js do
+      it "select all/none", :js do
         create_list(:proposal, 2)
 
         visit moderation_proposals_path
@@ -108,7 +108,7 @@ feature 'Moderate proposals' do
         end
       end
 
-      scenario "remembering page, filter and order" do
+      it "remembering page, filter and order" do
         create_list(:proposal, 52)
 
         visit moderation_proposals_path(filter: 'all', page: '2', order: 'created_at')
@@ -123,7 +123,7 @@ feature 'Moderate proposals' do
       end
     end
 
-    scenario "Current filter is properly highlighted" do
+    it "Current filter is properly highlighted" do
       visit moderation_proposals_path
       expect(page).not_to have_link('Pending')
       expect(page).to have_link('All')
@@ -151,7 +151,7 @@ feature 'Moderate proposals' do
       end
     end
 
-    scenario "Filtering proposals" do
+    it "Filtering proposals" do
       create(:proposal, title: "Regular proposal")
       create(:proposal, :flagged, title: "Pending proposal")
       create(:proposal, :hidden, title: "Hidden proposal")
@@ -176,7 +176,7 @@ feature 'Moderate proposals' do
       expect(page).to have_content('Ignored proposal')
     end
 
-    scenario "sorting proposals" do
+    it "sorting proposals" do
       flagged_proposal = create(:proposal, title: "Flagged proposal", created_at: Time.current - 1.day, flags_count: 5)
       flagged_new_proposal = create(:proposal, title: "Flagged new proposal", created_at: Time.current - 12.hours, flags_count: 3)
       newer_proposal = create(:proposal, title: "Newer proposal", created_at: Time.current)

--- a/spec/features/moderation/users_spec.rb
+++ b/spec/features/moderation/users_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Moderate users' do
+describe 'Moderate users' do
 
-  scenario 'Hide' do
+  it 'Hide' do
     citizen = create(:user)
     moderator = create(:moderator)
 
@@ -50,7 +50,7 @@ feature 'Moderate users' do
     expect(page).to have_current_path(new_user_session_path)
   end
 
-  scenario 'Search and ban users' do
+  it 'Search and ban users' do
     citizen = create(:user, username: 'Wanda Maximoff')
     moderator = create(:moderator)
 

--- a/spec/features/moderation_spec.rb
+++ b/spec/features/moderation_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-feature 'Moderation' do
+describe 'Moderation' do
   let(:user) { create(:user) }
 
-  scenario 'Access as regular user is not authorized' do
+  it 'Access as regular user is not authorized' do
     login_as(user)
     visit root_path
 
@@ -15,7 +15,7 @@ feature 'Moderation' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as valuator is not authorized' do
+  it 'Access as valuator is not authorized' do
     create(:valuator, user: user)
 
     login_as(user)
@@ -29,7 +29,7 @@ feature 'Moderation' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as manager is not authorized' do
+  it 'Access as manager is not authorized' do
     create(:manager, user: user)
 
     login_as(user)
@@ -43,7 +43,7 @@ feature 'Moderation' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as poll officer is not authorized' do
+  it 'Access as poll officer is not authorized' do
     create(:poll_officer, user: user)
 
     login_as(user)
@@ -57,7 +57,7 @@ feature 'Moderation' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as a moderator is authorized' do
+  it 'Access as a moderator is authorized' do
     create(:moderator, user: user)
 
     login_as(user)
@@ -70,7 +70,7 @@ feature 'Moderation' do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as an administrator is authorized' do
+  it 'Access as an administrator is authorized' do
     create(:administrator, user: user)
 
     login_as(user)
@@ -83,7 +83,7 @@ feature 'Moderation' do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Moderation access links" do
+  it "Moderation access links" do
     create(:moderator, user: user)
     login_as(user)
     visit root_path
@@ -94,7 +94,7 @@ feature 'Moderation' do
   end
 
   context 'Moderation dashboard' do
-    background do
+    before do
       Setting['org_name'] = 'OrgName'
     end
 
@@ -102,7 +102,7 @@ feature 'Moderation' do
       Setting['org_name'] = 'CONSUL'
     end
 
-    scenario 'Contains correct elements' do
+    it 'Contains correct elements' do
       create(:moderator, user: user)
       login_as(user)
       visit root_path

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature "Notifications" do
+describe "Notifications" do
 
   let(:user) { create :user }
 
   context "mark as read" do
 
-    scenario "mark a single notification as read" do
+    it "mark a single notification as read" do
       notification = create :notification, user: user
 
       login_as user
@@ -20,7 +20,7 @@ feature "Notifications" do
       expect(page).to have_css ".notification", count: 0
     end
 
-    scenario "mark all notifications as read" do
+    it "mark all notifications as read" do
       2.times { create :notification, user: user }
 
       login_as user
@@ -35,7 +35,7 @@ feature "Notifications" do
 
   end
 
-  scenario "no notifications" do
+  it "no notifications" do
     login_as user
     visit notifications_path
 

--- a/spec/features/official_positions_spec.rb
+++ b/spec/features/official_positions_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature 'Official positions' do
+describe 'Official positions' do
 
   context "Badge" do
 
-    background do
+    before do
       @user1 = create(:user, official_level: 1, official_position: "Employee", official_position_badge: true)
       @user2 = create(:user, official_level: 0, official_position: "")
     end
 
-    scenario "Comments" do
+    it "Comments" do
       proposal = create(:proposal)
       comment1 = create(:comment, commentable: proposal, user: @user1)
       comment2 = create(:comment, commentable: proposal, user: @user2)
@@ -22,19 +22,19 @@ feature 'Official positions' do
 
     context "Debates" do
 
-      background do
+      before do
         @debate1 = create(:debate, author: @user1)
         @debate2 = create(:debate, author: @user2)
       end
 
-      scenario "Index" do
+      it "Index" do
         visit debates_path
 
         expect_badge_for("debate", @debate1)
         expect_no_badge_for("debate", @debate2)
       end
 
-      scenario "Show" do
+      it "Show" do
         visit debate_path(@debate1)
         expect_badge_for("debate", @debate1)
 
@@ -46,21 +46,21 @@ feature 'Official positions' do
 
     context "Proposals" do
 
-      background do
+      before do
         @proposal1 = create(:proposal, author: @user1)
         @proposal2 = create(:proposal, author: @user2)
 
         create_featured_proposals
       end
 
-      scenario "Index" do
+      it "Index" do
         visit proposals_path
 
         expect_badge_for("proposal", @proposal1)
         expect_no_badge_for("proposal", @proposal2)
       end
 
-      scenario "Show" do
+      it "Show" do
         visit proposal_path(@proposal1)
         expect_badge_for("proposal", @proposal1)
 
@@ -72,7 +72,7 @@ feature 'Official positions' do
 
     context "Spending proposals" do
 
-      background do
+      before do
         Setting["feature.spending_proposals"] = true
         @spending_proposal1 = create(:spending_proposal, author: @user1)
         @spending_proposal2 = create(:spending_proposal, author: @user2)
@@ -82,14 +82,14 @@ feature 'Official positions' do
         Setting["feature.spending_proposals"] = nil
       end
 
-      scenario "Index" do
+      it "Index" do
         visit spending_proposals_path
 
         expect_badge_for("spending_proposal", @spending_proposal1)
         expect_no_badge_for("spending_proposal", @spending_proposal2)
       end
 
-      scenario "Show" do
+      it "Show" do
         visit spending_proposal_path(@spending_proposal1)
         expect_badge_for("spending_proposal", @spending_proposal1)
 

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-feature 'Residence' do
+describe 'Residence' do
   let(:officer) { create(:poll_officer) }
 
-  feature "Officers without assignments" do
+  describe "Officers without assignments" do
 
-    scenario "Can not access residence verification" do
+    it "Can not access residence verification" do
       login_as(officer.user)
       visit officing_root_path
 
@@ -24,15 +24,15 @@ feature 'Residence' do
 
   end
 
-  feature "Assigned officers" do
+  describe "Assigned officers" do
 
-    background do
+    before do
       create(:poll_officer_assignment, officer: officer)
       login_as(officer.user)
       visit officing_root_path
     end
 
-    scenario "Verify voter" do
+    it "Verify voter" do
       within("#side_menu") do
         click_link "Validate document"
       end
@@ -46,7 +46,7 @@ feature 'Residence' do
       expect(page).to have_content 'Document verified with Census'
     end
 
-    scenario "Error on verify" do
+    it "Error on verify" do
       within("#side_menu") do
         click_link "Validate document"
       end
@@ -55,7 +55,7 @@ feature 'Residence' do
       expect(page).to have_content(/\d errors? prevented the verification of this document/)
     end
 
-    scenario "Error on Census (document number)" do
+    it "Error on Census (document number)" do
       initial_failed_census_calls_count = officer.failed_census_calls_count
       within("#side_menu") do
         click_link "Validate document"
@@ -77,7 +77,7 @@ feature 'Residence' do
       expect(officer.failed_census_calls_count).to eq(initial_failed_census_calls_count + 1)
     end
 
-    scenario "Error on Census (year of birth)" do
+    it "Error on Census (year of birth)" do
       within("#side_menu") do
         click_link "Validate document"
       end

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Officing Results' do
+describe 'Officing Results' do
 
-  background do
+  before do
     @poll_officer = create(:poll_officer)
     @officer_assignment = create(:poll_officer_assignment, :final, officer: @poll_officer)
     @poll = @officer_assignment.booth_assignment.poll
@@ -17,7 +17,7 @@ feature 'Officing Results' do
     login_as(@poll_officer.user)
   end
 
-  scenario 'Only polls where user is officer for results are accessible' do
+  it 'Only polls where user is officer for results are accessible' do
     regular_officer_assignment_1 = create(:poll_officer_assignment, officer: @poll_officer)
     regular_officer_assignment_2 = create(:poll_officer_assignment, officer: @poll_officer)
 
@@ -43,7 +43,7 @@ feature 'Officing Results' do
     expect(page).to have_content('You are allowed to add results for this poll')
   end
 
-  scenario 'Add results' do
+  it 'Add results' do
     visit officing_root_path
 
     within('#side_menu') do
@@ -80,7 +80,7 @@ feature 'Officing Results' do
     end
   end
 
-  scenario 'Edit result' do
+  it 'Edit result' do
     partial_result = create(:poll_partial_result,
                       officer_assignment: @officer_assignment,
                       booth_assignment: @officer_assignment.booth_assignment,
@@ -121,7 +121,7 @@ feature 'Officing Results' do
     within("#question_#{@question_1.id}_1_result") { expect(page).to have_content('200') }
   end
 
-  scenario 'Index lists all questions and answers' do
+  it 'Index lists all questions and answers' do
     partial_result = create(:poll_partial_result,
                       officer_assignment: @officer_assignment,
                       booth_assignment: @officer_assignment.booth_assignment,

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature 'Voters' do
+describe 'Voters' do
 
   let(:poll) { create(:poll, :current) }
   let(:booth) { create(:poll_booth) }
   let(:officer) { create(:poll_officer) }
 
-  background do
+  before do
     login_as(officer.user)
     create(:geozone, :in_census)
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
@@ -14,7 +14,7 @@ feature 'Voters' do
     create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
   end
 
-  scenario "Can vote", :js do
+  it "Can vote", :js do
     visit new_officing_residence_path
     officing_verify_residence
 
@@ -33,7 +33,7 @@ feature 'Voters' do
     expect(Poll::Voter.last.officer_id).to eq(officer.id)
   end
 
-  scenario "Already voted", :js do
+  it "Already voted", :js do
     poll2 = create(:poll, :current)
     booth_assignment = create(:poll_booth_assignment, poll: poll2, booth: booth)
     create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
@@ -53,7 +53,7 @@ feature 'Voters' do
     end
   end
 
-  scenario "Had already verified his residence, but is not level 2 yet", :js do
+  it "Had already verified his residence, but is not level 2 yet", :js do
     user = create(:user, residence_verified_at: Time.current, document_type: "1", document_number: "12345678Z")
     expect(user).not_to be_level_two_verified
 
@@ -64,7 +64,7 @@ feature 'Voters' do
     expect(page).to have_content poll.name
   end
 
-  scenario "Display only current polls on which officer has a voting shift today, and user can answer", :js do
+  it "Display only current polls on which officer has a voting shift today, and user can answer", :js do
     poll_current = create(:poll, :current)
     second_booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll_current, booth: second_booth)

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 require 'sessions_helper'
 
-feature 'Poll Officing' do
+describe 'Poll Officing' do
   let(:user) { create(:user) }
 
-  scenario 'Access as regular user is not authorized' do
+  it 'Access as regular user is not authorized' do
     login_as(user)
     visit root_path
 
@@ -16,7 +16,7 @@ feature 'Poll Officing' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as moderator is not authorized' do
+  it 'Access as moderator is not authorized' do
     create(:moderator, user: user)
     login_as(user)
     visit root_path
@@ -29,7 +29,7 @@ feature 'Poll Officing' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as manager is not authorized' do
+  it 'Access as manager is not authorized' do
     create(:manager, user: user)
     login_as(user)
     visit root_path
@@ -42,7 +42,7 @@ feature 'Poll Officing' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as a valuator is not authorized' do
+  it 'Access as a valuator is not authorized' do
     create(:valuator, user: user)
     login_as(user)
     visit root_path
@@ -55,7 +55,7 @@ feature 'Poll Officing' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as an administrator is not authorized' do
+  it 'Access as an administrator is not authorized' do
     create(:administrator, user: user)
     create(:poll)
     login_as(user)
@@ -69,7 +69,7 @@ feature 'Poll Officing' do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as an administrator with poll officer role is authorized' do
+  it 'Access as an administrator with poll officer role is authorized' do
     create(:administrator, user: user)
     create(:poll_officer, user: user)
     create(:poll)
@@ -83,7 +83,7 @@ feature 'Poll Officing' do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario 'Access as an poll officer is authorized' do
+  it 'Access as an poll officer is authorized' do
     create(:poll_officer, user: user)
     create(:poll)
     login_as(user)
@@ -96,7 +96,7 @@ feature 'Poll Officing' do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Poll officer access links" do
+  it "Poll officer access links" do
     create(:poll_officer, user: user)
     login_as(user)
     visit root_path
@@ -107,7 +107,7 @@ feature 'Poll Officing' do
     expect(page).not_to have_link('Moderation')
   end
 
-  scenario 'Officing dashboard' do
+  it 'Officing dashboard' do
     create(:poll_officer, user: user)
     create(:poll)
     login_as(user)
@@ -122,7 +122,7 @@ feature 'Poll Officing' do
     expect(page).not_to have_css('#moderation_menu')
   end
 
-  scenario 'Officing dashboard available for multiple sessions', :js do
+  it 'Officing dashboard available for multiple sessions', :js do
     poll = create(:poll)
     booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Organizations' do
+describe 'Organizations' do
 
-  scenario 'Organizations can be created' do
+  it 'Organizations can be created' do
     user = User.organizations.where(email: 'green@peace.com').first
     expect(user).not_to be
 
@@ -23,7 +23,7 @@ feature 'Organizations' do
     expect(user.organization).not_to be_verified
   end
 
-  scenario 'Create with invisible_captcha honeypot field' do
+  it 'Create with invisible_captcha honeypot field' do
     visit new_organization_registration_path
 
     fill_in 'user_organization_attributes_name',  with: 'robot'
@@ -42,7 +42,7 @@ feature 'Organizations' do
     expect(page).to have_current_path(organization_registration_path)
   end
 
-  scenario 'Create organization too fast' do
+  it 'Create organization too fast' do
     allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
     visit new_organization_registration_path
     fill_in 'user_organization_attributes_name', with: 'robot'
@@ -58,7 +58,7 @@ feature 'Organizations' do
     expect(page).to have_current_path(new_organization_registration_path)
   end
 
-  scenario 'Errors on create' do
+  it 'Errors on create' do
     visit new_organization_registration_path
 
     click_button 'Register'
@@ -66,7 +66,7 @@ feature 'Organizations' do
     expect(page).to have_content error_message
   end
 
-  scenario 'Shared links' do
+  it 'Shared links' do
     # visit new_user_registration_path
     # expect(page).to have_link "Sign up as an organization / collective"
 

--- a/spec/features/polls/answers_spec.rb
+++ b/spec/features/polls/answers_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature 'Answers' do
+describe 'Answers' do
 
   let(:question) { create(:poll_question) }
   let(:admin) { create(:administrator) }
 
-  background do
+  before do
     login_as(admin.user)
   end
 
-  scenario "Index" do
+  it "Index" do
     answer1 = create(:poll_question_answer, question: question, given_order: 2)
     answer2 = create(:poll_question_answer, question: question, given_order: 1)
 
@@ -24,7 +24,7 @@ feature 'Answers' do
     end
   end
 
-  scenario "Create" do
+  it "Create" do
     visit admin_question_path(question)
 
     click_link "Add answer"
@@ -38,7 +38,7 @@ feature 'Answers' do
     expect(page).to have_content "Adding more trees, creating a play area..."
   end
 
-  scenario 'Add video to answer' do
+  it 'Add video to answer' do
     answer1 = create(:poll_question_answer, question: question)
     answer2 = create(:poll_question_answer, question: question)
 

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Polls' do
+describe 'Polls' do
 
   context "Concerns" do
     it_behaves_like 'notifiable in-app', Poll
@@ -8,7 +8,7 @@ feature 'Polls' do
 
   context '#index' do
 
-    scenario 'Polls can be listed' do
+    it 'Polls can be listed' do
       polls = create_list(:poll, 3)
       create(:image, imageable: polls[0])
       create(:image, imageable: polls[1])
@@ -23,7 +23,7 @@ feature 'Polls' do
       end
     end
 
-    scenario 'Filtering polls' do
+    it 'Filtering polls' do
       create(:poll, name: "Current poll")
       create(:poll, :incoming, name: "Incoming poll")
       create(:poll, :expired, name: "Expired poll")
@@ -47,7 +47,7 @@ feature 'Polls' do
       expect(page).to have_link('Poll ended')
     end
 
-    scenario "Current filter is properly highlighted" do
+    it "Current filter is properly highlighted" do
       visit polls_path
       expect(page).not_to have_link('Open')
       expect(page).to have_link('Incoming')
@@ -64,7 +64,7 @@ feature 'Polls' do
       expect(page).not_to have_link('Expired')
     end
 
-    scenario "Poll title link to stats if enabled" do
+    it "Poll title link to stats if enabled" do
       poll = create(:poll, name: "Poll with stats", stats_enabled: true)
 
       visit polls_path
@@ -72,7 +72,7 @@ feature 'Polls' do
       expect(page).to have_link("Poll with stats", href: stats_poll_path(poll))
     end
 
-    scenario "Poll title link to results if enabled" do
+    it "Poll title link to results if enabled" do
       poll = create(:poll, name: "Poll with results", stats_enabled: true, results_enabled: true)
 
       visit polls_path
@@ -85,7 +85,7 @@ feature 'Polls' do
     let(:geozone) { create(:geozone) }
     let(:poll) { create(:poll, summary: "Summary", description: "Description") }
 
-    scenario 'Show answers with videos' do
+    it 'Show answers with videos' do
       question = create(:poll_question, poll: poll)
       answer = create(:poll_question_answer, question: question, title: 'Chewbacca')
       video = create(:poll_answer_video, answer: answer, title: "Awesome project video", url: "https://www.youtube.com/watch?v=123")
@@ -95,7 +95,7 @@ feature 'Polls' do
       expect(page).to have_link("Awesome project video", href: "https://www.youtube.com/watch?v=123")
     end
 
-    scenario 'Lists questions from proposals as well as regular ones' do
+    it 'Lists questions from proposals as well as regular ones' do
       normal_question = create(:poll_question, poll: poll)
       proposal_question = create(:poll_question, poll: poll, proposal: create(:proposal))
 
@@ -108,7 +108,7 @@ feature 'Polls' do
       expect(page).to have_content(proposal_question.title)
     end
 
-    scenario "Question answers appear in the given order" do
+    it "Question answers appear in the given order" do
       question = create(:poll_question, poll: poll)
       answer1 = create(:poll_question_answer, title: 'First', question: question, given_order: 2)
       answer2 = create(:poll_question_answer, title: 'Second', question: question, given_order: 1)
@@ -120,7 +120,7 @@ feature 'Polls' do
       end
     end
 
-    scenario "More info answers appear in the given order" do
+    it "More info answers appear in the given order" do
       question = create(:poll_question, poll: poll)
       answer1 = create(:poll_question_answer, title: 'First', question: question, given_order: 2)
       answer2 = create(:poll_question_answer, title: 'Second', question: question, given_order: 1)
@@ -132,7 +132,7 @@ feature 'Polls' do
       end
     end
 
-    scenario 'Non-logged in users' do
+    it 'Non-logged in users' do
       question = create(:poll_question, poll: poll)
       answer1 = create(:poll_question_answer, question: question, title: 'Han Solo')
       answer2 = create(:poll_question_answer, question: question, title: 'Chewbacca')
@@ -147,7 +147,7 @@ feature 'Polls' do
       expect(page).not_to have_link('Chewbacca')
     end
 
-    scenario 'Level 1 users' do
+    it 'Level 1 users' do
       visit polls_path
       expect(page).not_to have_selector('.already-answer')
 
@@ -170,7 +170,7 @@ feature 'Polls' do
       expect(page).not_to have_link('Chewbacca')
     end
 
-    scenario 'Level 2 users in an incoming poll' do
+    it 'Level 2 users in an incoming poll' do
       incoming_poll = create(:poll, :incoming, geozone_restricted: true)
       incoming_poll.geozones << geozone
 
@@ -190,7 +190,7 @@ feature 'Polls' do
       expect(page).to have_content('This poll has not yet started')
     end
 
-    scenario 'Level 2 users in an expired poll' do
+    it 'Level 2 users in an expired poll' do
       expired_poll = create(:poll, :expired, geozone_restricted: true)
       expired_poll.geozones << geozone
 
@@ -210,7 +210,7 @@ feature 'Polls' do
       expect(page).to have_content('This poll has finished')
     end
 
-    scenario 'Level 2 users in a poll with questions for a geozone which is not theirs' do
+    it 'Level 2 users in a poll with questions for a geozone which is not theirs' do
       poll.update(geozone_restricted: true)
       poll.geozones << create(:geozone)
 
@@ -228,7 +228,7 @@ feature 'Polls' do
       expect(page).not_to have_link('Palpatine')
     end
 
-    scenario 'Level 2 users reading a same-geozone poll' do
+    it 'Level 2 users reading a same-geozone poll' do
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 
@@ -243,7 +243,7 @@ feature 'Polls' do
       expect(page).to have_link('Chewbacca')
     end
 
-    scenario 'Level 2 users reading a all-geozones poll' do
+    it 'Level 2 users reading a all-geozones poll' do
       question = create(:poll_question, poll: poll)
       answer1 = create(:poll_question_answer, question: question, title: 'Han Solo')
       answer2 = create(:poll_question_answer, question: question, title: 'Chewbacca')
@@ -255,7 +255,7 @@ feature 'Polls' do
       expect(page).to have_link('Chewbacca')
     end
 
-    scenario 'Level 2 users who have already answered' do
+    it 'Level 2 users who have already answered' do
       question = create(:poll_question, poll: poll)
       answer1 = create(:poll_question_answer, question: question, title: 'Han Solo')
       answer2 = create(:poll_question_answer, question: question, title: 'Chewbacca')
@@ -269,7 +269,7 @@ feature 'Polls' do
       expect(page).to have_link('Chewbacca')
     end
 
-    scenario 'Level 2 users answering', :js do
+    it 'Level 2 users answering', :js do
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 
@@ -288,7 +288,7 @@ feature 'Polls' do
       expect(page).to have_link('Chewbacca')
     end
 
-    scenario 'Level 2 users changing answer', :js do
+    it 'Level 2 users changing answer', :js do
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 
@@ -312,7 +312,7 @@ feature 'Polls' do
       expect(page).to have_link('Han Solo')
     end
 
-    scenario 'Level 2 votes, signs out, signs in, votes again', :js do
+    it 'Level 2 votes, signs out, signs in, votes again', :js do
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 
@@ -353,7 +353,7 @@ feature 'Polls' do
     let(:booth) { create(:poll_booth) }
     let(:officer) { create(:poll_officer) }
 
-    scenario 'Already voted on booth cannot vote on website', :js do
+    it 'Already voted on booth cannot vote on website', :js do
 
       create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
       booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
@@ -389,7 +389,7 @@ feature 'Polls' do
   end
 
   context "Results and stats" do
-    scenario "Show poll results and stats if enabled and poll expired" do
+    it "Show poll results and stats if enabled and poll expired" do
       poll = create(:poll, :expired, results_enabled: true, stats_enabled: true)
       user = create(:user)
 
@@ -406,7 +406,7 @@ feature 'Polls' do
       expect(page).to have_content("Participation data")
     end
 
-    scenario "Don't show poll results and stats if not enabled" do
+    it "Don't show poll results and stats if not enabled" do
       poll = create(:poll, :expired, results_enabled: false, stats_enabled: false)
       user = create(:user)
 
@@ -423,7 +423,7 @@ feature 'Polls' do
       expect(page).to have_content("You do not have permission to carry out the action 'stats' on poll.")
     end
 
-    scenario "Don't show poll results and stats if is not expired" do
+    it "Don't show poll results and stats if is not expired" do
       poll = create(:poll, :current, results_enabled: true, stats_enabled: true)
       user = create(:user)
 
@@ -440,7 +440,7 @@ feature 'Polls' do
       expect(page).to have_content("You do not have permission to carry out the action 'stats' on poll.")
     end
 
-    scenario "Show poll results and stats if user is administrator" do
+    it "Show poll results and stats if user is administrator" do
       poll = create(:poll, :current, results_enabled: false, stats_enabled: false)
       user = create(:administrator).user
 

--- a/spec/features/polls/questions_spec.rb
+++ b/spec/features/polls/questions_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Poll Questions' do
+describe 'Poll Questions' do
 
-  scenario 'Lists questions from proposals before regular questions' do
+  it 'Lists questions from proposals before regular questions' do
     poll = create(:poll)
     normal_question = create(:poll_question, poll: poll)
     proposal_question = create(:poll_question, proposal: create(:proposal), poll: poll)

--- a/spec/features/polls/results_spec.rb
+++ b/spec/features/polls/results_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature 'Poll Results' do
-  scenario 'List each Poll question', :js do
+describe 'Poll Results' do
+  it 'List each Poll question', :js do
     user1 = create(:user, :level_two)
     user2 = create(:user, :level_two)
     user3 = create(:user, :level_two)

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "Voter" do
+describe "Voter" do
 
   context "Origin" do
 
@@ -11,14 +11,14 @@ feature "Voter" do
     let!(:answer_yes) { create(:poll_question_answer, question: question, title: 'Yes') }
     let!(:answer_no) { create(:poll_question_answer, question: question, title: 'No') }
 
-    background do
+    before do
       create(:geozone, :in_census)
       create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
       booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
       create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
     end
 
-    scenario "Voting via web - Standard", :js do
+    it "Voting via web - Standard", :js do
       user = create(:user, :level_two)
 
       login_as user
@@ -38,7 +38,7 @@ feature "Voter" do
       expect(Poll::Voter.first.origin).to eq("web")
     end
 
-    scenario "Voting via web as unverified user", :js do
+    it "Voting via web as unverified user", :js do
       user = create(:user, :incomplete_verification)
 
       login_as user
@@ -53,7 +53,7 @@ feature "Voter" do
       expect(page).not_to have_content("You have already participated in this poll. If you vote again it will be overwritten")
     end
 
-    scenario "Voting in booth", :js do
+    it "Voting in booth", :js do
       user = create(:user, :in_census)
 
       login_through_form_as_officer(officer.user)
@@ -78,10 +78,10 @@ feature "Voter" do
 
       let!(:user) { create(:user, :in_census) }
 
-      background do
+      before do
       end
 
-      scenario "Trying to vote in web and then in booth", :js do
+      it "Trying to vote in web and then in booth", :js do
         login_as user
         vote_for_poll_via_web(poll, question, answer_yes.title)
         expect(Poll::Voter.count).to eq(1)
@@ -98,7 +98,7 @@ feature "Voter" do
         expect(page).to have_content "Has already participated in this poll"
       end
 
-      scenario "Trying to vote in booth and then in web", :js do
+      it "Trying to vote in booth and then in web", :js do
         login_through_form_as_officer(officer.user)
 
         vote_for_poll_via_booth
@@ -114,7 +114,7 @@ feature "Voter" do
         expect(Poll::Voter.count).to eq(1)
       end
 
-      scenario "Trying to vote in web again", :js do
+      it "Trying to vote in web again", :js do
         login_as user
         vote_for_poll_via_web(poll, question, answer_yes.title)
         expect(Poll::Voter.count).to eq(1)
@@ -140,7 +140,7 @@ feature "Voter" do
       end
     end
 
-    scenario "Voting in poll and then verifiying account", :js do
+    it "Voting in poll and then verifiying account", :js do
       user = create(:user)
 
       login_through_form_as_officer(officer.user)

--- a/spec/features/proposal_ballots_spec.rb
+++ b/spec/features/proposal_ballots_spec.rb
@@ -1,9 +1,9 @@
 # coding: utf-8
 require 'rails_helper'
 
-feature 'Proposal ballots' do
+describe 'Proposal ballots' do
 
-  scenario 'Successful proposals do not show support buttons in index' do
+  it 'Successful proposals do not show support buttons in index' do
     successful_proposals = create_successful_proposals
 
     visit proposals_path
@@ -15,7 +15,7 @@ feature 'Proposal ballots' do
     end
   end
 
-  scenario 'Successful proposals do not show support buttons in show' do
+  it 'Successful proposals do not show support buttons in show' do
     successful_proposals = create_successful_proposals
 
     successful_proposals.each do |proposal|

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Proposal Notifications' do
+describe 'Proposal Notifications' do
 
-  scenario "Send a notification" do
+  it "Send a notification" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -24,7 +24,7 @@ feature 'Proposal Notifications' do
     expect(page).to have_content "Please share it with others so we can make it happen!"
   end
 
-  scenario "Send a notification (Active voter)" do
+  it "Send a notification (Active voter)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -36,7 +36,7 @@ feature 'Proposal Notifications' do
     expect(Notification.count).to eq(1)
   end
 
-  scenario "Send a notification (Follower)" do
+  it "Send a notification (Follower)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
     user_follower = create(:user)
@@ -47,7 +47,7 @@ feature 'Proposal Notifications' do
     expect(Notification.count).to eq(1)
   end
 
-  scenario "Send a notification (Follower and Voter)" do
+  it "Send a notification (Follower and Voter)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -63,7 +63,7 @@ feature 'Proposal Notifications' do
     expect(Notification.count).to eq(2)
   end
 
-  scenario "Send a notification (Blocked voter)" do
+  it "Send a notification (Blocked voter)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -76,7 +76,7 @@ feature 'Proposal Notifications' do
     expect(Notification.count).to eq(0)
   end
 
-  scenario "Send a notification (Erased voter)" do
+  it "Send a notification (Erased voter)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -89,7 +89,7 @@ feature 'Proposal Notifications' do
     expect(Notification.count).to eq(0)
   end
 
-  scenario "Show notifications" do
+  it "Show notifications" do
     proposal = create(:proposal)
     notification1 = create(:proposal_notification, proposal: proposal, title: "Hey guys", body: "Just wanted to let you know that...")
     notification2 = create(:proposal_notification, proposal: proposal, title: "Another update",
@@ -104,7 +104,7 @@ feature 'Proposal Notifications' do
     expect(page).to have_content "We are almost there please share with your peoples!"
   end
 
-  scenario "Message about receivers (Voters)" do
+  it "Message about receivers (Voters)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -117,7 +117,7 @@ feature 'Proposal Notifications' do
     expect(page).to have_link("the proposal's page", href: proposal_path(proposal, anchor: 'comments'))
   end
 
-  scenario "Message about receivers (Followers)" do
+  it "Message about receivers (Followers)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -130,7 +130,7 @@ feature 'Proposal Notifications' do
     expect(page).to have_link("the proposal's page", href: proposal_path(proposal, anchor: 'comments'))
   end
 
-  scenario "Message about receivers (Disctinct Followers and Voters)" do
+  it "Message about receivers (Disctinct Followers and Voters)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -144,7 +144,7 @@ feature 'Proposal Notifications' do
     expect(page).to have_link("the proposal's page", href: proposal_path(proposal, anchor: 'comments'))
   end
 
-  scenario "Message about receivers (Same Followers and Voters)" do
+  it "Message about receivers (Same Followers and Voters)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 
@@ -161,7 +161,7 @@ feature 'Proposal Notifications' do
 
   context "Permissions" do
 
-    scenario "Link to send the message" do
+    it "Link to send the message" do
       user = create(:user)
       author = create(:user)
       proposal = create(:proposal, author: author)
@@ -181,7 +181,7 @@ feature 'Proposal Notifications' do
       end
     end
 
-    scenario "Accessing form directly" do
+    it "Accessing form directly" do
       user = create(:user)
       author = create(:user)
       proposal = create(:proposal, author: author)
@@ -197,7 +197,7 @@ feature 'Proposal Notifications' do
 
   context "In-app notifications from the proposal's author" do
 
-    scenario "Voters should receive a notification", :js do
+    it "Voters should receive a notification", :js do
       author = create(:user)
 
       user1 = create(:user)
@@ -254,7 +254,7 @@ feature 'Proposal Notifications' do
       expect(page).to have_css ".notification", count: 0
     end
 
-    scenario "Followers should receive a notification", :js do
+    it "Followers should receive a notification", :js do
       author = create(:user)
 
       user1 = create(:user)
@@ -308,7 +308,7 @@ feature 'Proposal Notifications' do
       expect(page).to have_css ".notification", count: 0
     end
 
-    scenario "Proposal hidden", :js do
+    it "Proposal hidden", :js do
       author = create(:user)
       user = create(:user)
 
@@ -342,7 +342,7 @@ feature 'Proposal Notifications' do
       expect(page).not_to have_xpath "//a[@href='#{notification_path(notification_for_user)}']"
     end
 
-    scenario "Proposal retired by author", :js do
+    it "Proposal retired by author", :js do
       author = create(:user)
       user = create(:user)
 
@@ -359,7 +359,7 @@ feature 'Proposal Notifications' do
     pending "group notifications for the same proposal"
   end
 
-  scenario "Error messages" do
+  it "Error messages" do
     author = create(:user)
     proposal = create(:proposal, author: author)
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1,9 +1,9 @@
 # coding: utf-8
 require 'rails_helper'
 
-feature 'Proposals' do
+describe 'Proposals' do
 
-  scenario 'Disabled with a feature flag' do
+  it 'Disabled with a feature flag' do
     Setting['feature.proposals'] = nil
     expect{ visit proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     Setting['feature.proposals'] = true
@@ -24,7 +24,7 @@ feature 'Proposals' do
       Setting['feature.allow_images'] = nil
     end
 
-    scenario 'Lists featured and regular proposals' do
+    it 'Lists featured and regular proposals' do
       featured_proposals = create_featured_proposals
       proposals = [create(:proposal), create(:proposal), create(:proposal)]
 
@@ -48,7 +48,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario 'Pagination' do
+    it 'Pagination' do
       per_page = Kaminari.config.default_per_page
       (per_page + 5).times { create(:proposal) }
 
@@ -66,7 +66,7 @@ feature 'Proposals' do
       expect(page).to have_selector('#proposals .proposal', count: 2)
     end
 
-    scenario 'Index should show proposal descriptive image only when is defined' do
+    it 'Index should show proposal descriptive image only when is defined' do
       featured_proposals = create_featured_proposals
       proposal = create(:proposal)
       proposal_with_image = create(:proposal)
@@ -83,7 +83,7 @@ feature 'Proposals' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     proposal = create(:proposal)
 
     visit proposal_path(proposal)
@@ -106,7 +106,7 @@ feature 'Proposals' do
   end
 
   context "Show" do
-    scenario 'When path matches the friendly url' do
+    it 'When path matches the friendly url' do
       proposal = create(:proposal)
 
       right_path = proposal_path(proposal)
@@ -115,7 +115,7 @@ feature 'Proposals' do
       expect(page).to have_current_path(right_path)
     end
 
-    scenario 'When path does not match the friendly url' do
+    it 'When path does not match the friendly url' do
       proposal = create(:proposal)
 
       right_path = proposal_path(proposal)
@@ -126,7 +126,7 @@ feature 'Proposals' do
       expect(page).to have_current_path(right_path)
     end
 
-    scenario 'Can access the community' do
+    it 'Can access the community' do
       Setting['feature.community'] = true
 
       proposal = create(:proposal)
@@ -136,7 +136,7 @@ feature 'Proposals' do
       Setting['feature.community'] = false
     end
 
-    scenario 'Can not access the community' do
+    it 'Can not access the community' do
       Setting['feature.community'] = false
 
       proposal = create(:proposal)
@@ -147,21 +147,21 @@ feature 'Proposals' do
 
   context "Embedded video" do
 
-    scenario "Show YouTube video" do
+    it "Show YouTube video" do
       proposal = create(:proposal, video_url: "http://www.youtube.com/watch?v=a7UFm6ErMPU")
       visit proposal_path(proposal)
       expect(page).to have_selector("div[id='js-embedded-video']")
       expect(page.html).to include 'https://www.youtube.com/embed/a7UFm6ErMPU'
     end
 
-    scenario "Show Vimeo video" do
+    it "Show Vimeo video" do
       proposal = create(:proposal, video_url: "https://vimeo.com/7232823")
       visit proposal_path(proposal)
       expect(page).to have_selector("div[id='js-embedded-video']")
       expect(page.html).to include 'https://player.vimeo.com/video/7232823'
     end
 
-    scenario "Dont show video" do
+    it "Dont show video" do
       proposal = create(:proposal, video_url: nil)
 
       visit proposal_path(proposal)
@@ -169,7 +169,7 @@ feature 'Proposals' do
     end
   end
 
-  scenario 'Social Media Cards' do
+  it 'Social Media Cards' do
     proposal = create(:proposal)
 
     visit proposal_path(proposal)
@@ -177,7 +177,7 @@ feature 'Proposals' do
     expect(page).to have_css "meta[property='og:title'][content=\"#{proposal.title}\"]", visible: false
   end
 
-  scenario 'Create' do
+  it 'Create' do
     author = create(:user)
     login_as(author)
 
@@ -212,7 +212,7 @@ feature 'Proposals' do
     expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)
   end
 
-  scenario 'Create with proposal improvement info link' do
+  it 'Create with proposal improvement info link' do
     Setting['proposal_improvement_path'] = '/more-information/proposal-improvement'
     author = create(:user)
     login_as(author)
@@ -240,7 +240,7 @@ feature 'Proposals' do
     Setting['proposal_improvement_path'] = nil
   end
 
-  scenario 'Create with invisible_captcha honeypot field' do
+  it 'Create with invisible_captcha honeypot field' do
     author = create(:user)
     login_as(author)
 
@@ -261,7 +261,7 @@ feature 'Proposals' do
     expect(page).to have_current_path(proposals_path)
   end
 
-  scenario 'Create proposal too fast' do
+  it 'Create proposal too fast' do
     allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
 
     author = create(:user)
@@ -283,7 +283,7 @@ feature 'Proposals' do
     expect(page).to have_current_path(new_proposal_path)
   end
 
-  scenario 'Responsible name is stored for anonymous users' do
+  it 'Responsible name is stored for anonymous users' do
     author = create(:user)
     login_as(author)
 
@@ -306,7 +306,7 @@ feature 'Proposals' do
     expect(Proposal.last.responsible_name).to eq('Isabel Garcia')
   end
 
-  scenario 'Responsible name field is not shown for verified users' do
+  it 'Responsible name field is not shown for verified users' do
     author = create(:user, :level_two)
     login_as(author)
 
@@ -328,7 +328,7 @@ feature 'Proposals' do
     expect(Proposal.last.responsible_name).to eq(author.document_number)
   end
 
-  scenario 'Errors on create' do
+  it 'Errors on create' do
     author = create(:user)
     login_as(author)
 
@@ -338,7 +338,7 @@ feature 'Proposals' do
     expect(page).to have_content error_message
   end
 
-  scenario 'JS injection is prevented but safe html is respected' do
+  it 'JS injection is prevented but safe html is respected' do
     author = create(:user)
     login_as(author)
 
@@ -363,7 +363,7 @@ feature 'Proposals' do
     expect(page.html).not_to include '&lt;p&gt;This is'
   end
 
-  scenario 'Autolinking is applied to description' do
+  it 'Autolinking is applied to description' do
     author = create(:user)
     login_as(author)
 
@@ -385,7 +385,7 @@ feature 'Proposals' do
     expect(page).to have_link('www.example.org', href: 'http://www.example.org')
   end
 
-  scenario 'JS injection is prevented but autolinking is respected' do
+  it 'JS injection is prevented but autolinking is respected' do
     author = create(:user)
     js_injection_string = "<script>alert('hey')</script> <a href=\"javascript:alert('surprise!')\">click me<a/> http://example.org"
     login_as(author)
@@ -418,7 +418,7 @@ feature 'Proposals' do
 
   context 'Geozones' do
 
-    scenario "Default whole city" do
+    it "Default whole city" do
       author = create(:user)
       login_as(author)
 
@@ -444,7 +444,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario "Specific geozone" do
+    it "Specific geozone" do
       geozone = create(:geozone, name: 'California')
       geozone = create(:geozone, name: 'New York')
       author = create(:user)
@@ -476,7 +476,7 @@ feature 'Proposals' do
   end
 
   context 'Retired proposals' do
-    scenario 'Retire' do
+    it 'Retire' do
       proposal = create(:proposal)
       login_as(proposal.author)
 
@@ -500,7 +500,7 @@ feature 'Proposals' do
       expect(page).to have_content 'There are three other better proposals with the same subject'
     end
 
-    scenario 'Fields are mandatory' do
+    it 'Fields are mandatory' do
       proposal = create(:proposal)
       login_as(proposal.author)
 
@@ -512,7 +512,7 @@ feature 'Proposals' do
       expect(page).to have_content "can't be blank", count: 2
     end
 
-    scenario 'Index do not list retired proposals by default' do
+    it 'Index do not list retired proposals by default' do
       create_featured_proposals
       not_retired = create(:proposal)
       retired = create(:proposal, retired_at: Time.current)
@@ -526,7 +526,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario 'Index has a link to retired proposals list' do
+    it 'Index has a link to retired proposals list' do
       create_featured_proposals
       not_retired = create(:proposal)
       retired = create(:proposal, retired_at: Time.current)
@@ -540,7 +540,7 @@ feature 'Proposals' do
       expect(page).not_to have_content not_retired.title
     end
 
-    scenario 'Retired proposals index interface elements' do
+    it 'Retired proposals index interface elements' do
       visit proposals_path(retired: 'all')
 
       expect(page).not_to have_content 'Advanced search'
@@ -548,7 +548,7 @@ feature 'Proposals' do
       expect(page).not_to have_content 'Districts'
     end
 
-    scenario 'Retired proposals index has links to filter by retired_reason' do
+    it 'Retired proposals index has links to filter by retired_reason' do
       unfeasible = create(:proposal, retired_at: Time.current, retired_reason: 'unfeasible')
       duplicated = create(:proposal, retired_at: Time.current, retired_reason: 'duplicated')
 
@@ -569,7 +569,7 @@ feature 'Proposals' do
     end
   end
 
-  scenario 'Update should not be posible if logged user is not the author' do
+  it 'Update should not be posible if logged user is not the author' do
     proposal = create(:proposal)
     expect(proposal).to be_editable
     login_as(create(:user))
@@ -580,7 +580,7 @@ feature 'Proposals' do
     expect(page).to have_content 'You do not have permission'
   end
 
-  scenario 'Update should not be posible if proposal is not editable' do
+  it 'Update should not be posible if proposal is not editable' do
     proposal = create(:proposal)
     Setting["max_votes_for_proposal_edit"] = 10
     11.times { create(:vote, votable: proposal) }
@@ -596,7 +596,7 @@ feature 'Proposals' do
     Setting["max_votes_for_proposal_edit"] = 1000
   end
 
-  scenario 'Update should be posible for the author of an editable proposal' do
+  it 'Update should be posible for the author of an editable proposal' do
     proposal = create(:proposal)
     login_as(proposal.author)
 
@@ -618,7 +618,7 @@ feature 'Proposals' do
     expect(page).to have_content "Let's do something to end child poverty"
   end
 
-  scenario 'Errors on update' do
+  it 'Errors on update' do
     proposal = create(:proposal)
     login_as(proposal.author)
 
@@ -629,9 +629,9 @@ feature 'Proposals' do
     expect(page).to have_content error_message
   end
 
-  feature 'Proposal index order filters' do
+  describe 'Proposal index order filters' do
 
-    scenario 'Default order is hot_score', :js do
+    it 'Default order is hot_score', :js do
       create_featured_proposals
 
       best_proposal = create(:proposal, title: 'Best proposal')
@@ -647,7 +647,7 @@ feature 'Proposals' do
       expect(medium_proposal.title).to appear_before(worst_proposal.title)
     end
 
-    scenario 'Proposals are ordered by confidence_score', :js do
+    it 'Proposals are ordered by confidence_score', :js do
       create_featured_proposals
 
       best_proposal = create(:proposal, title: 'Best proposal')
@@ -670,7 +670,7 @@ feature 'Proposals' do
       expect(current_url).to include('page=1')
     end
 
-    scenario 'Proposals are ordered by newest', :js do
+    it 'Proposals are ordered by newest', :js do
       create_featured_proposals
 
       best_proposal = create(:proposal, title: 'Best proposal', created_at: Time.current)
@@ -704,13 +704,13 @@ feature 'Proposals' do
         Setting['feature.user.recommendations'] = nil
       end
 
-      scenario 'Proposals can not ordered by recommendations when there is not an user logged', :js do
+      it 'Proposals can not ordered by recommendations when there is not an user logged', :js do
         visit proposals_path
 
         expect(page).not_to have_selector('a', text: 'recommendations')
       end
 
-      scenario 'Should display text when there are not recommendeds results', :js do
+      it 'displays text when there are not recommendeds results', :js do
         user = create(:user)
         proposal = create(:proposal, tag_list: "Distinct_to_sport")
         create(:follow, followable: proposal, user: user)
@@ -722,7 +722,7 @@ feature 'Proposals' do
         expect(page).to have_content "There are not proposals related to your interests"
       end
 
-      scenario 'Should display text when user has not related interests', :js do
+      it 'displays text when user has not related interests', :js do
         user = create(:user)
         login_as(user)
         visit proposals_path
@@ -732,7 +732,7 @@ feature 'Proposals' do
         expect(page).to have_content "Follow proposals so we can give you recommendations"
       end
 
-      scenario 'Proposals are ordered by recommendations when there is an user logged', :js do
+      it 'Proposals are ordered by recommendations when there is an user logged', :js do
         user = create(:user)
         proposal = create(:proposal, tag_list: "Sport")
         create(:follow, followable: proposal, user: user)
@@ -755,9 +755,9 @@ feature 'Proposals' do
     end
   end
 
-  feature 'Archived proposals' do
+  describe 'Archived proposals' do
 
-    scenario 'show on archived tab' do
+    it 'show on archived tab' do
       create_featured_proposals
       archived_proposals = create_archived_proposals
 
@@ -771,7 +771,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario 'do not show in other index tabs' do
+    it 'do not show in other index tabs' do
       create_featured_proposals
       archived_proposal = create(:proposal, :archived)
 
@@ -791,7 +791,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario 'do not show support buttons in index' do
+    it 'do not show support buttons in index' do
       create_featured_proposals
       archived_proposals = create_archived_proposals
 
@@ -806,14 +806,14 @@ feature 'Proposals' do
       end
     end
 
-    scenario 'do not show support buttons in show' do
+    it 'do not show support buttons in show' do
       archived_proposal = create(:proposal, :archived)
 
       visit proposal_path(archived_proposal)
       expect(page).to have_content "This proposal has been archived and can't collect supports"
     end
 
-    scenario 'do not show in featured proposals section' do
+    it 'do not show in featured proposals section' do
       featured_proposal = create(:proposal, :with_confidence_score, cached_votes_up: 100)
       archived_proposal = create(:proposal, :archived, :with_confidence_score, cached_votes_up: 10000)
 
@@ -840,7 +840,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario "Order by votes" do
+    it "Order by votes" do
       create(:proposal, :archived, title: "Least voted").update_column(:confidence_score, 10)
       create(:proposal, :archived, title: "Most voted").update_column(:confidence_score, 50)
       create(:proposal, :archived, title: "Some votes").update_column(:confidence_score, 25)
@@ -861,7 +861,7 @@ feature 'Proposals' do
 
     context "Basic search" do
 
-      scenario 'Search by text' do
+      it 'Search by text' do
         proposal1 = create(:proposal, title: "Get Schwifty")
         proposal2 = create(:proposal, title: "Schwifty Hello")
         proposal3 = create(:proposal, title: "Do not show me")
@@ -882,7 +882,7 @@ feature 'Proposals' do
         end
       end
 
-      scenario 'Search by proposal code' do
+      it 'Search by proposal code' do
         proposal1 = create(:proposal, title: "Get Schwifty")
         proposal2 = create(:proposal, title: "Schwifty Hello")
 
@@ -901,7 +901,7 @@ feature 'Proposals' do
         end
       end
 
-      scenario "Maintain search criteria" do
+      it "Maintain search criteria" do
         visit proposals_path
 
         within(".expanded #search_form") do
@@ -916,7 +916,7 @@ feature 'Proposals' do
 
     context "Advanced search" do
 
-      scenario "Search by text", :js do
+      it "Search by text", :js do
         proposal1 = create(:proposal, title: "Get Schwifty")
         proposal2 = create(:proposal, title: "Schwifty Hello")
         proposal3 = create(:proposal, title: "Do not show me")
@@ -939,7 +939,7 @@ feature 'Proposals' do
 
       context "Search by author type" do
 
-        scenario "Public employee", :js do
+        it "Public employee", :js do
           ana = create :user, official_level: 1
           john = create :user, official_level: 2
 
@@ -962,7 +962,7 @@ feature 'Proposals' do
           end
         end
 
-        scenario "Municipal Organization", :js do
+        it "Municipal Organization", :js do
           ana = create :user, official_level: 2
           john = create :user, official_level: 3
 
@@ -985,7 +985,7 @@ feature 'Proposals' do
           end
         end
 
-        scenario "General director", :js do
+        it "General director", :js do
           ana = create :user, official_level: 3
           john = create :user, official_level: 4
 
@@ -1008,7 +1008,7 @@ feature 'Proposals' do
           end
         end
 
-        scenario "City councillor", :js do
+        it "City councillor", :js do
           ana = create :user, official_level: 4
           john = create :user, official_level: 5
 
@@ -1031,7 +1031,7 @@ feature 'Proposals' do
           end
         end
 
-        scenario "Mayoress", :js do
+        it "Mayoress", :js do
           ana = create :user, official_level: 5
           john = create :user, official_level: 4
 
@@ -1060,7 +1060,7 @@ feature 'Proposals' do
 
         context "Predefined date ranges" do
 
-          scenario "Last day", :js do
+          it "Last day", :js do
             proposal1 = create(:proposal, created_at: 1.minute.ago)
             proposal2 = create(:proposal, created_at: 1.hour.ago)
             proposal3 = create(:proposal, created_at: 2.days.ago)
@@ -1080,7 +1080,7 @@ feature 'Proposals' do
             end
           end
 
-          scenario "Last week", :js do
+          it "Last week", :js do
             proposal1 = create(:proposal, created_at: 1.day.ago)
             proposal2 = create(:proposal, created_at: 5.days.ago)
             proposal3 = create(:proposal, created_at: 8.days.ago)
@@ -1100,7 +1100,7 @@ feature 'Proposals' do
             end
           end
 
-          scenario "Last month", :js do
+          it "Last month", :js do
             proposal1 = create(:proposal, created_at: 10.days.ago)
             proposal2 = create(:proposal, created_at: 20.days.ago)
             proposal3 = create(:proposal, created_at: 33.days.ago)
@@ -1120,7 +1120,7 @@ feature 'Proposals' do
             end
           end
 
-          scenario "Last year", :js do
+          it "Last year", :js do
             proposal1 = create(:proposal, created_at: 300.days.ago)
             proposal2 = create(:proposal, created_at: 350.days.ago)
             proposal3 = create(:proposal, created_at: 370.days.ago)
@@ -1142,7 +1142,7 @@ feature 'Proposals' do
 
         end
 
-        scenario "Search by custom date range", :js do
+        it "Search by custom date range", :js do
           proposal1 = create(:proposal, created_at: 2.days.ago)
           proposal2 = create(:proposal, created_at: 3.days.ago)
           proposal3 = create(:proposal, created_at: 9.days.ago)
@@ -1164,7 +1164,7 @@ feature 'Proposals' do
           end
         end
 
-        scenario "Search by custom invalid date range", :js do
+        it "Search by custom invalid date range", :js do
           proposal1 = create(:proposal, created_at: 2.days.ago)
           proposal2 = create(:proposal, created_at: 3.days.ago)
           proposal3 = create(:proposal, created_at: 9.days.ago)
@@ -1186,7 +1186,7 @@ feature 'Proposals' do
           end
         end
 
-        scenario "Search by multiple filters", :js do
+        it "Search by multiple filters", :js do
           ana  = create :user, official_level: 1
           john = create :user, official_level: 1
 
@@ -1210,7 +1210,7 @@ feature 'Proposals' do
           end
         end
 
-        scenario "Maintain advanced search criteria", :js do
+        it "Maintain advanced search criteria", :js do
           visit proposals_path
           click_link "Advanced search"
 
@@ -1229,7 +1229,7 @@ feature 'Proposals' do
           end
         end
 
-        scenario "Maintain custom date search criteria", :js do
+        it "Maintain custom date search criteria", :js do
           visit proposals_path
           click_link "Advanced search"
 
@@ -1250,7 +1250,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario "Order by relevance by default", :js do
+    it "Order by relevance by default", :js do
       proposal1 = create(:proposal, title: "Show you got",      cached_votes_up: 10)
       proposal2 = create(:proposal, title: "Show what you got", cached_votes_up: 1)
       proposal3 = create(:proposal, title: "Show you got",      cached_votes_up: 100)
@@ -1268,7 +1268,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario "Reorder results maintaing search", :js do
+    it "Reorder results maintaing search", :js do
       proposal1 = create(:proposal, title: "Show you got",      cached_votes_up: 10,  created_at: 1.week.ago)
       proposal2 = create(:proposal, title: "Show what you got", cached_votes_up: 1,   created_at: 1.month.ago)
       proposal3 = create(:proposal, title: "Show you got",      cached_votes_up: 100, created_at: Time.current)
@@ -1288,7 +1288,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario "Reorder by recommendations results maintaing search", :js do
+    it "Reorder by recommendations results maintaing search", :js do
       Setting['feature.user.recommendations'] = true
       user = create(:user)
       login_as(user)
@@ -1314,7 +1314,7 @@ feature 'Proposals' do
       Setting['feature.user.recommendations'] = nil
     end
 
-    scenario 'After a search do not show featured proposals' do
+    it 'After a search do not show featured proposals' do
       featured_proposals = create_featured_proposals
       proposal = create(:proposal, title: "Abcdefghi")
 
@@ -1330,7 +1330,7 @@ feature 'Proposals' do
 
   end
 
-  scenario 'Conflictive' do
+  it 'Conflictive' do
     good_proposal = create(:proposal)
     conflictive_proposal = create(:proposal, :conflictive)
 
@@ -1341,7 +1341,7 @@ feature 'Proposals' do
     expect(page).not_to have_content "This proposal has been flagged as inappropriate by several users."
   end
 
-  scenario "Flagging", :js do
+  it "Flagging", :js do
     user = create(:user)
     proposal = create(:proposal)
 
@@ -1358,7 +1358,7 @@ feature 'Proposals' do
     expect(Flag.flagged?(user, proposal)).to be
   end
 
-  scenario "Unflagging", :js do
+  it "Unflagging", :js do
     user = create(:user)
     proposal = create(:proposal)
     Flag.flag(user, proposal)
@@ -1376,7 +1376,7 @@ feature 'Proposals' do
     expect(Flag.flagged?(user, proposal)).not_to be
   end
 
-  scenario 'Flagging/Unflagging AJAX', :js do
+  it 'Flagging/Unflagging AJAX', :js do
     user = create(:user)
     proposal = create(:proposal)
 
@@ -1452,7 +1452,7 @@ feature 'Proposals' do
                   "proposal_path",
                   { }
 
-  scenario 'Erased author' do
+  it 'Erased author' do
     user = create(:user)
     proposal = create(:proposal, author: user)
     user.erase
@@ -1473,7 +1473,7 @@ feature 'Proposals' do
 
     context "By geozone" do
 
-      background do
+      before do
         @california = Geozone.create(name: "California")
         @new_york   = Geozone.create(name: "New York")
 
@@ -1482,7 +1482,7 @@ feature 'Proposals' do
         @proposal3 = create(:proposal, geozone: @new_york)
       end
 
-      scenario "From map" do
+      it "From map" do
         visit proposals_path
 
         click_link "map"
@@ -1499,7 +1499,7 @@ feature 'Proposals' do
         end
       end
 
-      scenario "From geozone list" do
+      it "From geozone list" do
         visit proposals_path
 
         click_link "map"
@@ -1514,7 +1514,7 @@ feature 'Proposals' do
         end
       end
 
-      scenario "From proposal" do
+      it "From proposal" do
         visit proposal_path(@proposal1)
 
         within("#geozone") do
@@ -1533,7 +1533,7 @@ feature 'Proposals' do
   end
 
   context 'Suggesting proposals' do
-    scenario 'Show up to 5 suggestions', :js do
+    it 'Show up to 5 suggestions', :js do
       author = create(:user)
       login_as(author)
 
@@ -1554,7 +1554,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario 'No found suggestions', :js do
+    it 'No found suggestions', :js do
       author = create(:user)
       login_as(author)
 
@@ -1573,7 +1573,7 @@ feature 'Proposals' do
 
   context "Summary" do
 
-    scenario "Displays proposals grouped by category" do
+    it "Displays proposals grouped by category" do
       create(:tag, :category, name: 'Culture')
       create(:tag, :category, name: 'Social Services')
 
@@ -1596,7 +1596,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario "Displays proposals grouped by district" do
+    it "Displays proposals grouped by district" do
       california = create(:geozone, name: 'California')
       new_york   = create(:geozone, name: 'New York')
 
@@ -1617,7 +1617,7 @@ feature 'Proposals' do
       end
     end
 
-    scenario "Displays a maximum of 3 proposals per category" do
+    it "Displays a maximum of 3 proposals per category" do
       create(:tag, :category, name: 'culture')
       4.times { create(:proposal, tag_list: 'culture') }
 
@@ -1626,7 +1626,7 @@ feature 'Proposals' do
       expect(page).to have_css(".proposal", count: 3)
     end
 
-    scenario "Orders proposals by votes" do
+    it "Orders proposals by votes" do
       create(:tag, :category, name: 'culture')
       best_proposal = create(:proposal, title: 'Best', tag_list: 'culture')
       best_proposal.update_column(:confidence_score, 10)
@@ -1641,7 +1641,7 @@ feature 'Proposals' do
       expect(medium_proposal.title).to appear_before(worst_proposal.title)
     end
 
-    scenario "Displays proposals from last week" do
+    it "Displays proposals from last week" do
       create(:tag, :category, name: 'culture')
       proposal1 = create(:proposal, tag_list: 'culture', created_at: 1.day.ago)
       proposal2 = create(:proposal, tag_list: 'culture', created_at: 5.days.ago)
@@ -1662,9 +1662,9 @@ feature 'Proposals' do
 
 end
 
-feature 'Successful proposals' do
+describe 'Successful proposals' do
 
-  scenario 'Successful proposals do not show support buttons in index' do
+  it 'Successful proposals do not show support buttons in index' do
     successful_proposals = create_successful_proposals
 
     visit proposals_path
@@ -1677,7 +1677,7 @@ feature 'Successful proposals' do
     end
   end
 
-  scenario 'Successful proposals do not show support buttons in show' do
+  it 'Successful proposals do not show support buttons in show' do
     successful_proposals = create_successful_proposals
 
     successful_proposals.each do |proposal|
@@ -1689,7 +1689,7 @@ feature 'Successful proposals' do
     end
   end
 
-  scenario 'Successful proposals show create question button to admin users' do
+  it 'Successful proposals show create question button to admin users' do
     successful_proposals = create_successful_proposals
 
     visit proposals_path

--- a/spec/features/registration_form_spec.rb
+++ b/spec/features/registration_form_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Registration form' do
+describe 'Registration form' do
 
-  scenario 'username is not available', :js do
+  it 'username is not available', :js do
     user = create(:user)
 
     visit new_user_registration_path
@@ -14,7 +14,7 @@ feature 'Registration form' do
     expect(page).to have_content I18n.t("devise_views.users.registrations.new.username_is_not_available")
   end
 
-  scenario 'username is available', :js do
+  it 'username is available', :js do
     visit new_user_registration_path
     expect(page).not_to have_content I18n.t("devise_views.users.registrations.new.username_is_available")
 
@@ -24,7 +24,7 @@ feature 'Registration form' do
     expect(page).to have_content I18n.t("devise_views.users.registrations.new.username_is_available")
   end
 
-  scenario 'do not save blank redeemable codes' do
+  it 'do not save blank redeemable codes' do
     visit new_user_registration_path(use_redeemable_code: 'true')
 
     fill_in 'user_username',              with: "NewUserWithCode77"
@@ -43,7 +43,7 @@ feature 'Registration form' do
     expect(new_user.redeemable_code).to be_nil
   end
 
-  scenario 'Create with invisible_captcha honeypot field' do
+  it 'Create with invisible_captcha honeypot field' do
     visit new_user_registration_path
 
     fill_in 'user_username',              with: "robot"
@@ -60,7 +60,7 @@ feature 'Registration form' do
     expect(page).to have_current_path(user_registration_path)
   end
 
-  scenario 'Create organization too fast' do
+  it 'Create organization too fast' do
     allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
     visit new_user_registration_path
 

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Sessions' do
+describe 'Sessions' do
 
-  scenario 'Staying in the same page after doing login/logout' do
+  it 'Staying in the same page after doing login/logout' do
     user = create(:user, sign_in_count: 10)
     debate = create(:debate)
 

--- a/spec/features/site_customization/content_blocks_spec.rb
+++ b/spec/features/site_customization/content_blocks_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature "Custom content blocks" do
-  scenario "top links" do
+describe "Custom content blocks" do
+  it "top links" do
     create(:site_customization_content_block, name: "top_links", locale: "en", body: "content for top links")
     create(:site_customization_content_block, name: "top_links", locale: "es", body: "contenido para top links")
 
@@ -16,7 +16,7 @@ feature "Custom content blocks" do
     expect(page).not_to have_content("content for top links")
   end
 
-  scenario "footer" do
+  it "footer" do
     create(:site_customization_content_block, name: "footer", locale: "en", body: "content for footer")
     create(:site_customization_content_block, name: "footer", locale: "es", body: "contenido para footer")
 

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature "Custom Pages" do
+describe "Custom Pages" do
   context "Override existing page" do
-    scenario "See default content when custom page is not published" do
+    it "See default content when custom page is not published" do
       custom_page = create(:site_customization_page,
         slug: "conditions",
         title: "Custom conditions",
@@ -19,7 +19,7 @@ feature "Custom Pages" do
       expect(page).to have_content("Print this info")
     end
 
-    scenario "See custom content when custom page is published" do
+    it "See custom content when custom page is published" do
       custom_page = create(:site_customization_page, :published,
         slug: "conditions",
         title: "Custom conditions",
@@ -39,7 +39,7 @@ feature "Custom Pages" do
 
   context "New custom page" do
     context "Draft" do
-      scenario "See page" do
+      it "See page" do
         custom_page = create(:site_customization_page,
           slug: "other-slug",
           title: "Custom page",
@@ -55,7 +55,7 @@ feature "Custom Pages" do
     end
 
     context "Published" do
-      scenario "See page" do
+      it "See page" do
         custom_page = create(:site_customization_page, :published,
           slug: "other-slug",
           title: "Custom page",
@@ -72,7 +72,7 @@ feature "Custom Pages" do
         expect(page).not_to have_content("Print this info")
       end
 
-      scenario "Listed in more information page" do
+      it "Listed in more information page" do
         custom_page = create(:site_customization_page, :published,
           slug: "another-slug", title: "Another custom page",
           subtitle: "Subtitle for custom page",
@@ -85,7 +85,7 @@ feature "Custom Pages" do
         expect(page).to have_content("Another custom page")
       end
 
-      scenario "Not listed in more information page" do
+      it "Not listed in more information page" do
         custom_page = create(:site_customization_page, :published,
           slug: "another-slug", title: "Another custom page",
           subtitle: "Subtitle for custom page",
@@ -104,7 +104,7 @@ feature "Custom Pages" do
         expect(page).to have_content("Subtitle for custom page")
       end
 
-      scenario "Not listed in more information page due to different locale" do
+      it "Not listed in more information page due to different locale" do
         custom_page = create(:site_customization_page, :published,
           slug: "another-slug", title: "Ce texte est en français",
           subtitle: "Subtitle for custom page",

--- a/spec/features/social_media_meta_tags_spec.rb
+++ b/spec/features/social_media_meta_tags_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Social media meta tags' do
+describe 'Social media meta tags' do
 
   context 'Setting social media meta tags' do
 
@@ -40,7 +40,7 @@ feature 'Social media meta tags' do
       Setting['org_name'] = 'CONSUL'
     end
 
-    scenario 'Social media meta tags partial render settings content' do
+    it 'Social media meta tags partial render settings content' do
 
       visit root_path
 

--- a/spec/features/stats_spec.rb
+++ b/spec/features/stats_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-feature 'Stats' do
+describe 'Stats' do
 
   context 'Summary' do
 
-    scenario 'General' do
+    it 'General' do
       create(:debate)
       2.times { create(:proposal) }
       3.times { create(:comment, commentable: Debate.first) }
@@ -18,7 +18,7 @@ feature 'Stats' do
       expect(page).to have_content "Visits 4"
     end
 
-    scenario 'Votes' do
+    it 'Votes' do
       debate = create(:debate)
       create(:vote, votable: debate)
 
@@ -36,7 +36,7 @@ feature 'Stats' do
       expect(page).to have_content "Total votes 6"
     end
 
-    scenario 'Users' do
+    it 'Users' do
       1.times { create(:user, :level_three) }
       2.times { create(:user, :level_two) }
       2.times { create(:user) }

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Tags' do
+describe 'Tags' do
 
   let(:author)  { create(:user, :level_two, username: 'Isabel') }
   let(:budget)  { create(:budget, name: "Big Budget") }
@@ -10,7 +10,7 @@ feature 'Tags' do
   let!(:tag_economia) { create(:tag, :category, name: 'Economía') }
   let(:admin) { create(:administrator).user }
 
-  scenario 'Index' do
+  it 'Index' do
     earth = create(:budget_investment, heading: heading, tag_list: tag_medio_ambiente.name)
     money = create(:budget_investment, heading: heading, tag_list: tag_economia.name)
 
@@ -25,7 +25,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Index shows 3 tags with no plus link' do
+  it 'Index shows 3 tags with no plus link' do
     tag_list = ["Medio Ambiente", "Corrupción", "Fiestas populares"]
     create :budget_investment, heading: heading, tag_list: tag_list
 
@@ -39,7 +39,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Index shows up to 5 tags per proposal' do
+  it 'Index shows up to 5 tags per proposal' do
     create_featured_proposals
     tag_list = ["Hacienda", "Economía", "Medio Ambiente", "Corrupción", "Fiestas populares", "Prensa"]
     create :budget_investment, heading: heading, tag_list: tag_list
@@ -51,7 +51,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     investment = create(:budget_investment, heading: heading, tag_list: "#{tag_medio_ambiente.name}, #{tag_economia.name}")
 
     visit budget_investment_path(budget, investment)
@@ -60,7 +60,7 @@ feature 'Tags' do
     expect(page).to have_content(tag_economia.name)
   end
 
-  scenario 'Create with custom tags' do
+  it 'Create with custom tags' do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
@@ -79,7 +79,7 @@ feature 'Tags' do
     expect(page).to have_content tag_medio_ambiente.name
   end
 
-  scenario 'Category with category tags', :js do
+  it 'Category with category tags', :js do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
@@ -100,7 +100,7 @@ feature 'Tags' do
     end
   end
 
-  scenario "Turbolinks sanity check from budget's show", :js do
+  it "Turbolinks sanity check from budget's show", :js do
     login_as(author)
 
     education = create(:tag, name: 'Education', kind: 'category')
@@ -125,7 +125,7 @@ feature 'Tags' do
     end
   end
 
-  scenario "Turbolinks sanity check from budget heading's show", :js do
+  it "Turbolinks sanity check from budget heading's show", :js do
     login_as(author)
 
     education = create(:tag, name: 'Education', kind: 'category')
@@ -150,7 +150,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Create with too many tags' do
+  it 'Create with too many tags' do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
@@ -168,7 +168,7 @@ feature 'Tags' do
     expect(page).to have_content 'tags must be less than or equal to 6'
   end
 
-  scenario 'Create with dangerous strings' do
+  it 'Create with dangerous strings' do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
@@ -191,7 +191,7 @@ feature 'Tags' do
 
   context "Filter" do
 
-    scenario "From index" do
+    it "From index" do
 
       investment1 = create(:budget_investment, heading: heading, tag_list: tag_economia.name)
       investment2 = create(:budget_investment, heading: heading, tag_list: 'Health')
@@ -208,7 +208,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "From show" do
+    it "From show" do
       investment1 = create(:budget_investment, heading: heading, tag_list: tag_economia.name)
       investment2 = create(:budget_investment, heading: heading, tag_list: 'Health')
 
@@ -232,7 +232,7 @@ feature 'Tags' do
     let!(:investment2) { create(:budget_investment, heading: heading, tag_list: new_tag) }
     let!(:investment3) { create(:budget_investment, heading: heading, tag_list: newer_tag) }
 
-    scenario 'Display user tags' do
+    it 'Display user tags' do
       Budget::Phase::PHASE_KINDS.each do |phase|
         budget.update(phase: phase)
 
@@ -246,7 +246,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "Filter by user tags" do
+    it "Filter by user tags" do
       Budget::Phase::PHASE_KINDS.each do |phase|
         budget.update(phase: phase)
 
@@ -279,7 +279,7 @@ feature 'Tags' do
     let!(:investment2) { create(:budget_investment, heading: heading, tag_list: tag_medio_ambiente.name) }
     let!(:investment3) { create(:budget_investment, heading: heading, tag_list: tag_economia.name) }
 
-    scenario 'Display category tags' do
+    it 'Display category tags' do
       Budget::Phase::PHASE_KINDS.each do |phase|
         budget.update(phase: phase)
 
@@ -293,7 +293,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "Filter by category tags" do
+    it "Filter by category tags" do
       Budget::Phase::PHASE_KINDS.each do |phase|
         budget.update(phase: phase)
 
@@ -321,7 +321,7 @@ feature 'Tags' do
 
   context "Valuation" do
 
-    scenario "Users do not see valuator tags" do
+    it "Users do not see valuator tags" do
       investment = create(:budget_investment, heading: heading, tag_list: 'Park')
       investment.set_tag_list_on(:valuation, 'Education')
       investment.save
@@ -332,7 +332,7 @@ feature 'Tags' do
       expect(page).not_to have_content 'Education'
     end
 
-    scenario "Valuators do not see user tags" do
+    it "Valuators do not see user tags" do
       investment = create(:budget_investment, heading: heading, tag_list: 'Park')
       investment.set_tag_list_on(:valuation, 'Education')
       investment.save

--- a/spec/features/tags/debates_spec.rb
+++ b/spec/features/tags/debates_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Tags' do
+describe 'Tags' do
 
-  scenario 'Index' do
+  it 'Index' do
     earth = create(:debate, tag_list: 'Medio Ambiente')
     money = create(:debate, tag_list: 'Economía')
 
@@ -17,7 +17,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Index shows up to 5 tags per proposal' do
+  it 'Index shows up to 5 tags per proposal' do
     tag_list = ["Hacienda", "Economía", "Medio Ambiente", "Corrupción", "Fiestas populares", "Prensa"]
     create :debate, tag_list: tag_list
 
@@ -28,7 +28,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Index shows 3 tags with no plus link' do
+  it 'Index shows 3 tags with no plus link' do
     tag_list = ["Medio Ambiente", "Corrupción", "Fiestas populares"]
     create :debate, tag_list: tag_list
 
@@ -42,7 +42,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Index tag does not show featured debates' do
+  it 'Index tag does not show featured debates' do
     featured_debates = create_featured_debates
     debates = create(:debate, tag_list: "123")
 
@@ -52,7 +52,7 @@ feature 'Tags' do
     expect(page).not_to have_selector('#featured-debates')
   end
 
-  scenario 'Show' do
+  it 'Show' do
     debate = create(:debate, tag_list: 'Hacienda, Economía')
 
     visit debate_path(debate)
@@ -61,7 +61,7 @@ feature 'Tags' do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario 'Create' do
+  it 'Create' do
     user = create(:user)
     login_as(user)
 
@@ -80,7 +80,7 @@ feature 'Tags' do
     expect(page).to have_content 'Impuestos'
   end
 
-  scenario 'Create with too many tags' do
+  it 'Create with too many tags' do
     user = create(:user)
     login_as(user)
 
@@ -97,7 +97,7 @@ feature 'Tags' do
     expect(page).to have_content 'tags must be less than or equal to 6'
   end
 
-  scenario 'Create with dangerous strings' do
+  it 'Create with dangerous strings' do
     user = create(:user)
     login_as(user)
 
@@ -118,7 +118,7 @@ feature 'Tags' do
     expect(page.html).not_to include 'user_id=1, &a=3, <script>alert("hey");</script>'
   end
 
-  scenario 'Update' do
+  it 'Update' do
     debate = create(:debate, tag_list: 'Economía')
 
     login_as(debate.author)
@@ -136,7 +136,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Delete' do
+  it 'Delete' do
     debate = create(:debate, tag_list: 'Economía')
 
     login_as(debate.author)
@@ -151,7 +151,7 @@ feature 'Tags' do
 
   context "Filter" do
 
-    scenario "From index" do
+    it "From index" do
       debate1 = create(:debate, tag_list: 'Education')
       debate2 = create(:debate, tag_list: 'Health')
 
@@ -167,7 +167,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "From show" do
+    it "From show" do
       debate1 = create(:debate, tag_list: 'Education')
       debate2 = create(:debate, tag_list: 'Health')
 
@@ -185,7 +185,7 @@ feature 'Tags' do
 
   context 'Tag cloud' do
 
-    scenario 'Display user tags' do
+    it 'Display user tags' do
       earth = create(:debate, tag_list: 'Medio Ambiente')
       money = create(:debate, tag_list: 'Economía')
 
@@ -197,7 +197,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "Filter by user tags" do
+    it "Filter by user tags" do
       debate1 = create(:debate, tag_list: 'Medio Ambiente')
       debate2 = create(:debate, tag_list: 'Medio Ambiente')
       debate3 = create(:debate, tag_list: 'Economía')

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Tags' do
+describe 'Tags' do
 
-  scenario 'Index' do
+  it 'Index' do
     create_featured_proposals
     earth = create(:proposal, tag_list: 'Medio Ambiente')
     money = create(:proposal, tag_list: 'Economía')
@@ -18,7 +18,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Index shows up to 5 tags per proposal' do
+  it 'Index shows up to 5 tags per proposal' do
     create_featured_proposals
     tag_list = ["Hacienda", "Economía", "Medio Ambiente", "Corrupción", "Fiestas populares", "Prensa"]
     create :proposal, tag_list: tag_list
@@ -30,7 +30,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Index featured proposals does not show tags' do
+  it 'Index featured proposals does not show tags' do
     featured_proposals = create_featured_proposals
     proposal = create(:proposal, tag_list: "123")
 
@@ -40,7 +40,7 @@ feature 'Tags' do
     expect(page).not_to have_selector('#featured-proposals')
   end
 
-  scenario 'Index shows 3 tags with no plus link' do
+  it 'Index shows 3 tags with no plus link' do
     create_featured_proposals
     tag_list = ["Medio Ambiente", "Corrupción", "Fiestas populares"]
     create :proposal, tag_list: tag_list
@@ -55,7 +55,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     proposal = create(:proposal, tag_list: 'Hacienda, Economía')
 
     visit proposal_path(proposal)
@@ -64,7 +64,7 @@ feature 'Tags' do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario 'Create with custom tags' do
+  it 'Create with custom tags' do
     user = create(:user)
     login_as(user)
 
@@ -87,7 +87,7 @@ feature 'Tags' do
     expect(page).to have_content 'Hacienda'
   end
 
-  scenario 'Category with category tags', :js do
+  it 'Category with category tags', :js do
     user = create(:user)
     login_as(user)
 
@@ -118,7 +118,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Create with too many tags' do
+  it 'Create with too many tags' do
     user = create(:user)
     login_as(user)
 
@@ -135,7 +135,7 @@ feature 'Tags' do
     expect(page).to have_content 'tags must be less than or equal to 6'
   end
 
-  scenario 'Create with dangerous strings' do
+  it 'Create with dangerous strings' do
     author = create(:user)
     login_as(author)
 
@@ -163,7 +163,7 @@ feature 'Tags' do
     expect(page.html).not_to include 'user_id=1, &a=3, <script>alert("hey");</script>'
   end
 
-  scenario 'Update' do
+  it 'Update' do
     proposal = create(:proposal, tag_list: 'Economía')
 
     login_as(proposal.author)
@@ -181,7 +181,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Delete' do
+  it 'Delete' do
     proposal = create(:proposal, tag_list: 'Economía')
 
     login_as(proposal.author)
@@ -196,7 +196,7 @@ feature 'Tags' do
 
   context "Filter" do
 
-    scenario "From index" do
+    it "From index" do
       create_featured_proposals
       proposal1 = create(:proposal, tag_list: 'Education')
       proposal2 = create(:proposal, tag_list: 'Health')
@@ -213,7 +213,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "From show" do
+    it "From show" do
       proposal1 = create(:proposal, tag_list: 'Education')
       proposal2 = create(:proposal, tag_list: 'Health')
 
@@ -231,7 +231,7 @@ feature 'Tags' do
 
   context 'Tag cloud' do
 
-    scenario 'Display user tags' do
+    it 'Display user tags' do
       earth = create(:proposal, tag_list: 'Medio Ambiente')
       money = create(:proposal, tag_list: 'Economía')
 
@@ -243,7 +243,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "Filter by user tags" do
+    it "Filter by user tags" do
       proposal1 = create(:proposal, tag_list: 'Medio Ambiente')
       proposal2 = create(:proposal, tag_list: 'Medio Ambiente')
       proposal3 = create(:proposal, tag_list: 'Economía')
@@ -264,7 +264,7 @@ feature 'Tags' do
 
   context "Categories" do
 
-    scenario 'Display category tags' do
+    it 'Display category tags' do
       create(:tag, :category, name: 'Medio Ambiente')
       create(:tag, :category, name: 'Economía')
 
@@ -279,7 +279,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "Filter by category tags" do
+    it "Filter by category tags" do
       create(:tag, :category, name: 'Medio Ambiente')
       create(:tag, :category, name: 'Economía')
 

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Tags' do
+describe 'Tags' do
 
-  scenario 'Index' do
+  it 'Index' do
     earth = create(:debate, tag_list: 'Medio Ambiente')
     money = create(:debate, tag_list: 'Economía')
 
@@ -17,7 +17,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Filtered' do
+  it 'Filtered' do
     debate1 = create(:debate, tag_list: 'Salud')
     debate2 = create(:debate, tag_list: 'salud')
     debate3 = create(:debate, tag_list: 'Hacienda')
@@ -45,7 +45,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Show' do
+  it 'Show' do
     debate = create(:debate, tag_list: 'Hacienda, Economía')
 
     visit debate_path(debate)
@@ -54,7 +54,7 @@ feature 'Tags' do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario 'Create' do
+  it 'Create' do
     user = create(:user)
     login_as(user)
 
@@ -73,7 +73,7 @@ feature 'Tags' do
     expect(page).to have_content 'Impuestos'
   end
 
-  scenario 'Create with too many tags' do
+  it 'Create with too many tags' do
     user = create(:user)
     login_as(user)
 
@@ -90,7 +90,7 @@ feature 'Tags' do
     expect(page).to have_content 'tags must be less than or equal to 6'
   end
 
-  scenario 'Update' do
+  it 'Update' do
     debate = create(:debate, tag_list: 'Economía')
 
     login_as(debate.author)
@@ -108,7 +108,7 @@ feature 'Tags' do
     end
   end
 
-  scenario 'Delete' do
+  it 'Delete' do
     debate = create(:debate, tag_list: 'Economía')
 
     login_as(debate.author)
@@ -123,7 +123,7 @@ feature 'Tags' do
 
   context 'Tag cloud' do
 
-    scenario 'Proposals' do
+    it 'Proposals' do
       earth = create(:proposal, tag_list: 'Medio Ambiente')
       money = create(:proposal, tag_list: 'Economía')
 
@@ -135,7 +135,7 @@ feature 'Tags' do
       end
     end
 
-    scenario 'Debates' do
+    it 'Debates' do
       earth = create(:debate, tag_list: 'Medio Ambiente')
       money = create(:debate, tag_list: 'Economía')
 
@@ -147,7 +147,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "scoped by category" do
+    it "scoped by category" do
       create(:tag, :category, name: 'Medio Ambiente')
       create(:tag, :category, name: 'Economía')
 
@@ -163,7 +163,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "scoped by district" do
+    it "scoped by district" do
       create(:geozone, name: 'Madrid')
       create(:geozone, name: 'Barcelona')
 
@@ -179,7 +179,7 @@ feature 'Tags' do
       end
     end
 
-    scenario "tag links" do
+    it "tag links" do
       proposal1 = create(:proposal, tag_list: 'Medio Ambiente')
       proposal2 = create(:proposal, tag_list: 'Medio Ambiente')
       proposal3 = create(:proposal, tag_list: 'Economía')

--- a/spec/features/topics_specs.rb
+++ b/spec/features/topics_specs.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Topics' do
+describe 'Topics' do
 
   context "Concerns" do
     it_behaves_like 'notifiable in-app', Topic
@@ -8,7 +8,7 @@ feature 'Topics' do
 
   context 'New' do
 
-    scenario 'Create new topic link should redirect to sign up for anonymous users', :js do
+    it 'Create new topic link should redirect to sign up for anonymous users', :js do
       proposal = create(:proposal)
       community = proposal.community
 
@@ -20,7 +20,7 @@ feature 'Topics' do
       expect(page).to have_current_path(new_user_session_path)
     end
 
-    scenario 'Can access to new topic page with user logged', :js do
+    it 'Can access to new topic page with user logged', :js do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -32,7 +32,7 @@ feature 'Topics' do
       expect(page).to have_content "Create a topic"
     end
 
-    scenario 'Should have content on new topic page', :js do
+    it 'has content on new topic page', :js do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -54,7 +54,7 @@ feature 'Topics' do
 
   context 'Create' do
 
-    scenario 'Can create a new topic', :js do
+    it 'Can create a new topic', :js do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -69,7 +69,7 @@ feature 'Topics' do
       expect(page).to have_current_path(community_path(community))
     end
 
-    scenario 'Can not create a new topic when user not logged', :js do
+    it 'Can not create a new topic when user not logged', :js do
       proposal = create(:proposal)
       community = proposal.community
 
@@ -82,7 +82,7 @@ feature 'Topics' do
 
   context 'Edit' do
 
-    scenario 'Can edit a topic' do
+    it 'Can edit a topic' do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -98,7 +98,7 @@ feature 'Topics' do
       expect(page).to have_current_path(community_path(community))
     end
 
-    scenario 'Can not edit a topic when user logged is not an author' do
+    it 'Can not edit a topic when user logged is not an author' do
       proposal = create(:proposal)
       community = proposal.community
       topic = create(:topic, community: community)
@@ -114,7 +114,7 @@ feature 'Topics' do
 
   context 'Show' do
 
-    scenario 'Can show topic' do
+    it 'Can show topic' do
       proposal = create(:proposal)
       community = proposal.community
       topic = create(:topic, community: community)
@@ -129,7 +129,7 @@ feature 'Topics' do
 
   context 'Destroy' do
 
-    scenario 'Can destroy a topic' do
+    it 'Can destroy a topic' do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -144,7 +144,7 @@ feature 'Topics' do
       expect(page).to have_current_path(community_path(community))
     end
 
-    scenario 'Can not destroy a topic when user logged is not an author' do
+    it 'Can not destroy a topic when user logged is not an author' do
       proposal = create(:proposal)
       community = proposal.community
       topic = create(:topic, community: community)

--- a/spec/features/tracks_spec.rb
+++ b/spec/features/tracks_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-feature 'Tracking' do
+describe 'Tracking' do
 
   context 'Custom variable' do
 
-     scenario 'Usertype anonymous' do
+     it 'Usertype anonymous' do
       visit proposals_path
 
       expect(page.html).to include "anonymous"
      end
 
-    scenario 'Usertype level_1_user' do
+    it 'Usertype level_1_user' do
       create(:geozone)
       user = create(:user)
       login_as(user)
@@ -20,7 +20,7 @@ feature 'Tracking' do
       expect(page.html).to include "level_1_user"
     end
 
-    scenario 'Usertype level_2_user' do
+    it 'Usertype level_2_user' do
       create(:geozone)
       user = create(:user)
       login_as(user)
@@ -42,7 +42,7 @@ feature 'Tracking' do
   end
 
   context 'Tracking events' do
-    scenario 'Verification: start census' do
+    it 'Verification: start census' do
       user = create(:user)
       login_as(user)
 
@@ -53,7 +53,7 @@ feature 'Tracking' do
       expect(page.html).to include "data-track-event-action=start_census"
     end
 
-    scenario 'Verification: success census & start sms' do
+    it 'Verification: success census & start sms' do
       create(:geozone)
       user = create(:user)
       login_as(user)
@@ -70,7 +70,7 @@ feature 'Tracking' do
       expect(page.html).to include "data-track-event-action=start_sms"
     end
 
-    scenario 'Verification: success sms' do
+    it 'Verification: success sms' do
       create(:geozone)
       user = create(:user)
       login_as(user)
@@ -91,7 +91,7 @@ feature 'Tracking' do
       expect(page.html).to include "data-track-event-action=success_sms"
     end
 
-    scenario 'Verification: letter' do
+    it 'Verification: letter' do
       create(:geozone)
       user = create(:user)
       login_as(user)

--- a/spec/features/user_invites_spec.rb
+++ b/spec/features/user_invites_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-feature 'User invites' do
+describe 'User invites' do
 
-  background do
+  before do
     login_as_manager
   end
 
-  scenario "Send invitations" do
+  it "Send invitations" do
     visit new_management_user_invite_path
 
     fill_in "emails", with: "john@example.com, ana@example.com, isable@example.com"

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-feature 'Users' do
+describe 'Users' do
 
   context 'Regular authentication' do
     context 'Sign up' do
 
-      scenario 'Success' do
+      it 'Success' do
         message = "You have been sent a message containing a verification link. Please click on this link to activate your account."
         visit '/'
         click_link 'Register'
@@ -25,7 +25,7 @@ feature 'Users' do
         expect(page).to have_content "Your account has been confirmed."
       end
 
-      scenario 'Errors on sign up' do
+      it 'Errors on sign up' do
         visit '/'
         click_link 'Register'
         click_button 'Register'
@@ -37,7 +37,7 @@ feature 'Users' do
 
     context 'Sign in' do
 
-      scenario 'sign in with email' do
+      it 'sign in with email' do
         create(:user, email: 'manuela@consul.dev', password: 'judgementday')
 
         visit '/'
@@ -49,7 +49,7 @@ feature 'Users' do
         expect(page).to have_content 'You have been signed in successfully.'
       end
 
-      scenario 'Sign in with username' do
+      it 'Sign in with username' do
         create(:user, username: '👻👽👾🤖', email: 'ash@nostromo.dev', password: 'xenomorph')
 
         visit '/'
@@ -61,7 +61,7 @@ feature 'Users' do
         expect(page).to have_content 'You have been signed in successfully.'
       end
 
-      scenario 'Avoid username-email collisions' do
+      it 'Avoid username-email collisions' do
         u1 = create(:user, username: 'Spidey', email: 'peter@nyc.dev', password: 'greatpower')
         u2 = create(:user, username: 'peter@nyc.dev', email: 'venom@nyc.dev', password: 'symbiote')
 
@@ -120,7 +120,7 @@ feature 'Users' do
         }
       end
 
-      scenario 'Sign up when Oauth provider has a verified email' do
+      it 'Sign up when Oauth provider has a verified email' do
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_verified_email)
 
         visit '/'
@@ -137,7 +137,7 @@ feature 'Users' do
         expect(page).to have_field('user_email', with: 'manuelacarmena@example.com')
       end
 
-      scenario 'Sign up when Oauth provider has an unverified email' do
+      it 'Sign up when Oauth provider has an unverified email' do
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_email)
 
         visit '/'
@@ -163,7 +163,7 @@ feature 'Users' do
         expect(page).to have_field('user_email', with: 'manuelacarmena@example.com')
       end
 
-      scenario 'Sign up, when no email was provided by OAuth provider' do
+      it 'Sign up, when no email was provided by OAuth provider' do
         OmniAuth.config.add_mock(:twitter, twitter_hash)
 
         visit '/'
@@ -191,7 +191,7 @@ feature 'Users' do
         expect(page).to have_field('user_email', with: 'manueladelascarmenas@example.com')
       end
 
-      scenario 'Cancelling signup' do
+      it 'Cancelling signup' do
         OmniAuth.config.add_mock(:twitter, twitter_hash)
 
         visit '/'
@@ -205,7 +205,7 @@ feature 'Users' do
         expect_to_not_be_signed_in
       end
 
-      scenario 'Sign in, user was already signed up with OAuth' do
+      it 'Sign in, user was already signed up with OAuth' do
         user = create(:user, email: 'manuela@consul.dev', password: 'judgementday')
         create(:identity, uid: '12345', provider: 'twitter', user: user)
         OmniAuth.config.add_mock(:twitter, twitter_hash)
@@ -224,7 +224,7 @@ feature 'Users' do
 
       end
 
-      scenario 'Try to register with the username of an already existing user' do
+      it 'Try to register with the username of an already existing user' do
         create(:user, username: 'manuela', email: 'manuela@consul.dev', password: 'judgementday')
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_verified_email)
 
@@ -252,7 +252,7 @@ feature 'Users' do
         expect(page).to have_field('user_email', with: 'manuelacarmena@example.com')
       end
 
-      scenario 'Try to register with the email of an already existing user, when no email was provided by oauth' do
+      it 'Try to register with the email of an already existing user, when no email was provided by oauth' do
         create(:user, username: 'peter', email: 'manuela@example.com')
         OmniAuth.config.add_mock(:twitter, twitter_hash)
 
@@ -287,7 +287,7 @@ feature 'Users' do
         expect(page).to have_field('user_email', with: 'somethingelse@example.com')
       end
 
-      scenario 'Try to register with the email of an already existing user, when an unconfirmed email was provided by oauth' do
+      it 'Try to register with the email of an already existing user, when an unconfirmed email was provided by oauth' do
         create(:user, username: 'peter', email: 'manuelacarmena@example.com')
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_email)
 
@@ -320,7 +320,7 @@ feature 'Users' do
     end
   end
 
-  scenario 'Sign out' do
+  it 'Sign out' do
     user = create(:user)
     login_as(user)
 
@@ -330,7 +330,7 @@ feature 'Users' do
     expect(page).to have_content 'You have been signed out successfully.'
   end
 
-  scenario 'Reset password' do
+  it 'Reset password' do
     create(:user, email: 'manuela@consul.dev')
 
     visit '/'
@@ -352,7 +352,7 @@ feature 'Users' do
     expect(page).to have_content "Your password has been changed successfully."
   end
 
-  scenario 'Sign in, admin with password expired' do
+  it 'Sign in, admin with password expired' do
     user = create(:user, password_changed_at: Time.current - 1.year)
     admin = create(:administrator, user: user)
 
@@ -370,7 +370,7 @@ feature 'Users' do
     expect(page).to have_content "Password successfully updated"
   end
 
-  scenario 'Sign in, admin without password expired' do
+  it 'Sign in, admin without password expired' do
     user = create(:user, password_changed_at: Time.current - 360.days)
     admin = create(:administrator, user: user)
 
@@ -380,7 +380,7 @@ feature 'Users' do
     expect(page).not_to have_content "Your password is expired"
   end
 
-  scenario 'Sign in, user with password expired' do
+  it 'Sign in, user with password expired' do
     user = create(:user, password_changed_at: Time.current - 1.year)
 
     login_as(user)
@@ -389,7 +389,7 @@ feature 'Users' do
     expect(page).not_to have_content "Your password is expired"
   end
 
-  scenario 'Admin with password expired trying to use same password' do
+  it 'Admin with password expired trying to use same password' do
     user = create(:user, password_changed_at: Time.current - 1.year, password: '123456789')
     admin = create(:administrator, user: user)
 

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-feature 'Users' do
+describe 'Users' do
 
-  feature 'Show (public page)' do
+  describe 'Show (public page)' do
 
-    background do
+    before do
       @user = create(:user)
       1.times {create(:debate, author: @user)}
       2.times {create(:proposal, author: @user)}
@@ -14,14 +14,14 @@ feature 'Users' do
       visit user_path(@user)
     end
 
-    scenario 'shows user public activity' do
+    it 'shows user public activity' do
       expect(page).to have_content('1 Debate')
       expect(page).to have_content('2 Proposals')
       expect(page).to have_content('3 Investments')
       expect(page).to have_content('4 Comments')
     end
 
-    scenario 'shows only items where user has activity' do
+    it 'shows only items where user has activity' do
       @user.proposals.destroy_all
 
       expect(page).not_to have_content('0 Proposals')
@@ -30,7 +30,7 @@ feature 'Users' do
       expect(page).to have_content('4 Comments')
     end
 
-    scenario 'default filter is proposals' do
+    it 'default filter is proposals' do
       @user.proposals.each do |proposal|
         expect(page).to have_content(proposal.title)
       end
@@ -44,14 +44,14 @@ feature 'Users' do
       end
     end
 
-    scenario 'shows debates by default if user has no proposals' do
+    it 'shows debates by default if user has no proposals' do
       @user.proposals.destroy_all
       visit user_path(@user)
 
       expect(page).to have_content(@user.debates.first.title)
     end
 
-    scenario 'shows investments by default if user has no proposals nor debates' do
+    it 'shows investments by default if user has no proposals nor debates' do
       @user.proposals.destroy_all
       @user.debates.destroy_all
       visit user_path(@user)
@@ -59,7 +59,7 @@ feature 'Users' do
       expect(page).to have_content(@user.budget_investments.first.title)
     end
 
-    scenario 'shows comments by default if user has no proposals nor debates nor investments' do
+    it 'shows comments by default if user has no proposals nor debates nor investments' do
       @user.proposals.destroy_all
       @user.debates.destroy_all
       @user.budget_investments.destroy_all
@@ -70,7 +70,7 @@ feature 'Users' do
       end
     end
 
-    scenario 'filters' do
+    it 'filters' do
       click_link '1 Debate'
 
       @user.debates.each do |debate|
@@ -116,19 +116,19 @@ feature 'Users' do
 
   end
 
-  feature 'Public activity' do
-    background do
+  describe 'Public activity' do
+    before do
       @user = create(:user)
     end
 
-    scenario 'visible by default' do
+    it 'visible by default' do
       visit user_path(@user)
 
       expect(page).to have_content(@user.username)
       expect(page).not_to have_content('activity list private')
     end
 
-    scenario 'user can hide public page' do
+    it 'user can hide public page' do
       login_as(@user)
       visit account_path
 
@@ -141,7 +141,7 @@ feature 'Users' do
       expect(page).to have_content('activity list private')
     end
 
-    scenario 'is always visible for the owner' do
+    it 'is always visible for the owner' do
       login_as(@user)
       visit account_path
 
@@ -152,7 +152,7 @@ feature 'Users' do
       expect(page).not_to have_content('activity list private')
     end
 
-    scenario 'is always visible for admins' do
+    it 'is always visible for admins' do
       login_as(@user)
       visit account_path
 
@@ -166,7 +166,7 @@ feature 'Users' do
       expect(page).not_to have_content('activity list private')
     end
 
-    scenario 'is always visible for moderators' do
+    it 'is always visible for moderators' do
       login_as(@user)
       visit account_path
 
@@ -180,30 +180,30 @@ feature 'Users' do
       expect(page).not_to have_content('activity list private')
     end
 
-    feature 'User email' do
+    describe 'User email' do
 
-      background do
+      before do
         @user = create(:user)
       end
 
-      scenario 'is not shown if no user logged in' do
+      it 'is not shown if no user logged in' do
         visit user_path(@user)
         expect(page).not_to have_content(@user.email)
       end
 
-      scenario 'is not shown if logged in user is a regular user' do
+      it 'is not shown if logged in user is a regular user' do
         login_as(create(:user))
         visit user_path(@user)
         expect(page).not_to have_content(@user.email)
       end
 
-      scenario 'is not shown if logged in user is moderator' do
+      it 'is not shown if logged in user is moderator' do
         login_as(create(:moderator).user)
         visit user_path(@user)
         expect(page).not_to have_content(@user.email)
       end
 
-      scenario 'is shown if logged in user is admin' do
+      it 'is shown if logged in user is admin' do
         login_as(create(:administrator).user)
         visit user_path(@user)
         expect(page).to have_content(@user.email)
@@ -213,12 +213,12 @@ feature 'Users' do
 
   end
 
-  feature 'Public interests' do
-    background do
+  describe 'Public interests' do
+    before do
       @user = create(:user)
     end
 
-    scenario 'Display interests' do
+    it 'Display interests' do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, :followed_proposal, followable: proposal, user: @user)
 
@@ -234,7 +234,7 @@ feature 'Users' do
       expect(page).to have_content("Sport")
     end
 
-    scenario 'Not display interests when proposal has been destroyed' do
+    it 'Not display interests when proposal has been destroyed' do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, :followed_proposal, followable: proposal, user: @user)
       proposal.destroy
@@ -251,14 +251,14 @@ feature 'Users' do
       expect(page).not_to have_content("Sport")
     end
 
-    scenario 'No visible by default' do
+    it 'No visible by default' do
       visit user_path(@user)
 
       expect(page).to have_content(@user.username)
       expect(page).not_to have_css('#public_interests')
     end
 
-    scenario 'User can display public page' do
+    it 'User can display public page' do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, :followed_proposal, followable: proposal, user: @user)
 
@@ -275,7 +275,7 @@ feature 'Users' do
       expect(page).to have_css('#public_interests')
     end
 
-    scenario 'Is always visible for the owner' do
+    it 'Is always visible for the owner' do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, :followed_proposal, followable: proposal, user: @user)
 
@@ -289,7 +289,7 @@ feature 'Users' do
       expect(page).to have_css('#public_interests')
     end
 
-    scenario 'Is always visible for admins' do
+    it 'Is always visible for admins' do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, :followed_proposal, followable: proposal, user: @user)
 
@@ -306,7 +306,7 @@ feature 'Users' do
       expect(page).to have_css('#public_interests')
     end
 
-    scenario 'Is always visible for moderators' do
+    it 'Is always visible for moderators' do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, :followed_proposal, followable: proposal, user: @user)
 
@@ -323,7 +323,7 @@ feature 'Users' do
       expect(page).to have_css('#public_interests')
     end
 
-    scenario 'Should display generic interests title' do
+    it 'displays generic interests title' do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, :followed_proposal, followable: proposal, user: @user)
 
@@ -333,7 +333,7 @@ feature 'Users' do
       expect(page).to have_content("Tags of elements this user follows")
     end
 
-    scenario 'Should display custom interests title when user is visiting own user page' do
+    it 'displays custom interests title when user is visiting own user page' do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, :followed_proposal, followable: proposal, user: @user)
 
@@ -345,9 +345,9 @@ feature 'Users' do
     end
   end
 
-  feature 'Special comments' do
+  describe 'Special comments' do
 
-    scenario 'comments posted as moderator are not visible in user activity' do
+    it 'comments posted as moderator are not visible in user activity' do
       moderator = create(:administrator).user
       comment = create(:comment, user: moderator)
       moderator_comment = create(:comment, user: moderator, moderator_id: moderator.id)
@@ -358,7 +358,7 @@ feature 'Users' do
       expect(page).not_to have_content(moderator_comment.body)
     end
 
-    scenario 'comments posted as admin are not visible in user activity' do
+    it 'comments posted as admin are not visible in user activity' do
       admin = create(:administrator).user
       comment = create(:comment, user: admin)
       admin_comment = create(:comment, user: admin, administrator_id: admin.id)
@@ -368,7 +368,7 @@ feature 'Users' do
       expect(page).not_to have_content(admin_comment.body)
     end
 
-    scenario 'valuation comments are not visible in user activity' do
+    it 'valuation comments are not visible in user activity' do
       admin = create(:administrator).user
       comment = create(:comment, user: admin)
       investment = create(:budget_investment)
@@ -379,7 +379,7 @@ feature 'Users' do
       expect(page).not_to have_content(valuation_comment.body)
     end
 
-    scenario 'shows only comments from active features' do
+    it 'shows only comments from active features' do
       user = create(:user)
       1.times {create(:comment, user: user, commentable: create(:debate))}
       2.times {create(:comment, user: user, commentable: create(:budget_investment))}
@@ -401,19 +401,19 @@ feature 'Users' do
     end
   end
 
-  feature 'Following (public page)' do
+  describe 'Following (public page)' do
 
     before do
       @user = create(:user)
     end
 
-    scenario 'Not display following tab when user is not following any followable' do
+    it 'Not display following tab when user is not following any followable' do
       visit user_path(@user)
 
       expect(page).not_to have_content('0 Following')
     end
 
-    scenario 'Active following tab by default when follows filters selected', :js do
+    it 'Active following tab by default when follows filters selected', :js do
       proposal = create(:proposal, author: @user)
       create(:follow, followable: proposal, user: @user)
 
@@ -424,7 +424,7 @@ feature 'Users' do
 
     describe 'Proposals' do
 
-      scenario 'Display following tab when user is following one proposal at least' do
+      it 'Display following tab when user is following one proposal at least' do
         proposal = create(:proposal)
         create(:follow, followable: proposal, user: @user)
 
@@ -433,7 +433,7 @@ feature 'Users' do
         expect(page).to have_content('1 Following')
       end
 
-      scenario 'Display proposal tab when user is following one proposal at least' do
+      it 'Display proposal tab when user is following one proposal at least' do
         proposal = create(:proposal)
         create(:follow, followable: proposal, user: @user)
 
@@ -442,13 +442,13 @@ feature 'Users' do
         expect(page).to have_link('Citizen proposals', href: "#citizen_proposals")
       end
 
-      scenario 'Not display proposal tab when user is not following any proposal' do
+      it 'Not display proposal tab when user is not following any proposal' do
         visit user_path(@user, filter: "follows")
 
         expect(page).not_to have_link('Citizen proposals', href: "#citizen_proposals")
       end
 
-      scenario 'Display proposals with link to proposal' do
+      it 'Display proposals with link to proposal' do
         proposal = create(:proposal, author: @user)
         create(:follow, followable: proposal, user: @user)
         login_as @user
@@ -462,7 +462,7 @@ feature 'Users' do
 
     describe 'Budget Investments' do
 
-      scenario 'Display following tab when user is following one budget investment at least' do
+      it 'Display following tab when user is following one budget investment at least' do
         budget_investment = create(:budget_investment)
         create(:follow, followable: budget_investment, user: @user)
 
@@ -471,7 +471,7 @@ feature 'Users' do
         expect(page).to have_content('1 Following')
       end
 
-      scenario 'Display budget investment tab when user is following one budget investment at least' do
+      it 'Display budget investment tab when user is following one budget investment at least' do
         budget_investment = create(:budget_investment)
         create(:follow, followable: budget_investment, user: @user)
 
@@ -480,13 +480,13 @@ feature 'Users' do
         expect(page).to have_link('Investments', href: "#investments")
       end
 
-      scenario 'Not display budget investment tab when user is not following any budget investment' do
+      it 'Not display budget investment tab when user is not following any budget investment' do
         visit user_path(@user, filter: "follows")
 
         expect(page).not_to have_link('Investments', href: "#investments")
       end
 
-      scenario 'Display budget investment with link to budget investment' do
+      it 'Display budget investment with link to budget investment' do
         user = create(:user, :level_two)
         budget_investment = create(:budget_investment, author: user)
         create(:follow, followable: budget_investment, user: user)

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -1,26 +1,26 @@
 require 'rails_helper'
 
-feature 'Valuation budget investments' do
+describe 'Valuation budget investments' do
 
-  background do
+  before do
     @valuator = create(:valuator, user: create(:user, username: 'Rachel', email: 'rachel@valuators.org'))
     login_as(@valuator.user)
     @budget = create(:budget, :valuating)
   end
 
-  scenario 'Disabled with a feature flag' do
+  it 'Disabled with a feature flag' do
     Setting['feature.budgets'] = nil
     expect{ visit valuation_budget_budget_investments_path(create(:budget)) }.to raise_exception(FeatureFlags::FeatureDisabled)
 
     Setting['feature.budgets'] = true
   end
 
-  scenario 'Display link to valuation section' do
+  it 'Display link to valuation section' do
     visit root_path
     expect(page).to have_link "Valuation", href: valuation_root_path
   end
 
-  scenario 'Index shows budget investments assigned to current valuator' do
+  it 'Index shows budget investments assigned to current valuator' do
     investment1 = create(:budget_investment, budget: @budget)
     investment2 = create(:budget_investment, budget: @budget)
 
@@ -32,7 +32,7 @@ feature 'Valuation budget investments' do
     expect(page).not_to have_content(investment2.title)
   end
 
-  scenario 'Index shows no budget investment to admins no valuators' do
+  it 'Index shows no budget investment to admins no valuators' do
     investment1 = create(:budget_investment, budget: @budget)
     investment2 = create(:budget_investment, budget: @budget)
 
@@ -46,7 +46,7 @@ feature 'Valuation budget investments' do
     expect(page).not_to have_content(investment2.title)
   end
 
-  scenario 'Index orders budget investments by votes' do
+  it 'Index orders budget investments by votes' do
     investment10  = create(:budget_investment, budget: @budget, cached_votes_up: 10)
     investment100 = create(:budget_investment, budget: @budget, cached_votes_up: 100)
     investment1   = create(:budget_investment, budget: @budget, cached_votes_up: 1)
@@ -61,7 +61,7 @@ feature 'Valuation budget investments' do
     expect(investment10.title).to appear_before(investment1.title)
   end
 
-  scenario "Index filtering by heading", :js do
+  it "Index filtering by heading", :js do
     group = create(:budget_group, budget: @budget)
     heading1 = create(:budget_heading, name: "District 9", group: group)
     heading2 = create(:budget_heading, name: "Down to the river", group: group)
@@ -94,7 +94,7 @@ feature 'Valuation budget investments' do
     expect(page).to have_link("Destroy the city")
   end
 
-  scenario "Current filter is properly highlighted" do
+  it "Current filter is properly highlighted" do
     filters_links = {'valuating' => 'Under valuation',
                      'valuation_finished' => 'Valuation finished'}
 
@@ -114,7 +114,7 @@ feature 'Valuation budget investments' do
     end
   end
 
-  scenario "Index filtering by valuation status" do
+  it "Index filtering by valuation status" do
     valuating = create(:budget_investment, budget: @budget, title: "Ongoing valuation")
     valuated  = create(:budget_investment, budget: @budget, title: "Old idea", valuation_finished: true)
     valuating.valuators << @valuator
@@ -136,8 +136,8 @@ feature 'Valuation budget investments' do
     expect(page).to have_content("Old idea")
   end
 
-  feature 'Show' do
-    scenario 'visible for assigned valuators' do
+  describe 'Show' do
+    it 'visible for assigned valuators' do
       administrator = create(:administrator, user: create(:user, username: 'Ana', email: 'ana@admins.org'))
       valuator2 = create(:valuator, user: create(:user, username: 'Rick', email: 'rick@valuators.org'))
       investment = create(:budget_investment,
@@ -167,7 +167,7 @@ feature 'Valuation budget investments' do
       end
     end
 
-    scenario 'visible for admins' do
+    it 'visible for admins' do
       logout
       login_as create(:administrator).user
 
@@ -198,7 +198,7 @@ feature 'Valuation budget investments' do
       end
     end
 
-    scenario 'not visible for not assigned valuators' do
+    it 'not visible for not assigned valuators' do
       logout
       login_as create(:valuator).user
 
@@ -216,8 +216,8 @@ feature 'Valuation budget investments' do
 
   end
 
-  feature 'Valuate' do
-    background do
+  describe 'Valuate' do
+    before do
       @investment = create(:budget_investment,
                             budget: @budget,
                             price: nil,
@@ -225,7 +225,7 @@ feature 'Valuation budget investments' do
       @investment.valuators << @valuator
     end
 
-    scenario 'Dossier empty by default' do
+    it 'Dossier empty by default' do
       visit valuation_budget_budget_investments_path(@budget)
       click_link @investment.title
 
@@ -236,7 +236,7 @@ feature 'Valuation budget investments' do
       expect(page).not_to have_content('Valuation finished')
     end
 
-    scenario 'Edit dossier' do
+    it 'Edit dossier' do
       visit valuation_budget_budget_investments_path(@budget)
       within("#budget_investment_#{@investment.id}") do
         click_link "Edit dossier"
@@ -262,7 +262,7 @@ feature 'Valuation budget investments' do
       expect(page).not_to have_content('Valuation finished')
     end
 
-    scenario 'Feasibility can be marked as pending' do
+    it 'Feasibility can be marked as pending' do
       visit valuation_budget_budget_investment_path(@budget, @investment)
       click_link 'Edit dossier'
 
@@ -282,7 +282,7 @@ feature 'Valuation budget investments' do
       expect(find("#budget_investment_feasibility_undecided")).to be_checked
     end
 
-    scenario 'Feasibility selection makes proper fields visible', :js do
+    it 'Feasibility selection makes proper fields visible', :js do
       feasible_fields = ['Price (€)', 'Cost during the first year (€)', 'Price explanation', 'Time scope']
       unfeasible_fields = ['Feasibility explanation']
       any_feasibility_fields = ['Valuation finished']
@@ -336,7 +336,7 @@ feature 'Valuation budget investments' do
       end
     end
 
-    scenario 'Finish valuation' do
+    it 'Finish valuation' do
       visit valuation_budget_budget_investment_path(@budget, @investment)
       click_link 'Edit dossier'
 
@@ -352,7 +352,7 @@ feature 'Valuation budget investments' do
       expect(page).to have_content('Valuation finished')
     end
 
-    scenario 'Validates price formats' do
+    it 'Validates price formats' do
       visit valuation_budget_budget_investments_path(@budget)
       within("#budget_investment_#{@investment.id}") do
         click_link "Edit dossier"

--- a/spec/features/valuation/budgets_spec.rb
+++ b/spec/features/valuation/budgets_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'Valuation budgets' do
+describe 'Valuation budgets' do
 
-  background do
+  before do
     @valuator = create(:valuator, user: create(:user, username: 'Rachel', email: 'rachel@valuators.org'))
     login_as(@valuator.user)
   end
 
-  scenario 'Disabled with a feature flag' do
+  it 'Disabled with a feature flag' do
     Setting['feature.budgets'] = nil
     expect{ visit valuation_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
 
@@ -16,14 +16,14 @@ feature 'Valuation budgets' do
 
   context 'Index' do
 
-    scenario 'Displaying budgets' do
+    it 'Displaying budgets' do
       budget = create(:budget)
       visit valuation_budgets_path
 
       expect(page).to have_content(budget.name)
     end
 
-    scenario 'Filters by phase' do
+    it 'Filters by phase' do
       budget1 = create(:budget, :finished)
       budget2 = create(:budget, :finished)
       budget3 = create(:budget, :accepting)

--- a/spec/features/valuation_spec.rb
+++ b/spec/features/valuation_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-feature 'Valuation' do
+describe 'Valuation' do
   let(:user) { create(:user) }
 
   context 'Access' do
-    scenario 'Access as regular user is not authorized' do
+    it 'Access as regular user is not authorized' do
       login_as(user)
       visit root_path
 
@@ -16,7 +16,7 @@ feature 'Valuation' do
       expect(page).to have_content "You do not have permission to access this page"
     end
 
-    scenario 'Access as moderator is not authorized' do
+    it 'Access as moderator is not authorized' do
       create(:moderator, user: user)
       login_as(user)
       visit root_path
@@ -29,7 +29,7 @@ feature 'Valuation' do
       expect(page).to have_content "You do not have permission to access this page"
     end
 
-    scenario 'Access as manager is not authorized' do
+    it 'Access as manager is not authorized' do
       create(:manager, user: user)
       login_as(user)
       visit root_path
@@ -42,7 +42,7 @@ feature 'Valuation' do
       expect(page).to have_content "You do not have permission to access this page"
     end
 
-    scenario 'Access as poll officer is not authorized' do
+    it 'Access as poll officer is not authorized' do
       create(:poll_officer, user: user)
       login_as(user)
       visit root_path
@@ -55,7 +55,7 @@ feature 'Valuation' do
       expect(page).to have_content "You do not have permission to access this page"
     end
 
-    scenario 'Access as a valuator is authorized' do
+    it 'Access as a valuator is authorized' do
       create(:valuator, user: user)
       create(:budget)
 
@@ -69,7 +69,7 @@ feature 'Valuation' do
       expect(page).not_to have_content "You do not have permission to access this page"
     end
 
-    scenario 'Access as an administrator is authorized' do
+    it 'Access as an administrator is authorized' do
       create(:administrator, user: user)
       create(:budget)
 
@@ -84,7 +84,7 @@ feature 'Valuation' do
     end
   end
 
-  scenario 'Valuation access links' do
+  it 'Valuation access links' do
     create(:valuator, user: user)
     create(:budget)
 
@@ -96,7 +96,7 @@ feature 'Valuation' do
     expect(page).not_to have_link('Moderation')
   end
 
-  scenario 'Valuation dashboard' do
+  it 'Valuation dashboard' do
     create(:valuator, user: user)
     create(:budget)
 

--- a/spec/features/verification/email_spec.rb
+++ b/spec/features/verification/email_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Verify email' do
+describe 'Verify email' do
 
-  scenario 'Verify' do
+  it 'Verify' do
     user = create(:user,
                   residence_verified_at: Time.current,
                   document_number:       '12345678Z',
@@ -33,7 +33,7 @@ feature 'Verify email' do
     expect(page).to have_content "Account verified"
   end
 
-  scenario "Errors on token verification" do
+  it "Errors on token verification" do
     user = create(:user, residence_verified_at: Time.current)
 
     login_as(user)
@@ -42,7 +42,7 @@ feature 'Verify email' do
     expect(page).to have_content "Verification code incorrect"
   end
 
-  scenario "Errors on sending confirmation email" do
+  it "Errors on sending confirmation email" do
     user = create(:user,
                   residence_verified_at: Time.current,
                   document_number:       '12345678Z',

--- a/spec/features/verification/letter_spec.rb
+++ b/spec/features/verification/letter_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Verify Letter' do
+describe 'Verify Letter' do
 
-  scenario 'Request a letter' do
+  it 'Request a letter' do
     user = create(:user, residence_verified_at: Time.current,
                          confirmed_phone:       "611111111")
 
@@ -20,7 +20,7 @@ feature 'Verify Letter' do
     expect(user.letter_verification_code).to be
   end
 
-  scenario 'Go to office instead of send letter' do
+  it 'Go to office instead of send letter' do
     Setting["verification_offices_url"] = "http://offices.consul"
     user = create(:user, residence_verified_at: Time.current,
                          confirmed_phone:       "611111111")
@@ -31,7 +31,7 @@ feature 'Verify Letter' do
     expect(page).to have_link "Citizen Support Offices", href: "http://offices.consul"
   end
 
-  scenario "Deny access unless verified residence" do
+  it "Deny access unless verified residence" do
     user = create(:user)
 
     login_as(user)
@@ -41,7 +41,7 @@ feature 'Verify Letter' do
     expect(page).to have_current_path(new_residence_path)
   end
 
-  scenario "Deny access unless verified phone/email" do
+  it "Deny access unless verified phone/email" do
     user = create(:user, residence_verified_at: Time.current)
 
     login_as(user)
@@ -53,7 +53,7 @@ feature 'Verify Letter' do
 
   context "Code verification" do
 
-    scenario "Valid verification user logged in" do
+    it "Valid verification user logged in" do
       user = create(:user, residence_verified_at: Time.current,
                            confirmed_phone:       "611111111",
                            letter_verification_code: "123456")
@@ -70,7 +70,7 @@ feature 'Verify Letter' do
       expect(page).to have_current_path(account_path)
     end
 
-    scenario "Valid verification of user failing to add trailing zeros" do
+    it "Valid verification of user failing to add trailing zeros" do
       user = create(:user, residence_verified_at: Time.current,
                            confirmed_phone:       "611111111",
                            letter_verification_code: "012345")
@@ -87,7 +87,7 @@ feature 'Verify Letter' do
       expect(page).to have_current_path(account_path)
     end
 
-    scenario "Valid verification user not logged in" do
+    it "Valid verification user not logged in" do
       user = create(:user, residence_verified_at: Time.current,
                            confirmed_phone:       "611111111",
                            letter_verification_code: "123456")
@@ -103,7 +103,7 @@ feature 'Verify Letter' do
       expect(page).to have_current_path(account_path)
     end
 
-    scenario "Error messages on authentication" do
+    it "Error messages on authentication" do
       visit edit_letter_path
 
       click_button "Verify my account"
@@ -111,7 +111,7 @@ feature 'Verify Letter' do
       expect(page).to have_content "Invalid email or password."
     end
 
-    scenario "Error messages on verification" do
+    it "Error messages on verification" do
       user = create(:user, residence_verified_at: Time.current,
                            confirmed_phone:       "611111111")
 
@@ -123,7 +123,7 @@ feature 'Verify Letter' do
       expect(page).to have_content "can't be blank"
     end
 
-    scenario '6 tries allowed' do
+    it '6 tries allowed' do
       user = create(:user, residence_verified_at:    Time.current,
                            confirmed_phone:          "611111111",
                            letter_verification_code: "123456")

--- a/spec/features/verification/level_three_verification_spec.rb
+++ b/spec/features/verification/level_three_verification_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature 'Level three verification' do
-  scenario 'Verification with residency and verified sms' do
+describe 'Level three verification' do
+  it 'Verification with residency and verified sms' do
     create(:geozone)
     user = create(:user)
 
@@ -33,7 +33,7 @@ feature 'Level three verification' do
     expect(page).to have_content "Account verified"
   end
 
-  scenario 'Verification with residency and verified email' do
+  it 'Verification with residency and verified email' do
     create(:geozone)
     user = create(:user)
 
@@ -64,7 +64,7 @@ feature 'Level three verification' do
     expect(page).to have_content "Account verified"
   end
 
-  scenario 'Verification with residency and sms and letter' do
+  it 'Verification with residency and sms and letter' do
     create(:geozone)
     user = create(:user)
     login_as(user)

--- a/spec/features/verification/level_two_verification_spec.rb
+++ b/spec/features/verification/level_two_verification_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Level two verification' do
+describe 'Level two verification' do
 
-  scenario 'Verification with residency and sms' do
+  it 'Verification with residency and sms' do
     create(:geozone)
     user = create(:user)
     login_as(user)

--- a/spec/features/verification/residence_spec.rb
+++ b/spec/features/verification/residence_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-feature 'Residence' do
+describe 'Residence' do
 
-  background { create(:geozone) }
+  before { create(:geozone) }
 
-  scenario 'Verify resident' do
+  it 'Verify resident' do
     user = create(:user)
     login_as(user)
 
@@ -22,7 +22,7 @@ feature 'Residence' do
     expect(page).to have_content 'Residence verified'
   end
 
-  scenario 'When trying to verify a deregistered account old votes are reassigned' do
+  it 'When trying to verify a deregistered account old votes are reassigned' do
     erased_user = create(:user, document_number: '12345678Z', document_type: '1', erased_at: Time.current)
     vote = create(:vote, voter: erased_user)
     new_user = create(:user)
@@ -47,7 +47,7 @@ feature 'Residence' do
     expect(new_user.reload.document_number).to eq('12345678Z')
   end
 
-  scenario 'Error on verify' do
+  it 'Error on verify' do
     user = create(:user)
     login_as(user)
 
@@ -59,7 +59,7 @@ feature 'Residence' do
     expect(page).to have_content(/\d errors? prevented the verification of your residence/)
   end
 
-  scenario 'Error on postal code not in census' do
+  it 'Error on postal code not in census' do
     user = create(:user)
     login_as(user)
 
@@ -79,7 +79,7 @@ feature 'Residence' do
     expect(page).to have_content 'In order to be verified, you must be registered'
   end
 
-  scenario 'Error on census' do
+  it 'Error on census' do
     user = create(:user)
     login_as(user)
 
@@ -99,7 +99,7 @@ feature 'Residence' do
     expect(page).to have_content 'The Census was unable to verify your information'
   end
 
-  scenario '5 tries allowed' do
+  it '5 tries allowed' do
     user = create(:user)
     login_as(user)
 

--- a/spec/features/verification/sms_spec.rb
+++ b/spec/features/verification/sms_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'SMS Verification' do
+describe 'SMS Verification' do
 
-  scenario 'Verify' do
+  it 'Verify' do
     user = create(:user, residence_verified_at: Time.current)
     login_as(user)
 
@@ -20,7 +20,7 @@ feature 'SMS Verification' do
     expect(page).to have_content 'Code correct'
   end
 
-  scenario 'Errors on phone number' do
+  it 'Errors on phone number' do
     user = create(:user, residence_verified_at: Time.current)
     login_as(user)
 
@@ -31,7 +31,7 @@ feature 'SMS Verification' do
     expect(page).to have_content error_message("phone")
   end
 
-  scenario 'Errors on verification code' do
+  it 'Errors on verification code' do
     user = create(:user, residence_verified_at: Time.current)
     login_as(user)
 
@@ -47,7 +47,7 @@ feature 'SMS Verification' do
     expect(page).to have_content 'Incorrect confirmation code'
   end
 
-  scenario 'Deny access unless residency verified' do
+  it 'Deny access unless residency verified' do
     user = create(:user)
     login_as(user)
 
@@ -57,7 +57,7 @@ feature 'SMS Verification' do
     expect(page).to have_current_path(new_residence_path)
   end
 
-  scenario '5 tries allowed' do
+  it '5 tries allowed' do
     user = create(:user, residence_verified_at: Time.current)
     login_as(user)
 

--- a/spec/features/verification/verification_path_spec.rb
+++ b/spec/features/verification/verification_path_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Verification path' do
+describe 'Verification path' do
 
-  scenario "User is an organization" do
+  it "User is an organization" do
     user = create(:user, verified_at: Time.current)
     create(:organization, user: user)
 
@@ -12,7 +12,7 @@ feature 'Verification path' do
     expect(page).to have_current_path(account_path)
   end
 
-  scenario "User is verified" do
+  it "User is verified" do
     user = create(:user, verified_at: Time.current)
 
     login_as(user)
@@ -22,7 +22,7 @@ feature 'Verification path' do
     expect(page).to have_content 'Your account is already verified'
   end
 
-  scenario "User requested a letter" do
+  it "User requested a letter" do
     user = create(:user, confirmed_phone: "623456789", residence_verified_at: Time.current,
                          letter_requested_at: Time.current, letter_verification_code: "666")
 
@@ -32,7 +32,7 @@ feature 'Verification path' do
     expect(page).to have_current_path(edit_letter_path)
   end
 
-  scenario "User is level two verified" do
+  it "User is level two verified" do
     user = create(:user, residence_verified_at: Time.current, confirmed_phone: "666666666")
 
     login_as(user)
@@ -41,7 +41,7 @@ feature 'Verification path' do
     expect(page).to have_current_path(new_letter_path)
   end
 
-  scenario "User received a verification sms" do
+  it "User received a verification sms" do
     user = create(:user, residence_verified_at: Time.current, unconfirmed_phone: "666666666", sms_confirmation_code: "666")
 
     login_as(user)
@@ -50,7 +50,7 @@ feature 'Verification path' do
     expect(page).to have_current_path(edit_sms_path)
   end
 
-  scenario "User received verification email" do
+  it "User received verification email" do
     user = create(:user, residence_verified_at: Time.current, email_verification_token: "1234")
 
     login_as(user)
@@ -63,7 +63,7 @@ feature 'Verification path' do
     expect(page).to have_current_path(verification_redirect)
   end
 
-  scenario "User has verified residence" do
+  it "User has verified residence" do
     user = create(:user, residence_verified_at: Time.current)
 
     login_as(user)
@@ -76,7 +76,7 @@ feature 'Verification path' do
     expect(page).to have_current_path(verification_redirect)
   end
 
-  scenario "User has not started verification process" do
+  it "User has not started verification process" do
     user = create(:user)
 
     login_as(user)
@@ -85,7 +85,7 @@ feature 'Verification path' do
     expect(page).to have_current_path(new_residence_path)
   end
 
-  scenario "A verified user can not access verification pages" do
+  it "A verified user can not access verification pages" do
     user = create(:user, verified_at: Time.current)
 
     login_as(user)

--- a/spec/features/verification/verified_user_spec.rb
+++ b/spec/features/verification/verified_user_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Verified users' do
+describe 'Verified users' do
 
-  scenario "Verified emails" do
+  it "Verified emails" do
     user = create(:user,
                   residence_verified_at: Time.current,
                   document_number:       '12345678Z')
@@ -27,7 +27,7 @@ feature 'Verified users' do
     expect(page).not_to have_content 'ano*@example.com'
   end
 
-  scenario "Verified phones" do
+  it "Verified phones" do
     user = create(:user,
                   residence_verified_at: Time.current,
                   document_number:       '12345678Z')
@@ -52,7 +52,7 @@ feature 'Verified users' do
     expect(page).not_to have_content '******333'
   end
 
-  scenario "No emails or phones" do
+  it "No emails or phones" do
     user = create(:user,
                   residence_verified_at: Time.current,
                   document_number:       '12345678Z')
@@ -69,7 +69,7 @@ feature 'Verified users' do
     expect(page).to have_current_path(new_sms_path)
   end
 
-  scenario "Select a verified email" do
+  it "Select a verified email" do
     user = create(:user,
               residence_verified_at: Time.current,
               document_number:       '12345678Z')
@@ -89,7 +89,7 @@ feature 'Verified users' do
     expect(page).to have_current_path(account_path)
   end
 
-  scenario "Select a verified phone" do
+  it "Select a verified phone" do
     user = create(:user,
                   residence_verified_at: Time.current,
                   document_number:       '12345678Z')
@@ -108,7 +108,7 @@ feature 'Verified users' do
     expect(page).to have_content 'Enter the confirmation code'
   end
 
-  scenario "Continue without selecting any verified information" do
+  it "Continue without selecting any verified information" do
     user = create(:user,
                   residence_verified_at: Time.current,
                   document_number:       '12345678Z')
@@ -125,7 +125,7 @@ feature 'Verified users' do
     expect(page).to have_current_path(new_sms_path)
   end
 
-  scenario "No verified information" do
+  it "No verified information" do
     user = create(:user, residence_verified_at: Time.current)
 
     login_as(user)

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-feature 'Votes' do
+describe 'Votes' do
 
-  background do
+  before do
     @manuela = create(:user, verified_at: Time.current)
     @pablo = create(:user)
   end
 
-  feature 'Debates' do
-    background { login_as(@manuela) }
+  describe 'Debates' do
+    before { login_as(@manuela) }
 
-    scenario "Index shows user votes on debates" do
+    it "Index shows user votes on debates" do
 
       debate1 = create(:debate)
       debate2 = create(:debate)
@@ -59,9 +59,9 @@ feature 'Votes' do
       end
     end
 
-    feature 'Single debate' do
+    describe 'Single debate' do
 
-      scenario 'Show no votes' do
+      it 'Show no votes' do
         visit debate_path(create(:debate))
 
         expect(page).to have_content "No votes"
@@ -79,7 +79,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Update', :js do
+      it 'Update', :js do
         visit debate_path(create(:debate))
 
         find('.in-favor a').click
@@ -98,7 +98,7 @@ feature 'Votes' do
         expect(page).to have_content "1 vote"
       end
 
-      scenario 'Trying to vote multiple times', :js do
+      it 'Trying to vote multiple times', :js do
         visit debate_path(create(:debate))
 
         find('.in-favor a').click
@@ -115,7 +115,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Show' do
+      it 'Show' do
         debate = create(:debate)
         create(:vote, voter: @manuela, votable: debate, vote_flag: true)
         create(:vote, voter: @pablo, votable: debate, vote_flag: false)
@@ -135,7 +135,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Create from debate show', :js do
+      it 'Create from debate show', :js do
         visit debate_path(create(:debate))
 
         find('.in-favor a').click
@@ -153,7 +153,7 @@ feature 'Votes' do
         expect(page).to have_content "1 vote"
       end
 
-      scenario 'Create in index', :js do
+      it 'Create in index', :js do
         create(:debate)
         visit debates_path
 
@@ -178,10 +178,10 @@ feature 'Votes' do
     end
   end
 
-  feature 'Proposals' do
-    background { login_as(@manuela) }
+  describe 'Proposals' do
+    before { login_as(@manuela) }
 
-    scenario "Index shows user votes on proposals" do
+    it "Index shows user votes on proposals" do
       proposal1 = create(:proposal)
       proposal2 = create(:proposal)
       proposal3 = create(:proposal)
@@ -204,17 +204,17 @@ feature 'Votes' do
       end
     end
 
-    feature 'Single proposal' do
-      background do
+    describe 'Single proposal' do
+      before do
         @proposal = create(:proposal)
       end
 
-      scenario 'Show no votes' do
+      it 'Show no votes' do
         visit proposal_path(@proposal)
         expect(page).to have_content "No supports"
       end
 
-      scenario 'Trying to vote multiple times', :js do
+      it 'Trying to vote multiple times', :js do
         visit proposal_path(@proposal)
 
         within('.supports') do
@@ -225,7 +225,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Show' do
+      it 'Show' do
         create(:vote, voter: @manuela, votable: @proposal, vote_flag: true)
         create(:vote, voter: @pablo, votable: @proposal, vote_flag: true)
 
@@ -236,7 +236,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Create from proposal show', :js do
+      it 'Create from proposal show', :js do
         visit proposal_path(@proposal)
 
         within('.supports') do
@@ -247,7 +247,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Create in listed proposal in index', :js do
+      it 'Create in listed proposal in index', :js do
         create_featured_proposals
         visit proposals_path
 
@@ -260,7 +260,7 @@ feature 'Votes' do
         expect(page).to have_current_path(proposals_path)
       end
 
-      scenario 'Create in featured proposal in index', :js do
+      it 'Create in featured proposal in index', :js do
         visit proposals_path
 
         within("#proposal_#{@proposal.id}") do
@@ -273,7 +273,7 @@ feature 'Votes' do
     end
   end
 
-  scenario 'Not logged user trying to vote debates', :js do
+  it 'Not logged user trying to vote debates', :js do
     debate = create(:debate)
 
     visit debates_path
@@ -283,7 +283,7 @@ feature 'Votes' do
     end
   end
 
-  scenario 'Not logged user trying to vote proposals', :js do
+  it 'Not logged user trying to vote proposals', :js do
     proposal = create(:proposal)
 
     visit proposals_path
@@ -299,7 +299,7 @@ feature 'Votes' do
     end
   end
 
-  scenario 'Not logged user trying to vote comments in debates', :js do
+  it 'Not logged user trying to vote comments in debates', :js do
     debate = create(:debate)
     comment = create(:comment, commentable: debate)
 
@@ -310,7 +310,7 @@ feature 'Votes' do
     end
   end
 
-  scenario 'Not logged user trying to vote comments in proposals', :js do
+  it 'Not logged user trying to vote comments in proposals', :js do
     proposal = create(:proposal)
     comment = create(:comment, commentable: proposal)
 
@@ -321,7 +321,7 @@ feature 'Votes' do
     end
   end
 
-  scenario 'Anonymous user trying to vote debates', :js do
+  it 'Anonymous user trying to vote debates', :js do
     user = create(:user)
     debate = create(:debate)
 
@@ -343,7 +343,7 @@ feature 'Votes' do
     end
   end
 
-  scenario "Anonymous user trying to vote proposals", :js do
+  it "Anonymous user trying to vote proposals", :js do
     user = create(:user)
     proposal = create(:proposal)
 
@@ -362,8 +362,8 @@ feature 'Votes' do
     end
   end
 
-  feature 'Spending Proposals' do
-    background do
+  describe 'Spending Proposals' do
+    before do
      Setting['feature.spending_proposals'] = true
      Setting['feature.spending_proposal_features.voting_allowed'] = true
      login_as(@manuela)
@@ -374,8 +374,8 @@ feature 'Votes' do
       Setting['feature.spending_proposal_features.voting_allowed'] = nil
     end
 
-    feature 'Index' do
-      scenario "Index shows user votes on proposals" do
+    describe 'Index' do
+      it "Index shows user votes on proposals" do
         spending_proposal1 = create(:spending_proposal)
         spending_proposal2 = create(:spending_proposal)
         spending_proposal3 = create(:spending_proposal)
@@ -398,7 +398,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Create from spending proposal index', :js do
+      it 'Create from spending proposal index', :js do
         spending_proposal = create(:spending_proposal)
         visit spending_proposals_path
 
@@ -411,17 +411,17 @@ feature 'Votes' do
       end
     end
 
-    feature 'Single spending proposal' do
-      background do
+    describe 'Single spending proposal' do
+      before do
         @proposal = create(:spending_proposal)
       end
 
-      scenario 'Show no votes' do
+      it 'Show no votes' do
         visit spending_proposal_path(@proposal)
         expect(page).to have_content "No supports"
       end
 
-      scenario 'Trying to vote multiple times', :js do
+      it 'Trying to vote multiple times', :js do
         visit spending_proposal_path(@proposal)
 
         within('.supports') do
@@ -432,7 +432,7 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Create from proposal show', :js do
+      it 'Create from proposal show', :js do
         visit spending_proposal_path(@proposal)
 
         within('.supports') do
@@ -444,7 +444,7 @@ feature 'Votes' do
       end
     end
 
-    scenario 'Disable voting on spending proposals', :js do
+    it 'Disable voting on spending proposals', :js do
       login_as(@manuela)
       Setting["feature.spending_proposal_features.voting_allowed"] = nil
       spending_proposal = create(:spending_proposal)

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature "Welcome screen" do
+describe "Welcome screen" do
 
-  scenario 'a regular users sees it the first time he logs in' do
+  it 'a regular users sees it the first time he logs in' do
     user = create(:user)
 
     login_through_form_as(user)
@@ -10,7 +10,7 @@ feature "Welcome screen" do
     expect(page).to have_current_path(welcome_path)
   end
 
-  scenario 'a regular user does not see it when coing to /email' do
+  it 'a regular user does not see it when coing to /email' do
 
     plain, encrypted = Devise.token_generator.generate(User, :email_verification_token)
 
@@ -28,7 +28,7 @@ feature "Welcome screen" do
     expect(page).to have_current_path(account_path)
   end
 
-  scenario 'it is not shown more than once' do
+  it 'is not shown more than once' do
     user = create(:user, sign_in_count: 2)
 
     login_through_form_as(user)
@@ -36,7 +36,7 @@ feature "Welcome screen" do
     expect(page).to have_current_path(root_path)
   end
 
-  scenario 'is not shown to organizations' do
+  it 'is not shown to organizations' do
     organization = create(:organization)
 
     login_through_form_as(organization.user)
@@ -44,7 +44,7 @@ feature "Welcome screen" do
     expect(page).to have_current_path(root_path)
   end
 
-  scenario 'it is not shown to level-2 users' do
+  it 'is not shown to level-2 users' do
     user = create(:user, residence_verified_at: Time.current, confirmed_phone: "123")
 
     login_through_form_as(user)
@@ -52,7 +52,7 @@ feature "Welcome screen" do
     expect(page).to have_current_path(root_path)
   end
 
-  scenario 'it is not shown to level-3 users' do
+  it 'is not shown to level-3 users' do
     user = create(:user, verified_at: Time.current)
 
     login_through_form_as(user)
@@ -60,7 +60,7 @@ feature "Welcome screen" do
     expect(page).to have_current_path(root_path)
   end
 
-  scenario 'is not shown to administrators' do
+  it 'is not shown to administrators' do
     administrator = create(:administrator)
 
     login_through_form_as(administrator.user)

--- a/spec/lib/tasks/sitemap_spec.rb
+++ b/spec/lib/tasks/sitemap_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 Rails.application.load_tasks
 Rake::Task.define_task(:environment)
 
-feature 'rake sitemap:create' do
+describe 'rake sitemap:create' do
   before do
     @file ||= Rails.root.join('public', 'sitemap.xml')
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -58,13 +58,13 @@ describe Organization do
       expect(search.first).to eq organization
     end
 
-    scenario "finds by users email" do
+    it "finds by users email" do
       search = described_class.search(organization.user.email)
       expect(search.size).to eq 1
       expect(search.first).to eq organization
     end
 
-    scenario "finds by users phone number" do
+    it "finds by users phone number" do
       search = described_class.search(organization.user.phone_number)
       expect(search.size).to eq 1
       expect(search.first).to eq organization

--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -17,7 +17,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
 
   context "Show documents tab" do
 
-    scenario "Download action should be able to anyone" do
+    it "Download action should be able to anyone" do
       visit send(documentable_path, arguments)
 
       within "#tab-documents" do
@@ -25,7 +25,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       end
     end
 
-    scenario "Download file link should have blank target attribute" do
+    it "Download file link should have blank target attribute" do
       visit send(documentable_path, arguments)
 
       within "#tab-documents" do
@@ -33,7 +33,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       end
     end
 
-    scenario "Download file links should have rel attribute setted to no follow" do
+    it "Download file links should have rel attribute setted to no follow" do
       visit send(documentable_path, arguments)
 
       within "#tab-documents" do
@@ -43,7 +43,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
 
     describe "Destroy action" do
 
-      scenario "Should not be able when no user logged in" do
+      it "is not able when no user logged in" do
         visit send(documentable_path, arguments)
 
         within "#tab-documents" do
@@ -51,7 +51,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
         end
       end
 
-      scenario "Should be able when documentable author is logged in" do
+      it "is able when documentable author is logged in" do
         login_as documentable.author
         visit send(documentable_path, arguments)
 
@@ -60,7 +60,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
         end
       end
 
-      scenario "Administrators cannot destroy documentables they have not authored" do
+      it "Administrators cannot destroy documentables they have not authored" do
         login_as(administrator)
         visit send(documentable_path, arguments)
 
@@ -69,7 +69,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
         end
       end
 
-      scenario "Users cannot destroy documentables they have not authored" do
+      it "Users cannot destroy documentables they have not authored" do
         login_as(create(:user))
         visit send(documentable_path, arguments)
 
@@ -84,7 +84,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
 
   context "Destroy" do
 
-    scenario "Should show success notice after successful document upload" do
+    it "shows success notice after successful document upload" do
       login_as documentable.author
 
       visit send(documentable_path, arguments)
@@ -97,7 +97,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       expect(page).to have_content "Document was deleted successfully."
     end
 
-    scenario "Should update documents tab count after successful deletion" do
+    it "updates documents tab count after successful deletion" do
       login_as documentable.author
 
       visit send(documentable_path, arguments)
@@ -110,7 +110,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       expect(page).to have_link "Documents (0)"
     end
 
-    scenario "Should redirect to documentable path after successful deletion" do
+    it "redirects to documentable path after successful deletion" do
       login_as documentable.author
 
       visit send(documentable_path, arguments)

--- a/spec/shared/features/followable.rb
+++ b/spec/shared/features/followable.rb
@@ -13,7 +13,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
 
   context "Show" do
 
-    scenario "Should not display follow button when there is no logged user" do
+    it "does not display follow button when there is no logged user" do
       visit send(followable_path, arguments)
 
       within "##{dom_id(followable)}" do
@@ -21,7 +21,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       end
     end
 
-    scenario "Should display follow button when user is logged in" do
+    it "displays follow button when user is logged in" do
       user = create(:user)
       login_as(user)
 
@@ -32,7 +32,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       end
     end
 
-    scenario "Should display follow button when user is logged and is not following" do
+    it "displays follow button when user is logged and is not following" do
       user = create(:user)
       login_as(user)
 
@@ -40,7 +40,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       expect(page).to have_link("Follow #{followable.model_name.human.downcase}")
     end
 
-    scenario "Should display unfollow after user clicks on follow button", :js do
+    it "displays unfollow after user clicks on follow button", :js do
       user = create(:user)
       login_as(user)
 
@@ -53,7 +53,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       end
     end
 
-    scenario "Should display new follower notice after user clicks on follow button", :js do
+    it "displays new follower notice after user clicks on follow button", :js do
       user = create(:user)
       login_as(user)
 
@@ -65,7 +65,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       expect(page).to have_content strip_tags(t("shared.followable.#{followable_class_name}.create.notice_html"))
     end
 
-    scenario "Display unfollow button when user already following" do
+    it "Display unfollow button when user already following" do
       user = create(:user)
       follow = create(:follow, user: user, followable: followable)
       login_as(user)
@@ -75,7 +75,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       expect(page).to have_link("Following")
     end
 
-    scenario "Should update follow button and show destroy notice after user clicks on unfollow button", :js do
+    it "updates follow button and show destroy notice after user clicks on unfollow button", :js do
       user = create(:user)
       follow = create(:follow, user: user, followable: followable)
       login_as(user)
@@ -89,7 +89,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       end
     end
 
-    scenario "Should display destroy follower notice after user clicks on unfollow button", :js do
+    it "displays destroy follower notice after user clicks on unfollow button", :js do
       user = create(:user)
       follow = create(:follow, user: user, followable: followable)
       login_as(user)

--- a/spec/shared/features/imageable.rb
+++ b/spec/shared/features/imageable.rb
@@ -20,7 +20,7 @@ shared_examples "imageable" do |imageable_factory_name, imageable_path, imageabl
 
   context "Show" do
 
-    scenario "Show descriptive image when exists", :js do
+    it "Show descriptive image when exists", :js do
       image = create(:image, imageable: imageable)
 
       visit send(imageable_path, imageable_arguments)
@@ -28,7 +28,7 @@ shared_examples "imageable" do |imageable_factory_name, imageable_path, imageabl
       expect(page).to have_css("img[alt='#{image.title}'][title='#{image.title}']")
     end
 
-    scenario "Show image title when image exists" do
+    it "Show image title when image exists" do
       image = create(:image, imageable: imageable)
 
       visit send(imageable_path, imageable_arguments)
@@ -40,25 +40,25 @@ shared_examples "imageable" do |imageable_factory_name, imageable_path, imageabl
 
   context "Destroy" do
 
-    background do
+    before do
       create(:image, imageable: imageable, user: imageable.author)
     end
 
-    scenario "Administrators cannot destroy imageables they have not authored" do
+    it "Administrators cannot destroy imageables they have not authored" do
       login_as(administrator)
 
       visit send(imageable_path, imageable_arguments)
       expect(page).not_to have_link "Remove image"
     end
 
-    scenario "Users cannot destroy imageables they have not authored" do
+    it "Users cannot destroy imageables they have not authored" do
       login_as(create(:user))
 
       visit send(imageable_path, imageable_arguments)
       expect(page).not_to have_link "Remove image"
     end
 
-    scenario "Should show success notice after successful deletion" do
+    it "shows success notice after successful deletion" do
       login_as imageable.author
 
       visit send(imageable_path, imageable_arguments)
@@ -67,7 +67,7 @@ shared_examples "imageable" do |imageable_factory_name, imageable_path, imageabl
       expect(page).to have_content "Image was deleted successfully."
     end
 
-    scenario "Should not show image after successful deletion" do
+    it "does not show image after successful deletion" do
       login_as imageable.author
 
       visit send(imageable_path, imageable_arguments)
@@ -76,7 +76,7 @@ shared_examples "imageable" do |imageable_factory_name, imageable_path, imageabl
       expect(page).not_to have_selector "figure img"
     end
 
-    scenario "Should redirect to imageable path after successful deletion" do
+    it "redirects to imageable path after successful deletion" do
       login_as imageable.author
 
       visit send(imageable_path, imageable_arguments)

--- a/spec/shared/features/mappable.rb
+++ b/spec/shared/features/mappable.rb
@@ -15,7 +15,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
     before { set_arguments(arguments, mappable, mappable_path_arguments) }
 
-    scenario "Should not show marker by default on create #{mappable_factory_name}", :js do
+    it "Should not show marker by default on create #{mappable_factory_name}", :js do
       login_as user
       visit send(mappable_new_path, arguments)
 
@@ -26,7 +26,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       end
     end
 
-    scenario "Should show marker on create #{mappable_factory_name} when click on map", :js do
+    it "Should show marker on create #{mappable_factory_name} when click on map", :js do
       login_as user
       visit send(mappable_new_path, arguments)
 
@@ -38,7 +38,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       end
     end
 
-    scenario "Should create #{mappable_factory_name} with map", :js do
+    it "Should create #{mappable_factory_name} with map", :js do
       login_as user
       visit send(mappable_new_path, arguments)
 
@@ -49,7 +49,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).to have_css(".map_location")
     end
 
-    scenario "Can not display map on #{mappable_factory_name} when not fill marker on map", :js do
+    it "Can not display map on #{mappable_factory_name} when not fill marker on map", :js do
       login_as user
       visit send(mappable_new_path, arguments)
 
@@ -61,7 +61,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_css(".map_location")
     end
 
-    scenario "Can not display map on #{mappable_factory_name} when feature.map is disabled", :js do
+    it "Can not display map on #{mappable_factory_name} when feature.map is disabled", :js do
       Setting['feature.map'] = false
       login_as user
       visit send(mappable_new_path, arguments)
@@ -73,7 +73,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_css(".map_location")
     end
 
-    scenario 'Errors on create' do
+    it 'Errors on create' do
       login_as user
       visit send(mappable_new_path, arguments)
 
@@ -82,7 +82,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).to have_content "Map location can't be blank"
     end
 
-    scenario 'Skip map', :js do
+    it 'Skip map', :js do
       login_as user
       visit send(mappable_new_path, arguments)
 
@@ -93,7 +93,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_content "Map location can't be blank"
     end
 
-    scenario 'Toggle map', :js do
+    it 'Toggle map', :js do
       login_as user
       visit send(mappable_new_path, arguments)
 
@@ -114,7 +114,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
     before { skip } if mappable_edit_path.blank?
 
-    scenario "Should edit map on #{mappable_factory_name} and contain default values", :js do
+    it "Should edit map on #{mappable_factory_name} and contain default values", :js do
       login_as mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
@@ -123,7 +123,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       validate_latitude_longitude(mappable_factory_name)
     end
 
-    scenario "Should edit default values from map on #{mappable_factory_name} edit page", :js do
+    it "Should edit default values from map on #{mappable_factory_name} edit page", :js do
       login_as mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
@@ -136,7 +136,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).to have_selector(".map_location[data-marker-latitude='#{mappable.map_location.latitude}']")
     end
 
-    scenario "Should edit mappable on #{mappable_factory_name} without change map", :js do
+    it "Should edit mappable on #{mappable_factory_name} without change map", :js do
       login_as mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
@@ -149,7 +149,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).to have_selector(".map_location[data-marker-latitude='#{mappable.map_location.latitude}']")
     end
 
-    scenario "Can not display map on #{mappable_factory_name} edit when remove map marker", :js do
+    it "Can not display map on #{mappable_factory_name} edit when remove map marker", :js do
       login_as mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
@@ -160,7 +160,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_css(".map_location")
     end
 
-    scenario "Can not display map on #{mappable_factory_name} edit when feature.map is disabled", :js do
+    it "Can not display map on #{mappable_factory_name} edit when feature.map is disabled", :js do
       Setting['feature.map'] = false
       login_as mappable.author
 
@@ -171,7 +171,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_css(".map_location")
     end
 
-    scenario 'No errors on update', :js do
+    it 'No errors on update', :js do
       skip ""
       login_as mappable.author
 
@@ -182,7 +182,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_content "Map location can't be blank"
     end
 
-    scenario 'No need to skip map on update' do
+    it 'No need to skip map on update' do
       login_as mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
@@ -198,7 +198,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
     before { set_arguments(arguments, mappable, mappable_path_arguments) }
 
-    scenario "Should display map on #{mappable_factory_name} show page", :js do
+    it "Should display map on #{mappable_factory_name} show page", :js do
       arguments[:id] = mappable.id
 
       visit send(mappable_show_path, arguments)
@@ -206,7 +206,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).to have_css(".map_location")
     end
 
-    scenario "Should not display map on #{mappable_factory_name} show when marker is not defined", :js do
+    it "Should not display map on #{mappable_factory_name} show when marker is not defined", :js do
       mappable_without_map = create(mappable_factory_name.to_s.to_sym)
       set_arguments(arguments, mappable_without_map, mappable_path_arguments)
       arguments[:id] = mappable_without_map.id
@@ -216,7 +216,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_css(".map_location")
     end
 
-    scenario "Should not display map on #{mappable_factory_name} show page when feature.map is disable", :js do
+    it "Should not display map on #{mappable_factory_name} show page when feature.map is disable", :js do
       Setting['feature.map'] = false
       arguments[:id] = mappable.id
 

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -19,14 +19,14 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
 
   describe "at #{path}" do
 
-    scenario "Should show new document link when max documents allowed limit is not reached" do
+    it "shows new document link when max documents allowed limit is not reached" do
       login_as user_to_login
       visit send(path, arguments)
 
       expect(page).to have_css "#new_document_link", visible: true
     end
 
-    scenario "Should not show new document link when documentable max documents allowed limit is reached", :js do
+    it "does not show new document link when documentable max documents allowed limit is reached", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -37,14 +37,14 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css "#new_document_link", visible: false
     end
 
-    scenario "Should not show max documents warning when no documents added", :js do
+    it "does not show max documents warning when no documents added", :js do
       login_as user_to_login
       visit send(path, arguments)
 
       expect(page).to have_css ".max-documents-notice", visible: false
     end
 
-    scenario "Should show max documents warning when max documents allowed limit is reached", :js do
+    it "shows max documents warning when max documents allowed limit is reached", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -55,7 +55,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css ".max-documents-notice", visible: true
     end
 
-    scenario "Should hide max documents warning after any document removal", :js do
+    it "hides max documents warning after any document removal", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -68,7 +68,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css ".max-documents-notice", visible: false
     end
 
-    scenario "Should update nested document file name after choosing a file", :js do
+    it "updates nested document file name after choosing a file", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -81,7 +81,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css ".file-name", text: "empty.pdf"
     end
 
-    scenario "Should update nested document file title with file name after choosing a file when no title defined", :js do
+    it "updates nested document file title with file name after choosing a file when no title defined", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -90,7 +90,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect_document_has_title(0, "empty.pdf")
     end
 
-    scenario "Should not update nested document file title with file name after choosing a file when title already defined", :js do
+    it "does not update nested document file title with file name after choosing a file when title already defined", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -105,7 +105,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect_document_has_title(0, "My Title")
     end
 
-    scenario "Should update loading bar style after valid file upload", :js do
+    it "updates loading bar style after valid file upload", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -114,7 +114,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css ".loading-bar.complete"
     end
 
-    scenario "Should update loading bar style after unvalid file upload", :js do
+    it "updates loading bar style after unvalid file upload", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -123,7 +123,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css ".loading-bar.errors"
     end
 
-    scenario "Should update document cached_attachment field after valid file upload", :js do
+    it "updates document cached_attachment field after valid file upload", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -132,7 +132,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect_document_has_cached_attachment(0, ".pdf")
     end
 
-    scenario "Should not update document cached_attachment field after unvalid file upload", :js do
+    it "does not update document cached_attachment field after unvalid file upload", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -141,7 +141,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect_document_has_cached_attachment(0, "")
     end
 
-    scenario "Should show document errors after documentable submit with empty document fields", :js do
+    it "shows document errors after documentable submit with empty document fields", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -153,7 +153,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       end
     end
 
-    scenario "Should delete document after valid file upload and click on remove button", :js do
+    it "deletes document after valid file upload and click on remove button", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -163,7 +163,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).not_to have_css("#nested-documents .document")
     end
 
-    scenario "Should show successful notice when resource filled correctly without any nested documents", :js do
+    it "shows successful notice when resource filled correctly without any nested documents", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -173,7 +173,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_content documentable_success_notice
     end
 
-    scenario "Should show successful notice when resource filled correctly and after valid file uploads", :js do
+    it "shows successful notice when resource filled correctly and after valid file uploads", :js do
       login_as user_to_login
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
@@ -184,7 +184,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_content documentable_success_notice
     end
 
-    scenario "Should show new document after successful creation with one uploaded file", :js do
+    it "shows new document after successful creation with one uploaded file", :js do
       login_as user_to_login
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
@@ -204,7 +204,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css("a[href$='.pdf']")
     end
 
-    scenario "Should show resource with new document after successful creation with maximum allowed uploaded files", :js do
+    it "shows resource with new document after successful creation with maximum allowed uploaded files", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -220,7 +220,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
 
     if path.include? "edit"
 
-      scenario "Should show persisted documents and remove nested_field" do
+      it "shows persisted documents and remove nested_field" do
         login_as user_to_login
         create(:document, documentable: documentable)
         visit send(path, arguments)
@@ -228,7 +228,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
         expect(page).to have_css ".document", count: 1
       end
 
-      scenario "Should not show add document button when documentable has reached maximum of documents allowed", :js do
+      it "does not show add document button when documentable has reached maximum of documents allowed", :js do
         login_as user_to_login
         create_list(:document, documentable.class.max_documents_allowed, documentable: documentable)
         visit send(path, arguments)
@@ -236,7 +236,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
         expect(page).to have_css "#new_document_link", visible: false
       end
 
-      scenario "Should show add document button after destroy one document", :js do
+      it "shows add document button after destroy one document", :js do
         login_as user_to_login
         create_list(:document, documentable.class.max_documents_allowed, documentable: documentable)
         visit send(path, arguments)
@@ -248,7 +248,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
         expect(page).to have_css "#new_document_link", visible: true
       end
 
-      scenario "Should remove nested field after remove document", :js do
+      it "removes nested field after remove document", :js do
         login_as user_to_login
         create(:document, documentable: documentable)
         visit send(path, arguments)

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -25,14 +25,14 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
 
   describe "at #{path}" do
 
-    scenario "Should show new image link when imageable has not an associated image defined" do
+    it "shows new image link when imageable has not an associated image defined" do
       login_as user
       visit send(path, arguments)
 
       expect(page).to have_selector "#new_image_link", visible: true
     end
 
-    scenario "Should hide new image link after add one image" do
+    it "hides new image link after add one image" do
       login_as user
       visit send(path, arguments)
 
@@ -41,7 +41,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_selector "#new_image_link", visible: true
     end
 
-    scenario "Should update nested image file name after choosing any file", :js do
+    it "updates nested image file name after choosing any file", :js do
       login_as user
       visit send(path, arguments)
 
@@ -52,7 +52,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_selector ".file-name", text: "clippy.jpg"
     end
 
-    scenario "Should update nested image file title with file name after choosing a file when no title defined", :js do
+    it "updates nested image file title with file name after choosing a file when no title defined", :js do
       login_as user
       visit send(path, arguments)
 
@@ -61,7 +61,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect_image_has_title("clippy.jpg")
     end
 
-    scenario "Should not update nested image file title with file name after choosing a file when title already defined", :js do
+    it "does not update nested image file title with file name after choosing a file when title already defined", :js do
       login_as user
       visit send(path, arguments)
 
@@ -78,7 +78,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       end
     end
 
-    scenario "Should update loading bar style after valid file upload", :js do
+    it "updates loading bar style after valid file upload", :js do
       login_as user
       visit send(path, arguments)
 
@@ -87,7 +87,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_selector ".loading-bar.complete"
     end
 
-    scenario "Should update loading bar style after invalid file upload", :js do
+    it "updates loading bar style after invalid file upload", :js do
       login_as user
       visit send(path, arguments)
 
@@ -96,7 +96,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_selector ".loading-bar.errors"
     end
 
-    scenario "Should update image cached_attachment field after valid file upload", :js do
+    it "updates image cached_attachment field after valid file upload", :js do
       login_as user
       visit send(path, arguments)
 
@@ -105,7 +105,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect_image_has_cached_attachment(".jpg")
     end
 
-    scenario "Should not update image cached_attachment field after unvalid file upload", :js do
+    it "does not update image cached_attachment field after unvalid file upload", :js do
       login_as user
       visit send(path, arguments)
 
@@ -114,7 +114,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect_image_has_cached_attachment("")
     end
 
-    scenario "Should show nested image errors after unvalid form submit", :js do
+    it "shows nested image errors after unvalid form submit", :js do
       login_as user
       visit send(path, arguments)
 
@@ -130,7 +130,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       end
     end
 
-    scenario "Should remove nested image after valid file upload and click on remove button", :js do
+    it "removes nested image after valid file upload and click on remove button", :js do
       login_as user
       visit send(path, arguments)
 
@@ -142,7 +142,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).not_to have_selector("#nested-image .image")
     end
 
-    scenario "Should show successful notice when resource filled correctly without any nested images", :js do
+    it "shows successful notice when resource filled correctly without any nested images", :js do
       login_as user
       visit send(path, arguments)
 
@@ -156,7 +156,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       end
     end
 
-    scenario "Should show successful notice when resource filled correctly and after valid file uploads", :js do
+    it "shows successful notice when resource filled correctly and after valid file uploads", :js do
       login_as user
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
@@ -167,7 +167,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_content imageable_success_notice
     end
 
-    scenario "Should show new image after successful creation with one uploaded file", :js do
+    it "shows new image after successful creation with one uploaded file", :js do
       login_as user
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
@@ -186,7 +186,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
 
     if path.include? "edit"
 
-      scenario "Should show persisted image" do
+      it "shows persisted image" do
         login_as user
         create(:image, imageable: imageable)
         visit send(path, arguments)
@@ -194,7 +194,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
         expect(page).to have_css ".image", count: 1
       end
 
-      scenario "Should not show add image button when image already exists", :js do
+      it "does not show add image button when image already exists", :js do
         login_as user
         create(:image, imageable: imageable)
         visit send(path, arguments)
@@ -202,7 +202,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
         expect(page).to have_css "a#new_image_link", visible: false
       end
 
-      scenario "Should remove nested field after remove image", :js do
+      it "removes nested field after remove image", :js do
         login_as user
         create(:image, imageable: imageable)
         visit send(path, arguments)
@@ -211,7 +211,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
         expect(page).not_to have_css ".image"
       end
 
-      scenario "Should show add image button after remove image", :js do
+      it "shows add image button after remove image", :js do
         login_as user
         create(:image, imageable: imageable)
         visit send(path, arguments)

--- a/spec/shared/features/notifiable_in_app.rb
+++ b/spec/shared/features/notifiable_in_app.rb
@@ -3,7 +3,7 @@ shared_examples "notifiable in-app" do |described_class|
   let(:author) { create(:user, :verified) }
   let!(:notifiable) { create(model_name(described_class), author: author) }
 
-  scenario "A user commented on my notifiable", :js do
+  it "A user commented on my notifiable", :js do
     notification = create(:notification, notifiable: notifiable, user: author)
 
     login_as author
@@ -15,7 +15,7 @@ shared_examples "notifiable in-app" do |described_class|
     expect(page).to have_xpath "//a[@href='#{notification_path(notification)}']"
   end
 
-  scenario "Multiple users commented on my notifiable", :js do
+  it "Multiple users commented on my notifiable", :js do
     3.times do
       login_as(create(:user, :verified))
 
@@ -39,7 +39,7 @@ shared_examples "notifiable in-app" do |described_class|
     expect(page).to have_xpath "//a[@href='#{notification_path(Notification.last)}']"
   end
 
-  scenario "A user replied to my comment", :js do
+  it "A user replied to my comment", :js do
     comment = create :comment, commentable: notifiable, user: author
 
     login_as(create(:user, :verified))
@@ -66,7 +66,7 @@ shared_examples "notifiable in-app" do |described_class|
     expect(page).to have_xpath "//a[@href='#{notification_path(Notification.last)}']"
   end
 
-  scenario "Multiple replies to my comment", :js do
+  it "Multiple replies to my comment", :js do
     comment = create :comment, commentable: notifiable, user: author
 
     3.times do |n|
@@ -95,7 +95,7 @@ shared_examples "notifiable in-app" do |described_class|
     expect(page).to have_xpath "//a[@href='#{notification_path(Notification.last)}']"
   end
 
-  scenario "Author commented on his own notifiable", :js do
+  it "Author commented on his own notifiable", :js do
     login_as(author)
     visit path_for(notifiable)
 
@@ -111,7 +111,7 @@ shared_examples "notifiable in-app" do |described_class|
     end
   end
 
-  scenario "Author replied to his own comment", :js do
+  it "Author replied to his own comment", :js do
     comment = create :comment, commentable: notifiable, user: author
 
     login_as author

--- a/spec/shared/features/relationable.rb
+++ b/spec/shared/features/relationable.rb
@@ -5,7 +5,7 @@ shared_examples "relationable" do |relationable_model_name|
   let(:related2) { create([:proposal, :debate, :budget_investment].sample) }
   let(:user) { create(:user) }
 
-  scenario 'related contents are listed' do
+  it 'related contents are listed' do
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     visit relationable.url
@@ -19,12 +19,12 @@ shared_examples "relationable" do |relationable_model_name|
     end
   end
 
-  scenario 'related contents list is not rendered if there are no relations' do
+  it 'related contents list is not rendered if there are no relations' do
     visit relationable.url
     expect(page).not_to have_css("#related-content-list")
   end
 
-  scenario 'related contents can be added' do
+  it 'related contents can be added' do
     login_as(user)
     visit relationable.url
 
@@ -57,7 +57,7 @@ shared_examples "relationable" do |relationable_model_name|
     end
   end
 
-  scenario 'if related content URL is invalid returns error' do
+  it 'if related content URL is invalid returns error' do
     login_as(user)
     visit relationable.url
 
@@ -71,7 +71,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(page).to have_content("Link not valid. Remember to start with #{Setting[:url]}.")
   end
 
-  scenario 'returns error when relating content URL to itself' do
+  it 'returns error when relating content URL to itself' do
     login_as(user)
     visit relationable.url
 
@@ -85,7 +85,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(page).to have_content("Link not valid. You cannot relate a content to itself")
   end
 
-  scenario 'related content can be scored positively', :js do
+  it 'related content can be scored positively', :js do
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     login_as(user)
@@ -102,7 +102,7 @@ shared_examples "relationable" do |relationable_model_name|
 
   end
 
-  scenario 'related content can be scored negatively', :js do
+  it 'related content can be scored negatively', :js do
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     login_as(user)
@@ -118,7 +118,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(related_content.opposite_related_content.related_content_scores.find_by(user_id: user.id, related_content_id: related_content.opposite_related_content.id).value).to eq(-1)
   end
 
-  scenario 'if related content has negative score it will be hidden' do
+  it 'if related content has negative score it will be hidden' do
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     2.times do


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2440

What
====
Consistency is important in this codebase. Use capybara aliases whenever on a feature spec

http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods

How
===
Enabling rubocop-rspec cop Capybara/FeatureMethods and autocorrecting all offenses

Screenshots
===========
No need, backend changes only.


Test
====
Lets see what travis thinks of the changes

Deployment
==========
As usual

Warnings
========
Huge and opinionated changes to review 🙈 