### PR TITLE
Rollback chromedriver version in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN bundle install --full-index
 
 # Install Chromium and ChromeDriver for E2E integration tests
 RUN apt-get update -qq && apt-get install -y chromium
-RUN wget -N http://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip
+RUN wget -N http://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip
 RUN chmod +x chromedriver
 RUN mv -f chromedriver /usr/local/share/chromedriver


### PR DESCRIPTION
References
===================
 - https://github.com/consul/consul/pull/2563

Objectives
===================
Rollback chromedriver version in Docker image to a version compatible
with the version of chromium used.

Commit message:

> Our Docker image uses Chromium v57, which is not supported by
> chromedriver versions after 2.38. See
> https://bugs.chromium.org/p/chromedriver/issues/detail?id=2445
> 
> The reason that the version of chromium is so old is that our base
> image ruby:2.3.6 (the standard image for Ruby 2.3.6 on DockerHub) is
> built on Debian 8 (jessie), which was made obsolete over a year ago.
> 
> The best solution is probably to upgrade the application to Ruby 2.3.7
> (if not later), so we can use the official ruby:2.3.7 image, which is
> kept up-to-date (it has Chromium 68).
> 
> Alternatively, we could try to install Chromium from a more up-to-date
> repository, but this is probably not worth the trouble.

There is already an open PR to upgrade to Ruby 2.3.7: #2565 