### PR TITLE
Fixes tags budget investments specs

### DIFF
--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -254,6 +254,12 @@ feature 'Tags' do
           investment.update(selected: true, feasibility: "feasible")
         end
 
+        if budget.finished?
+          [investment1, investment2, investment3].each do |investment|
+            investment.update(selected: true, feasibility: "feasible", winner: true)
+          end
+        end
+
         login_as(admin) if budget.drafting?
         visit budget_path(budget)
         click_link group.name


### PR DESCRIPTION
References
===================
Continue with PR https://github.com/consul/consul/pull/2782

Objectives
===================
Fixes tags budget investments specs. 

The previous PR is a backport for Madrid's fork where this specs are marked as `xscenario` (temporally we are hiding `shared/tag_cloud` partial on budget investments index sidebar). This PR fixes this specs for CONSUL 🎉 
