### PR TITLE
Removed icon_home and fixed corresponding test

### DIFF
--- a/app/models/site_customization/image.rb
+++ b/app/models/site_customization/image.rb
@@ -1,6 +1,5 @@
 class SiteCustomization::Image < ActiveRecord::Base
   VALID_IMAGES = {
-    "icon_home" => [330, 240],
     "logo_header" => [260, 80],
     "social_media_icon" => [470, 246],
     "social_media_icon_twitter" => [246, 246],

--- a/spec/features/admin/site_customization/images_spec.rb
+++ b/spec/features/admin/site_customization/images_spec.rb
@@ -30,13 +30,13 @@ feature "Admin custom images" do
       click_link "Custom images"
     end
 
-    within("tr.icon_home") do
+    within("tr.social_media_icon") do
       attach_file "site_customization_image_image", "spec/fixtures/files/logo_header.png"
       click_button "Update"
     end
 
-    expect(page).to have_content("Width must be 330px")
-    expect(page).to have_content("Height must be 240px")
+    expect(page).to have_content("Width must be 470px")
+    expect(page).to have_content("Height must be 246px")
   end
 
   scenario "Delete image" do


### PR DESCRIPTION
References
===================
#2853

Objectives
===================
- Removes the icon_home from the list in the settings
- Changes the spec that was testing an invalid image on its uploader

Visual Changes
===================
![capture d ecran 2018-10-12 a 10 02 17](https://user-images.githubusercontent.com/7223028/46856171-f972aa80-ce05-11e8-8c6a-8583b5601576.png)

![capture d ecran 2018-10-12 a 10 02 30](https://user-images.githubusercontent.com/7223028/46856187-02fc1280-ce06-11e8-862a-b2f20bc7527d.png)
