### PR TITLE
Fix flaky specs using CKEditor

### DIFF
--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -1,4 +1,4 @@
 Ckeditor.setup do |config|
   config.assets_languages = Rails.application.config.i18n.available_locales.map{|l| l.to_s.downcase}
-  config.assets_plugins = []
+  config.assets_plugins = %w[copyformatting tableselection scayt wsc]
 end


### PR DESCRIPTION
# References

* AyuntamientoMadrid#1317 ([recent Travis fail](https://travis-ci.org/consul/consul/jobs/396908742))
* AyuntamientoMadrid#1429 ([recent Travis fail](https://travis-ci.org/consul/consul/jobs/395938528))
* AyuntamientoMadrid#1430 ([recent Travis fail](https://travis-ci.org/consul/consul/jobs/397298334))
* AyuntamientoMadrid#1431 ([recent Travis fail](https://travis-ci.org/consul/consul/jobs/397957410))
* [Failed suggesting debates shows up suggestions spec](https://travis-ci.org/consul/consul/jobs/395890858)
* [Failed nested documentable investments spec](https://travis-ci.org/consul/consul/jobs/395890857)
* <del>[Failed nested documentable proposals spec](https://travis-ci.org/consul/consul/jobs/399587929)</del> Failure log not available anymore.
* [Failed nested imageable spec](https://travis-ci.org/AyuntamientoMadrid/consul/jobs/370507529)
* [Failed Turbolinks sanity check from budget's show spec](https://travis-ci.org/AyuntamientoMadrid/consul/jobs/370709360)
* [Failed investment creation with category tags spec](https://travis-ci.org/consul/consul/jobs/389821901)
* Pull Request #1196

# Objectives

Fix the flaky specs that appeared in `spec/features/ckeditor_spec.rb:14` ("CKEditor is present before & after turbolinks update page"), `spec/features/debates_spec.rb:998` ("Debates Suggesting debates Shows up to 5 suggestions"), `spec/features/debates_spec.rb:1019` ("Debates Suggesting debates No found suggestions"), `spec/features/proposals_spec.rb:1597` ("Proposals Suggesting proposals No found suggestions"), `spec/features/budgets/investments_spec.rb:728` ("Budget Investments Phase I - Accepting Suggest Show up to 5 suggestions"), `spec/features/budgets/investments_spec.rb:1061` ("Budget Investments behaves like nested documentable at new budget investment path Should not update document cached attachment field after unvalid file upload"), `spec/features/proposals_spec.rb:1440` ("Proposals behaves like nested imageable at new_proposal_path Should show new image after successful creation with one uploaded file"), `spec/features/tags/budget_investments_spec.rb:120` ("Tags Turbolinks sanity check from budget's show"), `spec/features/proposals_spec:1467` ("Proposals behaves like nested documentable at edit proposal path Should update loading bar style after valid file upload") and `spec/features/tags/budget_investments_spec.rb:82` ("Tags Category with category tags").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

Most assets are precompiled before running a Travis build. However, as mentioned in pull request #1196, precompiling all CKEditor plugins would take too long, and so they aren't included.

On the other hand, when no plugins are precompiled, the first time a page loading CKEditor is rendered, the application takes a few seconds to compile the plugins it uses. If there's an AJAX request during that time, the test will probably fail because the compilation will take longer than Capybara's wait time.

In a similar way, tests using `fill_in_ckeditor` may fail because this method is executed while the plugins are still being compiled. It results in the editor area not being filled properly, as shown in this screenshot taken by Capybara:

![Description is empty](https://user-images.githubusercontent.com/348557/42203031-15ca86c6-7e8d-11e8-9920-4722031bf624.png)

To reproduce one of these failures locally, run:

```
RAILS_ENV=test bundle exec rake assets:precompile
rm -r tmp/cache/assets/sprockets
rspec spec/features/ckeditor_spec.rb
```

If it still passes, maybe your machine is too fast :smiley:. Try setting `Capybara.default_max_wait_time = 1`, deleting the sprockets cache again, and running the spec again.

## Explain why your PR fixes it

By precompiling only the CKEditor plugins the application uses, they don't need to be compiled in the middle of a test, AJAX calls don't exceed Capybara's wait time, and compiling CKEditor assets doesn't take too long.