### PR TITLE
Minor fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,17 +1,17 @@
 References
-==========
+===================
 > Add references to related Issues/Pull Requests/Travis Builds/Rollbar errors/etc...
 
 Objectives
-==========
+===================
 > What are the objectives of this changes? (If there is no related Issue with an explanation)
 
-Visual Changes (if any)
-=======================
+Visual Changes
+===================
 > Any visual changes? please attach screenshots (or gifs) showing them.
 > If modified views are public (not the admin panel), try them in mobile display (with your browser's developer console) and add screenshots.
 
 Notes
-=====================
+===================
 > Mention rake tasks or actions to be done when deploying this changes to a server (if any).
 > Explain any caveats, or important things to notice like deprecations (if any).

--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -81,22 +81,22 @@ $button-radius: $global-radius;
 
 $font-family-serif: Georgia, 'Times New Roman', Times, serif;
 
-$header-sizes: (
+$header-styles: (
   small: (
-    'h1': 34,
-    'h2': 24,
-    'h3': 20,
-    'h4': 18,
-    'h5': 16,
-    'h6': 14,
+    'h1': ('font-size': 34),
+    'h2': ('font-size': 24),
+    'h3': ('font-size': 20),
+    'h4': ('font-size': 18),
+    'h5': ('font-size': 16),
+    'h6': ('font-size': 14),
   ),
   medium: (
-    'h1': 44,
-    'h2': 34,
-    'h3': 24,
-    'h4': 19,
-    'h5': 16,
-    'h6': 13,
+    'h1': ('font-size': 44),
+    'h2': ('font-size': 34),
+    'h3': ('font-size': 24),
+    'h4': ('font-size': 19),
+    'h5': ('font-size': 16),
+    'h6': ('font-size': 13),
   ),
 );
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -244,6 +244,7 @@ $sidebar-active: #f4fcd0;
 }
 
 .admin-content {
+  overflow: scroll;
   padding: $line-height !important;
 }
 

--- a/app/views/admin/poll/booth_assignments/show.html.erb
+++ b/app/views/admin/poll/booth_assignments/show.html.erb
@@ -12,19 +12,24 @@
   </p>
 <% end %>
 
-<div class="tabs-content" data-tabs-content="booths-tabs" role="tablist">
-  <ul class="tabs" data-tabs id="booths-tabs">
-    <li class="tabs-title">
-      <%= link_to t("admin.poll_booth_assignments.show.officers"), "#tab-officers" %>
-    </li>
-    <li class="tabs-title">
-      <%= link_to t("admin.poll_booth_assignments.show.recounts"), "#tab-recounts" %>
-    </li>
-    <li class="tabs-title is-active">
-      <%= link_to t("admin.poll_booth_assignments.show.results"), "#tab-results" %>
-    </li>
-  </ul>
+<ul class="tabs" id="booths_tabs" role="tablist"
+    data-deep-link="true"
+    data-update-history="true"
+    data-deep-link-smudge="true"
+    data-deep-link-smudge-delay="500"
+    data-tabs>
+  <li class="tabs-title">
+    <%= link_to t("admin.poll_booth_assignments.show.officers"), "#tab-officers" %>
+  </li>
+  <li class="tabs-title">
+    <%= link_to t("admin.poll_booth_assignments.show.recounts"), "#tab-recounts" %>
+  </li>
+  <li class="tabs-title is-active">
+    <%= link_to t("admin.poll_booth_assignments.show.results"), "#tab-results" %>
+  </li>
+</ul>
 
+<div class="tabs-content" data-tabs-content="booths_tabs" role="tablist">
   <div class="tabs-panel" id="tab-officers" role="tab">
     <% if @booth_assignment.officers.empty? %>
       <div class="callout primary margin-top">

--- a/app/views/budgets/investments/_filter_subnav.html.erb
+++ b/app/views/budgets/investments/_filter_subnav.html.erb
@@ -4,7 +4,7 @@
     data-deep-link="true"
     data-update-history="true"
     data-deep-link-smudge="true"
-    data-deep-link-smudge="500"
+    data-deep-link-smudge-delay="500"
     data-tabs>
   <li class="tabs-title is-active">
     <%= link_to "#tab-comments" do %>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -146,15 +146,15 @@
             <%= t("budgets.investments.show.project_not_selected_html") %>
           </div>
         <% end %>
-      <% end %>
-      <% if investment.should_show_price? %>
-        <div class="sidebar-divider"></div>
-        <h2><%= t("budgets.investments.show.price") %></h2>
-        <div class="supports text-center">
-          <p class="investment-project-amount">
-            <%= investment.formatted_price %>
-          </p>
-        </div>
+        <% if investment.should_show_price? %>
+          <div class="sidebar-divider"></div>
+          <h2><%= t("budgets.investments.show.price") %></h2>
+          <div class="supports text-center">
+            <p class="investment-project-amount">
+              <%= investment.formatted_price %>
+            </p>
+          </div>
+        <% end %>
       <% end %>
       <%= render partial: 'shared/social_share', locals: {
         share_title: t("budgets.investments.show.share"),

--- a/app/views/debates/new.html.erb
+++ b/app/views/debates/new.html.erb
@@ -1,7 +1,7 @@
 <div class="debate-form row">
 
   <div class="small-12 medium-9 column">
-    <%= back_link_to %>
+    <%= back_link_to debates_path %>
 
     <h1><%= t("debates.new.start_new") %></h1>
     <div data-alert class="callout primary">

--- a/app/views/legislation/proposals/_filter_subnav.html.erb
+++ b/app/views/legislation/proposals/_filter_subnav.html.erb
@@ -4,7 +4,7 @@
     data-deep-link="true"
     data-update-history="true"
     data-deep-link-smudge="true"
-    data-deep-link-smudge="500"
+    data-deep-link-smudge-delay="500"
     data-tabs>
   <li class="tabs-title is-active">
     <%= link_to "#tab-comments" do %>

--- a/app/views/proposals/_filter_subnav.html.erb
+++ b/app/views/proposals/_filter_subnav.html.erb
@@ -4,7 +4,7 @@
     data-deep-link="true"
     data-update-history="true"
     data-deep-link-smudge="true"
-    data-deep-link-smudge="500"
+    data-deep-link-smudge-delay="500"
     data-tabs>
   <li class="tabs-title is-active">
     <%= link_to "#tab-comments" do %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -206,9 +206,13 @@
   </div>
 <% end %>
 
-<div class="row">
-  <div class="small-12 column">
-    <%= render "proposals/filter_subnav" %>
+<div class="additional-content">
+  <div class="filter-subnav">
+    <div class="row">
+      <div class="small-12 column">
+        <%= render "proposals/filter_subnav" %>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -1,18 +1,22 @@
 <% provide :title do %><%= @proposal.title %><% end %>
 <% content_for :meta_description do %><%= @proposal.summary %><% end %>
 <% provide :social_media_meta_tags do %>
-<%= render "shared/social_media_meta_tags",
-            social_url: proposal_url(@proposal),
-            social_title: @proposal.title,
-            social_description: @proposal.summary,
-            twitter_image_url: (@proposal.image.present? ? @proposal.image_url(:thumb) : nil),
-            og_image_url: (@proposal.image.present? ? @proposal.image_url(:thumb) : nil) %>
+  <%= render "shared/social_media_meta_tags",
+              social_url: proposal_url(@proposal),
+              social_title: @proposal.title,
+              social_description: @proposal.summary,
+              twitter_image_url: (@proposal.image.present? ? @proposal.image_url(:thumb) : nil),
+              og_image_url: (@proposal.image.present? ? @proposal.image_url(:thumb) : nil) %>
 <% end %>
 <% content_for :canonical do %>
   <%= render "shared/canonical", href: proposal_url(@proposal) %>
 <% end %>
 
-<% cache [locale_and_user_status(@proposal), @proposal, @proposal.author, Flag.flagged?(current_user, @proposal), @proposal_votes] do %>
+<% cache [locale_and_user_status(@proposal),
+          @proposal,
+          @proposal.author,
+          Flag.flagged?(current_user, @proposal),
+          @proposal_votes] do %>
   <div class="proposal-show">
     <div id="<%= dom_id(@proposal) %>" class="row">
       <div class="small-12 medium-9 column">
@@ -23,7 +27,8 @@
           <div data-alert class="callout alert margin-top proposal-retired">
             <strong>
               <%= t("proposals.show.retired_warning") %><br>
-              <%= link_to t("proposals.show.retired_warning_link_to_explanation"), "#retired_explanation" %>
+              <%= link_to t("proposals.show.retired_warning_link_to_explanation"),
+                          "#retired_explanation" %>
             </strong>
           </div>
         <% elsif @proposal.conflictive? %>
@@ -101,7 +106,10 @@
 
         <% if @proposal.retired? %>
           <div id="retired_explanation" class="callout">
-            <h2><%= t('proposals.show.retired') %>: <%= t("proposals.retire_options.#{@proposal.retired_reason}") unless @proposal.retired_reason == 'other' %></h2>
+            <h2>
+              <%= t("proposals.show.retired") %>:
+              <%= t("proposals.retire_options.#{@proposal.retired_reason}") unless @proposal.retired_reason == 'other' %>
+            </h2>
             <%= simple_format text_with_links(@proposal.retired_explanation), {}, sanitize: false %>
           </div>
         <% end %>

--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -32,7 +32,7 @@
         <%= layout_menu_link_to t("layouts.header.collaborative_legislation"),
                                 legislation_processes_path,
                                 controller.class.parent == Legislation,
-                                accesskey: "l" %>
+                                accesskey: "4" %>
       </li>
     <% end %>
     <% if feature?(:spending_proposals) %>
@@ -48,14 +48,14 @@
         <%= layout_menu_link_to t("layouts.header.budgets"),
                                   budgets_path,
                                   controller_name == "budgets" || controller_name == "investments",
-                                  accesskey: "4",
+                                  accesskey: "5",
                                   title: t("shared.go_to_page") + t("layouts.header.budgets") %>
       </li>
     <% end %>
     <li>
       <%= link_to t("layouts.header.help"),
                     help_path,
-                    accesskey: "5",
+                    accesskey: "6",
                     class: ("is-active" if current_page?(help_path)),
                     title: t("shared.go_to_page") + t("layouts.header.help") %>
     </li>

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -47,6 +47,9 @@ en:
       map: Proposals and budget investments geolocation
       allow_images: Allow upload and show images
       allow_attached_documents: Allow upload and show of attached documents
+      guides: Guides to create proposals or investment projects
+      public_stats: Public stats
+    related_content_score_threshold: Related content score threshold
     map_latitude: Latitude
     map_longitude: Longitude
     map_zoom: Zoom

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -47,6 +47,9 @@ es:
       map: Geolocalización de propuestas y proyectos de gasto
       allow_images: Permitir subir y mostrar imágenes
       allow_attached_documents: Permitir creación de documentos adjuntos
+      guides: Guías para crear propuestas o proyectos de inversión
+      public_stats: Estadísticas públicas
+    related_content_score_threshold: Umbral de puntuación de contenido relacionado
     map_latitude: Latitud
     map_longitude: Longitud
     map_zoom: Zoom


### PR DESCRIPTION
References
==========
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1483

Objectives
==========
 This PR:
- Updates pull request template.
- Fixes duplicated `data-deep-link-smudge` attribute on tabs.
- Adds missing features i18n and cleans i18n-tasks file.
- Replaces foundation `$header-sizes` to `$header-styles` (to avoid some warnings).
- Adds missing class on proposals show view.
- Adds `debates_path` on backlink to on debates new.
- Fixes typo.
- Prevents hide content on equalizer container (when admin-content resizes some overflow content was hidden).
- Updates header logo for the mailer with the new image of Decide Madrid.
- Avoids show duplicated budget investment price.

**Also**
- Fixes accesskey on subnavigation.
- Fixes indentation on proposals show.
- Adds data-tabs on admin poll booth assignments show.
