### PR TITLE
Fixes admin menu toggle

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -61,6 +61,41 @@ $sidebar-active: #f4fcd0;
     [class^="icon-"]:not(.icon-circle) {
       font-size: $base-font-size;
     }
+
+    @include breakpoint(small only) {
+
+      .top-bar-left ul {
+        display: inline-block;
+      }
+
+      .top-bar-right {
+
+        .submenu {
+          border: 0;
+          display: block;
+          margin-top: 0;
+          position: initial;
+          width: 100%;
+        }
+
+        .is-active {
+          font-weight: normal;
+          text-decoration: none;
+        }
+
+        .is-submenu-item {
+          padding: $line-height / 2 0;
+        }
+
+        a {
+          font-weight: normal !important;
+        }
+      }
+
+      [class^="icon-"] {
+        display: none;
+      }
+    }
   }
 
   .menu .menu-text {

--- a/app/views/admin/shared/_admin_shortcuts.html.erb
+++ b/app/views/admin/shared/_admin_shortcuts.html.erb
@@ -2,11 +2,17 @@
   <li>
     <%= link_to admin_stats_path, title: t("admin.menu.stats") do %>
       <span class="icon-stats"></span>
+      <span class="show-for-small-only">
+        <%= t("admin.menu.stats") %>
+      </span>
     <% end %>
   </li>
   <li>
     <%= link_to admin_settings_path, title: t("admin.menu.settings") do %>
       <span class="icon-settings"></span>
+      <span class="show-for-small-only">
+        <%= t("admin.menu.settings") %>
+      </span>
     <% end %>
   </li>
 <% end %>

--- a/app/views/layouts/_notification_item.html.erb
+++ b/app/views/layouts/_notification_item.html.erb
@@ -1,28 +1,28 @@
 <% if user_signed_in? %>
   <li id="notifications">
-    <%= link_to notifications_path, rel: "nofollow", 
+    <%= link_to notifications_path, rel: "nofollow",
                 class: "notifications" do %>
       <span class="show-for-sr">
         <%= t("layouts.header.notification_item.notifications") %>
       </span>
-      
+
       <% if current_user.notifications.unread.count > 0 %>
         <span class="icon-circle" aria-hidden="true"></span>
-        <span class="icon-notification" aria-hidden="true" 
-              title="<%= t('layouts.header.notification_item.new_notifications', 
+        <span class="icon-notification" aria-hidden="true"
+              title="<%= t("layouts.header.notification_item.new_notifications",
                          count: current_user.notifications_count).html_safe %>">
         </span>
-        <small class="show-for-small-only">
-          <%= t('layouts.header.notification_item.new_notifications', 
+        <span class="show-for-small-only">
+          <%= t("layouts.header.notification_item.new_notifications",
               count: current_user.notifications_count).html_safe %>
-        </small>
-      <% else %>
-        <span class="icon-no-notification" aria-hidden="true" 
-              title="<%= t('layouts.header.notification_item.no_notifications') %>">
         </span>
-        <small class="show-for-small-only">
-          <%= t('layouts.header.notification_item.no_notifications') %>
-        </small>
+      <% else %>
+        <span class="icon-no-notification" aria-hidden="true"
+              title="<%= t("layouts.header.notification_item.no_notifications") %>">
+        </span>
+        <span class="show-for-small-only">
+          <%= t("layouts.header.notification_item.no_notifications") %>
+        </span>
       <% end %>
 
     <% end %>


### PR DESCRIPTION
References
===================
This close https://github.com/consul/consul/issues/2682

Objectives
===================
Fixes admin menu toggle (the title was overlapping the toggle menu and was impossible to use).

Also hides icons on the mobile version and includes text to settings and stats links.

Visual Changes
===================
**Desktop (same as before)**
![consul_desktop](https://user-images.githubusercontent.com/631897/41659079-955023fa-7498-11e8-93fd-ebb65bda7a95.png)

**Mobile (fixed!)** 🎉 
![consul_mobile](https://user-images.githubusercontent.com/631897/41659086-9751c8c0-7498-11e8-917f-719f3185cbea.png)
