### PR TITLE
[Backport] Make homepage content translatable

### DIFF
--- a/app/controllers/admin/widget/cards_controller.rb
+++ b/app/controllers/admin/widget/cards_controller.rb
@@ -1,4 +1,5 @@
 class Admin::Widget::CardsController < Admin::BaseController
+  include Translatable
 
   def new
     @card = ::Widget::Card.new(header: header_card?)
@@ -44,6 +45,7 @@ class Admin::Widget::CardsController < Admin::BaseController
     params.require(:widget_card).permit(
       :label, :title, :description, :link_text, :link_url,
       :button_text, :button_url, :alignment, :header,
+      *translation_params(Widget::Card),
       image_attributes: image_attributes
     )
   end
@@ -52,4 +54,7 @@ class Admin::Widget::CardsController < Admin::BaseController
     params[:header_card].present?
   end
 
+  def resource
+    Widget::Card.find(params[:id])
+  end
 end

--- a/app/models/widget/card.rb
+++ b/app/models/widget/card.rb
@@ -1,7 +1,14 @@
 class Widget::Card < ActiveRecord::Base
   include Imageable
 
+  # table_name must be set before calls to 'translates'
   self.table_name = "widget_cards"
+
+  translates :label,       touch: true
+  translates :title,       touch: true
+  translates :description, touch: true
+  translates :link_text,   touch: true
+  globalize_accessors
 
   def self.header
     where(header: true)

--- a/app/views/admin/widget/cards/_form.html.erb
+++ b/app/views/admin/widget/cards/_form.html.erb
@@ -12,7 +12,6 @@
 
   <div class="small-12 medium-6">
     <%= f.translatable_text_field :link_text %>
-    <%= f.label :link_text %>
   </div>
 
   <div class="small-12 medium-6">

--- a/app/views/admin/widget/cards/_form.html.erb
+++ b/app/views/admin/widget/cards/_form.html.erb
@@ -1,14 +1,18 @@
-<%= form_for [:admin, @card] do |f| %>
+<%= render "admin/shared/globalize_locales", resource: @card %>
+
+<%= translatable_form_for [:admin, @card] do |f| %>
+
   <div class="small-12 medium-6">
-    <%= f.text_field :label %>
+    <%= f.translatable_text_field :label %>
   </div>
 
-  <%= f.text_field :title %>
+  <%= f.translatable_text_field :title %>
 
-  <%= f.text_area :description, rows: 5 %>
+  <%= f.translatable_text_area :description, rows: 5 %>
 
   <div class="small-12 medium-6">
-    <%= f.text_field :link_text %>
+    <%= f.translatable_text_field :link_text %>
+    <%= f.label :link_text %>
   </div>
 
   <div class="small-12 medium-6">

--- a/db/dev_seeds/widgets.rb
+++ b/db/dev_seeds/widgets.rb
@@ -9,41 +9,73 @@ section "Creating header and cards for the homepage" do
   end
 
   Widget::Card.create!(
-    title: 'CONSUL',
-    description: 'Free software for citizen participation.',
-    link_text: 'More information',
+    title_en: 'CONSUL',
+    title_es: 'CONSUL',
+
+    description_en: 'Free software for citizen participation.',
+    description_es: 'Software libre para la participación ciudadana.',
+
+    link_text_en: 'More information',
+    link_text_es: 'Más información',
+
+    label_en: 'Welcome to',
+    label_es: 'Bienvenido a',
+
     link_url: 'help_path',
-    label: 'Welcome to',
     header: TRUE,
     image_attributes: create_image_attachment('header')
   )
 
   Widget::Card.create!(
-    title: 'How do debates work?',
-    description: 'Anyone can open threads on any subject, creating separate spaces where people can discuss the proposed topic. Debates are valued by everybody, to highlight the most important issues.',
-    link_text: 'More about debates',
+    title_en: 'How do debates work?',
+    title_es: '¿Cómo funcionan los debates?',
+
+    description_en: 'Anyone can open threads on any subject, creating separate spaces where people can discuss the proposed topic. Debates are valued by everybody, to highlight the most important issues.',
+    description_es: 'Cualquiera puede iniciar un debate sobre cualquier tema, creando un espacio separado donde compartir puntos de vista con otras personas. Los debates son valorados por todos para destacar los temas más importantes.',
+
+    link_text_en: 'More about debates',
+    link_text_es: 'Más sobre debates',
+
+    label_en: 'Debates',
+    label_es: 'Debates',
+
     link_url: 'https://youtu.be/zU_0UN4VajY',
-    label: 'Debates',
     header: FALSE,
     image_attributes: create_image_attachment('debate')
   )
 
   Widget::Card.create!(
-    title: 'How do citizen proposals work?',
-    description: "A space for everyone to create a citizens' proposal and seek supports. Proposals which reach to enough supports will be voted and so, together we can decide the issues that matter to us.",
-    link_text: 'More about proposals',
+    title_en: 'How do citizen proposals work?',
+    title_es: '¿Cómo funcionan las propuestas ciudadanas?',
+
+    description_en: "A space for everyone to create a citizens' proposal and seek supports. Proposals which reach to enough supports will be voted and so, together we can decide the issues that matter to us.",
+    description_es: 'Un espacio para que el ciudadano cree una propuesta y busque apoyo. Las propuestas que obtengan el apoyo necesario serán votadas. Así juntos podemos decidir sobre los temas que nos importan.',
+
+    link_text_en: 'More about proposals',
+    link_text_es: 'Más sobre propuestas',
+
+    label_en: 'Citizen proposals',
+    label_es: 'Propuestas ciudadanas',
+
     link_url: 'https://youtu.be/ZHqBpT4uCoM',
-    label: 'Citizen proposals',
     header: FALSE,
     image_attributes: create_image_attachment('proposal')
   )
 
   Widget::Card.create!(
-    title: 'How do participatory budgets work?',
-    description: " Participatory budgets allow citizens to propose and decide directly how to spend part of the budget, with monitoring and rigorous evaluation of proposals by the institution. Maximum effectiveness and control with satisfaction for everyone.",
-    link_text: 'More about Participatory budgets',
+    title_en: 'How do participatory budgets work?',
+    title_es: '¿Cómo funcionan los propuestos participativos?',
+
+    description_en: " Participatory budgets allow citizens to propose and decide directly how to spend part of the budget, with monitoring and rigorous evaluation of proposals by the institution. Maximum effectiveness and control with satisfaction for everyone.",
+    description_es: "Los presupuestos participativos permiten que los ciudadanos propongan y decidan directamente cómo gastar parte del presupuesto, con la supervisión y valoración de la institución. Máxima eficacia y control para la satisfacción de todos",
+
+    link_text_en: 'More about Participatory budgets',
+    link_text_es: 'Más sobre presupuestos participativos',
+
+    label_en: 'Participatory budgets',
+    label_es: 'Presupuestos participativos',
+
     link_url: 'https://youtu.be/igQ8KGZdk9c',
-    label: 'Participatory budgets',
     header: FALSE,
     image_attributes: create_image_attachment('budget')
   )

--- a/db/migrate/20180730120800_add_homepage_content_translations.rb
+++ b/db/migrate/20180730120800_add_homepage_content_translations.rb
@@ -1,0 +1,16 @@
+class AddHomepageContentTranslations < ActiveRecord::Migration
+
+  def self.up
+    Widget::Card.create_translation_table!(
+      label:       :string,
+      title:       :string,
+      description: :text,
+      link_text:   :string
+    )
+  end
+
+  def self.down
+    Widget::Card.drop_translation_table!
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1404,6 +1404,20 @@ ActiveRecord::Schema.define(version: 20180813141443) do
   add_index "votes", ["votable_id", "votable_type", "vote_scope"], name: "index_votes_on_votable_id_and_votable_type_and_vote_scope", using: :btree
   add_index "votes", ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope", using: :btree
 
+  create_table "widget_card_translations", force: :cascade do |t|
+    t.integer  "widget_card_id", null: false
+    t.string   "locale",         null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.string   "label"
+    t.string   "title"
+    t.text     "description"
+    t.string   "link_text"
+  end
+
+  add_index "widget_card_translations", ["locale"], name: "index_widget_card_translations_on_locale", using: :btree
+  add_index "widget_card_translations", ["widget_card_id"], name: "index_widget_card_translations_on_widget_card_id", using: :btree
+
   create_table "widget_cards", force: :cascade do |t|
     t.string   "title"
     t.text     "description"

--- a/spec/features/admin/widgets/cards_spec.rb
+++ b/spec/features/admin/widgets/cards_spec.rb
@@ -7,14 +7,19 @@ feature 'Cards' do
     login_as(admin)
   end
 
+  it_behaves_like "translatable",
+                  "widget_card",
+                  "edit_admin_widget_card_path",
+                  %w[title description link_text label]
+
   scenario "Create", :js do
     visit admin_homepage_path
     click_link "Create card"
 
-    fill_in "widget_card_label", with: "Card label"
-    fill_in "widget_card_title", with: "Card text"
-    fill_in "widget_card_description", with: "Card description"
-    fill_in "widget_card_link_text", with: "Link text"
+    fill_in "widget_card_label_en", with: "Card label"
+    fill_in "widget_card_title_en", with: "Card text"
+    fill_in "widget_card_description_en", with: "Card description"
+    fill_in "widget_card_link_text_en", with: "Link text"
     fill_in "widget_card_link_url", with: "consul.dev"
     attach_image_to_card
     click_button "Create card"
@@ -59,10 +64,10 @@ feature 'Cards' do
       click_link "Edit"
     end
 
-    fill_in "widget_card_label", with: "Card label updated"
-    fill_in "widget_card_title", with: "Card text updated"
-    fill_in "widget_card_description", with: "Card description updated"
-    fill_in "widget_card_link_text", with: "Link text updated"
+    fill_in "widget_card_label_en", with: "Card label updated"
+    fill_in "widget_card_title_en", with: "Card text updated"
+    fill_in "widget_card_description_en", with: "Card description updated"
+    fill_in "widget_card_link_text_en", with: "Link text updated"
     fill_in "widget_card_link_url", with: "consul.dev updated"
     click_button "Save card"
 
@@ -99,10 +104,10 @@ feature 'Cards' do
       visit admin_homepage_path
       click_link "Create header"
 
-      fill_in "widget_card_label", with: "Header label"
-      fill_in "widget_card_title", with: "Header text"
-      fill_in "widget_card_description", with: "Header description"
-      fill_in "widget_card_link_text", with: "Link text"
+      fill_in "widget_card_label_en", with: "Header label"
+      fill_in "widget_card_title_en", with: "Header text"
+      fill_in "widget_card_description_en", with: "Header description"
+      fill_in "widget_card_link_text_en", with: "Link text"
       fill_in "widget_card_link_url", with: "consul.dev"
       click_button "Create header"
 

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -3,11 +3,13 @@ require 'rails_helper'
 feature 'Localization' do
 
   scenario 'Wrong locale' do
-    card = create(:widget_card, title: 'Bienvenido a CONSUL',
-                                description: 'Software libre para la participación ciudadana.',
-                                link_text: 'Más información',
-                                link_url: 'http://consulproject.org/',
-                                header: true)
+    Globalize.with_locale(:es) do
+      create(:widget_card, title: 'Bienvenido a CONSUL',
+                           description: 'Software libre para la participación ciudadana.',
+                           link_text: 'Más información',
+                           link_url: 'http://consulproject.org/',
+                           header: true)
+    end
 
     visit root_path(locale: :es)
     visit root_path(locale: :klingon)

--- a/spec/shared/features/translatable.rb
+++ b/spec/shared/features/translatable.rb
@@ -192,6 +192,8 @@ def update_button_text
     "Update poll"
   when "Poll::Question"
     "Save"
+  when "Widget::Card"
+    "Save card"
   else
     "Save changes"
   end


### PR DESCRIPTION
## References

* Issue #2668 (closes #2668)
* Backport AyuntamientoMadrid#1633
* Related meta-issue: AyuntamientoMadrid#1612

## Objectives

Quoting from AyuntamientoMadrid#1588 (all credit to Marko):

> Allow `Widgets::Card`s to exist in multiple languages. This applies to 4 of its fields: label, title, description, link_text.

## Visual Changes

Same as all other admin "translatable" forms

![peek 2018-07-30 15-46](https://user-images.githubusercontent.com/7111622/43401237-e34fa53a-940f-11e8-8e5c-9d70053a97fd.gif)

This PR also adds Spanish translations to the seed Cards. This will be visible after generating the dev seed data when using the application in Spanish (the default).

**Before**

![selection_121](https://user-images.githubusercontent.com/7111622/44837302-8b00d100-ac39-11e8-9ca7-de720588c865.png)

**After**

![selection_122](https://user-images.githubusercontent.com/7111622/44837311-918f4880-ac39-11e8-846a-e4f069c7be58.png)

## Notes

As with the original [Milestones PR](https://github.com/consul/consul/pull/2619), data migration is not implemented: 

> At this moment, the migration that creates the milestones translations table is not migrating the existing data. If this is the desired behaviour, it's OK with it. If not, the migration should have the :migrate_data => true option, as seen in the globalize readme: