### PR TITLE
Fix Flaky spec: Moderate debates Hide

### DIFF
--- a/spec/features/moderation/debates_spec.rb
+++ b/spec/features/moderation/debates_spec.rb
@@ -25,7 +25,7 @@ feature 'Moderate debates' do
       click_link 'Hide'
     end
 
-    expect(page).to have_css("#debate_#{debate.id}.faded")
+    expect(find("div#debate_#{debate.id}.faded")).to have_text debate.title
 
     login_as(citizen)
     visit debates_path


### PR DESCRIPTION
References
==========
- This is a **backport** of the issue https://github.com/AyuntamientoMadrid/consul/issues/1222 from Madrid's fork about a flaky spec.
- The **original PR** is https://github.com/AyuntamientoMadrid/consul/pull/1372

Objectives
==========
There was a flaky in the file `spec/features/moderation/debates_spec.rb` when hidding debates. The problem was a race condition that appeared after clicking the 'Hide' button.
This button hides a debate, and in the UI it fades using JS. If the test was fast enought and the expect assertion executes before the CSS class changes, Capybara won't find any id that matches `#debates_#{debate.id}.faded`; there is a div with id `#debate_5`, but it's not faded yet.

To make Capybara wait the stablished wait_time (capybara's `max_wait_time`, by default 2 secs), I changed the assertion. Instead of using `have_css(...)`, I used `find(...)`, that, according to [this](https://www.urbanbound.com/make/fix-flaky-feature-tests-by-using-capybaras-apis-properly), waits for the element to appear in the screen.
So, it expects to find and object and then checks if that object has a text (the debate title in this case)

Visual Changes
=======================
There aren't, it's a flaky.

Notes
=====================
Nothing to mention.
