### PR TITLE
Store budget heading voters in database

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -66,6 +66,12 @@ module Budgets
 
     def vote
       @investment.register_selection(current_user)
+
+      unless @investment.heading.already_voted_in_by_user?(current_user)
+        Budget::Heading::Voter.create(user_id: current_user.id,
+                                      budget_heading_id: @investment.heading.id)
+      end
+
       load_investment_votes(@investment)
       respond_to do |format|
         format.html { redirect_to budget_investments_path(heading_id: @investment.heading.id) }

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -5,6 +5,8 @@ class Budget
     belongs_to :group
 
     has_many :investments
+    has_many :budget_heading_voters, class_name: "Budget::Heading::Voter", foreign_key: :budget_heading_id
+    has_many :voters, through: :budget_heading_voters, source: :user
 
     validates :group_id, presence: true
     validates :name, presence: true, uniqueness: { if: :name_exists_in_budget_headings }
@@ -26,6 +28,10 @@ class Budget
 
     def can_be_deleted?
       investments.empty?
+    end
+
+    def already_voted_in_by_user?(user)
+      voters.include?(user)
     end
 
     private

--- a/app/models/budget/heading/voter.rb
+++ b/app/models/budget/heading/voter.rb
@@ -1,0 +1,7 @@
+class Budget::Heading::Voter < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :budget_heading, class_name: "Budget::Heading"
+
+  validates :user_id, presence: true
+  validates :budget_heading_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,8 @@ class User < ActiveRecord::Base
   has_many :direct_messages_received, class_name: 'DirectMessage', foreign_key: :receiver_id
   has_many :legislation_answers, class_name: 'Legislation::Answer', dependent: :destroy, inverse_of: :user
   has_many :follows
+  has_many :budget_heading_voters, class_name: "Budget::Heading::Voter", foreign_key: :user_id
+  has_many :budget_headings, through: :budget_heading_voters, source: :budget_heading
   belongs_to :geozone
 
   validates :username, presence: true, if: :username_required?

--- a/db/migrate/20180301151415_create_budget_heading_voters.rb
+++ b/db/migrate/20180301151415_create_budget_heading_voters.rb
@@ -1,0 +1,9 @@
+class CreateBudgetHeadingVoters < ActiveRecord::Migration
+  def change
+    create_table :budget_heading_voters do |t|
+      t.belongs_to :user, index: true
+      t.belongs_to :budget_heading, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180220211105) do
+ActiveRecord::Schema.define(version: 20180301151415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,16 @@ ActiveRecord::Schema.define(version: 20180220211105) do
   end
 
   add_index "budget_groups", ["budget_id"], name: "index_budget_groups_on_budget_id", using: :btree
+
+  create_table "budget_heading_voters", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "budget_heading_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "budget_heading_voters", ["budget_heading_id"], name: "index_budget_heading_voters_on_budget_heading_id", using: :btree
+  add_index "budget_heading_voters", ["user_id"], name: "index_budget_heading_voters_on_user_id", using: :btree
 
   create_table "budget_headings", force: :cascade do |t|
     t.integer "group_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -295,6 +295,11 @@ FactoryBot.define do
     end
   end
 
+  factory :budget_heading_voter, class: 'Budget::Heading::Voter' do
+    association :heading, factory: :budget_heading
+    association :user, factory: :user
+  end
+
   factory :budget_investment, class: 'Budget::Investment' do
     sequence(:title) { |n| "Budget Investment #{n} title" }
     association :heading, factory: :budget_heading

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1097,6 +1097,30 @@ feature 'Budget Investments' do
       end
     end
 
+    context "Voting an investment" do
+      scenario "saves in which budget heading the user has voted and only once" do
+        south_district = create(:budget_heading, group: group)
+        investment1 = create(:budget_investment, heading: south_district)
+        investment2 = create(:budget_investment, heading: south_district)
+
+        login_as(author)
+        visit budget_investment_path(budget, investment1)
+        within("aside") do
+          click_link "Support"
+        end
+
+        expect(Budget::Heading::Voter.count).to be(1)
+        expect(Budget::Heading::Voter.last.user_id).to be(author.id)
+        expect(Budget::Heading::Voter.last.budget_heading_id).to be(south_district.id)
+
+        visit budget_investment_path(budget, investment2)
+        within("aside") do
+          click_link "Support"
+        end
+
+        expect(Budget::Heading::Voter.count).to be(1)
+      end
+    end
   end
 
   context "Evaluating Phase" do

--- a/spec/models/budget/heading/voters_spec.rb
+++ b/spec/models/budget/heading/voters_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe Budget::Heading::Voters do
+
+  let(:budget) { create(:budget) }
+  let(:group) { create(:budget_group, budget: budget) }
+  let(:heading) { create(:budget_heading, group: group, price: 1000000) }
+  let(:budget_heading_voter) { create(:heading_voter) }
+
+  describe 'Validations' do
+    it "is valid" do
+      expect(heading_voter).to be_valid
+    end
+
+    it "is not valid if user_id is empty" do
+      heading_voter.user_id = nil
+      expect(heading_voter).not_to be_valid
+    end
+
+    it "is not valid if budget_heading_id is empty" do
+      heading_voter.budget_heading_id = nil
+      expect(heading_voter).not_to be_valid
+    end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2498

What
====
In order to be able to store in the database in which budget headings a user has supported investments, I've created a new model called `Budget::Heading::Voter` for a table that associates users with budget headings.

When a user supports *for the first time* an investment in a budget heading, a new record is created. So in the following supports the users give in the same heading the relation won't be overwritten (obviously but just in case).