### PR TITLE
[Backport] Adds Sluggable concern to Poll model

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -3,6 +3,7 @@ class Poll < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
   include Notifiable
+  include Sluggable
 
   RECOUNT_DURATION = 1.week
 
@@ -90,6 +91,22 @@ class Poll < ActiveRecord::Base
     unless starts_at.present? && ends_at.present? && starts_at <= ends_at
       errors.add(:starts_at, I18n.t('errors.messages.invalid_date_range'))
     end
+  end
+
+  def self.server_shared_key
+    Rails.application.secrets["nvotes_shared_key"] || ENV["nvotes_shared_key"]
+  end
+
+  def self.server_url
+    Rails.application.secrets["nvotes_server_url"] || ENV["nvotes_server_url"]
+  end
+
+  def budget_poll?
+    budget.present?
+  end
+
+  def generate_slug?
+    slug.nil?
   end
 
 end

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -70,6 +70,7 @@ feature 'Admin polls' do
     expect(page).to have_content "Upcoming poll"
     expect(page).to have_content I18n.l(start_date.to_date)
     expect(page).to have_content I18n.l(end_date.to_date)
+    expect(Poll.last.slug).to eq "#{Poll.last.name.to_s.parameterize}"
   end
 
   scenario "Edit" do


### PR DESCRIPTION
References
===================
Backport https://github.com/AyuntamientoMadrid/consul/pull/1560
Related issue https://github.com/AyuntamientoMadrid/consul/issues/1559

Objectives
===================
Add the Sluggable concern to Poll model to generate a slug when the Poll is created or updated.
