### PR TITLE
Fix management helper when user id has multiple digits

### DIFF
--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -56,7 +56,8 @@ class Management::BaseController < ActionController::Base
 
     def manager_logged_in
       if current_manager
-        @manager_logged_in = User.find_by(id: session[:manager]["login"].last(1))
+        user_id = session[:manager]["login"].split('_').last.to_i
+        @manager_logged_in = User.find_by(id: user_id)
       end
     end
 


### PR DESCRIPTION


References
===================
 -  Bug introduced in #2137

Objectives
===================
Fix helper in `Management::BaseController`:

> The old code was only reading the last digit of the id.
> This caused failures when the id was >9. Should also
> fix `spec/features/management_spec.rb:15`, which would fail
> occasionally because of this.

Should also prevent all of the recent failures from `spec/features/management_spec.rb:15` (e.g. https://travis-ci.org/wairbut-m2c-aytomadrid/consul/jobs/412676445)

Notes
====================
This change was also pulled into AyuntamientoMadrid/consul, so it should be ported there as well.