### PR TITLE
Custom content

### DIFF
--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -183,11 +183,6 @@
         <strong><%= t("budgets.index.section_footer.title") %></strong>
       </p>
       <p><%= t("budgets.index.section_footer.description") %></p>
-      <p><%= t("budgets.index.section_footer.help_text_1") %></p>
-      <p><%= t("budgets.index.section_footer.help_text_2") %></p>
-      <p><%= t("budgets.index.section_footer.help_text_3",
-                org: link_to(setting['org_name'], new_user_registration_path)).html_safe %></p>
-      <p><%= t("budgets.index.section_footer.help_text_4") %></p>
     </div>
   </div>
 </div>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -88,9 +88,6 @@
           <p><%= t("debates.index.section_footer.help_text_1") %></p>
           <p><%= t("debates.index.section_footer.help_text_2",
                     org: link_to(setting["org_name"], new_user_registration_path)).html_safe %></p>
-          <p><%= t("debates.index.section_footer.help_text_3",
-                    proposal: link_to(t("debates.index.section_footer.proposals_link"), proposals_path),
-                    budget: link_to(t("debates.index.section_footer.budget_link"), budgets_path)).html_safe %>
           </p>
         </div>
       <% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -11,7 +11,6 @@
           consul:  link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), target: "blank", rel: "nofollow")).html_safe
         %>
         <%= t("layouts.footer.contact_us") %>
-        <%= link_to t("layouts.footer.faq"), faq_path %>
       </p>
     </div>
 
@@ -19,16 +18,6 @@
       <div class="small-12 medium-4 column">
         <%= link_to t("layouts.footer.participation_title"), root_path, class: "title" %>
         <p><%= t("layouts.footer.participation_text") %></p>
-      </div>
-
-      <div class="small-12 medium-4 column">
-        <%= link_to t("layouts.footer.transparency_title"), setting['transparency_url'].presence || t("layouts.footer.transparency_url"), class: "title", rel: "nofollow" %>
-        <p><%= t("layouts.footer.transparency_text") %></p>
-      </div>
-
-      <div class="small-12 medium-4 column">
-        <%= link_to t("layouts.footer.open_data_title"), setting['opendata_url'].presence || t("layouts.header.external_link_opendata_url"), class: "title", rel: "nofollow" %>
-        <p><%= t("layouts.footer.open_data_text") %></p>
       </div>
     </div>
   </div>

--- a/app/views/legislation/processes/index.html.erb
+++ b/app/views/legislation/processes/index.html.erb
@@ -24,10 +24,6 @@
           <strong><%= t("legislation.processes.index.section_footer.title") %></strong>
         </p>
         <p><%= t("legislation.processes.index.section_footer.description") %></p>
-        <p><%= t("legislation.processes.index.section_footer.help_text_1") %></p>
-        <p><%= t("legislation.processes.index.section_footer.help_text_2",
-                  org: setting['org_name']) %></p>
-        <p><%= t("legislation.processes.index.section_footer.help_text_3") %></p>
       </div>
     </div>
   </div>

--- a/app/views/mailer/budget_investment_created.html.erb
+++ b/app/views/mailer/budget_investment_created.html.erb
@@ -35,9 +35,5 @@
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
     <%= t("mailers.budget_investment_created.sincerely") %>
-    <br>
-    <span style="color: #ccc; font-size: 12px;">
-      <%= t("mailers.budget_investment_created.signatory") %>
-    </span>
   </p>
 </td>

--- a/app/views/mailer/budget_investment_selected.html.erb
+++ b/app/views/mailer/budget_investment_selected.html.erb
@@ -5,11 +5,6 @@
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_selected.selected_html",
-        title: @investment.title) %>
-  </p>
-
-  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
     <%= t("mailers.budget_investment_selected.share") %>
   </p>
 
@@ -31,8 +26,6 @@
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_selected.sincerely") %><br>
-  <span style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 24px; color: #ccc;">
-    <%= t("mailers.budget_investment_selected.signatory") %></span>
+    <%= t("mailers.budget_investment_selected.sincerely") %>
   </p>
 </td>

--- a/app/views/mailer/budget_investment_unfeasible.html.erb
+++ b/app/views/mailer/budget_investment_unfeasible.html.erb
@@ -4,11 +4,6 @@
     <%= t("mailers.budget_investment_unfeasible.hi") %>
   </p>
 
-  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_unfeasible.unfeasible_html",
-        title: @investment.title) %>
-  </p>
-
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; padding-left: 12px; border-left: 2px solid #ccc;">
     <%= @investment.unfeasibility_explanation %>
   </p>
@@ -20,16 +15,10 @@
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_unfeasible.reconsider_html", code: @investment.code) %>
-  </p>
-
-  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
     <%= t("mailers.budget_investment_unfeasible.sorry") %>
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_unfeasible.sincerely") %><br>
-  <span style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 24px; color: #ccc;">
-    <%= t("mailers.budget_investment_unfeasible.signatory") %></span>
+    <%= t("mailers.budget_investment_unfeasible.sincerely") %>
   </p>
 </td>

--- a/app/views/mailer/budget_investment_unselected.html.erb
+++ b/app/views/mailer/budget_investment_unselected.html.erb
@@ -5,23 +5,10 @@
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_unselected.unselected_html",
-        title: @investment.title) %>
-  </p>
-
-  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-  <%= t("mailers.budget_investment_unselected.participate_html",
-      url: link_to(t("mailers.budget_investment_unselected.participate_url"),
-      budget_url(@investment.budget), style: "color: #2895F1; text-decoration: underline;")) %>
-  </p>
-
-  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
     <%= t("mailers.budget_investment_unselected.thanks") %>
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_unselected.sincerely") %><br>
-  <span style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 24px; color: #ccc;">
-    <%= t("mailers.budget_investment_unselected.signatory") %></span>
+    <%= t("mailers.budget_investment_unselected.sincerely") %>
   </p>
 </td>

--- a/app/views/mailer/unfeasible_spending_proposal.html.erb
+++ b/app/views/mailer/unfeasible_spending_proposal.html.erb
@@ -4,11 +4,6 @@
     <%= t("mailers.unfeasible_spending_proposal.hi") %>
   </p>
 
-  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.unfeasible_spending_proposal.unfeasible_html",
-        title: @spending_proposal.title) %>
-  </p>
-
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; padding-left: 12px; border-left: 2px solid #ccc;">
     <%= @spending_proposal.feasible_explanation %>
   </p>
@@ -20,16 +15,10 @@
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.unfeasible_spending_proposal.reconsider_html", code: @spending_proposal.code) %>
-  </p>
-
-  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
     <%= t("mailers.unfeasible_spending_proposal.sorry") %>
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.unfeasible_spending_proposal.sincerely") %><br>
-  <span style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 24px; color: #ccc;">
-    <%= t("mailers.unfeasible_spending_proposal.signatory") %></span>
+    <%= t("mailers.unfeasible_spending_proposal.sincerely") %>
   </p>
 </td>

--- a/app/views/management/budgets/investments/print.html.erb
+++ b/app/views/management/budgets/investments/print.html.erb
@@ -32,8 +32,7 @@
       <% end %>
 
       <div class="for-print-only">
-        <p><strong><%= t("management.print.budget_investments_info") %></strong><br>
-        <%= t("management.print.budget_investments_note") %></p>
+        <p><strong><%= t("management.print.budget_investments_info") %></strong></p>
       </div>
     </div>
   </div>

--- a/app/views/management/proposals/print.html.erb
+++ b/app/views/management/proposals/print.html.erb
@@ -20,8 +20,7 @@
       <%= render @proposals %>
 
       <div class="for-print-only">
-        <p><strong><%= t("management.print.proposals_info") %></strong><br>
-        <%= t("management.print.proposals_note") %></p>
+        <p><strong><%= t("management.print.proposals_info") %></strong></p>
       </div>
     </div>
   </div>

--- a/app/views/management/spending_proposals/print.html.erb
+++ b/app/views/management/spending_proposals/print.html.erb
@@ -26,8 +26,7 @@
       <%= render @spending_proposals %>
 
       <div class="for-print-only">
-        <p><strong><%= t("management.print.spending_proposals_info") %></strong><br>
-        <%= t("management.print.spending_proposals_note") %></p>
+        <p><strong><%= t("management.print.spending_proposals_info") %></strong></p>
       </div>
     </div>
   </div>

--- a/app/views/pages/census_terms.html.erb
+++ b/app/views/pages/census_terms.html.erb
@@ -6,7 +6,6 @@
   <div class="row">
     <div class="text small-12 column">
       <h2>Terminos de acceso al Padrón</h2>
-      <%= simple_format t('pages.census_terms') %>
     </div>
   </div>
 </div>

--- a/app/views/pages/help/_budgets.html.erb
+++ b/app/views/pages/help/_budgets.html.erb
@@ -7,18 +7,6 @@
       <%= t("pages.help.budgets.description",
            link: link_to(t("pages.help.budgets.link"), budgets_path)).html_safe %>
     </p>
-    <ul class="features">
-      <li>
-        <%= t("pages.help.budgets.feature") %>
-      </li>
-      <li><%= t("pages.help.budgets.phase_1_html",
-                org: setting['org_name']).html_safe %></li>
-      <li><%= t("pages.help.budgets.phase_2_html") %></li>
-      <li><%= t("pages.help.budgets.phase_3_html") %></li>
-      <li><%= t("pages.help.budgets.phase_4_html") %></li>
-    </ul>
-
-    <p><%= t("pages.help.budgets.phase_5_html") %></p>
 
     <figure>
       <%= image_tag "help/budgets_#{I18n.locale}.png", alt: t("pages.help.budgets.image_alt") %>

--- a/app/views/pages/help/_polls.html.erb
+++ b/app/views/pages/help/_polls.html.erb
@@ -11,8 +11,6 @@
               link: link_to(t("pages.help.polls.feature_1_link", org_name: setting['org_name']),
                                new_user_registration_path)).html_safe %>
       </li>
-      <li><%= t("pages.help.polls.feature_2") %></li>
-      <li><%= t("pages.help.polls.feature_3") %></li>
     </ul>
   </div>
 </div>

--- a/app/views/pages/help/_processes.html.erb
+++ b/app/views/pages/help/_processes.html.erb
@@ -11,9 +11,6 @@
     <ul class="features">
       <li>
         <% link = link_to(t("pages.help.processes.link"), legislation_processes_path) %>
-        <% sign_up_link = t("pages.help.processes.sign_up", org: setting['org_name']) %>
-        <% sign_up = link_to(sign_up_link, new_user_registration_path) %>
-        <%= t("pages.help.processes.feature", link: link, sign_up: sign_up).html_safe %>
       </li>
     </ul>
   </div>

--- a/app/views/pages/help/_proposals.html.erb
+++ b/app/views/pages/help/_proposals.html.erb
@@ -7,13 +7,6 @@
       <%= t("pages.help.proposals.description",
               link: link_to(t("pages.help.proposals.link"), proposals_path)).html_safe %>
     </p>
-    <ul class="features">
-      <li>
-        <%= t("pages.help.proposals.feature_html",
-              org: setting['org_name'],
-              supports: setting['votes_for_proposal_success']).html_safe %>
-      </li>
-    </ul>
 
     <figure>
       <%= image_tag "help/proposals_#{I18n.locale}.png", alt: t("pages.help.proposals.image_alt") %>

--- a/app/views/pages/help/index.html.erb
+++ b/app/views/pages/help/index.html.erb
@@ -11,7 +11,6 @@
   <div class="row">
     <div class="small-12 medium-9 column">
       <h2><%= t("pages.help.title", org: setting['org_name']) %></h2>
-      <p><%= t("pages.help.subtitle", org: setting['org_name']) %></p>
       <p><%= t("pages.help.guide", org: setting['org_name']) %></p>
     </div>
   </div>

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -38,9 +38,6 @@
         <strong><%= t("polls.index.section_footer.title") %></strong>
       </p>
       <p><%= t("polls.index.section_footer.description") %></p>
-      <p><%= t("polls.index.section_footer.help_text_1") %></p>
-      <p><%= t("polls.index.section_footer.help_text_2",
-                org: link_to(setting['org_name'], new_user_registration_path)).html_safe %></p>
     </div>
   </div>
 </div>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -70,8 +70,7 @@
           <div class="padding text-center">
 
             <p>
-              <%= t("proposals.proposal.successful",
-                  voting: link_to(t("proposals.proposal.voting"), polls_path)).html_safe %>
+              <%= t("proposals.proposal.successful") %>
             </p>
           </div>
           <% if can? :create, Poll::Question %>

--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -9,7 +9,7 @@
   <span class="total-supports">
     <%= t("proposals.proposal.supports", count: proposal.total_votes) %>&nbsp;
     <span>
-      <abbr title="<%= t("proposals.proposal.reason_for_supports_necessary") %>">
+      <abbr>
         <%= t("proposals.proposal.supports_necessary", number: number_with_delimiter(Proposal.votes_needed_for_success)) %>
       </abbr>
     </span>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -101,11 +101,6 @@
               <strong><%= t("proposals.index.section_footer.title") %></strong>
             </p>
             <p><%= t("proposals.index.section_footer.description") %></p>
-            <p><%= t("proposals.index.section_footer.help_text_1") %></p>
-            <p><%= t("proposals.index.section_footer.help_text_2",
-                      org: link_to(setting['org_name'], new_user_registration_path),
-                      supports: setting["votes_for_proposal_success"]).html_safe %></p>
-            <p><%= t("proposals.index.section_footer.help_text_3") %></p>
           </div>
         <% end %>
       </div>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -171,8 +171,7 @@
 
           <% if @proposal.successful? %>
             <p>
-              <%= t("proposals.proposal.successful",
-                  voting: link_to(t("proposals.proposal.voting"), polls_path)).html_safe %>
+              <%= t("proposals.proposal.successful") %>
             </p>
             <% if can? :create, Poll::Question %>
               <p class="text-center">

--- a/app/views/shared/_top_links.html.erb
+++ b/app/views/shared/_top_links.html.erb
@@ -1,19 +1,4 @@
 <ul class="no-bullet external-links">
-  <li>
-    <%= link_to t("layouts.header.external_link_transparency"),
-                setting['transparency_url'].presence || t("layouts.header.external_link_transparency_url"),
-                target: "_blank",
-                rel: "nofollow",
-                title: t("shared.go_to_page") + t("layouts.header.external_link_transparency") + t('shared.target_blank_html') %>
-  </li>
-  <li>
-    <%= link_to t("layouts.header.external_link_opendata"),
-                setting['opendata_url'].presence || t("layouts.header.external_link_opendata_url"),
-                target: "_blank",
-                rel: "nofollow",
-                title: t("shared.go_to_page") + t("layouts.header.external_link_opendata") + t('shared.target_blank_html') %>
-  </li>
-
   <% if setting['blog_url'] %>
     <li>
       <%= link_to t("layouts.header.external_link_blog"),

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -56,11 +56,7 @@ en:
       see_results: See results
       section_footer:
         title: Help with participatory budgets
-        description: With the participatory budgets the citizens decide to which projects presented by the neighbors is destined a part of the municipal budget.
-        help_text_1: "Participatory budgets are processes in which citizens decide directly on what is spent part of the municipal budget. Any registered person over 16 years old can propose an investment project that is preselected in a phase of citizen supports."
-        help_text_2: "The most voted projects are evaluated and passed to a final vote in which they decide the actions to be carried out by the City Council once the municipal budgets of the next year are approved."
-        help_text_3: "The presentation of participatory budgeting projects takes place from January and over a period of one and a half months. To participate and propose proposals for the entire city and / or districts, you must sign up on %{org} and verify your account."
-        help_text_4: "To get as many supports and votes as possible, choose a descriptive and understandable headline for your project. Then you have a space to develop the approach of your proposal. Provide all the data and explanations, and even documents and images, to help other participants to better understand what you are proposing."
+        description: With the participatory budgets the citizens decide to which projects is destined a part of the budget.
     investments:
       form:
         tag_category_label: "Categories"

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -38,11 +38,7 @@ en:
       updated: "Your password has been changed successfully. Authentication successful."
       updated_not_active: "Your password has been changed successfully."
     registrations:
-      destroyed:
-        "Goodbye! Your account has been cancelled. We hope to see you again soon. In accordance with your request, personal data registered as
-        a user of the site and form part of the file 'File' under the responsibility of the
-        'Responsible', they have been canceled under the terms of the provisions of Article 16 of the
-        Ley Orgánica 15/1999 de Protección de Datos de Carácter Personal and Article 31 of its Reglamento de desarrollo (RD 1720/2007)."
+      destroyed: "Goodbye! Your account has been cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have been authenticated."
       signed_up_but_inactive: "Your registration was successful, but you could not be signed in because your account has not been activated."
       signed_up_but_locked: "Your registration was successful, but you could not be signed in because your account is locked."

--- a/config/locales/en/devise_views.yml
+++ b/config/locales/en/devise_views.yml
@@ -16,7 +16,7 @@ en:
       confirmation_instructions:
         confirm_link: Confirm my account
         text: 'You can confirm your email account at the following link:'
-        title: Welcome to the Open Government Portal
+        title: Welcome
         welcome: Welcome
       reset_password_instructions:
         change_link: Change my password

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -136,9 +136,6 @@ en:
         description: Start a debate to share opinions with others about the topics you are concerned about.
         help_text_1: "The space for citizen debates is aimed at anyone who can expose issues of their concern and those who want to share opinions with other people."
         help_text_2: 'To open a debate you need to sign up on %{org}. Users can also comment on open debates and rate them with the "I agree" or "I disagree" buttons found in each of them.'
-        help_text_3: "Keep in mind that a debate does not start any specific action. If you want to make a %{proposal} for the city or raise a investment project of %{budget} when the phase is open, go to the corresponding section."
-        proposals_link: proposal
-        budget_link: participatory budgeting
     new:
       form:
         submit_button: Start a debate
@@ -400,10 +397,7 @@ en:
         help: Help about proposals
       section_footer:
         title: Help about proposals
-        description: Make a citizen proposal. If it gets enough supports it will go to voting phase, so you can get all the citizens to decide how they want their city to be.
-        help_text_1: "The citizen proposals are an opportunity for neighbours and collectives to decide directly how they want to shape their city. Any person can make a proposal about a topic or concern of their interest, for the City Council to make it, after it gets enough supports to be put to a citizens vote."
-        help_text_2: "To create a proposal, you must sign up on %{org}. The proposals that get the support of 1% of the users in the web, goes to voting phase. To support proposals it is necessary to have a verified account."
-        help_text_3: "A citizen vote is celebrated when the proposals get the necessary supports. Once celebrated, if there are more people in favor than against, the City Council assumes the proposal and carries it out."
+        description: Citizens' proposals are an opportunity for neighbours and collectives to decide directly how they want their city to be, after getting sufficient support and submitting to a citizens' vote.
     new:
       form:
         submit_button: Create proposal
@@ -493,9 +487,7 @@ en:
         help: Help about voting
       section_footer:
         title: Help about voting
-        description: Sign up to vote on citizen proposals and questions the City Council ask to the neighbors. Make municipal decisions directly.
-        help_text_1: "Voting takes place when a citizen proposal supports reaches 1% of the census with voting rights. Voting can also include questions that the City Council ask to the citizens decision."
-        help_text_2: "To participate in the next vote you have to sign up on %{org} and verify your account. All registered voters in the city over 16 years old can vote. The results of all votes are binding on the government."
+        description: Citizens' polls are a participatory mechanism by which citizens with voting rights can make direct decisions
       no_polls: "There are no open votings."
     show:
       already_voted_in_booth: "You have already participated in a physical booth. You can not participate again."

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -225,10 +225,6 @@ en:
       collaborative_legislation: Legislation processes
       debates: Debates
       external_link_blog: Blog
-      external_link_opendata: Open data
-      external_link_opendata_url: https://opendata.consul
-      external_link_transparency: Transparency
-      external_link_transparency_url: https://transparency.consul
       locale: 'Language:'
       logo: CONSUL logo
       management: Management

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -322,7 +322,7 @@ en:
       geozone: Scope of operation
       proposal_external_url: Link to additional documentation
       proposal_question: Proposal question
-      proposal_question_example_html: "Must be summarised in one question with a Yes or No answer. <br>E.g. 'Do you agree with the pedestrianisation of Calle Mayor?'"
+      proposal_question_example_html: "Must be summarised in one question with a Yes or No answer"
       proposal_responsible_name: Full name of the person submitting the proposal
       proposal_responsible_name_note: "(individually or as representative of a collective; will not be displayed publically)"
       proposal_summary: Proposal summary
@@ -412,7 +412,6 @@ en:
         one: 1 comment
         other: "%{count} comments"
         zero: No comments
-      reason_for_supports_necessary: 1% of Census
       support: Support
       support_title: Support this proposal
       supports:
@@ -426,8 +425,7 @@ en:
       supports_necessary: "%{number} supports needed"
       total_percent: 100%
       archived: "This proposal has been archived and can't collect supports."
-      successful: "This proposal has reached the required supports and will be voted in the %{voting}."
-      voting: "next voting"
+      successful: "This proposal has reached the required supports."
     show:
       author_deleted: User deleted
       code: 'Proposal code:'

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -207,17 +207,11 @@ en:
       contact_us: For technical assistance enters
       copyright: CONSUL, %{year}
       description: This portal uses the %{consul} which is %{open_source}.
-      faq: technical assistance
-      open_data_text: Every detail about the City Council is yours to access.
-      open_data_title: Open data
       open_source: open-source software
       open_source_url: http://www.gnu.org/licenses/agpl-3.0.html
       participation_text: Decide how to shape the city you want to live in.
       participation_title: Participation
       privacy: Privacy Policy
-      transparency_text: Find out anything about the city.
-      transparency_title: Transparency
-      transparency_url: https://transparency.consul
     header:
       administration_menu: Admin
       administration: Administration

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -71,9 +71,6 @@ en:
         section_footer:
           title: Help about legislation processes
           description: Participate in the debates and processes prior to the approval of a ordinance or a municipal action. Your opinion will be considered by the City Council.
-          help_text_1: "In participatory processes, the City Council offers to its citizens the opportunity to participate in the drafting and modification of regulations, affecting the city and to be able to give their opinion on certain actions that it plans to carry out."
-          help_text_2: "People registered in %{org} can participate with contributions in the public consultation of new ordinances, regulations and guidelines, among others. Your comments are analyzed by the corresponding area and considered for the final drafting of the ordinances."
-          help_text_3: "The City Council also opens processes to receive contributions and opinions on municipal actions."
       phase_not_open:
         not_open: This phase is not open yet
       phase_empty:

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -11,7 +11,7 @@ en:
     email_verification:
       click_here_to_verify: this link
       instructions_2_html: This email will verify your account with <b>%{document_type} %{document_number}</b>. If these don't belong to you, please don't click on the previous link and ignore this email.
-      instructions_html: To complete the verification of your user account in the Open Government Portal, you must click %{verification_link}.
+      instructions_html: To complete the verification of your user account you must click %{verification_link}.
       subject: Confirm your email
       thanks: Thank you very much.
       title: Confirm your account using the following link
@@ -24,12 +24,9 @@ en:
       hi: "Dear user,"
       new_html: "For all these, we invite you to elaborate a <strong>new proposal</strong> that ajusts to the conditions of this process. You can do it following this link: %{url}."
       new_href: "new investment project"
-      reconsider_html: "If you believe that the rejected proposal meets the requirements to be an investment proposal, you can communicate this, within 48 hours, responding to the email address examples@consul.es. Including the code %{code} in the subject of the email."
       sincerely: "Sincerely"
-      signatory: "DEPARTMENT OF PUBLIC PARTICIPATION"
       sorry: "Sorry for the inconvenience and we again thank you for your invaluable participation."
       subject: "Your investment project '%{code}' has been marked as unfeasible"
-      unfeasible_html: "From the City Council we want to thank you for your participation in the <strong>participatory budgets</strong>. We regret to inform you that your proposal <strong>'%{title}'</strong> will be excluded from this participatory process for the following reason:"
     proposal_notification_digest:
       info: "Here are the new notifications that have been published by authors of the proposals that you have supported in %{org_name}."
       title: "Proposal notifications in %{org_name}"
@@ -47,7 +44,7 @@ en:
       title_html: "You have send a new private message to <strong>%{receiver}</strong> with the content:"
     user_invite:
       ignore: "If you have not requested this invitation don't worry, you can ignore this email."
-      text: "Thank you for applying to join %{org}! In seconds you can start to decide the city you want, just fill the form below:"
+      text: "Thank you for applying to join %{org}! In seconds you can start to participate, just fill the form below:"
       thanks: "Thank you very much."
       title: "Welcome to %{org}"
       button: Complete registration
@@ -60,33 +57,23 @@ en:
       follow_html: "We will inform you about how the process progresses, which you can also follow on <strong>%{link}</strong>."
       follow_link: "Participatory Budgets"
       sincerely: "Sincerely,"
-      signatory: "DEPARTMENT OF PUBLIC PARTICIPATION"
       share: "Share your project"
     budget_investment_unfeasible:
       hi: "Dear user,"
       new_html: "For all these, we invite you to elaborate a <strong>new investment</strong> that ajusts to the conditions of this process. You can do it following this link: %{url}."
       new_href: "new investment project"
-      reconsider_html: "If you believe that the rejected investment meets the requirements to be an investment project, you can communicate this, within 48 hours, responding to the email address examples@consul.es. Including the code %{code} in the subject of the email."
       sincerely: "Sincerely"
-      signatory: "DEPARTMENT OF PUBLIC PARTICIPATION"
       sorry: "Sorry for the inconvenience and we again thank you for your invaluable participation."
       subject: "Your investment project '%{code}' has been marked as unfeasible"
-      unfeasible_html: "From the City Council we want to thank you for your participation in the <strong>participatory budgets</strong>. We regret to inform you that your investment <strong>'%{title}'</strong> will be excluded from this participatory process for the following reason:"
     budget_investment_selected:
       subject: "Your investment project '%{code}' has been selected"
       hi: "Dear user,"
-      selected_html: "From the City Council we want to thank you for your participation in the <strong>participatory budgets</strong>. We would like to inform you that your investment project <strong>'%{title}'</strong> has been selected for the final voting phase that will happen from <strong>May 15th to June 30th</strong>."
       share: "Start to get votes, share your investment project on social networks. Share is essential to make it a reality."
       share_button: "Share your investment project"
       thanks: "Thank you again for participating."
       sincerely: "Sincererly"
-      signatory: "DEPARTMENT OF PUBLIC PARTICIPATION"
     budget_investment_unselected:
       subject: "Your investment project '%{code}' has not been selected"
       hi: "Dear user,"
-      unselected_html: "From the City Council we want to thank you for your participation in the <strong>participatory budgets</strong>. We regret to inform you that your investment project <strong>'%{title}'</strong> has not been selected for the final voting phase."
-      participate_html: "You can continue participating in the final voting phase voting for investments projects from <strong>May 15th to June 30th</strong>."
-      participate_url: "participate in the final voting"
       thanks: "Thank you again for participating."
       sincerely: "Sincererly"
-      signatory: "DEPARTMENT OF PUBLIC PARTICIPATION"

--- a/config/locales/en/management.yml
+++ b/config/locales/en/management.yml
@@ -78,12 +78,9 @@ en:
       vote_proposals: Vote proposals
     print:
       proposals_info: Create yor proposal on http://url.consul
-      proposals_note: The proposals more supported will be voted. If are accepted by a majority, the city Council shall be carried out.
       proposals_title: 'Proposals:'
       spending_proposals_info: Participate at http://url.consul
-      spending_proposals_note: Participatory budget will be assigned to the most voted budget investment.
       budget_investments_info: Participate at http://url.consul
-      budget_investments_note: Participatory budget will be assigned to the most voted budget investment.
     print_info: Print this info
     proposals:
       alert:
@@ -106,7 +103,7 @@ en:
         unverified_user: User is not verified
       create: Create a budget investment
       filters:
-        heading: Concepto
+        heading: Concept
         unfeasible: Unfeasible investment
       print:
         print_button: Print

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -1,11 +1,9 @@
 en:
   pages:
-    census_terms: To confirm the account, you must be 16 or older and be registered, having provided the information requested previously, will verify. By accepting the verification process, you also consent to the verification of this information, as well as the contact methods featuring in said files. The data provided will be acquired and processed in a file mentioned previously in the terms and conditions of use for the Portal.
     conditions: Terms and conditions of use
     general_terms: Terms and Conditions
     help:
       title: "%{org} is a platform for citizen participation"
-      subtitle: "In %{org} you can make proposals, vote in citizen consultations, propose participatory budget projects, decide on municipal regulations and open debates to exchange opinions with others."
       guide: "This guide explains what each of the %{org} sections are for and how they work."
       menu:
         debates: "Debates"
@@ -26,19 +24,12 @@ en:
         title: "Proposals"
         description: "In the %{link} section you can make proposals for the City Council to carry them out. The proposals require support, and if they reach sufficient support, they are put to a public vote. The proposals approved in these citizens' votes are accepted by the City Council and carried out."
         link: "citizen proposals"
-        feature_html: "To create a proposal you must register in %{org}. The proposals that get the support on the website of 1% of people with the right to vote (%{supports} supports of people over 16 years old registered) go to vote. To support proposals it is necessary to verify your account."
         image_alt: "Button to support a proposal"
-        figcaption_html: 'Button to "Support" a proposal.<br>When it reaches the number of supports will go to vote.'
+        figcaption_html: 'Button to "Support" a proposal.'
       budgets:
         title: "Participatory Budgeting"
         description: "The %{link} section helps people make a direct decision on what part of the municipal budget is spent on."
         link: "participative budgets"
-        feature: "In this process, every year people raise, support and vote on projects. The most voted votes are financed by the municipal budget."
-        phase_1_html: "Between January and early March, people registered in %{org} can <strong>present</strong>."
-        phase_2_html: "In March, proposers have to gather support, in the form of <strong>preselection</strong>."
-        phase_3_html: "Between April and the beginning of May, the experts from the <strong>City Council rate</strong> projects on an order of more or less supported and check that they are viable."
-        phase_4_html: "Finally, between May and June, all citizens can <strong>vote</strong> projects that interest them the most."
-        phase_5_html: "From the approval of the budgets the following year the City Council begins to carry out the winning projects."
         image_alt: "Different phases of a participatory budget"
         figcaption_html: '"Support" and "Voting" phases of participatory budgets.'
       polls:
@@ -47,14 +38,10 @@ en:
         link: "polls"
         feature_1: "To participate in the voting you have to %{link} and verify your account."
         feature_1_link: "register in %{org_name}"
-        feature_2: "All registered voters over the age of 16 can vote."
-        feature_3: "The results of all votes are binding on the municipal government."
       processes:
         title: "Processes"
         description: "In the %{link} section, citizens participate in the drafting and modification of regulations affecting the city and can give their opinion on municipal policies in previous debates."
         link: "processes"
-        feature: "To participate in a process you have to %{sign_up} and check the %{link} page periodically to see which regulations and policies are being discussed and consulted."
-        sign_up: "sign up on %{org}"
       faq:
         title: "Technical problems?"
         description: "Read the FAQs and solve your questions."

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -56,11 +56,7 @@ es:
       see_results: Ver resultados
       section_footer:
         title: Ayuda sobre presupuestos participativos
-        description: Con los presupuestos participativos la ciudadanía decide a qué proyectos presentados por los vecinos y vecinas va destinada una parte del presupuesto municipal.
-        help_text_1: "Los presupuestos participativos son unos procesos en los que la ciudadanía decide de forma directa en qué se gasta una parte del presupuesto municipal. Cualquier persona empadronada mayor de 16 años puede proponer un proyecto de gasto que se preselecciona en una fase de apoyos ciudadanos."
-        help_text_2: "Los proyectos más votados se evalúan y pasan a una votación final en la que se deciden las actuaciones que llevará a cabo el Ayuntamiento una vez se aprueben los presupuestos municipales del año próximo."
-        help_text_3: "La presentación de proyectos de presupuestos participativos se lleva a cabo desde enero y a lo largo de un periodo de mes y medio, aproximadamente. Para participar y plantear propuestas para toda la ciudad y/ los distritos hay que registrarse en %{org} y verificar la cuenta."
-        help_text_4: "Para conseguir el mayor número de apoyos y votos posible, elige un titular descriptivo y comprensible de tu proyecto. Después tienes un espacio para desarrollar el planteamiento de tu propuesta. Aporta todos los datos y explicaciones, e incluso documentos e imágenes, para ayudar a otras personas participantes a entender mejor lo que planteas."
+        description: Con los presupuestos participativos la ciudadanía decide a qué proyectos va destinada una parte del presupuesto.
     investments:
       form:
         tag_category_label: "Categorías"

--- a/config/locales/es/devise.yml
+++ b/config/locales/es/devise.yml
@@ -37,7 +37,7 @@ es:
       updated: "Tu contraseña ha cambiado correctamente. Has sido identificado correctamente."
       updated_not_active: "Tu contraseña se ha cambiado correctamente."
     registrations:
-      destroyed: "¡Adiós! Tu cuenta ha sido cancelada. Esperamos volver a verte pronto. Le informamos que de conformidad con su petición, sus datos personales registrados como usuario de la Web y que forman parte del fichero 'Fichero' cuyo responsable es 'Responsable', han sido cancelados en los términos de lo previsto en el artículo 16 de la Ley Orgánica 15/1999 de Protección de Datos de Carácter Personal y del artículo 31 de su Reglamento de desarrollo (RD 1720/2007)."
+      destroyed: "¡Adiós! Tu cuenta ha sido cancelada. Esperamos volver a verte pronto."
       signed_up: "¡Bienvenido! Has sido identificado."
       signed_up_but_inactive: "Te has registrado correctamente, pero no has podido iniciar sesión porque tu cuenta no ha sido activada."
       signed_up_but_locked: "Te has registrado correctamente, pero no has podido iniciar sesión porque tu cuenta está bloqueada."

--- a/config/locales/es/devise_views.yml
+++ b/config/locales/es/devise_views.yml
@@ -16,7 +16,7 @@ es:
       confirmation_instructions:
         confirm_link: Confirmar mi cuenta
         text: 'Puedes confirmar tu cuenta de correo electrónico en el siguiente enlace:'
-        title: Te damos la bienvenida al Portal de Gobierno Abierto
+        title: Bienvenido/a
         welcome: Bienvenido/a
       reset_password_instructions:
         change_link: Cambiar mi contraseña

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -207,17 +207,11 @@ es:
       contact_us: Para asistencia técnica entra en
       copyright: CONSUL, %{year}
       description: Este portal usa la %{consul} que es %{open_source}.
-      faq: Asistencia técnica
-      open_data_text: Todos los datos del Ayuntamiento son tuyos.
-      open_data_title: Datos Abiertos
       open_source: software de código abierto
       open_source_url: http://www.gnu.org/licenses/agpl-3.0.html
       participation_text: Decide cómo debe ser la ciudad que quieres.
       participation_title: Participación
       privacy: Política de privacidad
-      transparency_text: Obtén cualquier información sobre la ciudad.
-      transparency_title: Transparencia
-      transparency_url: https://transparency.consul
     header:
       administration_menu: Admin
       administration: Administración

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -322,7 +322,7 @@ es:
       geozone: Ámbito de actuación
       proposal_external_url: Enlace a documentación adicional
       proposal_question: Pregunta de la propuesta
-      proposal_question_example_html: "Debe ser resumida en una pregunta cuya respuesta sea Sí o No. <br>Ej. '¿Está usted de acuerdo en peatonalizar la calle Mayor?'"
+      proposal_question_example_html: "Debe ser resumida en una pregunta cuya respuesta sea Sí o No"
       proposal_responsible_name: Nombre y apellidos de la persona que hace esta propuesta
       proposal_responsible_name_note: "(individualmente o como representante de un colectivo; no se mostrará públicamente)"
       proposal_summary: Resumen de la propuesta
@@ -412,7 +412,6 @@ es:
         zero: Sin comentarios
         one: 1 Comentario
         other: "%{count} Comentarios"
-      reason_for_supports_necessary: 1% del Censo
       support: Apoyar
       support_title: Apoyar esta propuesta
       supports:
@@ -426,8 +425,7 @@ es:
       supports_necessary: "%{number} apoyos necesarios"
       total_percent: 100%
       archived: "Esta propuesta ha sido archivada y ya no puede recoger apoyos."
-      successful: "Esta propuesta ha alcanzado los apoyos necesarios y pasará a la %{voting}."
-      voting: "próxima votación"
+      successful: "Esta propuesta ha alcanzado los apoyos necesarios."
     show:
       author_deleted: Usuario eliminado
       code: 'Código de la propuesta:'

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -225,10 +225,6 @@ es:
       collaborative_legislation: Procesos legislativos
       debates: Debates
       external_link_blog: Blog
-      external_link_opendata: Datos abiertos
-      external_link_opendata_url: https://opendata.consul
-      external_link_transparency: Transparencia
-      external_link_transparency_url: https://transparency.consul
       locale: 'Idioma:'
       logo: Logo de CONSUL
       management: Gestión

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -136,9 +136,6 @@ es:
         description: Inicia un debate para compartir puntos de vista con otras personas sobre los temas que te preocupan.
         help_text_1: "El espacio de debates ciudadanos está dirigido a que cualquier persona pueda exponer temas que le preocupan y sobre los que quiera compartir puntos de vista con otras personas."
         help_text_2: 'Para abrir un debate es necesario registrarse en %{org}. Los usuarios ya registrados también pueden comentar los debates abiertos y valorarlos con los botones de "Estoy de acuerdo" o "No estoy de acuerdo" que se encuentran en cada uno de ellos.'
-        help_text_3: "Ten en cuenta que un debate no activa ningún mecanismo de actuación concreto. Si quieres hacer una %{proposal} para la ciudad o plantear un proyecto de %{budget} cuando se abra la convocatoria, ve a la sección correspondiente."
-        proposals_link: propuesta
-        budget_link: presupuestos participativos
     new:
       form:
         submit_button: Empieza un debate
@@ -400,10 +397,7 @@ es:
         help: Ayuda sobre las propuestas
       section_footer:
         title: Ayuda sobre las propuestas
-        description: Haz una propuesta ciudadana. Si obtiene los apoyos suficientes y pasa a votación, puedes conseguir que todos los habitantes decidan cómo quieren que sea nuestra ciudad.
-        help_text_1: "Las propuestas ciudadanas son una oportunidad para que los vecinos y colectivos decidan directamente cómo quieren que sea su ciudad. Cualquier persona puede hacer una propuesta sobre un tema que le interese o preocupe para que el ayuntamiento la lleve a cabo, después de conseguir los apoyos suficientes y de someterse a votación ciudadana."
-        help_text_2: "Para crear una propuesta hay que registrarse en %{org}. Las propuestas que consigan el apoyo del 1% de la gente en la web, pasan a votación. Para apoyar propuestas es necesario tener una cuenta verificada."
-        help_text_3: "Se convoca una votación ciudadana cuando las propuestas consiguen los apoyos necesarios. Una vez celebrada, si hay más gente a favor que en contra, el Consistorio asume la propuesta y la lleva a cabo."
+        description: Las propuestas ciudadanas son una oportunidad para que los vecinos y colectivos decidan directamente cómo quieren que sea su ciudad, después de conseguir los apoyos suficientes y de someterse a votación ciudadana.
     new:
       form:
         submit_button: Crear propuesta
@@ -493,9 +487,7 @@ es:
         help: Ayuda sobre las votaciones
       section_footer:
         title: Ayuda sobre las votaciones
-        description: Regístrate para poder votar propuestas ciudadanas y las cuestiones que pregunta a sus vecinos el Ayuntamiento. Toma decisiones municipales de forma directa.
-        help_text_1: "Las votaciones se convocan cuando una propuesta ciudadana alcanza el 1% de apoyos del censo con derecho a voto. En las votaciones también se pueden incluir cuestiones que el Ayuntamiento somete a decisión directa de la ciudadanía."
-        help_text_2: "Para participar en la próxima votación tienes que registrarte en %{org} y verificar tu cuenta. Pueden votar todas las personas empadronadas en la ciudad mayores de 16 años. Los resultados de todas las votaciones serán vinculantes para el gobierno."
+        description: Las votaciones ciudadanas son un mecanismo de participación por el que la ciudadanía con derecho a voto puede tomar decisiones de forma directa.
       no_polls: "No hay votaciones abiertas."
     show:
       already_voted_in_booth: "Ya has participado en esta votación en urnas presenciales, no puedes volver a participar."

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -71,9 +71,6 @@ es:
         section_footer:
           title: Ayuda sobre procesos legislativos
           description: Participa en los debates y procesos previos a la aprobación de una norma o de una actuación municipal. Tu opinión será tenida en cuenta por el Ayuntamiento.
-          help_text_1: "En los procesos participativos, el Ayuntamiento ofrece a la ciudadanía la oportunidad de participar en la elaboración y modificación de normativa que afecta a la ciudad y de dar su opinión sobre ciertas actuaciones que tiene previsto llevar a cabo."
-          help_text_2: "Las personas registradas en %{org} pueden participar con aportaciones en la consulta pública de nuevas ordenanzas, reglamentos y directrices, entre otros. Sus comentarios son analizados por el área correspondiente y tenidos en cuenta de cara a la redacción final de las normas."
-          help_text_3: "El Ayuntamiento también abre procesos para recibir aportaciones y opiniones sobre actuaciones municipales."
       phase_not_open:
         not_open: Esta fase del proceso todavía no está abierta
       phase_empty:

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -11,7 +11,7 @@ es:
     email_verification:
       click_here_to_verify: en este enlace
       instructions_2_html: Este email es para verificar tu cuenta con <b>%{document_type} %{document_number}</b>. Si esos no son tus datos, por favor no pulses el enlace anterior e ignora este email.
-      instructions_html: Para terminar de verificar tu cuenta de usuario en el Portal de Gobierno Abierto, necesitamos que pulses %{verification_link}.
+      instructions_html: Para terminar de verificar tu cuenta de usuario pulsa %{verification_link}.
       subject: Verifica tu email
       thanks: Muchas gracias.
       title: Verifica tu cuenta con el siguiente enlace
@@ -24,22 +24,16 @@ es:
       hi: "Estimado usuario,"
       new_html: 'Por todo ello, te invitamos a que elabores una <strong>nueva propuesta</strong> que se ajuste a las condiciones de este proceso. Esto lo puedes hacer en este enlace: %{url}.'
       new_href: "nueva propuesta de inversión"
-      reconsider_html: "Si consideras que la propuesta rechazada cumple los requisitos para mantenerla como propuesta de inversión, podrás comunicarlo, en el plazo de 48 horas, al correo example@consul.es, indicando necesariamente para su tramitación el código %{code} como asunto del correo, correspondiente a tu propuesta."
       sincerely: "Atentamente"
-      signatory: "DIRECCIÓN GENERAL DE PARTICIPACIÓN CIUDADANA"
       sorry: "Sentimos las molestias ocasionadas y volvemos a darte las gracias por tu inestimable participación."
       subject: "Tu propuesta de inversión '%{code}' ha sido marcada como inviable"
-      unfeasible_html: "Desde el Ayuntamiento queremos agradecer tu participación en los <strong>Presupuestos Participativos</strong>. Lamentamos informarte de que tu propuesta <strong>'%{title}'</strong> quedará excluida de este proceso participativo por el siguiente motivo:"
     budget_investment_unfeasible:
       hi: "Estimado usuario,"
       new_html: 'Por todo ello, te invitamos a que elabores un <strong>nuevo proyecto de gasto</strong> que se ajuste a las condiciones de este proceso. Esto lo puedes hacer en este enlace: %{url}.'
       new_href: "nuevo proyecto de gasto"
-      reconsider_html: "Si consideras que el proyecto rechazado cumple los requisitos para mantenerlo como proyecto de gasto, podrás comunicarlo, en el plazo de 48 horas, al correo example@consul.es, indicando necesariamente para su tramitación el código %{code} como asunto del correo, correspondiente a tu proyecto."
       sincerely: "Atentamente"
-      signatory: "DIRECCIÓN GENERAL DE PARTICIPACIÓN CIUDADANA"
       sorry: "Sentimos las molestias ocasionadas y volvemos a darte las gracias por tu inestimable participación."
       subject: "Tu proyecto de gasto '%{code}' ha sido marcado como inviable"
-      unfeasible_html: "Desde el Ayuntamiento queremos agradecer tu participación en los <strong>Presupuestos Participativos</strong>. Lamentamos informarte de que tu proyecto <strong>'%{title}'</strong> quedará excluido de este proceso participativo por el siguiente motivo:"
     proposal_notification_digest:
       info: "A continuación te mostramos las nuevas notificaciones que han publicado los autores de las propuestas que estás apoyando en %{org_name}."
       title: "Notificaciones de propuestas en %{org_name}"
@@ -57,7 +51,7 @@ es:
       title_html: "Has enviado un nuevo mensaje privado a <strong>%{receiver}</strong> con el siguiente contenido:"
     user_invite:
       ignore: "Si no has solicitado esta invitación no te preocupes, puedes ignorar este correo."
-      text: "¡Gracias por solicitar unirte a %{org}! En unos segundos podrás empezar a decidir la ciudad que quieres, sólo tienes que rellenar el siguiente formulario:"
+      text: "¡Gracias por solicitar unirte a %{org}! En unos segundos podrás empezar a participar, sólo tienes que rellenar el siguiente formulario:"
       thanks: "Muchas gracias."
       title: "Bienvenido a %{org}"
       button: Completar registro
@@ -70,23 +64,16 @@ es:
       follow_html: "Te informaremos de cómo avanza el proceso, que también puedes seguir en la página de <strong>%{link}</strong>."
       follow_link: "Presupuestos participativos"
       sincerely: "Atentamente,"
-      signatory: "DIRECCIÓN GENERAL DE PARTICIPACIÓN CIUDADANA"
       share: "Comparte tu proyecto"
     budget_investment_selected:
       subject: "Tu proyecto de gasto '%{code}' ha sido seleccionado"
       hi: "Estimado/a usuario/a"
-      selected_html: "Desde el Ayuntamiento de Madrid agradecemos que hayas participado con tu idea en los <strong>Presupuestos Participativos</strong>. Te informamos de que tu proyecto <strong>'%{title}'</strong> ha sido seleccionado y pasa a la fase de votación final que tiene lugar desde el <strong>15 de mayo hasta el 30 de junio de 2017</strong>."
       share: "Empieza ya a conseguir votos, comparte tu proyecto de gasto en redes sociales. La difusión es fundamental para conseguir que se haga realidad."
       share_button: "Comparte tu proyecto"
       thanks: "Gracias de nuevo por tu participación."
       sincerely: "Atentamente"
-      signatory: "DIRECCIÓN GENERAL DE PARTICIPACIÓN CIUDADANA"
     budget_investment_unselected:
       subject: "Tu proyecto de gasto '%{code}' no ha sido seleccionado"
       hi: "Estimado/a usuario/a"
-      unselected_html: "Desde el Ayuntamiento de Madrid agradecemos que hayas participado con tu idea en los <strong>Presupuestos Participativos</strong>. Lamentamos informarte de que tu proyecto <strong>'%{title}'</strong> no ha sido seleccionado para la fase de votación final."
-      participate_html: "Puedes continuar participando en la votación final votando proyectos para toda la ciudad y el distrito que elijas desde el <strong>15 de mayo hasta el 30 de junio de 2017.</strong>"
-      participate_url: "participes en la votación final"
       thanks: "Gracias de nuevo por tu participación."
       sincerely: "Atentamente"
-      signatory: "DIRECCIÓN GENERAL DE PARTICIPACIÓN CIUDADANA"

--- a/config/locales/es/management.yml
+++ b/config/locales/es/management.yml
@@ -78,12 +78,9 @@ es:
       vote_proposals: Participar en las votaciones finales
     print:
       proposals_info: Haz tu propuesta en http://url.consul
-      proposals_note: Las propuestas más apoyadas serán llevadas a votación. Y si las acepta una mayoría, el Ayuntamiento las llevará a cabo.
       proposals_title: 'Propuestas:'
       spending_proposals_info: Participa en http://url.consul
-      spending_proposals_note: Los presupuestos participativos se invertirán en las propuestas de inversión más apoyadas.
       budget_investments_info: 'Participa en http://url.consul'
-      budget_investments_note: Los presupuestos participativos se invertirán en los proyectos de gasto más apoyados.
     print_info: Imprimir esta información
     proposals:
       alert:

--- a/config/locales/es/pages.yml
+++ b/config/locales/es/pages.yml
@@ -1,11 +1,9 @@
 es:
   pages:
-    census_terms: Para verificar la cuenta hay que tener 16 años o más y estar empadronado aportando los datos indicados anteriormente, los cuales serán contrastados. Aceptando el proceso de verificación acepta dar su consentimiento para contrastar dicha información, así como medios de contacto que figuren en dichos ficheros. Los datos aportados serán incorporados y tratados en un fichero indicado anteriormente en las condiciones de uso del portal.
     conditions: Condiciones de uso
     general_terms: Términos y Condiciones
     help:
       title: "%{org} es una plataforma de participación ciudadana"
-      subtitle: "En %{org} se pueden hacer propuestas, votar en consultas ciudadanas, plantear proyectos de presupuestos participativos, decidir la normativa municipal y abrir debates para intercambiar opiniones con otras personas."
       guide: 'Esta guía explica para qué sirven y cómo funcionan cada una de las secciones de %{org}.'
       menu:
         debates: "Debates"
@@ -26,19 +24,12 @@ es:
         title: "Propuestas"
         description: "En la sección de %{link} puedes plantear propuestas para que el Ayuntamiento las lleve a cabo. Las propuestas recaban apoyos, y si alcanzan los apoyos suficientes se someten a votación ciudadana. Las propuestas aprobadas en estas votaciones ciudadanas son asumidas por el Ayuntamiento y se llevan a cabo."
         link: "propuestas ciudadanas"
-        feature_html: "Para crear una propuesta hay que registrarse en %{org}. Las propuestas que consiguen el apoyo en la web del 1% de la gente con derecho a voto (%{supports} apoyos de personas mayores de 16 años empadronadas) pasan a votación. Para apoyar propuestas es necesario verificar tu cuenta."
         image_alt: "Botón para apoyar una propuesta"
-        figcaption_html: 'Botón para "Apoyar" una propuesta.<br>Cuando alcance el número de apoyos pasará a votación.'
+        figcaption_html: 'Botón para "Apoyar" una propuesta.'
       budgets:
         title: "Presupuestos participativos"
         description: "La sección de %{link} sirve para que la gente decida de manera directa a qué se destina una parte del presupuesto municipal."
         link: "presupuestos participativos"
-        feature: "En este proceso cada año la gente plantea, apoya y vota proyectos. Los más votados pasan a financiarse con el presupuesto municipal."
-        phase_1_html: "Entre enero y principios de marzo, las personas registradas en %{org} pueden <strong>presentar proyectos</strong>."
-        phase_2_html: "En marzo, los proponentes tienen que recabar apoyos, a modo de <strong>fase de preselección</strong>."
-        phase_3_html: "Entre abril y comienzos de mayo los técnicos del Ayuntamiento <strong>tasan los proyectos</strong> por orden de más a menos apoyados y comprueban que son viables."
-        phase_4_html: "Finalmente, entre mayo y junio, toda la ciudadanía puede <strong>votar los proyectos</strong> que más le interesan."
-        phase_5_html: "A partir de la aprobación de los presupuestos al año siguiente el Ayuntamiento empieza a llevar a cabo los proyectos ganadores."
         image_alt: "Diferentes fases de un presupuesto participativo"
         figcaption_html: 'Fase de "Apoyos" y fase de "Votación" de los presupuestos participativos.'
       polls:
@@ -47,8 +38,6 @@ es:
         link: "votaciones ciudadanas"
         feature_1: "Para participar en las votaciones tienes que %{link} y verificar tu cuenta."
         feature_1_link: "registrarte en %{org_name}"
-        feature_2: "Pueden votar todas las personas empadronadas en la ciudad mayores de 16 años."
-        feature_3: "Los resultados de todas las votaciones son vinculantes para el gobierno municipal."
       processes:
         title: "Procesos legislativos"
         description: "En la sección de %{link} la ciudadanía participa en la elaboración y modificación de normativa que afecta a la ciudad y puede dar su opinión sobre las políticas municipales en debates previos."

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -233,8 +233,6 @@ feature 'Emails' do
     email = open_last_email
     expect(email).to have_subject("Your investment project '#{spending_proposal.code}' has been marked as unfeasible")
     expect(email).to deliver_to(spending_proposal.author.email)
-    expect(email).to have_body_text(spending_proposal.title)
-    expect(email).to have_body_text(spending_proposal.code)
     expect(email).to have_body_text(spending_proposal.feasible_explanation)
 
     Setting["feature.spending_proposals"] = nil
@@ -426,8 +424,6 @@ feature 'Emails' do
       email = open_last_email
       expect(email).to have_subject("Your investment project '#{investment.code}' has been marked as unfeasible")
       expect(email).to deliver_to(investment.author.email)
-      expect(email).to have_body_text(investment.title)
-      expect(email).to have_body_text(investment.code)
       expect(email).to have_body_text(investment.unfeasibility_explanation)
     end
 
@@ -451,7 +447,6 @@ feature 'Emails' do
       investment = investment2
       expect(email).to have_subject("Your investment project '#{investment.code}' has been selected")
       expect(email).to deliver_to(investment.author.email)
-      expect(email).to have_body_text(investment.title)
     end
 
     scenario "Unselected investment" do
@@ -474,7 +469,6 @@ feature 'Emails' do
       investment = investment2
       expect(email).to have_subject("Your investment project '#{investment.code}' has not been selected")
       expect(email).to deliver_to(investment.author.email)
-      expect(email).to have_body_text(investment.title)
     end
 
   end


### PR DESCRIPTION
Objectives
===================

This PR removes a lot of custom content to clean views and making translation easier. So this removes custont i18n keys on:

- Help pages
- On index views pages (section footer with help text)
- Top links
- Content of mailers
- Management and devise views
-  Footer page
- Proposals

Release notes
===================
📝 If you was using some of this removed keys, remember to include them on your custom folders to keep it on use. For example on `config/locales/custom/en/custom.yml`