### PR TITLE
Backport Flaky spec: Polls Booth & Website Already voted on booth cannot vote on website

### DIFF
--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -352,15 +352,21 @@ feature 'Polls' do
 
   context 'Booth & Website' do
 
-    let(:poll) { create(:poll, summary: "Summary", description: "Description") }
+    let(:poll) { create(:poll, summary: "Summary", description: "Description", starts_at: '2017-12-01', ends_at: '2018-02-01') }
     let(:booth) { create(:poll_booth) }
     let(:officer) { create(:poll_officer) }
+
+    before do
+      allow(Date).to receive(:current).and_return Date.new(2018,1,1)
+      allow(Date).to receive(:today).and_return Date.new(2018,1,1)
+      allow(Time).to receive(:current).and_return Time.zone.parse("2018-01-01 12:00:00")
+    end
 
     scenario 'Already voted on booth cannot vote on website', :js do
 
       create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
       booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-      create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.current)
       question = create(:poll_question, poll: poll)
       create(:poll_question_answer, question: question, title: 'Han Solo')
       create(:poll_question_answer, question: question, title: 'Chewbacca')


### PR DESCRIPTION
References
===================
- PR: https://github.com/AyuntamientoMadrid/consul/pull/1349
- Issue: https://github.com/AyuntamientoMadrid/consul/issues/1208

Objectives
===================
- Backport to consul the solution found by @iagirre  to the Flaky error:
```1) Polls Booth & Website Already voted on booth cannot vote on website
     Failure/Error: select 'DNI', from: 'residence_document_type'
     Capybara::ElementNotFound:
       Unable to find visible select box "residence_document_type" that is not disabled
     # ./spec/support/common_actions.rb:204:in `officing_verify_residence'
     # ./spec/features/polls/polls_spec.rb:462:in `block (3 levels) in <top (required)>'
```

Visual Changes
===================
- none

Notes
===================
- none