### PR TITLE
Prevent authors from receiving their own proposals notification emails 

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -205,7 +205,7 @@ class Proposal < ActiveRecord::Base
   end
 
   def users_to_notify
-    (voters + followers).uniq
+    (voters + followers).uniq - [author]
   end
 
   def self.proposals_orders(user)

--- a/app/views/admin/activity/show.html.erb
+++ b/app/views/admin/activity/show.html.erb
@@ -33,12 +33,16 @@
               <%= activity.actionable.username %> (<%= activity.actionable.email %>)
             <% when "Comment" %>
               <%= activity.actionable.body %>
+            <% when "Newsletter" %>
+              <strong><%= activity.actionable.subject %></strong>
+            <% when "ProposalNotification" %>
+              <strong><%= activity.actionable.title %></strong>
+              <br>
+              <%= activity.actionable.body %>
             <% else %>
               <strong><%= activity.actionable.title %></strong>
               <br>
-              <div class="proposal-description">
-                <%= activity.actionable.description %>
-              </div>
+              <%= activity.actionable.description %>
             <% end %>
           <td class="align-top">
             <%= activity.user.name %> (<%= activity.user.email %>)

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -895,6 +895,19 @@ describe Proposal do
       expect(proposal.users_to_notify).to eq([voter_and_follower])
     end
 
+    it "returns voters and followers except the proposal author" do
+      author = create(:user, :level_two)
+      proposal = create(:proposal, author: author)
+      voter_and_follower = create(:user, :level_two)
+
+      create(:follow, user: author, followable: proposal)
+      create(:follow, user: voter_and_follower, followable: proposal)
+      create(:vote, voter: author, votable: proposal)
+      create(:vote, voter: voter_and_follower, votable: proposal)
+
+      expect(proposal.users_to_notify).to eq([voter_and_follower])
+    end
+
   end
 
   describe "#recommendations" do


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1486
Related issue https://github.com/AyuntamientoMadrid/consul/issues/1484

Objectives
===================
Avoid sending email notifications to proposal authors who voted or followed their own proposals.
