### PR TITLE
Regenerate Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,7 +500,6 @@ DEPENDENCIES
   acts_as_votable (~> 0.11.1)
   ahoy_matey (~> 1.6.0)
   ancestry (~> 3.0.1)
-  animate-rails (~> 1.0.10)
   autoprefixer-rails (~> 8.2.0)
   browser (~> 2.5.2)
   bullet (~> 5.7.0)
@@ -581,4 +580,4 @@ DEPENDENCIES
   whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
What
===================
- Regenerate Gemfile.lock
- Bump bundler version

Why
===================
We had an extra dependency in Gemfile.lock and capistrano was complaining when deploying

Thanks to @taitus for pointing this out! 👏