### PR TITLE
Fix suggestions being requested with every keystroke

### DIFF
--- a/app/assets/javascripts/suggest.js.coffee
+++ b/app/assets/javascripts/suggest.js.coffee
@@ -16,8 +16,10 @@ App.Suggest =
             js_suggest_selector = $this.data('js-suggest')
             $(js_suggest_selector).html(stHtml)
 
+      timer = null
+
       $this.on 'keyup', ->
-        window.clearTimeout(callback)
-        window.setTimeout(callback, 1000)
+        window.clearTimeout(timer)
+        timer = window.setTimeout(callback, 1000)
 
       $this.on 'change', callback


### PR DESCRIPTION
# Objectives

* Make suggestions work as intended, sending a request only when users stop typing.

# Context

Here's what happens when filling in the budget investment title with "search":

![Six XHR requests](https://user-images.githubusercontent.com/348557/42056881-294e8e84-7b0b-11e8-8120-ffcbc850be96.png)

As shown in the image, there are 6 XHR requests, one per keystroke. The test affecting the investments spec randomly sends between 3 and 6 requests (maybe even between 0 and 6).

The relevant code is in `suggest.js.coffee`:

```coffee
$this.on 'keyup', ->
  window.clearTimeout(callback)
  window.setTimeout(callback, 1000)

$this.on 'change', callback
```

The callback is being used as the parameter for the `clearTimeout()` method; however, it looks like [the ID value returned by setTimeout() should be used as the parameter](https://www.w3schools.com/jsref/met_win_cleartimeout.asp).

# Explain why your PR fixes it

By fixing the way `clearTimeout()` is being used, now the keyup event only generates one request:

![One XHR request](https://user-images.githubusercontent.com/348557/42057031-8b5dc32e-7b0b-11e8-8411-66fce33d09eb.png)

# Notes

* Originally this PR was also an attempt to fix flaky specs mentioned in AyuntamientoMadrid#1429, AyuntamientoMadrid#1430 and AyuntamientoMadrid#1431. But travis builds show [the tests still fail sometimes](https://travis-ci.org/javierv/consul/jobs/397998342).
* Is there a way to add a JavaScript test to the application (maybe using [Jasmine](https://github.com/jasmine/jasmine)?) to make sure this bug doesn't appear again?