### PR TITLE
A11y

### DIFF
--- a/app/views/admin/poll/booth_assignments/show.html.erb
+++ b/app/views/admin/poll/booth_assignments/show.html.erb
@@ -12,7 +12,7 @@
   </p>
 <% end %>
 
-<ul class="tabs" id="booths_tabs" role="tablist"
+<ul class="tabs" id="booths_tabs"
     data-deep-link="true"
     data-update-history="true"
     data-deep-link-smudge="true"
@@ -29,8 +29,8 @@
   </li>
 </ul>
 
-<div class="tabs-content" data-tabs-content="booths_tabs" role="tablist">
-  <div class="tabs-panel" id="tab-officers" role="tab">
+<div class="tabs-content" data-tabs-content="booths_tabs">
+  <div class="tabs-panel" id="tab-officers">
     <% if @booth_assignment.officers.empty? %>
       <div class="callout primary margin-top">
         <%= t("admin.poll_booth_assignments.show.no_officers") %>
@@ -51,7 +51,7 @@
     <% end %>
   </div>
 
-  <div class="tabs-panel" id="tab-recounts" role="tab">
+  <div class="tabs-panel" id="tab-recounts">
     <h3><%= t("admin.poll_booth_assignments.show.recounts_list") %></h3>
 
     <table id="totals">
@@ -91,7 +91,7 @@
       </tbody>
     </table>
   </div>
-  <div class="tabs-panel is-active" id="tab-results" role="tab">
+  <div class="tabs-panel is-active" id="tab-results">
     <%= render "results" %>
   </div>
 </div>

--- a/app/views/admin/poll/questions/index.html.erb
+++ b/app/views/admin/poll/questions/index.html.erb
@@ -7,14 +7,14 @@
   <%= render 'search' %>
 </div>
 
-<div class="tabs-content" data-tabs-content="questions-tabs" role="tablist">
+<div class="tabs-content" data-tabs-content="questions-tabs">
   <%= render "filter_subnav" %>
 
-  <div class="tabs-panel is-active" id="tab-questions" role="tab">
+  <div class="tabs-panel is-active" id="tab-questions">
     <%= render "questions" %>
   </div>
 
-  <div class="tabs-panel" id="tab-successful-proposals" role="tab">
+  <div class="tabs-panel" id="tab-successful-proposals">
     <%= render "successful_proposals" %>
   </div>
 </div>

--- a/app/views/budgets/investments/_filter_subnav.html.erb
+++ b/app/views/budgets/investments/_filter_subnav.html.erb
@@ -1,6 +1,5 @@
 <ul class="tabs"
     id="investments_tabs"
-    role="tablist"
     data-deep-link="true"
     data-update-history="true"
     data-deep-link-smudge="true"

--- a/app/views/budgets/investments/_milestones.html.erb
+++ b/app/views/budgets/investments/_milestones.html.erb
@@ -1,4 +1,4 @@
-<div class="tabs-panel tab-milestones" id="tab-milestones" role="tab">
+<div class="tabs-panel tab-milestones" id="tab-milestones">
   <div class="row">
     <div class="small-12 column">
       <% if @investment.milestones.blank? %>

--- a/app/views/budgets/investments/show.html.erb
+++ b/app/views/budgets/investments/show.html.erb
@@ -16,8 +16,8 @@
   </div>
 </div>
 
-<div class="tabs-content" data-tabs-content="investments_tabs" role="tablist">
-  <div class="tabs-panel is-active" id="tab-comments" role="tab">
+<div class="tabs-content" data-tabs-content="investments_tabs">
+  <div class="tabs-panel is-active" id="tab-comments">
     <%= render partial: '/comments/comment_tree', locals: { comment_tree: @comment_tree,
                                                             comment_flags: @comment_flags,
                                                             display_comments_count: false } %>

--- a/app/views/legislation/proposals/_filter_subnav.html.erb
+++ b/app/views/legislation/proposals/_filter_subnav.html.erb
@@ -1,6 +1,5 @@
 <ul class="tabs"
     id="legislation_proposals_tabs"
-    role="tablist"
     data-deep-link="true"
     data-update-history="true"
     data-deep-link-smudge="true"

--- a/app/views/legislation/proposals/_notifications.html.erb
+++ b/app/views/legislation/proposals/_notifications.html.erb
@@ -1,4 +1,4 @@
-<div class="tabs-panel" id="tab-notifications" role="tab">
+<div class="tabs-panel" id="tab-notifications">
   <div class="row">
     <div class="small-12 column">
       <% if @notifications.blank? %>

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -119,8 +119,8 @@
   </div>
 </div>
 
-<div class="tabs-content" data-tabs-content="legislation_proposals_tabs" role="tablist">
-  <div class="tabs-panel is-active" id="tab-comments" role="tab">
+<div class="tabs-content" data-tabs-content="legislation_proposals_tabs">
+  <div class="tabs-panel is-active" id="tab-comments">
     <%= render "legislation/proposals/comments" %>
   </div>
 </div>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -124,10 +124,10 @@
 
   </div>
 
-  <div class="tabs-content" data-tabs-content="polls_tabs" role="tablist">
+  <div class="tabs-content" data-tabs-content="polls_tabs">
     <%= render "filter_subnav" %>
 
-    <div class="tabs-panel is-active" id="tab-comments" role="tab">
+    <div class="tabs-panel is-active" id="tab-comments">
       <%= render "comments" %>
     </div>
   </div>

--- a/app/views/proposal_notifications/_actions.html.erb
+++ b/app/views/proposal_notifications/_actions.html.erb
@@ -1,14 +1,16 @@
-<div class="reply">
-  <span class='js-moderation-actions'>
-    <% if can? :hide, notification %>
-      <%= link_to t("admin.actions.hide").capitalize, hide_moderation_proposal_notification_path(notification),
-                  method: :put, remote: true, data: { confirm: t('admin.actions.confirm') } %>
-    <% end %>
+<% if can? :hide, (notification || notification.author) %>
+  <div class="reply">
+    <span class='js-moderation-actions'>
+      <% if can? :hide, notification %>
+        <%= link_to t("admin.actions.hide").capitalize, hide_moderation_proposal_notification_path(notification),
+                    method: :put, remote: true, data: { confirm: t('admin.actions.confirm') } %>
+      <% end %>
 
-    <% if can? :hide, notification.author %>
-      <span class="divider">&nbsp;&bull;&nbsp;</span>
-      <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(notification.author_id),
-                  method: :put, data: { confirm: t('admin.actions.confirm') } %>
-    <% end %>
-  </span>
-</div>
+      <% if can? :hide, notification.author %>
+        <span class="divider">&nbsp;&bull;&nbsp;</span>
+        <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(notification.author_id),
+                    method: :put, data: { confirm: t('admin.actions.confirm') } %>
+      <% end %>
+    </span>
+  </div>
+<% end %>

--- a/app/views/proposals/_filter_subnav.html.erb
+++ b/app/views/proposals/_filter_subnav.html.erb
@@ -1,6 +1,5 @@
 <ul class="tabs"
     id="proposals_tabs"
-    role="tablist"
     data-deep-link="true"
     data-update-history="true"
     data-deep-link-smudge="true"

--- a/app/views/proposals/_notifications.html.erb
+++ b/app/views/proposals/_notifications.html.erb
@@ -1,4 +1,4 @@
-<div class="tabs-panel" id="tab-notifications" role="tab">
+<div class="tabs-panel" id="tab-notifications">
   <div class="row">
     <div id="proposal_notifications" class="small-12 column notification-body">
       <% if @notifications.blank? %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -224,8 +224,8 @@
   </div>
 </div>
 
-<div class="tabs-content" data-tabs-content="proposals_tabs" role="tablist">
-  <div class="tabs-panel is-active" id="tab-comments" role="tab">
+<div class="tabs-content" data-tabs-content="proposals_tabs">
+  <div class="tabs-panel is-active" id="tab-comments">
     <%= render "proposals/comments" %>
   </div>
 

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -38,9 +38,9 @@
   </div>
 
 
-  <div class="tabs-content" data-tabs-content="topics-tabs" role="tablist">
+  <div class="tabs-content" data-tabs-content="topics-tabs">
     <%= render "topics/filter_subnav" %>
-    <div class="tabs-panel is-active" id="tab-comments" role="tab">
+    <div class="tabs-panel is-active" id="tab-comments">
       <%= render "topics/comments" %>
     </div>
   </div>


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1517

Objectives
===================
Fixes the A11y warning **`Certain ARIA roles must contain particular children`**.

We are including the `role="tablist"` but it unnecessary beacuse Foundation includes automatically on the tabs using  `role="tablist"` for `<ul>` and  `role="presentation"`  for `<li>`.