### PR TITLE
Fix flaky spec: Budget Investments Show milestones

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,6 +59,7 @@ class ApplicationController < ActionController::Base
       end
 
       I18n.locale = locale
+      Globalize.locale = I18n.locale
     end
 
     def set_layout

--- a/app/controllers/concerns/translatable.rb
+++ b/app/controllers/concerns/translatable.rb
@@ -2,7 +2,6 @@ module Translatable
   extend ActiveSupport::Concern
 
   included do
-    before_action :set_translation_locale
     before_action :delete_translations, only: [:update]
   end
 
@@ -10,10 +9,6 @@ module Translatable
 
     def translation_params(params)
       resource_model.globalize_attribute_names.select { |k, v| params.include?(k.to_sym) && params[k].present? }
-    end
-
-    def set_translation_locale
-      Globalize.locale = I18n.locale
     end
 
     def delete_translations

--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -39,6 +39,7 @@ class Management::BaseController < ActionController::Base
       session[:locale] ||= I18n.default_locale
 
       I18n.locale = session[:locale]
+      Globalize.locale = I18n.locale
     end
 
     def current_budget

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,7 @@ RSpec.configure do |config|
   config.before do |example|
     DatabaseCleaner.strategy = :transaction
     I18n.locale = :en
+    Globalize.locale = I18n.locale
     load Rails.root.join('db', 'seeds.rb').to_s
     Setting["feature.user.skip_verification"] = nil
   end


### PR DESCRIPTION
# References

* Issue #2718

# Objectives

Fix the flaky spec that appeared in `spec/features/budgets/investments_spec.rb:994` ("Budget Investments Show milestones").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

The test fails if `Globalize.locale != I18n.locale` when the test starts. AFAIK there's only one test which can modify that locale: `spec/features/translations_spec.rb:76` ("Translations Milestones Globalize javascript interface Highlight current locale"). So, to reproduce it locally, run those tests making sure the translations test runs first. On my machine, this command makes the test fail every time:

`bin/rspec spec/features/budgets/investments_spec.rb:994 spec/features/translations_spec.rb:76 --seed 6700`

Here's what happens during those two tests:

1. The translations test sets `Globalize.locale = :es`.
2. The milestones test `config.before` block sets `I18n.locale = :en`
3. The test creates data like `first_milestone`, which will get assigned `description_es` (as set by Globalize).
4. The `visit budget_investment_path` renders the milestones, which include the line `globalize(neutral_locale(locale))`.
5. Since `locale` is `I18n.locale` (that is, `:en`), the block will call `first_milestone.description_en`, which will return `nil`.
6. The test fails because it expects a description and finds `nil` instead.

## Explain why your PR fixes it

By setting `Globalize.locale = I18n.locale` before each test, the changes one test might cause don't affect any other test.

# Notes

* Changing code in `ApplicationController` and `Management::BaseController` isn't necessary to make the test pass. However, since having different values in `Globalize.locale` and `I18n.locale` has proven to be an issue on the test enviroment, I've also changed application code in order to avoid similar situations on production. Different opinions are welcome!
