### PR TITLE
[Backport] Make collaborative legislation translatable

### DIFF
--- a/app/assets/javascripts/globalize.js.coffee
+++ b/app/assets/javascripts/globalize.js.coffee
@@ -36,6 +36,10 @@ App.Globalize =
   disable_locale: (locale) ->
     $("#enabled_translations_" + locale).val(0)
 
+  refresh_visible_translations: ->
+    locale = $('.js-globalize-locale-link.is-active').data("locale")
+    App.Globalize.display_translations(locale)
+
   initialize: ->
     $('.js-globalize-locale').on 'change', ->
       App.Globalize.display_translations($(this).val())

--- a/app/assets/javascripts/legislation_admin.js.coffee
+++ b/app/assets/javascripts/legislation_admin.js.coffee
@@ -12,3 +12,5 @@ App.LegislationAdmin =
           else
             $(this).val("")
 
+    $("#nested-question-options").on "cocoon:after-insert", ->
+      App.Globalize.refresh_visible_translations()

--- a/app/assets/javascripts/markdown_editor.js.coffee
+++ b/app/assets/javascripts/markdown_editor.js.coffee
@@ -1,9 +1,14 @@
 App.MarkdownEditor =
 
   refresh_preview: (element, md) ->
-    textarea_content = element.find('textarea').val()
+    textarea_content = App.MarkdownEditor.find_textarea(element).val()
     result = md.render(textarea_content)
     element.find('#markdown-preview').html(result)
+
+  # Multi-locale (translatable) form fields work by hiding inputs of locales
+  # which are not "active".
+  find_textarea: (editor) ->
+    editor.find('textarea:visible')
 
   initialize: ->
     $('.markdown-editor').each ->
@@ -13,18 +18,18 @@ App.MarkdownEditor =
         typographer: true,
       })
 
-      App.MarkdownEditor.refresh_preview($(this), md)
+      editor = $(this)
 
-      $(this).on 'change input paste keyup', ->
+      editor.on 'input', ->
         App.MarkdownEditor.refresh_preview($(this), md)
         $('.legislation-draft-versions-edit .warning').show()
         return
 
-      $(this).find('textarea').on 'scroll', ->
+      editor.find('textarea').on 'scroll', ->
         $('#markdown-preview').scrollTop($(this).scrollTop())
 
-      $(this).find('.fullscreen-toggle').on 'click', ->
-        $('.markdown-editor').toggleClass('fullscreen')
+      editor.find('.fullscreen-toggle').on 'click', ->
+        editor.toggleClass('fullscreen')
         $('.fullscreen-container').toggleClass('medium-8', 'medium-12')
         span = $(this).find('span')
         current_html = span.html()
@@ -33,7 +38,8 @@ App.MarkdownEditor =
         else
           span.html(span.data('open-text'))
 
-        if $('.markdown-editor').hasClass('fullscreen')
-          $('.markdown-editor textarea').height($(window).height() - 100)
+        if editor.hasClass('fullscreen')
+          App.MarkdownEditor.find_textarea(editor).height($(window).height() - 100)
+          App.MarkdownEditor.refresh_preview(editor, md)
         else
-          $('.markdown-editor textarea').height("10em")
+          App.MarkdownEditor.find_textarea(editor).height("10em")

--- a/app/controllers/admin/legislation/draft_versions_controller.rb
+++ b/app/controllers/admin/legislation/draft_versions_controller.rb
@@ -1,6 +1,8 @@
 class Admin::Legislation::DraftVersionsController < Admin::Legislation::BaseController
-  load_and_authorize_resource :process, class: "Legislation::Process"
-  load_and_authorize_resource :draft_version, class: "Legislation::DraftVersion", through: :process
+  include Translatable
+
+  load_and_authorize_resource :draft_version, class: "Legislation::DraftVersion", through: :process, prepend: true
+  load_and_authorize_resource :process, class: "Legislation::Process", prepend: true
 
   def index
     @draft_versions = @process.draft_versions
@@ -44,7 +46,12 @@ class Admin::Legislation::DraftVersionsController < Admin::Legislation::BaseCont
         :status,
         :final_version,
         :body,
-        :body_html
+        :body_html,
+        *translation_params(Legislation::DraftVersion)
       )
+    end
+
+    def resource
+      @draft_version
     end
 end

--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Legislation::ProcessesController < Admin::Legislation::BaseController
+  include Translatable
+
   has_filters %w{open next past all}, only: :index
 
   load_and_authorize_resource :process, class: "Legislation::Process"
@@ -61,6 +63,7 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         :result_publication_enabled,
         :published,
         :custom_list,
+        *translation_params(Legislation::Process),
         documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
       )
     end
@@ -68,5 +71,9 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
     def set_tag_list
       @process.set_tag_list_on(:customs, process_params[:custom_list])
       @process.save
+    end
+
+    def resource
+      @process || Legislation::Process.find(params[:id])
     end
 end

--- a/app/controllers/admin/legislation/questions_controller.rb
+++ b/app/controllers/admin/legislation/questions_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Legislation::QuestionsController < Admin::Legislation::BaseController
+  include Translatable
+
   load_and_authorize_resource :process, class: "Legislation::Process"
   load_and_authorize_resource :question, class: "Legislation::Question", through: :process
 
@@ -46,7 +48,13 @@ class Admin::Legislation::QuestionsController < Admin::Legislation::BaseControll
     def question_params
       params.require(:legislation_question).permit(
         :title,
-        question_options_attributes: [:id, :value, :_destroy]
+        *translation_params(::Legislation::Question),
+        question_options_attributes: [:id, :value,
+                                      *translation_params(::Legislation::QuestionOption)]
       )
+    end
+
+    def resource
+      @question || ::Legislation::Question.find(params[:id])
     end
 end

--- a/app/controllers/concerns/translatable.rb
+++ b/app/controllers/concerns/translatable.rb
@@ -8,6 +8,8 @@ module Translatable
   private
 
     def translation_params(resource_model)
+      return [] unless params[:enabled_translations]
+
       resource_model.translated_attribute_names.product(enabled_translations).map do |attr_name, loc|
         resource_model.localized_attr_name_for(attr_name, loc)
       end

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -1,8 +1,8 @@
 class AdminNotification < ActiveRecord::Base
   include Notifiable
 
-  translates :title, touch: :true
-  translates :body,  touch: :true
+  translates :title, touch: true
+  translates :body,  touch: true
   globalize_accessors
 
   validates :title, presence: true

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -7,7 +7,7 @@ class Legislation::DraftVersion < ActiveRecord::Base
   translates :title,     touch: true
   translates :changelog, touch: true
   translates :body,      touch: true
-  translates :body_html,  touch: true
+  translates :body_html, touch: true
   translates :toc_html,  touch: true
   globalize_accessors
 

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -4,6 +4,13 @@ class Legislation::DraftVersion < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
+  translates :title,     touch: true
+  translates :changelog, touch: true
+  translates :body,      touch: true
+  translates :body_html,  touch: true
+  translates :toc_html,  touch: true
+  globalize_accessors locales: [:en, :es, :fr, :nl, :val, :pt_br]
+
   belongs_to :process, class_name: 'Legislation::Process', foreign_key: 'legislation_process_id'
   has_many :annotations, class_name: 'Legislation::Annotation', foreign_key: 'legislation_draft_version_id', dependent: :destroy
 
@@ -21,6 +28,13 @@ class Legislation::DraftVersion < ActiveRecord::Base
 
     self.body_html = Redcarpet::Markdown.new(renderer).render(body)
     self.toc_html = Redcarpet::Markdown.new(toc_renderer).render(body)
+
+    translations.each do |translation|
+      if translation.body_changed?
+        translation.body_html = Redcarpet::Markdown.new(renderer).render(translation.body)
+        translation.toc_html = Redcarpet::Markdown.new(toc_renderer).render(translation.body)
+      end
+    end
   end
 
   def display_title

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -26,8 +26,10 @@ class Legislation::DraftVersion < ActiveRecord::Base
     renderer = Redcarpet::Render::HTML.new(with_toc_data: true)
     toc_renderer = Redcarpet::Render::HTML_TOC.new(with_toc_data: true)
 
-    self.body_html = Redcarpet::Markdown.new(renderer).render(body)
-    self.toc_html = Redcarpet::Markdown.new(toc_renderer).render(body)
+    if body_changed?
+      self.body_html = Redcarpet::Markdown.new(renderer).render(body)
+      self.toc_html = Redcarpet::Markdown.new(toc_renderer).render(body)
+    end
 
     translations.each do |translation|
       if translation.body_changed?

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -9,7 +9,7 @@ class Legislation::DraftVersion < ActiveRecord::Base
   translates :body,      touch: true
   translates :body_html,  touch: true
   translates :toc_html,  touch: true
-  globalize_accessors locales: [:en, :es, :fr, :nl, :val, :pt_br]
+  globalize_accessors
 
   belongs_to :process, class_name: 'Legislation::Process', foreign_key: 'legislation_process_id'
   has_many :annotations, class_name: 'Legislation::Annotation', foreign_key: 'legislation_draft_version_id', dependent: :destroy

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -9,10 +9,10 @@ class Legislation::Process < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   acts_as_taggable_on :customs
 
-  translates :title,           touch: :true
-  translates :summary,         touch: :true
-  translates :description,     touch: :true
-  translates :additional_info, touch: :true
+  translates :title,           touch: true
+  translates :summary,         touch: true
+  translates :description,     touch: true
+  translates :additional_info, touch: true
   globalize_accessors
 
   PHASES_AND_PUBLICATIONS = %i(debate_phase allegations_phase proposals_phase draft_publication result_publication).freeze

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -9,6 +9,12 @@ class Legislation::Process < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   acts_as_taggable_on :customs
 
+  translates :title,           touch: :true
+  translates :summary,         touch: :true
+  translates :description,     touch: :true
+  translates :additional_info, touch: :true
+  globalize_accessors
+
   PHASES_AND_PUBLICATIONS = %i(debate_phase allegations_phase proposals_phase draft_publication result_publication).freeze
 
   has_many :draft_versions, -> { order(:id) }, class_name: 'Legislation::DraftVersion',

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -3,6 +3,9 @@ class Legislation::Question < ActiveRecord::Base
   include ActsAsParanoidAliases
   include Notifiable
 
+  translates :title, touch: :true
+  globalize_accessors
+
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
   belongs_to :process, class_name: 'Legislation::Process', foreign_key: 'legislation_process_id'
 
@@ -11,7 +14,7 @@ class Legislation::Question < ActiveRecord::Base
   has_many :answers, class_name: 'Legislation::Answer', foreign_key: 'legislation_question_id', dependent: :destroy, inverse_of: :question
   has_many :comments, as: :commentable, dependent: :destroy
 
-  accepts_nested_attributes_for :question_options, reject_if: proc { |attributes| attributes[:value].blank? }, allow_destroy: true
+  accepts_nested_attributes_for :question_options, reject_if: proc { |attributes| attributes.all? { |k, v| v.blank? } }, allow_destroy: true
 
   validates :process, presence: true
   validates :title, presence: true

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -3,7 +3,7 @@ class Legislation::Question < ActiveRecord::Base
   include ActsAsParanoidAliases
   include Notifiable
 
-  translates :title, touch: :true
+  translates :title, touch: true
   globalize_accessors
 
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'

--- a/app/models/legislation/question_option.rb
+++ b/app/models/legislation/question_option.rb
@@ -2,6 +2,9 @@ class Legislation::QuestionOption < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
+  translates :value, touch: :true
+  globalize_accessors
+
   belongs_to :question, class_name: 'Legislation::Question', foreign_key: 'legislation_question_id', inverse_of: :question_options
   has_many :answers, class_name: 'Legislation::Answer', foreign_key: 'legislation_question_id', dependent: :destroy, inverse_of: :question
 

--- a/app/models/legislation/question_option.rb
+++ b/app/models/legislation/question_option.rb
@@ -2,7 +2,7 @@ class Legislation::QuestionOption < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
-  translates :value, touch: :true
+  translates :value, touch: true
   globalize_accessors
 
   belongs_to :question, class_name: 'Legislation::Question', foreign_key: 'legislation_question_id', inverse_of: :question_options

--- a/app/views/admin/legislation/draft_versions/_form.html.erb
+++ b/app/views/admin/legislation/draft_versions/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form_for [:admin, @process, @draft_version], url: url, html: {data: {watch_changes: true}} do |f| %>
+<%= render "admin/shared/globalize_locales", resource: @draft_version  %>
+
+<%= translatable_form_for [:admin, @process, @draft_version], url: url, html: {data: {watch_changes: true}} do |f| %>
 
   <% if @draft_version.errors.any? %>
     <div id="error_explanation" data-alert class="callout alert" data-closable>
@@ -14,14 +16,17 @@
   <% end %>
 
   <div class="small-12 medium-9 column">
-    <%= f.label :title %>
-    <%= f.text_field :title, label: false, placeholder: t("admin.legislation.draft_versions.form.title_placeholder") %>
+    <%= f.translatable_text_field :title,
+                                  placeholder: t("admin.legislation.draft_versions.form.title_placeholder") %>
   </div>
 
   <div class="small-12 medium-9 column">
     <%= f.label :changelog %>
     <span class="help-text"><%= t("admin.legislation.draft_versions.form.use_markdown") %></span>
-    <%= f.text_area :changelog, label: false, rows: 5, placeholder: t("admin.legislation.draft_versions.form.changelog_placeholder") %>
+    <%= f.translatable_text_area :changelog,
+                                 label: false,
+                                 rows: 5,
+                                 placeholder: t("admin.legislation.draft_versions.form.changelog_placeholder") %>
   </div>
 
   <div class="small-12 medium-9 column">
@@ -65,7 +70,9 @@
       <% end %>
     </div>
     <div class="small-12 medium-6 column markdown-area">
-      <%= f.text_area :body, label: false, placeholder: t("admin.legislation.draft_versions.form.body_placeholder") %>
+      <%= f.translatable_text_area :body,
+                                   label: false,
+                                   placeholder: t("admin.legislation.draft_versions.form.body_placeholder") %>
     </div>
 
     <div id="markdown-preview" class="small-12 medium-6 column markdown-preview">

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -181,19 +181,19 @@
   <div class="small-12 medium-9 column">
     <%= f.label :summary %>
     <span class="help-text"><%= t("admin.legislation.processes.form.use_markdown") %></span>
-    <%= f.translatable_text_field :summary,
-                                  rows: 2,
-                                  placeholder: t("admin.legislation.processes.form.summary_placeholder"),
-                                  label: false %>
+    <%= f.translatable_text_area :summary,
+                                 rows: 2,
+                                 placeholder: t("admin.legislation.processes.form.summary_placeholder"),
+                                 label: false %>
   </div>
 
   <div class="small-12 medium-9 column">
     <%= f.label :description %>
     <span class="help-text"><%= t("admin.legislation.processes.form.use_markdown") %></span>
-    <%= f.translatable_text_field :description,
-                                  rows: 5,
-                                  placeholder: t("admin.legislation.processes.form.description_placeholder"),
-                                  label: false %>
+    <%= f.translatable_text_area :description,
+                                 rows: 5,
+                                 placeholder: t("admin.legislation.processes.form.description_placeholder"),
+                                 label: false %>
   </div>
 
   <div class="small-12 medium-9 column">

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form_for [:admin, @process], html: {data: {watch_changes: true}} do |f| %>
+<%= render "admin/shared/globalize_locales", resource: @process  %>
+
+<%= translatable_form_for [:admin, @process], html: {data: {watch_changes: true}} do |f| %>
 
   <% if @process.errors.any? %>
 
@@ -172,37 +174,35 @@
   </div>
 
   <div class="small-12 medium-9 column">
-    <%= f.label :title %>
-    <%= f.text_field :title,
-                     label: false,
-                     placeholder: t("admin.legislation.processes.form.title_placeholder") %>
+    <%= f.translatable_text_field :title,
+                                  placeholder: t("admin.legislation.processes.form.title_placeholder") %>
   </div>
 
   <div class="small-12 medium-9 column">
     <%= f.label :summary %>
     <span class="help-text"><%= t("admin.legislation.processes.form.use_markdown") %></span>
-    <%= f.text_area :summary,
-                     label: false,
-                     rows: 2,
-                     placeholder: t("admin.legislation.processes.form.summary_placeholder") %>
+    <%= f.translatable_text_field :summary,
+                                  rows: 2,
+                                  placeholder: t("admin.legislation.processes.form.summary_placeholder"),
+                                  label: false %>
   </div>
 
   <div class="small-12 medium-9 column">
     <%= f.label :description %>
     <span class="help-text"><%= t("admin.legislation.processes.form.use_markdown") %></span>
-    <%= f.text_area :description,
-                     label: false,
-                     rows: 5,
-                     placeholder: t("admin.legislation.processes.form.description_placeholder") %>
+    <%= f.translatable_text_field :description,
+                                  rows: 5,
+                                  placeholder: t("admin.legislation.processes.form.description_placeholder"),
+                                  label: false %>
   </div>
 
   <div class="small-12 medium-9 column">
     <%= f.label :additional_info %>
     <span class="help-text"><%= t("admin.legislation.processes.form.use_markdown") %></span>
-    <%= f.text_area :additional_info,
-                     label: false,
-                     rows: 10,
-                     placeholder: t("admin.legislation.processes.form.additional_info_placeholder") %>
+    <%= f.translatable_text_area :additional_info,
+                                  rows: 10,
+                                  placeholder: t("admin.legislation.processes.form.additional_info_placeholder"),
+                                  label: false %>
   </div>
 
   <div class="small-12 medium-3 column clear end">

--- a/app/views/admin/legislation/questions/_form.html.erb
+++ b/app/views/admin/legislation/questions/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form_for [:admin, @process, @question], url: url, html: {data: {watch_changes: true}} do |f| %>
+<%= render "admin/shared/globalize_locales", resource: @question  %>
+
+<%= translatable_form_for [:admin, @process, @question], url: url, html: {data: {watch_changes: true}} do |f| %>
 
   <% if @question.errors.any? %>
     <div class="small-12 medium-9 column">
@@ -16,23 +18,25 @@
   <% end %>
 
   <div class="small-12 medium-9 column">
-    <%= f.label :title, t("admin.legislation.questions.form.title") %>
-    <%= f.text_area :title, rows: 5, label: false, placeholder: t("admin.legislation.questions.form.title_placeholder") %>
+    <%= f.translatable_text_area :title,
+                                 rows: 5,
+                                 placeholder: t("admin.legislation.questions.form.title_placeholder"),
+                                 label: t("admin.legislation.questions.form.title") %>
   </div>
 
   <div class="small-12 medium-9 column">
     <%= f.label :question_options, t("admin.legislation.questions.form.question_options") %>
   </div>
 
-  <div>
+  <div id="nested-question-options">
     <%= f.fields_for :question_options do |ff| %>
       <%= render 'question_option_fields', f: ff %>
     <% end %>
-  </div>
 
-  <div class="small-12 medium-9 column">
-    <%= link_to_add_association t("admin.legislation.questions.form.add_option"),
-                                f, :question_options, class: "button hollow" %>
+    <div class="small-12 medium-9 column">
+      <%= link_to_add_association t("admin.legislation.questions.form.add_option"),
+                                  f, :question_options, class: "button hollow"  %>
+    </div>
   </div>
 
   <div class="small-12 medium-6 large-3 clear column end margin-top">

--- a/app/views/admin/legislation/questions/_question_option_fields.html.erb
+++ b/app/views/admin/legislation/questions/_question_option_fields.html.erb
@@ -1,7 +1,9 @@
 <div class="nested-fields">
   <div class="field">
     <div class="small-12 medium-9 column">
-      <%= f.text_field :value, label: false, placeholder: t("admin.legislation.questions.form.value_placeholder") %>
+      <%= f.translatable_text_field :value,
+                                    placeholder: t("admin.legislation.questions.form.value_placeholder"),
+                                    label: false %>
     </div>
     <div class="small-12 medium-3 column">
       <%= link_to_remove_association t("admin.legislation.questions.question_option_fields.remove_option"), f, class: "delete"%>

--- a/config/initializers/routes_hierarchy.rb
+++ b/config/initializers/routes_hierarchy.rb
@@ -11,7 +11,7 @@ module ActionDispatch::Routing::UrlFor
       [resource.investment.budget, resource.investment, resource]
     when "Legislation::Annotation"
       [resource.draft_version.process, resource.draft_version, resource]
-    when "Legislation::Proposal", "Legislation::Question"
+    when "Legislation::Proposal", "Legislation::Question", "Legislation::DraftVersion"
       [resource.process, resource]
     when "Topic"
       [resource.community, resource]

--- a/db/dev_seeds/legislation_processes.rb
+++ b/db/dev_seeds/legislation_processes.rb
@@ -25,8 +25,12 @@ section "Creating legislation processes" do
 
   Legislation::Process.find_each do |process|
     (1..3).each do |i|
-      process.draft_versions.create!(title: "Version #{i}",
-                                     body: Faker::Lorem.paragraphs.join("\n\n"))
+      process.draft_versions.create!(title_en: "Version #{i}",
+                                     title_es: "Versión #{i}",
+                                     body_en: ["Draft version in English",
+                                               *Faker::Lorem.paragraphs].join("\n\n"),
+                                     body_es: ["Versión borrador en Español",
+                                               *Faker::Lorem.paragraphs].join("\n\n"))
     end
   end
 end

--- a/db/migrate/20180801140800_add_collaborative_legislation_translations.rb
+++ b/db/migrate/20180801140800_add_collaborative_legislation_translations.rb
@@ -1,0 +1,33 @@
+class AddCollaborativeLegislationTranslations < ActiveRecord::Migration
+
+  def self.up
+    Legislation::Process.create_translation_table!(
+      title:           :string,
+      summary:         :text,
+      description:     :text,
+      additional_info: :text,
+    )
+
+    Legislation::Question.create_translation_table!(
+      title:           :text
+    )
+
+    Legislation::DraftVersion.create_translation_table!(
+      title:           :string,
+      changelog:       :text,
+      body:            :text,
+      body_html:       :text,
+      toc_html:        :text
+    )
+    Legislation::QuestionOption.create_translation_table!(
+      value:           :string
+    )
+  end
+
+  def self.down
+    Legislation::Process.drop_translation_table!
+    Legislation::DraftVersion.drop_translation_table!
+    Legislation::Question.drop_translation_table!
+    Legislation::QuestionOption.drop_translation_table!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -575,6 +575,21 @@ ActiveRecord::Schema.define(version: 20180813141443) do
   add_index "legislation_answers", ["legislation_question_option_id"], name: "index_legislation_answers_on_legislation_question_option_id", using: :btree
   add_index "legislation_answers", ["user_id"], name: "index_legislation_answers_on_user_id", using: :btree
 
+  create_table "legislation_draft_version_translations", force: :cascade do |t|
+    t.integer  "legislation_draft_version_id", null: false
+    t.string   "locale",                       null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.text     "title"
+    t.text     "changelog"
+    t.text     "body"
+    t.text     "body_html"
+    t.text     "toc_html"
+  end
+
+  add_index "legislation_draft_version_translations", ["legislation_draft_version_id"], name: "index_900e5ba94457606e69e89193db426e8ddff809bc", using: :btree
+  add_index "legislation_draft_version_translations", ["locale"], name: "index_legislation_draft_version_translations_on_locale", using: :btree
+
   create_table "legislation_draft_versions", force: :cascade do |t|
     t.integer  "legislation_process_id"
     t.string   "title"
@@ -592,6 +607,20 @@ ActiveRecord::Schema.define(version: 20180813141443) do
   add_index "legislation_draft_versions", ["hidden_at"], name: "index_legislation_draft_versions_on_hidden_at", using: :btree
   add_index "legislation_draft_versions", ["legislation_process_id"], name: "index_legislation_draft_versions_on_legislation_process_id", using: :btree
   add_index "legislation_draft_versions", ["status"], name: "index_legislation_draft_versions_on_status", using: :btree
+
+  create_table "legislation_process_translations", force: :cascade do |t|
+    t.integer  "legislation_process_id", null: false
+    t.string   "locale",                 null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.string   "title"
+    t.text     "summary"
+    t.text     "description"
+    t.text     "additional_info"
+  end
+
+  add_index "legislation_process_translations", ["legislation_process_id"], name: "index_199e5fed0aca73302243f6a1fca885ce10cdbb55", using: :btree
+  add_index "legislation_process_translations", ["locale"], name: "index_legislation_process_translations_on_locale", using: :btree
 
   create_table "legislation_processes", force: :cascade do |t|
     t.string   "title"
@@ -662,6 +691,17 @@ ActiveRecord::Schema.define(version: 20180813141443) do
 
   add_index "legislation_proposals", ["legislation_process_id"], name: "index_legislation_proposals_on_legislation_process_id", using: :btree
 
+  create_table "legislation_question_option_translations", force: :cascade do |t|
+    t.integer  "legislation_question_option_id", null: false
+    t.string   "locale",                         null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.string   "value"
+  end
+
+  add_index "legislation_question_option_translations", ["legislation_question_option_id"], name: "index_61bcec8729110b7f8e1e9e5ce08780878597a209", using: :btree
+  add_index "legislation_question_option_translations", ["locale"], name: "index_legislation_question_option_translations_on_locale", using: :btree
+
   create_table "legislation_question_options", force: :cascade do |t|
     t.integer  "legislation_question_id"
     t.string   "value"
@@ -673,6 +713,17 @@ ActiveRecord::Schema.define(version: 20180813141443) do
 
   add_index "legislation_question_options", ["hidden_at"], name: "index_legislation_question_options_on_hidden_at", using: :btree
   add_index "legislation_question_options", ["legislation_question_id"], name: "index_legislation_question_options_on_legislation_question_id", using: :btree
+
+  create_table "legislation_question_translations", force: :cascade do |t|
+    t.integer  "legislation_question_id", null: false
+    t.string   "locale",                  null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.text     "title"
+  end
+
+  add_index "legislation_question_translations", ["legislation_question_id"], name: "index_d34cc1e1fe6d5162210c41ce56533c5afabcdbd3", using: :btree
+  add_index "legislation_question_translations", ["locale"], name: "index_legislation_question_translations_on_locale", using: :btree
 
   create_table "legislation_questions", force: :cascade do |t|
     t.integer  "legislation_process_id"

--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 feature 'Admin legislation draft versions' do
 
+  it_behaves_like "translatable",
+                  "legislation_draft_version",
+                  "edit_admin_legislation_process_draft_version_path",
+                  %w[title changelog]
+
   background do
     admin = create(:administrator)
     login_as(admin.user)
@@ -107,73 +112,14 @@ feature 'Admin legislation draft versions' do
     end
   end
 
-  context "Translations" do
+  context "Special translation behaviour" do
 
-    let!(:draft_version) { create(:legislation_draft_version,
-                                    title_en: "Title in English",
-                                    title_es: "Título en Español",
-                                    changelog_en: "Changes in English",
-                                    changelog_es: "Cambios en Español",
-                                    body_en: "Body in English",
-                                    body_es: "Texto en Español") }
+    let!(:draft_version) { create(:legislation_draft_version) }
 
-    before do
-      @edit_draft_version_url = edit_admin_legislation_process_draft_version_path(draft_version.process, draft_version)
-    end
+    scenario 'Add body translation through markup editor', :js do
+      edit_path = edit_admin_legislation_process_draft_version_path(draft_version.process, draft_version)
 
-    scenario "Add a translation", :js do
-      visit @edit_draft_version_url
-
-      select "Français", from: "translation_locale"
-      fill_in 'legislation_draft_version_title_fr', with: 'Titre en Français'
-
-      click_button 'Save changes'
-
-      visit @edit_draft_version_url
-      expect(page).to have_field('legislation_draft_version_title_en', with: 'Title in English')
-
-      click_link "Español"
-      expect(page).to have_field('legislation_draft_version_title_es', with: 'Título en Español')
-
-      click_link "Français"
-      expect(page).to have_field('legislation_draft_version_title_fr', with: 'Titre en Français')
-    end
-
-    scenario "Update a translation", :js do
-      draft_version.update!(status: 'published')
-      draft_version.process.update!(title_es: 'Título de proceso')
-
-      visit @edit_draft_version_url
-
-      click_link "Español"
-      fill_in 'legislation_draft_version_title_es', with: 'Título correcto en Español'
-
-      click_button 'Save changes'
-
-      visit legislation_process_draft_version_path(draft_version.process, draft_version)
-
-      expect(page).to have_content("Title in English")
-
-      select('Español', from: 'locale-switcher')
-
-      expect(page).to have_content('Título correcto en Español')
-    end
-
-    scenario "Remove a translation", :js do
-      visit @edit_draft_version_url
-
-      click_link "Español"
-      click_link "Remove language"
-
-      expect(page).not_to have_link "Español"
-
-      click_button "Save changes"
-      visit @edit_draft_version_url
-      expect(page).not_to have_link "Español"
-    end
-
-    scenario 'Add translation through markup editor', :js do
-      visit @edit_draft_version_url
+      visit edit_path
 
       select "Français", from: "translation_locale"
 
@@ -184,57 +130,12 @@ feature 'Admin legislation draft versions' do
       click_link 'Close text editor'
       click_button "Save changes"
 
-      visit @edit_draft_version_url
+      visit edit_path
 
       click_link "Français"
       click_link 'Launch text editor'
 
       expect(page).to have_field('legislation_draft_version_body_fr', with: 'Texte en Français')
-    end
-
-    context "Globalize javascript interface" do
-
-      scenario "Highlight current locale", :js do
-        visit @edit_draft_version_url
-
-        expect(find("a.js-globalize-locale-link.is-active")).to have_content "English"
-
-        select('Español', from: 'locale-switcher')
-
-        expect(find("a.js-globalize-locale-link.is-active")).to have_content "Español"
-      end
-
-      scenario "Highlight selected locale", :js do
-        visit @edit_draft_version_url
-
-        expect(find("a.js-globalize-locale-link.is-active")).to have_content "English"
-
-        click_link "Español"
-
-        expect(find("a.js-globalize-locale-link.is-active")).to have_content "Español"
-      end
-
-      scenario "Show selected locale form", :js do
-        visit @edit_draft_version_url
-
-        expect(page).to have_field('legislation_draft_version_title_en', with: 'Title in English')
-
-        click_link "Español"
-
-        expect(page).to have_field('legislation_draft_version_title_es', with: 'Título en Español')
-      end
-
-      scenario "Select a locale and add it to the draft_version form", :js do
-        visit @edit_draft_version_url
-
-        select "Français", from: "translation_locale"
-
-        expect(page).to have_link "Français"
-
-        click_link "Français"
-
-        expect(page).to have_field('legislation_draft_version_title_fr')
-      end
     end
   end
 end

--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -2,11 +2,6 @@ require 'rails_helper'
 
 feature 'Admin legislation draft versions' do
 
-  it_behaves_like "translatable",
-                  "legislation_draft_version",
-                  "edit_admin_legislation_process_draft_version_path",
-                  %w[title changelog]
-
   background do
     admin = create(:administrator)
     login_as(admin.user)

--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -7,6 +7,11 @@ feature 'Admin legislation draft versions' do
     login_as(admin.user)
   end
 
+  it_behaves_like "translatable",
+                  "legislation_draft_version",
+                  "edit_admin_legislation_process_draft_version_path",
+                  %w[title changelog]
+
   context "Feature flag" do
 
     scenario 'Disabled with a feature flag' do
@@ -53,9 +58,9 @@ feature 'Admin legislation draft versions' do
 
       click_link 'Create version'
 
-      fill_in 'legislation_draft_version_title', with: 'Version 3'
-      fill_in 'legislation_draft_version_changelog', with: 'Version 3 changes'
-      fill_in 'legislation_draft_version_body', with: 'Version 3 body'
+      fill_in 'legislation_draft_version_title_en', with: 'Version 3'
+      fill_in 'legislation_draft_version_changelog_en', with: 'Version 3 changes'
+      fill_in 'legislation_draft_version_body_en', with: 'Version 3 body'
 
       within('.end') do
         click_button 'Create version'
@@ -86,11 +91,11 @@ feature 'Admin legislation draft versions' do
 
       click_link 'Version 1'
 
-      fill_in 'legislation_draft_version_title', with: 'Version 1b'
+      fill_in 'legislation_draft_version_title_en', with: 'Version 1b'
 
       click_link 'Launch text editor'
 
-      fill_in 'legislation_draft_version_body', with: '# Version 1 body\r\n\r\nParagraph\r\n\r\n>Quote'
+      fill_in 'legislation_draft_version_body_en', with: '# Version 1 body\r\n\r\nParagraph\r\n\r\n>Quote'
 
       within('.fullscreen') do
         click_link 'Close text editor'
@@ -99,6 +104,137 @@ feature 'Admin legislation draft versions' do
       click_button 'Save changes'
 
       expect(page).to have_content 'Version 1b'
+    end
+  end
+
+  context "Translations" do
+
+    let!(:draft_version) { create(:legislation_draft_version,
+                                    title_en: "Title in English",
+                                    title_es: "Título en Español",
+                                    changelog_en: "Changes in English",
+                                    changelog_es: "Cambios en Español",
+                                    body_en: "Body in English",
+                                    body_es: "Texto en Español") }
+
+    before do
+      @edit_draft_version_url = edit_admin_legislation_process_draft_version_path(draft_version.process, draft_version)
+    end
+
+    scenario "Add a translation", :js do
+      visit @edit_draft_version_url
+
+      select "Français", from: "translation_locale"
+      fill_in 'legislation_draft_version_title_fr', with: 'Titre en Français'
+
+      click_button 'Save changes'
+
+      visit @edit_draft_version_url
+      expect(page).to have_field('legislation_draft_version_title_en', with: 'Title in English')
+
+      click_link "Español"
+      expect(page).to have_field('legislation_draft_version_title_es', with: 'Título en Español')
+
+      click_link "Français"
+      expect(page).to have_field('legislation_draft_version_title_fr', with: 'Titre en Français')
+    end
+
+    scenario "Update a translation", :js do
+      draft_version.update!(status: 'published')
+      draft_version.process.update!(title_es: 'Título de proceso')
+
+      visit @edit_draft_version_url
+
+      click_link "Español"
+      fill_in 'legislation_draft_version_title_es', with: 'Título correcto en Español'
+
+      click_button 'Save changes'
+
+      visit legislation_process_draft_version_path(draft_version.process, draft_version)
+
+      expect(page).to have_content("Title in English")
+
+      select('Español', from: 'locale-switcher')
+
+      expect(page).to have_content('Título correcto en Español')
+    end
+
+    scenario "Remove a translation", :js do
+      visit @edit_draft_version_url
+
+      click_link "Español"
+      click_link "Remove language"
+
+      expect(page).not_to have_link "Español"
+
+      click_button "Save changes"
+      visit @edit_draft_version_url
+      expect(page).not_to have_link "Español"
+    end
+
+    scenario 'Add translation through markup editor', :js do
+      visit @edit_draft_version_url
+
+      select "Français", from: "translation_locale"
+
+      click_link 'Launch text editor'
+
+      fill_in 'legislation_draft_version_body_fr', with: 'Texte en Français'
+
+      click_link 'Close text editor'
+      click_button "Save changes"
+
+      visit @edit_draft_version_url
+
+      click_link "Français"
+      click_link 'Launch text editor'
+
+      expect(page).to have_field('legislation_draft_version_body_fr', with: 'Texte en Français')
+    end
+
+    context "Globalize javascript interface" do
+
+      scenario "Highlight current locale", :js do
+        visit @edit_draft_version_url
+
+        expect(find("a.js-globalize-locale-link.is-active")).to have_content "English"
+
+        select('Español', from: 'locale-switcher')
+
+        expect(find("a.js-globalize-locale-link.is-active")).to have_content "Español"
+      end
+
+      scenario "Highlight selected locale", :js do
+        visit @edit_draft_version_url
+
+        expect(find("a.js-globalize-locale-link.is-active")).to have_content "English"
+
+        click_link "Español"
+
+        expect(find("a.js-globalize-locale-link.is-active")).to have_content "Español"
+      end
+
+      scenario "Show selected locale form", :js do
+        visit @edit_draft_version_url
+
+        expect(page).to have_field('legislation_draft_version_title_en', with: 'Title in English')
+
+        click_link "Español"
+
+        expect(page).to have_field('legislation_draft_version_title_es', with: 'Título en Español')
+      end
+
+      scenario "Select a locale and add it to the draft_version form", :js do
+        visit @edit_draft_version_url
+
+        select "Français", from: "translation_locale"
+
+        expect(page).to have_link "Français"
+
+        click_link "Français"
+
+        expect(page).to have_field('legislation_draft_version_title_fr')
+      end
     end
   end
 end

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -130,5 +130,16 @@ feature 'Admin legislation processes' do
 
       expect(page).not_to have_content 'Draft publication'
     end
+
+    scenario "Change proposal categories" do
+      visit edit_admin_legislation_process_path(process)
+      within(".admin-content") { click_link "Proposals" }
+
+      fill_in "Categories", with: "recycling,bicycles"
+      click_button "Save changes"
+
+      visit admin_legislation_process_proposals_path(process)
+      expect(page).to have_field("Categories", with: "bicycles, recycling")
+    end
   end
 end

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -7,6 +7,11 @@ feature 'Admin legislation processes' do
     login_as(admin.user)
   end
 
+  it_behaves_like "translatable",
+                  "legislation_process",
+                  "edit_admin_legislation_process_path",
+                  %w[title summary description additional_info]
+
   context "Feature flag" do
 
     scenario 'Disabled with a feature flag' do
@@ -38,9 +43,9 @@ feature 'Admin legislation processes' do
 
       click_link "New process"
 
-      fill_in 'legislation_process_title', with: 'An example legislation process'
-      fill_in 'legislation_process_summary', with: 'Summary of the process'
-      fill_in 'legislation_process_description', with: 'Describing the process'
+      fill_in 'legislation_process_title_en', with: 'An example legislation process'
+      fill_in 'legislation_process_summary_en', with: 'Summary of the process'
+      fill_in 'legislation_process_description_en', with: 'Describing the process'
 
       base_date = Date.current
       fill_in 'legislation_process[start_date]', with: base_date.strftime("%d/%m/%Y")
@@ -93,7 +98,7 @@ feature 'Admin legislation processes' do
       expect(find("#legislation_process_debate_phase_enabled")).to be_checked
       expect(find("#legislation_process_published")).to be_checked
 
-      fill_in 'legislation_process_summary', with: ''
+      fill_in 'legislation_process_summary_en', with: ''
       click_button "Save changes"
 
       expect(page).to have_content "Process updated successfully"

--- a/spec/models/legislation/draft_version_spec.rb
+++ b/spec/models/legislation/draft_version_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe Legislation::DraftVersion, type: :model do
     expect(legislation_draft_version.toc_html).to eq(toc_html)
   end
 
+  it "renders and saves the html from the markdown body field with alternative translation" do
+    legislation_draft_version.body_fr = body_markdown
+
+    legislation_draft_version.save!
+
+    expect(legislation_draft_version.body_html_fr).to eq(body_html)
+    expect(legislation_draft_version.toc_html_fr).to eq(toc_html)
+  end
+
   def body_markdown
 <<-BODY_MARKDOWN
 # Title 1

--- a/spec/shared/features/translatable.rb
+++ b/spec/shared/features/translatable.rb
@@ -84,7 +84,7 @@ shared_examples "translatable" do |factory_name, path_name, fields|
       expect(page).not_to have_link "Español"
     end
 
-    scenario 'Change value of a translated field to blank' do
+    scenario 'Change value of a translated field to blank', :js do
       possible_blanks = fields.select do |field|
         translatable.dup.tap { |duplicate| duplicate.send(:"#{field}=", '') }.valid?
       end


### PR DESCRIPTION
# References

* Issue #2736
* Backport AyuntamientoMadrid#1628
* Related meta-issue: AyuntamientoMadrid#1612

# Objectives

Quoting from AyuntamientoMadrid#1628 (all credit to Marko):

> Allow Admin Notifications to exist in multiple languages. This applies to 2 of its fields: title and body. Also a couple of fixes.

# Notes

* Proposal categories aren't translated as part of this PR. There's another issue for that: consul#2874.
* As with the original Milestones PR, data migration is not implemented.