### PR TITLE
Fix flaky specs: Votes Debates and Voting comments Update

### DIFF
--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -471,6 +471,11 @@ feature 'Commenting Budget::Investments' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -476,6 +476,11 @@ feature 'Commenting debates' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -553,6 +553,11 @@ feature 'Commenting legislation questions' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -485,6 +485,11 @@ feature 'Commenting polls' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -515,6 +515,11 @@ feature 'Commenting topics from proposals' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do
@@ -1065,6 +1070,11 @@ feature 'Commenting topics from budget investments' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -83,6 +83,12 @@ feature 'Votes' do
         visit debate_path(create(:debate))
 
         find('.in-favor a').click
+
+        within('.in-favor') do
+          expect(page).to have_content "100%"
+          expect(page).to have_css("a.voted")
+        end
+
         find('.against a').click
 
         within('.in-favor') do


### PR DESCRIPTION
# References

* Issue #2713
* Pull Request #2448
* AyuntamientoMadrid#1173
* AyuntamientoMadrid#1174
* AyuntamientoMadrid#1177
* AyuntamientoMadrid#1192
* AyuntamientoMadrid#1201

# Objectives

Fix the flaky specs that appeared in `spec/features/votes_spec.rb:82` ("Votes Debates Single debate Update"), `spec/features/comments/polls_spec.rb:495` ("Commenting polls Voting comments Update"), `spec/features/comments/topics_spec.rb:525` ("Commenting topics from proposals Voting comments Update"), `spec/features/comments/topics_spec.rb:525` ("Commenting topics from budget investments Voting comments Update"), `spec/features/comments/debates_spec.rb:486` ("Commenting debates Voting comments Update"), `spec/features/comments/budget_investments_spec.rb:481` ("Commenting Budget::Investments Voting comments Update") and `spec/features/comments/legislation_annotations_spec.rb:562` ("Commenting legislation questions Voting comments Update").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

Here's the relevant part of the spec:

```ruby
visit debate_path(create(:debate))

find('.in-favor a').click
find('.against a').click
```

After clicking the first link, there's an AJAX request which replaces the existing `.in-favor a` and `.against a` links with new elements. So if Capybara tries to click the existing `.against a` link at the same moment it's being replaced, clicking the link won't generate a new request, similar to what happened in #2696.

## Explain why your PR fixes it

Making Capybara check the page for new content before clicking the second link solves the problem.

## Original solution (obsolete)

Another option would be to update the content without replacing the existing links, so it's always available for Capybara to click. That way would also solve a small issue affecting keyboard users (note the way the focus disappears after clicking an icon, and how it goes to the "like" icon when pressing "tab"):

![The link loses focus after being clicked and using tab focuses the like icon](https://user-images.githubusercontent.com/348557/42348697-f412bbac-8099-11e8-9614-b46550294291.gif)

Since the links are regenerated after being clicked, the focus goes back to the element being replaced, and that leads to awkward behaviour like clicking "dislike", pressing "tab" and the focus going back to "like".

By changing the content without regenerating the links, the links wouldn't lose focus after being clicked and the "tab" key behaves as expected:

![The link is still focused after being clicked and using tab focuses the next link](https://user-images.githubusercontent.com/348557/42348712-0129f670-809a-11e8-8081-5ca3ee597d46.gif)