### PR TITLE
Admin budget investment info

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -507,8 +507,7 @@ $sidebar-active: #f4fcd0;
 }
 
 .account-info,
-.login-as,
-.spending-proposal-info {
+.login-as {
   background-color: #e7e7e7;
   border-radius: rem-calc(3);
   font-size: rem-calc(16);
@@ -521,8 +520,26 @@ $sidebar-active: #f4fcd0;
   }
 }
 
-.spending-proposal-info p {
-  margin-bottom: 0;
+.extra-info {
+  background: #fafafa;
+  border-bottom-left-radius: rem-calc(6);
+  border-bottom-right-radius: rem-calc(6);
+  border-top: 2px solid #000;
+  font-size: $small-font-size;
+  padding: $line-height / 2;
+}
+
+.admin-budget-investment-info {
+  background: $highlight-soft;
+  border: 2px solid $highlight;
+  border-radius: rem-calc(4);
+  margin-bottom: $line-height;
+  padding: $line-height / 2;
+
+  p {
+    font-size: $small-font-size;
+    margin-bottom: 0;
+  }
 }
 
 .admin {

--- a/app/views/admin/budget_investments/_written_by_author.html.erb
+++ b/app/views/admin/budget_investments/_written_by_author.html.erb
@@ -1,50 +1,53 @@
-<div class="callout primary float-right">
-  <%= t "admin.budget_investments.show.info", budget_name: @budget.name, group_name: @investment.group.name, id: @investment.id %>
+<div class="extra-info float-right">
+  <%= t "admin.budget_investments.show.info",
+         budget_name: @budget.name,
+         group_name: @investment.group.name,
+         id: @investment.id %>
 </div>
 
 <br>
 <h1 class="inline-block"><%= @investment.title %></h1>
 
-<div class="row small-collapse spending-proposal-info">
-  <div class="row">
+<div class="admin-budget-investment-info">
+  <div class="row expanded">
     <div class="small-12 medium-4 column">
       <p title="<%= t("admin.budget_investments.show.group") %>: <%= @investment.group.name %>">
-        <strong><%= t("admin.budget_investments.show.heading") %>:</strong>
+        <strong><%= t("admin.budget_investments.show.heading") %></strong>:
         <%= @investment.heading.name %>
       </p>
     </div>
 
     <div class="small-12 medium-4 column">
       <p>
-        <strong><%= t("admin.budget_investments.show.by") %>:</strong>
+        <strong><%= t("admin.budget_investments.show.by") %></strong>:
         <%= link_to @investment.author.name, admin_hidden_user_path(@investment.author) %>
       </p>
     </div>
 
     <div class="small-12 medium-4 column">
       <p>
-        <strong><%= t("admin.budget_investments.show.sent") %>:</strong>
+        <strong><%= t("admin.budget_investments.show.sent") %></strong>:
         <%= l @investment.created_at, format: :datetime %>
       </p>
     </div>
   </div>
 
-  <div class="row">
+  <div class="row expanded">
     <div class="small-12 medium-4 column">
       <p>
-        <strong><%= t("admin.budget_investments.show.compatibility.title") %>:</strong>
+        <strong><%= t("admin.budget_investments.show.compatibility.title") %></strong>:
         <%= t("admin.budget_investments.show.compatibility.#{@investment.incompatible?}") %>
       </p>
     </div>
     <div class="small-12 medium-4 column">
       <p>
-        <strong><%= t("admin.budget_investments.show.selection.title") %>:</strong>
+        <strong><%= t("admin.budget_investments.show.selection.title") %></strong>:
         <%= t("admin.budget_investments.show.selection.#{@investment.selected?}") %>
       </p>
     </div>
     <div class="small-12 medium-4 column">
       <p>
-        <strong><%= t("admin.budget_investments.show.winner.title") %>:</strong>
+        <strong><%= t("admin.budget_investments.show.winner.title") %></strong>:
         <%= t("admin.budget_investments.show.winner.#{@investment.winner?}") %>
       </p>
     </div>
@@ -52,10 +55,37 @@
 </div>
 
 <% if @investment.external_url.present? %>
-  <p><%= text_with_links @investment.external_url %>&nbsp;<span class="icon-external small"></span></p>
+  <p>
+    <%= text_with_links @investment.external_url %>&nbsp;<span class="icon-external small"></span>
+  </p>
 <% end %>
 
 <%= safe_html_with_links @investment.description %>
+
+<p>
+  <strong><%= t("admin.budget_investments.show.image") %></strong>:
+
+  <% if @investment.image.present? %>
+    <%= link_to t("admin.budget_investments.show.see_image"),
+                   namespaced_budget_investment_path(@investment, {anchor: 'image'}),
+                   target: "blank" %>
+  <% else %>
+    <%= t("admin.budget_investments.show.no_image") %>
+  <% end %>
+</p>
+
+<p>
+  <strong><%= t("admin.budget_investments.show.documents") %></strong>:
+
+  <% if @investment.documents.present? %>
+    <%= link_to t("admin.budget_investments.show.see_documents",
+                   count: @investment.documents.count),
+                   namespaced_budget_investment_path(@investment, {anchor: 'documents'}),
+                   target: "blank" %>
+  <% else %>
+    <%= t("admin.budget_investments.show.no_documents") %>
+  <% end %>
+</p>
 
 <p id="user-tags">
   <strong><%= t("admin.budget_investments.show.user_tags") %>: </strong>

--- a/app/views/documents/_documents.html.erb
+++ b/app/views/documents/_documents.html.erb
@@ -1,4 +1,4 @@
-<div class="documents">
+<div id="documents" class="documents">
   <h2><%= t("documents.title") %>&nbsp;<span>(<%= documents.count %>)</span></h2>
 
   <% if documents.any? %>

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -1,4 +1,4 @@
-<div class="small-12 column text-center image-preview">
+<div id="image" class="small-12 column text-center image-preview">
   <figure>
     <%= image_tag image.attachment.url(version),
                   class: image_class(image),

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -214,6 +214,12 @@ en:
           title: Winner
           "true": "Yes"
           "false": "No"
+        image: "Image"
+        see_image: "See image"
+        no_image: "Without image"
+        documents: "Documents"
+        see_documents: "See documents (%{count})"
+        no_documents: "Without documents"
       edit:
         classification: Classification
         compatibility: Compatibility

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -213,6 +213,12 @@ es:
           title: Ganadora
           "true": "Si"
           "false": "No"
+        image: "Imagen"
+        see_image: "Ver imagen"
+        no_image: "Sin imagen"
+        documents: "Documentos"
+        see_documents: "Ver documentos (%{count})"
+        no_documents: "Sin documentos"
       edit:
         classification: Clasificación
         compatibility: Compatibilidad

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -443,6 +443,8 @@ feature 'Admin budget investments' do
       expect(page).to have_content(budget_investment.description)
       expect(page).to have_content(budget_investment.author.name)
       expect(page).to have_content(budget_investment.heading.name)
+      expect(page).to have_content('Without image')
+      expect(page).to have_content('Without documents')
       expect(page).to have_content('1234')
       expect(page).to have_content('1000')
       expect(page).to have_content('Unfeasible')
@@ -454,6 +456,33 @@ feature 'Admin budget investments' do
       end
 
       expect(page).to have_button "Publish comment"
+    end
+
+    scenario 'Show image and documents on investment details' do
+      budget_investment = create(:budget_investment,
+                                  price: 1234,
+                                  price_first_year: 1000,
+                                  feasibility: "unfeasible",
+                                  unfeasibility_explanation: 'It is impossible',
+                                  administrator: administrator)
+      create(:image, imageable: budget_investment)
+      document = create(:document, documentable: budget_investment)
+
+      visit admin_budget_budget_investments_path(budget_investment.budget)
+
+      click_link budget_investment.title
+
+      expect(page).to have_content(budget_investment.title)
+      expect(page).to have_content(budget_investment.description)
+      expect(page).to have_content(budget_investment.author.name)
+      expect(page).to have_content(budget_investment.heading.name)
+      expect(page).to have_content('See image')
+      expect(page).to have_content('See documents (1)')
+      expect(page).to have_content('1234')
+      expect(page).to have_content('1000')
+      expect(page).to have_content('Unfeasible')
+      expect(page).to have_content('It is impossible')
+      expect(page).to have_content('Ana (ana@admins.org)')
     end
 
     scenario "If budget is finished, investment cannot be edited or valuation comments created" do


### PR DESCRIPTION
References
==========
This closes https://github.com/consul/consul/issues/2376
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1353

Objectives
==========
If the budget investments have an image or documents now appears a link to budget investment with a `#image` or `#documents` anchor on a new tab to allow admin check easily the associated images and docs of the budget investment on evaluation.

Visual Changes
=======================
### **Admin budget investment show before**
![admin_investment_before](https://user-images.githubusercontent.com/631897/37216186-7922590c-23ba-11e8-833e-87f7339c27e7.png)

### **Admin budget investment show after (with image and docs)**
<img width="1239" alt="screen shot 2018-03-12 at 16 51 47" src="https://user-images.githubusercontent.com/631897/37294264-bcac3e2e-2615-11e8-8a1d-45146ec7a193.png">

###  **Admin budget investment show after (without image or docs)**
<img width="1233" alt="screen shot 2018-03-12 at 16 52 02" src="https://user-images.githubusercontent.com/631897/37294278-c098e5b4-2615-11e8-8885-ed4279ca6321.png">