### PR TITLE
Officing sidebar menu

### DIFF
--- a/app/helpers/officers_helper.rb
+++ b/app/helpers/officers_helper.rb
@@ -4,4 +4,12 @@ module OfficersHelper
     truncate([officer.name, officer.email].compact.join(' - '), length: 100)
   end
 
+  def vote_collection_shift?
+    current_user.poll_officer.officer_assignments.where(date: Time.current.to_date).any?
+  end
+
+  def final_recount_shift?
+    current_user.poll_officer.officer_assignments.final.where(date: Time.current.to_date).any?
+  end
+
 end

--- a/app/views/officing/_menu.html.erb
+++ b/app/views/officing/_menu.html.erb
@@ -1,18 +1,21 @@
 <div class="admin-sidebar" data-equalizer-watch>
   <ul id="officing_menu">
+    <% if vote_collection_shift? %>
+      <li <%= "class=is-active" if controller_name == "voters" %>>
+        <%= link_to new_officing_residence_path do %>
+          <span class="icon-user"></span>
+          <%= t("officing.menu.voters") %>
+        <% end %>
+      </li>
+    <% end %>
 
-    <li <%= "class=is-active" if controller_name == "voters" %>>
-      <%= link_to new_officing_residence_path do %>
-        <span class="icon-user"></span>
-        <%= t("officing.menu.voters") %>
-      <% end %>
-    </li>
-
-    <li <%= "class=is-active" if ["results"].include?(controller_name) || (controller_name == "polls" && action_name == "final") %>>
-      <%= link_to final_officing_polls_path do %>
-        <span class="icon-user"></span>
-        <%= t("officing.menu.total_recounts") %>
-      <% end %>
-    </li>
+    <% if final_recount_shift? %>
+      <li <%= "class=is-active" if ["results"].include?(controller_name) || (controller_name == "polls" && action_name == "final") %>>
+        <%= link_to final_officing_polls_path do %>
+          <span class="icon-user"></span>
+          <%= t("officing.menu.total_recounts") %>
+        <% end %>
+      </li>
+    <% end%>
   </ul>
 </div>

--- a/app/views/officing/dashboard/index.html.erb
+++ b/app/views/officing/dashboard/index.html.erb
@@ -2,4 +2,10 @@
   <h2><%= t("officing.dashboard.index.title") %></h2>
 
   <p><%= t("officing.dashboard.index.info") %></p>
+
+  <% unless final_recount_shift? && vote_collection_shift? %>
+    <div class="callout warning">
+      <%= t("officing.dashboard.index.no_shifts") %>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/en/officing.yml
+++ b/config/locales/en/officing.yml
@@ -6,6 +6,7 @@ en:
       index:
         title: Poll officing
         info: Here you can validate user documents and store voting results
+        no_shifts: You don't have officing shifts today.
     menu:
       voters: Validate document
       total_recounts: Total recounts and results

--- a/config/locales/es/officing.yml
+++ b/config/locales/es/officing.yml
@@ -6,6 +6,7 @@ es:
       index:
         title: Presidir mesa de votaciones
         info: Aquí puedes validar documentos de ciudadanos y guardar los resultados de las urnas
+        no_shifts: No tienes turnos de presidente de mesa asignados hoy.
     menu:
       voters: Validar documento y votar
       total_recounts: Recuento total y escrutinio

--- a/spec/features/budget_polls/officing_spec.rb
+++ b/spec/features/budget_polls/officing_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 feature 'Budget Poll Officing' do
 
   scenario 'Show sidebar menu if officer has shifts assigned' do
-    budget = create(:budget)
-    poll = create(:poll, budget: budget)
+    poll = create(:poll)
     booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
 

--- a/spec/features/budget_polls/officing_spec.rb
+++ b/spec/features/budget_polls/officing_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+feature 'Budget Poll Officing' do
+
+  scenario 'Show sidebar menu if officer has shifts assigned' do
+    budget = create(:budget)
+    poll = create(:poll, budget: budget)
+    booth = create(:poll_booth)
+    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+
+    user = create(:user)
+    officer = create(:poll_officer, user: user)
+
+    create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :recount_scrutiny)
+
+    officer_assignment = create(:poll_officer_assignment,
+                                 booth_assignment: booth_assignment,
+                                 officer: officer)
+
+    login_as user
+    visit officing_root_path
+
+    expect(page).not_to have_content("You don't have officing shifts today")
+    expect(page).to have_content("Validate document")
+    expect(page).to have_content("Total recounts and results")
+  end
+
+  scenario 'Do not show sidebar menu if officer has no shifts assigned' do
+    user = create(:user)
+    officer = create(:poll_officer, user: user)
+
+    login_as user
+    visit officing_root_path
+
+    expect(page).to have_content("You don't have officing shifts today")
+    expect(page).not_to have_content("Validate document")
+    expect(page).not_to have_content("Total recounts and results")
+  end
+
+end

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -9,10 +9,7 @@ feature 'Residence' do
       login_as(officer.user)
       visit officing_root_path
 
-      within("#side_menu") do
-        click_link "Validate document"
-      end
-
+      expect(page).not_to have_link("Validate document")
       expect(page).to have_content("You don't have officing shifts today")
 
       create(:poll_officer_assignment, officer: officer, date: 1.day.from_now)


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1525

Objectives
===================
Hides sidebar menu if officer has no shifts assigned. Also show "You don't have officing shifts today" message.

Visual Changes
===================
![no menu](https://user-images.githubusercontent.com/631897/41482968-950f7b62-70d7-11e8-90a4-776ae1d70bdb.png)
