### PR TITLE
[Backport] Add legislation proposal's categories

### DIFF
--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -88,7 +88,10 @@ class Legislation::ProcessesController < Legislation::BaseController
   def proposals
     set_process
     @phase = :proposals_phase
-    @proposals = ::Legislation::Proposal.where(process: @process).order('random()').page(params[:page])
+
+    @proposals = ::Legislation::Proposal.where(process: @process)
+    @proposals = @proposals.search(params[:search]) if params[:search].present?
+    @proposals = @proposals.order('random()').page(params[:page])
 
     if @process.proposals_phase.started? || (current_user && current_user.administrator?)
       legislation_proposal_votes(@proposals)

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -152,7 +152,7 @@ LOREM_IPSUM
   end
 
   factory :legislation_proposal, class: 'Legislation::Proposal' do
-    title "Example proposal for a legislation"
+    sequence(:title) { |n| "Proposal #{n} for a legislation" }
     summary "This law should include..."
     terms_of_service '1'
     process factory: :legislation_process


### PR DESCRIPTION
## References

* Backport pull request AyuntamientoMadrid#1638

## Objectives

* Ease the backport of AyuntamientoMadrid#1640, since it's related to the actions in legislation proposals.

## Notes

* The code regarding the `genre` key hasn't been backported since it's specific to Madrid's fork.
* The tests in the original pull request are specific to Madrid's film library, and so they aren't being backported either.