### PR TITLE
Add geozones as user segments

### DIFF
--- a/app/controllers/admin/emails_download_controller.rb
+++ b/app/controllers/admin/emails_download_controller.rb
@@ -4,7 +4,7 @@ class Admin::EmailsDownloadController < Admin::BaseController
 
   def generate_csv
     users_segment = params[:users_segment]
-    filename = t("admin.segment_recipient.#{users_segment}")
+    filename = UserSegments.segment_name(users_segment)
 
     csv_file = users_segment_emails_csv(users_segment)
     send_data csv_file, filename: "#{filename}.csv"

--- a/app/helpers/user_segments_helper.rb
+++ b/app/helpers/user_segments_helper.rb
@@ -1,6 +1,6 @@
 module UserSegmentsHelper
   def user_segments_options
-    UserSegments::SEGMENTS.map do |user_segment_name|
+    UserSegments.segments.map do |user_segment_name|
       [t("admin.segment_recipient.#{user_segment_name}"), user_segment_name]
     end
   end

--- a/app/helpers/user_segments_helper.rb
+++ b/app/helpers/user_segments_helper.rb
@@ -1,15 +1,11 @@
 module UserSegmentsHelper
   def user_segments_options
     UserSegments.segments.map do |user_segment_name|
-      [t("admin.segment_recipient.#{user_segment_name}"), user_segment_name]
+      [segment_name(user_segment_name), user_segment_name]
     end
   end
 
   def segment_name(user_segment)
-    if user_segment && UserSegments.respond_to?(user_segment)
-      I18n.t("admin.segment_recipient.#{user_segment}")
-    else
-      I18n.t("admin.segment_recipient.invalid_recipients_segment")
-    end
+    UserSegments.segment_name(user_segment) || I18n.t("admin.segment_recipient.invalid_recipients_segment")
   end
 end

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -13,11 +13,11 @@ class AdminNotification < ApplicationRecord
   before_validation :complete_link_url
 
   def list_of_recipients
-    UserSegments.send(segment_recipient) if valid_segment_recipient?
+    UserSegments.recipients(segment_recipient) if valid_segment_recipient?
   end
 
   def valid_segment_recipient?
-    segment_recipient && UserSegments.respond_to?(segment_recipient)
+    UserSegments.valid_segment?(segment_recipient)
   end
 
   def draft?

--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -15,7 +15,7 @@ class Newsletter < ApplicationRecord
   end
 
   def valid_segment_recipient?
-    segment_recipient && UserSegments.respond_to?(segment_recipient)
+    UserSegments.valid_segment?(segment_recipient)
   end
 
   def draft?

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -81,6 +81,7 @@ search:
    - app/
    - db/pages/
    - db/dev_seeds/
+   - lib/
 
   ## Root directories for relative keys resolution.
   # relative_roots:

--- a/db/dev_seeds/newsletters.rb
+++ b/db/dev_seeds/newsletters.rb
@@ -14,7 +14,7 @@ section "Creating Newsletters" do
   5.times do |n|
     Newsletter.create!(
       subject: "Newsletter subject #{n}",
-      segment_recipient: UserSegments::SEGMENTS.sample,
+      segment_recipient: UserSegments.segments.sample,
       from: "no-reply@consul.dev",
       body: newsletter_body.sample,
       sent_at: [Time.current, nil].sample

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -84,6 +84,12 @@ class UserSegments
     end
 
     def self.geozones
-      Geozone.order(:name).map { |geozone| [geozone.name.parameterize.underscore, geozone] }.to_h
+      Geozone.order(:name).map do |geozone|
+        [geozone.name.gsub(/./) { |char| character_approximation(char) }.underscore.tr(" ", "_"), geozone]
+      end.to_h
+    end
+
+    def self.character_approximation(char)
+      I18n::Backend::Transliterator::HashTransliterator::DEFAULT_APPROXIMATIONS[char] || char
     end
 end

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -11,6 +11,10 @@ class UserSegments
        not_supported_on_current_budget].freeze
   end
 
+  def self.segment_name(segment)
+    I18n.t("admin.segment_recipient.#{segment}") if segments.include?(segment.to_s)
+  end
+
   def self.all_users
     User.active.where.not(confirmed_at: nil)
   end
@@ -53,8 +57,8 @@ class UserSegments
     )
   end
 
-  def self.user_segment_emails(users_segment)
-    UserSegments.send(users_segment).newsletter.order(:created_at).pluck(:email).compact
+  def self.user_segment_emails(segment)
+    UserSegments.send(segment).newsletter.order(:created_at).pluck(:email).compact
   end
 
   private

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -1,13 +1,15 @@
 class UserSegments
-  SEGMENTS = %w[all_users
-                administrators
-                all_proposal_authors
-                proposal_authors
-                investment_authors
-                feasible_and_undecided_investment_authors
-                selected_investment_authors
-                winner_investment_authors
-                not_supported_on_current_budget].freeze
+  def self.segments
+    %w[all_users
+       administrators
+       all_proposal_authors
+       proposal_authors
+       investment_authors
+       feasible_and_undecided_investment_authors
+       selected_investment_authors
+       winner_investment_authors
+       not_supported_on_current_budget].freeze
+  end
 
   def self.all_users
     User.active.where.not(confirmed_at: nil)

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -57,8 +57,16 @@ class UserSegments
     )
   end
 
+  def self.valid_segment?(segment)
+    segment && respond_to?(segment)
+  end
+
+  def self.recipients(segment)
+    send(segment)
+  end
+
   def self.user_segment_emails(segment)
-    UserSegments.send(segment).newsletter.order(:created_at).pluck(:email).compact
+    recipients(segment).newsletter.order(:created_at).pluck(:email).compact
   end
 
   private

--- a/spec/factories/emails.rb
+++ b/spec/factories/emails.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :newsletter do
     sequence(:subject) { |n| "Subject #{n}" }
-    segment_recipient  { UserSegments::SEGMENTS.sample }
+    segment_recipient  { UserSegments.segments.sample }
     sequence(:from)    { |n| "noreply#{n}@consul.dev" }
     sequence(:body)    { |n| "Body #{n}" }
   end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     sequence(:title)  { |n| "Admin Notification title #{n}" }
     sequence(:body)   { |n| "Admin Notification body #{n}" }
     link              { nil }
-    segment_recipient { UserSegments::SEGMENTS.sample }
+    segment_recipient { UserSegments.segments.sample }
     recipients_count  { nil }
     sent_at           { nil }
 

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -5,6 +5,22 @@ describe UserSegments do
   let(:user2) { create(:user) }
   let(:user3) { create(:user) }
 
+  describe ".segment_name" do
+    it "returns a readable name of the segment" do
+      expect(UserSegments.segment_name("all_users")).to eq "All users"
+      expect(UserSegments.segment_name("administrators")).to eq "Administrators"
+      expect(UserSegments.segment_name("proposal_authors")).to eq "Proposal authors"
+    end
+
+    it "accepts symbols as parameters" do
+      expect(UserSegments.segment_name(:all_users)).to eq "All users"
+    end
+
+    it "returns nil for invalid segments" do
+      expect(UserSegments.segment_name("invalid")).to be nil
+    end
+  end
+
   describe ".all_users" do
     it "returns all active users enabled" do
       active_user = create(:user)

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -5,7 +5,7 @@ describe UserSegments do
   let(:user2) { create(:user) }
   let(:user3) { create(:user) }
 
-  describe "#all_users" do
+  describe ".all_users" do
     it "returns all active users enabled" do
       active_user = create(:user)
       erased_user = create(:user, erased_at: Time.current)
@@ -15,7 +15,7 @@ describe UserSegments do
     end
   end
 
-  describe "#administrators" do
+  describe ".administrators" do
     it "returns all active administrators users" do
       active_user = create(:user)
       active_admin = create(:administrator).user
@@ -27,7 +27,7 @@ describe UserSegments do
     end
   end
 
-  describe "#all_proposal_authors" do
+  describe ".all_proposal_authors" do
     it "returns users that have created a proposal even if is archived or retired" do
       create(:proposal, author: user1)
       create(:proposal, :archived, author: user2)
@@ -49,7 +49,7 @@ describe UserSegments do
     end
   end
 
-  describe "#proposal_authors" do
+  describe ".proposal_authors" do
     it "returns users that have created a proposal" do
       create(:proposal, author: user1)
 
@@ -67,7 +67,7 @@ describe UserSegments do
     end
   end
 
-  describe "#investment_authors" do
+  describe ".investment_authors" do
     it "returns users that have created a budget investment" do
       investment = create(:budget_investment, author: user1)
       budget = create(:budget)
@@ -90,7 +90,7 @@ describe UserSegments do
     end
   end
 
-  describe "#feasible_and_undecided_investment_authors" do
+  describe ".feasible_and_undecided_investment_authors" do
     it "returns authors of a feasible or an undecided budget investment" do
       user4 = create(:user)
       user5 = create(:user)
@@ -128,7 +128,7 @@ describe UserSegments do
     end
   end
 
-  describe "#selected_investment_authors" do
+  describe ".selected_investment_authors" do
     it "returns authors of selected budget investments" do
       selected_investment = create(:budget_investment, :selected, author: user1)
       unselected_investment = create(:budget_investment, :unselected, author: user2)
@@ -153,7 +153,7 @@ describe UserSegments do
     end
   end
 
-  describe "#winner_investment_authors" do
+  describe ".winner_investment_authors" do
     it "returns authors of winner budget investments" do
       winner_investment = create(:budget_investment, :winner, author: user1)
       selected_investment = create(:budget_investment, :selected, author: user2)
@@ -178,7 +178,7 @@ describe UserSegments do
     end
   end
 
-  describe "#current_budget_investments" do
+  describe ".current_budget_investments" do
     it "only returns investments from the current budget" do
       investment1 = create(:budget_investment, author: create(:user))
       investment2 = create(:budget_investment, author: create(:user))
@@ -192,7 +192,7 @@ describe UserSegments do
     end
   end
 
-  describe "#not_supported_on_current_budget" do
+  describe ".not_supported_on_current_budget" do
     it "only returns users that haven't supported investments on current budget" do
       investment1 = create(:budget_investment)
       investment2 = create(:budget_investment)
@@ -209,7 +209,7 @@ describe UserSegments do
     end
   end
 
-  describe "#user_segment_emails" do
+  describe ".user_segment_emails" do
     it "returns list of emails sorted by user creation date" do
       create(:user, email: "first@email.com", created_at: 1.day.ago)
       create(:user, email: "last@email.com")

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -31,6 +31,16 @@ describe UserSegments do
         expect(UserSegments.segment_name("lowlands_and_highlands")).to eq "Lowlands and Highlands"
       end
 
+      it "supports international alphabets" do
+        create(:geozone, name: "Česká republika")
+        create(:geozone, name: "България")
+        create(:geozone, name: "日本")
+
+        expect(UserSegments.segment_name("ceska_republika")).to eq "Česká republika"
+        expect(UserSegments.segment_name("България")).to eq "България"
+        expect(UserSegments.segment_name("日本")).to eq "日本"
+      end
+
       it "returns regular segments when the geozone doesn't exist" do
         expect(UserSegments.segment_name("all_users")).to eq "All users"
       end

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -21,6 +21,28 @@ describe UserSegments do
     end
   end
 
+  describe ".valid_segment?" do
+    it "returns true when the segment exists" do
+      expect(UserSegments.valid_segment?("all_proposal_authors")).to be true
+      expect(UserSegments.valid_segment?("investment_authors")).to be true
+      expect(UserSegments.valid_segment?("feasible_and_undecided_investment_authors")).to be true
+    end
+
+    it "accepts symbols as parameters" do
+      expect(UserSegments.valid_segment?(:selected_investment_authors)).to be true
+      expect(UserSegments.valid_segment?(:winner_investment_authors)).to be true
+      expect(UserSegments.valid_segment?(:not_supported_on_current_budget)).to be true
+    end
+
+    it "is falsey when the segment doesn't exist" do
+      expect(UserSegments.valid_segment?("imaginary_segment")).to be_falsey
+    end
+
+    it "is falsey when nil is passed" do
+      expect(UserSegments.valid_segment?(nil)).to be_falsey
+    end
+  end
+
   describe ".all_users" do
     it "returns all active users enabled" do
       active_user = create(:user)

--- a/spec/system/admin/admin_notifications_spec.rb
+++ b/spec/system/admin/admin_notifications_spec.rb
@@ -215,15 +215,14 @@ describe "Admin Notifications", :admin do
   end
 
   scenario "Select list of users to send notification" do
-    UserSegments.segments.each do |segment|
-      segment_recipient = UserSegments.segment_name(segment)
+    segment = UserSegments.segments.sample
+    segment_recipient = UserSegments.segment_name(segment)
 
-      visit new_admin_admin_notification_path
+    visit new_admin_admin_notification_path
 
-      fill_in_admin_notification_form(segment_recipient: segment_recipient)
-      click_button "Create notification"
+    fill_in_admin_notification_form(segment_recipient: segment_recipient)
+    click_button "Create notification"
 
-      expect(page).to have_content segment_recipient
-    end
+    expect(page).to have_content segment_recipient
   end
 end

--- a/spec/system/admin/admin_notifications_spec.rb
+++ b/spec/system/admin/admin_notifications_spec.rb
@@ -215,7 +215,7 @@ describe "Admin Notifications", :admin do
   end
 
   scenario "Select list of users to send notification" do
-    UserSegments::SEGMENTS.each do |user_segment|
+    UserSegments.segments.each do |user_segment|
       segment_recipient = I18n.t("admin.segment_recipient.#{user_segment}")
 
       visit new_admin_admin_notification_path

--- a/spec/system/admin/admin_notifications_spec.rb
+++ b/spec/system/admin/admin_notifications_spec.rb
@@ -215,15 +215,15 @@ describe "Admin Notifications", :admin do
   end
 
   scenario "Select list of users to send notification" do
-    UserSegments.segments.each do |user_segment|
-      segment_recipient = I18n.t("admin.segment_recipient.#{user_segment}")
+    UserSegments.segments.each do |segment|
+      segment_recipient = UserSegments.segment_name(segment)
 
       visit new_admin_admin_notification_path
 
       fill_in_admin_notification_form(segment_recipient: segment_recipient)
       click_button "Create notification"
 
-      expect(page).to have_content(I18n.t("admin.segment_recipient.#{user_segment}"))
+      expect(page).to have_content segment_recipient
     end
   end
 end

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -16,7 +16,7 @@ describe "Admin newsletter emails", :admin do
 
       expect(page).to have_link "Go back", href: admin_newsletters_path
       expect(page).to have_content "This is a subject"
-      expect(page).to have_content I18n.t("admin.segment_recipient.#{newsletter.segment_recipient}")
+      expect(page).to have_content "All users"
       expect(page).to have_content "no-reply@consul.dev"
       expect(page).to have_content "This is a body"
     end
@@ -40,10 +40,9 @@ describe "Admin newsletter emails", :admin do
       expect(page).to have_css(".newsletter", count: 3)
 
       newsletters.each do |newsletter|
-        segment_recipient = I18n.t("admin.segment_recipient.#{newsletter.segment_recipient}")
         within("#newsletter_#{newsletter.id}") do
           expect(page).to have_content newsletter.subject
-          expect(page).to have_content segment_recipient
+          expect(page).to have_content UserSegments.segment_name(newsletter.segment_recipient)
         end
       end
     end
@@ -162,13 +161,15 @@ describe "Admin newsletter emails", :admin do
   end
 
   scenario "Select list of users to send newsletter" do
-    UserSegments.segments.each do |user_segment|
+    UserSegments.segments.each do |segment|
+      segment_recipient = UserSegments.segment_name(segment)
+
       visit new_admin_newsletter_path
 
-      fill_in_newsletter_form(segment_recipient: I18n.t("admin.segment_recipient.#{user_segment}"))
+      fill_in_newsletter_form(segment_recipient: segment_recipient)
       click_button "Create Newsletter"
 
-      expect(page).to have_content(I18n.t("admin.segment_recipient.#{user_segment}"))
+      expect(page).to have_content segment_recipient
     end
   end
 end

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -162,7 +162,7 @@ describe "Admin newsletter emails", :admin do
   end
 
   scenario "Select list of users to send newsletter" do
-    UserSegments::SEGMENTS.each do |user_segment|
+    UserSegments.segments.each do |user_segment|
       visit new_admin_newsletter_path
 
       fill_in_newsletter_form(segment_recipient: I18n.t("admin.segment_recipient.#{user_segment}"))

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -162,16 +162,15 @@ describe "Admin newsletter emails", :admin do
 
   describe "Select list of users to send newsletter" do
     scenario "Custom user segments" do
-      UserSegments.segments.each do |segment|
-        segment_recipient = UserSegments.segment_name(segment)
+      segment = UserSegments.segments.sample
+      segment_recipient = UserSegments.segment_name(segment)
 
-        visit new_admin_newsletter_path
+      visit new_admin_newsletter_path
 
-        fill_in_newsletter_form(segment_recipient: segment_recipient)
-        click_button "Create Newsletter"
+      fill_in_newsletter_form(segment_recipient: segment_recipient)
+      click_button "Create Newsletter"
 
-        expect(page).to have_content segment_recipient
-      end
+      expect(page).to have_content segment_recipient
     end
 
     scenario "Geozone segments" do

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -160,16 +160,29 @@ describe "Admin newsletter emails", :admin do
     end
   end
 
-  scenario "Select list of users to send newsletter" do
-    UserSegments.segments.each do |segment|
-      segment_recipient = UserSegments.segment_name(segment)
+  describe "Select list of users to send newsletter" do
+    scenario "Custom user segments" do
+      UserSegments.segments.each do |segment|
+        segment_recipient = UserSegments.segment_name(segment)
+
+        visit new_admin_newsletter_path
+
+        fill_in_newsletter_form(segment_recipient: segment_recipient)
+        click_button "Create Newsletter"
+
+        expect(page).to have_content segment_recipient
+      end
+    end
+
+    scenario "Geozone segments" do
+      create(:geozone, name: "Queens and Brooklyn")
 
       visit new_admin_newsletter_path
 
-      fill_in_newsletter_form(segment_recipient: segment_recipient)
+      fill_in_newsletter_form(segment_recipient: "Queens and Brooklyn")
       click_button "Create Newsletter"
 
-      expect(page).to have_content segment_recipient
+      expect(page).to have_content "Queens and Brooklyn"
     end
   end
 end


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1579
* Backports AyuntamientoMadrid#1583

## Objectives

Allow sending newsletters and admin notifications to users of a specific geozone.

## Visual changes

### Before these changes

![When sending admin notifications and newsletters, geozones don't appear in the list of possible recipients](https://user-images.githubusercontent.com/35156/142733451-bc7419f8-70db-4974-be36-7a2239a7aa61.png)

### After these changes

![When sending admin notifications and newsletters, geozones appear in the list of possible recipients](https://user-images.githubusercontent.com/35156/142733448-25817d73-2fe7-4b47-859a-a69d12b465c9.png)

## Notes for reviewers

There are some changes over the original pulls request used in Madrid's fork. The original pull requests were done with the idea that geozones were already in the database and geozones never change (which was the case in Madrid). So they used YAML files to get the geozone's name, they assumed the database already existed (and so new installations might crash when running `db:create`) and they defined the geozone segments methods when the `UserSegments` class was loaded (meaning that changing the database in production wouldn't have any effect until the server was restarted).

Here we're supporting the case of new installations (where geozones aren't already defined) and installations adding or removing geozones as time goes by.