### PR TITLE
Hide Featured section on Home Page if there are no cards

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -20,11 +20,11 @@
 
 
   <div class="row">
-	<% if @cards.any? %>  
+    <% if @cards.any? %>  
       <div class="small-12 column <%= 'large-8' if feed_processes_enabled? %>">
         <%= render "cards" %>
       </div>
-	<% end %>  
+    <% end %>  
 
     <div class="small-12 large-4 column">
       <%= render "processes" %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -20,9 +20,11 @@
 
 
   <div class="row">
-    <div class="small-12 column <%= 'large-8' if feed_processes_enabled? %>">
-      <%= render "cards" %>
-    </div>
+	<% if @cards.any? %>  
+      <div class="small-12 column <%= 'large-8' if feed_processes_enabled? %>">
+        <%= render "cards" %>
+      </div>
+	<% end %>  
 
     <div class="small-12 large-4 column">
       <%= render "processes" %>

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -143,4 +143,24 @@ feature "Home" do
       "/html/body/div[@class='wrapper ']/comment()[contains(.,'ie-callout')]"
     end
   end
+  
+  
+  scenario 'if there are cards, the "featured" title will render' do
+    card = create(:widget_card,
+      title: "Card text",
+      description: "Card description",
+      link_text: "Link text",
+      link_url: "consul.dev"
+    )
+    
+    visit root_path
+
+    expect(page).to have_css(".title", text: "Featured")
+  end
+  
+  scenario 'if there are no cards, the "featured" title will not render' do
+    visit root_path
+    
+    expect(page).not_to have_css(".title", text: "Featured")
+  end
 end


### PR DESCRIPTION
===================
Issue [#2890](https://github.com/consul/consul/issues/2890)

Objectives
===================
Fix Issue [#2890](https://github.com/consul/consul/issues/2890)

Visual Changes
===================
**Before:**
If there are no cards on the homepage it still says "Featured"
![screen shot realy before](https://user-images.githubusercontent.com/5271149/45647040-8128fb80-ba8a-11e8-8aba-7d75848c0d60.jpg)


**After:**
If there are no cards on the homepage it does not says "Featured" anymore
![screen shot before](https://user-images.githubusercontent.com/5271149/45647043-8423ec00-ba8a-11e8-8613-7479723f0473.jpg)


