### PR TITLE
Fix `rake db:dev_seed` task flaky spec

### DIFF
--- a/spec/lib/tasks/dev_seed_spec.rb
+++ b/spec/lib/tasks/dev_seed_spec.rb
@@ -1,5 +1,7 @@
-require 'rails_helper'
 require 'rake'
+require 'rails_helper'
+Rake::Task.define_task(:environment)
+Rake.application.rake_require('tasks/db')
 
 describe 'rake db:dev_seed' do
   let :run_rake_task do


### PR DESCRIPTION
References
==========
* Related PR: AyuntamientoMadrid/consul#1259

Objectives
==========
* Backport of the aforementioned PR into CONSUL to mitigate entirely this flaky spec, see original PR for full details

Visual Changes (if any)
=======================
* None

Notes
=====================
* Fixed coverage, so all green! :white_check_mark:
* This is a partial backport —that is, not all commits done on the original PR were cherry picked into this branch but rather the only one that was relevant
