### PR TITLE
Add visible_to_valuators and author_username to admin investments CSV

### DIFF
--- a/app/models/budget/investment/exporter.rb
+++ b/app/models/budget/investment/exporter.rb
@@ -25,7 +25,9 @@ class Budget::Investment::Exporter
       I18n.t("admin.budget_investments.index.list.geozone"),
       I18n.t("admin.budget_investments.index.list.feasibility"),
       I18n.t("admin.budget_investments.index.list.valuation_finished"),
-      I18n.t("admin.budget_investments.index.list.selected")
+      I18n.t("admin.budget_investments.index.list.selected"),
+      I18n.t("admin.budget_investments.index.list.visible_to_valuators"),
+      I18n.t("admin.budget_investments.index.list.author_username")
     ]
   end
 
@@ -40,7 +42,9 @@ class Budget::Investment::Exporter
       investment.heading.name,
       price(investment),
       investment.valuation_finished? ? I18n.t('shared.yes') : I18n.t('shared.no'),
-      investment.selected? ? I18n.t('shared.yes') : I18n.t('shared.no')
+      investment.selected? ? I18n.t('shared.yes') : I18n.t('shared.no'),
+      investment.visible_to_valuators? ? I18n.t('shared.yes') : I18n.t('shared.no'),
+      investment.author.username
     ]
   end
 

--- a/app/models/budget/investment/exporter.rb
+++ b/app/models/budget/investment/exporter.rb
@@ -16,16 +16,16 @@ class Budget::Investment::Exporter
 
   def headers
     [
-      I18n.t("admin.budget_investments.index.table_id"),
-      I18n.t("admin.budget_investments.index.table_title"),
-      I18n.t("admin.budget_investments.index.table_supports"),
-      I18n.t("admin.budget_investments.index.table_admin"),
-      I18n.t("admin.budget_investments.index.table_valuator"),
-      I18n.t("admin.budget_investments.index.table_valuation_group"),
-      I18n.t("admin.budget_investments.index.table_geozone"),
-      I18n.t("admin.budget_investments.index.table_feasibility"),
-      I18n.t("admin.budget_investments.index.table_valuation_finished"),
-      I18n.t("admin.budget_investments.index.table_selection")
+      I18n.t("admin.budget_investments.index.list.id"),
+      I18n.t("admin.budget_investments.index.list.title"),
+      I18n.t("admin.budget_investments.index.list.supports"),
+      I18n.t("admin.budget_investments.index.list.admin"),
+      I18n.t("admin.budget_investments.index.list.valuator"),
+      I18n.t("admin.budget_investments.index.list.valuation_group"),
+      I18n.t("admin.budget_investments.index.list.geozone"),
+      I18n.t("admin.budget_investments.index.list.feasibility"),
+      I18n.t("admin.budget_investments.index.list.valuation_finished"),
+      I18n.t("admin.budget_investments.index.list.selected")
     ]
   end
 

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -35,21 +35,21 @@
   <table class="table-for-mobile">
     <thead>
       <tr>
-        <th><%= t("admin.budget_investments.index.table_id") %></th>
-        <th class="small-3"><%= t("admin.budget_investments.index.table_title") %></th>
-        <th><%= t("admin.budget_investments.index.table_supports") %></th>
-        <th><%= t("admin.budget_investments.index.table_admin") %></th>
+        <th><%= t("admin.budget_investments.index.index.list.id") %></th>
+        <th class="small-3"><%= t("admin.budget_investments.index.list.title") %></th>
+        <th><%= t("admin.budget_investments.index.list.supports") %></th>
+        <th><%= t("admin.budget_investments.index.list.admin") %></th>
         <th>
-          <%= t("admin.budget_investments.index.table_valuation_group") %>
-          <%= t("admin.budget_investments.index.table_valuator") %>
+          <%= t("admin.budget_investments.index.list.valuation_group") %>
+          <%= t("admin.budget_investments.index.list.valuator") %>
         </th>
-        <th><%= t("admin.budget_investments.index.table_geozone") %></th>
-        <th><%= t("admin.budget_investments.index.table_feasibility") %></th>
-        <th class="text-center"><%= t("admin.budget_investments.index.table_valuation_finished") %></th>
-        <th class="text-center"><%= t("admin.budget_investments.index.table_evaluation") %></th>
-        <th class="text-center"><%= t("admin.budget_investments.index.table_selection") %></th>
+        <th><%= t("admin.budget_investments.index.list.geozone") %></th>
+        <th><%= t("admin.budget_investments.index.list.feasibility") %></th>
+        <th class="text-center"><%= t("admin.budget_investments.index.list.valuation_finished") %></th>
+        <th class="text-center"><%= t("admin.budget_investments.index.list.visible_to_valuators") %></th>
+        <th class="text-center"><%= t("admin.budget_investments.index.list.selected") %></th>
         <% if params[:filter]  == "selected" %>
-          <th class="text-center"><%= t("admin.budget_investments.index.table_incompatible") %></th>
+          <th class="text-center"><%= t("admin.budget_investments.index.list.incompatible") %></th>
         <% end %>
       </tr>
     </thead>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -35,7 +35,7 @@
   <table class="table-for-mobile">
     <thead>
       <tr>
-        <th><%= t("admin.budget_investments.index.index.list.id") %></th>
+        <th><%= t("admin.budget_investments.index.list.id") %></th>
         <th class="small-3"><%= t("admin.budget_investments.index.list.title") %></th>
         <th><%= t("admin.budget_investments.index.list.supports") %></th>
         <th><%= t("admin.budget_investments.index.list.admin") %></th>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -187,18 +187,19 @@ en:
           undecided: "Undecided"
         selected: "Selected"
         select: "Select"
-        table_id: "ID"
-        table_title: "Title"
-        table_supports: "Supports"
-        table_admin: "Administrator"
-        table_valuator: "Valuator"
-        table_valuation_group: "Valuation Group"
-        table_geozone: "Scope of operation"
-        table_feasibility: "Feasibility"
-        table_valuation_finished: "Val. Fin."
-        table_selection: "Selected"
-        table_evaluation: "Show to valuators"
-        table_incompatible: "Incompatible"
+        list:
+          id: ID
+          title: Title
+          supports: Supports
+          admin: Administrator
+          valuator: Valuator
+          valuation_group: Valuation Group
+          geozone: Scope of operation
+          feasibility: Feasibility
+          valuation_finished: Val. Fin.
+          selected: Selected
+          visible_to_valuators: Show to valuators
+          incompatible: Incompatible
         cannot_calculate_winners: The budget has to stay on phase "Balloting projects", "Reviewing Ballots" or "Finished budget" in order to calculate winners projects
         see_results: "See results"
       show:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -199,6 +199,7 @@ en:
           valuation_finished: Val. Fin.
           selected: Selected
           visible_to_valuators: Show to valuators
+          author_username: Author username
           incompatible: Incompatible
         cannot_calculate_winners: The budget has to stay on phase "Balloting projects", "Reviewing Ballots" or "Finished budget" in order to calculate winners projects
         see_results: "See results"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -187,18 +187,19 @@ es:
           undecided: "Sin decidir"
         selected: "Seleccionada"
         select: "Seleccionar"
-        table_id: "ID"
-        table_title: "Título"
-        table_supports: "Apoyos"
-        table_admin: "Administrador"
-        table_valuator: "Evaluador"
-        table_valuation_group: "Grupos evaluadores"
-        table_geozone: "Ámbito de actuación"
-        table_feasibility: "Viabilidad"
-        table_valuation_finished: "Ev. Fin."
-        table_selection: "Seleccionado"
-        table_evaluation: "Mostrar a evaluadores"
-        table_incompatible: "Incompatible"
+        list:
+          id: ID
+          title: Título
+          supports: Apoyos
+          admin: Administrador
+          valuator: Evaluador
+          valuation_group: Grupos evaluadores
+          geozone: Ámbito de actuación
+          feasibility: Viabilidad
+          valuation_finished: Ev. Fin.
+          selected: Seleccionado
+          visible_to_valuators: Mostrar a evaluadores
+          incompatible: Incompatible
         cannot_calculate_winners: El presupuesto debe estar en las fases "Votación final", "Votación finalizada" o "Resultados" para poder calcular las propuestas ganadoras
         see_results: "Ver resultados"
       show:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -199,6 +199,7 @@ es:
           valuation_finished: Ev. Fin.
           selected: Seleccionado
           visible_to_valuators: Mostrar a evaluadores
+          author_username: Usuario autor
           incompatible: Incompatible
         cannot_calculate_winners: El presupuesto debe estar en las fases "Votación final", "Votación finalizada" o "Resultados" para poder calcular las propuestas ganadoras
         see_results: "Ver resultados"

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1060,13 +1060,15 @@ feature 'Admin budget investments' do
                                                          cached_votes_up: 88, price: 99,
                                                          valuators: [],
                                                          valuator_groups: [valuator_group],
-                                                         administrator: admin)
+                                                         administrator: admin,
+                                                         visible_to_valuators: true)
       second_investment = create(:budget_investment, :unfeasible, title: "Alt Investment",
                                                          budget: budget, group: budget_group,
                                                          heading: second_budget_heading,
                                                          cached_votes_up: 66, price: 88,
                                                          valuators: [valuator],
-                                                         valuator_groups: [])
+                                                         valuator_groups: [],
+                                                         visible_to_valuators: false)
 
       visit admin_budget_budget_investments_path(budget)
 
@@ -1077,10 +1079,11 @@ feature 'Admin budget investments' do
       expect(header).to match(/filename="budget_investments.csv"$/)
 
       csv_contents = "ID,Title,Supports,Administrator,Valuator,Valuation Group,Scope of operation,"\
-                     "Feasibility,Val. Fin.,Selected\n#{first_investment.id},Le Investment,88,"\
-                     "Admin,-,Valuator Group,Budget Heading,Feasible (€99),Yes,Yes\n"\
-                     "#{second_investment.id},Alt Investment,66,No admin assigned,Valuator,-,"\
-                     "Other Heading,Unfeasible,No,No\n"
+                     "Feasibility,Val. Fin.,Selected,Show to valuators,Author username\n"\
+                     "#{first_investment.id},Le Investment,88,Admin,-,Valuator Group,"\
+                     "Budget Heading,Feasible (€99),Yes,Yes,Yes,#{first_investment.author.username}\n#{second_investment.id},"\
+                     "Alt Investment,66,No admin assigned,Valuator,-,Other Heading,"\
+                     "Unfeasible,No,No,No,#{second_investment.author.username}\n"
       expect(page.body).to eq(csv_contents)
     end
 


### PR DESCRIPTION
References
===================
 - Backport of: https://github.com/AyuntamientoMadrid/consul/pull/1424
 - Original issue: https://github.com/AyuntamientoMadrid/consul/issues/1421

Objectives
===================
601e305 Add `visible_to_valuators` and author username to admin investments CSV
5413c34 Restructure and rename translations


Visual Changes
===================
The only visible change is 2 extra columns in the exportable budget investments CSV

Notes
====================
Original commit is broken up into 2 commits, with the same "logical" diff