### PR TITLE
I18n maintenance

### DIFF
--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -59,8 +59,8 @@ en:
         one: "Citizen proposal"
         other: "Citizen proposals"
       spending_proposal:
-        one: "Spending proposal"
-        other: "Spending proposals"
+        one: "Investment project"
+        other: "Investment projects"
       site_customization/page:
         one: Custom page
         other: Custom pages
@@ -113,15 +113,11 @@ en:
         phase: "Phase"
         currency_symbol: "Currency"
       budget/investment:
-        heading_id: "Sección de presupuesto"
-        title: "Title"
-        description: "Description"
-        external_url: "External url"
-        administrator_id: "Administrator"
-        description: "Description"
-        external_url: "Link to additional documentation"
         heading_id: "Heading"
         title: "Title"
+        description: "Description"
+        external_url: "Link to additional documentation"
+        administrator_id: "Administrator"
         location: "Location (optional)"
         organization_name: "If you are proposing in the name of a collective/organization, or on behalf of more people, write its name"
         image: "Proposal descriptive image"
@@ -163,7 +159,7 @@ en:
         name: "Name of organisation"
         responsible_name: "Person responsible for the group"
       spending_proposal:
-        administrator_id: "Administrador"
+        administrator_id: "Administrator"
         association_name: "Association name"
         description: "Description"
         external_url: "Link to additional documentation"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -27,8 +27,8 @@ en:
         preview: Preview
       banner:
         title: Title
-        description:  Description
-        target_url:  Link
+        description: Description
+        target_url: Link
         style: Style
         image: Image
         post_started_at: Post started at
@@ -41,7 +41,7 @@ en:
         form:
           error:
             one: "error prevented this banner from being saved"
-            other: 'errors prevented this banner from being saved'
+            other: "errors prevented this banner from being saved"
       new:
         creating: Create banner
     activity:
@@ -62,7 +62,7 @@ en:
           on_users: Users
         title: Moderator activity
         type: Type
-        no_activity: There ares no moderators activity.
+        no_activity: There are no moderators activity.
     budgets:
       index:
         title: Participatory budgets
@@ -664,7 +664,7 @@ en:
         search_officer_placeholder: Search officer
         search_officer_text: Search for an officer to assign a new shift
         select_date: "Select day"
-        no_voting_days: "Los dias de votación terminaron"
+        no_voting_days: "Voting days ended"
         select_task: "Select task"
         table_shift: "Shift"
         table_email: "Email"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -41,7 +41,7 @@ es:
         form:
           error:
             one: "error impidió guardar el banner"
-            other: 'errores impidieron guardar el banner.'
+            other: "errores impidieron guardar el banner"
       new:
         creating: Crear banner
     activity:
@@ -257,7 +257,7 @@ es:
       edit:
         title: Editar hito
       create:
-        notice: Nuevo hito creado con éxito!
+        notice: ¡Nuevo hito creado con éxito!
       update:
         notice: Hito actualizado
       delete:

--- a/spec/models/signature_sheet_spec.rb
+++ b/spec/models/signature_sheet_spec.rb
@@ -51,7 +51,7 @@ describe SignatureSheet do
       spending_proposal = create(:spending_proposal)
       signature_sheet.signable = spending_proposal
 
-      expect(signature_sheet.name).to eq("Spending proposal #{spending_proposal.id}")
+      expect(signature_sheet.name).to eq("Investment project #{spending_proposal.id}")
     end
 
     it "returns name for budget investment signature sheets" do


### PR DESCRIPTION
Where
=====
* **Related issue:** AyuntamientoMadrid/consul#1129
* **Related PRs:** #2109, AyuntamientoMadrid/consul#1273

What
====
* Add missing exclamation marks (for Spanish)
* Fix typos
* Remove duplicated strings
* Remove trailing whitespaces
* Replace single quotes with double quotes
* Replace untranslated strings

Notes
========
* This is the first PR in a series of reviews to achieve clean, concise I18n files
* To facilitate the review for these kind of changes, small PRs will be done on a weekly basis