### PR TITLE
Heading link on budgets message

### DIFF
--- a/app/helpers/budget_headings_helper.rb
+++ b/app/helpers/budget_headings_helper.rb
@@ -6,4 +6,10 @@ module BudgetHeadingsHelper
     end
   end
 
+  def heading_link(assigned_heading = nil, budget = nil)
+    return nil unless assigned_heading && budget
+    heading_path = budget_investments_path(budget, heading_id: assigned_heading.try(:id))
+    link_to(assigned_heading.name, heading_path)
+  end
+
 end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -208,11 +208,11 @@ class Budget
     end
 
     def reason_for_not_being_ballotable_by(user, ballot)
-      return permission_problem(user)    if permission_problem?(user)
-      return :not_selected               unless selected?
-      return :no_ballots_allowed         unless budget.balloting?
-      return :different_heading_assigned unless ballot.valid_heading?(heading)
-      return :not_enough_money_html      if ballot.present? && !enough_money?(ballot)
+      return permission_problem(user)         if permission_problem?(user)
+      return :not_selected                    unless selected?
+      return :no_ballots_allowed              unless budget.balloting?
+      return :different_heading_assigned_html unless ballot.valid_heading?(heading)
+      return :not_enough_money_html           if ballot.present? && !enough_money?(ballot)
     end
 
     def permission_problem(user)

--- a/app/views/budgets/investments/_ballot.html.erb
+++ b/app/views/budgets/investments/_ballot.html.erb
@@ -42,17 +42,31 @@
 
   <% if reason.present? && !ballot.has_investment?(investment) %>
 
-    <div class="js-participation-not-allowed participation-not-allowed" style='display:none'>
+    <div class="js-participation-not-allowed participation-not-allowed" style="display:none">
+
+      <% verify_account = link_to(t("votes.verify_account"), verification_path) %>
+      <% signin = link_to(t("votes.signin"), new_user_session_path) %>
+      <% signup = link_to(t("votes.signup"), new_user_registration_path) %>
+      <% my_heading = link_to(investment.heading.name,
+                      budget_investments_path(budget_id: investment.budget_id,
+                                              heading_id: investment.heading_id)) %>
+      <% change_ballot = link_to(t("budgets.ballots.reasons_for_not_balloting.change_ballot"),
+                                          budget_ballot_path(@budget))%>
+
+      <% if @assigned_heading.present? %>
+        <% heading_link = link_to(@assigned_heading.name,
+                                  budget_investments_path(@budget,
+                                  heading_id: @assigned_heading.try(:id))) %>
+      <% end %>
+
       <p>
-        <%= t("budgets.ballots.reasons_for_not_balloting.#{reason}",
-              verify_account: link_to(t("votes.verify_account"), verification_path),
-              signin: link_to(t("votes.signin"), new_user_session_path),
-              signup: link_to(t("votes.signup"), new_user_registration_path),
-              my_heading: link_to(investment.heading.name,
-                                  budget_investments_path(budget_id: investment.budget_id,
-                                                          heading_id: investment.heading_id)),
-              change_ballot: link_to(t("budgets.ballots.reasons_for_not_balloting.change_ballot"),
-                                    budget_ballot_path(@budget))).html_safe %>
+        <small>
+          <%= t("budgets.ballots.reasons_for_not_balloting.#{reason}",
+                verify_account: verify_account, signin: signin,
+                signup: signup, my_heading: my_heading,
+                change_ballot: change_ballot,
+                heading_link: heading_link).html_safe %>
+        </small>
       </p>
     </div>
 

--- a/app/views/budgets/investments/_ballot.html.erb
+++ b/app/views/budgets/investments/_ballot.html.erb
@@ -53,19 +53,13 @@
       <% change_ballot = link_to(t("budgets.ballots.reasons_for_not_balloting.change_ballot"),
                                           budget_ballot_path(@budget))%>
 
-      <% if @assigned_heading.present? %>
-        <% heading_link = link_to(@assigned_heading.name,
-                                  budget_investments_path(@budget,
-                                  heading_id: @assigned_heading.try(:id))) %>
-      <% end %>
-
       <p>
         <small>
           <%= t("budgets.ballots.reasons_for_not_balloting.#{reason}",
                 verify_account: verify_account, signin: signin,
                 signup: signup, my_heading: my_heading,
                 change_ballot: change_ballot,
-                heading_link: heading_link).html_safe %>
+                heading_link: heading_link(@assigned_heading, @budget)).html_safe %>
         </small>
       </p>
     </div>

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -37,10 +37,7 @@
               <div class="small-12 medium-9">
                 <div class="callout warning margin-top">
                   <%= t("budgets.investments.header.different_heading_assigned_html",
-                        heading_link: link_to(
-                          @assigned_heading.name,
-                          budget_investments_path(@budget, heading_id: @assigned_heading.try(:id)))
-                       ) %>
+                        heading_link: heading_link(@assigned_heading, @budget)) %>
                   <br>
                   <small>
                     <%= t("budgets.investments.header.change_ballot",

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -35,7 +35,7 @@
                 <%= t("budgets.investments.index.by_heading", heading: @heading.name) %>
               </h2>
               <div class="small-12 medium-9">
-                <div class="callout warning">
+                <div class="callout warning margin-top">
                   <%= t("budgets.investments.header.different_heading_assigned_html",
                         heading_link: link_to(
                           @assigned_heading.name,

--- a/app/views/budgets/investments/_sidebar.html.erb
+++ b/app/views/budgets/investments/_sidebar.html.erb
@@ -43,9 +43,7 @@
   <% elsif @assigned_heading.present? %>
     <p>
       <%= t("budgets.investments.index.sidebar.different_heading_assigned_html",
-              heading_link: link_to(
-                @assigned_heading.name,
-                budget_investments_path(@budget, heading_id: @assigned_heading.try(:id)))
+              heading_link: heading_link(@assigned_heading, @budget)
             ) %>
       <br>
       <small>

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -29,11 +29,13 @@
   <% if reason.present? && !user_voted_for %>
     <div class="js-participation-not-allowed participation-not-allowed" style='display:none' aria-hidden="false">
       <p>
+        <small>
           <%= t("votes.budget_investments.#{reason}",
                 verify_account: link_to(t("votes.verify_account"), verification_path),
                 signin: link_to(t("votes.signin"), new_user_session_path),
                 signup: link_to(t("votes.signup"), new_user_registration_path)
            ).html_safe %>
+        </small>
       </p>
     </div>
   <% end %>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -19,7 +19,7 @@ en:
         not_selected: Unselected investment projects can not be supported
         not_enough_money_html: "You have already assigned the available budget.<br><small>Remember you can %{change_ballot} at any time</small>"
         no_ballots_allowed: Selecting phase is closed
-        different_heading_assigned: You have already voted a different heading
+        different_heading_assigned_html: "You have already voted a different heading: %{heading_link}"
         change_ballot: change your votes
     groups:
       show:

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -19,7 +19,7 @@ es:
         not_selected: No se pueden votar proyectos inviables.
         not_enough_money_html: "Ya has asignado el presupuesto disponible.<br><small>Recuerda que puedes %{change_ballot} en cualquier momento</small>"
         no_ballots_allowed: El periodo de votación está cerrado.
-        different_heading_assigned: Ya votaste en una sección distinta del presupuesto.
+        different_heading_assigned_html: "Ya has votado proyectos de otra partida: %{heading_link}"
         change_ballot: cambiar tus votos
     groups:
       show:

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -226,7 +226,7 @@ feature 'Ballots' do
         click_link "Districts"
         click_link "District 2"
 
-        expect(page).to have_content("You have active votes in another heading")
+        expect(page).to have_content("You have active votes in another heading: District 1")
       end
     end
 
@@ -296,7 +296,7 @@ feature 'Ballots' do
       visit budget_investments_path(budget, heading_id: new_york.id)
 
       expect(page).not_to have_css "#progressbar"
-      expect(page).to have_content "You have active votes in another heading:"
+      expect(page).to have_content "You have active votes in another heading: California"
       expect(page).to have_link california.name, href: budget_investments_path(budget, heading_id: california.id)
     end
 

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -756,7 +756,7 @@ describe Budget::Investment do
           ballot = create(:budget_ballot, user: user, budget: budget)
           ballot.investments << inv1
 
-          expect(inv2.reason_for_not_being_ballotable_by(user, ballot)).to eq(:different_heading_assigned)
+          expect(inv2.reason_for_not_being_ballotable_by(user, ballot)).to eq(:different_heading_assigned_html)
         end
 
         it "rejects proposals with price higher than current available money" do


### PR DESCRIPTION
References
==========

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1326

Objectives
==========

When a user already has voted a heading, adds heading link on the different heading assigned message.

Visual Changes 
=======================
**Message before (with the link only on header message)**

<img width="960" alt="heading_before" src="https://user-images.githubusercontent.com/631897/36933251-1dc6e070-1ed6-11e8-8908-7e21f1995997.png">

**Message after (with the link on the header and each item on hover)**

<img width="912" alt="heading_after" src="https://user-images.githubusercontent.com/631897/36933253-1fa3d182-1ed6-11e8-91e7-ef2cb40c3ffc.png">

Notes
==========
On screenshots show "district" (we use that on Madrid) but here we maintain the "heading" term.