### PR TITLE
follow button added to communities page 

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -4,9 +4,7 @@ class Community < ActiveRecord::Base
   has_many :topics
 
   def participants
-    users_participants = users_who_commented +
-                         users_who_topics_author +
-                         author_from_community
+    users_participants = users_who_follow_community
     users_participants.uniq
   end
 
@@ -31,4 +29,8 @@ class Community < ActiveRecord::Base
     from_proposal? ? User.where(id: proposal&.author_id) : User.where(id: investment&.author_id)
   end
 
+  def users_who_follow_community
+    followers=Follow.pluck(:user_id)
+    User.by_community(followers)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,7 @@ class User < ActiveRecord::Base
   scope :public_for_api, -> { all }
   scope :by_comments,    ->(query, topics_ids) { joins(:comments).where(query, topics_ids).uniq }
   scope :by_authors,     ->(author_ids) { where("users.id IN (?)", author_ids) }
+  scope :by_community,   ->(community_id){ where("users.id IN (?)",community_id)}
   scope :by_username_email_or_document_number, ->(search_string) do
     string = "%#{search_string}%"
     where("username ILIKE ? OR email ILIKE ? OR document_number ILIKE ?", string, string, string)

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -1,4 +1,4 @@
-<div class="communities-show">
+<div id="<%= dom_id(@community) %>" class="communities-show">
 
   <div class="jumbo light">
     <div class="row">
@@ -31,6 +31,8 @@
       <div class="sidebar-divider"></div>
       <h2><%= t("community.show.sidebar.participate") %></h2>
       <%= link_to t("community.show.sidebar.new_topic"), create_topic_link(@community) , class: "button expanded" %>
+      <h2><%= t("community.show.sidebar.follow") %></h2>
+      <%= render 'follows/follow_button', follow: find_or_build_follow(current_user, @community)%>
     </aside>
   </div>
 </div>

--- a/app/views/follows/_follow_button.html.erb
+++ b/app/views/follows/_follow_button.html.erb
@@ -1,6 +1,6 @@
 <div class="js-follow">
   <span class="followable-content">
-    <% if follow.followable.followed_by?(current_user) %>
+    <% if follow.followable.class.name == "Community" ? current_user && current_user.follows.present? : follow.followable.followed_by?(current_user) %>
       <%= link_to t('shared.following'),
                   follow_path(follow),
                   method: :delete, remote: true,

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -1,6 +1,8 @@
 en:
   activerecord:
     models:
+      community:
+        one: "Community"
       activity:
         one: "activity"
         other: "activities"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -577,6 +577,11 @@ en:
             notice_html: "Now you are following this citizen proposal! </br> We will notify you of changes as they occur so that you are up-to-date."
           destroy:
             notice_html: "You have stopped following this citizen proposal! </br> You will no longer receive notifications related to this proposal."
+      community:
+          create:
+            notice_html: "Now you are following this community! <br> We will notify you of changes as they occur so that you are up-to-date."
+          destroy:
+            notice_html: "You have stopped following this community! <br>
     hide: Hide
     print:
       print_button: Print this info

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -61,6 +61,8 @@ es:
       proposal:
         one: "Propuesta ciudadana"
         other: "Propuestas ciudadanas"
+      community:
+        one: "Comunidad"
       spending_proposal:
         one: "Propuesta de inversión"
         other: "Propuestas de inversión"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -576,6 +576,11 @@ es:
           notice_html: "¡Ahora estás siguiendo esta propuesta ciudadana! </br> Te notificaremos los cambios a medida que se produzcan para que estés al día."
         destroy:
           notice_html: "¡Has dejado de seguir esta propuesta ciudadana! </br> Ya no recibirás más notificaciones relacionadas con esta propuesta."
+      community:
+        create:
+          notice_html: "¡Ahora estás siguiendo esta comunidad!<br>Te notificaremos los cambios a medida que se produzcan para que estés al día."
+        destroy:
+          notice_html: "¡Has dejado de seguir esta comunidad!<br>Ya no recibirás más notificaciones relacionadas con esta propuesta."
     hide: Ocultar
     print:
       print_button: Imprimir esta información


### PR DESCRIPTION
Objectives
===================
1.Add "Follow community" button on /communities/N (see screenshot_1)
2.The participants should be only the users who are following the community.
3.If user create a topic or comment on existing one but is no followinf the community *shouldn't appear on participants list.

References
===================

* Closes https://github.com/consul/consul/issues/2772

Visual Changes
===================
![42809860-db59772e-89b6-11e8-8172-93c21db0b1ee](https://user-images.githubusercontent.com/41967374/43477583-351784d2-9519-11e8-8b6f-a000cd682126.png)
