### PR TITLE
Fixes logo header on devise layout

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -878,11 +878,6 @@ footer {
   h1 {
     margin-top: $line-height;
 
-    img {
-      height: rem-calc(80);
-      width: rem-calc(80);
-    }
-
     a {
       color: #fff;
       display: block;

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -11,7 +11,6 @@
         <h1 class="logo margin">
           <%= link_to root_path do %>
             <%= image_tag(image_path_for('logo_header.png'), class: 'float-left', alt: t("layouts.header.logo")) %>
-            <%= setting['org_name'] %>
           <% end %>
         </h1>
       </div>


### PR DESCRIPTION
Objectives
===================
This PR fixes logo header size on devise layout. Removes the org name and modify the CSS.

Visual Changes
===================
**Before**
![screen shot 2018-07-31 at 15 31 48](https://user-images.githubusercontent.com/631897/43472072-d404a1a6-94ec-11e8-8e87-b427ca38b27b.png)

**After**
![screen shot 2018-07-31 at 15 33 35](https://user-images.githubusercontent.com/631897/43472079-d748a3b2-94ec-11e8-9944-bf6a8a886199.png)
