### PR TITLE
Backport PR #1206 from Madrid's fork

### DIFF
--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -492,11 +492,15 @@ feature 'Emails' do
   end
 
   context "Users without email" do
-    scenario "should not receive emails", :js do
+    scenario "should not receive emails" do
       user = create(:user, :verified, email_on_comment: true)
       proposal = create(:proposal, author: user)
+
+      user_commenting = create(:user)
+      comment = create(:comment, commentable: proposal, user: user_commenting)
       user.update(email: nil)
-      comment_on(proposal)
+
+      Mailer.comment(comment).deliver_now
 
       expect { open_last_email }.to raise_error "No email has been sent!"
     end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1176
* **Related PR's:** https://github.com/AyuntamientoMadrid/consul/pull/1206

What
====
Hunt the flaky that appears in `spec/features/emails_spec.rb:509`.

How
===
Explained in the related PR.

Screenshots
===========
There aren't

Test
====
Explained in the related PR

Deployment
==========
Nothing to apply

Warnings
========
Nothing to apply