### PR TITLE
Fix flaky spec for translations

### DIFF
--- a/spec/helpers/locales_helper_spec.rb
+++ b/spec/helpers/locales_helper_spec.rb
@@ -13,6 +13,7 @@ describe LocalesHelper do
     after do
       I18n.backend.reload!
       I18n.enforce_available_locales = default_enforce
+      I18n.backend.send(:init_translations)
     end
 
     it "returns the language name in i18n.language.name translation" do


### PR DESCRIPTION
# References

* PR https://github.com/consul/consul/pull/2949

# Objectives

Fix the flaky spec that appeared in `spec/features/localization_spec.rb:20` ("Available locales appear in the locale switcher").

# How to reproduce
From the master branch:
`bin/rspec spec/features/localization_spec.rb spec/helpers/locales_helper_spec.rb --seed 12144`

## Explain why the test is flaky
I think it was because no translation had been called yet, in the old spec, and so the the i18n backend translations had not been initialized, and was always returning empty translations for any locale. 

This might have been due to tampering with translations in the new spec

## Explain why your PR fixes it
By forcing translations to load after this new spec, the other spec passes again