### PR TITLE
Show active tab in custom info texts

### DIFF
--- a/app/views/admin/site_customization/information_texts/_tabs.html.erb
+++ b/app/views/admin/site_customization/information_texts/_tabs.html.erb
@@ -1,7 +1,11 @@
 <ul id="information-texts-tabs" class="tabs" >
   <% [:debates, :community, :proposals, :polls, :layouts, :mailers, :management, :guides, :welcome].each do |tab| %>
-      <li class="tabs-title <%= "is-active" if tab.to_s == @tab %>">
+    <li class="tabs-title">
+      <% if tab.to_s == @tab %>  			
+        <%= link_to t("admin.menu.site_customization.information_texts_menu.#{tab}"), admin_site_customization_information_texts_path(tab: tab), :class => 'is-active' %>
+      <% else %>
         <%= link_to t("admin.menu.site_customization.information_texts_menu.#{tab}"), admin_site_customization_information_texts_path(tab: tab) %>
-      </li>
+      <% end %>  
+    </li>
   <% end %>
 </ul>

--- a/spec/features/admin/site_customization/information_texts_spec.rb
+++ b/spec/features/admin/site_customization/information_texts_spec.rb
@@ -43,6 +43,13 @@ feature "Admin custom information texts" do
     click_link 'Welcome'
     expect(page).to have_content 'See all debates'
   end
+  
+  scenario 'check that tabs are highlight when click it' do
+    visit admin_site_customization_information_texts_path
+
+    click_link 'Proposals'
+    expect(find("a[href=\"/admin/site_customization/information_texts?tab=proposals\"].is-active")).to have_content "Proposals"
+  end
 
   context "Globalization" do
 


### PR DESCRIPTION
References
===================
Issue [#2889](https://github.com/consul/consul/issues/2889)

Objectives
===================
Fix Issue [#2889](https://github.com/consul/consul/issues/2889)

Visual Changes
===================
**Before:**
When you select a tab it does not active title in blue and underlined.
![screen shot before](https://user-images.githubusercontent.com/5271149/45647722-314b3400-ba8c-11e8-8af9-aec532c6670c.jpg)

**After:**
When you select a tab it does active title in blue and underlined.
![screen shot after](https://user-images.githubusercontent.com/5271149/45647724-327c6100-ba8c-11e8-9a15-adb56a9f198e.jpg)



