### PR TITLE
User segment for users that haven't supported in budget

### DIFF
--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -524,6 +524,7 @@ en:
       feasible_and_undecided_investment_authors: "Authors of some investment in the current budget that does not comply with: [valuation finished unfesasible]"
       selected_investment_authors: Authors of selected investments in the current budget
       winner_investment_authors: Authors of winner investments in the current budget
+      not_supported_on_current_budget: Users that haven't supported investments on current budget
       invalid_recipients_segment: "Recipients user segment is invalid"
     newsletters:
       create_success: Newsletter created successfully

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -523,6 +523,7 @@ es:
       feasible_and_undecided_investment_authors: "Usuarios autores de algún proyecto de gasto en los actuales presupuestos que no cumpla: [evaluación finalizada inviable]"
       selected_investment_authors: Usuarios autores de proyectos de gasto seleccionadas en los actuales presupuestos
       winner_investment_authors: Usuarios autores de proyectos de gasto ganadoras en los actuales presupuestos
+      not_supported_on_current_budget: Usuarios que no han apoyado proyectos de los actuales presupuestos
       invalid_recipients_segment: "El segmento de destinatarios es inválido"
     newsletters:
       create_success: Newsletter creada correctamente

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -5,7 +5,8 @@ class UserSegments
                 investment_authors
                 feasible_and_undecided_investment_authors
                 selected_investment_authors
-                winner_investment_authors)
+                winner_investment_authors
+                not_supported_on_current_budget)
 
   def self.all_users
     User.active
@@ -35,6 +36,17 @@ class UserSegments
 
   def self.winner_investment_authors
     author_ids(current_budget_investments.winners.pluck(:author_id).uniq)
+  end
+
+  def self.not_supported_on_current_budget
+    author_ids(
+      User.where(
+                  'id NOT IN (SELECT DISTINCT(voter_id) FROM votes'\
+                  ' WHERE votable_type = ? AND votes.votable_id IN (?))',
+                  'Budget::Investment',
+                  current_budget_investments.pluck(:id)
+                )
+    )
   end
 
   def self.user_segment_emails(users_segment)

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -172,4 +172,22 @@ describe UserSegments do
       expect(current_budget_investments).not_to include investment2
     end
   end
+
+  describe "#not_supported_on_current_budget" do
+    it "only returns users that haven't supported investments on current budget" do
+      investment1 = create(:budget_investment)
+      investment2 = create(:budget_investment)
+      budget = create(:budget)
+      investment1.vote_by(voter: user1, vote: 'yes')
+      investment2.vote_by(voter: user2, vote: 'yes')
+      investment1.update(budget: budget)
+      investment2.update(budget: budget)
+
+      not_supported_on_current_budget = described_class.not_supported_on_current_budget
+      expect(not_supported_on_current_budget).to include user3
+      expect(not_supported_on_current_budget).not_to include user1
+      expect(not_supported_on_current_budget).not_to include user2
+    end
+  end
+
 end


### PR DESCRIPTION
Created not_supported_on_current_budget at UserSegment along with model
spec scenario and translation strings.

References
==========
This is a backport from madrid's fork https://github.com/AyuntamientoMadrid/consul/pull/1369

Objectives
==========
Create a segment that returns all users that haven't supported investments on current budget

Visual Changes (if any)
=======================
None

Notes
=====================
Query looks ugly but after trying in preproduction servers
```ruby
users = Vote.where(votable_type: 'Budget::Investment', votable: Budget.current.investments).select(:voter_id).distinct.pluck(:voter_id)
User.active.where.not(id: users)
```
It became clear that for installations with more than half million users it would take an overkill time to complete the where.not query.