### PR TITLE
Flaky spec fix: Debates Show: "Back" link directs to previous page

### DIFF
--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -64,11 +64,15 @@ feature 'Debates' do
     end
   end
 
-  scenario 'Show: "Back" link directs to previous page', :js do
+  scenario 'Show: "Back" link directs to previous page' do
     debate = create(:debate, title: 'Test Debate 1')
 
     visit debates_path(order: :hot_score, page: 1)
-    first(:link, debate.title).click
+
+    within("#debate_#{debate.id}") do
+      click_link debate.title
+    end
+
     link_text = find_link('Go back')[:href]
 
     expect(link_text).to include(debates_path(order: :hot_score, page: 1))


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1213
* **Related PR's:** https://github.com/AyuntamientoMadrid/consul/pull/1312

What
====
This is a backport from madrid's https://github.com/AyuntamientoMadrid/consul/pull/1312 that fixes a flaky spec

Deployment
==========
As usual

Warnings
========
None