### PR TITLE
UI design

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1194,17 +1194,6 @@ table {
   }
 }
 
-.max-headings-label {
-  color: $text-medium;
-  font-size: $small-font-size;
-  margin-left: $line-height / 2;
-}
-
-.current-of-max-headings {
-  color: #000;
-  font-weight: bold;
-}
-
 // 11. Newsletters
 // -----------------
 

--- a/app/assets/stylesheets/datepicker_overrides.scss
+++ b/app/assets/stylesheets/datepicker_overrides.scss
@@ -23,7 +23,7 @@
   thead {
 
     tr th {
-      color: $dark;
+      border: 1px solid $brand;
     }
   }
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -881,7 +881,6 @@ footer {
     a {
       color: #fff;
       display: block;
-      line-height: rem-calc(80); // Same as logo image height
       text-align: center;
 
       @include breakpoint(medium) {

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -19,18 +19,6 @@
     line-height: $line-height * 2;
     margin-top: 0;
   }
-
-  img {
-    height: 48px;
-    width: 48px;
-
-    @include breakpoint(medium) {
-      height: 80px;
-      margin-right: $line-height / 2;
-      margin-top: 0;
-      width: 80px;
-    }
-  }
 }
 
 // 02. Orbit bullet

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1094,7 +1094,7 @@
     }
   }
 
-  .active {
+  .is-active {
     color: $brand;
 
     &::after {

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1831,10 +1831,6 @@
 
 .orbit-slide {
   max-height: none !important;
-
-  img {
-    image-rendering: pixelated;
-  }
 }
 
 .orbit-caption {

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -4,7 +4,7 @@
       <th colspan="4" class="with-button">
         <%= content_tag(:span, group.name, class:"group-toggle-#{group.id}", id:"group-name-#{group.id}") %>
 
-        <%= content_tag(:span, (render 'admin/budgets/max_headings_label', current: group.max_votable_headings, max: group.headings.count, group: group if group.max_votable_headings), class:"max-headings-label group-toggle-#{group.id}", id:"max-heading-label-#{group.id}") %>
+        <%= content_tag(:span, (render 'admin/budgets/max_headings_label', current: group.max_votable_headings, max: group.headings.count, group: group if group.max_votable_headings), class:"small group-toggle-#{group.id}", id:"max-heading-label-#{group.id}") %>
 
         <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: t("admin.budgets.form.submit"), css_class: "group-toggle-#{group.id}" %>
         <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link hollow", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>

--- a/app/views/admin/budgets/_max_headings_label.html.erb
+++ b/app/views/admin/budgets/_max_headings_label.html.erb
@@ -1,4 +1,2 @@
 <%= t("admin.budgets.form.max_votable_headings")%>
-<%= content_tag(:strong,
-                t("admin.budgets.form.current_of_max_headings", current: current, max: max),
-                class: "current-of-max-headings") %>
+<%= t("admin.budgets.form.current_of_max_headings", current: current, max: max) %>

--- a/app/views/budgets/investments/_view_mode.html.erb
+++ b/app/views/budgets/investments/_view_mode.html.erb
@@ -11,7 +11,7 @@
     </span>
     <ul class="no-bullet">
       <% if investments_default_view? %>
-        <li class="view-card active">
+        <li class="view-card is-active">
           <%= t("shared.view_mode.cards") %>
         </li>
         <li class="view-list">
@@ -21,7 +21,7 @@
         <li class="view-card">
           <%= link_to t("shared.view_mode.cards"), investments_minimal_view_path %>
         </li>
-        <li class="view-list active">
+        <li class="view-list is-active">
           <%= t("shared.view_mode.list") %>
         </li>
       <% end %>

--- a/app/views/debates/_view_mode.html.erb
+++ b/app/views/debates/_view_mode.html.erb
@@ -11,7 +11,7 @@
     </span>
     <ul class="no-bullet">
       <% if debates_default_view? %>
-        <li class="view-card active">
+        <li class="view-card is-active">
           <%= t("shared.view_mode.cards") %>
         </li>
         <li class="view-list">
@@ -21,7 +21,7 @@
         <li class="view-card">
           <%= link_to t("shared.view_mode.cards"), debates_minimal_view_path %>
         </li>
-        <li class="view-list active">
+        <li class="view-list is-active">
           <%= t("shared.view_mode.list") %>
         </li>
       <% end %>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -1,17 +1,15 @@
 <div id="<%= dom_id(proposal) %>"
-     class="proposal clear <%= ("successful" if proposal.total_votes > Proposal.votes_needed_for_success) %>"
+     class="proposal clear
+            <%= ("successful" if proposal.total_votes > Proposal.votes_needed_for_success) %>"
      data-type="proposal">
-  <div class="panel <%= ('with-image' if feature?(:allow_images) && proposal.image.present?) %>">
+  <div class="panel <%= 'with-image' if proposal.image.present? %>">
     <div class="icon-successful"></div>
 
-    <% if feature?(:allow_images) && proposal.image.present? %>
-      <div class="row" data-equalizer>
-
+    <% if proposal.image.present? %>
+      <div class="row">
         <div class="small-12 medium-3 large-2 column text-center">
-          <div data-equalizer-watch>
-            <%= image_tag proposal.image_url(:thumb),
-                          alt: proposal.image.title.unicode_normalize %>
-          </div>
+          <%= image_tag proposal.image_url(:thumb),
+                        alt: proposal.image.title.unicode_normalize %>
         </div>
 
         <div class="small-12 medium-6 large-7 column">
@@ -24,7 +22,8 @@
             <h3><%= link_to proposal.title, namespaced_proposal_path(proposal) %></h3>
             <p class="proposal-info">
               <span class="icon-comments"></span>&nbsp;
-              <%= link_to t("proposals.proposal.comments", count: proposal.comments_count), namespaced_proposal_path(proposal, anchor: "comments") %>
+              <%= link_to t("proposals.proposal.comments", count: proposal.comments_count),
+                          namespaced_proposal_path(proposal, anchor: "comments") %>
 
               <span class="bullet">&nbsp;&bull;&nbsp;</span>
               <%= l proposal.created_at.to_date %>
@@ -64,8 +63,7 @@
       </div>
 
       <div id="<%= dom_id(proposal) %>_votes"
-           class="small-12 medium-3 column supports-container"
-           <%= 'data-equalizer-watch' if feature?(:allow_images) && proposal.image.present? %>>
+           class="small-12 medium-3 column supports-container">
         <% if proposal.successful? %>
           <div class="padding text-center">
 

--- a/app/views/proposals/_view_mode.html.erb
+++ b/app/views/proposals/_view_mode.html.erb
@@ -11,7 +11,7 @@
     </span>
     <ul class="no-bullet">
       <% if proposals_default_view? %>
-        <li class="view-card active">
+        <li class="view-card is-active">
           <%= t("shared.view_mode.cards") %>
         </li>
         <li class="view-list">
@@ -21,7 +21,7 @@
         <li class="view-card">
           <%= link_to t("shared.view_mode.cards"), proposals_minimal_view_path %>
         </li>
-        <li class="view-list active">
+        <li class="view-list is-active">
           <%= t("shared.view_mode.list") %>
         </li>
       <% end %>


### PR DESCRIPTION
Objectives
===================

This PR fix some UI details:

- Updates `active` to `is-active` class for view mode.

- Fixes color of **datepicker calendar**.

- Removes unnecessary styles for admin budgets groups.

- Removes styles to fix logo size on devise views.

- Removes condition to allow images and data equalizer on proposals (the proposal image only can be present if feature `:allow_images` is enabled, so there is no need to include both conditions. The `data-equalizer` also is unnecessary because the `:thumb` image already has an fix height).

- Removes unnecessary style to orbit slide.

Visual Changes
===================

**Fixes color of datepicker calendar**

<img width="295" alt="4 before" src="https://user-images.githubusercontent.com/631897/47185078-c0b66200-d32c-11e8-8bf0-f7c7861b6b66.png">
<img width="303" alt="4 after" src="https://user-images.githubusercontent.com/631897/47185079-c0b66200-d32c-11e8-9645-e100142e7e3d.png">

**Removes unnecessary styles for admin budgets groups**
<img width="559" alt="3 before" src="https://user-images.githubusercontent.com/631897/47185086-c744d980-d32c-11e8-8970-d39577bb4653.png">
<img width="486" alt="3 after" src="https://user-images.githubusercontent.com/631897/47185087-c744d980-d32c-11e8-932f-24fd808ca951.png">

**Removes styles to fix logo size on devise views**
<img width="356" alt="2 before" src="https://user-images.githubusercontent.com/631897/47185099-cd3aba80-d32c-11e8-8270-b3ce2096d4ac.png">
<img width="429" alt="2 after" src="https://user-images.githubusercontent.com/631897/47185101-ce6be780-d32c-11e8-80e3-0037edf3c567.png">
