### PR TITLE
Fix flaky spec: Proposals Voting Voting proposals on behalf of someone in show view

### DIFF
--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -159,6 +159,7 @@ feature 'Proposals' do
       click_link "Support proposals"
 
       within(".proposals-list") { click_link proposal.title }
+      expect(page).to have_content proposal.code
       within("#proposal_#{proposal.id}_votes") { click_link('Support') }
 
       expect(page).to have_content "1 support"


### PR DESCRIPTION
# References

* Issue #2558.

# Objectives

Fix the flaky that appeared in `spec/features/management/proposals_spec.rb:164`: "Proposals Voting Voting proposals on behalf of someone in show view".

## Explain why the test is flaky, or under which conditions/scenario it fails randomly
It's hard to reproduce and be sure about what was going on, so here is my best guess. Given the code:
```ruby
within(".proposals-list") { click_link proposal.title }
within("#proposal_#{proposal.id}_votes") { click_link('Support') }
```
The first clicked link generates an AJAX request. Usually, Capybara would wait for the AJAX request to generate a "Support" link in the element `#proposal_XX_votes`. However, there's already a `#proposal_XX_votes` element with a "Support" link on the proposals index page!

![Support link inspection in the browser](https://user-images.githubusercontent.com/348557/41825883-6934fdde-7814-11e8-8626-1bc5f192e7c2.png)

So Capybara doesn't have to wait for the AJAX request to finish before clicking the "Support" link. From then on, anything can happen.

As stated on issue #2558, on my machine the best chance to reproduce the failure was running `bundle exec rspec spec/features/management/proposals_spec.rb --seed 8625` (fails about 20% of the time).

## Explain why your PR fixes it

By checking the proposal code is present, which is present on the proposals show page but not on the proposals index page, we ensure we've left the proposals index page when we click the "Support" link.

Notes
===================
* In the commit message there's a mention to two possible implementations. One of them depends on the proposal code being present while the other one depends on a CSS selector being present. I'm not sure which one is better.