### PR TITLE
Add logic to show only winner investments if budget is finished

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -32,7 +32,11 @@ module Budgets
     respond_to :html, :js
 
     def index
-      @investments = investments.page(params[:page]).per(10).for_render
+      if @budget.finished?
+        @investments = investments.winners.page(params[:page]).per(10).for_render
+      else
+        @investments = investments.page(params[:page]).per(10).for_render
+      end
 
       @investment_ids = @investments.pluck(:id)
       load_investment_votes(@investments)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -146,6 +146,8 @@ class Budget < ActiveRecord::Base
       %w{random}
     when 'publishing_prices', 'balloting', 'reviewing_ballots'
       %w{random price}
+    when 'finished'
+      %w{random}
     else
       %w{random confidence_score}
     end
@@ -193,5 +195,3 @@ class Budget < ActiveRecord::Base
     slug.nil? || drafting?
   end
 end
-
-

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -883,6 +883,10 @@ feature 'Budget Investments' do
           expect(page).to have_content(investment.formatted_price)
           expect(page).to have_content(investment.price_explanation)
 
+          if budget.finished?
+            investment.update(winner: true)
+          end
+
           visit budget_investments_path(budget)
 
           expect(page).to have_content(investment.formatted_price)

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -681,6 +681,20 @@ feature 'Budget Investments' do
       end
     end
 
+    scenario 'Order is random if budget is finished' do
+      10.times { create(:budget_investment) }
+
+      budget.update(phase: 'finished')
+
+      visit budget_investments_path(budget, heading_id: heading.id)
+      order = all(".budget-investment h3").collect {|i| i.text }
+
+      visit budget_investments_path(budget, heading_id: heading.id)
+      new_order = eq(all(".budget-investment h3").collect {|i| i.text })
+
+      expect(order).not_to eq(new_order)
+    end
+
     def investments_order
       all(".budget-investment h3").collect {|i| i.text }
     end
@@ -1114,6 +1128,20 @@ feature 'Budget Investments' do
     within("#tab-milestones") do
       expect(page).to have_content("Don't have defined milestones")
     end
+  end
+
+  scenario "Only winner investments are show when budget is finished" do
+    3.times { create(:budget_investment, heading: heading) }
+
+    Budget::Investment.first.update(feasibility: 'feasible', selected: true, winner: true)
+    Budget::Investment.second.update(feasibility: 'feasible', selected: true, winner: true)
+    budget.update(phase: 'finished')
+
+    visit budget_investments_path(budget, heading_id: heading.id)
+
+    expect(page).to have_content("#{Budget::Investment.first.title}")
+    expect(page).to have_content("#{Budget::Investment.second.title}")
+    expect(page).not_to have_content("#{Budget::Investment.third.title}")
   end
 
   it_behaves_like "followable", "budget_investment", "budget_investment_path", { "budget_id": "budget_id", "id": "id" }

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -299,6 +299,12 @@ feature 'Tags' do
           investment.update(selected: true, feasibility: "feasible")
         end
 
+        if budget.finished?
+          [investment1, investment2, investment3].each do |investment|
+            investment.update(selected: true, feasibility: "feasible", winner: true)
+          end
+        end
+
         login_as(admin) if budget.drafting?
         visit budget_path(budget)
         click_link group.name


### PR DESCRIPTION
References
===================
 - Addresses issue https://github.com/AyuntamientoMadrid/consul/issues/1570
 - Backport of https://github.com/AyuntamientoMadrid/consul/issues/1571

Objectives
===================
From original PR https://github.com/AyuntamientoMadrid/consul/issues/1571:
> In `/budgets/[:budget_id]/[:group_id]/[:heading_id]` show only those investments that won when the budget is finished ordered randomly.