### PR TITLE
Deal gracefully with hidden followable in my activity

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
                           debates: (Setting['feature.debates'] ? Debate.where(author_id: @user.id).count : 0),
                           budget_investments: (Setting['feature.budgets'] ? Budget::Investment.where(author_id: @user.id).count : 0),
                           comments: only_active_commentables.count,
-                          follows: @user.follows.count)
+                          follows: @user.follows.map(&:followable).compact.count)
     end
 
     def load_filtered_activity

--- a/app/helpers/followables_helper.rb
+++ b/app/helpers/followables_helper.rb
@@ -12,6 +12,8 @@ module FollowablesHelper
   end
 
   def render_follow(follow)
+    return unless follow.followable.present?
+
     followable = follow.followable
     partial = followable_class_name(followable) + "_follow"
     locals = {followable_class_name(followable).to_sym => followable}

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -428,7 +428,7 @@ feature 'Users' do
       @user = create(:user)
     end
 
-    scenario 'Not display following tab when user is not following any followable' do
+    scenario "Do not display follows' tab when user is not following any followables" do
       visit user_path(@user)
 
       expect(page).not_to have_content('0 Following')
@@ -441,6 +441,19 @@ feature 'Users' do
       visit user_path(@user, filter: "follows")
 
       expect(page).to have_selector(".activity li.is-active", text: "1 Following")
+    end
+
+    scenario "Gracefully handle followables that have been hidden", :focus do
+      active_proposal = create(:proposal)
+      hidden_proposal = create(:proposal)
+
+      create(:follow, followable: active_proposal, user: @user)
+      create(:follow, followable: hidden_proposal, user: @user)
+
+      hidden_proposal.hide
+      visit user_path(@user)
+
+      expect(page).to have_content('1 Following')
     end
 
     describe 'Proposals' do
@@ -463,7 +476,7 @@ feature 'Users' do
         expect(page).to have_link('Citizen proposals', href: "#citizen_proposals")
       end
 
-      scenario 'Not display proposal tab when user is not following any proposal' do
+      scenario "Do not display proposals' tab when user is not following any proposal" do
         visit user_path(@user, filter: "follows")
 
         expect(page).not_to have_link('Citizen proposals', href: "#citizen_proposals")


### PR DESCRIPTION
References
==========
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1466
Related issue: https://github.com/AyuntamientoMadrid/consul/issues/1462

Objectives
==========
- Avoid exception in my activity when displaying followed proposals that have been hidden
- Display correct number of followed proposals, without including proposals that have been hidden

