### PR TITLE
Change admin budget investments list order by supports from less to more

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -75,17 +75,9 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
       resource_model.parameterize('_')
     end
 
-    def sort_by(params)
-      if params.present? && Budget::Investment::SORTING_OPTIONS.include?(params)
-        "#{params == 'supports' ? 'cached_votes_up' : params} ASC"
-      else
-        "cached_votes_up DESC, created_at DESC"
-      end
-    end
-
     def load_investments
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
-                                       .order(sort_by(params[:sort_by]))
+      @investments = @investments.order_filter(params[:sort_by]) if params[:sort_by].present?
       @investments = @investments.page(params[:page]) unless request.format.csv?
     end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -608,8 +608,8 @@ feature 'Admin budget investments' do
     scenario 'Sort by ID' do
       visit admin_budget_budget_investments_path(budget, sort_by: 'id')
 
-      expect('B First Investment').to appear_before('A Second Investment')
-      expect('A Second Investment').to appear_before('C Third Investment')
+      expect('C Third Investment').to appear_before('A Second Investment')
+      expect('A Second Investment').to appear_before('B First Investment')
     end
 
     scenario 'Sort by title' do
@@ -622,8 +622,8 @@ feature 'Admin budget investments' do
     scenario 'Sort by supports' do
       visit admin_budget_budget_investments_path(budget, sort_by: 'supports')
 
-      expect('C Third Investment').to appear_before('A Second Investment')
-      expect('A Second Investment').to appear_before('B First Investment')
+      expect('B First Investment').to appear_before('A Second Investment')
+      expect('A Second Investment').to appear_before('C Third Investment')
     end
   end
 


### PR DESCRIPTION
References
===================
 - Backport of: https://github.com/AyuntamientoMadrid/consul/pull/1419
 - Original issue: https://github.com/consul/consul/issues/2589

Objectives
===================
 - Make admin budget investments list order by supports go from less to more.