### PR TITLE
Add valuator groups  assigned to investments to admin tables & csv export

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -20,7 +20,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
       format.html
       format.js
       format.csv do
-        send_data Budget::Investment.to_csv(@investments, headers: true),
+        send_data Budget::Investment.to_csv(@investments),
                   filename: 'budget_investments.csv'
       end
     end

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -20,7 +20,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
       format.html
       format.js
       format.csv do
-        send_data Budget::Investment.to_csv(@investments),
+        send_data Budget::Investment::Exporter.new(@investments).to_csv,
                   filename: 'budget_investments.csv'
       end
     end

--- a/app/helpers/valuation_helper.rb
+++ b/app/helpers/valuation_helper.rb
@@ -13,11 +13,6 @@ module ValuationHelper
     ValuatorGroup.order("name ASC").collect { |g| [ g.name, "group_#{g.id}"] }
   end
 
-  def assigned_valuators(investment)
-    [investment.valuator_groups.collect(&:name) +
-     investment.valuators.collect(&:description_or_name)].flatten.join(', ')
-  end
-
   def assigned_valuators_info(valuators)
     case valuators.size
     when 0

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -334,6 +334,7 @@ class Budget
                I18n.t("admin.budget_investments.index.table_supports"),
                I18n.t("admin.budget_investments.index.table_admin"),
                I18n.t("admin.budget_investments.index.table_valuator"),
+               I18n.t("admin.budget_investments.index.table_valuation_group"),
                I18n.t("admin.budget_investments.index.table_geozone"),
                I18n.t("admin.budget_investments.index.table_feasibility"),
                I18n.t("admin.budget_investments.index.table_valuation_finished"),
@@ -349,6 +350,8 @@ class Budget
                   else
                     I18n.t("admin.budget_investments.index.no_admin_assigned")
                   end
+          assigned_valuators = investment.assigned_valuators || '-'
+          assigned_valuation_groups = investment.assigned_valuation_groups || '-'
           vals = if investment.valuators.empty?
                    I18n.t("admin.budget_investments.index.no_valuators_assigned")
                  else
@@ -361,8 +364,8 @@ class Budget
           valuation_finished = investment.valuation_finished? ?
                                          I18n.t('shared.yes') :
                                          I18n.t('shared.no')
-          csv << [id, title, total_votes, admin, vals, heading_name, price,
-                  valuation_finished]
+          csv << [id, title, total_votes, admin, assigned_valuators, assigned_valuation_groups,
+                  heading_name, price, valuation_finished]
         end
       end
       csv_string

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -320,6 +320,14 @@ class Budget
       investments
     end
 
+    def assigned_valuators
+      self.valuators.collect(&:description_or_name).compact.join(', ').presence
+    end
+
+    def assigned_valuation_groups
+      self.valuator_groups.collect(&:name).compact.join(', ').presence
+    end
+
     def self.to_csv(investments, options = {})
       attrs = [I18n.t("admin.budget_investments.index.table_id"),
                I18n.t("admin.budget_investments.index.table_title"),

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -328,7 +328,7 @@ class Budget
       self.valuator_groups.collect(&:name).compact.join(', ').presence
     end
 
-    def self.to_csv(investments, options = {})
+    def self.to_csv(investments)
       attrs = [I18n.t("admin.budget_investments.index.table_id"),
                I18n.t("admin.budget_investments.index.table_title"),
                I18n.t("admin.budget_investments.index.table_supports"),
@@ -339,7 +339,7 @@ class Budget
                I18n.t("admin.budget_investments.index.table_feasibility"),
                I18n.t("admin.budget_investments.index.table_valuation_finished"),
                I18n.t("admin.budget_investments.index.table_selection")]
-      csv_string = CSV.generate(options) do |csv|
+      csv_string = CSV.generate(headers: true) do |csv|
         csv << attrs
         investments.each do |investment|
           id = investment.id.to_s

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,5 +1,3 @@
-require 'csv'
-
 class Budget
   class Investment < ActiveRecord::Base
     SORTING_OPTIONS = %w(id title supports).freeze
@@ -326,49 +324,6 @@ class Budget
 
     def assigned_valuation_groups
       self.valuator_groups.collect(&:name).compact.join(', ').presence
-    end
-
-    def self.to_csv(investments)
-      attrs = [I18n.t("admin.budget_investments.index.table_id"),
-               I18n.t("admin.budget_investments.index.table_title"),
-               I18n.t("admin.budget_investments.index.table_supports"),
-               I18n.t("admin.budget_investments.index.table_admin"),
-               I18n.t("admin.budget_investments.index.table_valuator"),
-               I18n.t("admin.budget_investments.index.table_valuation_group"),
-               I18n.t("admin.budget_investments.index.table_geozone"),
-               I18n.t("admin.budget_investments.index.table_feasibility"),
-               I18n.t("admin.budget_investments.index.table_valuation_finished"),
-               I18n.t("admin.budget_investments.index.table_selection")]
-      csv_string = CSV.generate(headers: true) do |csv|
-        csv << attrs
-        investments.each do |investment|
-          id = investment.id.to_s
-          title = investment.title
-          total_votes = investment.total_votes.to_s
-          admin = if investment.administrator.present?
-                    investment.administrator.name
-                  else
-                    I18n.t("admin.budget_investments.index.no_admin_assigned")
-                  end
-          assigned_valuators = investment.assigned_valuators || '-'
-          assigned_valuation_groups = investment.assigned_valuation_groups || '-'
-          vals = if investment.valuators.empty?
-                   I18n.t("admin.budget_investments.index.no_valuators_assigned")
-                 else
-                   investment.valuators.collect(&:description_or_name).join(', ')
-                 end
-          heading_name = investment.heading.name
-          price_string = "admin.budget_investments.index.feasibility"\
-                         ".#{investment.feasibility}"
-          price = I18n.t(price_string, price: investment.formatted_price)
-          valuation_finished = investment.valuation_finished? ?
-                                         I18n.t('shared.yes') :
-                                         I18n.t('shared.no')
-          csv << [id, title, total_votes, admin, assigned_valuators, assigned_valuation_groups,
-                  heading_name, price, valuation_finished]
-        end
-      end
-      csv_string
     end
 
     private

--- a/app/models/budget/investment/exporter.rb
+++ b/app/models/budget/investment/exporter.rb
@@ -1,0 +1,59 @@
+class Budget::Investment::Exporter
+  require 'csv'
+
+  def initialize(investments)
+    @investments = investments
+  end
+
+  def to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << headers
+      @investments.each { |investment| csv << csv_values(investment) }
+    end
+  end
+
+  private
+
+  def headers
+    [
+      I18n.t("admin.budget_investments.index.table_id"),
+      I18n.t("admin.budget_investments.index.table_title"),
+      I18n.t("admin.budget_investments.index.table_supports"),
+      I18n.t("admin.budget_investments.index.table_admin"),
+      I18n.t("admin.budget_investments.index.table_valuator"),
+      I18n.t("admin.budget_investments.index.table_valuation_group"),
+      I18n.t("admin.budget_investments.index.table_geozone"),
+      I18n.t("admin.budget_investments.index.table_feasibility"),
+      I18n.t("admin.budget_investments.index.table_valuation_finished"),
+      I18n.t("admin.budget_investments.index.table_selection")
+    ]
+  end
+
+  def csv_values(investment)
+    [
+      investment.id.to_s,
+      investment.title,
+      investment.total_votes.to_s,
+      admin(investment),
+      investment.assigned_valuators || '-',
+      investment.assigned_valuation_groups || '-',
+      investment.heading.name,
+      price(investment),
+      investment.valuation_finished? ? I18n.t('shared.yes') : I18n.t('shared.no'),
+      investment.selected? ? I18n.t('shared.yes') : I18n.t('shared.no')
+    ]
+  end
+
+  def admin(investment)
+    if investment.administrator.present?
+      investment.administrator.name
+    else
+      I18n.t("admin.budget_investments.index.no_admin_assigned")
+    end
+  end
+
+  def price(investment)
+    price_string = "admin.budget_investments.index.feasibility.#{investment.feasibility}"
+    I18n.t(price_string, price: investment.formatted_price)
+  end
+end

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -24,6 +24,7 @@
         <th><%= t("admin.budget_investments.index.table_supports") %></th>
         <th><%= t("admin.budget_investments.index.table_admin") %></th>
         <th><%= t("admin.budget_investments.index.table_valuator") %></th>
+        <th><%= t("admin.budget_investments.index.table_valuation_group") %></th>
         <th><%= t("admin.budget_investments.index.table_geozone") %></th>
         <th><%= t("admin.budget_investments.index.table_feasibility") %></th>
         <th class="text-center"><%= t("admin.budget_investments.index.table_valuation_finished") %></th>
@@ -60,11 +61,12 @@
             <% end %>
           </td>
           <td class="small">
-            <% if investment.valuators.size == 0 && investment.valuator_groups.size == 0  %>
-              <%= t("admin.budget_investments.index.no_valuators_assigned") %>
-            <% else %>
-              <%= investment.assigned_valuators %>
-            <% end %>
+            <% no_valuators_assigned = t("admin.budget_investments.index.no_valuators_assigned") %>
+            <%= investment.assigned_valuators || no_valuators_assigned %>
+          </td>
+          <td class="small">
+            <% no_valuation_groups = t("admin.budget_investments.index.no_valuation_groups") %>
+            <%= investment.assigned_valuation_groups || no_valuation_groups %>
           </td>
           <td class="small">
             <%= investment.heading.name %>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -63,7 +63,7 @@
             <% if investment.valuators.size == 0 && investment.valuator_groups.size == 0  %>
               <%= t("admin.budget_investments.index.no_valuators_assigned") %>
             <% else %>
-              <%= assigned_valuators(investment) %>
+              <%= investment.assigned_valuators %>
             <% end %>
           </td>
           <td class="small">

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -171,6 +171,7 @@ en:
         assigned_admin: Assigned administrator
         no_admin_assigned: No admin assigned
         no_valuators_assigned: No valuators assigned
+        no_valuation_groups: No valuation groups assigned
         feasibility:
           feasible: "Feasible (%{price})"
           unfeasible: "Unfeasible"
@@ -182,6 +183,7 @@ en:
         table_supports: "Supports"
         table_admin: "Administrator"
         table_valuator: "Valuator"
+        table_valuation_group: "Valuation Group"
         table_geozone: "Scope of operation"
         table_feasibility: "Feasibility"
         table_valuation_finished: "Val. Fin."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -171,6 +171,7 @@ es:
         assigned_admin: Administrador asignado
         no_admin_assigned: Sin admin asignado
         no_valuators_assigned: Sin evaluador
+        no_valuation_groups: Sin grupos evaluadores
         feasibility:
           feasible: "Viable (%{price})"
           unfeasible: "Inviable"
@@ -182,6 +183,7 @@ es:
         table_supports: "Apoyos"
         table_admin: "Administrador"
         table_valuator: "Evaluador"
+        table_valuation_group: "Grupos evaluadores"
         table_geozone: "Ámbito de actuación"
         table_feasibility: "Viabilidad"
         table_valuation_finished: "Ev. Fin."

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -991,22 +991,18 @@ feature 'Admin budget investments' do
     end
 
     scenario "Downloading CSV file with applied filter" do
-      investment1 = create(:budget_investment, :unfeasible, budget: budget,
-                                                            title: 'compatible')
-      investment2 = create(:budget_investment, :finished, budget: budget,
-                                                          title: 'finished')
+      unfeasible_investment = create(:budget_investment, :unfeasible, budget: budget,
+                                                                      title: 'Unfeasible one')
+      finished_investment = create(:budget_investment, :finished, budget: budget,
+                                                                  title: 'Finished Investment')
 
       visit admin_budget_budget_investments_path(budget)
       within('#filter-subnav') { click_link 'Valuation finished' }
 
       click_link "Download current selection"
 
-      header = page.response_headers['Content-Disposition']
-      expect(header).to match(/^attachment/)
-      expect(header).to match(/filename="budget_investments.csv"$/)
-
-      expect(page).to have_content investment2.title
-      expect(page).not_to have_content investment1.title
+      expect(page).to have_content('Finished Investment')
+      expect(page).not_to have_content('Unfeasible one')
     end
   end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -64,21 +64,26 @@ feature 'Admin budget investments' do
       admin = create(:administrator, user: create(:user, username: 'Gema'))
 
       budget_investment1.valuators << valuator1
-      budget_investment2.valuator_ids = [valuator1.id, valuator2.id]
-      budget_investment3.update(administrator_id: admin.id)
+      budget_investment2.valuators << valuator1
+      budget_investment2.valuators << valuator2
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
       within("#budget_investment_#{budget_investment1.id}") do
         expect(page).to have_content("No admin assigned")
         expect(page).to have_content("Valuator Olga")
+        expect(page).to have_content("No valuation groups assigned")
       end
 
       within("#budget_investment_#{budget_investment2.id}") do
         expect(page).to have_content("No admin assigned")
         expect(page).to have_content("Valuator Olga")
         expect(page).to have_content("Valuator Miriam")
+        expect(page).to have_content("No valuation groups assigned")
       end
+
+      budget_investment3.update(administrator_id: admin.id)
+      visit admin_budget_budget_investments_path(budget_id: budget.id)
 
       within("#budget_investment_#{budget_investment3.id}") do
         expect(page).to have_content("Gema")
@@ -109,7 +114,7 @@ feature 'Admin budget investments' do
       end
 
       within("#budget_investment_#{budget_investment3.id}") do
-        expect(page).to have_content("No valuators assigned")
+        expect(page).to have_content("No valuation groups assigned")
       end
     end
 
@@ -953,7 +958,9 @@ feature 'Admin budget investments' do
                                                          price: 100)
       valuator = create(:valuator, user: create(:user, username: 'Rachel',
                                                        email: 'rachel@val.org'))
-      investment.valuators.push(valuator)
+      group = create(:valuator_group, name: "Test name")
+
+      investment.valuator_groups << group
 
       admin = create(:administrator, user: create(:user, username: 'Gema'))
       investment.update(administrator_id: admin.id)
@@ -978,6 +985,7 @@ feature 'Admin budget investments' do
 
       expect(page).to have_content investment.administrator.name
       expect(page).to have_content valuators
+      expect(page).to have_content group.name
       expect(page).to have_content price
       expect(page).to have_content I18n.t('shared.no')
     end


### PR DESCRIPTION
References
==========
This is a backport & refactor from madrid's fork  https://github.com/AyuntamientoMadrid/consul/pull/1287 & https://github.com/AyuntamientoMadrid/consul/pull/1422

Objectives
==========
Valuator Groups are now assigned to Investments, and need to be displayed in both:
- Admin Investments list
- Investments export to csv from admins investment list

Visual Changes (if any)
=======================
Yes, check referenced PR's

Notes
=====================
Maybe too much refactor on a single PR... but we're trying to cleanup pending backports to be able to merge latest changes around this CSV export. 