### PR TITLE
Fix navigation menu under Legislation::Proposal show view

### DIFF
--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -13,7 +13,7 @@
       <li>
         <%= layout_menu_link_to t("layouts.header.proposals"),
                                 proposals_path,
-                                controller_name == 'proposals',
+                                controller.class == ProposalsController,
                                 accesskey: "2",
                                 title: t("shared.go_to_page") + t("layouts.header.proposals") %>
       </li>

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -35,5 +35,6 @@ require_relative 'dev_seeds/newsletters'
 require_relative 'dev_seeds/notifications'
 require_relative 'dev_seeds/widgets'
 require_relative 'dev_seeds/admin_notifications'
+require_relative 'dev_seeds/legislation_proposals'
 
 log "All dev seeds created successfuly 👍"

--- a/db/dev_seeds/legislation_processes.rb
+++ b/db/dev_seeds/legislation_processes.rb
@@ -1,28 +1,32 @@
 section "Creating legislation processes" do
   5.times do
-    process = ::Legislation::Process.create!(title: Faker::Lorem.sentence(3).truncate(60),
-                                             description: Faker::Lorem.paragraphs.join("\n\n"),
-                                             summary: Faker::Lorem.paragraph,
-                                             additional_info: Faker::Lorem.paragraphs.join("\n\n"),
-                                             start_date: Date.current - 3.days,
-                                             end_date: Date.current + 3.days,
-                                             debate_start_date: Date.current - 3.days,
-                                             debate_end_date: Date.current - 1.day,
-                                             draft_publication_date: Date.current + 1.day,
-                                             allegations_start_date: Date.current + 2.days,
-                                             allegations_end_date: Date.current + 3.days,
-                                             result_publication_date: Date.current + 4.days,
-                                             debate_phase_enabled: true,
-                                             allegations_phase_enabled: true,
-                                             draft_publication_enabled: true,
-                                             result_publication_enabled: true,
-                                             published: true)
+    Legislation::Process.create!(title: Faker::Lorem.sentence(3).truncate(60),
+                                 description: Faker::Lorem.paragraphs.join("\n\n"),
+                                 summary: Faker::Lorem.paragraph,
+                                 additional_info: Faker::Lorem.paragraphs.join("\n\n"),
+                                 proposals_description: Faker::Lorem.paragraph,
+                                 start_date: Date.current - 3.days,
+                                 end_date: Date.current + 3.days,
+                                 debate_start_date: Date.current - 3.days,
+                                 debate_end_date: Date.current - 1.day,
+                                 proposals_phase_start_date: Date.current - 3.days,
+                                 proposals_phase_end_date: Date.current - 1.day,
+                                 draft_publication_date: Date.current + 1.day,
+                                 allegations_start_date: Date.current + 2.days,
+                                 allegations_end_date: Date.current + 3.days,
+                                 result_publication_date: Date.current + 4.days,
+                                 debate_phase_enabled: true,
+                                 allegations_phase_enabled: true,
+                                 draft_publication_enabled: true,
+                                 result_publication_enabled: true,
+                                 proposals_phase_enabled: true,
+                                 published: true)
   end
 
-  ::Legislation::Process.all.each do |process|
+  Legislation::Process.all.each do |process|
     (1..3).each do |i|
-      version = process.draft_versions.create!(title: "Version #{i}",
-                                               body: Faker::Lorem.paragraphs.join("\n\n"))
+      process.draft_versions.create!(title: "Version #{i}",
+                                     body: Faker::Lorem.paragraphs.join("\n\n"))
     end
   end
 end

--- a/db/dev_seeds/legislation_proposals.rb
+++ b/db/dev_seeds/legislation_proposals.rb
@@ -6,7 +6,6 @@ section "Creating legislation proposals" do
                                   summary: Faker::Lorem.paragraph,
                                   author: User.all.sample,
                                   process: Legislation::Process.all.sample,
-                                  terms_of_service: '1',
-                                  proposal_type: 'proposal')
+                                  terms_of_service: '1')
   end
 end

--- a/db/dev_seeds/legislation_proposals.rb
+++ b/db/dev_seeds/legislation_proposals.rb
@@ -1,0 +1,12 @@
+section "Creating legislation proposals" do
+  10.times do
+    Legislation::Proposal.create!(title: Faker::Lorem.sentence(3).truncate(60),
+                                  description: Faker::Lorem.paragraphs.join("\n\n"),
+                                  question: Faker::Lorem.sentence(3),
+                                  summary: Faker::Lorem.paragraph,
+                                  author: User.all.sample,
+                                  process: Legislation::Process.all.sample,
+                                  terms_of_service: '1',
+                                  proposal_type: 'proposal')
+  end
+end

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -2,8 +2,18 @@ require 'rails_helper'
 
 feature 'Legislation Proposals' do
 
+  let(:proposal) { create(:legislation_proposal) }
+
   context "Concerns" do
     it_behaves_like 'notifiable in-app', Legislation::Proposal
+  end
+
+  scenario "Only one menu element has 'active' CSS selector" do
+    visit legislation_process_proposal_path(proposal.process, proposal)
+
+    within('#navigation_bar') do
+      expect(page).to have_css('.is-active', count: 1)
+    end
   end
 
 end


### PR DESCRIPTION
References
===================
* **Related issue**: AyuntamientoMadrid#1198
* **Related PR**: AyuntamientoMadrid#1264

Objectives
===================
This is a backport of the aforementioned PR to fix a bug where two (2) navigation items (`Proposals` and `Legislation processes`) would be "active" at the same time under the `Legislation::Proposal#show` view

Visual Changes
===================
## Before:

![screenshot_2018-08-06 consul](https://user-images.githubusercontent.com/9470839/43723814-91558004-9966-11e8-8ff9-f4f8030a3d12.png)

## After:

![screenshot_2018-08-06 est nisi totam est](https://user-images.githubusercontent.com/9470839/43723823-97931d5a-9966-11e8-8332-66a39a25ab24.png)

Notes
===================
* :warning: A new commit was included for this PR in order to remove a Madrid-specific DB attribute from `Legislation::Proposal` seeds :warning: