### PR TITLE
Split admin settings

### DIFF
--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -212,5 +212,12 @@
         </li>
       </ul>
     </li>
+
+    <li class="section-title <%= "active" if controller_name == "settings" %>">
+      <%= link_to admin_settings_path do %>
+        <span class="icon-settings"></span>
+        <strong><%= t("admin.settings.index.title") %></strong>
+      <% end %>
+    </li>
   </ul>
 </div>

--- a/app/views/admin/settings/_banner_images.html.erb
+++ b/app/views/admin/settings/_banner_images.html.erb
@@ -20,5 +20,5 @@
     </tbody>
   </table>
 <% else %>
-  <h3>No banner images to show.</h3>
+  <h3><%= t("admin.settings.index.no_banners_images") %></h3>
 <% end %>

--- a/app/views/admin/settings/_banner_images.html.erb
+++ b/app/views/admin/settings/_banner_images.html.erb
@@ -1,0 +1,24 @@
+<% if @banner_imgs.present?%>
+  <h2><%= t("admin.settings.index.banner_imgs") %></h2>
+
+  <table>
+    <tbody>
+      <% @banner_imgs.each do |setting| %>
+        <tr>
+          <td>
+            <strong><%= t("settings.#{setting.key}") %></strong>
+          </td>
+
+          <td>
+            <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
+              <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
+              <%= f.submit(t('admin.settings.index.update_setting'), class: "button small success") %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <h3>No banner images to show.</h3>
+<% end %>

--- a/app/views/admin/settings/_banner_styles.html.erb
+++ b/app/views/admin/settings/_banner_styles.html.erb
@@ -20,5 +20,5 @@
     </tbody>
   </table>
 <% else %>
-  <h3>No banner styles to show.</h3>
+  <h3><%= t("admin.settings.index.no_banners_styles") %></h3>
 <% end %>

--- a/app/views/admin/settings/_banner_styles.html.erb
+++ b/app/views/admin/settings/_banner_styles.html.erb
@@ -1,0 +1,24 @@
+<% if @banner_styles.present? %>
+  <h2><%= t("admin.settings.index.banners") %></h2>
+
+  <table>
+    <tbody>
+      <% @banner_styles.each do |setting| %>
+        <tr>
+          <td>
+            <strong><%= t("settings.#{setting.key}") %></strong>
+          </td>
+
+          <td>
+            <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
+              <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
+              <%= f.submit(t('admin.settings.index.update_setting'), class: "button hollow") %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <h3>No banner styles to show.</h3>
+<% end %>

--- a/app/views/admin/settings/_configuration.html.erb
+++ b/app/views/admin/settings/_configuration.html.erb
@@ -1,0 +1,23 @@
+<h2><%= t("admin.settings.index.title") %></h2>
+
+<table>
+  <tbody>
+    <% @settings.each do |setting| %>
+      <tr>
+        <td class="small-12 medium-4">
+          <strong><%= t("settings.#{setting.key}") %></strong>
+        </td>
+        <td class="small-12 medium-8">
+          <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
+            <div class="small-12 medium-6 large-9 column">
+              <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
+            </div>
+            <div class="small-12 medium-6 large-3 column">
+              <%= f.submit(t('admin.settings.index.update_setting'), class: "button hollow expanded") %>
+            </div>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/settings/_feature_flags.html.erb
+++ b/app/views/admin/settings/_feature_flags.html.erb
@@ -1,4 +1,3 @@
-
 <h2><%= t("admin.settings.index.feature_flags") %></h2>
 
 <table>

--- a/app/views/admin/settings/_feature_flags.html.erb
+++ b/app/views/admin/settings/_feature_flags.html.erb
@@ -1,0 +1,28 @@
+
+<h2><%= t("admin.settings.index.feature_flags") %></h2>
+
+<table>
+  <tbody>
+    <% @feature_flags.each do |feature_flag| %>
+      <tr>
+        <td>
+          <strong><%= t("settings.#{feature_flag.key}") %></strong>
+        </td>
+
+        <td>
+          <%= feature_flag.enabled? ? t("admin.settings.index.features.enabled") : t("admin.settings.index.features.disabled") %>
+        </td>
+
+        <td class="text-right">
+          <%= form_for(feature_flag, url: admin_setting_path(feature_flag), html: { id: "edit_#{dom_id(feature_flag)}"}) do |f| %>
+
+            <%= f.hidden_field :value, id: dom_id(feature_flag), value: (feature_flag.enabled? ? "" : "active") %>
+            <%= f.submit(t("admin.settings.index.features.#{feature_flag.enabled? ? 'disable' : 'enable'}"),
+                        class: "button expanded #{feature_flag.enabled? ? 'hollow alert' : 'success'}",
+                        data: {confirm: t("admin.actions.confirm")}) %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/settings/_filter_subnav.html.erb
+++ b/app/views/admin/settings/_filter_subnav.html.erb
@@ -23,7 +23,7 @@
     <% end %>
   </li>
 
-  <li class="tabs-title">
+  <li class="tabs-title" id="map-tab">
     <%= link_to "#tab-map-configuration" do %>
       <%= t("admin.settings.index.map.title") %>
     <% end %>

--- a/app/views/admin/settings/_filter_subnav.html.erb
+++ b/app/views/admin/settings/_filter_subnav.html.erb
@@ -5,7 +5,7 @@
     <% end %>
   </li>
 
-  <li class="tabs-title">
+  <li class="tabs-title" id="features-tab">
     <%= link_to "#tab-feature-flags" do %>
       <%= t("admin.settings.index.feature_flags") %>
     <% end %>

--- a/app/views/admin/settings/_filter_subnav.html.erb
+++ b/app/views/admin/settings/_filter_subnav.html.erb
@@ -1,0 +1,31 @@
+<ul class="tabs" data-tabs id="settings-tabs">
+  <li class="tabs-title is-active">
+    <%= link_to "#tab-configuration" do %>
+      <%= t("admin.settings.index.title") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title">
+    <%= link_to "#tab-feature-flags" do %>
+      <%= t("admin.settings.index.feature_flags") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title">
+    <%= link_to "#tab-banner-styles" do %>
+      <%= t("admin.settings.index.banners") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title">
+    <%= link_to "#tab-banner-images" do %>
+      <%= t("admin.settings.index.banner_imgs") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title">
+    <%= link_to "#tab-map-configuration" do %>
+      <%= t("admin.settings.index.map.title") %>
+    <% end %>
+  </li>
+</ul>

--- a/app/views/admin/settings/_map_configuration.html.erb
+++ b/app/views/admin/settings/_map_configuration.html.erb
@@ -1,0 +1,8 @@
+<% if feature?(:map) %>
+  <h2><%= t("admin.settings.index.map.title") %></h2>
+  <p><%= t("admin.settings.index.map.help") %></p>
+
+  <%= render "map_form" %>
+<% else %>
+  <h3>No map to show.</h3>
+<% end %>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,105 +1,24 @@
-<h2><%= t("admin.settings.index.title") %></h2>
+<h1>Settings</h1>
+<div class="tabs-content" data-tabs-content="settings-tabs">
+  <%= render "filter_subnav" %>
 
-<table>
-  <tbody>
-    <% @settings.each do |setting| %>
-      <tr>
-        <td class="small-12 medium-4">
-          <strong><%= t("settings.#{setting.key}") %></strong>
-        </td>
-        <td class="small-12 medium-8">
-          <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
-            <div class="small-12 medium-6 large-9 column">
-              <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
-            </div>
-            <div class="small-12 medium-6 large-3 column">
-              <%= f.submit(t('admin.settings.index.update_setting'), class: "button hollow expanded") %>
-            </div>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+  <div class="tabs-panel is-active" id="tab-configuration">
+    <%= render "configuration" %>
+  </div>
 
-<h2><%= t("admin.settings.index.feature_flags") %></h2>
+  <div class="tabs-panel" id="tab-feature-flags">
+    <%= render "feature_flags" %>
+  </div>
 
-<table>
-  <tbody>
-    <% @feature_flags.each do |feature_flag| %>
-      <tr>
-        <td>
-          <strong><%= t("settings.#{feature_flag.key}") %></strong>
-        </td>
+  <div class="tabs-panel" id="tab-banner-styles">
+    <%= render "banner_styles" %>
+  </div>
 
-        <td>
-          <%= feature_flag.enabled? ? t("admin.settings.index.features.enabled") : t("admin.settings.index.features.disabled") %>
-        </td>
+  <div class="tabs-panel" id="tab-banner-images">
+    <%= render "banner_images" %>
+  </div>
 
-        <td class="text-right">
-          <%= form_for(feature_flag, url: admin_setting_path(feature_flag), html: { id: "edit_#{dom_id(feature_flag)}"}) do |f| %>
-
-            <%= f.hidden_field :value, id: dom_id(feature_flag), value: (feature_flag.enabled? ? "" : "active") %>
-            <%= f.submit(t("admin.settings.index.features.#{feature_flag.enabled? ? 'disable' : 'enable'}"),
-                        class: "button expanded #{feature_flag.enabled? ? 'hollow alert' : 'success'}",
-                        data: {confirm: t("admin.actions.confirm")}) %>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<% if @banner_styles.present? %>
-  <h2><%= t("admin.settings.index.banners") %></h2>
-
-  <table>
-    <tbody>
-      <% @banner_styles.each do |setting| %>
-        <tr>
-          <td>
-            <strong><%= t("settings.#{setting.key}") %></strong>
-          </td>
-
-          <td>
-            <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
-              <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
-              <%= f.submit(t('admin.settings.index.update_setting'), class: "button hollow") %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% end %>
-
-<% if @banner_imgs.present?%>
-  <h2><%= t("admin.settings.index.banner_imgs") %></h2>
-
-  <table>
-    <tbody>
-      <% @banner_imgs.each do |setting| %>
-        <tr>
-          <td>
-            <strong><%= t("settings.#{setting.key}") %></strong>
-          </td>
-
-          <td>
-            <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
-              <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
-              <%= f.submit(t('admin.settings.index.update_setting'), class: "button small success") %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% end %>
-
-<% if feature?(:map) %>
-  <h2><%= t("admin.settings.index.map.title") %></h2>
-  <p><%= t("admin.settings.index.map.help") %></p>
-
-  <%= render "map_form" %>
-
-<% end %>
+  <div class="tabs-panel" id="tab-map-configuration">
+    <%= render "map_configuration" %>
+  </div>
+</div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -919,6 +919,8 @@ en:
       index:
         banners: Banner styles
         banner_imgs: Banner images
+        no_banners_images: No banner images
+        no_banners_styles: No banner styles
         title: Configuration settings
         update_setting: Update
         feature_flags: Features

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -917,8 +917,10 @@ es:
       flash:
         updated: Valor actualizado
       index:
-        banners: Banner style
-        banner_imgs: Banner images
+        banners: Estilo del banner
+        banner_imgs: Imagenes del banner
+        no_banners_images: No hay imagenes de banner
+        no_banners_styles: No hay estilos de banner
         title: Configuración global
         update_setting: Actualizar
         feature_flags: Funcionalidades

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -1,4 +1,3 @@
-# Failing spec
 require 'rails_helper'
 
 feature 'Admin settings' do
@@ -100,6 +99,7 @@ feature 'Admin settings' do
       setting = Setting.where(key: "feature.user.skip_verification").first
 
       visit admin_settings_path
+      find("#features-tab").click
 
       accept_alert do
         find("#edit_setting_#{setting.id} .button").click
@@ -113,6 +113,7 @@ feature 'Admin settings' do
       setting = Setting.where(key: "feature.user.skip_verification").first
 
       visit admin_settings_path
+      find("#features-tab").click
 
       accept_alert do
         find("#edit_setting_#{setting.id} .button").click

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -35,8 +35,9 @@ feature 'Admin settings' do
       admin = create(:administrator).user
       login_as(admin)
       visit admin_settings_path
+      find("#map-tab").click
 
-      expect(page).not_to have_content "Map configuration"
+      expect(page).not_to have_css("#admin-map")
     end
 
     scenario "Should be able when map feature activated" do
@@ -44,8 +45,9 @@ feature 'Admin settings' do
       admin = create(:administrator).user
       login_as(admin)
       visit admin_settings_path
+      find("#map-tab").click
 
-      expect(page).to have_content "Map configuration"
+      expect(page).to have_css("#admin-map")
     end
 
     scenario "Should show successful notice" do
@@ -78,6 +80,7 @@ feature 'Admin settings' do
       login_as(admin)
 
       visit admin_settings_path
+      find("#map-tab").click
       find("#admin-map").click
       within "#map-form" do
         click_on "Update"

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -1,3 +1,4 @@
+# Failing spec
 require 'rails_helper'
 
 feature 'Admin settings' do


### PR DESCRIPTION
@bertocq @decabeza this is a fix for issue #2586 😄 

Objectives
==========
> Break up the "settings" menu into different tabs for better visualization.

Visual Changes
=======================
> Screenshots
# Before/was:
<img width="1440" alt="admin setings view before any changes" src="https://user-images.githubusercontent.com/29871004/40457305-9d33c850-5eaa-11e8-8ae7-cbf5a2a1fef8.png">

# After/is:
<img width="1440" alt="screen shot 2018-05-23 at 4 53 07 pm" src="https://user-images.githubusercontent.com/29871004/40457343-cf98ec4e-5eaa-11e8-9882-9a88b91ddf6c.png">

# After/is (Cont.)
<img width="1440" alt="screen shot 2018-05-23 at 4 53 50 pm" src="https://user-images.githubusercontent.com/29871004/40457361-ebe7651a-5eaa-11e8-85c1-db93a95320df.png">


# After/is (Cont.)
<img width="1440" alt="screen shot 2018-05-23 at 4 53 39 pm" src="https://user-images.githubusercontent.com/29871004/40457369-f6c215fc-5eaa-11e8-97fa-823b6764a788.png">

Notes
=====================
> This change was implemented using the views structure from the "Admin/Polls/Poll Questions" menu.
