### PR TITLE
Fix for `voting comments` flaky specs

### DIFF
--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -418,15 +418,17 @@ feature 'Commenting Budget::Investments' do
   end
 
   feature 'Voting comments' do
-
     background do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @investment = create(:budget_investment)
       @comment = create(:comment, commentable: @investment)
       @budget = @investment.budget
-
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -470,14 +472,13 @@ feature 'Commenting Budget::Investments' do
       visit budget_investment_path(@budget, @investment)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 

--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -472,17 +472,17 @@ feature 'Commenting Budget::Investments' do
       visit budget_investment_path(@budget, @investment)
 
       within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
         within('.in_favor') do
-          first('a').click
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          first('a').click
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -478,17 +478,17 @@ feature 'Commenting debates' do
       visit debate_path(@debate)
 
       within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
         within('.in_favor') do
-          first('a').click
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          first('a').click
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -426,12 +426,15 @@ feature 'Commenting debates' do
 
   feature 'Voting comments' do
     background do
-      @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @debate = create(:debate)
       @comment = create(:comment, commentable: @debate)
-
+      @manuela = create(:user, verified_at: Time.current)
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -475,14 +478,13 @@ feature 'Commenting debates' do
       visit debate_path(@debate)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -554,17 +554,17 @@ feature 'Commenting legislation questions' do
                                                               @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
         within('.in_favor') do
-          first('a').click
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          first('a').click
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -501,8 +501,11 @@ feature 'Commenting legislation questions' do
       @pablo = create(:user)
       @legislation_annotation = create(:legislation_annotation)
       @comment = create(:comment, commentable: @legislation_annotation)
-
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -532,9 +535,8 @@ feature 'Commenting legislation questions' do
                                                               @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
-        find(".in_favor a").click
-
         within(".in_favor") do
+          first('a').click
           expect(page).to have_content "1"
         end
 
@@ -552,14 +554,13 @@ feature 'Commenting legislation questions' do
                                                               @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -486,17 +486,17 @@ feature 'Commenting polls' do
       visit poll_path(@poll)
 
       within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
         within('.in_favor') do
-          first('a').click
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          first('a').click
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -433,14 +433,16 @@ feature 'Commenting polls' do
   end
 
   feature 'Voting comments' do
-
     background do
-      @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @poll = create(:poll)
       @comment = create(:comment, commentable: @poll)
-
+      @manuela = create(:user, verified_at: Time.current)
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -484,14 +486,13 @@ feature 'Commenting polls' do
       visit poll_path(@poll)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -1066,17 +1066,16 @@ feature 'Commenting topics from budget investments' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -462,15 +462,17 @@ feature 'Commenting topics from proposals' do
   end
 
   feature 'Voting comments' do
-
     background do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @proposal = create(:proposal)
       @topic = create(:topic, community: @proposal.community)
       @comment = create(:comment, commentable: @topic)
-
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -514,14 +516,13 @@ feature 'Commenting topics from proposals' do
       visit community_topic_path(@proposal.community, @topic)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -1013,15 +1013,17 @@ feature 'Commenting topics from budget investments' do
   end
 
   feature 'Voting comments' do
-
     background do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @investment = create(:budget_investment)
       @topic = create(:topic, community: @investment.community)
       @comment = create(:comment, commentable: @topic)
-
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do


### PR DESCRIPTION
Where
=====
* **Related PR:** AyuntamientoMadrid/consul#1212

What
====
* Backport the aforementioned PR into CONSUL to avoid possible flaky specs, see original PR for more details

Test
====
* Fixed coverage, all green! ✅
