### PR TITLE
Adds logic to show 'see results' button only for finished budgets

### DIFF
--- a/app/views/admin/budget_investments/index.html.erb
+++ b/app/views/admin/budget_investments/index.html.erb
@@ -1,8 +1,10 @@
-<div class="float-right">
-  <%= link_to t("admin.budget_investments.index.see_results"),
-              budget_results_path(current_budget, heading_id: current_budget.headings.first),
-              class: "button hollow medium", target: "_blank" %>
-</div>
+<% if @budget.has_winning_investments? %>
+  <div class="float-right">
+    <%= link_to t("admin.budget_investments.index.see_results"),
+                budget_results_path(@budget, heading_id: @budget.headings.first),
+                class: "button hollow medium", target: "_blank" %>
+  </div>
+<% end %>
 
 <h2 class="inline-block"><%= @budget.name %> - <%= t("admin.budget_investments.index.title") %></h2>
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -541,21 +541,18 @@ feature 'Admin budget investments' do
     end
 
     scenario "See results button appears when budget status is finished" do
-
       finished_budget = create(:budget, :finished)
+      create(:budget_investment, :winner, budget: finished_budget, title: "Winner project")
 
       visit admin_budget_budget_investments_path(budget_id: finished_budget.id)
       expect(page).to have_content "See results"
-
     end
 
     scenario "See results button does not appear for unfinished budgets" do
-
       not_finished_budget = create(:budget, :valuating)
 
       visit admin_budget_budget_investments_path(budget_id: not_finished_budget.id)
       expect(page).not_to have_content "See results"
-
     end
 
   end

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -540,6 +540,24 @@ feature 'Admin budget investments' do
 
     end
 
+    scenario "See results button appears when budget status is finished" do
+
+      finished_budget = create(:budget, :finished)
+
+      visit admin_budget_budget_investments_path(budget_id: finished_budget.id)
+      expect(page).to have_content "See results"
+
+    end
+
+    scenario "See results button does not appear for unfinished budgets" do
+
+      not_finished_budget = create(:budget, :valuating)
+
+      visit admin_budget_budget_investments_path(budget_id: not_finished_budget.id)
+      expect(page).not_to have_content "See results"
+
+    end
+
   end
 
   context 'Search' do


### PR DESCRIPTION
References
=====================
 - Backport of: https://github.com/AyuntamientoMadrid/consul/pull/1542
 - Original issue: https://github.com/AyuntamientoMadrid/consul/issues/1541


Objectives
============
 - Only show button for finished budgets.
 - Use visited budget to form URL instead of the current_budget one.

Visual Changes
===================

![](https://user-images.githubusercontent.com/2141690/42095841-0dacf946-7bb4-11e8-8d07-27fddd1578b1.png)
