### PR TITLE
Show count of votes associated to verified signatures

### DIFF
--- a/app/controllers/admin/signature_sheets_controller.rb
+++ b/app/controllers/admin/signature_sheets_controller.rb
@@ -21,6 +21,7 @@ class Admin::SignatureSheetsController < Admin::BaseController
 
   def show
     @signature_sheet = SignatureSheet.find(params[:id])
+    @voted_signatures = Vote.where(signature: @signature_sheet.signatures.verified).count
   end
 
   private

--- a/app/views/admin/signature_sheets/show.html.erb
+++ b/app/views/admin/signature_sheets/show.html.erb
@@ -24,6 +24,12 @@
     <%= t("admin.signature_sheets.show.verified",
         count: @signature_sheet.signatures.verified.count ) %>
   </strong>
+  <br />
+  <strong>
+    <%= t("admin.signature_sheets.show.voted",
+        count: @voted_signatures) %>
+  </strong>
+
 </div>
 
 <div id="unverified_signatures" class="callout alert">

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1437,6 +1437,10 @@ en:
           one: "There is %{count} invalid signature"
           other: "There are %{count} invalid signatures"
         unverified_error: (Not verified by Census)
+        voted:
+          zero: "There is no votes created from the verified signatures."
+          one: "There is %{count} vote created from the verified signatures."
+          other: "There is %{count} votes created from verified signatures."
         loading: "There are still signatures that are being verified by the Census, please refresh the page in a few moments"
     stats:
       show:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1436,6 +1436,10 @@ es:
           one: "Hay %{count} firma inválida"
           other: "Hay %{count} firmas inválidas"
         unverified_error: (No verificadas por el Padrón)
+        voted:
+          zero: "No hay votos asociados con las firmas verificadas."
+          one: "Hay %{count} voto asociado a las firmas verificadas."
+          other: "Hay %{count} votos asociados a las firmas verificadas."
         loading: "Aún hay firmas que se están verificando por el Padrón, por favor refresca la página en unos instantes"
     stats:
       show:

--- a/spec/features/admin/signature_sheets_spec.rb
+++ b/spec/features/admin/signature_sheets_spec.rb
@@ -39,10 +39,13 @@ describe "Signature sheets" do
 
       select "Citizen proposal", from: "signature_sheet_signable_type"
       fill_in "signature_sheet_signable_id", with: proposal.id
-      fill_in "signature_sheet_document_numbers", with: "12345678Z, 99999999Z"
+      fill_in "signature_sheet_document_numbers", with: "12345678Z, 1234567L, 99999999Z"
       click_button "Create signature sheet"
 
       expect(page).to have_content "Signature sheet created successfully"
+      expect(page).to have_content "There is 1 valid signature"
+      expect(page).to have_content "There is 1 vote created from the verified signatures"
+      expect(page).to have_content "There are 2 invalid signatures"
 
       visit proposal_path(proposal)
 
@@ -58,10 +61,13 @@ describe "Signature sheets" do
 
       select "Investment", from: "signature_sheet_signable_type"
       fill_in "signature_sheet_signable_id", with: investment.id
-      fill_in "signature_sheet_document_numbers", with: "12345678Z, 99999999Z"
+      fill_in "signature_sheet_document_numbers", with: "12345678Z, 1234567L, 99999999Z"
       click_button "Create signature sheet"
 
       expect(page).to have_content "Signature sheet created successfully"
+      expect(page).to have_content "There is 1 valid signature"
+      expect(page).to have_content "There is 1 vote created from the verified signatures"
+      expect(page).to have_content "There are 2 invalid signatures"
 
       visit budget_investment_path(budget, investment)
 


### PR DESCRIPTION
## References

* Backports https://github.com/AyuntamientoMadrid/consul/pull/1449
* Backports the relevant parts of commit AyuntamientoMadrid@9f009065

## Objectives

Show the number of votes that have been created from the verified signatures of a loaded Signatures Sheet. Not all verified signatures end up generating a vote (a signature can be valid but the user may have already voted that investment/proposal)

## Visual Changes

Now we show a "There is X votes created from the verified signatures" text in the green block.
![screen shot 2018-05-03 at 12 19 36](https://user-images.githubusercontent.com/983242/39571611-5393cf12-4ecc-11e8-9128-c2aae48f795c.jpg)