### PR TITLE
Make budget investment links always use budget slug

### DIFF
--- a/app/controllers/admin/budget_groups_controller.rb
+++ b/app/controllers/admin/budget_groups_controller.rb
@@ -1,9 +1,9 @@
 class Admin::BudgetGroupsController < Admin::BaseController
   include FeatureFlags
   feature_flag :budgets
+  before_action :load_budget_by_budget_id
 
   def create
-    @budget = Budget.find params[:budget_id]
     @budget.groups.create(budget_group_params)
     @groups = @budget.groups.includes(:headings)
   end

--- a/app/controllers/admin/budget_headings_controller.rb
+++ b/app/controllers/admin/budget_headings_controller.rb
@@ -1,22 +1,20 @@
 class Admin::BudgetHeadingsController < Admin::BaseController
   include FeatureFlags
   feature_flag :budgets
+  before_action :load_budget_by_budget_id
 
   def create
-    @budget = Budget.find(params[:budget_id])
     @budget_group = @budget.groups.find(params[:budget_group_id])
     @budget_group.headings.create(budget_heading_params)
     @headings = @budget_group.headings
   end
 
   def edit
-    @budget = Budget.find(params[:budget_id])
     @budget_group = @budget.groups.find(params[:budget_group_id])
     @heading = Budget::Heading.find(params[:id])
   end
 
   def update
-    @budget = Budget.find(params[:budget_id])
     @budget_group = @budget.groups.find(params[:budget_group_id])
     @heading = Budget::Heading.find(params[:id])
     @heading.assign_attributes(budget_heading_params)
@@ -26,7 +24,6 @@ class Admin::BudgetHeadingsController < Admin::BaseController
   def destroy
     @heading = Budget::Heading.find(params[:id])
     @heading.destroy
-    @budget = Budget.find(params[:budget_id])
     redirect_to admin_budget_path(@budget)
   end
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -9,8 +9,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
                  valuation_finished winners},
               only: [:index, :toggle_selection])
 
-  before_action :load_budget
-  before_action :load_investment, only: [:show, :edit, :update, :toggle_selection]
+  before_action :load_budget_by_budget_id
+  before_action :load_investment_by_id, only: [:show, :edit, :update, :toggle_selection]
   before_action :load_ballot, only: [:show, :index]
   before_action :load_investments, only: [:index, :toggle_selection]
 
@@ -94,14 +94,6 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
       params.require(:budget_investment)
             .permit(:title, :description, :external_url, :heading_id, :administrator_id, :tag_list,
                     :valuation_tag_list, :incompatible, :selected, valuator_ids: [])
-    end
-
-    def load_budget
-      @budget = Budget.includes(:groups).find(params[:budget_id])
-    end
-
-    def load_investment
-      @investment = Budget::Investment.by_budget(@budget).find(params[:id])
     end
 
     def load_admins

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -125,4 +125,30 @@ class ApplicationController < ActionController::Base
     def current_budget
       Budget.current
     end
+
+    def load_budget_by_id
+      @budget = load_budget_by_param(params[:id])
+    end
+
+    def load_budget_by_budget_id
+      @budget = load_budget_by_param(params[:budget_id])
+      raise ActionController::RoutingError, 'Not Found' if @budget.blank?
+    end
+
+    def load_budget_by_param(param)
+      Budget.find_by(slug: param) || Budget.find_by(id: param)
+    end
+
+    def load_investment_by_id
+      @investment = load_investment_by_param(params[:id])
+    end
+
+    def load_investment_by_investment_id
+      @investment = load_investment_by_param(params[:investment_id])
+    end
+
+    def load_investment_by_param(param)
+      Budget::Investment.find_by(id: param)
+    end
+
 end

--- a/app/controllers/budgets/ballot/lines_controller.rb
+++ b/app/controllers/budgets/ballot/lines_controller.rb
@@ -3,11 +3,11 @@ module Budgets
     class LinesController < ApplicationController
       before_action :authenticate_user!
       #before_action :ensure_final_voting_allowed
-      before_action :load_budget
+      before_action :load_budget_by_budget_id
+      before_action :load_investments
       before_action :load_ballot
       before_action :load_tag_cloud
       before_action :load_categories
-      before_action :load_investments
       before_action :load_ballot_referer
 
       load_and_authorize_resource :budget
@@ -15,7 +15,7 @@ module Budgets
       load_and_authorize_resource :line, through: :ballot, find_by: :investment_id, class: "Budget::Ballot::Line"
 
       def create
-        load_investment
+        load_investment_by_investment_id
         load_heading
 
         @ballot.add_investment(@investment)
@@ -39,16 +39,8 @@ module Budgets
           params.permit(:investment_id, :budget_id)
         end
 
-        def load_budget
-          @budget = Budget.find(params[:budget_id])
-        end
-
         def load_ballot
           @ballot = Budget::Ballot.where(user: current_user, budget: @budget).first_or_create
-        end
-
-        def load_investment
-          @investment = Budget::Investment.find(params[:investment_id])
         end
 
         def load_investments

--- a/app/controllers/budgets/ballots_controller.rb
+++ b/app/controllers/budgets/ballots_controller.rb
@@ -1,6 +1,7 @@
 module Budgets
   class BallotsController < ApplicationController
     before_action :authenticate_user!
+    before_action :load_budget_by_budget_id
     load_and_authorize_resource :budget
     before_action :load_ballot
     after_action :store_referer, only: [:show]

--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -1,6 +1,6 @@
 module Budgets
   class ResultsController < ApplicationController
-    before_action :load_budget
+    before_action :load_budget_by_budget_id
     before_action :load_heading
 
     load_and_authorize_resource :budget
@@ -11,10 +11,6 @@ module Budgets
     end
 
     private
-
-      def load_budget
-        @budget = Budget.find_by(id: params[:budget_id])
-      end
 
       def load_heading
         @heading = if params[:heading_id].present?

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -5,7 +5,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
   feature_flag :budgets
 
   before_action :restrict_access_to_assigned_items, only: [:show, :edit, :valuate]
-  before_action :load_budget
+  before_action :load_budget_by_budget_id
   before_action :load_investment, only: [:show, :edit, :valuate]
 
   has_orders %w{oldest}, only: [:show, :edit]
@@ -63,12 +63,8 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
       resource_model.parameterize('_')
     end
 
-    def load_budget
-      @budget = Budget.find(params[:budget_id])
-    end
-
     def load_investment
-      @investment = @budget.investments.find params[:id]
+      load_investment_by_id
     end
 
     def heading_filters

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -45,7 +45,7 @@ module CommentsHelper
 
     case comment.commentable_type
     when "Budget::Investment"
-      budget_investment_path(commentable.budget_id, commentable)
+      budget_investment_path(commentable.budget, commentable)
     when "Legislation::Question"
       legislation_process_question_path(commentable.process, commentable)
     when "Legislation::Annotation"

--- a/app/helpers/communities_helper.rb
+++ b/app/helpers/communities_helper.rb
@@ -24,7 +24,7 @@ module CommunitiesHelper
     if community.from_proposal?
       proposal_path(community.proposal)
     else
-      budget_investment_path(community.investment.budget_id, community.investment)
+      budget_investment_path(community.investment.budget, community.investment)
     end
   end
 

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -5,7 +5,7 @@ module MailerHelper
     return debate_url(commentable) if commentable.is_a?(Debate)
     return proposal_url(commentable) if commentable.is_a?(Proposal)
     return community_topic_url(commentable.community_id, commentable) if commentable.is_a?(Topic)
-    return budget_investment_url(commentable.budget_id, commentable) if commentable.is_a?(Budget::Investment)
+    return budget_investment_url(commentable.budget, commentable) if commentable.is_a?(Budget::Investment)
   end
 
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -23,7 +23,7 @@ module TagsHelper
     when 'proposal'
       proposal_path(taggable)
     when 'budget/investment'
-      budget_investment_path(taggable.budget_id, taggable)
+      budget_investment_path(taggable.budget, taggable)
     when 'legislation/proposal'
       legislation_process_proposal_path(@process, taggable)
     else

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -37,6 +37,10 @@ class Budget < ActiveRecord::Base
     where.not(phase: "drafting").order(:created_at).last
   end
 
+  def to_param
+    slug
+  end
+
   def current_phase
     phases.send(phase)
   end

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -68,7 +68,7 @@
             <% group.headings.order_by_group_name.each do |heading| %>
               <li class="heading small-12 medium-4 large-2">
                 <% unless current_budget.informing? %>
-                  <%= link_to budget_investments_path(current_budget.id, heading_id: heading.id) do %>
+                  <%= link_to budget_investments_path(current_budget, heading_id: heading.id) do %>
                     <%= heading_name_and_price_html(heading, current_budget) %>
                   <% end %>
                 <% else %>
@@ -91,15 +91,15 @@
         <p>
           <% show_links = show_links_to_budget_investments(current_budget) %>
           <% if show_links %>
-            <%= link_to budget_investments_path(current_budget.id) do %>
+            <%= link_to budget_investments_path(current_budget) do %>
               <small><%= t("budgets.index.investment_proyects") %></small>
             <% end %><br>
           <% end %>
-          <%= link_to budget_investments_path(budget_id: current_budget.id, filter: 'unfeasible') do %>
+          <%= link_to budget_investments_path(budget_id: current_budget, filter: 'unfeasible') do %>
             <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
           <% end %><br>
           <% if show_links %>
-            <%= link_to budget_investments_path(budget_id: current_budget.id, filter: 'unselected') do %>
+            <%= link_to budget_investments_path(budget_id: current_budget, filter: 'unselected') do %>
               <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
             <% end %>
           <% end %>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -145,7 +145,7 @@
         share_title: t("budgets.investments.show.share"),
         title: investment.title,
         image_url: image_absolute_url(investment.image, :thumb),
-        url: budget_investment_url(budget_id: investment.budget_id, id: investment.id)
+        url: budget_investment_url(investment.budget, investment)
       } %>
 
       <% if current_user %>

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -40,7 +40,7 @@
 
   <% if user_voted_for && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag("#{investment.title} #{setting['twitter_hashtag']}", url: budget_investment_url(budget_id: investment.budget_id, id: investment.id), via: setting['twitter_handle']) %>
+      <%= social_share_button_tag("#{investment.title} #{setting['twitter_hashtag']}", url: budget_investment_url(investment.budget, investment), via: setting['twitter_handle']) %>
     </div>
   <% end %>
 </div>

--- a/db/migrate/20180214161527_add_index_to_budget_slug.rb
+++ b/db/migrate/20180214161527_add_index_to_budget_slug.rb
@@ -1,0 +1,5 @@
+class AddIndexToBudgetSlug < ActiveRecord::Migration
+  def change
+    add_index :budgets, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180129190950) do
+ActiveRecord::Schema.define(version: 20180214161527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -221,6 +221,8 @@ ActiveRecord::Schema.define(version: 20180129190950) do
     t.text     "description_publishing_prices"
     t.text     "description_informing"
   end
+
+  add_index "budgets", ["slug"], name: "index_budgets_on_slug", using: :btree
 
   create_table "campaigns", force: :cascade do |t|
     t.string   "name"

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -37,7 +37,7 @@ feature 'Budget Investments' do
     investments.each do |investment|
       within('#budget-investments') do
         expect(page).to have_content investment.title
-        expect(page).to have_css("a[href='#{budget_investment_path(budget_id: budget.id, id: investment.id)}']", text: investment.title)
+        expect(page).to have_css("a[href='#{budget_investment_path(budget, investment)}']", text: investment.title)
         expect(page).not_to have_content(unfeasible_investment.title)
       end
     end
@@ -426,7 +426,7 @@ feature 'Budget Investments' do
       investment3 = create(:budget_investment, heading: heading)
       investment4 = create(:budget_investment, :feasible, heading: heading)
 
-      visit budget_investments_path(budget_id: budget.id, heading_id: heading.id, filter: "unfeasible")
+      visit budget_investments_path(budget, heading_id: heading.id, filter: "unfeasible")
 
       within("#budget-investments") do
         expect(page).to have_css('.budget-investment', count: 1)
@@ -639,7 +639,7 @@ feature 'Budget Investments' do
 
       expect(page.status_code).to eq(200)
       expect(page.html).to be_empty
-      expect(page).to have_current_path(budget_investments_path(budget_id: budget.id))
+      expect(page).to have_current_path(budget_investments_path(budget))
     end
 
     scenario 'Create budget investment too fast' do
@@ -779,7 +779,7 @@ feature 'Budget Investments' do
 
     investment = create(:budget_investment, heading: heading)
 
-    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+    visit budget_investment_path(budget, investment)
 
     expect(page).to have_content(investment.title)
     expect(page).to have_content(investment.description)
@@ -799,7 +799,7 @@ feature 'Budget Investments' do
       scenario "Price & explanation is shown when Budget is on published prices phase" do
         Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
           budget.update(phase: phase)
-          visit budget_investment_path(budget_id: budget.id, id: investment.id)
+          visit budget_investment_path(budget, investment)
 
           expect(page).to have_content(investment.formatted_price)
           expect(page).to have_content(investment.price_explanation)
@@ -813,7 +813,7 @@ feature 'Budget Investments' do
       scenario "Price & explanation isn't shown when Budget is not on published prices phase" do
         (Budget::Phase::PHASE_KINDS - Budget::Phase::PUBLISHED_PRICES_PHASES).each do |phase|
           budget.update(phase: phase)
-          visit budget_investment_path(budget_id: budget.id, id: investment.id)
+          visit budget_investment_path(budget, investment)
 
           expect(page).not_to have_content(investment.formatted_price)
           expect(page).not_to have_content(investment.price_explanation)
@@ -834,7 +834,7 @@ feature 'Budget Investments' do
       scenario "Price & explanation isn't shown for any Budget's phase" do
         Budget::Phase::PHASE_KINDS.each do |phase|
           budget.update(phase: phase)
-          visit budget_investment_path(budget_id: budget.id, id: investment.id)
+          visit budget_investment_path(budget, investment)
 
           expect(page).not_to have_content(investment.formatted_price)
           expect(page).not_to have_content(investment.price_explanation)
@@ -852,7 +852,7 @@ feature 'Budget Investments' do
     Setting['feature.community'] = true
 
     investment = create(:budget_investment, heading: heading)
-    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+    visit budget_investment_path(budget, investment)
     expect(page).to have_content "Access the community"
 
     Setting['feature.community'] = false
@@ -862,14 +862,14 @@ feature 'Budget Investments' do
     Setting['feature.community'] = false
 
     investment = create(:budget_investment, heading: heading)
-    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+    visit budget_investment_path(budget, investment)
     expect(page).not_to have_content "Access the community"
   end
 
   scenario "Don't display flaggable buttons" do
     investment = create(:budget_investment, heading: heading)
 
-    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+    visit budget_investment_path(budget, investment)
 
     expect(page).not_to have_selector ".js-follow"
   end
@@ -900,7 +900,7 @@ feature 'Budget Investments' do
 
     scenario "Budget in selecting phase" do
       budget.update(phase: "selecting")
-      visit budget_investment_path(budget_id: budget.id, id: investment.id)
+      visit budget_investment_path(budget, investment)
 
       expect(page).not_to have_content("Unfeasibility explanation")
       expect(page).not_to have_content("Price explanation")
@@ -921,7 +921,7 @@ feature 'Budget Investments' do
                         heading: heading,
                         unfeasibility_explanation: 'Local government is not competent in this matter')
 
-    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+    visit budget_investment_path(budget, investment)
 
     expect(page).to have_content("Unfeasibility explanation")
     expect(page).to have_content(investment.unfeasibility_explanation)
@@ -940,7 +940,7 @@ feature 'Budget Investments' do
     document = create(:document, documentable: first_milestone)
 
     login_as(user)
-    visit budget_investment_path(budget_id: investment.budget.id, id: investment.id)
+    visit budget_investment_path(investment.budget, investment)
 
     find("#tab-milestones-label").trigger('click')
 
@@ -959,7 +959,7 @@ feature 'Budget Investments' do
     investment = create(:budget_investment)
 
     login_as(user)
-    visit budget_investment_path(budget_id: investment.budget.id, id: investment.id)
+    visit budget_investment_path(investment.budget, investment)
 
     find("#tab-milestones-label").trigger('click')
 
@@ -1292,7 +1292,7 @@ feature 'Budget Investments' do
       investment3 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
       investment4 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
 
-      visit budget_investments_path(budget_id: budget.id, heading_id: heading.id, filter: "unselected")
+      visit budget_investments_path(budget, heading_id: heading.id, filter: "unselected")
 
       within("#budget-investments") do
         expect(page).to have_css('.budget-investment', count: 1)
@@ -1336,7 +1336,7 @@ feature 'Budget Investments' do
     scenario "Do not display vote button for unselected investments in index" do
       investment = create(:budget_investment, :unselected, heading: heading)
 
-      visit budget_investments_path(budget_id: budget.id, heading_id: heading.id, filter: "unselected")
+      visit budget_investments_path(budget, heading_id: heading.id, filter: "unselected")
 
       expect(page).to have_content investment.title
       expect(page).not_to have_link("Vote")

--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -433,7 +433,7 @@ feature 'Commenting Budget::Investments' do
       create(:vote, voter: @manuela, votable: @comment, vote_flag: true)
       create(:vote, voter: @pablo, votable: @comment, vote_flag: false)
 
-      visit budget_investment_path(@budget, @budget, @investment)
+      visit budget_investment_path(@budget, @investment)
 
       within("#comment_#{@comment.id}_votes") do
         within(".in_favor") do

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -93,7 +93,7 @@ feature 'Emails' do
       email = open_last_email
       expect(email).to have_subject('Someone has commented on your investment')
       expect(email).to deliver_to(investment.author)
-      expect(email).to have_body_text(budget_investment_path(investment, budget_id: investment.budget_id))
+      expect(email).to have_body_text(budget_investment_path(investment.budget, investment))
       expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
       expect(email).to have_body_text(account_path)
     end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -86,7 +86,7 @@ module CommonActions
                        elsif commentable.is_a?(Poll)
                          poll_path(commentable)
                        else
-                         budget_investment_path(commentable, budget_id: commentable.budget_id)
+                         budget_investment_path(commentable.budget, commentable)
                        end
     visit commentable_path
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1163* 

What
====
This is a partial backport from Madrid's fork.

We've found out that many budget investment's paths/urls where badly composed (using budget id's instead of budget slugs). That doesn't play quite well for SEO. 

Also there is no need to be as explicit as `budget_investment_url(budget_id: investment.budget_id, id: investment.id)` if `budget_investment_url(investment.budget, investment)` would have the same result... The difference is that the firsts one harcodes the usage of budget ID for urls! The second one leaves that to whatever Budget model says with a `to_param` method.

How
===
- Fixed all explicity budget investment url/paths to just rely on budget & investment objects to know how to parameterize themselves. (This will be hugely needed whenever we backport the SpendingProposal => Budget::Investment migration as you can see at Madrid's issue explanation) https://github.com/consul/consul/commit/6d0d0cd7ad77d8f522ee9ea48e89bcbfe0176f07

- Overwritten default parameterization for Budget class to always use slug instead of id https://github.com/consul/consul/commit/e95c70036f939219c0432738e9496bc6b1b9dc97

- Moving all "load_budget" or "load_investment" methods from controllers to ApplicationController to have only one place to fix this things https://github.com/consul/consul/pull/2463/commits/823c264785a609acea981f58b4f0139ce250fa59 When we do the SpendingProposal => Budget::Investment migration we'll need to modify all `load_investment` calls... having just one would be 🙆‍♂️ for that refactor to be easy to be understood and tested


Screenshots
===========
No need, backend change affecting links only

Test
====
Had to change many tests as well, lets see if everything keeps being okey.

Deployment
==========
As usual

Warnings
========
None