### PR TITLE
Avoid InvalidPluralizationData exception when missing translations

### DIFF
--- a/config/initializers/i18n_pluralize.rb
+++ b/config/initializers/i18n_pluralize.rb
@@ -1,0 +1,19 @@
+### From official I18n::Backend::Base
+### https://github.com/svenfuchs/i18n/blob/f35b839693c5ecc7ea0ff0f57c5cbf6db1dd73f9/lib/i18n/backend/base.rb#L155
+### Just changed one line to return `count` instead of raising the exception `InvalidPluralizationData`
+
+module I18n
+  module Backend
+    module Base
+
+      def pluralize(locale, entry, count)
+        return entry unless entry.is_a?(Hash) && count
+
+        key = pluralization_key(entry, count)
+        return count unless entry.has_key?(key)
+        entry[key]
+      end
+
+    end
+  end
+end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,6 +1,7 @@
+require 'rails_helper'
 require 'i18n/tasks'
 
-RSpec.describe 'I18n' do
+describe 'I18n' do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
@@ -13,5 +14,50 @@ RSpec.describe 'I18n' do
   it 'does not have unused keys' do
     expect(unused_keys).to be_empty,
       "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+  end
+
+  context "Plurals" do
+
+    after do
+      I18n.backend.reload!
+    end
+
+    it "returns plural rule if translation present" do
+      keys = { zero:  "No comments",
+               one:   "1 comment",
+               other: "%{count} comments" }
+
+      I18n.backend.store_translations(:en, { test_plural: keys })
+
+      expect(I18n.t("test_plural", count: 0)).to eq("No comments")
+      expect(I18n.t("test_plural", count: 1)).to eq("1 comment")
+      expect(I18n.t("test_plural", count: 2)).to eq("2 comments")
+    end
+
+    it "returns default locale's plural rule if whole translation not present" do
+      keys = { zero:  "No comments",
+               one:   "1 comment",
+               other: "%{count} comments" }
+
+      I18n.backend.store_translations(I18n.default_locale, { test_plural: keys })
+      I18n.backend.store_translations(:zz, {} )
+
+      I18n.enforce_available_locales = false
+      I18n.locale = :zz
+
+      expect(I18n.t("test_plural", count: 0)).to eq("No comments")
+      expect(I18n.t("test_plural", count: 1)).to eq("1 comment")
+      expect(I18n.t("test_plural", count: 2)).to eq("2 comments")
+    end
+
+    it "returns count if specific plural rule not present" do
+      keys = { zero:  "No comments" }
+      I18n.backend.store_translations(:en, { test_plural: keys })
+
+      expect(I18n.t("test_plural", count: 0)).to eq("No comments")
+      expect(I18n.t("test_plural", count: 1)).to eq(1)
+      expect(I18n.t("test_plural", count: 2)).to eq(2)
+    end
+
   end
 end


### PR DESCRIPTION
Why
===
We work with many languages using [Crowdin](https://crowdin.com/project/consul)

Sometimes translators forget to fill in all the necessary plural forms of a translation (zero, one, other), and in those cases we were seing the exception `InvalidPluralizationData` being raised

What
===
Deal gracefully with this exception

How
===
There are a number of approaches to fix this... from being more strict when approving translations, to automatically extrapolating what those plural forms should be. Or even displaying the translation in the default language (this is my favourite, but requires a little more time 😌) 

For now, we've gone for a simple approach to display the actual count(0,1,2,3,4, etc), instead of the whole translation, as `count` is a readily available value when the exception is raised 

So, if the plural form of "4 supports" is missing, just a "4" will be displayed and no exceptions raised

Visual Changes
===
<img width="1168" alt="count instead of translation" src="https://user-images.githubusercontent.com/4169/46159953-d54d9000-c281-11e8-8d63-314771633449.png">

Notes
===================
The first [two specs](https://github.com/consul/consul/compare/i18n-pluralize?expand=1#diff-57713778027b554e3084405e21cdf298R24), test what is really Rails' functionalities. However as we are monkey patching the `pluralize` method, I thought it was appropriate to doble check it

