### PR TITLE
[Backport] Update custom pages translations

### DIFF
--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1350,11 +1350,11 @@ es:
         page:
           created_at: Creada
           status: Estado
-          title: Título
           updated_at: Última actualización
           status_draft: Borrador
           status_published: Publicada
-          locale: Idioma
+          title: Título
+          slug: Slug
     homepage:
       title: Homepage
       description: Los módulos activos aparecerán en la homepage en el mismo orden que aquí.

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -107,7 +107,7 @@ feature "Custom Pages" do
 
       scenario "Listed in more information page" do
         custom_page = create(:site_customization_page, :published,
-          slug: "another-slug", 
+          slug: "another-slug",
           title_en: "Another custom page",
           subtitle_en: "Subtitle for custom page",
           more_info_flag: true
@@ -136,10 +136,10 @@ feature "Custom Pages" do
         expect(page).to have_content("Subtitle for custom page")
       end
     end
-  end  
-    
+  end
+
   context "Translation" do
-    
+
     let(:custom_page) { create(:site_customization_page, :published,
                             slug: "example-page",
                             title_en: "Title in English",
@@ -148,7 +148,7 @@ feature "Custom Pages" do
                             subtitle_es: "Subtitulo en Español",
                             content_en: "Content in English",
                             content_es: "Contenido en Español"
-                            ) }                          
+                            ) }
 
     background do
       admin = create(:administrator)
@@ -167,7 +167,7 @@ feature "Custom Pages" do
 
       click_button 'Update Custom page'
       expect(page).to have_content "Page updated successfully"
-      
+
       visit @edit_page_url
       expect(page).to have_field('site_customization_page_title_en', with: 'Title in English')
 
@@ -190,11 +190,11 @@ feature "Custom Pages" do
       visit custom_page.url
 
       select('English', from: 'locale-switcher')
-      
+
       expect(page).to have_content("Title in English")
 
       select('Español', from: 'locale-switcher')
- 
+
       expect(page).to have_content("Titulo correcta en Español")
     end
 


### PR DESCRIPTION
## References

* Backports the last two commits in pull request AyuntamientoMadrid#1662
* The rest isn't backported it as was already included in pull request #2913

## Objectives

Update the Spanish locales we forgot to add when making custom pages translatable.