### PR TITLE
Fix flaky specs: Emails Budgets Selected/Unselected investment

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -152,13 +152,13 @@ class Budget < ActiveRecord::Base
   end
 
   def email_selected
-    investments.selected.each do |investment|
+    investments.selected.order(:id).each do |investment|
       Mailer.budget_investment_selected(investment).deliver_later
     end
   end
 
   def email_unselected
-    investments.unselected.each do |investment|
+    investments.unselected.order(:id).each do |investment|
       Mailer.budget_investment_unselected(investment).deliver_later
     end
   end


### PR DESCRIPTION
# References

* Issue #2446.
* Issue #2519.

# Objectives

Fix the flaky specs in `spec/features/emails_spec.rb:431` ("Emails Budgets Selected investment") and `spec/features/emails_spec.rb:454` ("Emails Budgets Unselected investment").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

The code in both specs is similar, so here's one of them (unnecessary lines omitted):

```ruby
investment1 = create(:budget_investment, :selected,   author: author1, budget: budget)
investment2 = create(:budget_investment, :selected,   author: author2, budget: budget)
# ...
budget.email_selected
# ...
email = open_last_email
investment = investment2
expect(email).to have_subject("Your investment project '#{investment.code}' has been selected")
```
The test assumes the last email sent will be the one addressed to the author of the last investment created. However, this isn't always the case. The code in `budget.email_selected` is:
```ruby
def email_selected
  investments.selected.each do
  # ...
```
And this code doesn't always return the selected investments in the order they were created, since postgresql by default doesn't guarantee in which order the records will be returned.

## Explain why your PR fixes it
By ordering the selected investments by ID, we ensure the last email is sent to the author of the last created investment, as the specs assume.

Notes
===================
* The implementation can probably be improved; suggestions are welcomed. IMHO the important thing is knowing these tests were failing because `open_last_email` doesn't always return the email for the last created investment.