### PR TITLE
Flaky spec: Polls Concerns behaves like notifiable in-app Multiple users commented on my notifiable

### DIFF
--- a/spec/shared/features/notifiable_in_app.rb
+++ b/spec/shared/features/notifiable_in_app.rb
@@ -3,6 +3,15 @@ shared_examples "notifiable in-app" do |described_class|
   let(:author) { create(:user, :verified) }
   let!(:notifiable) { create(model_name(described_class), author: author) }
 
+  scenario "Notification icon is shown" do
+    notification = create(:notification, notifiable: notifiable, user: author)
+
+    login_as author
+    visit root_path
+
+    expect(page).to have_css ".icon-notification"
+  end
+
   scenario "A user commented on my notifiable", :js do
     notification = create(:notification, notifiable: notifiable, user: author)
 
@@ -26,13 +35,11 @@ shared_examples "notifiable in-app" do |described_class|
       within "#comments" do
         expect(page).to have_content "I agree"
       end
+      logout
     end
 
-    logout
     login_as author
-    visit root_path
-    visit root_path
-    find(".icon-notification").click
+    visit notifications_path
 
     expect(page).to have_css ".notification", count: 1
     expect(page).to have_content "There are 3 new comments on"
@@ -57,9 +64,7 @@ shared_examples "notifiable in-app" do |described_class|
 
     logout
     login_as author
-    visit root_path
-    visit root_path
-    find(".icon-notification").click
+    visit notifications_path
 
     expect(page).to have_css ".notification", count: 1
     expect(page).to have_content "Someone replied to your comment on"
@@ -86,9 +91,7 @@ shared_examples "notifiable in-app" do |described_class|
     end
 
     login_as author
-    visit root_path
-    visit root_path
-    find(".icon-notification").click
+    visit notifications_path
 
     expect(page).to have_css ".notification", count: 1
     expect(page).to have_content "There are 3 new replies to your comment on"


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1294/

Where
=====
* **Related Issue:** #1271

What
====
Fix the flaky spec that appears in `spec/shared/features/notifiable_in_app.rb`

How
===
### Explain why the test is flaky, or under which conditions/scenario it fails randomly
As far as I was able to research, the problem with this flaky was around the `login_as author` function, where, for some reason, the `current_user` variable was not being set correctly. In the previous version of the test, after loging in as the notifiable's author, there were two `visit root_path`.

```
login_as author
visit root_path
visit root_path
find(".icon-notification").click
```

With both visits there, the test passed (always), but, when I removed one of them, the test started to fail (constantly). I realized that, after the first one, the current user was not set, so there weren't notifications available and the `.icon-notification` wasn't there (there was one `.icon-no-notification` class).
After the second one, however, the `current_user` was correctly set, so there were notifications (and the `.icon-notification` class was there).

I realized that this happens, inexplicably, for some tests (here [L18](https://github.com/AyuntamientoMadrid/consul/blob/master/spec/shared/features/notifiable_in_app.rb#L18), [L42](https://github.com/AyuntamientoMadrid/consul/blob/master/spec/shared/features/notifiable_in_app.rb#L42) and [L69](https://github.com/AyuntamientoMadrid/consul/blob/master/spec/shared/features/notifiable_in_app.rb#L69) )
and even removing all the code to generate the comments and notifications, like that:
```
3.times do
  user = create(:user, :verified)
  comment = create(:comment, commentable: notifiable, author: user)
  Notification.add(notifiable.author_id, notifiable)
end

login_as author
visit root_path
find(".icon-notification").click
```
it fails when searching `.icon-notification`

For those which only have one notification, visiting the `root_path` after the login works well (like here [L6](https://github.com/AyuntamientoMadrid/consul/blob/master/spec/shared/features/notifiable_in_app.rb#L6) )

### Explain why your PR fixes it
This fix changes the way the notifications page is accessed. To test if the notifications are been shown correctly, the test doesn't need to go through the UI. I removed 
```
visit root_path
visit root_path
find(".icon-notification").click
```
and changed for `visit notifications_path`. This way, the notifications page was accessed always, without relying on the UI.

In order to check that the notifications icon is shown, I added another test that generates a notification, visits the `root_path` and looks for the `.icon-notification` class.

Screenshots
===========
There aren't, it's a flaky.

Test
====
Some tests have been modified and another one added, as explained above.