### PR TITLE
Fix Rubocop warnings for Admin controllers

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -84,8 +84,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     def budget_investment_params
       params.require(:budget_investment)
             .permit(:title, :description, :external_url, :heading_id, :administrator_id, :tag_list,
-                    :valuation_tag_list, :incompatible, :visible_to_valuators, :selected, valuator_ids: [],
-                    valuator_group_ids: [])
+                    :valuation_tag_list, :incompatible, :visible_to_valuators, :selected,
+                    valuator_ids: [], valuator_group_ids: [])
     end
 
     def load_budget

--- a/app/controllers/admin/proposal_notifications_controller.rb
+++ b/app/controllers/admin/proposal_notifications_controller.rb
@@ -5,8 +5,10 @@ class Admin::ProposalNotificationsController < Admin::BaseController
   before_action :load_proposal, only: [:confirm_hide, :restore]
 
   def index
-    @proposal_notifications = ProposalNotification.only_hidden.send(@current_filter).order(hidden_at: :desc)
-                         .page(params[:page])
+    @proposal_notifications = ProposalNotification.only_hidden
+                                                  .send(@current_filter)
+                                                  .order(hidden_at: :desc)
+                                                  .page(params[:page])
   end
 
   def confirm_hide

--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -3,23 +3,28 @@ class Admin::StatsController < Admin::BaseController
   def show
     @event_types = Ahoy::Event.group(:name).count
 
-    @visits = Visit.count
-    @debates = Debate.with_hidden.count
+    @visits    = Visit.count
+    @debates   = Debate.with_hidden.count
     @proposals = Proposal.with_hidden.count
-    @comments = Comment.not_valuations.with_hidden.count
+    @comments  = Comment.not_valuations.with_hidden.count
 
-    @debate_votes = Vote.where(votable_type: 'Debate').count
+    @debate_votes   = Vote.where(votable_type: 'Debate').count
     @proposal_votes = Vote.where(votable_type: 'Proposal').count
-    @comment_votes = Vote.where(votable_type: 'Comment').count
+    @comment_votes  = Vote.where(votable_type: 'Comment').count
     @votes = Vote.count
 
-    @user_level_two = User.active.level_two_verified.count
+    @user_level_two   = User.active.level_two_verified.count
     @user_level_three = User.active.level_three_verified.count
-    @verified_users = User.active.level_two_or_three_verified.count
+    @verified_users   = User.active.level_two_or_three_verified.count
     @unverified_users = User.active.unverified.count
     @users = User.active.count
-    @user_ids_who_voted_proposals = ActsAsVotable::Vote.where(votable_type: 'Proposal').distinct.count(:voter_id)
+
+    @user_ids_who_voted_proposals = ActsAsVotable::Vote.where(votable_type: 'Proposal')
+                                                       .distinct
+                                                       .count(:voter_id)
+
     @user_ids_who_didnt_vote_proposals = @verified_users - @user_ids_who_voted_proposals
+
     @spending_proposals = SpendingProposal.count
     budgets_ids = Budget.where.not(phase: 'finished').pluck(:id)
     @budgets = budgets_ids.size

--- a/app/controllers/admin/verifications_controller.rb
+++ b/app/controllers/admin/verifications_controller.rb
@@ -5,7 +5,9 @@ class Admin::VerificationsController < Admin::BaseController
   end
 
   def search
-    @users = User.incomplete_verification.search(params[:name_or_email]).page(params[:page]).for_render
+    @users = User.incomplete_verification.search(params[:name_or_email])
+                                         .page(params[:page])
+                                         .for_render
     render :index
   end
 

--- a/app/controllers/admin/widget/cards_controller.rb
+++ b/app/controllers/admin/widget/cards_controller.rb
@@ -39,9 +39,13 @@ class Admin::Widget::CardsController < Admin::BaseController
   private
 
   def card_params
-    params.require(:widget_card).permit(:label, :title, :description, :link_text, :link_url,
-                                        :button_text, :button_url, :alignment, :header,
-                                        image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy])
+    image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
+
+    params.require(:widget_card).permit(
+      :label, :title, :description, :link_text, :link_url,
+      :button_text, :button_url, :alignment, :header,
+      image_attributes: image_attributes
+    )
   end
 
   def header_card?


### PR DESCRIPTION
References
===================
* None

Objectives
===================
* Fix all possible Rubocop warnings affecting Admin controllers

Visual Changes
===================
* None

Notes
===================
* Using `ci skip` on commit message to avoid unnecessary Travis build (this PR does not affect **at all** existing functionality)

* Rubocop warnings for `SpendingProposals` weren't fixed since said functionality will be deprecated in upcoming CONSUL releases

* Since there are so many Rubocop warnings, it's better to submit small PRs focusing on one module at a time so it's easier to review and to avoid possible conflicts —I'll be doing so in upcoming weeks but I encourage everybody to submit their own patches as well :hugs: 
