### PR TITLE
Make Community & Communitable truly polymorphic 

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -34,6 +34,6 @@ class CommunitiesController < ApplicationController
   end
 
   def communitable_exists?
-    @community.proposal.present? || @community.investment.present?
+    @community.communitable.present?
   end
 end

--- a/app/helpers/communities_helper.rb
+++ b/app/helpers/communities_helper.rb
@@ -1,9 +1,9 @@
 module CommunitiesHelper
   def community_back_link_path(community)
     if community.from_proposal?
-      proposal_path(community.proposal)
+      proposal_path(community.communitable)
     else
-      budget_investment_path(community.investment.budget_id, community.investment)
+      budget_investment_path(community.communitable.budget_id, community.communitable)
     end
   end
 

--- a/app/helpers/communities_helper.rb
+++ b/app/helpers/communities_helper.rb
@@ -1,35 +1,10 @@
 module CommunitiesHelper
-
-  def community_title(community)
-    community.from_proposal? ? community.proposal.title : community.investment.title
-  end
-
-  def community_text(community)
-    community.from_proposal? ? t("community.show.title.proposal") : t("community.show.title.investment")
-  end
-
-  def community_description(community)
-    community.from_proposal? ? t("community.show.description.proposal") : t("community.show.description.investment")
-  end
-
-  def author?(community, participant)
-    if community.from_proposal?
-      community.proposal.author_id == participant.id
-    else
-      community.investment.author_id == participant.id
-    end
-  end
-
   def community_back_link_path(community)
     if community.from_proposal?
       proposal_path(community.proposal)
     else
       budget_investment_path(community.investment.budget_id, community.investment)
     end
-  end
-
-  def community_access_text(community)
-    community.from_proposal? ? t("community.sidebar.description.proposal") : t("community.sidebar.description.investment")
   end
 
   def create_topic_link(community)

--- a/app/helpers/communities_helper.rb
+++ b/app/helpers/communities_helper.rb
@@ -1,6 +1,6 @@
 module CommunitiesHelper
   def community_back_link_path(community)
-    if community.from_proposal?
+    if community.communitable_type == "Proposal"
       proposal_path(community.communitable)
     else
       budget_investment_path(community.communitable.budget_id, community.communitable)

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -14,6 +14,18 @@ class Community < ActiveRecord::Base
     proposal.present?
   end
 
+  def communitable
+    from_proposal? ? proposal : investment
+  end
+
+  def communitable_type
+    communitable.class.name
+  end
+
+  def communitable_key
+    communitable_type.split("::").last.underscore
+  end
+
   private
 
   def users_who_commented

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,6 +1,5 @@
 class Community < ActiveRecord::Base
-  has_one :proposal
-  has_one :investment, class_name: Budget::Investment
+  belongs_to :communitable, polymorphic: true
   has_many :topics
 
   def participants
@@ -11,19 +10,25 @@ class Community < ActiveRecord::Base
   end
 
   def from_proposal?
-    proposal.present?
-  end
-
-  def communitable
-    from_proposal? ? proposal : investment
-  end
-
-  def communitable_type
-    communitable.class.name
+    communitable_type == "Proposal"
   end
 
   def communitable_key
     communitable_type.split("::").last.underscore
+  end
+
+  # @deprecated Please use {#communitable} instead
+  def proposal
+    warn "[DEPRECATION] `Community#proposal` is deprecated. " +
+         "Please use `Community#communitable` instead."
+    communitable
+  end
+
+  # @deprecated Please use {#communitable} instead
+  def investment
+    warn "[DEPRECATION] `Community#investment` is deprecated. " +
+         "Please use `Community#communitable` instead."
+    communitable
   end
 
   private

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -9,10 +9,6 @@ class Community < ActiveRecord::Base
     users_participants.uniq
   end
 
-  def from_proposal?
-    communitable_type == "Proposal"
-  end
-
   def communitable_key
     communitable_type.split("::").last.underscore
   end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -40,7 +40,7 @@ class Community < ActiveRecord::Base
   end
 
   def author_from_community
-    from_proposal? ? User.where(id: proposal&.author_id) : User.where(id: investment&.author_id)
+    User.where(id: communitable&.author_id)
   end
 
 end

--- a/app/models/concerns/communitable.rb
+++ b/app/models/concerns/communitable.rb
@@ -2,12 +2,15 @@ module Communitable
   extend ActiveSupport::Concern
 
   included do
-    belongs_to :community
+    has_one :community, as: :communitable
     before_create :associate_community
   end
 
   def associate_community
     community = Community.create
+    self.community = community
+
+    # TODO: remove once databases migrate to communitable columns.
     self.community_id = community.id
   end
 

--- a/app/views/communities/_access_button.html.erb
+++ b/app/views/communities/_access_button.html.erb
@@ -2,7 +2,7 @@
   <div class="sidebar-divider"></div>
   <h2><%= t("community.sidebar.title") %></h2>
   <p>
-    <%= community_access_text(community) %>
+    <%= t("community.sidebar.description.#{community.communitable_key}") %>
   </p>
   <%= link_to t("community.sidebar.button_to_access"), community_path(community.id), class: 'button hollow expanded' %>
 <% end %>

--- a/app/views/communities/_participant.html.erb
+++ b/app/views/communities/_participant.html.erb
@@ -9,7 +9,7 @@
         <%= link_to participant.name, user_path(participant)%>
       </span>
 
-      <% if author?(@community, participant) %>
+      <% if @community.communitable.author_id == participant.id %>
         &nbsp;&bull;&nbsp;
         <span class="label round is-author">
             <%= t("comments.comment.author") %>

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -3,12 +3,12 @@
   <div class="jumbo light">
     <div class="row">
       <div class="small-12 column">
-        <span class="uppercase"><%= community_text(@community) %></span>
-        <h2><%= link_to community_title(@community), community_back_link_path(@community) %></h2>
+        <span class="uppercase"><%= t("community.show.title.#{@community.communitable_key}") %></span>
+        <h2><%= link_to @community.communitable.title, community_back_link_path(@community) %></h2>
       </div>
 
       <div class="small-12 medium-9 column end">
-        <p><%= community_description(@community) %></p>
+        <p><%= t("community.show.description.#{@community.communitable_key}") %></p>
       </div>
     </div>
   </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -3,8 +3,8 @@
     <div class="small-12 medium-9 column">
 
       <%= back_link_to community_path(@community), t("community.show.back",
-                       community: community_text(@community),
-                       proposal: community_title(@community)) %>
+                       community: t("community.show.title.#{@community.communitable_key}"),
+                       proposal: @community.communitable.title) %>
 
       <h1><%= @topic.title %></h1>
 

--- a/db/dev_seeds/communities.rb
+++ b/db/dev_seeds/communities.rb
@@ -1,8 +1,3 @@
-section "Creating Communities" do
-  Proposal.all.each { |proposal| proposal.update(community: Community.create) }
-  Budget::Investment.all.each { |investment| investment.update(community: Community.create) }
-end
-
 section "Creating Communities Topics" do
   Community.all.each do |community|
     Topic.create(community: community, author: User.all.sample,

--- a/db/migrate/20180717122620_add_communitable_to_community.rb
+++ b/db/migrate/20180717122620_add_communitable_to_community.rb
@@ -1,0 +1,6 @@
+class AddCommunitableToCommunity < ActiveRecord::Migration
+  def change
+    add_column :communities, :communitable_id, :integer
+    add_column :communities, :communitable_type, :string
+  end
+end

--- a/db/migrate/20180723093127_remove_community_id_foreign_key.rb
+++ b/db/migrate/20180723093127_remove_community_id_foreign_key.rb
@@ -1,0 +1,6 @@
+class RemoveCommunityIdForeignKey < ActiveRecord::Migration
+  def change
+    remove_foreign_key "proposals", "communities"
+    remove_foreign_key "budget_investments", "communities"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -314,8 +314,10 @@ ActiveRecord::Schema.define(version: 20180718115545) do
   add_index "comments", ["valuation"], name: "index_comments_on_valuation", using: :btree
 
   create_table "communities", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.integer  "communitable_id"
+    t.string   "communitable_type"
   end
 
   create_table "debates", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180718115545) do
+ActiveRecord::Schema.define(version: 20180723093127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1308,7 +1308,6 @@ ActiveRecord::Schema.define(version: 20180718115545) do
   add_foreign_key "administrators", "users"
   add_foreign_key "annotations", "legacy_legislations"
   add_foreign_key "annotations", "users"
-  add_foreign_key "budget_investments", "communities"
   add_foreign_key "documents", "users"
   add_foreign_key "failed_census_calls", "poll_officers"
   add_foreign_key "failed_census_calls", "users"
@@ -1340,7 +1339,6 @@ ActiveRecord::Schema.define(version: 20180718115545) do
   add_foreign_key "poll_recounts", "poll_booth_assignments", column: "booth_assignment_id"
   add_foreign_key "poll_recounts", "poll_officer_assignments", column: "officer_assignment_id"
   add_foreign_key "poll_voters", "polls"
-  add_foreign_key "proposals", "communities"
   add_foreign_key "related_content_scores", "related_contents"
   add_foreign_key "related_content_scores", "users"
   add_foreign_key "users", "geozones"

--- a/lib/tasks/communities.rake
+++ b/lib/tasks/communities.rake
@@ -18,4 +18,27 @@ namespace :communities do
     end
   end
 
+  desc "Migrate communitable data to communitable columns"
+  task migrate_communitable: :environment do
+    (Proposal.all + Budget::Investment.all).each do |communitable|
+      if communitable.community_id.present?
+        community = Community.where(id: communitable.community_id).first
+
+        if community
+          community.update(
+            communitable_id:    communitable.id,
+            communitable_type:  communitable.class.name
+          )
+        else
+          warn "WARNING: The community associated to #{communitable.class.name} "\
+               "with ID #{communitable.id} no longer exists. "\
+               "Consider running `rake communities: associate_community`"
+        end
+      else
+        warn "WARNING: #{communitable.class.name} with ID #{communitable.id} "\
+             "should have an associated community. "\
+             "Consider running `rake communities: associate_community`"
+      end
+    end
+  end
 end

--- a/lib/tasks/communities.rake
+++ b/lib/tasks/communities.rake
@@ -5,15 +5,13 @@ namespace :communities do
 
     Proposal.all.each do |proposal|
       if proposal.community.blank?
-        community = Community.create
-        proposal.update(community_id: community.id)
+        proposal.update(community: Community.create)
       end
     end
 
     Budget::Investment.all.each do |investment|
       if investment.community.blank?
-        community = Community.create
-        investment.update(community_id: community.id)
+        investment.update(community: Community.create)
       end
     end
   end

--- a/spec/features/topics_specs.rb
+++ b/spec/features/topics_specs.rb
@@ -121,7 +121,7 @@ feature 'Topics' do
 
       visit community_topic_path(community, topic)
 
-      expect(page).to have_content community.proposal.title
+      expect(page).to have_content proposal.title
       expect(page).to have_content topic.title
     end
 

--- a/spec/lib/tasks/communities_spec.rb
+++ b/spec/lib/tasks/communities_spec.rb
@@ -18,7 +18,7 @@ describe 'Communities Rake' do
 
       it 'When proposal has not community_id' do
         proposal = create(:proposal)
-        proposal.update(community_id: nil)
+        proposal.update(community: nil)
         expect(proposal.community).to be_nil
 
         run_rake_task
@@ -32,7 +32,7 @@ describe 'Communities Rake' do
 
       it 'When budget investment has not community_id' do
         investment = create(:budget_investment)
-        investment.update(community_id: nil)
+        investment.update(community: nil)
         expect(investment.community).to be_nil
 
         run_rake_task

--- a/spec/lib/tasks/communities_spec.rb
+++ b/spec/lib/tasks/communities_spec.rb
@@ -2,13 +2,12 @@ require 'rails_helper'
 require 'rake'
 
 describe 'Communities Rake' do
+  before do
+    Rake.application.rake_require "tasks/communities"
+    Rake::Task.define_task(:environment)
+  end
 
   describe '#associate_community' do
-
-    before do
-      Rake.application.rake_require "tasks/communities"
-      Rake::Task.define_task(:environment)
-    end
 
     let :run_rake_task do
       Rake::Task['communities:associate_community'].reenable
@@ -46,4 +45,79 @@ describe 'Communities Rake' do
 
   end
 
+  describe "#migrate_communitable" do
+    let :run_rake_task do
+      Rake::Task["communities:migrate_communitable"].reenable
+      Rake.application.invoke_task "communities:migrate_communitable"
+    end
+
+    context "Associate community to Proposal" do
+      let(:proposal) { create(:proposal) }
+      let(:community) { proposal.community }
+
+      context "Community has no communitable_id" do
+        before { community.update(communitable_id: nil, communitable_type: nil) }
+
+        it "assigns the communitable_id" do
+          run_rake_task
+          community.reload
+          expect(community.communitable_id).to eq proposal.id
+          expect(community.communitable_type).to eq "Proposal"
+        end
+      end
+
+      context "Proposal has no community_id" do
+        before { proposal.update_column(:community_id, nil) }
+
+        it "writes a warning with the proposal id" do
+          warning = /Proposal(.+)#{proposal.id}(.+)should have an associated/
+          expect { run_rake_task }.to output(warning).to_stderr
+        end
+      end
+
+      context "The proposal community doesn't exist anymore" do
+        before { community.destroy }
+
+        it "writes a warning with the proposal id" do
+          warning = /community(.+)Proposal(.+)#{proposal.id}(.+)no longer exists/
+          expect { run_rake_task }.to output(warning).to_stderr
+        end
+      end
+    end
+
+    context "Associate community to Budget Investment" do
+      let(:investment) { create(:budget_investment) }
+      let(:community) { investment.community }
+
+      context "Community has no communitable_id" do
+        before { community.update(communitable_id: nil, communitable_type: nil) }
+
+        it "assigns the communitable_id" do
+          run_rake_task
+          community.reload
+          expect(community.communitable_id).to eq investment.id
+          expect(community.communitable_type).to eq "Budget::Investment"
+        end
+      end
+
+      context "Investment has no community_id" do
+        before { investment.update_column(:community_id, nil) }
+
+        it "writes a warning with the investment id" do
+          warning = /Investment(.+)#{investment.id}(.+)should have an associated/
+          expect { run_rake_task }.to output(warning).to_stderr
+        end
+      end
+
+      context "The investment community doesn't exist anymore" do
+        before { community.destroy }
+
+        it "writes a warning with the investment id" do
+          warning = /community(.+)Investment(.+)#{investment.id}(.+)no longer exists/
+          expect { run_rake_task }.to output(warning).to_stderr
+        end
+      end
+    end
+
+  end
 end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -5,6 +5,7 @@ describe Budget::Investment do
 
   describe "Concerns" do
     it_behaves_like "notifiable"
+    it_behaves_like "communitable"
   end
 
   it "is valid" do

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -26,4 +26,41 @@ RSpec.describe Community, type: :model do
       expect(community.participants).to include(proposal.author)
     end
   end
+
+  # TODO: remove the trivial ones after migrating to a polymorphic association.
+  describe "#communitable" do
+    context "from proposal" do
+      let(:proposal) { create(:proposal) }
+      let(:community) { proposal.community }
+
+      it "returns the proposal as communitable" do
+        expect(community.communitable).to be(proposal)
+      end
+
+      it "returns proposal as communitable type" do
+        expect(community.communitable_type).to eq "Proposal"
+      end
+
+      it "returns proposal as communitable key" do
+        expect(community.communitable_key).to eq "proposal"
+      end
+    end
+
+    context "from investment" do
+      let(:investment) { create(:budget_investment) }
+      let(:community) { investment.community }
+
+      it "returns the investment as communitable" do
+        expect(community.communitable).to be(investment)
+      end
+
+      it "returns budget investment as communitable type" do
+        expect(community.communitable_type).to eq "Budget::Investment"
+      end
+
+      it "returns investment as communitable key" do
+        expect(community.communitable_key).to eq "investment"
+      end
+    end
+  end
 end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -27,19 +27,10 @@ RSpec.describe Community, type: :model do
     end
   end
 
-  # TODO: remove the trivial ones after migrating to a polymorphic association.
-  describe "#communitable" do
+  describe "#communitable_key" do
     context "from proposal" do
       let(:proposal) { create(:proposal) }
       let(:community) { proposal.community }
-
-      it "returns the proposal as communitable" do
-        expect(community.communitable).to be(proposal)
-      end
-
-      it "returns proposal as communitable type" do
-        expect(community.communitable_type).to eq "Proposal"
-      end
 
       it "returns proposal as communitable key" do
         expect(community.communitable_key).to eq "proposal"
@@ -49,14 +40,6 @@ RSpec.describe Community, type: :model do
     context "from investment" do
       let(:investment) { create(:budget_investment) }
       let(:community) { investment.community }
-
-      it "returns the investment as communitable" do
-        expect(community.communitable).to be(investment)
-      end
-
-      it "returns budget investment as communitable type" do
-        expect(community.communitable_type).to eq "Budget::Investment"
-      end
 
       it "returns investment as communitable key" do
         expect(community.communitable_key).to eq "investment"

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -8,6 +8,7 @@ describe Proposal do
     it_behaves_like "has_public_author"
     it_behaves_like "notifiable"
     it_behaves_like "map validations"
+    it_behaves_like "communitable"
   end
 
   it "is valid" do

--- a/spec/shared/models/communitable.rb
+++ b/spec/shared/models/communitable.rb
@@ -1,0 +1,28 @@
+shared_examples "communitable" do
+
+  let(:communitable) { create(model_name(described_class)) }
+  let(:community) { communitable.community }
+
+  describe "#associate_community" do
+    it "creates the community" do
+      expect(community.new_record?).to be false
+    end
+
+    it "makes the polymorphic association work automatically" do
+      expect(community.communitable).to eq communitable
+    end
+
+    it "assigns the community id to the communitable object" do
+      expect(communitable.community_id).to eq community.id
+    end
+
+    it "assigns the communitable id to the community" do
+      expect(community.communitable_id).to eq communitable.id
+    end
+
+    it "assigns the communitable type to the community" do
+      expect(community.communitable_type).to eq communitable.class.name
+    end
+  end
+
+end


### PR DESCRIPTION
# References

* Issue #2361

# Context

Both proposals and budget investments have communities. However, their relationship in the database isn't properly defined, which makes it difficult to know when a community belongs to a proposal and when a community belongs to a budget investment. That leads to complex code to circumvent this lack of relationship.

# Objectives

Make a polymorphic relationship between community and communitable models in order to simplify the code and make it easier to add new communitable models in the future.

# Pending questions

* `Legislation::Proposal` includes `Communitable`, but I haven't found any references to communities there, nor to legislation proposals in communities. Is there something I'm missing?
* The I18n keys used in this section use the key `investment`. Other sections use `budget_investment`, and Active Record uses `budget/investment`. Although it would be easier to use `budget/investment here`, I've left the original `investment` key because I don't know the impact changing a key could have on the CONSUL community. Is it usually safe to change a translation key, or is it recommended not to do so?
* I've removed some helper methods but then I've realized some forks might be using those methods somewhere else. Is it safe to remove them, or shall we keep them in order to maintain the API?

# Notes

* :warning: After applying these changes, run `rake communities:migrate_communitable`.
* The method `communitable_key` is in the model, although similar funcionality was originally in the helper. IMHO the method doesn't belong in the model nor the helper, but since we aren't using classes like decorators, I've left it there.
* The `community_back_link_path` method is very hard to refactor, since the `budget_investment_path` method requires both the budget and the investment. I've left it (mostly) the same way it was.
* I thought implementing #2360 as well would be trivial, but it isn't :smile:, since usually we don't really destroy communitable objects but only hide them. So I haven't done anything related to that issue.

# Deprecation warnings:

Release v0.17 should include two warnings in the changelog:

* The column `community_id` from `proposals` and `budget_investments` will be removed in v0.18. Run `rake communities:migrate_communitable`.
* The methods `Community#proposal` and `Community#investment` are deprecated and will be removed in v0.18.