### PR TITLE
[Backport] Adds status icons on polls poll group

### DIFF
--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -1,9 +1,23 @@
 <% poll_group.each do |poll| %>
   <div class="poll with-image">
-    <% if user_signed_in? && !current_user.unverified? && !poll.votable_by?(current_user) %>
-      <div class="icon-poll-answer already-answer" title="<%= t("polls.index.already_answer") %>">
-        <span class="show-for-sr"><%= t("polls.index.already_answer") %></span>
+    <% if !user_signed_in? %>
+      <div class="icon-poll-answer not-logged-in" title="<%= t("polls.index.not_logged_in") %>">
+        <span class="show-for-sr"><%= t("polls.index.not_logged_in") %></span>
       </div>
+    <% elsif user_signed_in? %>
+      <% if current_user.unverified? %>
+        <div class="icon-poll-answer unverified" title="<%= t("polls.index.unverified") %>">
+          <span class="show-for-sr"><%= t("polls.index.unverified") %></span>
+        </div>
+      <% elsif cannot?(:answer, poll) %>
+        <div class="icon-poll-answer cant-answer" title="<%= t("polls.index.cant_answer") %>">
+          <span class="show-for-sr"><%= t("polls.index.cant_answer") %></span>
+        </div>
+      <% elsif !poll.votable_by?(current_user) %>
+        <div class="icon-poll-answer already-answer" title="<%= t("polls.index.already_answer") %>">
+          <span class="show-for-sr"><%= t("polls.index.already_answer") %></span>
+        </div>
+      <% end %>
     <% end %>
     <div class="row" data-equalizer data-equalize-on="medium">
       <div class="small-12 medium-3 column">

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -469,6 +469,9 @@ en:
       geozone_restricted: "Districts"
       geozone_info: "Can participate people in the Census of: "
       already_answer: "You already have participated in this poll"
+      not_logged_in: "You must sign in or sign up to participate"
+      unverified: "You must verify your account to participate"
+      cant_answer: "This poll is not available on your geozone"
       section_header:
         icon_alt: Voting icon
         title: Voting

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -469,6 +469,9 @@ es:
       geozone_restricted: "Distritos"
       geozone_info: 'Pueden participar las personas empadronadas en: '
       already_answer: "Ya has participado en esta votación"
+      not_logged_in: "Necesitas iniciar sesión o registrarte para participar"
+      unverified: "Por favor verifica tu cuenta para participar"
+      cant_answer: "Esta votación no está disponible en tu zona"
       section_header:
         icon_alt: Icono de Votaciones
         title: Votaciones

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -67,6 +67,43 @@ feature 'Polls' do
       expect(page).not_to have_link('Expired')
     end
 
+    scenario "Displays icon correctly", :js do
+      polls = create_list(:poll, 3)
+
+      visit polls_path
+
+      expect(page).to have_css(".not-logged-in", count: 3)
+      expect(page).to have_content("You must sign in or sign up to participate")
+
+      user = create(:user)
+      login_as(user)
+
+      visit polls_path
+
+      expect(page).to have_css(".unverified", count: 3)
+      expect(page).to have_content("You must verify your account to participate")
+
+      poll_district = create(:poll, geozone_restricted: true)
+      verified = create(:user, :level_two)
+      login_as(verified)
+
+      visit polls_path
+
+      expect(page).to have_css(".cant-answer", count: 1)
+      expect(page).to have_content("This poll is not available on your geozone")
+
+      poll_with_question = create(:poll)
+      question = create(:poll_question, poll: poll_with_question)
+      answer1 = create(:poll_question_answer, question: question, title: 'Yes')
+      answer2 = create(:poll_question_answer, question: question, title: 'No')
+      vote_for_poll_via_web(poll_with_question, question, 'Yes')
+
+      visit polls_path
+
+      expect(page).to have_css(".already-answer", count: 1)
+      expect(page).to have_content("You already have participated in this poll")
+    end
+
     scenario "Poll title link to stats if enabled" do
       poll = create(:poll, name: "Poll with stats", stats_enabled: true)
 


### PR DESCRIPTION
References
===================
Backport https://github.com/AyuntamientoMadrid/consul/pull/1582


Objectives
===================
This PR adds a "status" icon on polls poll group to indicate to the user:

- If not logged in: "You must sign in or sign up to participate"
- If it's unverified: "You must verify your account to participate"
- If can't answer: "This poll is not available on your geozone"
- If already answer: "You already have participated in this poll"
