### PR TITLE
[Backport] Random legislation proposal's order & pagination

### DIFF
--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -2,7 +2,7 @@ class Legislation::ProcessesController < Legislation::BaseController
   has_filters %w{open next past}, only: :index
   load_and_authorize_resource
 
-  before_action :set_random_seed, only: :index
+  before_action :set_random_seed, only: :proposals
 
   def index
     @current_filter ||= 'open'
@@ -115,6 +115,6 @@ class Legislation::ProcessesController < Legislation::BaseController
                0
              end
       session[:random_seed], params[:random_seed] = seed
-      ::Legislation::Process.connection.execute "select setseed(#{seed})"
+      ::Legislation::Proposal.connection.execute "select setseed(#{seed})"
     end
 end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -2,6 +2,8 @@ class Legislation::ProcessesController < Legislation::BaseController
   has_filters %w{open next past}, only: :index
   load_and_authorize_resource
 
+  before_action :set_random_seed, only: :index
+
   def index
     @current_filter ||= 'open'
     @processes = ::Legislation::Process.send(@current_filter).published.page(params[:page])
@@ -104,5 +106,15 @@ class Legislation::ProcessesController < Legislation::BaseController
     def set_process
       return if member_method?
       @process = ::Legislation::Process.find(params[:process_id])
+    end
+
+    def set_random_seed
+      seed = begin
+               Float(params[:random_seed] || session[:random_seed] || (rand(99) / 100.0))
+             rescue
+               0
+             end
+      session[:random_seed], params[:random_seed] = seed
+      ::Legislation::Process.connection.execute "select setseed(#{seed})"
     end
 end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -88,7 +88,7 @@ class Legislation::ProcessesController < Legislation::BaseController
   def proposals
     set_process
     @phase = :proposals_phase
-    @proposals = ::Legislation::Proposal.where(process: @process).order('random()')
+    @proposals = ::Legislation::Proposal.where(process: @process).order('random()').page(params[:page])
 
     if @process.proposals_phase.started?
       legislation_proposal_votes(@proposals)

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -88,8 +88,8 @@ class Legislation::ProcessesController < Legislation::BaseController
   def proposals
     set_process
     @phase = :proposals_phase
+    @proposals = ::Legislation::Proposal.where(process: @process).order('random()')
 
-    @proposals = Legislation::Proposal.where(process: @process)
     if @process.proposals_phase.started?
       legislation_proposal_votes(@proposals)
       render :proposals
@@ -110,11 +110,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     end
 
     def set_random_seed
-      seed = begin
-               Float(params[:random_seed] || session[:random_seed] || (rand(99) / 100.0))
-             rescue
-               0
-             end
+      seed = Float(params[:random_seed] || session[:random_seed] || (rand(99) / 100.0)) rescue 0
       session[:random_seed], params[:random_seed] = seed
       ::Legislation::Proposal.connection.execute "select setseed(#{seed})"
     end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -110,8 +110,13 @@ class Legislation::ProcessesController < Legislation::BaseController
     end
 
     def set_random_seed
-      seed = Float(params[:random_seed] || session[:random_seed] || (rand(99) / 100.0)) rescue 0
+      seed = begin
+               Float(params[:random_seed] || session[:random_seed] || (rand(99) / 100.0))
+             rescue
+               0
+             end
       session[:random_seed], params[:random_seed] = seed
+      seed = (-1..1).cover?(seed) ? seed : 1
       ::Legislation::Proposal.connection.execute "select setseed(#{seed})"
     end
 end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -89,8 +89,9 @@ class Legislation::ProcessesController < Legislation::BaseController
     set_process
     @phase = :proposals_phase
 
+    @proposals = Legislation::Proposal.where(process: @process)
     if @process.proposals_phase.started?
-      legislation_proposal_votes(@process.proposals)
+      legislation_proposal_votes(@proposals)
       render :proposals
     else
       render :phase_not_open

--- a/app/views/legislation/processes/proposals.html.erb
+++ b/app/views/legislation/processes/proposals.html.erb
@@ -9,12 +9,12 @@
     <div class="row">
       <div class="small-12 medium-9 column">
         <div class="legislation-proposals">
-          <% if @process.proposals.empty? %>
+          <% if @proposals.empty? %>
             <div class="callout primary">
               <p><%= t('.empty_proposals') %></p>
             </div>
           <% else %>
-            <%= render @process.proposals %>
+            <%= render @proposals %>
           <% end %>
         </div>
       </div>

--- a/app/views/legislation/processes/proposals.html.erb
+++ b/app/views/legislation/processes/proposals.html.erb
@@ -15,6 +15,7 @@
             </div>
           <% else %>
             <%= render @proposals %>
+            <%= paginate @proposals %>
           <% end %>
         </div>
       </div>

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -23,9 +23,12 @@ FactoryBot.define do
     draft_publication_date { Date.current - 1.day }
     allegations_start_date { Date.current }
     allegations_end_date { Date.current + 3.days }
+    proposals_phase_start_date { Date.current }
+    proposals_phase_end_date { Date.current + 2.days }
     result_publication_date { Date.current + 5.days }
     debate_phase_enabled true
     allegations_phase_enabled true
+    proposals_phase_enabled true
     draft_publication_enabled true
     result_publication_enabled true
     published true

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -48,6 +48,22 @@ feature 'Legislation Proposals' do
     end
   end
 
+  scenario 'Random order maintained with pagination', :js do
+    create_list(:legislation_proposal, (Kaminari.config.default_per_page + 2), process: process)
+
+    login_as user
+    visit legislation_process_proposals_path(process)
+    first_page_proposals_order = legislation_proposals_order
+
+    click_link 'Next'
+    expect(page).to have_content "You're on page 2"
+
+    click_link 'Previous'
+    expect(page).to have_content "You're on page 1"
+
+    expect(legislation_proposals_order).to eq(first_page_proposals_order)
+  end
+
   def legislation_proposals_order
     all("[id^='legislation_proposal_']").collect { |e| e[:id] }
   end

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
+require 'sessions_helper'
 
 feature 'Legislation Proposals' do
 
   let(:user)     { create(:user) }
+  let(:user2)    { create(:user) }
   let(:process)  { create(:legislation_process) }
   let(:proposal) { create(:legislation_proposal) }
 
@@ -15,6 +17,34 @@ feature 'Legislation Proposals' do
 
     within('#navigation_bar') do
       expect(page).to have_css('.is-active', count: 1)
+    end
+  end
+
+  scenario 'Each user as a different and consistent random proposals order', :js do
+    create_list(:legislation_proposal, 10, process: process)
+
+    in_browser(:one) do
+      login_as user
+      visit legislation_process_proposals_path(process)
+      @first_user_proposals_order = all("[id^='legislation_proposal_']").collect { |e| e[:id] }
+    end
+
+    in_browser(:two) do
+      login_as user2
+      visit legislation_process_proposals_path(process)
+      @second_user_proposals_order = all("[id^='legislation_proposal_']").collect { |e| e[:id] }
+    end
+
+    expect(@first_user_proposals_order).not_to eq(@second_user_proposals_order)
+
+    in_browser(:one) do
+      visit legislation_process_proposals_path(process)
+      expect(all("[id^='legislation_proposal_']").collect { |e| e[:id] }).to eq(@first_user_proposals_order)
+    end
+
+    in_browser(:two) do
+      visit legislation_process_proposals_path(process)
+      expect(all("[id^='legislation_proposal_']").collect { |e| e[:id] }).to eq(@second_user_proposals_order)
     end
   end
 

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -26,26 +26,30 @@ feature 'Legislation Proposals' do
     in_browser(:one) do
       login_as user
       visit legislation_process_proposals_path(process)
-      @first_user_proposals_order = all("[id^='legislation_proposal_']").collect { |e| e[:id] }
+      @first_user_proposals_order = legislation_proposals_order
     end
 
     in_browser(:two) do
       login_as user2
       visit legislation_process_proposals_path(process)
-      @second_user_proposals_order = all("[id^='legislation_proposal_']").collect { |e| e[:id] }
+      @second_user_proposals_order = legislation_proposals_order
     end
 
     expect(@first_user_proposals_order).not_to eq(@second_user_proposals_order)
 
     in_browser(:one) do
       visit legislation_process_proposals_path(process)
-      expect(all("[id^='legislation_proposal_']").collect { |e| e[:id] }).to eq(@first_user_proposals_order)
+      expect(legislation_proposals_order).to eq(@first_user_proposals_order)
     end
 
     in_browser(:two) do
       visit legislation_process_proposals_path(process)
-      expect(all("[id^='legislation_proposal_']").collect { |e| e[:id] }).to eq(@second_user_proposals_order)
+      expect(legislation_proposals_order).to eq(@second_user_proposals_order)
     end
+  end
+
+  def legislation_proposals_order
+    all("[id^='legislation_proposal_']").collect { |e| e[:id] }
   end
 
   scenario "Create a legislation proposal with an image", :js do


### PR DESCRIPTION
## References

* Pull request AyuntamientoMadrid#986
* Commit AyuntamientoMadrid@f038399

## Objectives

* Ease the backport of AyuntamientoMadrid#1640, since the feature to select legislation proposal winners depends on the proposals being in random order.
* Reduce the differences between CONSUL's repository and Decide Madrid's repository.

## Notes

* :warning: Both tests added here are flaky tests, since they depend on two random numbers being different. However, sometimes the random numbers are the same.