### PR TITLE
Failing back to knapsack from knapsack pro

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :development, :test do
   gem 'factory_bot_rails', '~> 4.8.2'
   gem 'faker', '~> 1.8.7'
   gem 'i18n-tasks', '~> 0.9.20'
-  gem 'knapsack_pro', '~> 0.53.0'
+  gem 'knapsack'
   gem 'launchy', '~> 2.4.3'
   gem 'letter_opener_web', '~> 1.3.2'
   gem 'quiet_assets', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
     kgio (2.11.1)
-    knapsack_pro (0.53.0)
+    knapsack (1.15.0)
       rake
     kramdown (1.14.0)
     launchy (2.4.3)
@@ -538,7 +538,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3.1)
   jquery-ui-rails (~> 6.0.1)
   kaminari (~> 1.1.1)
-  knapsack_pro (~> 0.53.0)
+  knapsack
   launchy (~> 2.4.3)
   letter_opener_web (~> 1.3.2)
   mdl (~> 0.4.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'factory_bot_rails'
 require 'database_cleaner'
 require 'email_spec'
 require 'devise'
-require 'knapsack_pro'
+require 'knapsack'
 
 Dir["./spec/models/concerns/*.rb"].each { |f| require f }
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
@@ -117,4 +117,4 @@ RSpec.configure do |config|
 end
 
 # Parallel build helper configuration for travis
-KnapsackPro::Adapters::RSpecAdapter.bind
+Knapsack::Adapters::RSpecAdapter.bind


### PR DESCRIPTION
The spec distribution in the Travis matrix is getting out of sync, and
some builds are running for over an hour for some forks
https://travis-ci.org/medialab-prado/consul/builds/405391781

With this commit we are falling back to knapsack to be able to execute
the command[1] to regenerate the spec distribution[1]

[1] `KNAPSACK_GENERATE_REPORT=true bundle exec rspec spec`
[2]
https://github.com/consul/consul/blob/master/knapsack_rspec_report.json

References
===================
> Add references to related Issues/Pull Requests/Travis Builds/Rollbar errors/etc...

Objectives
===================
> What are the objectives of this changes? (If there is no related Issue with an explanation)

Visual Changes
===================
> Any visual changes? please attach screenshots (or gifs) showing them.
> If modified views are public (not the admin panel), try them in mobile display (with your browser's developer console) and add screenshots.

Notes
===================
> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
> Explain any caveats, or important things to notice like deprecations (if any).
