### PR TITLE
Avoid db:dev_seed log print when run from its test

### DIFF
--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -1,7 +1,9 @@
 require 'database_cleaner'
 DatabaseCleaner.clean_with :truncation
 @logger = Logger.new(STDOUT)
-@logger.formatter = proc { |_severity, _datetime, _progname, msg| msg }
+@logger.formatter = proc do |_severity, _datetime, _progname, msg|
+                      msg unless @avoid_log
+                    end
 
 def section(section_title)
   @logger.info section_title

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,7 @@
 namespace :db do
   desc "Resets the database and loads it from db/dev_seeds.rb"
-  task dev_seed: :environment do
+  task :dev_seed, [:print_log] => [:environment] do |t, args|
+    @avoid_log = args[:print_log] == "avoid_log"
     load(Rails.root.join("db", "dev_seeds.rb"))
   end
 end

--- a/spec/lib/tasks/dev_seed_spec.rb
+++ b/spec/lib/tasks/dev_seed_spec.rb
@@ -5,7 +5,7 @@ Rake.application.rake_require('tasks/db')
 
 describe 'rake db:dev_seed' do
   let :run_rake_task do
-    Rake.application.invoke_task('db:dev_seed')
+    Rake.application.invoke_task('db:dev_seed[avoid_log]')
   end
 
   it 'seeds the database without errors' do


### PR DESCRIPTION
Objectives
==========
The db:dev_seed rake logs info as it progresses as information for the
developer. But that's not needed when ran from its tests file, and it
bloats the travis/rspec output with unnecessary information.

Now the task will always log info unless the rake task receives an
optional argument.

Notes
=====================
Maybe there are better options to pass the optional argument value from the rake task `lib/tasks/db.rake` to the `db/dev_seeds.rb` file, but I couldn't find it.