### PR TITLE
Budgets homepage map fixes

### DIFF
--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -12,6 +12,7 @@ App.Map =
           App.Map.toogleMap()
 
   initializeMap: (element) ->
+    App.Map.cleanInvestmentCoordinates(element)
 
     mapCenterLatitude        = $(element).data('map-center-latitude')
     mapCenterLongitude       = $(element).data('map-center-longitude')
@@ -102,7 +103,21 @@ App.Map =
           marker.options['id'] = i.investment_id
 
           marker.on 'click', openMarkerPopup
+          add_marker=createMarker(i.lat , i.long)
+          add_marker.bindPopup(contentPopup(i.investment_title, i.investment_id, i.budget_id))
 
   toogleMap: ->
       $('.map').toggle()
       $('.js-location-map-remove-marker').toggle()
+
+  cleanInvestmentCoordinates: (element) ->
+    markers = $(element).attr('data-marker-investments-coordinates')
+    if markers?
+      clean_markers = markers.replace(/-?(\*+)/g, null)
+      $(element).attr('data-marker-investments-coordinates', clean_markers)
+
+  validCoordinates: (coordinates) ->
+    App.Map.isNumeric(coordinates.lat) && App.Map.isNumeric(coordinates.long)
+
+  isNumeric: (n) ->
+    !isNaN(parseFloat(n)) && isFinite(n)

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -9,7 +9,7 @@ App.Map =
 
     $('.js-toggle-map').on
         click: ->
-          App.Map.toogleMap()
+          App.Map.toggleMap()
 
   initializeMap: (element) ->
     App.Map.cleanInvestmentCoordinates(element)
@@ -106,7 +106,7 @@ App.Map =
           add_marker=createMarker(i.lat , i.long)
           add_marker.bindPopup(contentPopup(i.investment_title, i.investment_id, i.budget_id))
 
-  toogleMap: ->
+  toggleMap: ->
       $('.map').toggle()
       $('.js-location-map-remove-marker').toggle()
 

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -103,8 +103,6 @@ App.Map =
           marker.options['id'] = i.investment_id
 
           marker.on 'click', openMarkerPopup
-          add_marker=createMarker(i.lat , i.long)
-          add_marker.bindPopup(contentPopup(i.investment_title, i.investment_id, i.budget_id))
 
   toggleMap: ->
       $('.map').toggle()

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -191,6 +191,58 @@ feature 'Budgets' do
     expect(page).to have_css(".phase.active", count: 1)
   end
 
+  context "Index map" do
+
+    let(:group) { create(:budget_group, budget: budget) }
+    let(:heading) { create(:budget_heading, group: group) }
+
+    before do
+      Setting['feature.map'] = true
+    end
+
+    scenario "Display investment's map location markers" , :js do
+      investment1 = create(:budget_investment, heading: heading)
+      investment2 = create(:budget_investment, heading: heading)
+      investment3 = create(:budget_investment, heading: heading)
+
+      investment1.create_map_location(longitude: 40.1234, latitude: 3.1234)
+      investment2.create_map_location(longitude: 40.1235, latitude: 3.1235)
+      investment3.create_map_location(longitude: 40.1236, latitude: 3.1236)
+
+      visit budgets_path
+
+      within ".map_location" do
+        expect(page).to have_css(".map-icon", count: 3)
+      end
+    end
+
+    scenario "Skip invalid map markers" , :js do
+      map_locations = []
+      map_locations << { longitude: 40.123456789, latitude: 3.12345678 }
+      map_locations << { longitude: 40.123456789, latitude: "*******" }
+      map_locations << { longitude: "**********", latitude: 3.12345678 }
+
+      budget_map_locations = map_locations.map do |map_location|
+        {
+          lat: map_location[:latitude],
+          long: map_location[:longitude],
+          investment_title: "#{rand(999)}",
+          investment_id: "#{rand(999)}",
+          budget_id: budget.id
+        }
+      end
+
+      allow_any_instance_of(BudgetsHelper).
+      to receive(:current_budget_map_locations).and_return(budget_map_locations)
+
+      visit budgets_path
+
+      within ".map_location" do
+        expect(page).to have_css(".map-icon", count: 1)
+      end
+    end
+  end
+
   context 'Show' do
 
     scenario "List all groups" do

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 feature 'Budgets' do
 
-  let(:budget) { create(:budget) }
-  let(:level_two_user) { create(:user, :level_two) }
+  let(:budget)             { create(:budget) }
+  let(:level_two_user)     { create(:user, :level_two) }
   let(:allowed_phase_list) { ['balloting', 'reviewing_ballots', 'finished'] }
 
   context 'Index' do
@@ -193,41 +193,44 @@ feature 'Budgets' do
 
   context "Index map" do
 
-    let(:group) { create(:budget_group, budget: budget) }
+    let(:group)   { create(:budget_group, budget: budget) }
     let(:heading) { create(:budget_heading, group: group) }
 
-    before do
+    background do
       Setting['feature.map'] = true
     end
 
-    scenario "Display investment's map location markers" , :js do
+    scenario "Display investment's map location markers", :js do
       investment1 = create(:budget_investment, heading: heading)
       investment2 = create(:budget_investment, heading: heading)
       investment3 = create(:budget_investment, heading: heading)
 
-      investment1.create_map_location(longitude: 40.1234, latitude: 3.1234)
-      investment2.create_map_location(longitude: 40.1235, latitude: 3.1235)
-      investment3.create_map_location(longitude: 40.1236, latitude: 3.1236)
+      create(:map_location, longitude: 40.1234, latitude: -3.634, investment: investment1)
+      create(:map_location, longitude: 40.1235, latitude: -3.635, investment: investment2)
+      create(:map_location, longitude: 40.1236, latitude: -3.636, investment: investment3)
 
       visit budgets_path
 
       within ".map_location" do
-        expect(page).to have_css(".map-icon", count: 3)
+        expect(page).to have_css(".map-icon", count: 3, visible: false)
       end
     end
 
-    scenario "Skip invalid map markers" , :js do
+    scenario "Skip invalid map markers", :js do
       map_locations = []
+
+      investment = create(:budget_investment, heading: heading)
+
       map_locations << { longitude: 40.123456789, latitude: 3.12345678 }
-      map_locations << { longitude: 40.123456789, latitude: "*******" }
+      map_locations << { longitude: 40.123456789, latitude: "********" }
       map_locations << { longitude: "**********", latitude: 3.12345678 }
 
       budget_map_locations = map_locations.map do |map_location|
         {
           lat: map_location[:latitude],
           long: map_location[:longitude],
-          investment_title: "#{rand(999)}",
-          investment_id: "#{rand(999)}",
+          investment_title: investment.title,
+          investment_id: investment.id,
           budget_id: budget.id
         }
       end
@@ -238,7 +241,7 @@ feature 'Budgets' do
       visit budgets_path
 
       within ".map_location" do
-        expect(page).to have_css(".map-icon", count: 1)
+        expect(page).to have_css(".map-icon", count: 1, visible: false)
       end
     end
   end


### PR DESCRIPTION
References
==========
* Related issues: #2380, #2389
* Related PR: AyuntamientoMadrid/consul#1162

Objectives
==========
* Backport the fixes implemented in AyuntamientoMadrid/consul#1162 and correction of its related tests

Visual Changes (if any)
=======================
None

Notes
=====================
It's worth noting that, during the tests, the markers **do appear** in the map but since we can't move the map to where they are located, they show up as "not visible", hence the need to use the `visible: false` syntax