### PR TITLE
Fix validation error when creating proposals without user verification

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -36,12 +36,12 @@ class Proposal < ActiveRecord::Base
   validates :question, presence: true
   validates :summary, presence: true
   validates :author, presence: true
-  validates :responsible_name, presence: true
+  validates :responsible_name, presence: true, unless: :skip_user_verification?
 
   validates :title, length: { in: 4..Proposal.title_max_length }
   validates :description, length: { maximum: Proposal.description_max_length }
   validates :question, length: { in: 10..Proposal.question_max_length }
-  validates :responsible_name, length: { in: 6..Proposal.responsible_name_max_length }
+  validates :responsible_name, length: { in: 6..Proposal.responsible_name_max_length }, unless: :skip_user_verification?
   validates :retired_reason, inclusion: { in: RETIRE_OPTIONS, allow_nil: true }
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
@@ -212,6 +212,10 @@ class Proposal < ActiveRecord::Base
     orders = %w{hot_score confidence_score created_at relevance archival_date}
     orders << "recommendations" if Setting['feature.user.recommendations_on_proposals'] && user&.recommended_proposals
     return orders
+  end
+
+  def skip_user_verification?
+    Setting["feature.user.skip_verification"].present?
   end
 
   protected

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1804,4 +1804,40 @@ feature 'Successful proposals' do
     end
 
   end
+
+  context "Skip user verification" do
+
+    before do
+      Setting["feature.user.skip_verification"] = 'true'
+    end
+
+    after do
+      Setting["feature.user.skip_verification"] = nil
+    end
+
+    scenario "Create" do
+      author = create(:user)
+      login_as(author)
+
+      visit proposals_path
+
+      within('aside') do
+        click_link 'Create a proposal'
+      end
+
+      expect(current_path).to eq(new_proposal_path)
+
+      fill_in 'proposal_title', with: 'Help refugees'
+      fill_in 'proposal_summary', with: 'In summary what we want is...'
+      fill_in 'proposal_description', with: 'This is very important because...'
+      fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
+      fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yPQfcG-eimk'
+      fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
+      check 'proposal_terms_of_service'
+
+      click_button 'Create proposal'
+
+      expect(page).to have_content 'Proposal created successfully.'
+    end
+  end
 end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1829,6 +1829,7 @@ feature 'Successful proposals' do
 
       fill_in 'proposal_title', with: 'Help refugees'
       fill_in 'proposal_summary', with: 'In summary what we want is...'
+      fill_in 'proposal_question', with: 'Would you like to?'
       fill_in 'proposal_description', with: 'This is very important because...'
       fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yPQfcG-eimk'


### PR DESCRIPTION
References
===================
**Issue: https://github.com/consul/consul/issues/2700**
**Backport: https://github.com/AyuntamientoMadrid/consul/pull/1574**

What
===
Allow empty responsible names when skipping user verification

Why
===
We are getting a [validation error](https://github.com/consul/consul/blob/master/app/models/proposal.rb#L44) when creating proposals, which is not displayed correctly in the page, as this field is not present in the form, only in the [model](https://github.com/consul/consul/blob/master/app/models/proposal.rb#L220)

Visual Changes
===================
None

Notes
===================
None