### PR TITLE
Call load_categories when failed to save investment

### DIFF
--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -23,6 +23,7 @@ class Management::Budgets::InvestmentsController < Management::BaseController
       notice = t('flash.actions.create.notice', resource_name: Budget::Investment.model_name.human, count: 1)
       redirect_to management_budget_investment_path(@budget, @investment), notice: notice
     else
+      load_categories
       render :new
     end
   end

--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -70,9 +70,15 @@ class Management::Budgets::InvestmentsController < Management::BaseController
     end
 
     def set_map_location
-      @investment.skip_map = params[:budget_investment][:skip_map]
-      return if @investment.skip_map == "1"
+      return if params[:budget_investment][:skip_map] == nil
 
+      @investment.skip_map = params[:budget_investment][:skip_map]
+      if @investment.skip_map != "1"
+        build_map_location
+      end
+    end
+
+    def build_map_location
       map_location = params[:budget_investment][:map_location_attributes]
       @investment.build_map_location(
         latitude: map_location[:latitude],

--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -18,6 +18,7 @@ class Management::Budgets::InvestmentsController < Management::BaseController
   def create
     @investment.terms_of_service = "1"
     @investment.author = managed_user
+    set_map_location
 
     if @investment.save
       notice = t('flash.actions.create.notice', resource_name: Budget::Investment.model_name.human, count: 1)
@@ -68,4 +69,15 @@ class Management::Budgets::InvestmentsController < Management::BaseController
       @categories = ActsAsTaggableOn::Tag.category.order(:name)
     end
 
+    def set_map_location
+      @investment.skip_map = params[:budget_investment][:skip_map]
+      return if @investment.skip_map == "1"
+
+      map_location = params[:budget_investment][:map_location_attributes]
+      @investment.build_map_location(
+        latitude: map_location[:latitude],
+        longitude: map_location[:longitude],
+        zoom: map_location[:zoom],
+      )
+    end
 end


### PR DESCRIPTION
References
===================
- Addresses issue: https://github.com/consul/consul/issues/2855 - 500 error when we created a budget investment from management panel

Objectives
===================
- Fixed NoMethodError.
It occurs When it fails to @investment.save in create.
because it attempt to render new page without categories variable.
So I added a load_caregories method when it failed.

- I Fixed storing map location error.
Error occurs when storing map location, or skipping map.
I fixed it so that you can store map location, or skip map location.