### PR TITLE
Fix display of unfeasibility explanation

### DIFF
--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1006,7 +1006,7 @@ feature 'Budget Investments' do
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
 
     expect(page).not_to have_content("Unfeasibility explanation")
-    expect(page).not_to have_content(investment.unfeasibility_explanation)
+    expect(page).not_to have_content("Local government is not competent in this matter")
   end
 
   scenario "Show milestones", :js do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -991,6 +991,24 @@ feature 'Budget Investments' do
     expect(page).not_to have_content("Local government is not competent in this matter")
   end
 
+  scenario "Show (unfeasible budget investment with valuation not finished)" do
+    user = create(:user)
+    login_as(user)
+
+    investment = create(:budget_investment,
+                        :unfeasible,
+                        valuation_finished: false,
+                        budget: budget,
+                        group: group,
+                        heading: heading,
+                        unfeasibility_explanation: 'Local government is not competent in this matter')
+
+    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+
+    expect(page).not_to have_content("Unfeasibility explanation")
+    expect(page).not_to have_content(investment.unfeasibility_explanation)
+  end
+
   scenario "Show milestones", :js do
     user = create(:user)
     investment = create(:budget_investment)

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -310,39 +310,25 @@ describe Budget::Investment do
 
   describe "#by_budget" do
 
-    it "returns true for unfeasible investments with unfeasibility explanation and valuation finished" do
-      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
-        budget.update(phase: phase)
+    it "returns investments scoped by budget" do
+       budget1 = create(:budget)
+       budget2 = create(:budget)
 
-        expect(investment.should_show_unfeasibility_explanation?).to eq(true)
-      end
-    end
+       group1 = create(:budget_group, budget: budget1)
+       group2 = create(:budget_group, budget: budget2)
 
-    it "returns false in valuation has not finished" do
-      investment.update(valuation_finished: false)
-      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
-        budget.update(phase: phase)
+       heading1 = create(:budget_heading, group: group1)
+       heading2 = create(:budget_heading, group: group2)
 
-        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
-      end
-    end
+       investment1 = create(:budget_investment, heading: heading1)
+       investment2 = create(:budget_investment, heading: heading1)
+       investment3 = create(:budget_investment, heading: heading2)
 
-    it "returns false if not unfeasible" do
-      investment.update(feasibility: "undecided")
-      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
-        budget.update(phase: phase)
+       investments_by_budget = Budget::Investment.by_budget(budget1)
 
-        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
-      end
-    end
-
-    it "returns false if unfeasibility explanation blank" do
-      investment.update(unfeasibility_explanation: "")
-      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
-        budget.update(phase: phase)
-
-        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
-      end
+       expect(investments_by_budget).to include investment1
+       expect(investments_by_budget).to include investment2
+       expect(investments_by_budget).to_not include investment3
     end
   end
 

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -308,6 +308,44 @@ describe Budget::Investment do
     end
   end
 
+  describe "#by_budget" do
+
+    it "returns true for unfeasible investments with unfeasibility explanation and valuation finished" do
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(true)
+      end
+    end
+
+    it "returns false in valuation has not finished" do
+      investment.update(valuation_finished: false)
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
+      end
+    end
+
+    it "returns false if not unfeasible" do
+      investment.update(feasibility: "undecided")
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
+      end
+    end
+
+    it "returns false if unfeasibility explanation blank" do
+      investment.update(unfeasibility_explanation: "")
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
+      end
+    end
+  end
+
   describe "#by_admin" do
     it "returns investments assigned to specific administrator" do
       investment1 = create(:budget_investment, administrator_id: 33)


### PR DESCRIPTION
References
====
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1328

What
====
- Only display unfeasibility explanation of a budget investment when the investment is unfeasible, valuation has finished and the unfeasibility_explanation is not blank

How
===
- Adding a check for valuation finished, it's the only one we were missing
