### PR TITLE
Restrict valuators access to edit/valute only on valuating phase

### DIFF
--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -5,6 +5,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
   feature_flag :budgets
 
   before_action :restrict_access_to_assigned_items, only: [:show, :edit, :valuate]
+  before_action :restrict_access, only: [:edit, :valuate]
   before_action :load_budget
   before_action :load_investment, only: [:show, :edit, :valuate]
 
@@ -96,6 +97,12 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
       params.require(:budget_investment).permit(:price, :price_first_year, :price_explanation,
                                                 :feasibility, :unfeasibility_explanation,
                                                 :duration, :valuation_finished)
+    end
+
+    def restrict_access
+      unless current_user.administrator? || current_budget.valuating?
+        raise CanCan::AccessDenied.new(I18n.t('valuation.budget_investments.not_in_valuating_phase'))
+      end
     end
 
     def restrict_access_to_assigned_items

--- a/config/locales/en/valuation.yml
+++ b/config/locales/en/valuation.yml
@@ -74,6 +74,7 @@ en:
       notice:
         valuate: "Dossier updated"
       valuation_comments: Valuation comments
+      not_in_valuating_phase: Investments can only be valuated when Budget is in valuating phase
     spending_proposals:
       index:
         geozone_filter_all: All zones

--- a/config/locales/es/valuation.yml
+++ b/config/locales/es/valuation.yml
@@ -74,6 +74,7 @@ es:
       notice:
         valuate: "Dossier actualizado"
       valuation_comments: Comentarios de evaluación
+      not_in_valuating_phase: Los proyectos sólo pueden ser evaluados cuando el Presupuesto este en fase de evaluación
     spending_proposals:
       index:
         geozone_filter_all: Todos los ámbitos de actuación

--- a/spec/features/comments/budget_investments_valuation_spec.rb
+++ b/spec/features/comments/budget_investments_valuation_spec.rb
@@ -5,7 +5,9 @@ feature 'Internal valuation comments on Budget::Investments' do
   let(:valuator_user) { create(:valuator).user }
   let(:admin_user) { create(:administrator).user }
   let(:budget) { create(:budget, :valuating) }
-  let(:investment) { create(:budget_investment, budget: budget) }
+  let(:group) { create(:budget_group, budget: budget) }
+  let(:heading) { create(:budget_heading, group: group) }
+  let(:investment) { create(:budget_investment, budget: budget, group: group, heading: heading) }
 
   background do
     Setting['feature.budgets'] = true

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -386,7 +386,8 @@ feature 'Emails' do
     end
 
     scenario "Unfeasible investment" do
-      investment = create(:budget_investment, author: author, budget: budget)
+      budget.update(phase: 'valuating')
+      investment = create(:budget_investment, author: author, budget: budget, heading: heading)
 
       valuator = create(:valuator)
       investment.valuators << valuator

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -216,8 +216,10 @@ feature 'Valuation budget investments' do
   feature 'Valuate' do
     let(:admin) { create(:administrator) }
     let(:investment) do
-      create(:budget_investment, budget: budget, price: nil,
-                                                        administrator: admin)
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+      create(:budget_investment, heading: heading, group: group, budget: budget, price: nil,
+                                 administrator: admin)
     end
 
     background do
@@ -410,9 +412,7 @@ feature 'Valuation budget investments' do
     scenario 'not visible to valuators when budget is not valuating' do
       budget.update(phase: 'publishing_prices')
 
-      investment = create(:budget_investment,
-                           :visible_to_valuators,
-                           budget: budget)
+      investment = create(:budget_investment, budget: budget)
       investment.valuators << [valuator]
 
       login_as(valuator.user)
@@ -428,9 +428,7 @@ feature 'Valuation budget investments' do
       admin = create(:administrator, user: user)
       valuator = create(:valuator, user: user)
 
-      investment = create(:budget_investment,
-                           :visible_to_valuators,
-                           budget: budget)
+      investment = create(:budget_investment, budget: budget)
       investment.valuators << [valuator]
 
 

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -406,5 +406,39 @@ feature 'Valuation budget investments' do
       expect(page).to have_content('2 errors')
       expect(page).to have_content('Only integer numbers', count: 2)
     end
+
+    scenario 'not visible to valuators when budget is not valuating' do
+      budget.update(phase: 'publishing_prices')
+
+      investment = create(:budget_investment,
+                           :visible_to_valuators,
+                           budget: budget)
+      investment.valuators << [valuator]
+
+      login_as(valuator.user)
+      visit edit_valuation_budget_budget_investment_path(budget, investment)
+
+      expect(page).to have_content('Investments can only be valuated when Budget is in valuating phase')
+    end
+
+    scenario 'visible to admins regardless of not being in valuating phase' do
+      budget.update(phase: 'publishing_prices')
+
+      user = create(:user)
+      admin = create(:administrator, user: user)
+      valuator = create(:valuator, user: user)
+
+      investment = create(:budget_investment,
+                           :visible_to_valuators,
+                           budget: budget)
+      investment.valuators << [valuator]
+
+
+      login_as(admin.user)
+      visit valuation_budget_budget_investment_path(budget, investment)
+      click_link 'Edit dossier'
+
+      expect(page).to have_content investment.title
+    end
   end
 end


### PR DESCRIPTION
References
==========
This is a backport from https://github.com/AyuntamientoMadrid/consul/pull/1348 tested in production.

Objectives
==========
Only allow valuator access to edit/valuate investments when budget is in Valuating phase.

Visual Changes (if any)
=======================
Check associated PR for error message screenshot

Notes
=====================
None