### PR TITLE
Debates and proposals recommendations for users

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2408,7 +2408,7 @@ table {
   background: #fafafa;
   border-bottom: 1px solid #eee;
   margin-bottom: $line-height;
-  margin-top: rem-calc(-25);
+  margin-top: rem-calc(-$line-height);
   padding: $line-height 0;
 
   @include breakpoint(medium) {
@@ -2449,7 +2449,7 @@ table {
   color: $text-light;
   position: absolute;
   right: 12px;
-  top: rem-calc(-18);
+  top: -18px;
 }
 
 // 20. Documents

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2408,7 +2408,7 @@ table {
   background: #fafafa;
   border-bottom: 1px solid #eee;
   margin-bottom: $line-height;
-  margin-top: rem-calc(-$line-height);
+  margin-top: rem-calc(-25);
   padding: $line-height 0;
 
   @include breakpoint(medium) {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2409,7 +2409,7 @@ table {
   border-bottom: 1px solid #eee;
   margin-bottom: $line-height;
   margin-top: rem-calc(-25);
-  padding: $line-height 0;
+  padding: $line-height 0 $line-height / 2;
 
   @include breakpoint(medium) {
     padding-top: 0;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -18,7 +18,7 @@
 // 16. Flags
 // 17. Activity
 // 18. Banners
-// 19. Recommended Section Home
+// 19. Recommendations
 // 20. Documents
 // 21. Related content
 // 22. Images
@@ -2261,8 +2261,8 @@ table {
   }
 }
 
-// 19. Recommended Section Home
-// ----------------------------
+// 19. Recommendations
+// -------------------
 
 .section-recommended {
   background: #fafafa;
@@ -2402,6 +2402,54 @@ table {
       margin: 0 auto;
     }
   }
+}
+
+.recommended-index {
+  background: #fafafa;
+  border-bottom: 1px solid #eee;
+  margin-bottom: $line-height;
+  margin-top: rem-calc(-25);
+  padding: $line-height 0;
+
+  @include breakpoint(medium) {
+    padding-top: 0;
+  }
+
+  h2 {
+    font-size: $small-font-size;
+    text-transform: uppercase;
+  }
+
+  h3 {
+    font-size: $base-font-size;
+    margin-bottom: 0;
+  }
+
+  a {
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .recommendation {
+    background: #fff;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.15);
+    display: block;
+    margin-bottom: $line-height / 4;
+    padding: $line-height / 2;
+
+    &:hover {
+      box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.15);
+    }
+  }
+}
+
+.hide-recommendations {
+  color: $text-light;
+  position: absolute;
+  right: 12px;
+  top: rem-calc(-18);
 }
 
 // 20. Documents

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -28,7 +28,7 @@ class AccountController < ApplicationController
                    else
                      [:username, :public_activity, :public_interests, :email_on_comment,
                       :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter,
-                      :official_position_badge, :recommended_debates]
+                      :official_position_badge, :recommended_debates, :recommended_proposals]
                    end
       params.require(:account).permit(*attributes)
     end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -28,7 +28,7 @@ class AccountController < ApplicationController
                    else
                      [:username, :public_activity, :public_interests, :email_on_comment,
                       :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter,
-                      :official_position_badge]
+                      :official_position_badge, :recommended_debates]
                    end
       params.require(:account).permit(*attributes)
     end

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -67,8 +67,9 @@ class DebatesController < ApplicationController
     end
 
     def debates_recommendations
-      return unless current_user.recommended_debates
-      @recommended_debates = Debate.recommendations(current_user).sort_by_random.limit(3)
+      if Setting['feature.user.recommendations_on_debates'] && current_user.recommended_debates
+        @recommended_debates = Debate.recommendations(current_user).sort_by_random.limit(3)
+      end
     end
 
 end

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -6,6 +6,7 @@ class DebatesController < ApplicationController
   before_action :parse_tag_filter, only: :index
   before_action :authenticate_user!, except: [:index, :show, :map]
   before_action :set_view, only: :index
+  before_action :debates_recommendations, only: :index, if: :current_user
 
   feature_flag :debates
 
@@ -57,4 +58,7 @@ class DebatesController < ApplicationController
       @view = (params[:view] == "minimal") ? "minimal" : "default"
     end
 
+    def debates_recommendations
+      @recommended_debates = Debate.recommendations(current_user).sort_by_random.limit(3)
+    end
 end

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -59,6 +59,8 @@ class DebatesController < ApplicationController
     end
 
     def debates_recommendations
+      return unless current_user.recommended_debates
       @recommended_debates = Debate.recommendations(current_user).sort_by_random.limit(3)
     end
+
 end

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -44,6 +44,14 @@ class DebatesController < ApplicationController
     redirect_to request.query_parameters.merge(action: :index)
   end
 
+  def disable_recommendations
+    if current_user.update(recommended_debates: false)
+      redirect_to debates_path, notice: t('debates.index.recommendations.actions.success')
+    else
+      redirect_to debates_path, error: t('debates.index.recommendations.actions.error')
+    end
+  end
+
   private
 
     def debate_params

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -154,8 +154,9 @@ class ProposalsController < ApplicationController
     end
 
     def proposals_recommendations
-      return unless current_user.recommended_proposals
-      @recommended_proposals = Proposal.recommendations(current_user).sort_by_random.limit(3)
+      if Setting['feature.user.recommendations_on_proposals'] && current_user.recommended_proposals
+        @recommended_proposals = Proposal.recommendations(current_user).sort_by_random.limit(3)
+      end
     end
 
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -146,6 +146,7 @@ class ProposalsController < ApplicationController
     end
 
     def proposals_recommendations
+      return unless current_user.recommended_proposals
       @recommended_proposals = Proposal.recommendations(current_user).sort_by_random.limit(3)
     end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -9,6 +9,7 @@ class ProposalsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show, :map, :summary]
   before_action :destroy_map_location_association, only: :update
   before_action :set_view, only: :index
+  before_action :proposals_recommendations, only: :index, if: :current_user
 
   feature_flag :proposals
 
@@ -142,6 +143,10 @@ class ProposalsController < ApplicationController
       if map_location && (map_location[:longitude] && map_location[:latitude]).blank? && !map_location[:id].blank?
         MapLocation.destroy(map_location[:id])
       end
+    end
+
+    def proposals_recommendations
+      @recommended_proposals = Proposal.recommendations(current_user).sort_by_random.limit(3)
     end
 
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -80,6 +80,14 @@ class ProposalsController < ApplicationController
     @tag_cloud = tag_cloud
   end
 
+  def disable_recommendations
+    if current_user.update(recommended_proposals: false)
+      redirect_to proposals_path, notice: t('proposals.index.recommendations.actions.success')
+    else
+      redirect_to proposals_path, error: t('proposals.index.recommendations.actions.error')
+    end
+  end
+
   private
 
     def proposal_params

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -94,6 +94,8 @@ module Abilities
 
       can [:create], Topic
       can [:update, :destroy], Topic, author_id: user.id
+
+      can :disable_recommendations, [Debate, Proposal]
     end
   end
 end

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -29,6 +29,7 @@ module Abilities
       can [:read], Legislation::Question
       can [:read, :map, :share], Legislation::Proposal
       can [:search, :comments, :read, :create, :new_comment], Legislation::Annotation
+      can :disable_recommendations, [Debate, Proposal]
     end
   end
 end

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -29,7 +29,6 @@ module Abilities
       can [:read], Legislation::Question
       can [:read, :map, :share], Legislation::Proposal
       can [:search, :comments, :read, :create, :new_comment], Legislation::Annotation
-      can :disable_recommendations, [Debate, Proposal]
     end
   end
 end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -151,7 +151,7 @@ class Debate < ActiveRecord::Base
 
   def self.debates_orders(user)
     orders = %w{hot_score confidence_score created_at relevance}
-    orders << "recommendations" if user.present?
-    orders
+    orders << "recommendations" if user&.recommended_debates
+    return orders
   end
 end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -151,7 +151,7 @@ class Debate < ActiveRecord::Base
 
   def self.debates_orders(user)
     orders = %w{hot_score confidence_score created_at relevance}
-    orders << "recommendations" if user&.recommended_debates
+    orders << "recommendations" if Setting['feature.user.recommendations_on_debates'] && user&.recommended_debates
     return orders
   end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -210,8 +210,8 @@ class Proposal < ActiveRecord::Base
 
   def self.proposals_orders(user)
     orders = %w{hot_score confidence_score created_at relevance archival_date}
-    orders << "recommendations" if user.present?
-    orders
+    orders << "recommendations" if user&.recommended_proposals
+    return orders
   end
 
   protected

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -210,7 +210,7 @@ class Proposal < ActiveRecord::Base
 
   def self.proposals_orders(user)
     orders = %w{hot_score confidence_score created_at relevance archival_date}
-    orders << "recommendations" if user&.recommended_proposals
+    orders << "recommendations" if Setting['feature.user.recommendations_on_proposals'] && user&.recommended_proposals
     return orders
   end
 

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -112,6 +112,19 @@
             </div>
           <% end %>
 
+          <% if feature?("user.recommendations") %>
+            <h2><%= t("account.show.recommendations") %></h2>
+
+            <% if feature?("user.recommendations_on_debates") %>
+              <div>
+                <%= f.check_box :recommended_debates, title: t("account.show.show_debates_recommendations"), label: false %>
+                <span class="checkbox">
+                  <%= t("account.show.show_debates_recommendations") %>
+                </span>
+              </div>
+            <% end %>
+          <% end %>
+
           <%= f.submit t("account.show.save_changes_submit"), class: "button margin-top" %>
         </div>
 

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -123,6 +123,15 @@
                 </span>
               </div>
             <% end %>
+
+            <% if feature?("user.recommendations_on_proposals") %>
+              <div>
+                <%= f.check_box :recommended_proposals, title: t("account.show.show_proposals_recommendations"), label: false %>
+                <span class="checkbox">
+                  <%= t("account.show.show_proposals_recommendations") %>
+                </span>
+              </div>
+            <% end %>
           <% end %>
 
           <%= f.submit t("account.show.save_changes_submit"), class: "button margin-top" %>

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -117,19 +117,23 @@
 
             <% if feature?("user.recommendations_on_debates") %>
               <div>
-                <%= f.check_box :recommended_debates, title: t("account.show.show_debates_recommendations"), label: false %>
-                <span class="checkbox">
-                  <%= t("account.show.show_debates_recommendations") %>
-                </span>
+                <%= f.label :recommended_debates do %>
+                  <%= f.check_box :recommended_debates, title: t("account.show.show_debates_recommendations"), label: false %>
+                  <span class="checkbox">
+                    <%= t("account.show.show_debates_recommendations") %>
+                  </span>
+                <% end %>
               </div>
             <% end %>
 
             <% if feature?("user.recommendations_on_proposals") %>
               <div>
-                <%= f.check_box :recommended_proposals, title: t("account.show.show_proposals_recommendations"), label: false %>
-                <span class="checkbox">
-                  <%= t("account.show.show_proposals_recommendations") %>
-                </span>
+                <%= f.label :recommended_proposals do %>
+                  <%= f.check_box :recommended_proposals, title: t("account.show.show_proposals_recommendations"), label: false %>
+                  <span class="checkbox">
+                    <%= t("account.show.show_proposals_recommendations") %>
+                  </span>
+                <% end %>
               </div>
             <% end %>
           <% end %>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -35,6 +35,10 @@
     <%= render "shared/section_header", i18n_namespace: "debates.index.section_header", image: "debates" %>
   <% end %>
 
+  <% if feature?("user.recommendations_on_debates") && @recommended_debates.present? %>
+    <%= render "shared/recommended_index", recommended: @recommended_debates %>
+  <% end %>
+
   <div class="row">
     <div id="debates" class="debates-list small-12 medium-9 column">
 

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -35,7 +35,7 @@
     <%= render "shared/section_header", i18n_namespace: "debates.index.section_header", image: "debates" %>
   <% end %>
 
-  <% if feature?("user.recommendations_on_debates") && @recommended_debates.present? %>
+  <% if @recommended_debates.present? %>
     <%= render "shared/recommended_index", recommended: @recommended_debates %>
   <% end %>
 

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -35,7 +35,7 @@
     <%= render "shared/section_header", i18n_namespace: "debates.index.section_header", image: "debates" %>
   <% end %>
 
-  <% if @recommended_debates.present? %>
+  <% if feature?('user.recommendations') && @recommended_debates.present? %>
     <%= render "shared/recommended_index", recommended: @recommended_debates,
                                            disable_recommendations_path: recommendations_disable_debates_path,
                                            namespace: "debates" %>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -36,7 +36,9 @@
   <% end %>
 
   <% if @recommended_debates.present? %>
-    <%= render "shared/recommended_index", recommended: @recommended_debates %>
+    <%= render "shared/recommended_index", recommended: @recommended_debates,
+                                           disable_recommendations_path: recommendations_disable_debates_path,
+                                           namespace: "debates" %>
   <% end %>
 
   <div class="row">

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -37,6 +37,10 @@
     <%= render "shared/section_header", i18n_namespace: "proposals.index.section_header", image: "proposals" %>
   <% end %>
 
+  <% if feature?("user.recommendations_on_proposals") && @recommended_proposals.present? %>
+    <%= render "shared/recommended_index", recommended: @recommended_proposals %>
+  <% end %>
+
   <div class="row">
     <div id="proposals" class="proposals-list small-12 medium-9 column">
 

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -37,7 +37,7 @@
     <%= render "shared/section_header", i18n_namespace: "proposals.index.section_header", image: "proposals" %>
   <% end %>
 
-  <% if feature?("user.recommendations_on_proposals") && @recommended_proposals.present? %>
+  <% if @recommended_proposals.present? %>
     <%= render "shared/recommended_index", recommended: @recommended_proposals %>
   <% end %>
 

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -37,7 +37,7 @@
     <%= render "shared/section_header", i18n_namespace: "proposals.index.section_header", image: "proposals" %>
   <% end %>
 
-  <% if @recommended_proposals.present? %>
+  <% if feature?('user.recommendations') && @recommended_proposals.present? %>
     <%= render "shared/recommended_index", recommended: @recommended_proposals,
                                            disable_recommendations_path: recommendations_disable_proposals_path,
                                            namespace: "proposals" %>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -38,7 +38,9 @@
   <% end %>
 
   <% if @recommended_proposals.present? %>
-    <%= render "shared/recommended_index", recommended: @recommended_proposals %>
+    <%= render "shared/recommended_index", recommended: @recommended_proposals,
+                                           disable_recommendations_path: recommendations_disable_proposals_path,
+                                           namespace: "proposals" %>
   <% end %>
 
   <div class="row">

--- a/app/views/shared/_recommended_index.html.erb
+++ b/app/views/shared/_recommended_index.html.erb
@@ -5,9 +5,13 @@
     </div>
 
     <div id="recommendations" data-toggler=".hide">
-      <%= link_to "#", title: t("shared.recommended_index.hide"),
-                       class: "float-right-medium small hide-recommendations",
-                       data: { toggle: "recommendations" } do %>
+      <%= link_to disable_recommendations_path, title: t("shared.recommended_index.hide"),
+                                                class: "float-right-medium small hide-recommendations",
+                                                data: {
+                                                  toggle: "recommendations",
+                                                  confirm: t("#{namespace}.index.recommendations.disable")
+                                                },
+                                                method: :put do %>
         <span class="icon-x"></span>
         <span class="show-for-sr"><%= t("shared.recommended_index.hide") %></span>
       <% end %>

--- a/app/views/shared/_recommended_index.html.erb
+++ b/app/views/shared/_recommended_index.html.erb
@@ -4,26 +4,29 @@
       <h2 class="show-for-sr"><%= t("shared.recommended_index.title") %></h2>
     </div>
 
-    <%= link_to "#", title: t("shared.recommended_index.hide"),
-                     class: "float-right-medium small hide-recommendations" do %>
-      <span class="icon-x"></span>
-      <span class="show-for-sr"><%= t("shared.recommended_index.hide") %></span>
-    <% end %>
+    <div id="recommendations" data-toggler=".hide">
+      <%= link_to "#", title: t("shared.recommended_index.hide"),
+                       class: "float-right-medium small hide-recommendations",
+                       data: { toggle: "recommendations" } do %>
+        <span class="icon-x"></span>
+        <span class="show-for-sr"><%= t("shared.recommended_index.hide") %></span>
+      <% end %>
 
-    <% recommended.each_with_index do |recommended, index| %>
-      <div class="small-12 medium-6 large-4 column end">
-        <%= link_to recommended_path(recommended) do %>
-          <div class="recommendation" data-equalizer-watch>
-            <h3><%= recommended.title %></h3>
-          </div>
-        <% end %>
+      <% recommended.each_with_index do |recommended, index| %>
+        <div class="small-12 medium-6 large-4 column end">
+          <%= link_to recommended_path(recommended) do %>
+            <div class="recommendation" data-equalizer-watch>
+              <h3><%= recommended.title %></h3>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <div class="small-12 column">
+        <%= link_to t("shared.recommended_index.see_more"),
+                    current_path_with_query_params(order: "recommendations"),
+                    class: "float-right-medium small" %>
       </div>
-    <% end %>
-
-    <div class="small-12 column">
-      <%= link_to t("shared.recommended_index.see_more"),
-                  current_path_with_query_params(order: "recommendations"),
-                  class: "float-right-medium small" %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_recommended_index.html.erb
+++ b/app/views/shared/_recommended_index.html.erb
@@ -1,0 +1,29 @@
+<div class="recommended-index">
+  <div class="row relative" data-equalizer data-equalizer-on="medium">
+    <div class="small-12 column">
+      <h2 class="show-for-sr"><%= t("shared.recommended_index.title") %></h2>
+    </div>
+
+    <%= link_to "#", title: t("shared.recommended_index.hide"),
+                     class: "float-right-medium small hide-recommendations" do %>
+      <span class="icon-x"></span>
+      <span class="show-for-sr"><%= t("shared.recommended_index.hide") %></span>
+    <% end %>
+
+    <% recommended.each_with_index do |recommended, index| %>
+      <div class="small-12 medium-6 large-4 column end">
+        <%= link_to recommended_path(recommended) do %>
+          <div class="recommendation" data-equalizer-watch>
+            <h3><%= recommended.title %></h3>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="small-12 column">
+      <%= link_to t("shared.recommended_index.see_more"),
+                  current_path_with_query_params(order: "recommendations"),
+                  class: "float-right-medium small" %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_section_header.html.erb
+++ b/app/views/shared/_section_header.html.erb
@@ -3,7 +3,9 @@
     <div class="small-12 column" data-magellan>
       <%= image_tag "help/help_icon_#{image}.png", alt: t("#{i18n_namespace}.icon_alt"), class: "align-top" %>
       <h1 class="inline-block"><%= t("#{i18n_namespace}.title") %></h1>
-      <%= link_to t("#{i18n_namespace}.help"), "#section_help", class: "float-right" %>
+      <div class="float-right-medium">
+        <%= link_to t("#{i18n_namespace}.help"), "#section_help" %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -113,6 +113,10 @@ en:
       recommendations:
         without_results: There are not debates related to your interests
         without_interests: Follow proposals so we can give you recommendations
+        disable: "If you dismiss debates recommendations, the setting will be automatically disabled. Do you wish to continue?"
+        actions:
+          success: "Recommendations for debates are now disabled for this account"
+          error: "An error has occured. Please go to 'Your account' page to manually disable recommendations for debates"
       search_form:
         button: Search
         placeholder: Search debates...
@@ -364,6 +368,10 @@ en:
       recommendations:
         without_results: There are not proposals related to your interests
         without_interests: Follow proposals so we can give you recommendations
+        disable: "If you dismiss proposals recommendations, the setting will be automatically disabled. Do you wish to continue?"
+        actions:
+          success: "Recommendations for proposals are now disabled for this account"
+          error: "An error has occured. Please go to 'Your account' page to manually disable recommendations for proposals"
       retired_proposals: Retired proposals
       retired_proposals_link: "Proposals retired by the author"
       retired_links:

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -20,6 +20,8 @@ en:
       email_on_direct_message_label: Receive emails about direct messages
       email_digest_label: Receive a summary of proposal notifications
       official_position_badge_label: Show official position badge
+      recommendations: Recommendations
+      show_debates_recommendations: Show debates recommendations
       title: My account
       user_permission_debates: Participate on debates
       user_permission_info: With your account you can...

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -113,7 +113,7 @@ en:
       recommendations:
         without_results: There are not debates related to your interests
         without_interests: Follow proposals so we can give you recommendations
-        disable: "If you dismiss debates recommendations, the setting will be automatically disabled. Do you wish to continue?"
+        disable: "Debates recommendations will stop showing if you dismiss them. You can enable them again in 'My account' page"
         actions:
           success: "Recommendations for debates are now disabled for this account"
           error: "An error has occured. Please go to 'Your account' page to manually disable recommendations for debates"
@@ -368,7 +368,7 @@ en:
       recommendations:
         without_results: There are not proposals related to your interests
         without_interests: Follow proposals so we can give you recommendations
-        disable: "If you dismiss proposals recommendations, the setting will be automatically disabled. Do you wish to continue?"
+        disable: "Proposals recommendations will stop showing if you dismiss them. You can enable them again in 'My account' page"
         actions:
           success: "Recommendations for proposals are now disabled for this account"
           error: "An error has occured. Please go to 'Your account' page to manually disable recommendations for proposals"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -632,6 +632,10 @@ en:
       title: View mode
       cards: Cards
       list: List
+    recommended_index:
+        title: Recommendations
+        see_more: See more recommendations
+        hide: Hide recommendations
   social:
     blog: "%{org} Blog"
     facebook: "%{org} Facebook"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -22,6 +22,7 @@ en:
       official_position_badge_label: Show official position badge
       recommendations: Recommendations
       show_debates_recommendations: Show debates recommendations
+      show_proposals_recommendations: Show proposals recommendations
       title: My account
       user_permission_debates: Participate on debates
       user_permission_info: With your account you can...

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -43,8 +43,8 @@ en:
       user:
         recommendations: Recommendations
         skip_verification: Skip user verification
-        recommendations_on_debates: Recommendeds on debates
-        recommendations_on_proposals: Recommendeds on proposals
+        recommendations_on_debates: Recommendations on debates
+        recommendations_on_proposals: Recommendations on proposals
       community: Community on proposals and investments
       map: Proposals and budget investments geolocation
       allow_images: Allow upload and show images

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -43,6 +43,7 @@ en:
       user:
         recommendations: Recommendations
         skip_verification: Skip user verification
+        recommendations_on_debates: Recommendeds on debates
       community: Community on proposals and investments
       map: Proposals and budget investments geolocation
       allow_images: Allow upload and show images

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -44,6 +44,7 @@ en:
         recommendations: Recommendations
         skip_verification: Skip user verification
         recommendations_on_debates: Recommendeds on debates
+        recommendations_on_proposals: Recommendeds on proposals
       community: Community on proposals and investments
       map: Proposals and budget investments geolocation
       allow_images: Allow upload and show images

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -113,6 +113,10 @@ es:
       recommendations:
         without_results: No existen debates relacionados con tus intereses
         without_interests: Sigue propuestas para que podamos darte recomendaciones
+        disable: "Si ocultas las recomendaciones para debates, se desactivará automáticamente el ajuste. ¿Deseas continuar?"
+        actions:
+          success: "Las recomendaciones de debates han sido desactivadas"
+          error: "Ha ocurrido un error. Por favor dirígete al apartado 'Mi cuenta' para desactivar las recomendaciones manualmente"
       search_form:
         button: Buscar
         placeholder: Buscar debates...
@@ -364,6 +368,10 @@ es:
       recommendations:
         without_results: No existen propuestas relacionadas con tus intereses
         without_interests: Sigue propuestas para que podamos darte recomendaciones
+        disable: "Si ocultas las recomendaciones para propuestas, se desactivará automáticamente el ajuste. ¿Deseas continuar?"
+        actions:
+          success: "Las recomendaciones de propuestas han sido desactivadas"
+          error: "Ha ocurrido un error. Por favor dirígete al apartado 'Mi cuenta' para desactivar las recomendaciones manualmente"
       retired_proposals: Propuestas retiradas
       retired_proposals_link: "Propuestas retiradas por sus autores"
       retired_links:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -20,6 +20,8 @@ es:
       email_on_direct_message_label: Recibir emails con mensajes privados
       email_digest_label: Recibir resumen de notificaciones sobre propuestas
       official_position_badge_label: Mostrar etiqueta de tipo de usuario
+      recommendations: Recomendaciones
+      show_debates_recommendations: Mostrar recomendaciones en el listado de debates
       title: Mi cuenta
       user_permission_debates: Participar en debates
       user_permission_info: Con tu cuenta ya puedes...

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -22,6 +22,7 @@ es:
       official_position_badge_label: Mostrar etiqueta de tipo de usuario
       recommendations: Recomendaciones
       show_debates_recommendations: Mostrar recomendaciones en el listado de debates
+      show_proposals_recommendations: Mostrar recomendaciones en el listado de propuestas
       title: Mi cuenta
       user_permission_debates: Participar en debates
       user_permission_info: Con tu cuenta ya puedes...

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -631,6 +631,10 @@ es:
       title: Modo de vista
       cards: Tarjetas
       list: Lista
+    recommended_index:
+        title: Recomendaciones
+        see_more: Ver más recomendaciones
+        hide: Ocultar recomendaciones
   social:
     blog: "Blog de %{org}"
     facebook: "Facebook de %{org}"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -113,7 +113,7 @@ es:
       recommendations:
         without_results: No existen debates relacionados con tus intereses
         without_interests: Sigue propuestas para que podamos darte recomendaciones
-        disable: "Si ocultas las recomendaciones para debates, se desactivará automáticamente el ajuste. ¿Deseas continuar?"
+        disable: "Si ocultas las recomendaciones para debates, no se volverán a mostrar. Puedes volver a activarlas en 'Mi cuenta'"
         actions:
           success: "Las recomendaciones de debates han sido desactivadas"
           error: "Ha ocurrido un error. Por favor dirígete al apartado 'Mi cuenta' para desactivar las recomendaciones manualmente"
@@ -368,7 +368,7 @@ es:
       recommendations:
         without_results: No existen propuestas relacionadas con tus intereses
         without_interests: Sigue propuestas para que podamos darte recomendaciones
-        disable: "Si ocultas las recomendaciones para propuestas, se desactivará automáticamente el ajuste. ¿Deseas continuar?"
+        disable: "Si ocultas las recomendaciones para propuestas, no se volverán a mostrar. Puedes volver a activarlas en 'Mi cuenta'"
         actions:
           success: "Las recomendaciones de propuestas han sido desactivadas"
           error: "Ha ocurrido un error. Por favor dirígete al apartado 'Mi cuenta' para desactivar las recomendaciones manualmente"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -43,6 +43,7 @@ es:
       user:
         recommendations: Recomendaciones
         skip_verification: Omitir verificación de usuarios
+        recommendations_on_debates: Recomendaciones en debates
       community: Comunidad en propuestas y proyectos de gasto
       map: Geolocalización de propuestas y proyectos de gasto
       allow_images: Permitir subir y mostrar imágenes

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -44,6 +44,7 @@ es:
         recommendations: Recomendaciones
         skip_verification: Omitir verificación de usuarios
         recommendations_on_debates: Recomendaciones en debates
+        recommendations_on_proposals: Recomendaciones en propuestas
       community: Comunidad en propuestas y proyectos de gasto
       map: Geolocalización de propuestas y proyectos de gasto
       allow_images: Permitir subir y mostrar imágenes

--- a/config/routes/debate.rb
+++ b/config/routes/debate.rb
@@ -10,5 +10,6 @@ resources :debates do
   collection do
     get :map
     get :suggest
+    put 'recommendations/disable', only: :index, controller: 'debates', action: :disable_recommendations
   end
 end

--- a/config/routes/proposal.rb
+++ b/config/routes/proposal.rb
@@ -13,5 +13,6 @@ resources :proposals do
     get :map
     get :suggest
     get :summary
+    put 'recommendations/disable', only: :index, controller: 'proposals', action: :disable_recommendations
   end
 end

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -40,6 +40,8 @@ section "Creating Settings" do
   Setting.create(key: 'feature.signature_sheets', value: "true")
   Setting.create(key: 'feature.legislation', value: "true")
   Setting.create(key: 'feature.user.recommendations', value: "true")
+  Setting.create(key: 'feature.user.recommendations_on_debates', value: "true")
+  Setting.create(key: 'feature.user.recommendations_on_proposals', value: "true")
   Setting.create(key: 'feature.community', value: "true")
   Setting.create(key: 'feature.map', value: "true")
   Setting.create(key: 'feature.allow_images', value: "true")

--- a/db/migrate/20180604124515_add_recommended_debates_setting_to_users.rb
+++ b/db/migrate/20180604124515_add_recommended_debates_setting_to_users.rb
@@ -1,0 +1,7 @@
+class AddRecommendedDebatesSettingToUsers < ActiveRecord::Migration
+  def change
+    change_table :users do |t|
+      t.boolean :recommended_debates, default: false
+    end
+  end
+end

--- a/db/migrate/20180604151014_add_recommended_proposals_setting_to_users.rb
+++ b/db/migrate/20180604151014_add_recommended_proposals_setting_to_users.rb
@@ -1,0 +1,7 @@
+class AddRecommendedProposalsSettingToUsers < ActiveRecord::Migration
+  def change
+    change_table :users do |t|
+      t.boolean :recommended_proposals, default: false
+    end
+  end
+end

--- a/db/migrate/20180711224810_enable_recommendations_by_default.rb
+++ b/db/migrate/20180711224810_enable_recommendations_by_default.rb
@@ -1,0 +1,6 @@
+class EnableRecommendationsByDefault < ActiveRecord::Migration
+  def change
+    change_column_default :users, :recommended_debates, true
+    change_column_default :users, :recommended_proposals, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1156,6 +1156,7 @@ ActiveRecord::Schema.define(version: 20180519132610) do
     t.integer  "failed_email_digests_count",                default: 0
     t.text     "former_users_data_log",                     default: ""
     t.boolean  "public_interests",                          default: false
+    t.boolean  "recommended_debates",                       default: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1157,6 +1157,7 @@ ActiveRecord::Schema.define(version: 20180519132610) do
     t.text     "former_users_data_log",                     default: ""
     t.boolean  "public_interests",                          default: false
     t.boolean  "recommended_debates",                       default: false
+    t.boolean  "recommended_proposals",                     default: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180519132610) do
+ActiveRecord::Schema.define(version: 20180711224810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1156,8 +1156,8 @@ ActiveRecord::Schema.define(version: 20180519132610) do
     t.integer  "failed_email_digests_count",                default: 0
     t.text     "former_users_data_log",                     default: ""
     t.boolean  "public_interests",                          default: false
-    t.boolean  "recommended_debates",                       default: false
-    t.boolean  "recommended_proposals",                     default: false
+    t.boolean  "recommended_debates",                       default: true
+    t.boolean  "recommended_proposals",                     default: true
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -82,6 +82,7 @@ Setting['feature.budgets'] = true
 Setting['feature.signature_sheets'] = true
 Setting['feature.legislation'] = true
 Setting['feature.user.recommendations'] = true
+Setting['feature.user.recommendations_on_debates'] = true
 Setting['feature.community'] = true
 Setting['feature.map'] = nil
 Setting['feature.allow_images'] = true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,6 +83,7 @@ Setting['feature.signature_sheets'] = true
 Setting['feature.legislation'] = true
 Setting['feature.user.recommendations'] = true
 Setting['feature.user.recommendations_on_debates'] = true
+Setting['feature.user.recommendations_on_proposals'] = true
 Setting['feature.community'] = true
 Setting['feature.map'] = nil
 Setting['feature.allow_images'] = true

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -13,4 +13,11 @@ namespace :settings do
     Setting['feature.allow_attached_documents'] = true
   end
 
+  desc "Enable recommendations settings"
+  task enable_recommendations: :environment do
+    Setting['feature.user.recommendations'] = true
+    Setting['feature.user.recommendations_on_debates'] = true
+    Setting['feature.user.recommendations_on_proposals'] = true
+  end
+
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,10 @@
+namespace :users do
+
+  desc "Enable recommendations for existing users"
+  task enable_recommendations: :environment do
+    User.find_each do |user|
+      user.update(recommended_debates: true, recommended_proposals: true)
+    end
+  end
+
+end

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -189,7 +189,7 @@ feature 'Account' do
       Setting['feature.user.recommendations_on_proposals'] = nil
     end
 
-    scenario 'show checkboxes to enable/disable recommendations (disabled by default)' do
+    scenario 'are disabled by default' do
       visit account_path
 
       expect(page).to have_content('Recommendations')
@@ -197,6 +197,29 @@ feature 'Account' do
       expect(page).to have_content('Show proposals recommendations')
       expect(find("#account_recommended_debates")).not_to be_checked
       expect(find("#account_recommended_proposals")).not_to be_checked
+    end
+
+    scenario "can be enabled through 'My account' page" do
+      visit account_path
+
+      expect(page).to have_content('Recommendations')
+      expect(page).to have_content('Show debates recommendations')
+      expect(page).to have_content('Show proposals recommendations')
+      expect(find("#account_recommended_debates")).not_to be_checked
+      expect(find("#account_recommended_proposals")).not_to be_checked
+
+      check 'account_recommended_debates'
+      check 'account_recommended_proposals'
+
+      click_button 'Save changes'
+
+      expect(find("#account_recommended_debates")).to be_checked
+      expect(find("#account_recommended_proposals")).to be_checked
+
+      @user.reload
+
+      expect(@user.recommended_debates).to be(true)
+      expect(@user.recommended_proposals).to be(true)
     end
 
   end

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -174,4 +174,30 @@ feature 'Account' do
 
     expect(page).to have_content "Invalid login or password"
   end
+
+  context 'Recommendations' do
+
+    background do
+      Setting['feature.user.recommendations'] = true
+      Setting['feature.user.recommendations_on_debates'] = true
+      Setting['feature.user.recommendations_on_proposals'] = true
+    end
+
+    after do
+      Setting['feature.user.recommendations'] = nil
+      Setting['feature.user.recommendations_on_debates'] = nil
+      Setting['feature.user.recommendations_on_proposals'] = nil
+    end
+
+    scenario 'show checkboxes to enable/disable recommendations (disabled by default)' do
+      visit account_path
+
+      expect(page).to have_content('Recommendations')
+      expect(page).to have_content('Show debates recommendations')
+      expect(page).to have_content('Show proposals recommendations')
+      expect(find("#account_recommended_debates")).not_to be_checked
+      expect(find("#account_recommended_proposals")).not_to be_checked
+    end
+
+  end
 end

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -189,37 +189,37 @@ feature 'Account' do
       Setting['feature.user.recommendations_on_proposals'] = nil
     end
 
-    scenario 'are disabled by default' do
+    scenario 'are enabled by default' do
       visit account_path
 
       expect(page).to have_content('Recommendations')
       expect(page).to have_content('Show debates recommendations')
       expect(page).to have_content('Show proposals recommendations')
-      expect(find("#account_recommended_debates")).not_to be_checked
-      expect(find("#account_recommended_proposals")).not_to be_checked
+      expect(find("#account_recommended_debates")).to be_checked
+      expect(find("#account_recommended_proposals")).to be_checked
     end
 
-    scenario "can be enabled through 'My account' page" do
+    scenario "can be disabled through 'My account' page" do
       visit account_path
 
       expect(page).to have_content('Recommendations')
       expect(page).to have_content('Show debates recommendations')
       expect(page).to have_content('Show proposals recommendations')
-      expect(find("#account_recommended_debates")).not_to be_checked
-      expect(find("#account_recommended_proposals")).not_to be_checked
-
-      check 'account_recommended_debates'
-      check 'account_recommended_proposals'
-
-      click_button 'Save changes'
-
       expect(find("#account_recommended_debates")).to be_checked
       expect(find("#account_recommended_proposals")).to be_checked
 
+      uncheck 'account_recommended_debates'
+      uncheck 'account_recommended_proposals'
+
+      click_button 'Save changes'
+
+      expect(find("#account_recommended_debates")).not_to be_checked
+      expect(find("#account_recommended_proposals")).not_to be_checked
+
       @user.reload
 
-      expect(@user.recommended_debates).to be(true)
-      expect(@user.recommended_proposals).to be(true)
+      expect(@user.recommended_debates).to be(false)
+      expect(@user.recommended_proposals).to be(false)
     end
 
   end

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -397,9 +397,9 @@ feature 'Debates' do
 
     context 'Recommendations' do
 
-      let!(:best_debate)   { create(:debate, title: 'Best',   cached_votes_total: 10, tag_list: "Sport") }
-      let!(:medium_debate) { create(:debate, title: 'Medium', cached_votes_total: 5,  tag_list: "Sport") }
-      let!(:worst_debate)  { create(:debate, title: 'Worst',  cached_votes_total: 1,  tag_list: "Sport") }
+      let!(:best_debate)   { create(:debate, title: 'Best',   cached_votes_total: 10, tag_list: 'Sport') }
+      let!(:medium_debate) { create(:debate, title: 'Medium', cached_votes_total: 5,  tag_list: 'Sport') }
+      let!(:worst_debate)  { create(:debate, title: 'Worst',  cached_votes_total: 1,  tag_list: 'Sport') }
 
       background do
         Setting['feature.user.recommendations'] = true
@@ -411,40 +411,29 @@ feature 'Debates' do
         Setting['feature.user.recommendations_on_debates'] = nil
       end
 
-      scenario 'Debates can not ordered by recommendations when there is not an user logged' do
+      scenario "Debates can't be ordered by recommendations if there's no logged user" do
         visit debates_path
         expect(page).not_to have_selector('a', text: 'recommendations')
       end
 
-      scenario 'Show recommended debates on index header' do
-        user     = create(:user)
-        proposal = create(:proposal, tag_list: "Sport")
+      scenario 'Show recommended debates on index header when user has recommendations enabled' do
+        user     = create(:user, recommended_debates: true)
+        proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
-        visit account_path
-
-        expect(page).to have_content('Recommendations')
-        expect(page).to have_content('Show debates recommendations')
-        expect(find("#account_recommended_debates")).not_to be_checked
-
-        check 'account_recommended_debates'
-        click_button 'Save changes'
-
-        expect(find("#account_recommended_debates")).to be_checked
-
         visit debates_path
 
         expect(page).to have_css('.recommendation', count: 3)
-        expect(page).to have_link "Best"
-        expect(page).to have_link "Medium"
-        expect(page).to have_link "Worst"
-        expect(page).to have_link "See more recommendations"
+        expect(page).to have_link 'Best'
+        expect(page).to have_link 'Medium'
+        expect(page).to have_link 'Worst'
+        expect(page).to have_link 'See more recommendations'
       end
 
       scenario 'Should display text when there are not recommended results' do
         user     = create(:user, recommended_debates: true)
-        proposal = create(:proposal, tag_list: "Distinct_to_sport")
+        proposal = create(:proposal, tag_list: 'Distinct_to_sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
@@ -452,22 +441,23 @@ feature 'Debates' do
 
         click_link 'recommendations'
 
-        expect(page).to have_content "There are not debates related to your interests"
+        expect(page).to have_content 'There are not debates related to your interests'
       end
 
       scenario 'Should display text when user has not related interests' do
         user = create(:user, recommended_debates: true)
+
         login_as(user)
         visit debates_path
 
         click_link 'recommendations'
 
-        expect(page).to have_content "Follow proposals so we can give you recommendations"
+        expect(page).to have_content 'Follow proposals so we can give you recommendations'
       end
 
-      scenario 'Debates are ordered by recommendations when there is a user logged' do
+      scenario "Debates are ordered by recommendations when there's an user logged" do
         user     = create(:user, recommended_debates: true)
-        proposal = create(:proposal, tag_list: "Sport")
+        proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
@@ -486,18 +476,12 @@ feature 'Debates' do
         expect(current_url).to include('page=1')
       end
 
-      scenario 'Recommendations are not shown if feature is disabled' do
+      scenario 'are not shown if user does not have recommendations enabled' do
         user     = create(:user)
-        proposal = create(:proposal, tag_list: "Sport")
+        proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
-        visit account_path
-
-        expect(page).to have_content('Recommendations')
-        expect(page).to have_content('Show debates recommendations')
-        expect(find("#account_recommended_debates")).not_to be_checked
-
         visit debates_path
 
         expect(page).not_to have_css('.recommendation', count: 3)
@@ -506,11 +490,10 @@ feature 'Debates' do
 
       scenario 'Recommendations shown in index are dismissable', :js do
         user     = create(:user, recommended_debates: true)
-        proposal = create(:proposal, tag_list: "Sport")
+        proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
-
         visit debates_path
 
         within("#recommendations") do

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -488,7 +488,7 @@ feature 'Debates' do
         expect(page).not_to have_link('recommendations')
       end
 
-      scenario 'shown on index header are dismissable', :js do
+      scenario 'are automatically disabled when dismissed from index', :js do
         user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
@@ -502,13 +502,19 @@ feature 'Debates' do
           expect(page).to have_content('Medium')
           expect(page).to have_css('.recommendation', count: 3)
 
-          find('.icon-x').click
-
-          expect(page).not_to have_content('Best')
-          expect(page).not_to have_content('Worst')
-          expect(page).not_to have_content('Medium')
-          expect(page).not_to have_css('.recommendation', count: 3)
+          accept_confirm { click_link 'Hide recommendations' }
         end
+
+        expect(page).not_to have_link('recommendations')
+        expect(page).not_to have_css('.recommendation', count: 3)
+        expect(page).to have_content('Recommendations for debates are now disabled for this account')
+
+        user.reload
+
+        visit account_path
+
+        expect(find("#account_recommended_debates")).not_to be_checked
+        expect(user.recommended_debates).to be(false)
       end
     end
   end

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -403,16 +403,33 @@ feature 'Debates' do
 
       background do
         Setting['feature.user.recommendations'] = true
+        Setting['feature.user.recommendations_on_debates'] = true
       end
 
       after do
         Setting['feature.user.recommendations'] = nil
+        Setting['feature.user.recommendations_on_debates'] = nil
       end
 
       scenario 'Debates can not ordered by recommendations when there is not an user logged', :js do
         visit debates_path
 
         expect(page).not_to have_selector('a', text: 'recommendations')
+      end
+
+      scenario 'Show recommended debates on index header' do
+        proposal = create(:proposal, tag_list: "Sport")
+        user = create(:user)
+        create(:follow, followable: proposal, user: user)
+        login_as(user)
+
+        visit debates_path
+
+        expect(page).to have_css('.recommendation', count: 3)
+        expect(page).to have_link "Best"
+        expect(page).to have_link "Medium"
+        expect(page).to have_link "Worst"
+        expect(page).to have_link "See more recommendations"
       end
 
       scenario 'Should display text when there are not recommendeds results', :js do

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -503,6 +503,30 @@ feature 'Debates' do
         expect(page).not_to have_css('.recommendation', count: 3)
         expect(page).not_to have_link('recommendations')
       end
+
+      scenario 'Recommendations shown in index are dismissable', :js do
+        user     = create(:user, recommended_debates: true)
+        proposal = create(:proposal, tag_list: "Sport")
+        create(:follow, followable: proposal, user: user)
+
+        login_as(user)
+
+        visit debates_path
+
+        within("#recommendations") do
+          expect(page).to have_content('Best')
+          expect(page).to have_content('Worst')
+          expect(page).to have_content('Medium')
+          expect(page).to have_css('.recommendation', count: 3)
+
+          find('.icon-x').click
+
+          expect(page).not_to have_content('Best')
+          expect(page).not_to have_content('Worst')
+          expect(page).not_to have_content('Medium')
+          expect(page).not_to have_css('.recommendation', count: 3)
+        end
+      end
     end
   end
 

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -411,13 +411,13 @@ feature 'Debates' do
         Setting['feature.user.recommendations_on_debates'] = nil
       end
 
-      scenario "Debates can't be ordered by recommendations if there's no logged user" do
+      scenario "can't be sorted if there's no logged user" do
         visit debates_path
         expect(page).not_to have_selector('a', text: 'recommendations')
       end
 
-      scenario 'Show recommended debates on index header when user has recommendations enabled' do
-        user     = create(:user, recommended_debates: true)
+      scenario 'are shown on index header when account setting is enabled' do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -431,8 +431,8 @@ feature 'Debates' do
         expect(page).to have_link 'See more recommendations'
       end
 
-      scenario 'Should display text when there are not recommended results' do
-        user     = create(:user, recommended_debates: true)
+      scenario 'should display text when there are no results' do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Distinct_to_sport')
         create(:follow, followable: proposal, user: user)
 
@@ -444,8 +444,8 @@ feature 'Debates' do
         expect(page).to have_content 'There are not debates related to your interests'
       end
 
-      scenario 'Should display text when user has not related interests' do
-        user = create(:user, recommended_debates: true)
+      scenario 'should display text when user has no related interests' do
+        user = create(:user)
 
         login_as(user)
         visit debates_path
@@ -455,8 +455,8 @@ feature 'Debates' do
         expect(page).to have_content 'Follow proposals so we can give you recommendations'
       end
 
-      scenario "Debates are ordered by recommendations when there's an user logged" do
-        user     = create(:user, recommended_debates: true)
+      scenario "can be sorted when there's a logged user" do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -476,8 +476,8 @@ feature 'Debates' do
         expect(current_url).to include('page=1')
       end
 
-      scenario 'are not shown if user does not have recommendations enabled' do
-        user     = create(:user)
+      scenario 'are not shown if account setting is disabled' do
+        user     = create(:user, recommended_debates: false)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -488,8 +488,8 @@ feature 'Debates' do
         expect(page).not_to have_link('recommendations')
       end
 
-      scenario 'Recommendations shown in index are dismissable', :js do
-        user     = create(:user, recommended_debates: true)
+      scenario 'shown on index header are dismissable', :js do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -727,16 +727,33 @@ feature 'Proposals' do
 
       before do
         Setting['feature.user.recommendations'] = true
+        Setting['feature.user.recommendations_on_proposals'] = true
       end
 
       after do
         Setting['feature.user.recommendations'] = nil
+        Setting['feature.user.recommendations_on_proposals'] = nil
       end
 
       scenario 'Proposals can not ordered by recommendations when there is not an user logged', :js do
         visit proposals_path
 
         expect(page).not_to have_selector('a', text: 'recommendations')
+      end
+
+      scenario 'Show recommended proposals on index header' do
+        proposal = create(:proposal, tag_list: "Sport")
+        user = create(:user)
+        create(:follow, followable: proposal, user: user)
+        login_as(user)
+
+        visit proposals_path
+
+        expect(page).to have_css('.recommendation', count: 3)
+        expect(page).to have_link "Best"
+        expect(page).to have_link "Medium"
+        expect(page).to have_link "Worst"
+        expect(page).to have_link "See more recommendations"
       end
 
       scenario 'Should display text when there are not recommendeds results', :js do

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -812,7 +812,7 @@ feature 'Proposals' do
         expect(page).not_to have_link('recommendations')
       end
 
-      scenario 'shown on index header are dismissable', :js do
+      scenario 'are automatically disabled when dismissed from index', :js do
         user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
@@ -826,13 +826,19 @@ feature 'Proposals' do
           expect(page).to have_content('Medium')
           expect(page).to have_css('.recommendation', count: 3)
 
-          find('.icon-x').click
-
-          expect(page).not_to have_content('Best')
-          expect(page).not_to have_content('Worst')
-          expect(page).not_to have_content('Medium')
-          expect(page).not_to have_css('.recommendation', count: 3)
+          accept_confirm { click_link 'Hide recommendations' }
         end
+
+        expect(page).not_to have_link('recommendations')
+        expect(page).not_to have_css('.recommendation', count: 3)
+        expect(page).to have_content('Recommendations for proposals are now disabled for this account')
+
+        user.reload
+
+        visit account_path
+
+        expect(find("#account_recommended_proposals")).not_to be_checked
+        expect(user.recommended_proposals).to be(false)
       end
     end
   end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -735,13 +735,13 @@ feature 'Proposals' do
         Setting['feature.user.recommendations_on_proposals'] = nil
       end
 
-      scenario "Proposals can't be ordered by recommendations if there's no logged user" do
+      scenario "can't be sorted if there's no logged user" do
         visit proposals_path
         expect(page).not_to have_selector('a', text: 'recommendations')
       end
 
-      scenario 'Show recommended proposals on index header when user has recommendations enabled' do
-        user     = create(:user, recommended_proposals: true)
+      scenario 'are shown on index header when account setting is enabled' do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -755,8 +755,8 @@ feature 'Proposals' do
         expect(page).to have_link 'See more recommendations'
       end
 
-      scenario 'Should display text when there are not recommended results' do
-        user     = create(:user, recommended_proposals: true)
+      scenario 'should display text when there are no results' do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Distinct_to_sport')
         create(:follow, followable: proposal, user: user)
 
@@ -768,8 +768,8 @@ feature 'Proposals' do
         expect(page).to have_content 'There are not proposals related to your interests'
       end
 
-      scenario 'Should display text when user has not related interests' do
-        user = create(:user, recommended_proposals: true)
+      scenario 'should display text when user has no related interests' do
+        user = create(:user)
 
         login_as(user)
         visit proposals_path
@@ -779,8 +779,8 @@ feature 'Proposals' do
         expect(page).to have_content 'Follow proposals so we can give you recommendations'
       end
 
-      scenario "Proposals are ordered by recommendations when there's an user logged" do
-        user     = create(:user, recommended_proposals: true)
+      scenario "can be sorted when there's a logged user" do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -800,8 +800,8 @@ feature 'Proposals' do
         expect(current_url).to include('page=1')
       end
 
-      scenario 'are not shown if user does not have recommendations enabled' do
-        user     = create(:user)
+      scenario 'are not shown if account setting is disabled' do
+        user     = create(:user, recommended_proposals: false)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -812,8 +812,8 @@ feature 'Proposals' do
         expect(page).not_to have_link('recommendations')
       end
 
-      scenario 'Recommendations shown in index are dismissable', :js do
-        user     = create(:user, recommended_proposals: true)
+      scenario 'shown on index header are dismissable', :js do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -833,6 +833,30 @@ feature 'Proposals' do
         expect(page).not_to have_css('.recommendation', count: 3)
         expect(page).not_to have_link('recommendations')
       end
+
+      scenario 'Recommendations shown in index are dismissable', :js do
+        user     = create(:user, recommended_proposals: true)
+        proposal = create(:proposal, tag_list: "Sport")
+        create(:follow, followable: proposal, user: user)
+
+        login_as(user)
+
+        visit proposals_path
+
+        within("#recommendations") do
+          expect(page).to have_content('Best')
+          expect(page).to have_content('Worst')
+          expect(page).to have_content('Medium')
+          expect(page).to have_css('.recommendation', count: 3)
+
+          find('.icon-x').click
+
+          expect(page).not_to have_content('Best')
+          expect(page).not_to have_content('Worst')
+          expect(page).not_to have_content('Medium')
+          expect(page).not_to have_css('.recommendation', count: 3)
+        end
+      end
     end
   end
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -721,9 +721,9 @@ feature 'Proposals' do
 
     context 'Recommendations' do
 
-      let!(:best_proposal)   { create(:proposal, title: 'Best',   cached_votes_up: 10, tag_list: "Sport") }
-      let!(:medium_proposal) { create(:proposal, title: 'Medium', cached_votes_up: 5,  tag_list: "Sport") }
-      let!(:worst_proposal)  { create(:proposal, title: 'Worst',  cached_votes_up: 1,  tag_list: "Sport") }
+      let!(:best_proposal)   { create(:proposal, title: 'Best',   cached_votes_up: 10, tag_list: 'Sport') }
+      let!(:medium_proposal) { create(:proposal, title: 'Medium', cached_votes_up: 5,  tag_list: 'Sport') }
+      let!(:worst_proposal)  { create(:proposal, title: 'Worst',  cached_votes_up: 1,  tag_list: 'Sport') }
 
       before do
         Setting['feature.user.recommendations'] = true
@@ -735,71 +735,56 @@ feature 'Proposals' do
         Setting['feature.user.recommendations_on_proposals'] = nil
       end
 
-      scenario 'Proposals can not ordered by recommendations when there is not an user logged' do
+      scenario "Proposals can't be ordered by recommendations if there's no logged user" do
         visit proposals_path
         expect(page).not_to have_selector('a', text: 'recommendations')
       end
 
-      scenario 'Show recommended proposals on index header' do
-        user     = create(:user)
-        proposal = create(:proposal, tag_list: "Sport")
+      scenario 'Show recommended proposals on index header when user has recommendations enabled' do
+        user     = create(:user, recommended_proposals: true)
+        proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
-
-        visit account_path
-
-        expect(page).to have_content('Recommendations')
-        expect(page).to have_content('Show proposals recommendations')
-        expect(find("#account_recommended_proposals")).not_to be_checked
-
-        check 'account_recommended_proposals'
-        click_button 'Save changes'
-
-        expect(find("#account_recommended_proposals")).to be_checked
-
         visit proposals_path
 
         expect(page).to have_css('.recommendation', count: 3)
-        expect(page).to have_link "Best"
-        expect(page).to have_link "Medium"
-        expect(page).to have_link "Worst"
-        expect(page).to have_link "See more recommendations"
+        expect(page).to have_link 'Best'
+        expect(page).to have_link 'Medium'
+        expect(page).to have_link 'Worst'
+        expect(page).to have_link 'See more recommendations'
       end
 
       scenario 'Should display text when there are not recommended results' do
         user     = create(:user, recommended_proposals: true)
-        proposal = create(:proposal, tag_list: "Distinct_to_sport")
+        proposal = create(:proposal, tag_list: 'Distinct_to_sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
-
         visit proposals_path
 
         click_link 'recommendations'
 
-        expect(page).to have_content "There are not proposals related to your interests"
+        expect(page).to have_content 'There are not proposals related to your interests'
       end
 
       scenario 'Should display text when user has not related interests' do
         user = create(:user, recommended_proposals: true)
 
         login_as(user)
-
         visit proposals_path
 
         click_link 'recommendations'
 
-        expect(page).to have_content "Follow proposals so we can give you recommendations"
+        expect(page).to have_content 'Follow proposals so we can give you recommendations'
       end
 
-      scenario 'Proposals are ordered by recommendations when there is an user logged' do
+      scenario "Proposals are ordered by recommendations when there's an user logged" do
         user     = create(:user, recommended_proposals: true)
-        proposal = create(:proposal, tag_list: "Sport")
+        proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
-
         visit proposals_path
 
         click_link 'recommendations'
@@ -815,19 +800,12 @@ feature 'Proposals' do
         expect(current_url).to include('page=1')
       end
 
-      scenario 'Recommendations are not shown if feature is disabled' do
+      scenario 'are not shown if user does not have recommendations enabled' do
         user     = create(:user)
-        proposal = create(:proposal, tag_list: "Sport")
+        proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
-
-        visit account_path
-
-        expect(page).to have_content('Recommendations')
-        expect(page).to have_content('Show proposals recommendations')
-        expect(find("#account_recommended_proposals")).not_to be_checked
-
         visit proposals_path
 
         expect(page).not_to have_css('.recommendation', count: 3)
@@ -836,11 +814,10 @@ feature 'Proposals' do
 
       scenario 'Recommendations shown in index are dismissable', :js do
         user     = create(:user, recommended_proposals: true)
-        proposal = create(:proposal, tag_list: "Sport")
+        proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
         login_as(user)
-
         visit proposals_path
 
         within("#recommendations") do

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -299,4 +299,10 @@ describe Abilities::Common do
       it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
     end
   end
+
+  describe "#disable_recommendations" do
+    it { should be_able_to(:disable_recommendations, Debate) }
+    it { should be_able_to(:disable_recommendations, Proposal) }
+  end
+
 end


### PR DESCRIPTION
References
===================
* **Related issue**: #2212
* **Related PRs**: AyuntamientoMadrid#1521, AyuntamientoMadrid#1562

Objectives
===================
* This is a backport of AyuntamientoMadrid#1521 alongside AyuntamientoMadrid#1562 (requested changes by @decabeza) for debates and proposals recommendations for users based on their interests

Visual Changes
===================
* Settings shown to the user:

![screenshot_2018-06-12_11-55-16](https://user-images.githubusercontent.com/9470839/41302594-dffbd40a-6e38-11e8-847d-1438cd42bf67.png)

* Debates recommendations:

![screenshot_2018-06-12_11-59-16](https://user-images.githubusercontent.com/9470839/41302652-06ec0e2c-6e39-11e8-8309-167a24d012e5.png)

* Proposals recommendations:

![peek 2018-06-12 11-56](https://user-images.githubusercontent.com/9470839/41302685-1c0d5bd0-6e39-11e8-903c-80e53a9d3ec5.gif)

**Note**: If the user dismisses proposals or debates recommendations, its related setting will be automatically disabled (it can be re-enabled later through 'My account' panel)

Notes
===================
* There are two (2) new settings:
  * `Setting['feature.user.recommendations_on_debates']`
  * `Setting['feature.user.recommendations_on_proposals']`

You can enable just one of them (in case you want to offer just one kind of recommendations) or both. `Setting['feature.user.recommendations']` must be enabled first.

* Recommendations are enabled by default for all users

* `rake settings:enable_recommendations` task is now available to enable recommendations for your CONSUL installation

* `rake users:enable_recommendations` task is also available to enable recommendations for existing users