### PR TITLE
Fix admin menu not showing for high IDs

### DIFF
--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -56,7 +56,7 @@ class Management::BaseController < ActionController::Base
 
     def manager_logged_in
       if current_manager
-        @manager_logged_in = User.find_by(id: session[:manager]["login"].last(1))
+        @manager_logged_in = User.find_by_manager_login(session[:manager]["login"])
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,6 +329,10 @@ class User < ActiveRecord::Base
     where(conditions.to_hash).where(["username = ?", login]).first
   end
 
+  def self.find_by_manager_login(manager_login)
+    find_by(id: manager_login.last(1))
+  end
+
   def interests
     followables = follows.map(&:followable)
     followables.compact.map { |followable| followable.tags.map(&:name) }.flatten.compact.uniq

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -330,7 +330,7 @@ class User < ActiveRecord::Base
   end
 
   def self.find_by_manager_login(manager_login)
-    find_by(id: manager_login.last(1))
+    find_by(id: manager_login.split("_").last)
   end
 
   def interests

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -690,4 +690,17 @@ describe User do
 
   end
 
+  describe ".find_by_manager_login" do
+    it "works with a low ID" do
+      user = create(:user)
+      expect(User.find_by_manager_login("admin_user_#{user.id}")).to eq user
+    end
+
+    it "works with a high ID" do
+      10.times { create(:user) }
+      user = User.last
+      expect(User.find_by_manager_login("admin_user_#{user.id}")).to eq user
+    end
+  end
+
 end


### PR DESCRIPTION
# References

* Issue #2812.
* Issue AyuntamientoMadrid#1591
* [Travis build 24150, job 2](https://travis-ci.org/consul/consul/jobs/408923975)

# Objectives

Fix a bug preventing an admin from seeing the admin menu when their user ID is 10 or higher.

## Explain why your PR fixes it

The query searching for the user was:

```ruby
User.find_by(id: session[:manager]["login"].last(1))
```

That line worked when `session[:manager]["login"]` had a value such as `"admin_user_1"`, but failed when it had a value like `"admin_user_76"`, since it only took the last character of the ID.

Taking everything after the last underscore instead of just the last character solves the issue.

# Notes

* Unless I've overlooked something, version 0.16 is **not** affected.
* As seen in the referenced travis build, there already was a failing test covering this issue. Since the test sometimes passed if the user's ID was less than 10, I've added a model test too. Now Travis' build should be green again (except when it's red :sweat_smile:).
* This solution is still fragile. Currently it always works (or so I think), but it assumes the manager login will always end with an underscore followed by the ID. Given the way we handle `session[:manager]`, that might not always be the case in the future. Suggestions are welcome! :wink:.
