### PR TITLE
Update README with production configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Development started on [2015 July 15th](https://github.com/consul/consul/commit/
 
 ## Configuration for development and test environments
 
-**NOTE**: For more detailed instructions check the [docs](https://github.com/consul/docs/tree/master/en/getting_started/prerequisites)
+**NOTE**: For more detailed instructions check the [docs](https://consul_docs.gitbooks.io/docs/)
 
 Prerequisites: install git, Ruby 2.3.2, `bundler` gem, Node.js and PostgreSQL (>=9.4).
 
@@ -64,6 +64,10 @@ But for some actions like voting, you will need a verified user, the seeds file 
  **user:** verified@consul.dev
  **pass:** 12345678
 
+## Configuration for production environments
+
+See [installer](https://github.com/consul/installer)
+
 ## Documentation
 
 Check the ongoing documentation at [https://consul_docs.gitbooks.io/docs/content/](https://consul_docs.gitbooks.io/docs/content/) to learn more about how to start your own CONSUL fork, install it, customize it and learn to use it from an administrator/maintainer perspective. You can contribute to it at [https://github.com/consul/docs](https://github.com/consul/docs)
@@ -75,7 +79,3 @@ Code published under AFFERO GPL v3 (see [LICENSE-AGPLv3.txt](LICENSE-AGPLv3.txt)
 ## Contributions
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
-
-## Local development with Docker
-
-Please check the documentation at [https://consul_docs.gitbooks.io/docs/content/en/getting_started/docker.html](https://consul_docs.gitbooks.io/docs/content/en/getting_started/docker.html)


### PR DESCRIPTION
What
===
- Updates url for gitbook docs, it was pointing to an obsolete url
- Remove Docker section, it is already covered in the extended docs
- Add section to configure CONSUL for a production environment