### PR TITLE
Design minor fixes

### DIFF
--- a/app/assets/stylesheets/legislation.scss
+++ b/app/assets/stylesheets/legislation.scss
@@ -86,7 +86,8 @@
   background: #e5ecf2;
   padding-top: 1rem;
 
-  h5 {
+  h4 {
+    font-size: rem-calc(16);
     margin-left: 0.25rem;
     margin-bottom: 0;
     color: #61686e;

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -753,6 +753,11 @@
 
   .tags {
     display: block;
+    margin-bottom: 0;
+
+    a {
+      font-size: $tiny-font-size;
+    }
   }
 
   .icon-debates,

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1174,26 +1174,6 @@
     }
   }
 
-  &.welcome {
-    background: $budget image-url('spending_proposals_bg.jpg');
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    background-size: cover;
-
-    .spending-proposal-timeline {
-      padding-top: $line-height;
-    }
-
-    ul li {
-      margin-right: $line-height;
-      padding-top: $line-height / 2;
-
-      .icon-calendar {
-        display: none;
-      }
-    }
-  }
-
   a {
     text-decoration: underline;
   }

--- a/app/views/budgets/investments/_investment.html.erb
+++ b/app/views/budgets/investments/_investment.html.erb
@@ -45,7 +45,7 @@
               <%= investment.heading.name %>
             </p>
             <div class="investment-project-description">
-              <p><%= investment.description %></p>
+              <%= investment.description %>
               <div class="truncate"></div>
             </div>
             <%= render "shared/tags", taggable: investment, limit: 5 %>

--- a/app/views/budgets/investments/_milestones.html.erb
+++ b/app/views/budgets/investments/_milestones.html.erb
@@ -18,7 +18,7 @@
                   </span>
                 <% end %>
                 <%= image_tag(milestone.image_url(:large), { alt: milestone.image.title, class: "margin", id: "image_#{milestone.id}" }) if milestone.image.present? %>
-                <p><%= milestone.description %></p>
+                <p><%= text_with_links milestone.description %></p>
                 <% if milestone.documents.present? %>
                   <div class="document-link text-center">
                     <p>

--- a/app/views/legislation/processes/_process.html.erb
+++ b/app/views/legislation/processes/_process.html.erb
@@ -7,8 +7,8 @@
     </div>
 
     <div class="small-12 medium-4 column">
-      <%= link_to process, class: "button hollow big expanded", title:  t('.see_latest_comments_title') do %>
-        <span class="icon-comments"></span>&nbsp; <%= t('.see_latest_comments') %>
+      <%= link_to process, class: "button hollow big expanded", title:  t(".see_latest_comments_title") do %>
+        <span class="icon-comments"></span>&nbsp; <%= t(".see_latest_comments") %>
       <% end %>
     </div>
 
@@ -21,43 +21,43 @@
     <% column_width = 12 / process.enabled_phases_and_publications_count %>
     <div class="column row">
       <div class="small-12 column legislation-calendar-info">
-        <p><%= t('legislation.processes.shared.key_dates') %></p>
+        <p><%= t("legislation.processes.shared.key_dates") %></p>
       </div>
     </div>
 
     <div class="column row small-collapse medium-uncollapse legislation-calendar">
       <% if process.debate_phase.enabled? %>
         <div class="small-6 medium-<%= column_width %> column">
-            <h5><%= t('legislation.processes.shared.debate_dates') %></h5>
-            <p><%= format_date(process.debate_start_date) %> - <%= format_date(process.debate_end_date) %></p>
+          <h4><%= t("legislation.processes.shared.debate_dates") %></h4>
+          <p><%= format_date(process.debate_start_date) %> - <%= format_date(process.debate_end_date) %></p>
         </div>
       <% end %>
 
       <% if process.draft_publication.enabled? %>
         <div class="small-6 medium-<%= column_width %> column">
-            <h5><%= t('legislation.processes.shared.draft_publication_date') %></h5>
-            <p><%= format_date(process.draft_publication_date) %></p>
+          <h4><%= t("legislation.processes.shared.draft_publication_date") %></h4>
+          <p><%= format_date(process.draft_publication_date) %></p>
         </div>
       <% end %>
 
       <% if process.proposals_phase.enabled? %>
         <div class="small-6 medium-<%= column_width %> column">
-            <h5><%= t('legislation.processes.shared.proposals_dates') %></h5>
-            <p><%= format_date(process.proposals_phase_start_date) %> - <%= format_date(process.proposals_phase_end_date) %></p>
+          <h4><%= t("legislation.processes.shared.proposals_dates") %></h4>
+          <p><%= format_date(process.proposals_phase_start_date) %> - <%= format_date(process.proposals_phase_end_date) %></p>
         </div>
       <% end %>
 
       <% if process.allegations_phase.enabled? %>
         <div class="small-6 medium-<%= column_width %> column">
-            <h5><%= t('legislation.processes.shared.allegations_dates') %></h5>
-            <p><%= format_date(process.allegations_start_date) %> - <%= format_date(process.allegations_end_date) %></p>
+          <h4><%= t("legislation.processes.shared.allegations_dates") %></h4>
+          <p><%= format_date(process.allegations_start_date) %> - <%= format_date(process.allegations_end_date) %></p>
         </div>
       <% end %>
 
       <% if process.result_publication.enabled? %>
         <div class="small-6 medium-<%= column_width %> column">
-            <h5><%= t('legislation.processes.shared.result_publication_date') %></h5>
-            <p><%= format_date(process.result_publication_date) %></p>
+          <h4><%= t("legislation.processes.shared.result_publication_date") %></h4>
+          <p><%= format_date(process.result_publication_date) %></p>
         </div>
       <% end %>
     </div>

--- a/app/views/pages/custom_page.html.erb
+++ b/app/views/pages/custom_page.html.erb
@@ -4,12 +4,16 @@
 
   <div class="small-12 medium-9 column">
     <h1><%= @custom_page.title %></h1>
-    <h2><%= @custom_page.subtitle %></h2>
+    <% if @custom_page.subtitle.present? %>
+      <h2><%= @custom_page.subtitle%></h2>
+    <% end %>
 
-    <%= raw @custom_page.content %>
+    <%= text_with_links @custom_page.content %>
   </div>
 
-  <div class="small-12 medium-3 column">
-    <%= render '/shared/print' if @custom_page.print_content_flag %>
-  </div>
+  <% if @custom_page.print_content_flag %>
+    <div class="small-12 medium-3 column">
+      <%= render '/shared/print' %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/pages/help/how_to_use/index.html.erb
+++ b/app/views/pages/help/how_to_use/index.html.erb
@@ -4,7 +4,7 @@
 
 <div class="row margin-top">
   <div class="text small-12 column">
-    <%= back_link_to %>
+    <%= back_link_to help_path %>
 
     <h1><%= t('pages.help.titles.how_to_use') %></h1>
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -931,7 +931,7 @@ feature 'Budget Investments' do
     user = create(:user)
     investment = create(:budget_investment)
     create(:budget_investment_milestone, investment: investment,
-                                         description: "Last milestone",
+                                         description: "Last milestone with a link to https://consul.dev",
                                          publication_date: Date.tomorrow)
     first_milestone = create(:budget_investment_milestone, investment: investment,
                                                            description: "First milestone",
@@ -945,12 +945,13 @@ feature 'Budget Investments' do
     find("#tab-milestones-label").trigger('click')
 
     within("#tab-milestones") do
-      expect(first_milestone.description).to appear_before('Last milestone')
+      expect(first_milestone.description).to appear_before('Last milestone with a link to https://consul.dev')
       expect(page).to have_content(Date.tomorrow)
       expect(page).to have_content(Date.yesterday)
       expect(page).not_to have_content(Date.current)
       expect(page.find("#image_#{first_milestone.id}")['alt']).to have_content(image.title)
       expect(page).to have_link(document.title)
+      expect(page).to have_link("https://consul.dev")
     end
   end
 

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -72,6 +72,45 @@ feature "Custom Pages" do
         expect(page).not_to have_content("Print this info")
       end
 
+      scenario "Show all fields and text with links" do
+        custom_page = create(:site_customization_page, :published,
+          slug: "slug-with-all-fields-filled",
+          title: "Custom page",
+          subtitle: "This is my new custom page",
+          content: "Text for new custom page with a link to https://consul.dev",
+          print_content_flag: true,
+          locale: "en"
+        )
+
+        visit custom_page.url
+
+        expect(page).to have_title("Custom page")
+        expect(page).to have_selector("h1", text: "Custom page")
+        expect(page).to have_selector("h2", text: "This is my new custom page")
+        expect(page).to have_content("Text for new custom page with a link to https://consul.dev")
+        expect(page).to have_link("https://consul.dev")
+        expect(page).to have_content("Print this info")
+      end
+
+      scenario "Don't show subtitle if its blank" do
+        custom_page = create(:site_customization_page, :published,
+          slug: "slug-without-subtitle",
+          title: "Custom page",
+          subtitle: "",
+          content: "Text for new custom page",
+          print_content_flag: false,
+          locale: "en"
+        )
+
+        visit custom_page.url
+
+        expect(page).to have_title("Custom page")
+        expect(page).to have_selector("h1", text: "Custom page")
+        expect(page).to have_content("Text for new custom page")
+        expect(page).not_to have_selector("h2")
+        expect(page).not_to have_content("Print this info")
+      end
+
       scenario "Listed in more information page" do
         custom_page = create(:site_customization_page, :published,
           slug: "another-slug", title: "Another custom page",


### PR DESCRIPTION
What
====
This PR include the following design minor fixes:


- Fixes back link to on "how to use" help page: changes `<%= back_link_to %>` to `<%= back_link_to help_path %>`

- Fixes heading structure and i18n format on legislation processes: avoid jump from `<h3>` to `<h5>`, changing with a correct `<h4>` tag.

- Refactors custom page view and include specs: if the subtitle field was empty this generates an empty `<h2>` tag, now only shows this tag if have content. Also allows include links to custom page texts.

- Removes unnecessary `<p></p>` tags on investment partial: it was generating a HTML error: with double tags `<p><p><%= investment.description %></p></p>`

- Adds links to milestone description: allows include links on milestone descriptions.

- Removes old unused CSS.

- Fixes image height on items list with tags (see screenshots).

Screenshots
===========

**`Proposals list before`**
![proposal_before](https://user-images.githubusercontent.com/631897/36257146-fac86ea4-1255-11e8-978c-6c19fdfc3836.png)

**`Proposals list after`**
![proposal_after](https://user-images.githubusercontent.com/631897/36257148-fc037b60-1255-11e8-9525-bae9d012b152.png)

Test
====

Specs updated with new changes and also added new ones.

