### PR TITLE
Show 'See Results' button in budget admin panel

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -159,6 +159,10 @@ class Budget < ActiveRecord::Base
     end
   end
 
+  def has_winning_investments?
+    investments.winners.any?
+  end
+
   private
 
   def sanitize_descriptions

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -63,6 +63,12 @@
                     class: "button hollow" %>
       <% end %>
 
+      <% if @budget.has_winning_investments? %>
+        <%= link_to t("budgets.show.see_results"),
+                    budget_results_path(@budget),
+                    class: "button hollow margin-left" %>
+      <% end %>
+
       <% if @budget.persisted? %>
         <%= link_to t("admin.budgets.edit.delete"),
             admin_budget_path(@budget),

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -186,31 +186,37 @@ feature 'Admin budgets' do
   end
 
   context "Calculate Budget's Winner Investments" do
-
     scenario 'For a Budget in reviewing balloting' do
       budget = create(:budget, phase: 'reviewing_ballots')
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group, price: 4)
       unselected = create(:budget_investment, :unselected, heading: heading, price: 1,
                                                            ballot_lines_count: 3)
-      winner = create(:budget_investment, :winner, heading: heading, price: 3,
+      winner = create(:budget_investment, :selected, heading: heading, price: 3,
                                                    ballot_lines_count: 2)
-      selected = create(:budget_investment, :selected, heading: heading, price: 2,
-                                                       ballot_lines_count: 1)
+      selected = create(:budget_investment, :selected, heading: heading, price: 2, ballot_lines_count: 1)
 
       visit edit_admin_budget_path(budget)
+      expect(page).not_to have_content 'See results'
       click_link 'Calculate Winner Investments'
       expect(page).to have_content 'Winners being calculated, it may take a minute.'
       expect(page).to have_content winner.title
       expect(page).not_to have_content unselected.title
       expect(page).not_to have_content selected.title
+
+
+      visit edit_admin_budget_path(budget)
+      expect(page).to have_content 'See results'
     end
 
     scenario 'For a finished Budget' do
       budget = create(:budget, phase: 'finished')
+      allow_any_instance_of(Budget).to receive(:has_winning_investments?).and_return true
 
       visit edit_admin_budget_path(budget)
+
       expect(page).not_to have_content 'Calculate Winner Investments'
+      expect(page).to have_content 'See results'
     end
 
   end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -190,6 +190,18 @@ describe Budget do
     end
   end
 
+  describe '#has_winning_investments?' do
+    it 'should return true if there is a winner investment' do
+      budget.investments << build(:budget_investment, :winner, price: 3, ballot_lines_count: 2)
+
+      expect(budget.has_winning_investments?).to eq true
+    end
+
+    it 'hould return false if there is not a winner investment' do
+      expect(budget.has_winning_investments?).to eq false
+    end
+  end
+
   describe "#generate_phases" do
     let(:drafting_phase)          { budget.phases.drafting }
     let(:informing_phase)         { budget.phases.informing }


### PR DESCRIPTION
References
==========
This closes #2603

Objectives
==========
> Show "See results" button in admin page, only if the results have been calculated.

In order to further clarify this, I chose to show "See results" button, only when there is a clear winner investment

Visual Changes
=======================
> 
![screenshot from 2018-05-17 01-48-39](https://user-images.githubusercontent.com/527550/40147988-80e30fc0-5974-11e8-92cc-03160d9a252b.png)

Notes
=====================
> ---
