### PR TITLE
Fixes action sorting

### DIFF
--- a/app/controllers/admin/dashboard/actions_controller.rb
+++ b/app/controllers/admin/dashboard/actions_controller.rb
@@ -2,7 +2,7 @@ class Admin::Dashboard::ActionsController < Admin::Dashboard::BaseController
   helper_method :dashboard_action, :resource
 
   def index
-    @dashboard_actions = ::Dashboard::Action.order(required_supports: :asc)
+    @dashboard_actions = proposed_actions + resources
   end
 
   def new
@@ -63,5 +63,13 @@ class Admin::Dashboard::ActionsController < Admin::Dashboard::BaseController
 
   def dashboard_action
     @dashboard_action ||= ::Dashboard::Action.find(params[:id])
+  end
+
+  def proposed_actions
+    ::Dashboard::Action.proposed_actions.order(order: :asc)
+  end
+
+  def resources
+    ::Dashboard::Action.resources.order(required_supports: :asc, day_offset: :asc)
   end
 end


### PR DESCRIPTION


References
===================
This enhancement has been requested from Medialab Prado.

Objectives
===================
Administration of dashboard actions currently shows proposed actions as
well as resources mixed. This patch tries to improve how they're shown
making things easier for administrators:

Resources will be shown after proposed actions, never mixed.
Proposed actions will be sorted according to the order attribute.

Resources will be sort according the two attributes that define its
availability:

The number of supports required.
The number of days after the proposal publication.

Visual Changes
===================
![fixactionssorting](https://user-images.githubusercontent.com/1701962/46466595-096a0900-c7cc-11e8-9915-470eaab61d18.gif)


