### PR TITLE
return 404 instead of 500 when budget_group url is invalid (budget or group not found)

### DIFF
--- a/app/controllers/budgets/groups_controller.rb
+++ b/app/controllers/budgets/groups_controller.rb
@@ -1,12 +1,18 @@
 module Budgets
   class GroupsController < ApplicationController
-    load_and_authorize_resource :budget
-    load_and_authorize_resource :group, class: "Budget::Group"
 
     before_action :set_default_budget_filter, only: :show
     has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: [:show]
 
     def show
+      begin
+        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+        @group = @budget.groups.find_by(id: params[:id])
+      rescue
+        raise ActionController::RoutingError, 'Not Found'
+      end
+      authorize! :show, @budget
+      authorize! :show, @group
     end
 
   end

--- a/spec/features/budgets/groups_spec.rb
+++ b/spec/features/budgets/groups_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+feature 'Groups' do
+
+  let(:user)   { create(:user, :level_two) }
+  let(:budget) { create(:budget) }
+  let(:group)  { create(:budget_group, budget: budget) }
+
+  context 'show' do
+
+    scenario "group not found raises 404 error" do
+      expect { visit budget_group_path('s', 'n') }.to raise_error(ActionController::RoutingError)
+    end
+
+    scenario "Budget correctly found" do
+      visit budget_group_path(budget.id, group.id)
+
+      expect(page.status_code).to eq 200
+    end
+
+    scenario "Budget correctly found using the slug" do
+      visit budget_group_path(budget.slug, group.id)
+
+      expect(page.status_code).to eq 200
+    end
+
+    scenario "Group correctly found" do
+      visit budget_group_path(group.budget.id, group.id)
+
+      expect(page.status_code).to eq 200
+    end
+
+  end
+
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2365

What
====
- Changed the error shown on budgets/groups#show from 500 to 404 when the budget is'n found, also adds the possibility to use slugs instead of ids in the url (mainly for the fork of the city council of Madrid)

How
===
- Removing before_action :load_and_authorize_resource (both budget and group) from budgets/groups_controller and loading manually or raising an ActionController::RoutingError when the budget isn't found

Screenshots
===========
![screenshot from 2018-01-25 12 09 32](https://user-images.githubusercontent.com/33748390/35385457-a556357a-01c8-11e8-82c3-cbf45d47b25d.png)

Test
====
- Created a new  spec file for budgets/group that checks the correct operation of the url with slugs and id's, and the correct type of error when the budget is not found

Deployment
==========
- As usual

Warnings
========
- None
