### PR TITLE
Fix misleading title on account creation confirmation page (en, fr)

### DIFF
--- a/config/locales/en/devise_views.yml
+++ b/config/locales/en/devise_views.yml
@@ -126,4 +126,4 @@ en:
           instructions_1_html: Please <b>check your email</b> - we have sent you a <b>link to confirm your account</b>.
           instructions_2_html: Once confirmed, you may begin participation.
           thank_you_html: Thank you for registering for the website. You must now <b>confirm your email address</b>.
-          title: Modify your email
+          title: Confirm your email address

--- a/config/locales/fr/devise_views.yml
+++ b/config/locales/fr/devise_views.yml
@@ -127,4 +127,4 @@ fr:
           instructions_1_html: Veuillez <b>vérifier votre adresse</b> - nous vous avons envoyé un <b>lien pour confirmer votre compte</b>.
           instructions_2_html: Une fois confirmé, vous pourrez commencer à participer.
           thank_you_html: Merci de vous être enregistré sur la plateforme. Vous devez maintenant <b>confirmer votre adresse</b>.
-          title: Modifier votre courriel
+          title: Confirmer votre adresse électronique


### PR DESCRIPTION
References
===================
> Fixes #2943 

Objectives
===================

See issue

Visual Changes
===================

Before:
![capture d ecran 2018-10-03 a 09 24 50](https://user-images.githubusercontent.com/7223028/46397513-b7a18000-c6f2-11e8-9783-7e3dc025259e.png)

After:
![capture d ecran 2018-10-03 a 09 58 47](https://user-images.githubusercontent.com/7223028/46397622-f33c4a00-c6f2-11e8-8248-386bd2538cb7.png)

Notes
===================
I also corrected the French version.
