### PR TITLE
Fix flaky specs: Officing Results Add/Edit results

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
 
     trait :level_two do
-      residence_verified_at Time.current
+      residence_verified_at { Time.current }
       unconfirmed_phone "611111111"
       confirmed_phone "611111111"
       sms_confirmation_code "1234"
@@ -36,28 +36,28 @@ FactoryBot.define do
     end
 
     trait :level_three do
-      verified_at Time.current
+      verified_at { Time.current }
       document_type "1"
       document_number
     end
 
     trait :hidden do
-      hidden_at Time.current
+      hidden_at { Time.current }
     end
 
     trait :with_confirmed_hide do
-      confirmed_hide_at Time.current
+      confirmed_hide_at { Time.current }
     end
 
     trait :verified do
-      residence_verified_at Time.current
-      verified_at Time.current
+      residence_verified_at { Time.current }
+      verified_at { Time.current }
     end
 
     trait :in_census do
       document_number "12345678Z"
       document_type "1"
-      verified_at Time.current
+      verified_at { Time.current }
     end
   end
 
@@ -112,7 +112,7 @@ FactoryBot.define do
   factory :lock do
     user
     tries 0
-    locked_until Time.current
+    locked_until { Time.current }
   end
 
   factory :verified_user do
@@ -127,15 +127,15 @@ FactoryBot.define do
     association :author, factory: :user
 
     trait :hidden do
-      hidden_at Time.current
+      hidden_at { Time.current }
     end
 
     trait :with_ignored_flag do
-      ignored_flag_at Time.current
+      ignored_flag_at { Time.current }
     end
 
     trait :with_confirmed_hide do
-      confirmed_hide_at Time.current
+      confirmed_hide_at { Time.current }
     end
 
     trait :flagged do
@@ -173,15 +173,15 @@ FactoryBot.define do
     association :author, factory: :user
 
     trait :hidden do
-      hidden_at Time.current
+      hidden_at { Time.current }
     end
 
     trait :with_ignored_flag do
-      ignored_flag_at Time.current
+      ignored_flag_at { Time.current }
     end
 
     trait :with_confirmed_hide do
-      confirmed_hide_at Time.current
+      confirmed_hide_at { Time.current }
     end
 
     trait :flagged do
@@ -369,8 +369,8 @@ FactoryBot.define do
     kind        :balloting
     summary     Faker::Lorem.sentence(3)
     description Faker::Lorem.sentence(10)
-    starts_at   Date.yesterday
-    ends_at     Date.tomorrow
+    starts_at   { Date.yesterday }
+    ends_at     { Date.tomorrow }
     enabled     true
   end
 
@@ -414,7 +414,7 @@ FactoryBot.define do
     association :status, factory: :budget_investment_status
     sequence(:title)     { |n| "Budget investment milestone #{n} title" }
     description          'Milestone description'
-    publication_date     Date.current
+    publication_date     { Date.current }
   end
 
   factory :vote do
@@ -467,15 +467,15 @@ FactoryBot.define do
     sequence(:body) { |n| "Comment body #{n}" }
 
     trait :hidden do
-      hidden_at Time.current
+      hidden_at { Time.current }
     end
 
     trait :with_ignored_flag do
-      ignored_flag_at Time.current
+      ignored_flag_at { Time.current }
     end
 
     trait :with_confirmed_hide do
-      confirmed_hide_at Time.current
+      confirmed_hide_at { Time.current }
     end
 
     trait :flagged do
@@ -601,7 +601,7 @@ FactoryBot.define do
   factory :poll_officer_assignment, class: 'Poll::OfficerAssignment' do
     association :officer, factory: :poll_officer
     association :booth_assignment, factory: :poll_booth_assignment
-    date Date.current
+    date { Date.current }
 
     trait :final do
       final true
@@ -611,7 +611,7 @@ FactoryBot.define do
   factory :poll_shift, class: 'Poll::Shift' do
     association :booth, factory: :poll_booth
     association :officer, factory: :poll_officer
-    date Date.current
+    date { Date.current }
 
     trait :vote_collection_task do
       task 0
@@ -669,7 +669,7 @@ FactoryBot.define do
     year_of_birth    "1980"
 
     trait :invalid do
-      year_of_birth Time.current.year
+      year_of_birth { Time.current.year }
     end
   end
 
@@ -679,11 +679,11 @@ FactoryBot.define do
     sequence(:name) { |n| "org#{n}" }
 
     trait :verified do
-      verified_at Time.current
+      verified_at { Time.current }
     end
 
     trait :rejected do
-      rejected_at Time.current
+      rejected_at { Time.current }
     end
   end
 
@@ -702,13 +702,13 @@ FactoryBot.define do
 
   factory :ahoy_event, class: Ahoy::Event do
     id { SecureRandom.uuid }
-    time DateTime.current
+    time { DateTime.current }
     sequence(:name) {|n| "Event #{n} type"}
   end
 
   factory :visit  do
     id { SecureRandom.uuid }
-    started_at DateTime.current
+    started_at { DateTime.current }
   end
 
   factory :campaign do
@@ -721,7 +721,7 @@ FactoryBot.define do
     association :notifiable, factory: :proposal
 
     trait :read do
-      read_at Time.current
+      read_at { Time.current }
     end
   end
 
@@ -741,8 +741,8 @@ FactoryBot.define do
     style {["banner-style-one", "banner-style-two", "banner-style-three"].sample}
     image {["banner.banner-img-one", "banner.banner-img-two", "banner.banner-img-three"].sample}
     target_url {["/proposals", "/debates" ].sample}
-    post_started_at Time.current - 7.days
-    post_ended_at Time.current + 7.days
+    post_started_at { Time.current - 7.days }
+    post_ended_at { Time.current + 7.days }
   end
 
   factory :proposal_notification do
@@ -790,14 +790,14 @@ FactoryBot.define do
     title "A collaborative legislation process"
     description "Description of the process"
     summary "Summary of the process"
-    start_date Date.current - 5.days
-    end_date Date.current + 5.days
-    debate_start_date Date.current - 5.days
-    debate_end_date Date.current + 2.days
-    draft_publication_date Date.current - 1.day
-    allegations_start_date Date.current
-    allegations_end_date Date.current + 3.days
-    result_publication_date Date.current + 5.days
+    start_date { Date.current - 5.days }
+    end_date { Date.current + 5.days }
+    debate_start_date { Date.current - 5.days }
+    debate_end_date { Date.current + 2.days }
+    draft_publication_date { Date.current - 1.day }
+    allegations_start_date { Date.current }
+    allegations_end_date { Date.current + 3.days }
+    result_publication_date { Date.current + 5.days }
     debate_phase_enabled true
     allegations_phase_enabled true
     draft_publication_enabled true
@@ -805,36 +805,36 @@ FactoryBot.define do
     published true
 
     trait :next do
-      start_date Date.current + 2.days
-      end_date Date.current + 8.days
-      debate_start_date Date.current + 2.days
-      debate_end_date Date.current + 4.days
-      draft_publication_date Date.current + 5.days
-      allegations_start_date Date.current + 5.days
-      allegations_end_date Date.current + 7.days
-      result_publication_date Date.current + 8.days
+      start_date { Date.current + 2.days }
+      end_date { Date.current + 8.days }
+      debate_start_date { Date.current + 2.days }
+      debate_end_date { Date.current + 4.days }
+      draft_publication_date { Date.current + 5.days }
+      allegations_start_date { Date.current + 5.days }
+      allegations_end_date { Date.current + 7.days }
+      result_publication_date { Date.current + 8.days }
     end
 
     trait :past do
-      start_date Date.current - 12.days
-      end_date Date.current - 2.days
-      debate_start_date Date.current - 12.days
-      debate_end_date Date.current - 9.days
-      draft_publication_date Date.current - 8.days
-      allegations_start_date Date.current - 8.days
-      allegations_end_date Date.current - 4.days
-      result_publication_date Date.current - 2.days
+      start_date { Date.current - 12.days }
+      end_date { Date.current - 2.days }
+      debate_start_date { Date.current - 12.days }
+      debate_end_date { Date.current - 9.days }
+      draft_publication_date { Date.current - 8.days }
+      allegations_start_date { Date.current - 8.days }
+      allegations_end_date { Date.current - 4.days }
+      result_publication_date { Date.current - 2.days }
     end
 
     trait :in_debate_phase do
-      start_date Date.current - 5.days
-      end_date Date.current + 5.days
-      debate_start_date Date.current - 5.days
-      debate_end_date Date.current + 1.day
-      draft_publication_date Date.current + 1.day
-      allegations_start_date Date.current + 2.days
-      allegations_end_date Date.current + 3.days
-      result_publication_date Date.current + 5.days
+      start_date { Date.current - 5.days }
+      end_date { Date.current + 5.days }
+      debate_start_date { Date.current - 5.days }
+      debate_end_date { Date.current + 1.day }
+      draft_publication_date { Date.current + 1.day }
+      allegations_start_date { Date.current + 2.days }
+      allegations_end_date { Date.current + 3.days }
+      result_publication_date { Date.current + 5.days }
     end
 
     trait :published do

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -3,6 +3,14 @@ require 'rails_helper'
 feature 'Residence' do
   let(:officer) { create(:poll_officer) }
 
+  background do
+    travel_to Time.now # TODO: use `freeze_time` after migrating to Rails 5.
+  end
+
+  after do
+    travel_back
+  end
+
   feature "Officers without assignments" do
 
     scenario "Can not access residence verification" do

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
-require 'time_helper'
 
 feature 'Officing Results' do
 
   background do
-    freeze_time
+    travel_to Time.now # TODO: use `freeze_time` after migrating to Rails 5.
     @poll_officer = create(:poll_officer)
     @officer_assignment = create(:poll_officer_assignment, :final, officer: @poll_officer)
     @poll = @officer_assignment.booth_assignment.poll

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
+require 'time_helper'
 
 feature 'Officing Results' do
 
   background do
+    freeze_time
     @poll_officer = create(:poll_officer)
     @officer_assignment = create(:poll_officer_assignment, :final, officer: @poll_officer)
     @poll = @officer_assignment.booth_assignment.poll
@@ -15,6 +17,10 @@ feature 'Officing Results' do
     create(:poll_question_answer, title: 'Tomorrow', question: @question_2)
 
     login_as(@poll_officer.user)
+  end
+
+  after do
+    travel_back
   end
 
   scenario 'Only polls where user is officer for results are accessible' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ RSpec.configure do |config|
   config.include(EmailSpec::Helpers)
   config.include(EmailSpec::Matchers)
   config.include(CommonActions)
+  config.include(ActiveSupport::Testing::TimeHelpers)
   config.before(:suite) do
     DatabaseCleaner.clean_with :truncation
   end

--- a/spec/time_helper.rb
+++ b/spec/time_helper.rb
@@ -1,8 +1,0 @@
-module ActiveSupport::Testing::TimeHelpers
-  # Copied from Rails 5.2. TODO: remove after migrating to Rails 5.
-  def freeze_time(&block)
-    travel_to Time.now, &block
-  end
-end
-
-include ActiveSupport::Testing::TimeHelpers

--- a/spec/time_helper.rb
+++ b/spec/time_helper.rb
@@ -1,0 +1,8 @@
+module ActiveSupport::Testing::TimeHelpers
+  # Copied from Rails 5.2. TODO: remove after migrating to Rails 5.
+  def freeze_time(&block)
+    travel_to Time.now, &block
+  end
+end
+
+include ActiveSupport::Testing::TimeHelpers


### PR DESCRIPTION
# References

* Issue #2520
* Issue #2521
* Pull Request AyuntamientoMadrid#1342
* Pull Request AyuntamientoMadrid#1349
* <del>Pull Request AyuntamientoMadrid#1351</del> [Forked repo build with failed residence specs](https://travis-ci.org/javierv/consul/jobs/400560476)

# Objectives

Fix the flaky specs that appeared in `spec/features/officing/results_spec.rb:48` ("Officing Results Add results"), `spec/features/officing/results_spec.rb:85` ("Officing Results Edit result"), `spec/features/officing/residence_spec.rb:35` ("Residence Assigned officers Verify voter"), `spec/features/officing/residence_spec.rb:83` ("Residence Assigned officers Error on Census (year of birth)"), `spec/features/officing/residence_spec.rb:49` ("Residence Assigned officers Error on verify") and `spec/features/officing/residence_spec.rb:61` ("Residence Assigned officers Error on Census (document number)").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

**This explanation is copied from AyuntamientoMadrid#1342 because the problem is exactly the same**. All credit to @iagirre.

The problems was that the test was not reaching to the residence verification page, so it couldn't find the select box for the DNI (and that's the error reported in the issue). To figure out what was going on there, \[she\] studied the flow that the test follows so that \[she\] could find the scenarios where it would crash, and, after doing it, step by step, \[she\] determined that the test will fail when:

* There are more than 1 `officer_assignments` (booths) for this user, so the page will redirect to the select booth page, instead to the residence verification page.
* There aren't any `officer_assignments`, so that the user can't even reach the target page (it redirects to the root).

The code that determines that is (this functions are run in `before_action` blocks):

```ruby
# app/controller/officing/base_controller.rb
# [...]

  def load_officer_assignment
    @officer_assignments ||= current_user.poll_officer.officer_assignments.where(date: Time.current.to_date)
    end

    def verify_officer_assignment
      if @officer_assignments.blank?
        redirect_to officing_root_path, notice: t("officing.residence.flash.not_allowed")
      end
    end

    def verify_booth
      return unless current_booth.blank?
      booths = todays_booths_for_officer(current_user.poll_officer)
      case booths.count
      when 0
        redirect_to officing_root_path
      when 1
        session[:booth_id] = booths.first.id
      else
        redirect_to new_officing_booth_path
      end
    end

    [...]

    def todays_booths_for_officer(officer)
      officer.officer_assignments.by_date(Date.today).map(&:booth).uniq
    end
```

After trying to reproduce it (without success), \[she\] saw the new piece of information about the probable failing hours, and \[she\] realized that the problem could be in the moment of creating the objects. If the `officer_assignments` are created at 23:59:59 and the rest of the test is executed after 00:00:00, the dates for the objects and the Date.current (used to check if there are any shifts today) won't be the same, because the shift will be for, lets say, 07/03/2018 and Date.current will be 08/03/2018, so, there are no shifts and we find the first scenario described above.

To prove that, \[she\] forced in the `factories.rb` the dates of the `officer_assignments` to an earlier date, and it failed in the exact same way as the reported one.

## Explain why your PR fixes it

Freezing time ensures the date won't change in the middle of a test, and using dynamic attributes for dates ensures factories don't assign static dates before freezing time. According to the [factory bot documentation](https://www.rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md):

> Most factory attributes can be added using static values that are evaluated when the factory is defined, but some attributes (such as associations and other attributes that must be dynamically generated) will need values assigned each time an instance is generated. These "dynamic" attributes can be added by passing a block instead of a parameter:
> (...)
> `date_of_birth   { 21.years.ago }`


# Notes

* I wasn't sure whether to use the same solution used in AyuntamientoMadrid#1342 or to add [Timecop](https://github.com/travisjeffery/timecop) to the `Gemfile`, but then realized Rails provides helpers to do exactly that and thought it was the easiest way. This decision is of course debatable; comments are welcome!
* Issues AyuntamientoMadrid#1195 and AyuntamientoMadrid#1208 are similar and their fixes (referenced above) haven't been backported yet.
* After upgrading to Rails 5, monkey-patching `ActiveSupport::Testing::TimeHelpers` won't be necessary. The `after { travel_back }` block won't be necessary either.