### PR TITLE
Let managers reset user's password

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -76,6 +76,7 @@
 //= require table_sortable
 //= require investment_report_alert
 //= require send_newsletter_alert
+//= require managers
 
 var initialize_modules = function() {
   App.Comments.initialize();
@@ -119,6 +120,7 @@ var initialize_modules = function() {
   App.TableSortable.initialize();
   App.InvestmentReportAlert.initialize();
   App.SendNewsletterAlert.initialize();
+  App.Managers.initialize();
 };
 
 $(function(){

--- a/app/assets/javascripts/managers.js.coffee
+++ b/app/assets/javascripts/managers.js.coffee
@@ -1,0 +1,25 @@
+App.Managers =
+
+  generatePassword: ->
+    chars = 'aAbcdeEfghiJkmnpqrstuUvwxyz23456789'
+    pass = ''
+    x = 0
+    while x < 12
+      i = Math.floor(Math.random() * chars.length)
+      pass += chars.charAt(i)
+      x++
+    return pass
+
+  togglePassword: (type) ->
+    $('#user_password').prop 'type', type
+
+  initialize: ->
+    $(".generate-random-value").on "click", (event) ->
+      password = App.Managers.generatePassword()
+      $('#user_password').val(password)
+
+    $(".show-password").on "click", (event) ->
+      if $("#user_password").is("input[type='password']")
+        App.Managers.togglePassword('text')
+      else
+        App.Managers.togglePassword('password')

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -278,6 +278,10 @@ $sidebar-active: #f4fcd0;
   cursor: pointer;
 }
 
+.no-margin-bottom {
+    margin-bottom: 0 !important;
+}
+
 // 02. Sidebar
 // -----------
 

--- a/app/controllers/management/account_controller.rb
+++ b/app/controllers/management/account_controller.rb
@@ -5,6 +5,26 @@ class Management::AccountController < Management::BaseController
   def show
   end
 
+  def edit
+  end
+
+  def print_password
+  end
+
+  def reset_password
+    managed_user.send_reset_password_instructions
+    redirect_to management_account_path, notice: t("management.account.edit.password.reset_email_send")
+  end
+
+  def change_password
+    if managed_user.reset_password(params[:user][:password], params[:user][:password])
+      session[:new_password] = params[:user][:password]
+      redirect_to print_password_management_account_path
+    else
+      render :edit_password_manually
+    end
+  end
+
   private
 
     def only_verified_users

--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -44,4 +44,8 @@ class Management::BaseController < ActionController::Base
     def current_budget
       Budget.current
     end
+
+    def clear_password
+      session[:new_password] = nil
+    end
 end

--- a/app/controllers/management/document_verifications_controller.rb
+++ b/app/controllers/management/document_verifications_controller.rb
@@ -40,6 +40,7 @@ class Management::DocumentVerificationsController < Management::BaseController
     def set_document
       session[:document_type] = params[:document_verification][:document_type]
       session[:document_number] = params[:document_verification][:document_number]
+      clear_password
     end
 
     def clean_document_number

--- a/app/controllers/management/users_controller.rb
+++ b/app/controllers/management/users_controller.rb
@@ -44,6 +44,7 @@ class Management::UsersController < Management::BaseController
     def destroy_session
       session[:document_type] = nil
       session[:document_number] = nil
+      clear_password
     end
 
     def user_without_email

--- a/app/views/management/_menu.html.erb
+++ b/app/views/management/_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="admin-sidebar">
-  <ul id="admin_menu">
+  <ul id="admin_menu" data-accordion-menu data-multi-open="false">
     <li <%= "class=active" if controller_name == "document_verifications" ||
                               controller_name == "email_verifications" ||
                               controller_name == "users" %>>
@@ -9,11 +9,21 @@
       <% end %>
     </li>
 
-    <li <%= "class=active" if controller_name == "account" %>>
-      <%= link_to management_account_path do %>
+    <li class="section-title">
+      <a href="#">
         <span class="icon-user"></span>
-        <%= t("management.menu.edit_user_accounts") %>
-      <% end %>
+        <strong><%= t("management.menu.edit_user_accounts") %></strong>
+      </a>
+      <ul <%= "class=is-active" if controller_name == "account" %>>
+        <% if managed_user.email %>
+          <li>
+            <%= link_to t("management.account.menu.reset_password_email"), edit_password_email_management_account_path %>
+          </li>
+        <% end %>
+        <li>
+          <%= link_to t("management.account.menu.reset_password_manually"), edit_password_manually_management_account_path %>
+        </li>
+      </ul>
     </li>
 
     <li <%= "class=active" if controller_name == "proposals" && action_name == "new" %>>

--- a/app/views/management/account/edit_password_email.html.erb
+++ b/app/views/management/account/edit_password_email.html.erb
@@ -1,0 +1,3 @@
+<h2 class="not-print"><%= t("management.account.menu.reset_password_email") %></h2>
+
+<%= link_to t("management.account.edit.password.send_email"), reset_password_management_account_path(managed_user.id), class: "button hollow" %>

--- a/app/views/management/account/edit_password_manually.html.erb
+++ b/app/views/management/account/edit_password_manually.html.erb
@@ -1,0 +1,20 @@
+<h2 class="not-print"><%= t("management.account.menu.reset_password_manually") %></h2>
+
+<%= form_for managed_user, url: change_password_management_account_path do |f| %>
+  <div class="row">
+    <%= f.label :password %>
+    <p class="help-text"><%= t("management.account.edit.password.print_help") %></p>
+    <div class="columns small-6 end">
+
+      <div class="input-group">
+        <%= f.password_field :password, class: "input-group-field no-margin-bottom", label: false, value: nil %>
+        <span class="input-group-label">
+          <a href="#" class="show-password"><i class="icon-eye"></i></a>
+        </span>
+      </div>
+
+      <%= link_to t("management.account.edit.password.random"), '#', class: 'generate-random-value float-right' %>
+    </div>
+  </div>
+  <%= f.submit t("management.account.edit.password.save"), class: "button success" %>
+<% end %>

--- a/app/views/management/account/print_password.html.erb
+++ b/app/views/management/account/print_password.html.erb
@@ -1,0 +1,21 @@
+<h2 class="not-print"><%= t("management.account.edit.title") %></h2>
+
+<div class="for-print-only">
+  <%= t("management.account.edit.password.password") %>:
+  <strong><%= session[:new_password] %></strong>
+</div>
+
+<div class="row">
+  <div class="columns small-4">
+    <p class="callout success not-print"><%= t("management.account.edit.password.reseted") %></p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="columns small-4">
+    <%= link_to t("management.account.edit.back"), edit_password_manually_management_account_path(managed_user.id), class: "button hollow" %>
+    <a id="print_link" href="javascript:window.print();" class="button warning">
+      <%= t('management.account.edit.password.print') %>
+    </a>
+  </div>
+</div>

--- a/config/locales/en/management.yml
+++ b/config/locales/en/management.yml
@@ -1,10 +1,25 @@
 en:
   management:
     account:
+      menu:
+        reset_password_email: Reset password via email
+        reset_password_manually: Reset password manually
       alert:
         unverified_user: No verified user logged in yet
       show:
         title: User account
+      edit:
+        title: 'Edit user account: Reset password'
+        back: Back
+        password:
+          password: Password
+          send_email: Send reset password email
+          reset_email_send: Email correctly sent.
+          reseted: Password reseted successfully
+          random: Generate random password
+          save: Save
+          print: Print password
+          print_help: You will be able to print the password when it is saved.
     account_info:
       change_user: Change user
       document_number_label: 'Document number:'

--- a/config/locales/es/management.yml
+++ b/config/locales/es/management.yml
@@ -1,10 +1,25 @@
 es:
   management:
     account:
+      menu:
+        reset_password_email: Restablecer contraseña via email
+        reset_password_manually: Restablecer contraseña manualmente
       alert:
         unverified_user: Solo se pueden editar cuentas de usuarios verificados
       show:
         title: Cuenta de usuario
+      edit:
+        title: 'Editar cuenta de usuario: Restablecer contraseña'
+        back: Atrás
+        password:
+          password: Contraseña
+          send_email: Enviar email para restablecer la contraseña
+          reset_email_send: Email enviado correctamente.
+          reseted: Contraseña restablecida correctamente
+          random: Generar contraseña aleatoria
+          save: Guardar
+          print: Imprimir contraseña
+          print_help: Podrás imprimir la contraseña cuando se haya guardado.
     account_info:
       change_user: Cambiar usuario
       document_number_label: 'Número de documento:'

--- a/config/routes/management.rb
+++ b/config/routes/management.rb
@@ -15,7 +15,14 @@ namespace :management do
     end
   end
 
-  resource :account, controller: "account", only: [:show]
+  resource :account, controller: "account", only: [:show] do
+    get :print_password
+    patch :change_password
+    get :reset_password
+    get :edit_password_email
+    get :edit_password_manually
+  end
+
   resource :session, only: [:create, :destroy]
   get 'sign_in', to: 'sessions#create', as: :sign_in
 

--- a/spec/features/management/account_spec.rb
+++ b/spec/features/management/account_spec.rb
@@ -6,11 +6,14 @@ feature 'Account' do
     login_as_manager
   end
 
-  scenario "Should not allow unverified users to create spending proposals" do
+  scenario "Should not allow unverified users to edit their account" do
     user = create(:user)
     login_managed_user(user)
 
-    click_link "Edit user account"
+    visit management_root_path
+
+    click_link 'Edit user account'
+    click_link 'Reset password via email'
 
     expect(page).to have_content "No verified user logged in yet"
   end
@@ -27,6 +30,83 @@ feature 'Account' do
     expect(page).to have_content "User account deleted."
 
     expect(user.reload.erase_reason).to eq "Deleted by manager: manager_user_#{Manager.last.user_id}"
+  end
+
+  scenario "Send reset password email to currently managed user session" do
+    user = create(:user, :level_three)
+    login_managed_user(user)
+    visit management_root_path
+
+    click_link 'Edit user account'
+    click_link 'Reset password via email'
+
+    click_link 'Send reset password email'
+
+    expect(page).to have_content 'Email correctly sent.'
+
+    email = ActionMailer::Base.deliveries.last
+
+    expect(email).to have_text 'Change your password'
+  end
+
+  scenario "Manager changes the password by hand (writen by them)" do
+    user = create(:user, :level_three)
+    login_managed_user(user)
+    visit management_root_path
+
+    click_link 'Edit user account'
+    click_link 'Reset password manually'
+
+    find(:css, "input[id$='user_password']").set("new_password")
+
+    click_button 'Save'
+
+    expect(page).to have_content 'Password reseted successfully'
+
+    logout
+
+    login_through_form_with_email_and_password(user.email, 'new_password')
+
+    expect(page).to have_content 'You have been signed in successfully.'
+  end
+
+  scenario "Manager generates random password", :js do
+    user = create(:user, :level_three)
+    login_managed_user(user)
+    visit management_root_path
+
+    click_link 'Edit user account'
+    click_link 'Reset password manually'
+    click_link 'Generate random password'
+
+    new_password = find_field('user_password').value
+
+    click_button 'Save'
+
+    expect(page).to have_content 'Password reseted successfully'
+
+    logout
+
+    login_through_form_with_email_and_password(user.username, new_password)
+
+    expect(page).to have_content 'You have been signed in successfully.'
+  end
+
+  scenario "The password is printed", :js do
+    user = create(:user, :level_three)
+    login_managed_user(user)
+    visit management_root_path
+
+    click_link 'Edit user account'
+    click_link 'Reset password manually'
+
+    find(:css, "input[id$='user_password']").set("another_new_password")
+
+    click_button 'Save'
+
+    expect(page).to have_content 'Password reseted successfully'
+    expect(page).to have_css("a[href='javascript:window.print();']", text: 'Print password')
+    expect(page).to have_css("div.for-print-only", text: 'another_new_password', visible: false)
   end
 
 end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -14,6 +14,16 @@ module CommonActions
     click_button 'Register'
   end
 
+  def login_through_form_with_email_and_password(email='manuela@consul.dev', password='judgementday')
+    visit root_path
+    click_link 'Sign in'
+
+    fill_in 'user_login', with: email
+    fill_in 'user_password', with: password
+
+    click_button 'Enter'
+  end
+
   def login_through_form_as(user)
     visit root_path
     click_link 'Sign in'


### PR DESCRIPTION
References
==========
This is a backport of the issue https://github.com/consul/consul/issues/2500 (done first at Madrid's fork).
The original PR is: https://github.com/AyuntamientoMadrid/consul/pull/1370

Objectives
==========
Let the manager change the users' password in two ways:

Send an email to the registered email so that the user can be able to change the password by themselves.
Change the password using a form. The manager can write it in plain text or generate a random value.
When the password is saved, the manager can print it for the user.

Visual Changes
=======================
- The new submenu and the overview
![password01](https://user-images.githubusercontent.com/31625251/37767514-ac7c4d0c-2dca-11e8-9708-6f2475aea698.gif)

- Random password generator and show/hide password
![password02_2](https://user-images.githubusercontent.com/31625251/37462218-72cb32cc-2851-11e8-82ff-88a75c5e86af.gif)

- Password saved and print password page
![password03](https://user-images.githubusercontent.com/31625251/37462226-7cf3aacc-2851-11e8-847f-caaac0780f55.png)

- How password is printed
![password04](https://user-images.githubusercontent.com/31625251/37462509-7d6d277a-2852-11e8-8763-28a855a75461.png)

Notes
=====================
I know that the 'Change user' link is still unchanged, but there is another PR waiting for merge that modifies that link. When both PR are merged the link will appear red and in the bottom of the box (I said this in order to avoid conflics when both PR will be merged, but If I should also change the link, let me know and I will).
