### PR TITLE
[WIP] Display unfeasibility explanation only when valuation has finished

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -298,6 +298,10 @@ class Budget
       should_show_price? && price_explanation.present?
     end
 
+    def should_show_unfeasibility_explanation?
+      unfeasible? && valuation_finished? && unfeasibility_explanation.present?
+    end
+
     def formatted_price
       budget.formatted_amount(price)
     end

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -63,7 +63,7 @@
         </div>
       <% end %>
 
-      <% if investment.unfeasible? && investment.unfeasibility_explanation.present? %>
+      <% if investment.should_show_unfeasibility_explanation? %>
         <h2><%= t('budgets.investments.show.unfeasibility_explanation') %></h2>
         <p><%= investment.unfeasibility_explanation %></p>
       <% end %>

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -921,7 +921,7 @@ feature 'Budget Investments' do
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
 
     expect(page).to have_content("Unfeasibility explanation")
-    expect(page).to have_content(investment.unfeasibility_explanation)
+    expect(page).to have_content("Local government is not competent in this matter")
   end
 
   scenario "Show (unfeasible budget investment with valuation not finished)" do
@@ -939,7 +939,7 @@ feature 'Budget Investments' do
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
 
     expect(page).not_to have_content("Unfeasibility explanation")
-    expect(page).not_to have_content(investment.unfeasibility_explanation)
+    expect(page).not_to have_content("Local government is not competent in this matter")
   end
 
   scenario "Show milestones", :js do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -924,6 +924,24 @@ feature 'Budget Investments' do
     expect(page).to have_content(investment.unfeasibility_explanation)
   end
 
+  scenario "Show (unfeasible budget investment with valuation not finished)" do
+    user = create(:user)
+    login_as(user)
+
+    investment = create(:budget_investment,
+                        :unfeasible,
+                        valuation_finished: false,
+                        budget: budget,
+                        group: group,
+                        heading: heading,
+                        unfeasibility_explanation: 'Local government is not competent in this matter')
+
+    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+
+    expect(page).not_to have_content("Unfeasibility explanation")
+    expect(page).not_to have_content(investment.unfeasibility_explanation)
+  end
+
   scenario "Show milestones", :js do
     user = create(:user)
     investment = create(:budget_investment)

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -263,7 +263,52 @@ describe Budget::Investment do
     end
   end
 
-  describe "by_admin" do
+  describe "#should_show_unfeasibility_explanation?" do
+    let(:budget) { create(:budget) }
+    let(:investment) do
+      create(:budget_investment, budget: budget,
+             unfeasibility_explanation: "because of reasons",
+             valuation_finished: true,
+             feasibility: "unfeasible")
+    end
+
+    it "returns true for unfeasible investments with unfeasibility explanation and valuation finished" do
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(true)
+      end
+    end
+
+    it "returns false in valuation has not finished" do
+      investment.update(valuation_finished: false)
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
+      end
+    end
+
+    it "returns false if not unfeasible" do
+      investment.update(feasibility: "undecided")
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
+      end
+    end
+
+    it "returns false if unfeasibility explanation blank" do
+      investment.update(unfeasibility_explanation: "")
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
+      end
+    end
+  end
+
+  describe "#by_admin" do
     it "returns investments assigned to specific administrator" do
       investment1 = create(:budget_investment, administrator_id: 33)
       create(:budget_investment)


### PR DESCRIPTION
References
==========
- Issue: https://github.com/consul/consul/issues/2512
- Backport: https://github.com/AyuntamientoMadrid/consul/pull/1328

Objectives
==========
- Add a check to make sure `unfeasibility explanation` is only displayed when an investment's valuation has finished

Notes
===
- In addition, to display the `unfeasibility explanation`, an investment must be `unfeasible` and the `unfeasibility_explanation` present. These checks were already present before this PR.
