### PR TITLE
Fix flaky spec: Moderate proposal notifications Hide

### DIFF
--- a/spec/features/moderation/proposal_notifications_spec.rb
+++ b/spec/features/moderation/proposal_notifications_spec.rb
@@ -16,7 +16,7 @@ feature 'Moderate proposal notifications' do
       accept_confirm { click_link 'Hide' }
     end
 
-    expect(page).to have_css("#proposal_notification_#{proposal.id}.faded")
+    expect(page).to have_css("#proposal_notification_#{proposal_notification.id}.faded")
 
     logout
     login_as(citizen)


### PR DESCRIPTION
# References

* Issue #2769

# Objectives

Fix the flaky spec that appeared in `spec/features/moderation/proposal_notifications_spec.rb:19` ("Moderate proposal notifications Hide").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

There was a typo in these lines:

```ruby
within("#proposal_notification_#{proposal_notification.id}") do
  accept_confirm { click_link 'Hide' }
end

expect(page).to have_css("#proposal_notification_#{proposal.id}.faded")
```
The last line references `proposal.id` instead of `proposal_notification.id`. Sometimes the test passes because sometimes both IDs are equal, but that isn't always the case.

## Explain why your PR fixes it

Using `proposal_notification.id` in both cases solves the problem.