### PR TITLE
[Backport] Fix pluralization spec when using different default locale

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -44,6 +44,7 @@ describe 'I18n' do
 
       I18n.enforce_available_locales = false
       I18n.locale = :zz
+      I18n.fallbacks[:zz] << I18n.default_locale
 
       expect(I18n.t("test_plural", count: 0)).to eq("No comments")
       expect(I18n.t("test_plural", count: 1)).to eq("1 comment")


### PR DESCRIPTION
References
===================
**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1664

Objectives
===================
Update i18n spec to make it pass with a `default_locale` different to `English`

Notes
==================
Check out the [commit's description](https://github.com/consul/consul/commit/3976b2f4f248ac5d4f35aafe29a31d46e0c20b2f) for details
