### PR TITLE
Admin users

### DIFF
--- a/app/views/admin/users/_users.html.erb
+++ b/app/views/admin/users/_users.html.erb
@@ -14,7 +14,7 @@
     <tbody>
       <% @users.each do |user| %>
         <tr>
-          <td><%= user.name %></td>
+          <td><%= link_to user.name, user_path(user), target: "_blank" %></td>
           <td><%= user.email %></td>
           <td><%= user.document_number %></td>
           <td><%= display_user_roles(user) %></td>

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -9,10 +9,16 @@ feature 'Admin users' do
   end
 
   scenario 'Index' do
-    expect(page).to have_content @user.name
+    expect(page).to have_link @user.name
     expect(page).to have_content @user.email
     expect(page).to have_content @admin.name
     expect(page).to have_content @admin.email
+  end
+
+  scenario 'The username links to their public profile' do
+    click_link @user.name
+
+    expect(current_path).to eq(user_path(@user))
   end
 
   scenario 'Search' do


### PR DESCRIPTION
References
==========
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1347/

Objectives
==========

Adds a link to the username on admin users index view to their public profile. As the link goes outside of Admin Panel I have included a `target="_blank"` on it.

Visual Changes
=======================
**Now the names are links!** 🎉

![admin users](https://user-images.githubusercontent.com/631897/37165886-fc1fe5b2-22fd-11e8-895c-90f4b01f2620.png)
