### PR TITLE
Budgets see results

### DIFF
--- a/app/views/admin/budget_investments/index.html.erb
+++ b/app/views/admin/budget_investments/index.html.erb
@@ -1,3 +1,9 @@
+<div class="float-right">
+  <%= link_to t("admin.budget_investments.index.see_results"),
+              budget_results_path(current_budget, heading_id: current_budget.headings.first),
+              class: "button hollow medium", target: "_blank" %>
+</div>
+
 <h2 class="inline-block"><%= @budget.name %> - <%= t("admin.budget_investments.index.title") %></h2>
 
 <%= render "search_form" %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -48,8 +48,7 @@
             <% end %>
           <% end %>
 
-
-        <% if current_budget.finished? || (current_budget.balloting? && can?(:read_results, current_budget)) %>
+        <% if current_budget.finished? %>
           <%= link_to t("budgets.show.see_results"),
                       budget_results_path(current_budget, heading_id: current_budget.headings.first),
                       class: "button margin-top expanded" %>
@@ -137,6 +136,7 @@
                         <h3><%= budget.name %></h3>
                       </div>
                     </div>
+
                     <div class="small-12 medium-3 column table" data-equalizer-watch>
                       <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
                         <%= link_to t("budgets.index.see_results"),

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -192,6 +192,7 @@ en:
         table_evaluation: "Show to valuators"
         table_incompatible: "Incompatible"
         cannot_calculate_winners: The budget has to stay on phase "Balloting projects", "Reviewing Ballots" or "Finished budget" in order to calculate winners projects
+        see_results: "See results"
       show:
         assigned_admin: Assigned administrator
         assigned_valuators: Assigned valuators

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -192,6 +192,7 @@ es:
         table_evaluation: "Mostrar a evaluadores"
         table_incompatible: "Incompatible"
         cannot_calculate_winners: El presupuesto debe estar en las fases "Votación final", "Votación finalizada" o "Resultados" para poder calcular las propuestas ganadoras
+        see_results: "Ver resultados"
       show:
         assigned_admin: Administrador asignado
         assigned_valuators: Evaluadores asignados


### PR DESCRIPTION
References
==========
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1459/

Objectives
==========
Shows **See results** button _[Screenshot_1]_ only if current budget is finished. 

Also included this button on admin panel `/admin/budgets/N/budget_investments`. _[Screenshot_2]_

Visual Changes
=======================
**[Screenshot_1]**
![screen shot 2018-05-09 at 16 06 15](https://user-images.githubusercontent.com/631897/39819140-f9e7cc9e-53a2-11e8-800c-43d8320d93ec.png)


**[Screenshot_2]**
![screen shot 2018-05-09 at 16 05 44](https://user-images.githubusercontent.com/631897/39819147-fb59561a-53a2-11e8-9016-914fadba868b.png)
