### PR TITLE
Improve Github's Pull Request Template file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,29 +1,17 @@
-Where
-=====
-* **Related Issue:** LINK_OR_#_REF
-* **Related PR's:** LINK_OR_#_REF_IF_ANY
-
-What
-====
-- Whats the objective of this changes ?
-
-How
-===
-- How you implemented/achieved the objective ?
-
-Screenshots
-===========
-- If changes affect UI just show them drag&dropping images here
-- If change could affect mobile view use your browser developer console to try it & grab another screenshot.
-
-Test
-====
-- Is manual test needed or you just increased/fixed coverage?
-
-Deployment
+References
 ==========
-- Any details to remember when this feature is deployed?
+> Add references to related Issues/Pull Requests/Travis Builds/Rollbar errors/etc...
 
-Warnings
-========
-- Some caveats or important things to notice?
+Objectives
+==========
+> What are the objectives of this changes? (If there is no related Issue with an explanation)
+
+Visual Changes (if any)
+=======================
+> Any visual changes? please attach screenshots (or gifs) showing them.
+> If modified views are public (not the admin panel), try them in mobile display (with your browser's developer console) and add screenshots.
+
+Notes
+=====================
+> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
+> Explain any caveats, or important things to notice like deprecations (if any).


### PR DESCRIPTION
References
==========
* **Related Issues:** None
* **Related Pull Requests:** None

Objectives
==========
The actual PR template feels more like bureaucracy than an actual guide
or checklist to help the PR author explain all important thigs that any
reviewer or changelog reader may need to understand.

We'll be moving most of the redundant things (like remembering tests are
needed, or explaning how things where implemented with a clear and
granular commit history) into a Wiki/Doc entry.

For regular contributors there is no need for reminders, we need to
improve new contributors landing with good guides and lowering the bar
for first PR's

Visual Changes (if any)
=======================
None

Deployment & Warnings
=====================
None