### PR TITLE
[Backport] Changes allegations dates label

### DIFF
--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -372,7 +372,7 @@ en:
           enabled: Enabled
           process: Process
           debate_phase: Debate phase
-          allegations_phase: Drafting phase
+          allegations_phase: Comments phase
           proposals_phase: Proposals phase
           start: Start
           end: End

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -82,7 +82,7 @@ en:
         key_dates: Key dates
         debate_dates: Debate
         draft_publication_date: Draft publication
-        allegations_dates: Allegations
+        allegations_dates: Comments
         result_publication_date: Final result publication
         proposals_dates: Proposals
     questions:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -373,7 +373,7 @@ es:
           enabled: Habilitado
           process: Proceso
           debate_phase: Fase de debate
-          allegations_phase: Fase de redacción
+          allegations_phase: Fase de comentarios
           proposals_phase: Fase de propuestas
           start: Inicio
           end: Fin

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -82,7 +82,7 @@ es:
         key_dates: Fechas clave
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
-        allegations_dates: Alegaciones
+        allegations_dates: Comentarios
         result_publication_date: Publicación resultados
         proposals_dates: Propuestas
     questions:

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -74,7 +74,9 @@ feature 'Legislation Draft Versions' do
 
         expect(page).to have_content("Final body")
         expect(page).not_to have_content("See all comments")
-        expect(page).not_to have_content("Comments")
+        within(".draft-panels") do
+          expect(page).not_to have_content("Comments")
+        end
       end
     end
   end


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1642 

Objectives
===================
To avoid confusions changes allegations dates label "Allegations" to "Comments".
