### PR TITLE
Minor fixes

### DIFF
--- a/app/views/admin/budget_investments/show.html.erb
+++ b/app/views/admin/budget_investments/show.html.erb
@@ -1,5 +1,6 @@
-<%= link_to admin_budget_budget_investments_path(Budget::Investment.filter_params(params)), data: {no_turbolink: true} do %>
-  <span class="icon-angle-left"></span> <%= t("shared.back") %>
+<%= link_to admin_budget_budget_investments_path(Budget::Investment.filter_params(params)),
+            class: "back", data: {no_turbolink: true} do %>
+  <span class="icon-angle-left"></span><%= t("shared.back") %>
 <% end %>
 
 <%= render 'written_by_author' %>

--- a/app/views/admin/valuators/index.html.erb
+++ b/app/views/admin/valuators/index.html.erb
@@ -14,7 +14,7 @@
         <th scope="col"><%= t("admin.valuators.index.email") %></th>
         <th scope="col"><%= t("admin.valuators.index.description") %></th>
         <th scope="col"><%= t("admin.valuators.index.group") %></th>
-        <th scope="col"><%= t("admin.actions.actions") %></th>
+        <th scope="col" class="small-2"><%= t("admin.actions.actions") %></th>
       </thead>
       <tbody>
         <% @valuators.each do |valuator| %>

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -38,7 +38,8 @@
                    label:    t("budgets.investments.form.map_location"),
                    help:     t("budgets.investments.form.map_location_instructions"),
                    remove_marker_label: t("budgets.investments.form.map_remove_marker"),
-                   parent_class: "budget_investment" %>
+                   parent_class: "budget_investment",
+                   i18n_namespace: "budgets.investments" %>
 
       </div>
     <% end %>

--- a/app/views/budgets/investments/_investment.html.erb
+++ b/app/views/budgets/investments/_investment.html.erb
@@ -6,7 +6,8 @@
 
       <div class="small-12 medium-3 large-2 column text-center">
         <div data-equalizer-watch>
-          <%= image_tag investment.image_url(:thumb), alt: investment.image.title %>
+          <%= image_tag investment.image_url(:thumb),
+                        alt: investment.image.title.unicode_normalize %>
         </div>
       </div>
 

--- a/app/views/budgets/investments/_milestones.html.erb
+++ b/app/views/budgets/investments/_milestones.html.erb
@@ -13,11 +13,16 @@
               <div class="milestone-content">
                 <% if milestone.publication_date.present? %>
                   <span class="milestone-date">
-                    <strong><%= t("budgets.investments.show.milestone_publication_date",
-                                publication_date: l(milestone.publication_date.to_date)) %></strong>
+                    <strong>
+                      <%= t("budgets.investments.show.milestone_publication_date",
+                                publication_date: l(milestone.publication_date.to_date)) %>
+                    </strong>
                   </span>
                 <% end %>
-                <%= image_tag(milestone.image_url(:large), { alt: milestone.image.title, class: "margin", id: "image_#{milestone.id}" }) if milestone.image.present? %>
+                <%= image_tag(milestone.image_url(:large),
+                             { alt: milestone.image.title.unicode_normalize,
+                               class: "margin",
+                               id: "image_#{milestone.id}" }) if milestone.image.present? %>
                 <p><%= text_with_links milestone.description %></p>
                 <% if milestone.documents.present? %>
                   <div class="document-link text-center">

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -2,11 +2,11 @@
   <figure>
     <%= image_tag image.attachment.url(version),
                   class: image_class(image),
-                  alt: image.title,
-                  title: image.title %>
+                  alt: image.title.unicode_normalize,
+                  title: image.title.unicode_normalize %>
     <% if show_caption %>
       <figcaption class="text-right">
-        <em><%= image.title %></em>
+        <em><%= image.title.unicode_normalize %></em>
       </figcaption>
     <% end %>
   </figure>

--- a/app/views/legislation/processes/_debate.html.erb
+++ b/app/views/legislation/processes/_debate.html.erb
@@ -1,15 +1,17 @@
 <div class="small-12 medium-9 column">
   <div class="debate-list">
     <% if process.questions.empty? %>
-      <p><%= t('.empty_questions') %></p>
+      <p><%= t("legislation.processes.debate.empty_questions") %></p>
     <% else %>
       <%= render process.questions %>
     <% end %>
   </div>
 </div>
 
-<div class="small-12 medium-3 column">
-  <div class="callout success">
-    <p><%= t('.participate') %></p>
+<% if process.questions.any? %>
+  <div class="small-12 medium-3 column">
+    <div class="callout success">
+      <p><%= t("legislation.processes.debate.participate") %></p>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/legislation/processes/debate.html.erb
+++ b/app/views/legislation/processes/debate.html.erb
@@ -13,7 +13,7 @@
         <div class="debate-list">
           <% if @process.questions.empty? %>
             <div class="callout primary">
-              <p><%= t('.empty_questions') %></p>
+              <p><%= t("legislation.processes.debate.empty_questions") %></p>
             </div>
           <% else %>
             <%= render @process.questions %>
@@ -21,11 +21,13 @@
         </div>
       </div>
 
-      <div class="small-12 medium-3 column">
-        <div class="callout success">
-          <p><%= t('.participate') %></p>
+      <% if @process.questions.any? %>
+        <div class="small-12 medium-3 column">
+          <div class="callout success">
+            <p><%= t("legislation.processes.debate.participate") %></p>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/map_locations/_form_fields.html.erb
+++ b/app/views/map_locations/_form_fields.html.erb
@@ -20,7 +20,7 @@
   <div>
     <%= form.label :skip_map do %>
       <%= form.check_box :skip_map,
-                         title: t("proposals.form.map_skip_checkbox"),
+                         title: t("#{i18n_namespace}.form.map_skip_checkbox"),
                          label: false,
                          class: 'js-toggle-map' %>
       <span class="checkbox">

--- a/app/views/map_locations/_form_fields.html.erb
+++ b/app/views/map_locations/_form_fields.html.erb
@@ -19,12 +19,12 @@
 
   <div>
     <%= form.label :skip_map do %>
-      <%= form.check_box :skip_map, 
-                         title: t("proposals.form.map_skip_checkbox"), 
+      <%= form.check_box :skip_map,
+                         title: t("proposals.form.map_skip_checkbox"),
                          label: false,
                          class: 'js-toggle-map' %>
       <span class="checkbox">
-        <%= t("proposals.form.map_skip_checkbox") %>
+        <%= t("#{i18n_namespace}.form.map_skip_checkbox") %>
       </span>
     <% end %>
   </div>

--- a/app/views/polls/_gallery.html.erb
+++ b/app/views/polls/_gallery.html.erb
@@ -21,9 +21,9 @@
         <%= link_to image.attachment.url(:original), target: "_blank" do %>
           <%= image_tag image.attachment.url(:original),
                         class: "orbit-image",
-                        alt: image.title %>
+                        alt: image.title.unicode_normalize %>
         <% end %>
-        <span class="orbit-caption"><%= image.title %></span>
+        <span class="orbit-caption"><%= image.title.unicode_normalize %></span>
       </li>
     <% end %>
 
@@ -32,7 +32,7 @@
   <nav class="orbit-bullets">
     <% answer.images.each_with_index do |image, index| %>
       <button class="<%= active_class(index) %>" data-slide="<%= index %>">
-        <span class="show-for-sr"><%= image.title %></span>
+        <span class="show-for-sr"><%= image.title.unicode_normalize %></span>
       </button>
     <% end %>
   </nav>

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -9,7 +9,7 @@
       <div class="small-12 medium-3 column">
         <div class="image-container" data-equalizer-watch>
           <% if poll.image.present? %>
-            <%= image_tag poll.image_url(:large), alt: poll.image.title %>
+            <%= image_tag poll.image_url(:large), alt: poll.image.title.unicode_normalize %>
           <% end %>
         </div>
       </div>

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -9,23 +9,29 @@
   <div class="small-12 column">
     <%= render 'shared/filter_subnav', i18n_namespace: "polls.index" %>
 
-    <% polls_by_geozone_restriction = @polls.group_by(&:geozone_restricted) %>
+    <% if @polls.any? %>
+      <% polls_by_geozone_restriction = @polls.group_by(&:geozone_restricted) %>
 
-    <% if polls_by_geozone_restriction[false].present? %>
-      <h3 class="section-title-divider">
-        <span><%= t("polls.index.no_geozone_restricted") %></span>
-      </h3>
-      <%= render partial: 'poll_group', locals: {poll_group: polls_by_geozone_restriction[false]} %>
+      <% if polls_by_geozone_restriction[false].present? %>
+        <h3 class="section-title-divider">
+          <span><%= t("polls.index.no_geozone_restricted") %></span>
+        </h3>
+        <%= render partial: 'poll_group', locals: {poll_group: polls_by_geozone_restriction[false]} %>
+      <% end %>
+
+      <% if polls_by_geozone_restriction[true].present? %>
+        <h3 class="section-title-divider">
+          <span><%= t("polls.index.geozone_restricted") %></span>
+        </h3>
+        <%= render partial: 'poll_group', locals: {poll_group: polls_by_geozone_restriction[true]} %>
+      <% end %>
+
+      <%= paginate @polls %>
+    <% else %>
+      <div class="callout primary margin-top">
+        <%= t("polls.index.no_polls") %>
+      </div>
     <% end %>
-
-    <% if polls_by_geozone_restriction[true].present? %>
-      <h3 class="section-title-divider">
-        <span><%= t("polls.index.geozone_restricted") %></span>
-      </h3>
-      <%= render partial: 'poll_group', locals: {poll_group: polls_by_geozone_restriction[true]} %>
-    <% end %>
-
-    <%= paginate @polls %>
 
     <div id="section_help" class="margin" data-magellan-target="section_help">
       <p class="lead">

--- a/app/views/polls/results.html.erb
+++ b/app/views/polls/results.html.erb
@@ -17,8 +17,8 @@
 
     <div class="small-12 medium-9 column" data-equalizer-watch>
       <%- @poll.questions.each do |question| %>
+        <h3 id="<%= question.title.parameterize %>"><%= question.title %></h3>
         <table id="question_<%= question.id %>_results_table">
-          <h3 id="<%= question.title.parameterize %>"><%= question.title %></h3>
           <thead>
             <tr>
               <%- question.question_answers.each do |answer| %>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -72,7 +72,8 @@
                    label:    t("proposals.form.map_location"),
                    help:     t("proposals.form.map_location_instructions"),
                    remove_marker_label: t("proposals.form.map_remove_marker"),
-                   parent_class: "proposal" %>
+                   parent_class: "proposal",
+                   i18n_namespace: "proposals" %>
 
       </div>
     <% end %>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -9,7 +9,8 @@
 
         <div class="small-12 medium-3 large-2 column text-center">
           <div data-equalizer-watch>
-            <%= image_tag proposal.image_url(:thumb), alt: proposal.image.title %>
+            <%= image_tag proposal.image_url(:thumb),
+                          alt: proposal.image.title.unicode_normalize %>
           </div>
         </div>
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -176,6 +176,7 @@ ignore_unused:
   - 'admin.legislation.processes.process.*'
   - 'legislation.processes.index.*'
   - 'votes.budget_investments.different_heading_assigned*'
+  - '*.form.map_skip_checkbox'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -71,6 +71,7 @@ en:
         map_location_instructions: "Navigate the map to the location and place the marker."
         map_remove_marker: "Remove map marker"
         location: "Location additional info"
+        map_skip_checkbox: "This investment doesn't have a concrete location or I'm not aware of it."
       index:
         title: Participatory budgeting
         unfeasible: Unfeasible investment projects

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -487,6 +487,7 @@ en:
         description: Sign up to vote on citizen proposals and questions the City Council ask to the neighbors. Make municipal decisions directly.
         help_text_1: "Voting takes place when a citizen proposal supports reaches 1% of the census with voting rights. Voting can also include questions that the City Council ask to the citizens decision."
         help_text_2: "To participate in the next vote you have to sign up on %{org} and verify your account. All registered voters in the city over 16 years old can vote. The results of all votes are binding on the government."
+      no_polls: "There are no open votings."
     show:
       already_voted_in_booth: "You have already participated in a physical booth. You can not participate again."
       already_voted_in_web: "You have already participated in this poll. If you vote again it will be overwritten."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -80,11 +80,11 @@ es:
         edit_groups: Editar grupos de partidas
         edit_budget: Editar presupuesto
       create:
-        notice: '¡Nueva campaña de presupuestos participativos creada con éxito!'
+        notice: "¡Presupuestos participativos creados con éxito!"
       update:
-        notice: Campaña de presupuestos participativos actualizada
+        notice: Presupuestos participativos actualizados
       edit:
-        title: Editar campaña de presupuestos participativos
+        title: Editar presupuestos participativos
         delete: Eliminar presupuesto
         phase: Fase
         dates: Fechas

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -71,6 +71,7 @@ es:
         map_location_instructions: "Navega por el mapa hasta la ubicación y coloca el marcador."
         map_remove_marker: "Eliminar el marcador"
         location: "Información adicional de la ubicación"
+        map_skip_checkbox: "Este proyecto no tiene una ubicación concreta o no la conozco."
       index:
         title: Presupuestos participativos
         unfeasible: Proyectos de gasto no viables

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -487,6 +487,7 @@ es:
         description: Regístrate para poder votar propuestas ciudadanas y las cuestiones que pregunta a sus vecinos el Ayuntamiento. Toma decisiones municipales de forma directa.
         help_text_1: "Las votaciones se convocan cuando una propuesta ciudadana alcanza el 1% de apoyos del censo con derecho a voto. En las votaciones también se pueden incluir cuestiones que el Ayuntamiento somete a decisión directa de la ciudadanía."
         help_text_2: "Para participar en la próxima votación tienes que registrarte en %{org} y verificar tu cuenta. Pueden votar todas las personas empadronadas en la ciudad mayores de 16 años. Los resultados de todas las votaciones serán vinculantes para el gobierno."
+      no_polls: "No hay votaciones abiertas."
     show:
       already_voted_in_booth: "Ya has participado en esta votación en urnas presenciales, no puedes volver a participar."
       already_voted_in_web: "Ya has participado en esta votación. Si vuelves a votar se sobreescribirá tu resultado anterior."

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -149,15 +149,30 @@ feature 'Legislation' do
 
         visit legislation_process_path(process)
 
-        expect(page).to have_content("This phase is not open yet")
+        expect(page).to     have_content("This phase is not open yet")
+        expect(page).to_not have_content("Participate in the debate")
       end
 
-      scenario 'open' do
+      scenario 'open without questions' do
         process = create(:legislation_process, debate_start_date: Date.current - 1.day, debate_end_date: Date.current + 2.days)
 
         visit legislation_process_path(process)
 
-        expect(page).to have_content("Participate in the debate")
+        expect(page).to_not have_content("Participate in the debate")
+        expect(page).to_not have_content("This phase is not open yet")
+      end
+
+      scenario 'open with questions' do
+        process = create(:legislation_process, debate_start_date: Date.current - 1.day, debate_end_date: Date.current + 2.days)
+        create(:legislation_question, process: process, title: "Question 1")
+        create(:legislation_question, process: process, title: "Question 2")
+
+        visit legislation_process_path(process)
+
+        expect(page).to     have_content("Question 1")
+        expect(page).to     have_content("Question 2")
+        expect(page).to     have_content("Participate in the debate")
+        expect(page).to_not have_content("This phase is not open yet")
       end
 
       include_examples "not published permissions", :debate_legislation_process_path

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -9,6 +9,9 @@ feature 'Polls' do
   context '#index' do
 
     scenario 'Polls can be listed' do
+      visit polls_path
+      expect(page).to have_content('There are no open votings')
+
       polls = create_list(:poll, 3)
       create(:image, imageable: polls[0])
       create(:image, imageable: polls[1])


### PR DESCRIPTION
Notes
=====================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1383

Objectives
==========
Minor fixes for i18n, HTML, and styles:
- Improves i18n of admin budgets.
- Adds class on backlink to admin budget investments show.
- Moves h3 tag outside of table on polls results (Fixes HTML validation error).
- Adds unicode_normalize for alt and title on image partial (Prevents HTML validation warning).
- Adds map skip checkbox i18n for budget investments.
- Adds a message on polls index if there are no open polls.
- Fixes actions buttons on admin valuators index table.
- Shows a message only if there are questions on legislation debate.
