### PR TITLE
[WIP] Add homepage content to production seeds

### DIFF
--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -1,20 +1,7 @@
 require 'database_cleaner'
 DatabaseCleaner.clean_with :truncation
-@logger = Logger.new(STDOUT)
-@logger.formatter = proc do |_severity, _datetime, _progname, msg|
-                      msg unless @avoid_log
-                    end
 
-def section(section_title)
-  @logger.info section_title
-  yield
-  log(' ✅')
-end
-
-def log(msg)
-  @logger.info "#{msg}\n"
-end
-
+require_relative 'seed_logger'
 require_relative 'dev_seeds/settings'
 require_relative 'dev_seeds/geozones'
 require_relative 'dev_seeds/users'

--- a/db/seed_logger.rb
+++ b/db/seed_logger.rb
@@ -1,0 +1,14 @@
+@logger = Logger.new(STDOUT)
+@logger.formatter = proc do |_severity, _datetime, _progname, msg|
+                      msg unless @avoid_log
+                    end
+
+def section(section_title)
+  @logger.info section_title
+  yield
+  log(' ✅')
+end
+
+def log(msg)
+  @logger.info "#{msg}\n"
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 # Default admin user (change password after first deploy to a server!)
-if Administrator.count == 0 && !Rails.env.test?
+if Administrator.count == 0
   admin = User.create!(username: 'admin', email: 'admin@consul.dev', password: '12345678', password_confirmation: '12345678', confirmed_at: Time.current, terms_of_service: "1")
   admin.create_administrator
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -130,3 +130,5 @@ Setting['feature.homepage.widgets.feeds.proposals'] = true
 Setting['feature.homepage.widgets.feeds.debates'] = true
 Setting['feature.homepage.widgets.feeds.processes'] = true
 
+require_relative 'seed_logger'
+require_relative 'dev_seeds/widgets'


### PR DESCRIPTION
References
===================
**Issue:** https://github.com/consul/consul/issues/2703
**PR:** https://github.com/consul/consul/pull/2679

Context
===
We have some nice content for the homepage in the development seeds, but it was not included in the production seeds

Objectives
===================
Load homepage content in the production seeds

Visual Changes
===================
Before:

![screenshot-2018-6-13 consul 1](https://user-images.githubusercontent.com/7223028/41377859-afbc5064-6f5d-11e8-821b-5e9e023b9c4c.png)

After:

![screenshot-2018-6-13 consul](https://user-images.githubusercontent.com/7223028/41377868-b52b57de-6f5d-11e8-9762-0622a9728e1a.png)

Notes
===
Had to do a tiny refactoring to include the logger methods in the production seeds

Pending
===
Consider failing specs due to creating an admin user when loading seed data for tests