### PR TITLE
Add imagemagick package to Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM coreapps/ruby2.3
 
 # Install essential Linux packages
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client nodejs
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client nodejs imagemagick
 
 # Define where our application will live inside the image
 ENV RAILS_ROOT /var/www/consul


### PR DESCRIPTION
References
==========
This is a **backport** of issue https://github.com/consul/consul/issues/2612, done first at Madrid's fork.
**Original PR**: https://github.com/AyuntamientoMadrid/consul/pull/1473

Objectives
==========
Add imagemagick package to the Docker configuration so that it's installed along with the others when Docker is configured. It is needed to upload images in the app.

Visual Changes
=======================
There aren't visual changes itself, but I added some GIFs to see how it works.

![docker01](https://user-images.githubusercontent.com/31625251/40107086-aa9ca36c-58f7-11e8-9c26-f5d1f829421a.gif)
![docker02](https://user-images.githubusercontent.com/31625251/40107096-ad00c98a-58f7-11e8-8fa3-f8df2d872b85.gif)
![docker03](https://user-images.githubusercontent.com/31625251/40107102-aef082bc-58f7-11e8-8737-33d312ba252f.gif)

![docker04](https://user-images.githubusercontent.com/31625251/40107288-266325ca-58f8-11e8-8efb-dd707a3bcf61.jpg)


Notes
=====================
As a side note, I was able to make it work ONLY after deleting the Docker cache. When I first set up Docker, the ImageMagick package wasn't included (I was just trying that everything was working on muy computer) and, for some reason, when I included it and rebuild everything, it was not taking into account the changes I made in the package installation instruction, even if it was in a separated `RUN` line.