### PR TITLE
Adds enable help page task

### DIFF
--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -20,4 +20,9 @@ namespace :settings do
     Setting['feature.user.recommendations_on_proposals'] = true
   end
 
+  desc "Enable Help page"
+  task enable_help_page: :environment do
+    Setting['feature.help_page'] = true
+  end
+
 end


### PR DESCRIPTION
References
===================
Feature help page https://github.com/consul/consul/pull/2933

Objectives
===================
Adds new task to enable `Help page` setting added on https://github.com/consul/consul/pull/2933.

Notes
===================
⚠️ **For release notes**:

Execute this command to enable help page:
`bin/rake settings:enable_help_page RAILS_ENV=production`