### PR TITLE
Fix random order for budget investments

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -112,7 +112,8 @@ module Budgets
       def set_random_seed
         if params[:order] == 'random' || params[:order].blank?
           seed = params[:random_seed] || session[:random_seed] || rand(-100000..100000)
-          params[:random_seed] ||= Float(seed) rescue 0
+          params[:random_seed] = Float(seed) / 1000000 rescue 0
+          session[:random_seed] = params[:random_seed]
         else
           params[:random_seed] = nil
         end

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -111,8 +111,8 @@ module Budgets
 
       def set_random_seed
         if params[:order] == 'random' || params[:order].blank?
-          seed = params[:random_seed] || session[:random_seed] || rand(-100000..100000)
-          params[:random_seed] = Float(seed) / 1000000 rescue 0
+          seed = params[:random_seed] || session[:random_seed] || rand
+          params[:random_seed] = seed
           session[:random_seed] = params[:random_seed]
         else
           params[:random_seed] = nil

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -610,7 +610,15 @@ feature 'Budget Investments' do
       end
 
       expect(@first_user_investments_order).to eq(@second_user_investments_order)
+    scenario "Convert seed to a value small enough for the modulus function to return investments in random order", :focus do
+      12.times { |i| create(:budget_investment, heading: heading, id: i) }
 
+      visit budget_investments_path(budget, heading_id: heading.id, random_seed: '12')
+
+      order = investments_order
+      orderd_by_id = Budget::Investment.order(:id).limit(10).pluck(:title)
+
+      expect(order).to_not eq(orderd_by_id)
     end
 
     def investments_order

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -621,6 +621,30 @@ feature 'Budget Investments' do
       expect(order).to_not eq(orderd_by_id)
     end
 
+    scenario "Set votes for investments randomized with a seed" do
+      voter = create(:user, :level_two)
+      login_as(voter)
+
+      10.times { create(:budget_investment, heading: heading) }
+
+      voted_investments = []
+      10.times do
+        investment = create(:budget_investment, heading: heading)
+        create(:vote, votable: investment, voter: voter)
+        voted_investments << investment
+      end
+
+      visit budget_investments_path(budget, heading_id: heading.id)
+
+      voted_investments.each do |investment|
+        if page.has_link?(investment.title)
+          within("#budget_investment_#{investment.id}") do
+            expect(page).to have_content "You have already supported this investment"
+          end
+        end
+      end
+    end
+
     def investments_order
       all(".budget-investment h3").collect {|i| i.text }
     end

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -624,15 +624,6 @@ feature 'Budget Investments' do
       end
 
       expect(@first_user_investments_order).to eq(@second_user_investments_order)
-    scenario "Convert seed to a value small enough for the modulus function to return investments in random order", :focus do
-      12.times { |i| create(:budget_investment, heading: heading, id: i) }
-
-      visit budget_investments_path(budget, heading_id: heading.id, random_seed: '12')
-
-      order = investments_order
-      orderd_by_id = Budget::Investment.order(:id).limit(10).pluck(:title)
-
-      expect(order).to_not eq(orderd_by_id)
     end
 
     scenario "Set votes for investments randomized with a seed" do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -470,7 +470,7 @@ feature 'Budget Investments' do
     end
   end
 
-  context("Orders") do
+  context "Orders" do
     before { budget.update(phase: 'selecting') }
 
     scenario "Default order is random" do
@@ -502,7 +502,7 @@ feature 'Budget Investments' do
       expect(order).not_to eq(new_order)
     end
 
-    scenario 'Random order maintained with pagination', :js do
+    scenario 'Random order maintained with pagination' do
       per_page = Kaminari.config.default_per_page
       (per_page + 2).times { create(:budget_investment, heading: heading) }
 
@@ -520,7 +520,21 @@ feature 'Budget Investments' do
       expect(order).to eq(new_order)
     end
 
-    scenario "Investments are not repeated with random order", :js do
+    scenario 'Random order maintained when going back from show' do
+      10.times { |i| create(:budget_investment, heading: heading) }
+
+      visit budget_investments_path(budget, heading_id: heading.id)
+
+      order = all(".budget-investment h3").collect {|i| i.text }
+
+      click_link Budget::Investment.first.title
+      click_link "Go back"
+
+      new_order = all(".budget-investment h3").collect {|i| i.text }
+      expect(order).to eq(new_order)
+    end
+
+    scenario "Investments are not repeated with random order" do
       12.times { create(:budget_investment, heading: heading) }
       # 12 instead of per_page + 2 because in each page there are 10 (in this case), not 25
 
@@ -539,7 +553,7 @@ feature 'Budget Investments' do
 
     end
 
-    scenario 'Proposals are ordered by confidence_score', :js do
+    scenario 'Proposals are ordered by confidence_score' do
       best_proposal = create(:budget_investment, heading: heading, title: 'Best proposal')
       best_proposal.update_column(:confidence_score, 10)
       worst_proposal = create(:budget_investment, heading: heading, title: 'Worst proposal')
@@ -560,7 +574,7 @@ feature 'Budget Investments' do
       expect(current_url).to include('page=1')
     end
 
-    scenario 'Each user has a different and consistent random budget investment order when random_seed is disctint', :js do
+    scenario 'Each user has a different and consistent random budget investment order when random_seed is disctint' do
       (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
       in_browser(:one) do
@@ -596,7 +610,7 @@ feature 'Budget Investments' do
       end
     end
 
-    scenario 'Each user has a equal and consistent budget investment order when the random_seed is equal', :js do
+    scenario 'Each user has a equal and consistent budget investment order when the random_seed is equal' do
       (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
       in_browser(:one) do


### PR DESCRIPTION
References
==========
- Issue: https://github.com/AyuntamientoMadrid/consul/issues/1313
- Backport: https://github.com/AyuntamientoMadrid/consul/pull/1318

Objectives
==========
- Fix random order for the case where a seed is too large to work correctly with the [modulus function](https://github.com/consul/consul/pull/2131)

How
===
- Using a float smaller than 1 as a seed

Test
====
- Manually tested in staging environment
- Verified bug in a [test](https://github.com/consul/consul/pull/2577/commits/ce3cb045f8a1143bc3e8b54fbb600ff34daef1b2) with a large seed
- Added a defensive [test](https://github.com/consul/consul/pull/2577/commits/ef30dc1efe6c7a2c31a502edbb0fcef508ffea96) in case we rollback to using `setseed`
