### PR TITLE
Display language name or language key

### DIFF
--- a/app/helpers/locales_helper.rb
+++ b/app/helpers/locales_helper.rb
@@ -1,10 +1,7 @@
 module LocalesHelper
 
   def name_for_locale(locale)
-    default = I18n.t("locale", locale: locale)
-    I18n.backend.translate(locale, "i18n.language.name", default: default)
-  rescue
-    nil
+    I18n.t("i18n.language.name", locale: locale, fallback: false, default: locale.to_s)
   end
 
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -43,6 +43,7 @@ data:
     - config/locales/%{locale}/images.yml
     - config/locales/%{locale}/guides.yml
     - config/locales/%{locale}/user_groups.yml
+    - config/locales/%{locale}/i18n.yml
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -249,7 +249,6 @@ en:
       text_sign_in: login
       text_sign_up: sign up
       title: How I can comment this document?
-  locale: English
   notifications:
     index:
       empty_notifications: You don't have new notifications.

--- a/config/locales/en/i18n.yml
+++ b/config/locales/en/i18n.yml
@@ -1,0 +1,4 @@
+en:
+  i18n:
+    language:
+      name: "English"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -249,7 +249,6 @@ es:
       text_sign_in: iniciar sesión
       text_sign_up: registrarte
       title: '¿Cómo puedo comentar este documento?'
-  locale: Español
   notifications:
     index:
       empty_notifications: No tienes notificaciones nuevas.

--- a/config/locales/es/i18n.yml
+++ b/config/locales/es/i18n.yml
@@ -1,0 +1,4 @@
+es:
+  i18n:
+    language:
+      name: "Español"

--- a/config/locales/fr/general.yml
+++ b/config/locales/fr/general.yml
@@ -892,7 +892,6 @@ fr:
       open_gov: Gouvernement ouvert
       proposals: Propositions
       spending_proposals: Propositions de dépense
-  locale: Français
   mailers:
     comment:
       hi: Bonjour

--- a/config/locales/fr/i18n.yml
+++ b/config/locales/fr/i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  i18n:
+    language:
+      name: "Français"

--- a/config/locales/he/general.yml
+++ b/config/locales/he/general.yml
@@ -192,7 +192,6 @@ he:
       poll_questions: הצבעות
       budgets: מימון השתתפותי
       spending_proposals: הצעות להוצאת כספים
-  locale: עברית
   notifications:
     index:
       empty_notifications: אין לך תגובות חדשות

--- a/config/locales/he/i18n.yml
+++ b/config/locales/he/i18n.yml
@@ -1,0 +1,4 @@
+he:
+  i18n:
+    language:
+      name: "עברית"

--- a/config/locales/it/general.yml
+++ b/config/locales/it/general.yml
@@ -244,7 +244,6 @@ it:
       text_sign_in: ""
       text_sign_up: ""
       title: ""
-  locale: ""
   notifications:
     index:
       comments_on:

--- a/config/locales/nl/general.yml
+++ b/config/locales/nl/general.yml
@@ -232,7 +232,6 @@ nl:
       text_sign_in: log in
       text_sign_up: registreer
       title: Hoe kan ik reageren?
-  locale: Nederlands
   notifications:
     index:
       comments_on:

--- a/config/locales/nl/i18n.yml
+++ b/config/locales/nl/i18n.yml
@@ -1,0 +1,4 @@
+nl:
+  i18n:
+    language:
+      name: "Nederlands"

--- a/config/locales/pt-BR/general.yml
+++ b/config/locales/pt-BR/general.yml
@@ -879,7 +879,6 @@ pt-BR:
       open_gov: Governo aberto
       proposals: Propostas
       spending_proposals: Propostas de despesas
-  locale: Português brasileiro
   mailers:
     comment:
       hi: Olá

--- a/config/locales/pt-BR/general.yml
+++ b/config/locales/pt-BR/general.yml
@@ -1,8 +1,5 @@
 ---
 pt-BR:
-  i18n:
-    language:
-      name: Português
   account:
     show:
       change_credentials_link: Alterar meus dados pessoais

--- a/config/locales/pt-BR/i18n.yml
+++ b/config/locales/pt-BR/i18n.yml
@@ -1,0 +1,4 @@
+pt-BR:
+  i18n:
+    language:
+      name: "Português brasileiro"

--- a/config/locales/val/general.yml
+++ b/config/locales/val/general.yml
@@ -250,7 +250,6 @@ val:
       text_sign_in: iniciar sessió
       text_sign_up: registrar-te
       title: Com puc comentar aquest document?
-  locale: Valencià
   notifications:
     index:
       empty_notifications: No tens noves notificacions.

--- a/config/locales/val/i18n.yml
+++ b/config/locales/val/i18n.yml
@@ -1,0 +1,4 @@
+val:
+  i18n:
+    language:
+      name: "Valencià"

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -52,7 +52,7 @@ feature 'Localization' do
   context "Missing language names" do
 
     let!(:default_enforce) { I18n.enforce_available_locales }
-    let!(:default_locales) { I18n.available_locales }
+    let!(:default_locales) { I18n.available_locales.dup }
 
     before do
       I18n.enforce_available_locales = false
@@ -63,6 +63,7 @@ feature 'Localization' do
     after do
       I18n.enforce_available_locales = default_enforce
       I18n.available_locales = default_locales
+      I18n.locale = I18n.default_locale
     end
 
     scenario 'Available locales without language translation display locale key' do

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -56,7 +56,7 @@ feature 'Localization' do
 
     before do
       I18n.enforce_available_locales = false
-      I18n.available_locales << :wl
+      I18n.available_locales = default_locales + [:wl]
       I18n.locale = :wl
     end
 

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -48,4 +48,30 @@ feature 'Localization' do
     expect(page).not_to have_content('Language')
     expect(page).not_to have_css('div.locale')
   end
+
+  context "Missing language names" do
+
+    let!(:default_enforce) { I18n.enforce_available_locales }
+    let!(:default_locales) { I18n.available_locales }
+
+    before do
+      I18n.enforce_available_locales = false
+      I18n.available_locales << :wl
+      I18n.locale = :wl
+    end
+
+    after do
+      I18n.enforce_available_locales = default_enforce
+      I18n.available_locales = default_locales
+    end
+
+    scenario 'Available locales without language translation display locale key' do
+      visit '/'
+
+      within('.locale-form .js-location-changer') do
+        expect(page).to have_content 'wl'
+      end
+    end
+
+  end
 end

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -107,7 +107,7 @@ feature "Custom Pages" do
 
       scenario "Listed in more information page" do
         custom_page = create(:site_customization_page, :published,
-          slug: "another-slug", 
+          slug: "another-slug",
           title_en: "Another custom page",
           subtitle_en: "Subtitle for custom page",
           more_info_flag: true
@@ -136,10 +136,10 @@ feature "Custom Pages" do
         expect(page).to have_content("Subtitle for custom page")
       end
     end
-  end  
-    
+  end
+
   context "Translation" do
-    
+
     let(:custom_page) { create(:site_customization_page, :published,
                             slug: "example-page",
                             title_en: "Title in English",
@@ -148,7 +148,7 @@ feature "Custom Pages" do
                             subtitle_es: "Subtitulo en Español",
                             content_en: "Content in English",
                             content_es: "Contenido en Español"
-                            ) }                          
+                            ) }
 
     background do
       admin = create(:administrator)
@@ -162,19 +162,19 @@ feature "Custom Pages" do
     scenario "Add a translation in Português", :js do
       visit @edit_page_url
 
-      select "Português", from: "translation_locale"
+      select "Português brasileiro", from: "translation_locale"
       fill_in 'site_customization_page_title_pt_br', with: 'Titulo em Português'
 
       click_button 'Update Custom page'
       expect(page).to have_content "Page updated successfully"
-      
+
       visit @edit_page_url
       expect(page).to have_field('site_customization_page_title_en', with: 'Title in English')
 
       click_link "Español"
       expect(page).to have_field('site_customization_page_title_es', with: 'Titulo en Español')
 
-      click_link "Português"
+      click_link "Português brasileiro"
       expect(page).to have_field('site_customization_page_title_pt_br', with: 'Titulo em Português')
     end
 
@@ -190,11 +190,11 @@ feature "Custom Pages" do
       visit custom_page.url
 
       select('English', from: 'locale-switcher')
-      
+
       expect(page).to have_content("Title in English")
 
       select('Español', from: 'locale-switcher')
- 
+
       expect(page).to have_content("Titulo correcta en Español")
     end
 

--- a/spec/features/translations/poll_question_answers_spec.rb
+++ b/spec/features/translations/poll_question_answers_spec.rb
@@ -91,11 +91,11 @@ feature "Translations" do
         scenario "Add a translation for a locale with non-underscored name", :js do
           visit @edit_answer_url
 
-          select('Português', from: 'translation_locale')
+          select('Português brasileiro', from: 'translation_locale')
           fill_in_ckeditor 'poll_question_answer_description_pt_br', with: 'resposta em Português'
           click_button 'Save'
 
-          select('Português', from: 'locale-switcher')
+          select('Português brasileiro', from: 'locale-switcher')
           expect(page).to have_content("resposta em Português")
         end
 

--- a/spec/helpers/locales_helper_spec.rb
+++ b/spec/helpers/locales_helper_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe LocalesHelper do
+
+  context "Language names" do
+
+    let!(:default_enforce) { I18n.enforce_available_locales }
+
+    before do
+      I18n.enforce_available_locales = false
+    end
+
+    after do
+      I18n.backend.reload!
+      I18n.enforce_available_locales = default_enforce
+    end
+
+    it "returns the language name in i18n.language.name translation" do
+      keys = { language: {
+                 name: "World Language" }}
+
+      I18n.backend.store_translations(:wl, { i18n: keys })
+
+      expect(name_for_locale(:wl)).to eq("World Language")
+    end
+
+    it "retuns the locale key if i18n.language.name translation is not found" do
+      expect(name_for_locale(:wl)).to eq("wl")
+    end
+
+  end
+end

--- a/spec/shared/features/translatable.rb
+++ b/spec/shared/features/translatable.rb
@@ -107,14 +107,14 @@ shared_examples "translatable" do |factory_name, path_name, fields|
       visit path
       field = fields.sample
 
-      select "Português", from: "translation_locale"
+      select "Português brasileiro", from: "translation_locale"
       fill_in field_for(field, :pt_br), with: text_for(field, :"pt-BR")
 
       click_button update_button_text
 
       visit path
 
-      select('Português', from: 'locale-switcher')
+      select('Português brasileiro', from: 'locale-switcher')
 
       expect(page).to have_field(field_for(field, :pt_br), with: text_for(field, :"pt-BR"))
     end


### PR DESCRIPTION
What
===
- Simplify I18n language name lookup
- Display language name if translation exists
- Display language key if translation does not exist
- Removes obsolete language name keys
- Adds missing language name keys

Visual Changes
===
Languages with and without translations
![language names](https://user-images.githubusercontent.com/4169/46481439-b2782a00-c7f3-11e8-8293-6a339c5fbb39.png)

Notes
===
Solution based on [recent comments](https://github.com/svenfuchs/i18n/issues/365#issuecomment-419263847) on a related I18n issue

Another PR on the way with language names for all locales