### PR TITLE
Adds support for phusion passenger in capistrano

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -10,7 +10,6 @@ require 'capistrano/rails/migrations'
 #require 'capistrano/passenger'
 require 'capistrano/delayed_job'
 require 'whenever/capistrano'
-require 'rvm1/capistrano3'
 
 #SCM: Git
 require "capistrano/scm/git"

--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -6,6 +6,11 @@ staging:
   user: "xxxxx"
   server_name: "staging.consul.es"
   full_app_name: "consul"
+# use_rvm: Yes
+# ruby_version: 2.3.7
+# repository: https://github.com/consul/consul.git
+# branch: master
+# rails_env: staging
 
 preproduction:
   deploy_to: "/var/www/consul"

--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -2,7 +2,6 @@ set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
 set :branch, ENV['branch'] || :master
-set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :preproduction
 set :rails_env, :preproduction
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -2,7 +2,6 @@ set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
 set :branch, :stable
-set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :production
 set :rails_env, :production
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,11 +1,9 @@
-set :deploy_to, deploysecret(:deploy_to)
+set :deploy_to, -> { deploysecret(:deploy_to) }
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
-set :branch, ENV['branch'] || :master
-set :ssh_options, port: deploysecret(:ssh_port)
+set :branch, deploysecret(:branch, ENV['branch']) || :master
 set :stage, :staging
-set :rails_env, :staging
+set :rails_env, deploysecret(:rails_env, 'staging').to_sym
 
 server deploysecret(:server), user: deploysecret(:user), roles: %w(web app db importer cron)
-
 

--- a/lib/capistrano/tasks/restart.cap
+++ b/lib/capistrano/tasks/restart.cap
@@ -1,9 +1,18 @@
 namespace :deploy do
-  desc 'Commands for unicorn application'
-  %w(start stop force-stop restart upgrade reopen-logs).each do |command|
-    task command.to_sym do
+  desc 'Commands for passenger/unicorn application'
+  if File.exist?("/etc/init.d/unicorn_#{fetch(:full_app_name)}")
+    %w(start stop force-stop restart upgrade reopen-logs).each do |command|
+      task command.to_sym do
+        on roles(:app), in: :sequence, wait: 5 do
+          execute "/etc/init.d/unicorn_#{fetch(:full_app_name)} #{command}"
+        end
+      end
+    end
+  else
+    task :restart do
       on roles(:app), in: :sequence, wait: 5 do
-        execute "/etc/init.d/unicorn_#{fetch(:full_app_name)} #{command}"
+        # Your restart mechanism here, for example:
+        execute :touch, release_path.join('tmp/restart.txt')
       end
     end
   end


### PR DESCRIPTION


References
===================
Pull request #2773 

Objectives
===================
Any change concerning other aspects apart from the proposal dashboard should be moved to a separate PR. This PR adds support for deploying over Phusion Passenger.

Adds support for phusion passenger in capistrano.
deploy-secrets.yml supports more options allowing the user:

* Not using rvm
* choosing the ruby version
* overriding the rails environment

The default options stays the same in comparision with the current
version.
