### PR TITLE
Fixed a bunch of typos

### DIFF
--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -315,7 +315,7 @@ en:
         proposal_notification:
           attributes:
             minimum_interval:
-              invalid: "You have to wait a minium of %{interval} days between notifications"
+              invalid: "You have to wait a minimum of %{interval} days between notifications"
         signature:
           attributes:
             document_number:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -386,7 +386,7 @@ en:
         index:
           create: New process
           delete: Delete
-          title: Legislation processess
+          title: Legislation processes
           filters:
             open: Open
             next: Next
@@ -1357,7 +1357,7 @@ en:
       create_header: Create header
       cards_title: Cards
       create_card: Create card
-      no_cards: There is no cards.
+      no_cards: There are no cards.
       cards:
         title: Title
         description: Description

--- a/config/locales/en/community.yml
+++ b/config/locales/en/community.yml
@@ -16,7 +16,7 @@ en:
       create_first_community_topic:
         first_theme_not_logged_in: No issue available, participate creating the first one.
         first_theme: Create the first community topic
-        sub_first_theme: "To create a theme you must to %{sign_in} o %{sign_up}."
+        sub_first_theme: "To create a theme you must to %{sign_in} or %{sign_up}."
         sign_in: "sign in"
         sign_up: "sign up"
       tab:

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -7,7 +7,7 @@ en:
       title_placeholder: Add a descriptive title for the document
       attachment_label: Choose document
       delete_button: Remove document
-      cancel_button: Cancelar
+      cancel_button: Cancel
       note: "You can upload up to a maximum of %{max_documents_allowed} documents of following content types: %{accepted_content_types}, up to %{max_file_size} MB per file."
       add_new_document: Add new document
     actions:

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -443,7 +443,7 @@ en:
       retired: Proposal retired by the author
       share: Share
       send_notification: Send notification
-      no_notifications: "This proposal has any notifications."
+      no_notifications: "This proposal doesn't have any notification."
       embed_video_title: "Video on %{proposal}"
       title_external_url: "Additional documentation"
       title_video_url: "External video"
@@ -526,7 +526,7 @@ en:
       title_label: "Title"
       body_label: "Message"
       submit_button: "Send message"
-      info_about_receivers_html: "This message will be send to <strong>%{count} people</strong> and it will be visible in %{proposal_page}.<br> Message are not sent immediately, users will receive periodically an email with all proposal notifications."
+      info_about_receivers_html: "This message will be sent to <strong>%{count} people</strong> and it will be visible in %{proposal_page}.<br> Messages are not sent immediately, users will receive periodically an email with all proposal notifications."
       proposal_page: "the proposal's page"
     show:
       back: "Go back to my activity"

--- a/config/locales/en/management.yml
+++ b/config/locales/en/management.yml
@@ -77,7 +77,7 @@ en:
       support_proposals: Support proposals
       vote_proposals: Vote proposals
     print:
-      proposals_info: Create yor proposal on http://url.consul
+      proposals_info: Create your proposal on http://url.consul
       proposals_title: 'Proposals:'
       spending_proposals_info: Participate at http://url.consul
       budget_investments_info: Participate at http://url.consul

--- a/config/locales/en/officing.yml
+++ b/config/locales/en/officing.yml
@@ -23,7 +23,7 @@ en:
         error_wrong_booth: "Wrong booth. Results NOT saved."
       new:
         title: "%{poll} - Add results"
-        not_allowed: "You are allowed to add results for this poll"
+        not_allowed: "You are not allowed to add results for this poll"
         booth: "Booth"
         date: "Date"
         select_booth: "Select booth"

--- a/spec/models/proposal_notification_spec.rb
+++ b/spec/models/proposal_notification_spec.rb
@@ -50,7 +50,7 @@ describe ProposalNotification do
       Setting[:proposal_notification_minimum_interval_in_days] = 3
     end
 
-    it "is not valid if below minium interval" do
+    it "is not valid if below minimum interval" do
       proposal = create(:proposal)
 
       notification1 = create(:proposal_notification, proposal: proposal)
@@ -60,7 +60,7 @@ describe ProposalNotification do
       expect(notification2).not_to be_valid
     end
 
-    it "is valid if notifications above minium interval" do
+    it "is valid if notifications above minimum interval" do
       proposal = create(:proposal)
 
       notification1 = create(:proposal_notification, proposal: proposal, created_at: 4.days.ago)

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -2,40 +2,40 @@ require 'rails_helper'
 
 describe Verification::Management::Document do
   let(:min_age)                         { User.minimum_required_age }
-  let(:over_minium_age_date_of_birth)   { Date.new((min_age + 10).years.ago.year, 12, 31) }
-  let(:under_minium_age_date_of_birth)  { Date.new(min_age.years.ago.year, 12, 31) }
-  let(:just_minium_age_date_of_birth)   { Date.new(min_age.years.ago.year, min_age.years.ago.month, min_age.years.ago.day) }
+  let(:over_minimum_age_date_of_birth)   { Date.new((min_age + 10).years.ago.year, 12, 31) }
+  let(:under_minimum_age_date_of_birth)  { Date.new(min_age.years.ago.year, 12, 31) }
+  let(:just_minimum_age_date_of_birth)   { Date.new(min_age.years.ago.year, min_age.years.ago.month, min_age.years.ago.day) }
 
   describe "#valid_age?" do
     it "returns false when the user is younger than the user's minimum required age" do
-      census_response = instance_double('CensusApi::Response', date_of_birth: under_minium_age_date_of_birth)
+      census_response = instance_double('CensusApi::Response', date_of_birth: under_minimum_age_date_of_birth)
       expect(described_class.new.valid_age?(census_response)).to be false
     end
 
     it "returns true when the user has the user's minimum required age" do
-      census_response = instance_double('CensusApi::Response', date_of_birth: just_minium_age_date_of_birth)
+      census_response = instance_double('CensusApi::Response', date_of_birth: just_minimum_age_date_of_birth)
       expect(described_class.new.valid_age?(census_response)).to be true
     end
 
     it "returns true when the user is older than the user's minimum required age" do
-      census_response = instance_double('CensusApi::Response', date_of_birth: over_minium_age_date_of_birth)
+      census_response = instance_double('CensusApi::Response', date_of_birth: over_minimum_age_date_of_birth)
       expect(described_class.new.valid_age?(census_response)).to be true
     end
   end
 
   describe "#under_age?" do
     it "returns true when the user is younger than the user's minimum required age" do
-      census_response = instance_double('CensusApi::Response', date_of_birth: under_minium_age_date_of_birth)
+      census_response = instance_double('CensusApi::Response', date_of_birth: under_minimum_age_date_of_birth)
       expect(described_class.new.under_age?(census_response)).to be true
     end
 
     it "returns false when the user is user's minimum required age" do
-      census_response = instance_double('CensusApi::Response', date_of_birth: just_minium_age_date_of_birth)
+      census_response = instance_double('CensusApi::Response', date_of_birth: just_minimum_age_date_of_birth)
       expect(described_class.new.under_age?(census_response)).to be false
     end
 
     it "returns false when the user is older than user's minimum required age" do
-      census_response = instance_double('CensusApi::Response', date_of_birth: over_minium_age_date_of_birth)
+      census_response = instance_double('CensusApi::Response', date_of_birth: over_minimum_age_date_of_birth)
       expect(described_class.new.under_age?(census_response)).to be false
     end
   end


### PR DESCRIPTION
References
===================
Last commits fixing typos reported through Crowdin:
- [34877ede57d35ba9edd207c7fb666ebb7ed4bbab](https://github.com/consul/consul/commit/34877ede57d35ba9edd207c7fb666ebb7ed4bbab)
- [5f5e9c4f26a6daee2d3229f70eb090200b66dbf1](https://github.com/consul/consul/commit/5f5e9c4f26a6daee2d3229f70eb090200b66dbf1)

Background
===================
People report typos and inconsistencies in the source locales by posting comments in [Crowdin](https://crowdin.com/project/consul/activity_stream). The last corrections of all these typos had been done in the commits above in February and March.

Objectives
===================
This PR fixes all the last reported typos from March to the 9th of August.
 
Visual Changes
===================
- Look at the changed files to get an idea of which strings are gonna be changed. It's mostly typos.
- One sentence is reversed for consistency with the name of the locale (`not_allowed`):
`"You are allowed to add results for this poll"` becomes `"You are not allowed to add results for this poll"`.

Notes
===================
Nothing to update