### PR TITLE
Fix string literal warning for admin menu

### DIFF
--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -50,7 +50,7 @@
 
     <% if feature?(:budgets) %>
       <li class="section-title <%= "is-active" if controller_name == "budgets" ||
-                                                                     "budget_investment_statuses" %>">
+                                                  controller_name == "budget_investment_statuses" %>">
         <%= link_to admin_budgets_path do %>
           <span class="icon-budget"></span>
           <strong><%= t("admin.menu.budgets") %></strong>


### PR DESCRIPTION
References
===================
* **Related PRs**: #2705, AyuntamientoMadrid#1414
* **Related Travis build**: [Build 24008](https://travis-ci.org/consul/consul/builds/398882808)

Objectives
===================
Fix string literal warning on admin menu

Visual Changes
===================
None

Notes
===================
None
