### PR TITLE
Fix routes deprecation warning for `to:` usage

### DIFF
--- a/config/routes/budget.rb
+++ b/config/routes/budget.rb
@@ -18,4 +18,4 @@ scope '/participatory_budget' do
   end
 end
 
-get 'investments/:id/json_data', to: :json_data, controller: 'budgets/investments'
+get 'investments/:id/json_data', action: :json_data, controller: 'budgets/investments'


### PR DESCRIPTION
References
==========
None

Objectives
==========
Running test suite the following appears: DEPRECATION WARNING: Defining
a route where `to` is a symbol is deprecated. Please change
`to: :json_data` to `action: :json_data`.

Visual Changes (if any)
=======================
None

Notes
=====================
None