### PR TITLE
Expire Coveralls badge cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Citizen Participation and Open Government Application
 [![Build Status](https://travis-ci.org/consul/consul.svg?branch=master)](https://travis-ci.org/consul/consul)
 [![Code Climate](https://codeclimate.com/github/consul/consul/badges/gpa.svg)](https://codeclimate.com/github/consul/consul)
 [![Dependency Status](https://gemnasium.com/consul/consul.svg)](https://gemnasium.com/consul/consul)
-[![Coverage Status](https://coveralls.io/repos/github/consul/consul/badge.svg?branch=master)](https://coveralls.io/github/consul/consul?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/consul/consul/badge.svg)](https://coveralls.io/github/consul/consul?branch=master)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/consul/localized.svg)](https://crowdin.com/project/consul)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](http://www.gnu.org/licenses/agpl-3.0)
 


### PR DESCRIPTION
What
===
- Expire cached Coveralls' badge

Why
===
- Coveralls' badge is not updating correctly https://github.com/lemurheavy/coveralls-public/issues/281

How
===
- Removing unnecessary parameter in badge image url

Screenshots
===========
![coverage](https://user-images.githubusercontent.com/4169/35859033-daa30ecc-0b3e-11e8-8ce3-5e3d65e757d5.png)

Deployment
==========
- As usual

Warnings
========
- None
