### PR TITLE
Fix Email Spec comment random failures

### DIFF
--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -25,7 +25,7 @@ feature 'Emails' do
   end
 
   context 'Proposal comments' do
-    scenario "Send email on proposal comment", :js do
+    scenario "Send email on proposal comment" do
       user = create(:user, email_on_comment: true)
       proposal = create(:proposal, author: user)
       comment_on(proposal)
@@ -36,7 +36,7 @@ feature 'Emails' do
       expect(email).to have_body_text(proposal_path(proposal))
     end
 
-    scenario 'Do not send email about own proposal comments', :js do
+    scenario 'Do not send email about own proposal comments' do
       user = create(:user, email_on_comment: true)
       proposal = create(:proposal, author: user)
       comment_on(proposal, user)
@@ -44,7 +44,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error "No email has been sent!"
     end
 
-    scenario 'Do not send email about proposal comment unless set in preferences', :js do
+    scenario 'Do not send email about proposal comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       proposal = create(:proposal, author: user)
       comment_on(proposal)
@@ -54,7 +54,7 @@ feature 'Emails' do
   end
 
   context 'Debate comments' do
-    scenario "Send email on debate comment", :js do
+    scenario "Send email on debate comment" do
       user = create(:user, email_on_comment: true)
       debate = create(:debate, author: user)
       comment_on(debate)
@@ -67,7 +67,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own debate comments', :js do
+    scenario 'Do not send email about own debate comments' do
       user = create(:user, email_on_comment: true)
       debate = create(:debate, author: user)
       comment_on(debate, user)
@@ -75,7 +75,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error "No email has been sent!"
     end
 
-    scenario 'Do not send email about debate comment unless set in preferences', :js do
+    scenario 'Do not send email about debate comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       debate = create(:debate, author: user)
       comment_on(debate)
@@ -85,7 +85,7 @@ feature 'Emails' do
   end
 
   context 'Budget investments comments' do
-    scenario 'Send email on budget investment comment', :js do
+    scenario 'Send email on budget investment comment' do
       user = create(:user, email_on_comment: true)
       investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment)
@@ -98,7 +98,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own budget investments comments', :js do
+    scenario 'Do not send email about own budget investments comments' do
       user = create(:user, email_on_comment: true)
       investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment, user)
@@ -106,7 +106,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error 'No email has been sent!'
     end
 
-    scenario 'Do not send email about budget investment comment unless set in preferences', :js do
+    scenario 'Do not send email about budget investment comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment)
@@ -120,7 +120,7 @@ feature 'Emails' do
       @proposal = create(:proposal)
     end
 
-    scenario 'Send email on topic comment', :js do
+    scenario 'Send email on topic comment' do
       user = create(:user, email_on_comment: true)
       topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic)
@@ -133,7 +133,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own topic comments', :js do
+    scenario 'Do not send email about own topic comments' do
       user = create(:user, email_on_comment: true)
       topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic, user)
@@ -141,7 +141,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error 'No email has been sent!'
     end
 
-    scenario 'Do not send email about topic comment unless set in preferences', :js do
+    scenario 'Do not send email about topic comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic)
@@ -151,7 +151,7 @@ feature 'Emails' do
   end
 
   context 'Poll comments' do
-    scenario 'Send email on poll comment', :js do
+    scenario 'Send email on poll comment' do
       user = create(:user, email_on_comment: true)
       poll = create(:poll, author: user)
       comment_on(poll)
@@ -164,7 +164,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own poll comments', :js do
+    scenario 'Do not send email about own poll comments' do
       user = create(:user, email_on_comment: true)
       poll = create(:poll, author: user)
       comment_on(poll, user)
@@ -172,7 +172,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error 'No email has been sent!'
     end
 
-    scenario 'Do not send email about poll question comment unless set in preferences', :js do
+    scenario 'Do not send email about poll question comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       poll = create(:poll, author: user)
       comment_on(poll)

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -76,25 +76,8 @@ module CommonActions
   def comment_on(commentable, user = nil)
     user ||= create(:user)
 
-    login_as(user)
-    commentable_path = if commentable.is_a?(Proposal)
-                         proposal_path(commentable)
-                       elsif commentable.is_a?(Debate)
-                         debate_path(commentable)
-                       elsif commentable.is_a?(Topic)
-                         community_topic_path(commentable, community_id: commentable.community_id)
-                       elsif commentable.is_a?(Poll)
-                         poll_path(commentable)
-                       else
-                         budget_investment_path(commentable, budget_id: commentable.budget_id)
-                       end
-    visit commentable_path
-
-    comment_field = "comment-body-#{commentable.class.name.parameterize('_')}_#{commentable.id}"
-    fill_in comment_field, with: 'Have you thought about...?'
-    click_button 'Publish comment'
-
-    expect(page).to have_content 'Have you thought about...?'
+    comment = create(:comment, commentable: commentable, user: user)
+    CommentNotifier.new(comment: comment).process
   end
 
   def reply_to(original_user, manuela = nil)


### PR DESCRIPTION
Where
=====
* **Related PR's:** https://github.com/AyuntamientoMadrid/consul/pull/1286

What
====
*This is a backport* from Madrid's fork that fixes many test failures
 (AyuntamientoMadrid#1236, AyuntamientoMadrid#1239 and AyuntamientoMadrid#1240)

Deployment
==========
As usual

Warnings
========
None