### PR TITLE
Fix MapLocation json_data to return mappable ids

### DIFF
--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -99,7 +99,7 @@ App.Map =
       for i in addMarkerInvestments
         if App.Map.validCoordinates(i)
           marker = createMarker(i.lat, i.long)
-          marker.options['id'] = i.id
+          marker.options['id'] = i.investment_id
 
           marker.on 'click', openMarkerPopup
 

--- a/app/models/map_location.rb
+++ b/app/models/map_location.rb
@@ -11,7 +11,8 @@ class MapLocation < ActiveRecord::Base
 
   def json_data
     {
-      id: id,
+      investment_id: investment_id,
+      proposal_id: proposal_id,
       lat: latitude,
       long: longitude
     }


### PR DESCRIPTION
References
==========
This is a backport from Madrid's fork merged & tested in production PR https://github.com/AyuntamientoMadrid/consul/pull/1444

Objectives
==========
The map at `/budgets` its showing some Investments that have no geolocalization, or even are from previous Budgets!

That's because right now code was returning current Budget MapLocation's IDs, and the JS is looking for Investments by those ids... sometimes finding a record with same ID but totally NOT the one associated to the MapLocation.

Visual Changes (if any)
=======================
None

Notes
=====================
Map feature still needs some important refactors to make increase our confidence in the code.