### PR TITLE
Deal gracefully with recommendations of hidden proposals

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -328,7 +328,8 @@ class User < ActiveRecord::Base
   end
 
   def interests
-    follows.map{|follow| follow.followable.tags.map(&:name)}.flatten.compact.uniq
+    followables = follows.map(&:followable)
+    followables.compact.map { |followable| followable.tags.map(&:name) }.flatten.compact.uniq
   end
 
   private

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -667,6 +667,15 @@ describe User do
       expect(user.interests).to eq ["Sport"]
     end
 
+    it "deals gracefully with hidden proposals" do
+      proposal = create(:proposal, tag_list: "Sport")
+      create(:follow, followable: proposal, user: user)
+
+      proposal.hide
+
+      expect(user.interests).to eq []
+    end
+
     it "discards followed objects duplicated tags" do
       proposal1 = create(:proposal, tag_list: "Sport")
       proposal2 = create(:proposal, tag_list: "Sport")


### PR DESCRIPTION
References
==========
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1465
Related issue: https://github.com/AyuntamientoMadrid/consul/issues/1463

Objectives
==========
Avoid exception in home page when displaying recommendations

Notes
=====================
The problem was related to loading tags of hidden proposals, which were then used to calculate recommendations. 

With this PR we are skipping proposals that have been hidden when calculating recommended proposals
