### PR TITLE
Fix flaky spec: Residence Assigned officers Error

### DIFF
--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -51,7 +51,10 @@ feature 'Residence' do
         click_link "Validate document"
       end
 
-      click_button 'Validate document'
+      within("#new_residence") do
+        click_button "Validate document"
+      end
+
       expect(page).to have_content(/\d errors? prevented the verification of this document/)
     end
 


### PR DESCRIPTION
Where
=====
* Related Issue: https://github.com/AyuntamientoMadrid/consul/issues/1211
* Related PR's: https://github.com/AyuntamientoMadrid/consul/pull/1227

What
====
- Backport from Madrid's fork to fix a flacky test. The test does not find the item that is being checked.
- Hunt the flaky that appears in `/spec/features/officing/residence_spec.rb:70:`

How
===
- Explained in the related PR

Screenshots
===========
![c_d_issue_1211](https://user-images.githubusercontent.com/34024463/36027692-9cefb8c2-0d9c-11e8-9839-ffabec902ae0.jpg)


Test
====
- N/A

Deployment
==========
- N/A

Warnings
========
- Explained in the related PR
