### PR TITLE
Fix flaky spec: random investments order scenario 

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -95,7 +95,7 @@ module Budgets
 
       def set_random_seed
         if params[:order] == 'random' || params[:order].blank?
-          seed = rand(-100..100) / 100.0
+          seed = params[:random_seed] || session[:random_seed] || rand(-100000..100000)
           params[:random_seed] ||= Float(seed) rescue 0
         else
           params[:random_seed] = nil

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -560,16 +560,19 @@ feature 'Budget Investments' do
       expect(current_url).to include('page=1')
     end
 
-    scenario 'Each user as a different and consistent random budget investment order', :js do
+    scenario 'Each user has a different and consistent random budget investment order when random_seed is disctint', :js do
       (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
+      r1 = 1
+      r2 = 2
+
       in_browser(:one) do
-        visit budget_investments_path(budget, heading: heading, random_seed: '0.8')
+        visit budget_investments_path(budget, heading: heading, random_seed: r1)
         @first_user_investments_order = investments_order
       end
 
       in_browser(:two) do
-        visit budget_investments_path(budget, heading: heading, random_seed: '-0.1')
+        visit budget_investments_path(budget, heading: heading, random_seed: r2)
         @second_user_investments_order = investments_order
       end
 
@@ -594,6 +597,23 @@ feature 'Budget Investments' do
 
         expect(investments_order).to eq(@second_user_investments_order)
       end
+    end
+
+    scenario 'Each user has a equal and consistent budget investment order when the random_seed is equal', :js do
+      (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
+
+      in_browser(:one) do
+        visit budget_investments_path(budget, heading: heading, random_seed: '1')
+        @first_user_investments_order = investments_order
+      end
+
+      in_browser(:two) do
+        visit budget_investments_path(budget, heading: heading, random_seed: '1')
+        @second_user_investments_order = investments_order
+      end
+
+      expect(@first_user_investments_order).to eq(@second_user_investments_order)
+
     end
 
     def investments_order

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -564,12 +564,12 @@ feature 'Budget Investments' do
       (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
       in_browser(:one) do
-        visit budget_investments_path(budget, heading: heading)
+        visit budget_investments_path(budget, heading: heading, random_seed: '0.8')
         @first_user_investments_order = investments_order
       end
 
       in_browser(:two) do
-        visit budget_investments_path(budget, heading: heading)
+        visit budget_investments_path(budget, heading: heading, random_seed: '-0.1')
         @second_user_investments_order = investments_order
       end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1191
* **Related PR's:** https://github.com/AyuntamientoMadrid/consul/pull/1231

What
====
Fix rspec ./spec/features/budgets/investments_spec.rb:256

How
===
Explained in the related PR.

Screenshots
===========
There aren't

Test
====
Explained in the related PR

Deployment
==========
Nothing to apply

Warnings
========
Nothing to apply
