### PR TITLE
Adds ballot booths menu on admin

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -21,7 +21,11 @@ module AdminHelper
   end
 
   def menu_polls?
-    %w[polls questions officers booths officer_assignments booth_assignments recounts results shifts questions answers].include?(controller_name)
+    %w[polls questions answers].include?(controller_name)
+  end
+
+  def menu_booths?
+    %w[officers booths officer_assignments booth_assignments recounts results shifts].include?(controller_name)
   end
 
   def menu_profiles?

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -7,8 +7,7 @@
           <strong><%= t("admin.menu.title_polls") %></strong>
         </a>
         <ul id="polls_menu" <%= "class=is-active" if menu_polls? || controller.class.parent == Admin::Poll::Questions::Answers %>>
-          <li <%= "class=is-active" if controller_name == "polls" && action_name != "booth_assignments" ||
-                                    %w(booth_assignments officer_assignments recounts results).include?(controller_name) %>>
+          <li <%= "class=is-active" if controller_name == "polls" && action_name != "booth_assignments" %>>
             <%= link_to t("admin.menu.polls"), admin_polls_path %>
           </li>
 
@@ -16,28 +15,36 @@
                                     controller.class.parent == Admin::Poll::Questions::Answers %>>
             <%= link_to t("admin.menu.poll_questions"), admin_questions_path %>
           </li>
-
-          <li <%= "class=is-active" if controller_name == "officers" %>>
-            <%= link_to t("admin.menu.poll_officers"), admin_officers_path %>
-          </li>
-
-          <li <%= "class=is-active" if controller_name == "booths" &&
-                                    action_name != "available" %>>
-            <%= link_to t("admin.menu.poll_booths"), admin_booths_path %>
-          </li>
-
-          <li <%= "class=is-active" if (controller_name == "polls" && action_name == "booth_assignments") ||
-                                    (controller_name == "booth_assignments" && action_name == "manage") %>>
-            <%= link_to t("admin.menu.poll_booth_assignments"), booth_assignments_admin_polls_path %>
-          </li>
-
-          <li <%= "class=is-active" if %w(shifts booths).include?(controller_name) &&
-                                    action_name == "available" %>>
-            <%= link_to t("admin.menu.poll_shifts"), available_admin_booths_path %>
-          </li>
         </ul>
       </li>
     <% end %>
+
+    <li class="section-title">
+      <a href="#">
+        <span class="icon-box"></span>
+        <strong><%= t("admin.menu.title_booths") %></strong>
+      </a>
+      <ul id="booths_menu" <%= "class=is-active" if menu_booths? || controller_name == "polls" && action_name == "booth_assignments" %>>
+                  <li <%= "class=is-active" if controller_name == "officers" %>>
+          <%= link_to t("admin.menu.poll_officers"), admin_officers_path %>
+        </li>
+
+        <li <%= "class=is-active" if controller_name == "booths" &&
+                                  action_name != "available" %>>
+          <%= link_to t("admin.menu.poll_booths"), admin_booths_path %>
+        </li>
+
+        <li <%= "class=is-active" if (controller_name == "polls" && action_name == "booth_assignments") ||
+                                  (controller_name == "booth_assignments" && action_name == "manage") %>>
+          <%= link_to t("admin.menu.poll_booth_assignments"), booth_assignments_admin_polls_path %>
+        </li>
+
+        <li <%= "class=is-active" if %w(shifts booths).include?(controller_name) &&
+                                  action_name == "available" %>>
+          <%= link_to t("admin.menu.poll_shifts"), available_admin_booths_path %>
+        </li>
+      </ul>
+    </li>
 
     <% if feature?(:legislation) %>
       <li class="section-title <%= "is-active" if controller.class.parent == Admin::Legislation %>">

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -534,6 +534,7 @@ en:
       title_profiles: Profiles
       title_settings: Settings
       title_site_customization: Site content
+      title_booths: Voting booths
       legislation: Collaborative Legislation
       users: Users
     administrators:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -534,6 +534,7 @@ es:
       title_profiles: Perfiles
       title_settings: Configuración
       title_site_customization: Contenido del sitio
+      title_booths: Urnas de votación
       legislation: Legislación colaborativa
       users: Usuarios
     administrators:


### PR DESCRIPTION
References
==========
Related issue: https://github.com/consul/consul/issues/2639
This is a backport of: https://github.com/AyuntamientoMadrid/consul/pull/1516

Objectives
==========
Extract ballot booths sections of poll on admin sidebar menu.

Visual Changes
============
**BEFORE**
![before](https://user-images.githubusercontent.com/631897/41161485-5823f5a6-6b33-11e8-990b-8a8c96363f40.png)

**AFTER**
![after](https://user-images.githubusercontent.com/631897/41172125-26e9713a-6b53-11e8-837c-247c9514c083.png)
