### PR TITLE
[Backport] Refactor code shared by admin-translatable resources

### DIFF
--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -11,7 +11,7 @@ module GlobalizeHelper
   end
 
   def display_translation?(locale)
-    same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none"
+    same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none;"
   end
 
   def translation_enabled_tag(locale, enabled)
@@ -19,7 +19,7 @@ module GlobalizeHelper
   end
 
   def css_to_display_translation?(resource, locale)
-    enable_locale?(resource, locale) ? "" : "display: none"
+    enable_locale?(resource, locale) ? "" : "display: none;"
   end
 
   def enable_locale?(resource, locale)

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -6,12 +6,12 @@ module GlobalizeHelper
 
   def locale_options
     I18n.available_locales.map do |locale|
-      [name_for_locale(locale), neutral_locale(locale)]
+      [name_for_locale(locale), locale]
     end
   end
 
   def display_translation?(locale)
-    same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none;"
+    same_locale?(I18n.locale, locale) ? "" : "display: none;"
   end
 
   def translation_enabled_tag(locale, enabled)
@@ -23,7 +23,7 @@ module GlobalizeHelper
   end
 
   def enable_locale?(resource, locale)
-    resource.translated_locales.include?(neutral_locale(locale)) || locale == I18n.locale
+    resource.translated_locales.include?(locale) || locale == I18n.locale
   end
 
   def highlight_current?(locale)
@@ -32,10 +32,6 @@ module GlobalizeHelper
 
   def show_delete?(locale)
     display_translation?(locale)
-  end
-
-  def neutral_locale(locale)
-    locale.to_s.downcase.underscore.to_sym
   end
 
   def globalize(locale, &block)

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -14,14 +14,6 @@ module GlobalizeHelper
     same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none"
   end
 
-  def render_translations_to_delete(resource)
-    capture do
-      resource.globalize_locales.each do |locale|
-        concat translation_enabled_tag(locale, enable_locale?(resource, locale))
-      end
-    end
-  end
-
   def translation_enabled_tag(locale, enabled)
     hidden_field_tag("enabled_translations[#{locale}]", (enabled ? 1 : 0))
   end

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -1,6 +1,6 @@
 module SiteCustomizationHelper
   def site_customization_enable_translation?(locale)
-    I18nContentTranslation.existing_languages.include?(neutral_locale(locale)) || locale == I18n.locale
+    I18nContentTranslation.existing_languages.include?(locale) || locale == I18n.locale
   end
 
   def site_customization_display_translation?(locale)

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -4,6 +4,6 @@ module SiteCustomizationHelper
   end
 
   def site_customization_display_translation?(locale)
-    site_customization_enable_translation?(locale) ? "" : "display: none"
+    site_customization_enable_translation?(locale) ? "" : "display: none;"
   end
 end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -41,7 +41,9 @@ module TranslatableFormHelper
         @template.capture do
           @object.globalize_locales.each do |locale|
             Globalize.with_locale(locale) do
+              label_without_locale = @object.class.human_attribute_name(method)
               final_options = @template.merge_translatable_field_options(options, locale)
+                                       .reverse_merge(label: label_without_locale)
               @template.concat send(field_type, "#{method}_#{locale}", final_options)
             end
           end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -14,11 +14,11 @@ module TranslatableFormHelper
 
   def merge_translatable_field_options(options, locale)
     options.merge(
-      class: (options.fetch(:class, "") + " js-globalize-attribute"),
+      class: "#{options[:class]} js-globalize-attribute".strip,
       style: display_translation?(locale),
       data:  options.fetch(:data, {}).merge(locale: locale),
       label_options: {
-        class: (options.fetch(:class, "") + " js-globalize-attribute"),
+        class: "#{options[:class]} js-globalize-attribute".strip,
         style: display_translation?(locale),
         data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
       }

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -32,7 +32,11 @@ class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
               class: (options.fetch(:class, "") + " js-globalize-attribute"),
               style: @template.display_translation?(locale),
               data:  options.fetch(:data, {}).merge(locale: locale),
-              label: false
+              label_options: {
+                class: (options.fetch(:class, "") + " js-globalize-attribute"),
+                style: @template.display_translation?(locale),
+                data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
+              }
             )
 
             @template.concat send(field_type, "#{method}_#{locale}", final_options)

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -1,0 +1,43 @@
+module TranslatableFormHelper
+  def translatable_form_for(record, options = {})
+    object = record.is_a?(Array) ? record.last : record
+
+    form_for(record, options.merge(builder: TranslatableFormBuilder)) do |f|
+
+      object.globalize_locales.each do |locale|
+        concat translation_enabled_tag(locale, enable_locale?(object, locale))
+      end
+
+      yield(f)
+    end
+  end
+end
+
+class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
+
+  def translatable_text_field(method, options = {})
+    translatable_field(:text_field, method, options)
+  end
+  def translatable_text_area(method, options = {})
+    translatable_field(:text_area, method, options)
+  end
+
+  private
+
+    def translatable_field(field_type, method, options = {})
+      @template.capture do
+        @object.globalize_locales.each do |locale|
+          Globalize.with_locale(locale) do
+            final_options = options.merge(
+              class: (options.fetch(:class, "") + " js-globalize-attribute"),
+              style: @template.display_translation?(locale),
+              data:  options.fetch(:data, {}).merge(locale: locale),
+              label: false
+            )
+
+            @template.concat send(field_type, "#{method}_#{locale}", final_options)
+          end
+        end
+      end
+    end
+end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -18,7 +18,7 @@ module TranslatableFormHelper
       style: display_translation?(locale),
       data:  options.fetch(:data, {}).merge(locale: locale),
       label_options: {
-        class: "#{options[:class]} js-globalize-attribute".strip,
+        class: "#{options.dig(:label_options, :class)} js-globalize-attribute".strip,
         style: display_translation?(locale),
         data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
       }

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -1,8 +1,8 @@
 module TranslatableFormHelper
-  def translatable_form_for(record, options = {})
-    object = record.is_a?(Array) ? record.last : record
+  def translatable_form_for(record_or_record_path, options = {})
+    object = record_or_record_path.is_a?(Array) ? record_or_record_path.last : record_or_record_path
 
-    form_for(record, options.merge(builder: TranslatableFormBuilder)) do |f|
+    form_for(record_or_record_path, options.merge(builder: TranslatableFormBuilder)) do |f|
 
       object.globalize_locales.each do |locale|
         concat translation_enabled_tag(locale, enable_locale?(object, locale))

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -24,28 +24,28 @@ module TranslatableFormHelper
       }
     )
   end
-end
 
-class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
+  class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
 
-  def translatable_text_field(method, options = {})
-    translatable_field(:text_field, method, options)
-  end
+    def translatable_text_field(method, options = {})
+      translatable_field(:text_field, method, options)
+    end
 
-  def translatable_text_area(method, options = {})
-    translatable_field(:text_area, method, options)
-  end
+    def translatable_text_area(method, options = {})
+      translatable_field(:text_area, method, options)
+    end
 
-  private
+    private
 
-    def translatable_field(field_type, method, options = {})
-      @template.capture do
-        @object.globalize_locales.each do |locale|
-          Globalize.with_locale(locale) do
-            final_options = @template.merge_translatable_field_options(options, locale)
-            @template.concat send(field_type, "#{method}_#{locale}", final_options)
+      def translatable_field(field_type, method, options = {})
+        @template.capture do
+          @object.globalize_locales.each do |locale|
+            Globalize.with_locale(locale) do
+              final_options = @template.merge_translatable_field_options(options, locale)
+              @template.concat send(field_type, "#{method}_#{locale}", final_options)
+            end
           end
         end
       end
-    end
+  end
 end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -41,10 +41,13 @@ module TranslatableFormHelper
         @template.capture do
           @object.globalize_locales.each do |locale|
             Globalize.with_locale(locale) do
+              localized_attr_name = @object.localized_attr_name_for(method, locale)
+
               label_without_locale = @object.class.human_attribute_name(method)
               final_options = @template.merge_translatable_field_options(options, locale)
                                        .reverse_merge(label: label_without_locale)
-              @template.concat send(field_type, "#{method}_#{locale}", final_options)
+
+              @template.concat send(field_type, localized_attr_name, final_options)
             end
           end
         end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -15,11 +15,11 @@ module TranslatableFormHelper
   def merge_translatable_field_options(options, locale)
     options.merge(
       class: "#{options[:class]} js-globalize-attribute".strip,
-      style: display_translation?(locale),
+      style: "#{options[:style]} #{display_translation?(locale)}".strip,
       data:  options.fetch(:data, {}).merge(locale: locale),
       label_options: {
         class: "#{options.dig(:label_options, :class)} js-globalize-attribute".strip,
-        style: display_translation?(locale),
+        style: "#{options.dig(:label_options, :style)} #{display_translation?(locale)}".strip,
         data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
       }
     )

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -31,6 +31,7 @@ class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
   def translatable_text_field(method, options = {})
     translatable_field(:text_field, method, options)
   end
+
   def translatable_text_area(method, options = {})
     translatable_field(:text_area, method, options)
   end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -11,6 +11,19 @@ module TranslatableFormHelper
       yield(f)
     end
   end
+
+  def merge_translatable_field_options(options, locale)
+    options.merge(
+      class: (options.fetch(:class, "") + " js-globalize-attribute"),
+      style: display_translation?(locale),
+      data:  options.fetch(:data, {}).merge(locale: locale),
+      label_options: {
+        class: (options.fetch(:class, "") + " js-globalize-attribute"),
+        style: display_translation?(locale),
+        data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
+      }
+    )
+  end
 end
 
 class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
@@ -28,17 +41,7 @@ class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
       @template.capture do
         @object.globalize_locales.each do |locale|
           Globalize.with_locale(locale) do
-            final_options = options.merge(
-              class: (options.fetch(:class, "") + " js-globalize-attribute"),
-              style: @template.display_translation?(locale),
-              data:  options.fetch(:data, {}).merge(locale: locale),
-              label_options: {
-                class: (options.fetch(:class, "") + " js-globalize-attribute"),
-                style: @template.display_translation?(locale),
-                data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
-              }
-            )
-
+            final_options = @template.merge_translatable_field_options(options, locale)
             @template.concat send(field_type, "#{method}_#{locale}", final_options)
           end
         end

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -5,7 +5,7 @@ class Banner < ActiveRecord::Base
 
   translates :title,       touch: true
   translates :description, touch: true
-  globalize_accessors locales: [:en, :es, :fr, :nl, :val, :pt_br]
+  globalize_accessors locales: I18n.available_locales.map { |l| l.to_s.underscore.to_sym }
 
   validates :title, presence: true,
                     length: { minimum: 2 }

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -5,7 +5,7 @@ class Banner < ActiveRecord::Base
 
   translates :title,       touch: true
   translates :description, touch: true
-  globalize_accessors locales: I18n.available_locales.map { |l| l.to_s.underscore.to_sym }
+  globalize_accessors
 
   validates :title, presence: true,
                     length: { minimum: 2 }

--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -8,7 +8,7 @@ class Budget
                    accepted_content_types: [ "application/pdf" ]
 
       translates :title, :description, touch: true
-      globalize_accessors locales: I18n.available_locales.map { |l| l.to_s.underscore.to_sym }
+      globalize_accessors
 
       belongs_to :investment
       belongs_to :status, class_name: 'Budget::Investment::Status'

--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -8,7 +8,7 @@ class Budget
                    accepted_content_types: [ "application/pdf" ]
 
       translates :title, :description, touch: true
-      globalize_accessors locales: [:en, :es, :fr, :nl, :val, :pt_br]
+      globalize_accessors locales: I18n.available_locales.map { |l| l.to_s.underscore.to_sym }
 
       belongs_to :investment
       belongs_to :status, class_name: 'Budget::Investment::Status'

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -1,10 +1,8 @@
 <%= render "admin/shared/globalize_locales", resource: @banner %>
 
-<%= form_for [:admin, @banner] do |f| %>
+<%= translatable_form_for [:admin, @banner] do |f| %>
 
   <%= render 'errors' %>
-
-  <%= render_translations_to_delete(@banner) %>
 
   <div class="row">
     <% date_started_at = @banner.post_started_at.present? ? I18n.localize(@banner.post_started_at) : "" %>
@@ -32,18 +30,9 @@
   <div class="row">
     <div class="small-12 medium-6 column">
       <%= f.label :title, t("admin.banners.banner.title") %>
-
-      <% @banner.globalize_locales.each do |locale| %>
-        <% globalize(locale) do %>
-          <%= f.text_field "title_#{locale}",
-                           placeholder: t("admin.banners.banner.title"),
-                           class: "js-globalize-attribute",
-                           data: {js_banner_title: "js_banner_title",
-                                  locale: locale},
-                           style: display_translation?(locale),
-                           label: false %>
-        <% end %>
-      <% end %>
+      <%= f.translatable_text_field :title,
+                                    placeholder: t("admin.banners.banner.title"),
+                                    data: {js_banner_title: "js_banner_title"}%>
     </div>
 
     <div class="small-12 medium-6 column">
@@ -57,17 +46,9 @@
   <div class="row">
     <div class="small-12 column">
       <%= f.label :description, t("admin.banners.banner.description") %>
-      <% @banner.globalize_locales.each do |locale| %>
-        <% globalize(locale) do %>
-          <%= f.text_field "description_#{locale}",
-                           placeholder: t("admin.banners.banner.description"),
-                           class: "js-globalize-attribute",
-                           data: {js_banner_description: "js_banner_description",
-                                  locale: locale},
-                           style: display_translation?(locale),
-                           label: false %>
-        <% end %>
-      <% end %>
+      <%= f.translatable_text_field :description,
+                                    placeholder: t("admin.banners.banner.description"),
+                                    data: {js_banner_description: "js_banner_description"} %>
     </div>
   </div>
 

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -29,10 +29,10 @@
 
   <div class="row">
     <div class="small-12 medium-6 column">
-      <%= f.label :title, t("admin.banners.banner.title") %>
       <%= f.translatable_text_field :title,
                                     placeholder: t("admin.banners.banner.title"),
-                                    data: {js_banner_title: "js_banner_title"}%>
+                                    data: {js_banner_title: "js_banner_title"},
+                                    label: t("admin.banners.banner.title") %>
     </div>
 
     <div class="small-12 medium-6 column">
@@ -45,10 +45,10 @@
 
   <div class="row">
     <div class="small-12 column">
-      <%= f.label :description, t("admin.banners.banner.description") %>
       <%= f.translatable_text_field :description,
                                     placeholder: t("admin.banners.banner.description"),
-                                    data: {js_banner_description: "js_banner_description"} %>
+                                    data: {js_banner_description: "js_banner_description"},
+                                    label: t("admin.banners.banner.description")  %>
     </div>
   </div>
 

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -1,8 +1,6 @@
 <%= render "admin/shared/globalize_locales", resource: @milestone %>
 
-<%= form_for [:admin, @investment.budget, @investment, @milestone] do |f| %>
-
-  <%= render_translations_to_delete(@milestone) %>
+<%= translatable_form_for [:admin, @investment.budget, @investment, @milestone] do |f| %>
 
   <%= f.hidden_field :title, value: l(Time.current, format: :datetime),
                              maxlength: Budget::Investment::Milestone.title_max_length %>
@@ -17,15 +15,7 @@
   </div>
 
   <%= f.label :description, t("admin.milestones.new.description") %>
-  <% @milestone.globalize_locales.each do |locale| %>
-    <% globalize(locale) do %>
-      <%= f.text_area "description_#{locale}", rows: 5,
-                      class: "js-globalize-attribute",
-                      data: { locale: locale },
-                      style: display_translation?(locale),
-                      label: false %>
-    <% end %>
-  <% end %>
+  <%= f.translatable_text_field :description, rows: 5 %>
 
   <%= f.label :publication_date, t("admin.milestones.new.date") %>
   <%= f.text_field :publication_date,

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -14,9 +14,9 @@
                 admin_budget_investment_statuses_path %>
   </div>
 
-  <%= f.translatable_text_field :description,
-                                rows: 5,
-                                label: t("admin.milestones.new.description") %>
+  <%= f.translatable_text_area :description,
+                               rows: 5,
+                               label: t("admin.milestones.new.description") %>
 
   <%= f.label :publication_date, t("admin.milestones.new.date") %>
   <%= f.text_field :publication_date,

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -14,8 +14,9 @@
                 admin_budget_investment_statuses_path %>
   </div>
 
-  <%= f.label :description, t("admin.milestones.new.description") %>
-  <%= f.translatable_text_field :description, rows: 5 %>
+  <%= f.translatable_text_field :description,
+                                rows: 5,
+                                label: t("admin.milestones.new.description") %>
 
   <%= f.label :publication_date, t("admin.milestones.new.date") %>
   <%= f.text_field :publication_date,

--- a/app/views/admin/shared/_globalize_locales.html.erb
+++ b/app/views/admin/shared/_globalize_locales.html.erb
@@ -1,9 +1,9 @@
 <% I18n.available_locales.each do |locale| %>
   <%= link_to t("admin.translations.remove_language"), "#",
-              id: "delete-#{neutral_locale(locale)}",
+              id: "delete-#{locale}",
               style: show_delete?(locale),
               class: 'float-right delete js-delete-language',
-              data: { locale: neutral_locale(locale) } %>
+              data: { locale: locale } %>
 
 <% end %>
 
@@ -13,7 +13,7 @@
       <%= link_to name_for_locale(locale), "#",
                   style: css_to_display_translation?(resource, locale),
                   class: "js-globalize-locale-link #{highlight_current?(locale)}",
-                  data: { locale: neutral_locale(locale) },
+                  data: { locale: locale },
                   remote: true %>
     </li>
   <% end %>

--- a/app/views/admin/site_customization/information_texts/_form_field.html.erb
+++ b/app/views/admin/site_customization/information_texts/_form_field.html.erb
@@ -11,9 +11,5 @@
   <%= text_area_tag "contents[content_#{content.key}]values[value_#{locale}]",
                     i18n_content_translation ||
                     t(content.key, locale: locale),
-                    { rows: 5,
-                      class: "js-globalize-attribute",
-                      style: display_translation?(locale),
-                      data: { locale: locale }
-                    } %>
+                    merge_translatable_field_options({rows: 5}, locale) %>
 <% end %>

--- a/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
+++ b/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
@@ -1,9 +1,9 @@
 <% I18n.available_locales.each do |locale| %>
   <%= link_to t("admin.translations.remove_language"), "#",
-              id: "delete-#{neutral_locale(locale)}",
+              id: "delete-#{locale}",
               style: show_delete?(locale),
               class: 'float-right delete js-delete-language',
-              data: { locale: neutral_locale(locale) } %>
+              data: { locale: locale } %>
 
 <% end %>
 
@@ -13,7 +13,7 @@
       <%= link_to name_for_locale(locale), "#",
                   style: site_customization_display_translation?(locale),
                   class: "js-globalize-locale-link #{highlight_current?(locale)}",
-                  data: { locale: neutral_locale(locale) },
+                  data: { locale: locale },
                   remote: true %>
     </li>
   <% end %>

--- a/app/views/budgets/investments/milestones/_milestone.html.erb
+++ b/app/views/budgets/investments/milestones/_milestone.html.erb
@@ -24,11 +24,9 @@
 
     <%= image_tag(milestone.image_url(:large), { id: "image_#{milestone.id}", alt: milestone.image.title, class: "margin" }) if milestone.image.present? %>
 
-    <% globalize(neutral_locale(locale)) do %>
-      <p>
-        <%= text_with_links milestone.description %>
-      </p>
-    <% end %>
+    <p>
+      <%= text_with_links milestone.description %>
+    </p>
 
     <% if milestone.documents.present? %>
       <div class="document-link text-center">

--- a/config/initializers/globalize.rb
+++ b/config/initializers/globalize.rb
@@ -1,0 +1,1 @@
+Globalize.fallbacks = {es: [:es, :en]}

--- a/config/initializers/globalize.rb
+++ b/config/initializers/globalize.rb
@@ -1,1 +1,0 @@
-Globalize.fallbacks = {es: [:es, :en]}

--- a/db/dev_seeds/banners.rb
+++ b/db/dev_seeds/banners.rb
@@ -10,8 +10,7 @@ section "Creating banners" do
                             post_ended_at:   rand((Time.current - 1.day)..(Time.current + 1.week)),
                             created_at: rand((Time.current - 1.week)..Time.current))
     I18n.available_locales.map do |locale|
-      neutral_locale = locale.to_s.downcase.underscore.to_sym
-      Globalize.with_locale(neutral_locale) do
+      Globalize.with_locale(locale) do
         banner.description = "Description for locale #{locale}"
         banner.title = "Title for locale #{locale}"
         banner.save!

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -143,8 +143,7 @@ section "Creating investment milestones" do
   Budget::Investment.all.each do |investment|
     milestone = Budget::Investment::Milestone.new(investment_id: investment.id, publication_date: Date.tomorrow)
     I18n.available_locales.map do |locale|
-      neutral_locale = locale.to_s.downcase.underscore.to_sym
-      Globalize.with_locale(neutral_locale) do
+      Globalize.with_locale(locale) do
         milestone.description = "Description for locale #{locale}"
         milestone.title = I18n.l(Time.current, format: :datetime)
         milestone.save!

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -98,7 +98,7 @@ feature "Translations" do
       expect(page).to have_content("Description in English")
 
       select('Português', from: 'locale-switcher')
-      click_link("Seguimiento (1)")
+      click_link("Milestones (1)")
 
       expect(page).to have_content('Description in pt-BR')
     end

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -83,6 +83,26 @@ feature "Translations" do
       expect(page).not_to have_content "Description in English"
     end
 
+    scenario "Add a translation for a locale with non-underscored name", :js do
+      visit @edit_milestone_url
+
+      select "Português", from: "translation_locale"
+      fill_in 'budget_investment_milestone_description_pt_br', with: 'Description in pt-BR'
+
+      click_button 'Update milestone'
+      expect(page).to have_content "Milestone updated successfully"
+
+      visit budget_investment_path(investment.budget, investment)
+
+      click_link("Milestones (1)")
+      expect(page).to have_content("Description in English")
+
+      select('Português', from: 'locale-switcher')
+      click_link("Seguimiento (1)")
+
+      expect(page).to have_content('Description in pt-BR')
+    end
+
     context "Globalize javascript interface" do
 
       scenario "Highlight current locale", :js do


### PR DESCRIPTION
# References

* Backport AyuntamientoMadrid#1613
* Related meta-issue: AyuntamientoMadrid#1612

# Objectives

Quoting from AyuntamientoMadrid#1613 (all credit to Marko):

> Includes various refactors to the code shared by all "translatable" admin-created resources

# Notes

* This PR seems to be different than AyuntamientoMadrid#1613. That's because AyuntamientoMadrid#1613 also includes changes already merged in #2886.
* The test for the Portuguese language has been changed slightly. It doesn't really matter because that test is going to be rewritten when we backport AyuntamientoMadrid#1617.