### PR TITLE
Enhances docker experience for developers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,9 @@ services:
     volumes:
       - .:/var/www/consul:delegated
       - bundle:/usr/local/bundle:delegated
+      - "$SSH_AUTH_SOCK:/tmp/agent.sock"
+    environment:
+      - SSH_AUTH_SOCK=/tmp/agent.sock
 volumes:
   docker-example-postgres: {}
   bundle: {}


### PR DESCRIPTION

References
===================
Pull request #2773

Objectives
===================
Changes related to other concerns like servers or docker should be moved in separate PR's. This PR enhances docker experience for developers in the following way:

* Executing cap <environment> deploy inside docker uses the user ssh keys outside docker.


Visual Changes
===================
If you relay on docker-compose to develop your face should show a bigger smile after this PR  is approved. Otherwise it's time for beach and cold beers.
