### PR TITLE
Fixed flaky spec: missing comment on legislation annotation

### DIFF
--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -137,7 +137,8 @@ feature 'Commenting legislation questions' do
   end
 
   scenario 'Turns links into html links' do
-    create :comment, commentable: legislation_annotation, body: 'Built with http://rubyonrails.org/'
+    legislation_annotation = create :legislation_annotation, author: user
+    legislation_annotation.comments << create(:comment, body: 'Built with http://rubyonrails.org/')
 
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
                                                             legislation_annotation.draft_version,


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1180
* **Related PR's:** https://github.com/AyuntamientoMadrid/consul/pull/1232

What
====
Fix flaky spec, rspec ./spec/features/comments/legislation_annotations_spec.rb:139 

How
===
Explained in the related PR.

Screenshots
===========
There aren't

Test
====
Explained in the related PR

Deployment
==========
Nothing to apply

Warnings
========
Nothing to apply