### PR TITLE
UI design

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -27,6 +27,10 @@ $sidebar-active: #f4fcd0;
     font-weight: 100;
     margin-bottom: $line-height;
 
+    small {
+      color: $text-medium;
+    }
+
     &.title {
       text-transform: uppercase;
     }
@@ -634,6 +638,7 @@ $sidebar-active: #f4fcd0;
 .admin-content .select-heading {
 
   a {
+    color: $text;
     display: block;
 
     &.is-active {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -413,11 +413,6 @@ a {
   text-transform: uppercase;
 }
 
-figure img {
-  height: 100%;
-  width: 100%;
-}
-
 // 02. Header
 // ----------
 
@@ -2704,6 +2699,11 @@ table {
       width: 100%;
       z-index: 2;
     }
+  }
+
+  figure img {
+    height: 100%;
+    width: 100%;
   }
 }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2395,6 +2395,7 @@ table {
 
   .carousel-image .orbit-wrapper img {
     display: block;
+    height: rem-calc(120);
 
     @include breakpoint(small) {
       margin: 0 auto;

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1368,6 +1368,10 @@
       }
     }
 
+    .heading-name {
+      padding: $line-height / 2;
+    }
+
     span {
       color: $text;
       display: block;

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -72,7 +72,7 @@
                       <%= heading_name_and_price_html(heading, current_budget) %>
                     <% end %>
                   <% else %>
-                    <div>
+                    <div class="heading-name">
                       <%= heading_name_and_price_html(heading, current_budget) %>
                     </div>
                   <% end %>

--- a/app/views/valuation/budget_investments/index.html.erb
+++ b/app/views/valuation/budget_investments/index.html.erb
@@ -1,9 +1,9 @@
 <h2>
   <%= @budget.name %> - <%= t("valuation.budget_investments.index.title") %>
-  <small><%= t('valuation.budget_investments.index.assigned_to', valuator: current_user.name) %></small>
+  <small><%= t("valuation.budget_investments.index.assigned_to", valuator: current_user.name) %></small>
 </h2>
 
-<div class="row collapse">
+<div class="row expanded collapse margin-bottom">
   <% @heading_filters.each_slice(8) do |slice| %>
     <div class="small-12 medium-4 column select-heading">
       <% slice.each do |filter| %>
@@ -18,37 +18,43 @@
 
 <%= render 'shared/filter_subnav', i18n_namespace: "valuation.budget_investments.index" %>
 
-<h3><%= page_entries_info @investments %></h3>
+<% if @investments.any? %>
+  <h3><%= page_entries_info @investments %></h3>
 
-<table>
-  <thead>
-    <tr>
-      <th><%= t("valuation.budget_investments.index.table_id") %></th>
-      <th><%= t("valuation.budget_investments.index.table_title") %></th>
-      <th><%= t("valuation.budget_investments.index.table_heading_name") %></th>
-      <th><%= t("valuation.budget_investments.index.table_actions") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @investments.each do |investment| %>
-      <tr id="<%= dom_id(investment) %>" class="budget_investment">
-        <td>
-          <strong><%= investment.id %></strong>
-        </td>
-        <td>
-          <%= link_to investment.title, valuation_budget_budget_investment_path(@budget, investment) %>
-        </td>
-        <td class="small">
-          <%= investment.heading.name %>
-        </td>
-        <td class="small">
-          <%= link_to t("valuation.budget_investments.index.edit"),
-                      edit_valuation_budget_budget_investment_path(@budget, investment),
-                      class: "button hollow expanded" %>
-        </td>
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("valuation.budget_investments.index.table_id") %></th>
+        <th><%= t("valuation.budget_investments.index.table_title") %></th>
+        <th><%= t("valuation.budget_investments.index.table_heading_name") %></th>
+        <th><%= t("valuation.budget_investments.index.table_actions") %></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @investments.each do |investment| %>
+        <tr id="<%= dom_id(investment) %>" class="budget_investment">
+          <td>
+            <strong><%= investment.id %></strong>
+          </td>
+          <td>
+            <%= link_to investment.title, valuation_budget_budget_investment_path(@budget, investment) %>
+          </td>
+          <td class="small">
+            <%= investment.heading.name %>
+          </td>
+          <td class="small">
+            <%= link_to t("valuation.budget_investments.index.edit"),
+                        edit_valuation_budget_budget_investment_path(@budget, investment),
+                        class: "button hollow expanded" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 
-<%= paginate @investments %>
+  <%= paginate @investments %>
+<% else %>
+  <div class="callout primary">
+    <%= t("valuation.budget_investments.index.no_investments") %>
+  </div>
+<% end %>

--- a/config/locales/en/valuation.yml
+++ b/config/locales/en/valuation.yml
@@ -35,6 +35,7 @@ en:
         table_title: Title
         table_heading_name: Heading name
         table_actions: Actions
+        no_investments: "There are no investment projects."
       show:
         back: Back
         title: Investment project

--- a/config/locales/es/valuation.yml
+++ b/config/locales/es/valuation.yml
@@ -35,6 +35,7 @@ es:
         table_title: Título
         table_heading_name: Nombre de la partida
         table_actions: Acciones
+        no_investments: "No hay proyectos de gasto."
       show:
         back: Volver
         title: Proyecto de gasto

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -91,33 +91,6 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario 'Display valuator group assignments' do
-      budget_investment1 = create(:budget_investment, budget: budget)
-      budget_investment2 = create(:budget_investment, budget: budget)
-      budget_investment3 = create(:budget_investment, budget: budget)
-
-      health_group = create(:valuator_group, name: "Health")
-      culture_group = create(:valuator_group, name: "Culture")
-
-      budget_investment1.valuator_groups << health_group
-      budget_investment2.valuator_group_ids = [health_group.id, culture_group.id]
-
-      visit admin_budget_budget_investments_path(budget_id: budget)
-
-      within("#budget_investment_#{budget_investment1.id}") do
-        expect(page).to have_content("Health")
-      end
-
-      within("#budget_investment_#{budget_investment2.id}") do
-        expect(page).to have_content("Health")
-        expect(page).to have_content("Culture")
-      end
-
-      within("#budget_investment_#{budget_investment3.id}") do
-        expect(page).to have_content("No valuation groups assigned")
-      end
-    end
-
     scenario "Filtering by budget heading", :js do
       group1 = create(:budget_group, name: "Streets", budget: budget)
       group2 = create(:budget_group, name: "Parks", budget: budget)


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1538/

Objectives
===================
This PR adds some minor UI improvements (See visual changes)

Visual Changes
===================
### Fixes images size on help pages
**BEFORE**
![1_before](https://user-images.githubusercontent.com/631897/41906490-45bc18c6-793e-11e8-9cd8-ae2647e61d1f.png)
**AFTER**
![1_after](https://user-images.githubusercontent.com/631897/41906494-472edb12-793e-11e8-8889-6c93b0eb8913.png)

### Adss image height to recommendations on homepage
**BEFORE**
![2_before](https://user-images.githubusercontent.com/631897/41906500-4ab28d42-793e-11e8-8cd0-77efab60de4e.png)
**AFTER**
![2_after](https://user-images.githubusercontent.com/631897/41906504-4c296f92-793e-11e8-9e99-11f49805665c.png)

### Fixes valuation budget investments UI
**BEFORE**
![3_before](https://user-images.githubusercontent.com/631897/41906507-4fb75098-793e-11e8-96be-774262cf53d4.png)
**AFTER**
![3_after](https://user-images.githubusercontent.com/631897/41906511-51a43844-793e-11e8-9a2b-5374d5e342c4.png)

### Fixes heading name on budgets index view
**BEFORE**
![4_before](https://user-images.githubusercontent.com/631897/41906519-55f4c846-793e-11e8-95f7-14a766d3f2cc.png)
**AFTER**
![4_after](https://user-images.githubusercontent.com/631897/41906525-57e519b2-793e-11e8-87ed-329d31904b84.png)
