### PR TITLE
Try if notifiable has notifiable methods

### DIFF
--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,5 +1,5 @@
 <li id="<%= dom_id(notification) %>" class="notification <%= 'unread' if notification&.unread? %>">
-  <% if notification.try(:notifiable_available?) %>
+  <% if notification.notifiable.try(:notifiable_available?) %>
     <% locals = { notification: notification,
                   timestamp: notification.timestamp,
                   title: notification.notifiable_title,

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -128,6 +128,14 @@ feature "Notifications" do
     expect(page).to_not have_css("#notifications")
   end
 
+  scenario "Notification's notifiable model no longer includes Notifiable module" do
+    create(:notification, notifiable: create(:spending_proposal), user: user)
+    create(:notification, notifiable: create(:poll_question), user: user)
+
+    click_notifications_icon
+    expect(page).to have_content('This resource is not available anymore.', count: 2)
+  end
+
   context "Admin Notifications" do
     let(:admin_notification) do
       create(:admin_notification, title: 'Notification title',


### PR DESCRIPTION
References
=====
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1333

Why
===
There are Notifications with associated `notifiables` that actually are
not anymore Notifiables (the class doesn't include the Notifiable
concern). So when Notification delegates certain "notifiable" methods
to them the is an error.
