### PR TITLE
[Backport] Admin permissions in legislation proposals

### DIFF
--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -27,7 +27,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     set_process
     @phase = :debate_phase
 
-    if @process.debate_phase.started? || current_user.administrator?
+    if @process.debate_phase.started? || (current_user && current_user.administrator?)
       render :debate
     else
       render :phase_not_open
@@ -90,7 +90,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     @phase = :proposals_phase
     @proposals = ::Legislation::Proposal.where(process: @process).order('random()').page(params[:page])
 
-    if @process.proposals_phase.started? || current_user.administrator?
+    if @process.proposals_phase.started? || (current_user && current_user.administrator?)
       legislation_proposal_votes(@proposals)
       render :proposals
     else

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -27,7 +27,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     set_process
     @phase = :debate_phase
 
-    if @process.debate_phase.started?
+    if @process.debate_phase.started? || current_user.administrator?
       render :debate
     else
       render :phase_not_open
@@ -90,7 +90,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     @phase = :proposals_phase
     @proposals = ::Legislation::Proposal.where(process: @process).order('random()').page(params[:page])
 
-    if @process.proposals_phase.started?
+    if @process.proposals_phase.started? || current_user.administrator?
       legislation_proposal_votes(@proposals)
       render :proposals
     else

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -14,6 +14,10 @@ module Abilities
       can :restore, Proposal
       cannot :restore, Proposal, hidden_at: nil
 
+      can :create, Legislation::Proposal
+      can :show, Legislation::Proposal
+      can :proposals, ::Legislation::Process
+
       can :restore, Legislation::Proposal
       cannot :restore, Legislation::Proposal, hidden_at: nil
 

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -66,6 +66,18 @@ FactoryBot.define do
       result_publication_date { Date.current + 5.days }
     end
 
+    trait :in_proposals_phase do
+      proposals_phase_start_date { Date.current - 1.day }
+      proposals_phase_end_date { Date.current + 2.days }
+      proposals_phase_enabled true
+    end
+
+    trait :upcoming_proposals_phase do
+      proposals_phase_start_date { Date.current + 1.day }
+      proposals_phase_end_date { Date.current + 2.days }
+      proposals_phase_enabled true
+    end
+
     trait :published do
       published true
     end

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -237,5 +237,25 @@ feature 'Legislation' do
 
       include_examples "not published permissions", :result_publication_legislation_process_path
     end
+
+    context 'proposals phase' do
+      scenario 'not open' do
+        process = create(:legislation_process, proposals_phase_start_date: Date.current + 1.day, proposals_phase_end_date: Date.current + 2.days)
+
+        visit legislation_process_proposals_path(process)
+
+        expect(page).to have_content("This phase is not open yet")
+      end
+
+      scenario 'open' do
+        process = create(:legislation_process, proposals_phase_start_date: Date.current - 1.day, proposals_phase_end_date: Date.current + 2.days, proposals_phase_enabled: true)
+
+        visit legislation_process_proposals_path(process)
+
+        expect(page).to have_content("There are no proposals")
+      end
+
+      include_examples "not published permissions", :legislation_process_proposals_path
+    end
   end
 end

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -240,7 +240,7 @@ feature 'Legislation' do
 
     context 'proposals phase' do
       scenario 'not open' do
-        process = create(:legislation_process, proposals_phase_start_date: Date.current + 1.day, proposals_phase_end_date: Date.current + 2.days)
+        process = create(:legislation_process, :upcoming_proposals_phase)
 
         visit legislation_process_proposals_path(process)
 
@@ -248,7 +248,7 @@ feature 'Legislation' do
       end
 
       scenario 'open' do
-        process = create(:legislation_process, proposals_phase_start_date: Date.current - 1.day, proposals_phase_end_date: Date.current + 2.days, proposals_phase_enabled: true)
+        process = create(:legislation_process, :in_proposals_phase)
 
         visit legislation_process_proposals_path(process)
 


### PR DESCRIPTION
## References

* Commit AyuntamientoMadrid@01ce8c9
* Commit AyuntamientoMadrid@4a0ac88
* Pull request AyuntamientoMadrid#983

## Objectives

* Ease the backport of AyuntamientoMadrid#1640 and AyuntamientoMadrid#1651, since they're related to the actions in legislation proposals.
* Reduce the differences between CONSUL's repository and Decide Madrid's repository.

## Notes

* :warning: Maybe none of the commits here should be backported.
* AyuntamientoMadrid#983 isn't being backported completely because the code affecting the link to new proposal has been changed in AyuntamientoMadrid#1651, which will be backported soon.