### PR TITLE
Fixes word wrap on document links

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2502,10 +2502,6 @@ table {
     padding: 0 $line-height / 2;
     position: relative;
 
-    a {
-      word-wrap: break-word;
-    }
-
     .icon-document {
       color: #007bb7;
       display: inline-block;
@@ -2518,6 +2514,10 @@ table {
       margin-bottom: 0;
     }
   }
+}
+
+.document-link a {
+  word-wrap: break-word;
 }
 
 .additional-document-link {


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1578

Objectives
===================
This PR fixes word wrap on (long) document links.

Visual Changes
===================
**BEFORE long links overlay sidebar**
![long_link](https://user-images.githubusercontent.com/631897/43134492-85877d8c-8f42-11e8-8377-927c9bf5c5fd.png)

**AFTER word wrap fixed for long links**
![fixed](https://user-images.githubusercontent.com/631897/43134496-8a2c7054-8f42-11e8-836a-4493afd42df8.png)

