### PR TITLE
Update loofah gem to 2.2.1 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
       actionmailer (>= 3.2)
       letter_opener (~> 1.0)
       railties (>= 3.2)
-    loofah (2.1.1)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
References
==========
Details at https://github.com/flavorjones/loofah/issues/144

Objectives
==========
Fix a possible Security risk, although seems like we're not affected by the "Affected versions" description but better safe than sorry.

Notes
=====================
Not sure if this should be included in the release at the Security section 🤔 