### PR TITLE
Adds message to selected budget investments

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -66,6 +66,12 @@ module BudgetsHelper
 
   def current_budget_map_locations
     return unless current_budget.present?
-    MapLocation.where(investment_id: current_budget.investments).map { |l| l.json_data }
+    if current_budget.valuating_or_later?
+      investments = current_budget.investments.selected
+    else
+      investments = current_budget.investments
+    end
+
+    MapLocation.where(investment_id: investments).map { |l| l.json_data }
   end
 end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -105,6 +105,10 @@ class Budget < ActiveRecord::Base
     Budget::Phase::PUBLISHED_PRICES_PHASES.include?(phase)
   end
 
+  def valuating_or_later?
+    valuating? || publishing_prices? || balloting_or_later?
+  end
+
   def balloting_process?
     balloting? || reviewing_ballots?
   end

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -191,6 +191,77 @@ feature 'Budgets' do
     expect(page).to have_css(".phase.active", count: 1)
   end
 
+  xcontext "Index map" do
+
+    let(:group) { create(:budget_group, budget: budget) }
+    let(:heading) { create(:budget_heading, group: group) }
+
+    before do
+      Setting['feature.map'] = true
+    end
+
+    scenario "Display investment's map location markers" , :js do
+      investment1 = create(:budget_investment, heading: heading)
+      investment2 = create(:budget_investment, heading: heading)
+      investment3 = create(:budget_investment, heading: heading)
+
+      investment1.create_map_location(longitude: 40.1234, latitude: 3.1234, zoom: 10)
+      investment2.create_map_location(longitude: 40.1235, latitude: 3.1235, zoom: 10)
+      investment3.create_map_location(longitude: 40.1236, latitude: 3.1236, zoom: 10)
+
+      visit budgets_path
+
+      within ".map_location" do
+        expect(page).to have_css(".map-icon", count: 3)
+      end
+    end
+
+    scenario "Display selected investment's map location markers" , :js do
+
+      budget.update(phase: :valuating)
+
+      investment1 = create(:budget_investment, :selected, heading: heading)
+      investment2 = create(:budget_investment, :selected, heading: heading)
+      investment3 = create(:budget_investment, heading: heading)
+
+      investment1.create_map_location(longitude: 40.1234, latitude: 3.1234, zoom: 10)
+      investment2.create_map_location(longitude: 40.1235, latitude: 3.1235, zoom: 10)
+      investment3.create_map_location(longitude: 40.1236, latitude: 3.1236, zoom: 10)
+
+      visit budgets_path
+
+      within ".map_location" do
+        expect(page).to have_css(".map-icon", count: 2)
+      end
+    end
+
+    scenario "Skip invalid map markers" , :js do
+      map_locations = []
+      map_locations << { longitude: 40.123456789, latitude: 3.12345678 }
+      map_locations << { longitude: 40.123456789, latitude: "*******" }
+      map_locations << { longitude: "**********", latitude: 3.12345678 }
+
+      budget_map_locations = map_locations.map do |map_location|
+        {
+          lat: map_location[:latitude],
+          long: map_location[:longitude],
+          investment_title: "#{rand(999)}",
+          investment_id: "#{rand(999)}",
+          budget_id: budget.id
+        }
+      end
+
+      allow_any_instance_of(BudgetsHelper).
+      to receive(:current_budget_map_locations).and_return(budget_map_locations)
+
+      visit budgets_path
+
+      within ".map_location" do
+        expect(page).to have_css(".map-icon", count: 1)
+      end
+    end
+  end
+
   context 'Show' do
 
     scenario "List all groups" do


### PR DESCRIPTION
References
==========
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1456

Objectives
==========
This PR shows only selected investments on budgets index map when current budget phase is valuating or later.

Visual Changes
=======================
**Map on first phases of current budget**
![all](https://user-images.githubusercontent.com/631897/39810382-1649688e-5385-11e8-85fa-9782ff59301e.png)

**Map on valuating or later phases of current budget**
![selected](https://user-images.githubusercontent.com/631897/39810384-18315f12-5385-11e8-8db7-db85d84b0a77.png)

Notes
=====================
I included new specs, but the **Index map** specs are commented `xcontext "Index map" do` at the moment.
