### PR TITLE
Feature help page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,8 @@
 class PagesController < ApplicationController
+  include FeatureFlags
   skip_authorization_check
+
+  feature_flag :help_page, if: lambda { params[:id] == "help/index" }
 
   def show
     @custom_page = SiteCustomization::Page.published.find_by(slug: params[:id])

--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -54,14 +54,16 @@
                                   title: t("shared.go_to_page") + t("layouts.header.budgets") %>
       </li>
     <% end %>
-    <li>
-      <%= link_to t("layouts.header.help"),
-                    help_path,
-                    accesskey: "6",
-                    class: ("is-active" if current_page?(help_path)),
-                    title: t("shared.go_to_page") + t("layouts.header.help") %>
-    </li>
-    
+    <% if feature?(:help_page) %>
+      <li>
+        <%= layout_menu_link_to t("layouts.header.help"),
+                                help_path,
+                                current_page?(help_path),
+                                accesskey: "6",
+                                title: t("shared.go_to_page") + t("layouts.header.help") %>
+      </li>
+    <% end %>
+
     <%= raw content_block("subnavigation_right", I18n.locale) %>
   </ul>
 </div>

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -119,3 +119,5 @@ en:
       guides_description: "Displays a guide to differences between proposals and investment projects if there is an active participatory budget"
       public_stats: "Public stats"
       public_stats_description: "Display public stats in the Administration panel"
+      help_page: "Help page"
+      help_page_description: "Displays a Help menu that contains a page with an info section about each enabled feature"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -119,3 +119,5 @@ es:
       guides_description: "Muestra una guía de diferencias entre las propuestas y los proyectos de gasto si hay un presupuesto participativo activo"
       public_stats: "Estadísticas públicas"
       public_stats_description: "Muestra las estadísticas públicas en el panel de Administración"
+      help_page: "Página de Ayuda"
+      help_page_description: "Muestra un menú Ayuda que contiene una página con una sección de información sobre cada funcionalidad habilitada."

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -49,6 +49,7 @@ section "Creating Settings" do
   Setting.create(key: 'feature.public_stats', value: "true")
   Setting.create(key: 'feature.guides', value: nil)
   Setting.create(key: 'feature.user.skip_verification', value: "true")
+  Setting.create(key: 'feature.help_page', value: "true")
 
   Setting.create(key: 'per_page_code_head', value: "")
   Setting.create(key: 'per_page_code_body', value: "")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,6 +89,7 @@ Setting['feature.map'] = nil
 Setting['feature.allow_images'] = true
 Setting['feature.allow_attached_documents'] = true
 Setting['feature.guides'] = nil
+Setting['feature.help_page'] = true
 
 # Spending proposals feature flags
 Setting['feature.spending_proposal_features.voting_allowed'] = nil

--- a/spec/features/help_page_spec.rb
+++ b/spec/features/help_page_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+feature 'Help page' do
+
+  context 'Index' do
+
+    scenario 'Help menu and page is visible if feature is enabled' do
+      Setting['feature.help_page'] = true
+
+      visit root_path
+
+      expect(page).to have_link 'Help'
+
+      within('#navigation_bar') do
+        click_link 'Help'
+      end
+
+      expect(page).to have_content('CONSUL is a platform for citizen participation')
+    end
+
+    scenario 'Help menu and page is hidden if feature is disabled' do
+      Setting['feature.help_page'] = nil
+
+      visit root_path
+
+      expect(page).not_to have_link 'Help'
+    end
+  end
+end


### PR DESCRIPTION
References
===================
This closes https://github.com/consul/consul/issues/2932

Objectives
===================
Adds a new setting `Setting['feature.help_page']` to enable or disable help page.

Visual Changes
===================
![setting](https://user-images.githubusercontent.com/631897/46142316-dc12dd80-c256-11e8-9b96-30e20e5c6d24.png)

