### PR TITLE
Fix moderation info positioning

### DIFF
--- a/app/views/moderation/comments/index.html.erb
+++ b/app/views/moderation/comments/index.html.erb
@@ -9,63 +9,61 @@
 </div>
 
 <%= form_tag moderate_moderation_comments_path(request.query_parameters), method: :put do %>
-  <p class="js-check">
+  <p class="float-left js-check">
     <%= t('shared.check') %>:
-    <%= link_to t('shared.check_all'), '#', data: {check_all: "comment_ids[]"} %>
+    <%= link_to t('shared.check_all'), '#', data: { check_all: "comment_ids[]" } %>
     |
-    <%= link_to t('shared.check_none'), '#', data: {check_none: "comment_ids[]"} %>
+    <%= link_to t('shared.check_none'), '#', data: { check_none: "comment_ids[]" } %>
   </p>
 
-  <table>
-    <tr>
-      <th>
-        <%= t("moderation.comments.index.headers.comment") %>
-      </th>
-      <th>
-        <%= t("moderation.comments.index.headers.moderate") %>
-      </th>
-    </tr>
-
-    <% @comments.each do |comment| %>
-      <tr id="comment_<%= comment.id %>">
-        <td>
-          <%= comment.commentable_type.constantize.model_name.human %> -
-          <%= link_to comment.commentable.title, commentable_path(comment) %>
-          <br>
-          <span class="date"><%= l comment.updated_at.to_date %></span>
-          <span class="bullet">&nbsp;&bull;&nbsp;</span>
-          <%= comment.flags_count %><span class="icon-flag flag-disable"></span>
-          <span class="bullet">&nbsp;&bull;&nbsp;</span>
-          <%= comment.author.username %>
-          <br>
-          <p>
-            <%= comment.body %>
-          </p>
-        </td>
-        <td class="text-center">
-          <%= check_box_tag "comment_ids[]", comment.id, nil, id: "#{dom_id(comment)}_check" %>
-        </td>
+  <table class="clear">
+    <thead>
+      <tr>
+        <th><%= t("moderation.comments.index.headers.comment") %></th>
+        <th><%= t("moderation.comments.index.headers.moderate") %></th>
       </tr>
-    <% end %>
+    </thead>
+
+    <tbody>
+      <% @comments.each do |comment| %>
+        <tr id="comment_<%= comment.id %>">
+          <td>
+            <%= comment.commentable_type.constantize.model_name.human %> -
+            <%= link_to comment.commentable.title, commentable_path(comment), target: "_blank" %>
+            <br>
+            <span class="date"><%= l comment.updated_at.to_date %></span>
+            <span class="bullet">&nbsp;&bull;&nbsp;</span>
+            <%= comment.flags_count %><span class="icon-flag flag-disable"></span>
+            <span class="bullet">&nbsp;&bull;&nbsp;</span>
+            <%= comment.author.username %>
+            <br>
+            <div class="moderation-description">
+              <%= comment.body %>
+            </div>
+          </td>
+          <td class="text-center">
+            <%= check_box_tag "comment_ids[]", comment.id, nil, id: "#{dom_id(comment)}_check" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
   </table>
 
   <%= submit_tag t('moderation.comments.index.block_authors'),
-    name: "block_authors",
-    class: "button hollow alert",
-    data: {confirm: t('moderation.comments.index.confirm')}
-  %>
+                 name: "block_authors",
+                 class: "button hollow alert",
+                 data: { confirm: t('moderation.comments.index.confirm') } %>
 
   <div class="float-right">
     <%= submit_tag t('moderation.comments.index.hide_comments'),
-      name: "hide_comments",
-      class: "button hollow alert",
-      data: {confirm: t('moderation.comments.index.confirm')}
-    %>
+                   name: "hide_comments",
+                   class: "button hollow alert",
+                   data: { confirm: t('moderation.comments.index.confirm') } %>
+
     <%= submit_tag t('moderation.comments.index.ignore_flags'),
-      name: "ignore_flags",
-      class: "button hollow",
-      data: {confirm: t('moderation.comments.index.confirm')}
-    %>
+                   name: "ignore_flags",
+                   class: "button hollow",
+                   data: { confirm: t('moderation.comments.index.confirm') } %>
   </div>
 
   <%= paginate @comments %>

--- a/app/views/moderation/comments/index.html.erb
+++ b/app/views/moderation/comments/index.html.erb
@@ -2,14 +2,10 @@
 
 <%= render 'shared/filter_subnav', i18n_namespace: "moderation.comments.index" %>
 
-<div class="row">
-  <h3 class="small-8 large-8 columns"><%= page_entries_info @comments %></h3>
-  <div class="small-4 large-4 columns">
-    <div class="float-right">
-      <%= t("moderation.comments.index.order") %>
-      <%= render 'shared/order_selector', i18n_namespace: "moderation.comments.index" %>
-    </div>
-  </div>
+<h3 class="inline-block"><%= page_entries_info @comments %></h3>
+<div class="float-right">
+  <%= t("moderation.comments.index.order") %>
+  <%= render 'shared/order_selector', i18n_namespace: "moderation.comments.index" %>
 </div>
 
 <%= form_tag moderate_moderation_comments_path(request.query_parameters), method: :put do %>

--- a/app/views/moderation/debates/index.html.erb
+++ b/app/views/moderation/debates/index.html.erb
@@ -2,14 +2,10 @@
 
 <%= render 'shared/filter_subnav', i18n_namespace: "moderation.debates.index" %>
 
-<div class="row">
-  <h3 class="small-8 large-8 columns"><%= page_entries_info @debates %></h3>
-  <div class="small-4 large-4 columns">
-    <div class="float-right">
-      <%= t("moderation.debates.index.order") %>
-      <%= render 'shared/order_selector', i18n_namespace: "moderation.debates.index" %>
-    </div>
-  </div>
+<h3 class="inline-block"><%= page_entries_info @debates %></h3>
+<div class="float-right">
+  <%= t("moderation.debates.index.order") %>
+  <%= render 'shared/order_selector', i18n_namespace: "moderation.debates.index" %>
 </div>
 
 <%= form_tag moderate_moderation_debates_path(request.query_parameters), method: :put do %>

--- a/app/views/moderation/debates/index.html.erb
+++ b/app/views/moderation/debates/index.html.erb
@@ -11,59 +11,58 @@
 <%= form_tag moderate_moderation_debates_path(request.query_parameters), method: :put do %>
   <p class="float-left js-check">
     <%= t('shared.check') %>:
-    <%= link_to t('shared.check_all'), '#', data: {check_all: "debate_ids[]"} %>
+    <%= link_to t('shared.check_all'), '#', data: { check_all: "debate_ids[]" } %>
     |
-    <%= link_to t('shared.check_none'), '#', data: {check_none: "debate_ids[]"} %>
+    <%= link_to t('shared.check_none'), '#', data: { check_none: "debate_ids[]" } %>
   </p>
 
   <table class="clear">
-    <tr>
-      <th>
-        <%= t("moderation.debates.index.headers.debate") %>
-      </th>
-      <th>
-       <%= t("moderation.debates.index.headers.moderate") %>
-      </th>
-    </tr>
-    <% @debates.each do |debate| %>
-      <tr id="debate_<%= debate.id %>">
-        <td>
-          <%= link_to debate.title, debate, target: "_blank" %>
-          <br>
-          <span class="date"><%= l debate.updated_at.to_date %></span>
-          <span class="bullet">&nbsp;&bull;&nbsp;</span>
-          <%= debate.flags_count %><span class="icon-flag flag-disable"></span>
-          <span class="bullet">&nbsp;&bull;&nbsp;</span>
-          <%= debate.author.username %>
-          <br>
-          <div class="moderation-description">
-            <%= debate.description %>
-          </div>
-        </td>
-        <td class="text-center">
-          <%= check_box_tag "debate_ids[]", debate.id, nil, id: "#{dom_id(debate)}_check" %>
-        </td>
+    <thead>
+      <tr>
+        <th><%= t("moderation.debates.index.headers.debate") %></th>
+        <th><%= t("moderation.debates.index.headers.moderate") %></th>
       </tr>
-    <% end %>
+    </thead>
+
+    <tbody>
+      <% @debates.each do |debate| %>
+        <tr id="debate_<%= debate.id %>">
+          <td>
+            <%= link_to debate.title, debate, target: "_blank" %>
+            <br>
+            <span class="date"><%= l debate.updated_at.to_date %></span>
+            <span class="bullet">&nbsp;&bull;&nbsp;</span>
+            <%= debate.flags_count %><span class="icon-flag flag-disable"></span>
+            <span class="bullet">&nbsp;&bull;&nbsp;</span>
+            <%= debate.author.username %>
+            <br>
+            <div class="moderation-description">
+              <%= debate.description %>
+            </div>
+          </td>
+          <td class="text-center">
+            <%= check_box_tag "debate_ids[]", debate.id, nil, id: "#{dom_id(debate)}_check" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
   </table>
 
   <%= submit_tag t('moderation.debates.index.block_authors'),
-    name: "block_authors",
-    class: "button alert",
-    data: {confirm: t('moderation.debates.index.confirm')}
-  %>
+                 name: "block_authors",
+                 class: "button hollow alert",
+                 data: { confirm: t('moderation.debates.index.confirm') } %>
 
   <div class="float-right">
     <%= submit_tag t('moderation.debates.index.hide_debates'),
-      name: "hide_debates",
-      class: "button alert",
-      data: {confirm: t('moderation.debates.index.confirm')}
-    %>
+                   name: "hide_debates",
+                   class: "button hollow alert",
+                   data: { confirm: t('moderation.debates.index.confirm') } %>
+
     <%= submit_tag t('moderation.debates.index.ignore_flags'),
-      name: "ignore_flags",
-      class: "button success",
-      data: {confirm: t('moderation.debates.index.confirm')}
-    %>
+                   name: "ignore_flags",
+                   class: "button hollow",
+                   data: { confirm: t('moderation.debates.index.confirm') } %>
   </div>
 
   <%= paginate @debates %>

--- a/app/views/moderation/proposal_notifications/index.html.erb
+++ b/app/views/moderation/proposal_notifications/index.html.erb
@@ -9,57 +9,59 @@
 </div>
 
 <%= form_tag moderate_moderation_proposal_notifications_path(request.query_parameters), method: :put do %>
-  <p class="js-check">
+  <p class="float-left js-check">
     <%= t('shared.check') %>:
-    <%= link_to t('shared.check_all'), '#', data: {check_all: "proposal_notification_ids[]"} %>
+    <%= link_to t('shared.check_all'), '#', data: { check_all: "proposal_notification_ids[]" } %>
     |
-    <%= link_to t('shared.check_none'), '#', data: {check_none: "proposal_notification_ids[]"} %>
+    <%= link_to t('shared.check_none'), '#', data: { check_none: "proposal_notification_ids[]" } %>
   </p>
 
   <table class="clear">
-    <tr>
-      <th>
-        <%= t("moderation.proposal_notifications.index.headers.proposal_notification") %>
-      </th>
-      <th>
-       <%= t("moderation.proposal_notifications.index.headers.moderate") %>
-      </th>
-    </tr>
-    <% @proposal_notifications.each do |proposal_notification| %>
-      <tr id="proposal_notification_<%= proposal_notification.id %>">
-        <td>
-          <%= link_to proposal_notification.title, proposal_notification, target: "_blank" %>
-          <br>
-          <span class="date"><%= l proposal_notification.updated_at.to_date %></span>
-          <br>
-          <div class="moderation-description">
-            <%= proposal_notification.body %>
-          </div>
-        </td>
-        <td class="text-center">
-          <%= check_box_tag "proposal_notification_ids[]", proposal_notification.id, nil, id: "#{dom_id(proposal_notification)}_check" %>
-        </td>
+    <thead>
+      <tr>
+        <th><%= t("moderation.proposal_notifications.index.headers.proposal_notification") %></th>
+        <th><%= t("moderation.proposal_notifications.index.headers.moderate") %></th>
       </tr>
-    <% end %>
+    </thead>
+
+    <tbody>
+      <% @proposal_notifications.each do |proposal_notification| %>
+        <tr id="proposal_notification_<%= proposal_notification.id %>">
+          <td>
+            <%= link_to proposal_notification.title, proposal_notification, target: "_blank" %>
+            <br>
+            <span class="date"><%= l proposal_notification.updated_at.to_date %></span>
+            <br>
+            <div class="moderation-description">
+              <%= proposal_notification.body %>
+            </div>
+          </td>
+          <td class="text-center">
+            <%= check_box_tag "proposal_notification_ids[]",
+                              proposal_notification.id,
+                              nil,
+                              id: "#{dom_id(proposal_notification)}_check" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
   </table>
 
   <%= submit_tag t('moderation.proposal_notifications.index.block_authors'),
-    name: "block_authors",
-    class: "button hollow alert",
-    data: {confirm: t('moderation.proposal_notifications.index.confirm')}
-  %>
+                 name: "block_authors",
+                 class: "button hollow alert",
+                 data: { confirm: t('moderation.proposal_notifications.index.confirm') } %>
 
   <div class="float-right">
     <%= submit_tag t('moderation.proposal_notifications.index.hide_proposal_notifications'),
-      name: "hide_proposal_notifications",
-      class: "button hollow alert",
-      data: {confirm: t('moderation.proposal_notifications.index.confirm')}
-    %>
+                   name: "hide_proposal_notifications",
+                   class: "button hollow alert",
+                   data: { confirm: t('moderation.proposal_notifications.index.confirm') } %>
+
     <%= submit_tag t('moderation.proposal_notifications.index.ignore_flags'),
-      name: "ignore_flags",
-      class: "button hollow",
-      data: {confirm: t('moderation.proposal_notifications.index.confirm')}
-    %>
+                   name: "ignore_flags",
+                   class: "button hollow",
+                   data: { confirm: t('moderation.proposal_notifications.index.confirm') } %>
   </div>
 
   <%= paginate @proposal_notifications %>

--- a/app/views/moderation/proposals/index.html.erb
+++ b/app/views/moderation/proposals/index.html.erb
@@ -9,64 +9,62 @@
 </div>
 
 <%= form_tag moderate_moderation_proposals_path(request.query_parameters), method: :put do %>
-  <p class="js-check">
+  <p class="float-left js-check">
     <%= t('shared.check') %>:
-    <%= link_to t('shared.check_all'), '#', data: {check_all: "proposal_ids[]"} %>
+    <%= link_to t('shared.check_all'), '#', data: { check_all: "proposal_ids[]" } %>
     |
-    <%= link_to t('shared.check_none'), '#', data: {check_none: "proposal_ids[]"} %>
+    <%= link_to t('shared.check_none'), '#', data: { check_none: "proposal_ids[]" } %>
   </p>
 
   <table class="clear">
-    <tr>
-      <th>
-        <%= t("moderation.proposals.index.headers.proposal") %>
-      </th>
-      <th>
-       <%= t("moderation.proposals.index.headers.moderate") %>
-      </th>
-    </tr>
-    <% @proposals.each do |proposal| %>
-      <tr id="proposal_<%= proposal.id %>">
-        <td>
-          <%= link_to proposal.title, proposal, target: "_blank" %>
-          <br>
-          <span class="date"><%= l proposal.updated_at.to_date %></span>
-          <span class="bullet">&nbsp;&bull;&nbsp;</span>
-          <%= proposal.flags_count %><span class="icon-flag flag-disable"></span>
-          <span class="bullet">&nbsp;&bull;&nbsp;</span>
-          <%= proposal.author.username %>
-          <br>
-          <div class="moderation-description">
-            <%= proposal.description %>
-          </div>
-        </td>
-        <td class="text-center">
-          <%= check_box_tag "proposal_ids[]", proposal.id, nil, id: "#{dom_id(proposal)}_check" %>
-        </td>
+    <thead>
+      <tr>
+        <th><%= t("moderation.proposals.index.headers.proposal") %></th>
+        <th><%= t("moderation.proposals.index.headers.moderate") %></th>
       </tr>
-    <% end %>
+    </thead>
+
+    <tbody>
+      <% @proposals.each do |proposal| %>
+        <tr id="proposal_<%= proposal.id %>">
+          <td>
+            <%= link_to proposal.title, proposal, target: "_blank" %>
+            <br>
+            <span class="date"><%= l proposal.updated_at.to_date %></span>
+            <span class="bullet">&nbsp;&bull;&nbsp;</span>
+            <%= proposal.flags_count %><span class="icon-flag flag-disable"></span>
+            <span class="bullet">&nbsp;&bull;&nbsp;</span>
+            <%= proposal.author.username %>
+            <br>
+            <div class="moderation-description">
+              <%= proposal.description %>
+            </div>
+          </td>
+          <td class="text-center">
+            <%= check_box_tag "proposal_ids[]", proposal.id, nil, id: "#{dom_id(proposal)}_check" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
   </table>
 
   <%= submit_tag t('moderation.proposals.index.block_authors'),
-    name: "block_authors",
-    class: "button hollow alert",
-    data: {confirm: t('moderation.proposals.index.confirm')}
-  %>
+                 name: "block_authors",
+                 class: "button hollow alert",
+                 data: { confirm: t('moderation.proposals.index.confirm') } %>
 
   <div class="float-right">
     <%= submit_tag t('moderation.proposals.index.hide_proposals'),
-      name: "hide_proposals",
-      class: "button hollow alert",
-      data: {confirm: t('moderation.proposals.index.confirm')}
-    %>
+                   name: "hide_proposals",
+                   class: "button hollow alert",
+                   data: { confirm: t('moderation.proposals.index.confirm') } %>
+
     <%= submit_tag t('moderation.proposals.index.ignore_flags'),
-      name: "ignore_flags",
-      class: "button hollow",
-      data: {confirm: t('moderation.proposals.index.confirm')}
-    %>
+                   name: "ignore_flags",
+                   class: "button hollow",
+                   data: { confirm: t('moderation.proposals.index.confirm') } %>
   </div>
 
   <%= paginate @proposals %>
 
 <% end %>
-

--- a/app/views/moderation/proposals/index.html.erb
+++ b/app/views/moderation/proposals/index.html.erb
@@ -2,14 +2,10 @@
 
 <%= render 'shared/filter_subnav', i18n_namespace: "moderation.proposals.index" %>
 
-<div class="row">
-  <h3 class="small-8 large-8 columns"><%= page_entries_info @proposals %></h3>
-  <div class="small-4 large-4 columns">
-    <div class="float-right">
-      <%= t("moderation.proposals.index.order") %>
-      <%= render 'shared/order_selector', i18n_namespace: "moderation.proposals.index" %>
-    </div>
-  </div>
+<h3 class="inline-block"><%= page_entries_info @proposals %></h3>
+<div class="float-right">
+  <%= t("moderation.proposals.index.order") %>
+  <%= render 'shared/order_selector', i18n_namespace: "moderation.proposals.index" %>
 </div>
 
 <%= form_tag moderate_moderation_proposals_path(request.query_parameters), method: :put do %>


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1530/

Objectives
===================
* Correct entries information and filter positioning for all `moderation#index` views, similar to what was done in #1415
* Add missing `thead` and `tbody` tags

Visual Changes
===================
**Note**: For brevity, and since the proposed changes are all the same, only one pair of `before/after` screenshots will be included

## Before

![before](https://user-images.githubusercontent.com/9470839/41612128-f7291958-73bf-11e8-9005-0bb740a30458.png)

## After

![after](https://user-images.githubusercontent.com/9470839/41612185-20357f08-73c0-11e8-88b5-4fd049c8ecb8.png)
