### PR TITLE
Make config.time_zone configurable at secrets.yml

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module Consul
 
     # Add lib to the autoload path
     config.autoload_paths << Rails.root.join('lib')
-    config.time_zone = 'Madrid'
+    config.time_zone = Rails.application.secrets.time_zone
     config.active_job.queue_adapter = :delayed_job
 
     # CONSUL specific custom overrides

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,4 +1,5 @@
 default: &default
+  time_zone: 'Madrid'
   secret_key_base: 56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4
 
 maps: &maps
@@ -40,6 +41,7 @@ staging:
   <<: *apis
 
 preproduction:
+  time_zone: 'Madrid'
   secret_key_base: ""
   server_name: ""
   rollbar_server_token: ""
@@ -57,6 +59,7 @@ preproduction:
   <<: *apis
 
 production:
+  time_zone: 'Madrid'
   secret_key_base: ""
   server_name: ""
   rollbar_server_token: ""


### PR DESCRIPTION
What
====
In order to use another timezone different from Madrid's, forks would have to overwrite [`/config/application.rb#35`](https://github.com/consul/consul/blob/master/config/application.rb#L35) `config.time_zone = 'Madrid'`

That should be easily configurable, at least from config/secrets.yml ... as making it a Settings variable could be a bit overkill (its something you'd change just once and forget about it)

How
===
Adding the new variable `timezone` to `secrets.yml.example` and using it to replace existent `'Madrid'` hardcoded value  https://github.com/consul/consul/commit/d531c884d452a08beada36872568b20918f6124c

Screenshots
===========
No need

Test
====
Not sure this should be tested with an spec, just manual testing should be okey.

Deployment
==========
⚠️ This will need an update of existin `config/secrets.yml` files on both local development machines and servers!! And there is no way to do it with some command line tricks... manual edit would be required :/.

Warnings
========
If this is merged, the release that includes it should have a big ⚠️ asking for the changes to be made upfront on server's `config/secrets.yml` files before the code is deployed!!