### PR TITLE
[WIP] Base Factories validation spec

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -650,7 +650,7 @@ FactoryBot.define do
   factory :officing_residence, class: 'Officing::Residence' do
     user
     association :officer, factory: :poll_officer
-    document_number
+    document_number  "12345678Z"
     document_type    "1"
     year_of_birth    "1980"
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -924,10 +924,14 @@ LOREM_IPSUM
 
   factory :direct_upload do
     user
+    resource_type "Proposal"
+    resource_relation "documents"
+    attachment { File.new("spec/fixtures/files/empty.pdf") }
 
     trait :proposal do
       resource_type "Proposal"
     end
+
     trait :budget_investment do
       resource_type "Budget::Investment"
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -962,6 +962,9 @@ LOREM_IPSUM
   end
 
   factory :related_content do
+    association :parent_relationable, factory: :proposal
+    association :child_relationable, factory: :debate
+
   end
 
   factory :newsletter do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -391,7 +391,19 @@ FactoryBot.define do
 
   factory :budget_ballot_line, class: 'Budget::Ballot::Line' do
     association :ballot, factory: :budget_ballot
-    association :investment, factory: :budget_investment
+
+    after(:build) do |ballot_line|
+      budget = create(:budget)
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+      group.headings << heading
+      budget.groups << group
+
+      ballot_line.ballot = create(:budget_ballot, budget: budget)
+      ballot_line.investment = create(:budget_investment, :selected, budget: budget,
+                                                                     heading: heading)
+      ballot_line.heading = heading
+    end
   end
 
   factory :budget_reclassified_vote, class: 'Budget::ReclassifiedVote' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -435,6 +435,7 @@ FactoryBot.define do
 
   factory :follow do
     association :user, factory: :user
+    association :followable, factory: :proposal
 
     trait :followed_proposal do
       association :followable, factory: :proposal

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -364,6 +364,10 @@ FactoryBot.define do
     starts_at   Date.yesterday
     ends_at     Date.tomorrow
     enabled     true
+
+    after(:build) do |phase|
+      phase.budget.phases.send(phase.kind).destroy
+    end
   end
 
   factory :image do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -75,7 +75,7 @@ FactoryBot.define do
 
   factory :verification_residence, class: Verification::Residence do
     user
-    document_number
+    document_number  "12345678Z"
     document_type    "1"
     date_of_birth    Date.new(1980, 12, 31)
     postal_code      "28013"

--- a/spec/factories_spec.rb
+++ b/spec/factories_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+FactoryBot.factories.map(&:name).each do |factory_name|
+  describe "The #{factory_name} factory" do
+    it 'is valid' do
+      expect(build(factory_name)).to be_valid
+    end
+  end
+end

--- a/spec/models/budget/ballot_spec.rb
+++ b/spec/models/budget/ballot_spec.rb
@@ -4,13 +4,6 @@ describe Budget::Ballot do
 
   describe "validations" do
 
-    it "is valid" do
-      budget = create(:budget)
-      ballot = create(:budget_ballot, budget: budget)
-
-      expect(ballot).to be_valid
-    end
-
     it "is not valid with the same investment twice" do
       budget = create(:budget)
       group  = create(:budget_group, budget: budget)

--- a/spec/models/budget/investment/milestone_spec.rb
+++ b/spec/models/budget/investment/milestone_spec.rb
@@ -5,10 +5,6 @@ describe Budget::Investment::Milestone do
   describe "Validations" do
     let(:milestone) { build(:budget_investment_milestone) }
 
-    it "is valid" do
-      expect(milestone).to be_valid
-    end
-
     it "is not valid without a title" do
       milestone.title = nil
       expect(milestone).not_to be_valid

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -7,10 +7,6 @@ describe Budget::Investment do
     it_behaves_like "notifiable"
   end
 
-  it "is valid" do
-    expect(investment).to be_valid
-  end
-
   it "is not valid without an author" do
     investment.author = nil
     expect(investment).not_to be_valid

--- a/spec/models/budget/phase_spec.rb
+++ b/spec/models/budget/phase_spec.rb
@@ -19,23 +19,6 @@ describe Budget::Phase do
   end
 
   describe "validates" do
-    it "is not valid without a budget" do
-      expect(build(:budget_phase, budget: nil)).not_to be_valid
-    end
-
-    describe "kind validations" do
-      it "is not valid without a kind" do
-        expect(build(:budget_phase, kind: nil)).not_to be_valid
-      end
-
-      it "is not valid with a kind not in valid budget phases" do
-        expect(build(:budget_phase, kind: 'invalid_phase_kind')).not_to be_valid
-      end
-
-      it "is not valid with the same kind as another budget's phase" do
-        expect(build(:budget_phase, budget: budget)).not_to be_valid
-      end
-    end
 
     describe "#dates_range_valid?" do
       it "is valid when start & end dates are different & consecutive" do

--- a/spec/models/budget/reclassified_vote_spec.rb
+++ b/spec/models/budget/reclassified_vote_spec.rb
@@ -5,10 +5,6 @@ describe Budget::ReclassifiedVote do
   describe "Validations" do
     let(:reclassified_vote) { build(:budget_reclassified_vote) }
 
-    it "is valid" do
-      expect(reclassified_vote).to be_valid
-    end
-
     it "is not valid without a user" do
       reclassified_vote.user_id = nil
       expect(reclassified_vote).not_to be_valid

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -6,10 +6,6 @@ describe Comment do
 
   it_behaves_like "has_public_author"
 
-  it "is valid" do
-    expect(comment).to be_valid
-  end
-
   it "updates cache_counter in debate after hide and restore" do
     debate  = create(:debate)
     comment = create(:comment, commentable: debate)

--- a/spec/models/custom/verification/residence_spec.rb
+++ b/spec/models/custom/verification/residence_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Verification::Residence do
 
-  let(:residence) { build(:verification_residence, document_number: "12345678Z") }
+  let(:residence) { build(:verification_residence) }
 
   describe "verification" do
 

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -9,10 +9,6 @@ describe Debate do
     it_behaves_like "notifiable"
   end
 
-  it "is valid" do
-    expect(debate).to be_valid
-  end
-
   it "is not valid without an author" do
     debate.author = nil
     expect(debate).not_to be_valid

--- a/spec/models/direct_message_spec.rb
+++ b/spec/models/direct_message_spec.rb
@@ -4,10 +4,6 @@ describe DirectMessage do
 
   let(:direct_message) { build(:direct_message) }
 
-  it "is valid" do
-    expect(direct_message).to be_valid
-  end
-
   it "is not valid without a title" do
     direct_message.title = nil
     expect(direct_message).not_to be_valid

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -4,10 +4,6 @@ describe Follow do
 
   let(:follow) { build(:follow, :followed_proposal) }
 
-  it "is valid" do
-    expect(follow).to be_valid
-  end
-
   it "is not valid without a user_id" do
     follow.user_id = nil
     expect(follow).not_to be_valid

--- a/spec/models/geozone_spec.rb
+++ b/spec/models/geozone_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 describe Geozone do
   let(:geozone) { build(:geozone) }
 
-  it "is valid" do
-    expect(geozone).to be_valid
-  end
-
   it "is not valid without a name" do
     geozone.name = nil
     expect(geozone).not_to be_valid

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -3,4 +3,41 @@ require 'rails_helper'
 RSpec.describe Identity, type: :model do
   let(:identity) { build(:identity) }
 
+  it "is not valid without a provider" do
+    identity.provider = nil
+    expect(identity).not_to be_valid
+  end
+
+  it "is not valid without an uid" do
+    identity.uid = nil
+    expect(identity).not_to be_valid
+  end
+
+  describe "#first_or_create_from_oauth" do
+    let(:auth) do
+      OpenStruct.new(uid: 'string', provider: 'Provider')
+    end
+
+    it "does not create an Identity if one already exists" do
+      identity = create(:identity, uid: 'string', provider: 'Provider')
+
+      expect{Identity.first_or_create_from_oauth(auth)}.to change { Identity.count }.by(0)
+    end
+
+    it "returns the first matching identity" do
+      first_identity = create(:identity, uid: 'string', provider: 'Provider')
+
+      expect(Identity.first_or_create_from_oauth(auth)).to eq(first_identity)
+    end
+
+    it "creates a new Identity if none exists" do
+      expect{Identity.first_or_create_from_oauth(auth)}.to change { Identity.count }.by(1)
+    end
+
+    it "returns a new Identity if none exists" do
+      expect(Identity.first_or_create_from_oauth(auth).uid).to eq('string')
+      expect(Identity.first_or_create_from_oauth(auth).provider).to eq('Provider')
+    end
+  end
+
 end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -3,7 +3,4 @@ require 'rails_helper'
 RSpec.describe Identity, type: :model do
   let(:identity) { build(:identity) }
 
-  it "is valid" do
-    expect(identity).to be_valid
-  end
 end

--- a/spec/models/legislation/annotation_spec.rb
+++ b/spec/models/legislation/annotation_spec.rb
@@ -4,11 +4,6 @@ RSpec.describe Legislation::Annotation, type: :model do
   let(:draft_version) { create(:legislation_draft_version) }
   let(:annotation) { create(:legislation_annotation, draft_version: draft_version) }
 
-  it "is valid" do
-    expect(draft_version).to be_valid
-    expect(annotation).to be_valid
-  end
-
   it "calculates the context for multinode annotations" do
     quote = "ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam"\
             " erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex"\

--- a/spec/models/legislation/answer_spec.rb
+++ b/spec/models/legislation/answer_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe Legislation::Answer, type: :model do
   let(:legislation_answer) { build(:legislation_answer) }
 
-  it "is valid" do
-    expect(legislation_answer).to be_valid
-  end
-
   it "counts answers" do
     question = create(:legislation_question)
     option_1 = create(:legislation_question_option, question: question, value: 'Yes')

--- a/spec/models/legislation/draft_version_spec.rb
+++ b/spec/models/legislation/draft_version_spec.rb
@@ -1,11 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Legislation::DraftVersion, type: :model do
-    let(:legislation_draft_version) { build(:legislation_draft_version) }
-
-  it "is valid" do
-    expect(legislation_draft_version).to be_valid
-  end
+  let(:legislation_draft_version) { build(:legislation_draft_version) }
 
   it "renders and saves the html from the markdown body field" do
     legislation_draft_version.body = body_markdown

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 describe Legislation::Process do
   let(:process) { create(:legislation_process) }
 
-  it "is valid" do
-    expect(process).to be_valid
-  end
-
   describe "dates validations" do
     it "is invalid if debate_start_date is present but debate_end_date is not" do
       process = build(:legislation_process, debate_start_date: Date.current, debate_end_date: "")

--- a/spec/models/legislation/proposal_spec.rb
+++ b/spec/models/legislation/proposal_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 describe Legislation::Proposal do
   let(:proposal) { build(:legislation_proposal) }
 
-  it "is valid" do
-    expect(proposal).to be_valid
-  end
-
   it "is not valid without a process" do
     proposal.process = nil
     expect(proposal).not_to be_valid

--- a/spec/models/legislation/question_option_spec.rb
+++ b/spec/models/legislation/question_option_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe Legislation::QuestionOption, type: :model do
   let(:legislation_question_option) { build(:legislation_question_option) }
 
-  it "is valid" do
-    expect(legislation_question_option).to be_valid
-  end
-
   it "is unique per question" do
     question = create(:legislation_question)
     valid_question_option = create(:legislation_question_option, question: question, value: "uno")

--- a/spec/models/legislation/question_spec.rb
+++ b/spec/models/legislation/question_spec.rb
@@ -7,10 +7,6 @@ describe Legislation::Question do
     it_behaves_like "notifiable"
   end
 
-  it "is valid" do
-    expect(question).to be_valid
-  end
-
   context "can be deleted" do
     example "when it has no options or answers" do
       question = create(:legislation_question)

--- a/spec/models/map_location_spec.rb
+++ b/spec/models/map_location_spec.rb
@@ -4,10 +4,6 @@ describe MapLocation do
 
   let(:map_location) { build(:map_location, :proposal_map_location) }
 
-  it "is valid" do
-    expect(map_location).to be_valid
-  end
-
   it "is invalid when longitude/latitude/zoom are not present" do
     map_location.longitude = nil
     map_location.latitude = nil

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 describe Newsletter do
   let(:newsletter) { build(:newsletter) }
 
-  it "is valid" do
-    expect(newsletter).to be_valid
-  end
-
   it 'is not valid without a subject' do
     newsletter.subject = nil
     expect(newsletter).not_to be_valid

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -7,10 +7,6 @@ describe Officing::Residence do
 
   describe "validations" do
 
-    it "is valid" do
-      expect(residence).to be_valid
-    end
-
     it "is not valid without a document number" do
       residence.document_number = nil
       expect(residence).not_to be_valid

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Officing::Residence do
 
   let!(:geozone)  { create(:geozone, census_code: "01") }
-  let(:residence) { build(:officing_residence, document_number: "12345678Z") }
+  let(:residence) { build(:officing_residence) }
 
   describe "validations" do
 
@@ -77,9 +77,7 @@ describe Officing::Residence do
                     gender: 'female',
                     geozone: geozone)
 
-      residence = build(:officing_residence,
-                        document_number: "12345678Z",
-                        document_type: "1")
+      residence = build(:officing_residence, document_type: "1")
 
       residence.save
       user = residence.user
@@ -96,7 +94,7 @@ describe Officing::Residence do
     it "makes half-verified users fully verified" do
       user = create(:user, residence_verified_at: Time.current, document_type: "1", document_number: "12345678Z")
       expect(user).to be_unverified
-      residence = build(:officing_residence, document_number: "12345678Z", year_of_birth: 1980)
+      residence = build(:officing_residence, year_of_birth: 1980)
       expect(residence).to be_valid
       expect(user.reload).to be_unverified
       residence.save
@@ -104,7 +102,7 @@ describe Officing::Residence do
     end
 
     it "stores failed census calls" do
-      residence = build(:officing_residence, :invalid, document_number: "12345678Z")
+      residence = build(:officing_residence, :invalid)
       residence.save
 
       expect(FailedCensusCall.count).to eq(1)

--- a/spec/models/poll/answer_spec.rb
+++ b/spec/models/poll/answer_spec.rb
@@ -6,10 +6,6 @@ describe Poll::Answer do
 
     let(:answer) { build(:poll_answer) }
 
-    it "is valid" do
-      expect(answer).to be_valid
-    end
-
     it "is not valid wihout a question" do
       answer.question = nil
       expect(answer).not_to be_valid

--- a/spec/models/poll/booth_spec.rb
+++ b/spec/models/poll/booth_spec.rb
@@ -4,10 +4,6 @@ describe Poll::Booth do
 
   let(:booth) { build(:poll_booth) }
 
-  it "is valid" do
-    expect(booth).to be_valid
-  end
-
   it "is not valid without a name" do
     booth.name = nil
     expect(booth).not_to be_valid

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -9,10 +9,6 @@ describe Poll do
   end
 
   describe "validations" do
-    it "is valid" do
-      expect(poll).to be_valid
-    end
-
     it "is not valid without a name" do
       poll.name = nil
       expect(poll).not_to be_valid

--- a/spec/models/poll/shift_spec.rb
+++ b/spec/models/poll/shift_spec.rb
@@ -10,10 +10,6 @@ describe Poll::Shift do
   describe "validations" do
     let(:shift) { build(:poll_shift) }
 
-    it "is valid" do
-      expect(shift).to be_valid
-    end
-
     it "is not valid without a booth" do
       shift.booth = nil
       expect(shift).not_to be_valid

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -9,10 +9,6 @@ describe Poll::Voter do
 
   describe "validations" do
 
-    it "is valid" do
-      expect(voter).to be_valid
-    end
-
     it "is not valid without a user" do
       voter.user = nil
       expect(voter).not_to be_valid

--- a/spec/models/proposal_notification_spec.rb
+++ b/spec/models/proposal_notification_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 describe ProposalNotification do
   let(:notification) { build(:proposal_notification) }
 
-  it "is valid" do
-    expect(notification).to be_valid
-  end
-
   it "is not valid without a title" do
     notification.title = nil
     expect(notification).not_to be_valid

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -10,10 +10,6 @@ describe Proposal do
     it_behaves_like "map validations"
   end
 
-  it "is valid" do
-    expect(proposal).to be_valid
-  end
-
   it "is not valid without an author" do
     proposal.author = nil
     expect(proposal).not_to be_valid

--- a/spec/models/related_content_spec.rb
+++ b/spec/models/related_content_spec.rb
@@ -12,9 +12,10 @@ describe RelatedContent do
   end
 
   it "does not allow empty relationables" do
-    expect(build(:related_content)).not_to be_valid
-    expect(build(:related_content, parent_relationable: parent_relationable)).not_to be_valid
-    expect(build(:related_content, child_relationable: child_relationable)).not_to be_valid
+    expect(build(:related_content, parent_relationable: nil)).not_to be_valid
+    expect(build(:related_content, child_relationable: nil)).not_to be_valid
+    expect(build(:related_content, parent_relationable: parent_relationable, child_relationable: nil)).not_to be_valid
+    expect(build(:related_content, child_relationable: child_relationable, parent_relationable: nil)).not_to be_valid
   end
 
   it "does not allow repeated related contents" do

--- a/spec/models/signature_sheet_spec.rb
+++ b/spec/models/signature_sheet_spec.rb
@@ -6,10 +6,6 @@ describe SignatureSheet do
 
   describe "validations" do
 
-    it "is valid" do
-      expect(signature_sheet).to be_valid
-    end
-
     it "is valid with a valid signable" do
       signature_sheet.signable = create(:proposal)
       expect(signature_sheet).to be_valid

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -6,10 +6,6 @@ describe Signature do
 
   describe "validations" do
 
-    it "is valid" do
-      expect(signature).to be_valid
-    end
-
     it "is not valid without a document number" do
       signature.document_number = nil
       expect(signature).not_to be_valid

--- a/spec/models/site_customization/content_block_spec.rb
+++ b/spec/models/site_customization/content_block_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe SiteCustomization::ContentBlock, type: :model do
   let(:block) { build(:site_customization_content_block) }
 
-  it "is valid" do
-    expect(block).to be_valid
-  end
-
   it "name is unique per locale" do
     create(:site_customization_content_block, name: "top_links", locale: "en")
     invalid_block = build(:site_customization_content_block, name: "top_links", locale: "en")

--- a/spec/models/site_customization/page_spec.rb
+++ b/spec/models/site_customization/page_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe SiteCustomization::Page, type: :model do
   let(:custom_page) { build(:site_customization_page) }
 
-  it "is valid" do
-    expect(custom_page).to be_valid
-  end
-
   it "is invalid if slug has symbols" do
     custom_page = build(:site_customization_page, slug: "as/as*la")
     expect(custom_page).to be_invalid

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -7,10 +7,6 @@ describe Topic do
     it_behaves_like "notifiable"
   end
 
-  it "is valid" do
-    expect(topic).to be_valid
-  end
-
   it "is not valid without an author" do
     topic.author = nil
     expect(topic).not_to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,10 +48,6 @@ describe User do
 
   subject { build(:user) }
 
-  it "is valid" do
-    expect(subject).to be_valid
-  end
-
   describe "#terms" do
     it "is not valid without accepting the terms of service" do
       subject.terms_of_service = nil

--- a/spec/models/verification/letter_spec.rb
+++ b/spec/models/verification/letter_spec.rb
@@ -8,10 +8,6 @@ describe Verification::Letter do
 
     let(:letter) { build(:verification_letter) }
 
-    it "is valid" do
-      expect(letter).to be_valid
-    end
-
     it "is not valid without a user" do
       letter.user = nil
       expect(letter).not_to be_valid

--- a/spec/models/verification/residence_spec.rb
+++ b/spec/models/verification/residence_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Verification::Residence do
 
   let!(:geozone) { create(:geozone, census_code: "01") }
-  let(:residence) { build(:verification_residence, document_number: "12345678Z") }
+  let(:residence) { build(:verification_residence) }
 
   describe "validations" do
 
@@ -97,7 +97,7 @@ describe Verification::Residence do
 
   describe "Failed census call" do
     it "stores failed census API calls" do
-      residence = build(:verification_residence, :invalid, document_number: "12345678Z")
+      residence = build(:verification_residence, :invalid)
       residence.save
 
       expect(FailedCensusCall.count).to eq(1)

--- a/spec/models/verification/residence_spec.rb
+++ b/spec/models/verification/residence_spec.rb
@@ -7,10 +7,6 @@ describe Verification::Residence do
 
   describe "validations" do
 
-    it "is valid" do
-      expect(residence).to be_valid
-    end
-
     describe "dates" do
       it "is valid with a valid date of birth" do
         residence = described_class.new("date_of_birth(3i)" => "1", "date_of_birth(2i)" => "1", "date_of_birth(1i)" => "1980")

--- a/spec/models/verification/sms_spec.rb
+++ b/spec/models/verification/sms_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 describe Verification::Sms do
-  it "is valid" do
-    sms = build(:verification_sms)
-    expect(sms).to be_valid
-  end
 
   it "validates uniqness of phone" do
     create(:user, confirmed_phone: "699999999")

--- a/spec/shared/models/acts_as_imageable.rb
+++ b/spec/shared/models/acts_as_imageable.rb
@@ -3,10 +3,6 @@ shared_examples "acts as imageable" do |imageable_factory|
   let!(:image)                  { build(:image, imageable_factory.to_sym) }
   let!(:imageable)              { image.imageable }
 
-  it "is valid" do
-    expect(image).to be_valid
-  end
-
   describe "file extension" do
 
     it "is not valid with '.png' extension" do

--- a/spec/shared/models/document_validations.rb
+++ b/spec/shared/models/document_validations.rb
@@ -7,10 +7,6 @@ shared_examples "document validations" do |documentable_factory|
   let!(:maxfilesize)            { max_file_size(document.documentable.class) }
   let!(:acceptedcontenttypes)   { accepted_content_types(document.documentable.class) }
 
-  it "is valid" do
-    expect(document).to be_valid
-  end
-
   it "is not valid without a title" do
     document.title = nil
 

--- a/spec/shared/models/image_validations.rb
+++ b/spec/shared/models/image_validations.rb
@@ -6,10 +6,6 @@ shared_examples "image validations" do |imageable_factory|
   let!(:imageable)              { image.imageable }
   let!(:acceptedcontenttypes)   { imageable_accepted_content_types }
 
-  it "is valid" do
-    expect(image).to be_valid
-  end
-
   it "is not valid without a title" do
     image.title = nil
 


### PR DESCRIPTION
References
=====
None

Objectives
====
We [had 39 "is valid" scenarios](https://github.com/consul/consul/commit/6e031a477d191b96ef19dae255a62b412b032984) on model specs that where checking if the model's base factory was valid "as it is"

But apart from that "redundancy" the problem was many model specs didn't had that scenario, as its a bit tedious to remember adding this scenario on every model spec. Also many base factories weren't valid and needed to be fix.

As a **bonus** the Identity model spec was completed (after removing the only scenario it had and realizing either the file should have to be removed or the spec completed https://github.com/consul/consul/commit/3ae7a4105f5fd8bdecc82401f04e3c27206286ba)

Screenshots
===========
No need

Notes
========
There is obviously an alternative... that is checking all model specs for that  basic `is valid` scenario and adding it wherever its missing.

But thinking about we should be ensuring all models have a model spec, and each and everyone of them has an associated factory present at `spec/factories.rb`... maybe "manual checks" are not the way to go. Automating that check might be a good  topic for next PR... 