### PR TITLE
Remove sitemap generator output when running specs

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -5,6 +5,7 @@ end
 SitemapGenerator::Sitemap.namer = SitemapGenerator::SimpleNamer.new(:sitemap, extension: '.xml')
 
 # default host
+SitemapGenerator::Sitemap.verbose = false if Rails.env.test?
 SitemapGenerator::Sitemap.default_host = Setting["url"]
 
 # sitemap generator


### PR DESCRIPTION
Objectives
==========
When running tests there is no need to pollute rspec's output with any
kind of log/info.
![screen shot 2018-04-14 at 22 49 39](https://user-images.githubusercontent.com/983242/38772403-244acf52-4036-11e8-8938-a9f4af7864b8.jpg)

Preventing that output its easy with the documented env variable usage https://github.com/kjvarga/sitemap_generator#preventing-output