### PR TITLE
Flaky spec: Admin budget investments Index Filtering by admin

### DIFF
--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -134,33 +134,46 @@ feature 'Admin budget investments' do
       expect(page).not_to have_link("Plant trees")
     end
 
-    scenario "Filtering by admin", :js do
-      user = create(:user, username: 'Admin 1')
-      administrator = create(:administrator, user: user)
+    context "Filtering by admin" do
+      background do
+        user = create(:user, username: 'Admin 1')
+        administrator = create(:administrator, user: user)
 
-      create(:budget_investment, title: "Realocate visitors", budget: budget, administrator: administrator)
-      create(:budget_investment, title: "Destroy the city", budget: budget)
+        create(:budget_investment, title: "Realocate visitors", budget: budget, administrator: administrator)
+        create(:budget_investment, title: "Destroy the city", budget: budget)
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id)
-      expect(page).to have_link("Realocate visitors")
-      expect(page).to have_link("Destroy the city")
+        visit admin_budget_budget_investments_path(budget_id: budget.id)
+      end
 
-      select "Admin 1", from: "administrator_id"
+      scenario "Should have budgets links", :js do
 
-      expect(page).to have_content('There is 1 investment')
-      expect(page).not_to have_link("Destroy the city")
-      expect(page).to have_link("Realocate visitors")
+        expect(page).to have_link("Realocate visitors")
+        expect(page).to have_link("Destroy the city")
+      end
 
-      select "All administrators", from: "administrator_id"
+      scenario "Should have specific admin budgets", :js do
 
-      expect(page).to have_content('There are 2 investments')
-      expect(page).to have_link("Destroy the city")
-      expect(page).to have_link("Realocate visitors")
+        select "Admin 1", from: "administrator_id"
 
-      select "Admin 1", from: "administrator_id"
-      expect(page).to have_content('There is 1 investment')
-      expect(page).not_to have_link("Destroy the city")
-      expect(page).to have_link("Realocate visitors")
+        expect(page).to have_content('There is 1 investment')
+        expect(page).not_to have_link("Destroy the city")
+        expect(page).to have_link("Realocate visitors")
+      end
+
+      scenario "Should have all admins budgets", :js do
+
+        select "All administrators", from: "administrator_id"
+
+        expect(page).to have_content('There are 2 investments')
+        expect(page).to have_link("Destroy the city")
+        expect(page).to have_link("Realocate visitors")
+
+        select "Admin 1", from: "administrator_id"
+
+        expect(page).to have_content('There is 1 investment')
+        expect(page).not_to have_link("Destroy the city")
+        expect(page).to have_link("Realocate visitors")
+      end
     end
 
     scenario "Filtering by valuator", :js do


### PR DESCRIPTION
References
=====
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1234
Related Issue: https://github.com/AyuntamientoMadrid/consul/issues/1217

What
====
- Hunt the flaky that appears in `spec/features/admin/budget_investments_spec.rb:148`
- Specific error in test: 
```  
2) Admin budget investments Index Filtering by admin
     Failure/Error: expect(page).to have_content('There are 2 investments')
       expected to find text "There are 2 investments" in "Language: Decide Madrid ADMINISTRATION Admin Notifications Delegation My activity My account Sign out Categories Moderated content Polls Participatory budgets Profiles Collaborative Legislation Banners Site customization Moderator activity Configuration settings Newsletters Statistics Manage geozones Signature Sheets iste 378 - Investment projects Advanced filters Filter: All Without assigned admin Without assigned valuator Under valuation Valuation finished Winners Download current selectionThere is 1 investment ID Title Supports Administrator Valuator Scope of operation Feasibility Val. Fin. Selected 3 Realocate visitors 0 Admin 1 No valuators assigned Heading 312 Undecided No"
     # ./spec/features/admin/budget_investments_spec.rb:148:in `block (3 levels) in <top (required)>'
```

How
===

**1.  Explanation:**

- After creating a budget investment in the index of the page, it is verified that the previously created is shown.
- Then the filters are used to show investment of specific budgets.

**2.  Flaky Explanation:**

- The test fails because it does not find the budget investments after being filtered several times. It is assumed that the entire page can not be fully rendered due to the existence of several selects

**3.  Fix Explantion:**

I have divided the test into three parts to create a context with the creation of the variables and the visit to the page. Then individually try the selects
```       
     context "Filtering by admin" do
            background do
            end
     
            scenario "Should have budgets links" , :js do
            end
      end
```

Notes
========
- This flaky is related to [https://github.com/AyuntamientoMadrid/consul/issues/1218](url) and has been treated in the same way.
