### PR TITLE
[Backport] Migrate globalize data

### DIFF
--- a/db/migrate/20180323190027_add_translate_milestones.rb
+++ b/db/migrate/20180323190027_add_translate_milestones.rb
@@ -1,9 +1,12 @@
 class AddTranslateMilestones < ActiveRecord::Migration
   def self.up
-    Budget::Investment::Milestone.create_translation_table!({
-      title: :string,
-      description: :text
-    })
+    Budget::Investment::Milestone.create_translation_table!(
+      {
+        title:       :string,
+        description: :text
+      },
+      { migrate_data: true }
+    )
   end
 
   def self.down

--- a/db/migrate/20180718115545_create_i18n_content_translations.rb
+++ b/db/migrate/20180718115545_create_i18n_content_translations.rb
@@ -6,7 +6,10 @@ class CreateI18nContentTranslations < ActiveRecord::Migration
 
     reversible do |dir|
       dir.up do
-        I18nContent.create_translation_table! :value => :text
+        I18nContent.create_translation_table!(
+          { value: :text },
+          { migrate_data: true }
+        )
       end
 
       dir.down do

--- a/db/migrate/20180727140800_add_banner_translations.rb
+++ b/db/migrate/20180727140800_add_banner_translations.rb
@@ -2,8 +2,11 @@ class AddBannerTranslations < ActiveRecord::Migration
 
   def self.up
     Banner.create_translation_table!(
-      title:       :string,
-      description: :text
+      {
+        title:       :string,
+        description: :text
+      },
+      { migrate_data: true }
     )
   end
 

--- a/db/migrate/20180730120800_add_homepage_content_translations.rb
+++ b/db/migrate/20180730120800_add_homepage_content_translations.rb
@@ -2,10 +2,13 @@ class AddHomepageContentTranslations < ActiveRecord::Migration
 
   def self.up
     Widget::Card.create_translation_table!(
-      label:       :string,
-      title:       :string,
-      description: :text,
-      link_text:   :string
+      {
+        label:       :string,
+        title:       :string,
+        description: :text,
+        link_text:   :string
+      },
+      { migrate_data: true }
     )
   end
 

--- a/db/migrate/20180730213824_add_poll_translations.rb
+++ b/db/migrate/20180730213824_add_poll_translations.rb
@@ -2,9 +2,12 @@ class AddPollTranslations < ActiveRecord::Migration
 
   def self.up
     Poll.create_translation_table!(
-      name:        :string,
-      summary:     :text,
-      description: :text
+      {
+        name:        :string,
+        summary:     :text,
+        description: :text
+      },
+      { migrate_data: true }
     )
   end
 

--- a/db/migrate/20180731150800_add_admin_notification_translations.rb
+++ b/db/migrate/20180731150800_add_admin_notification_translations.rb
@@ -2,8 +2,11 @@ class AddAdminNotificationTranslations < ActiveRecord::Migration
 
   def self.up
     AdminNotification.create_translation_table!(
-      title: :string,
-      body:  :text
+      {
+        title: :string,
+        body:  :text
+      },
+      { migrate_data: true }
     )
   end
 

--- a/db/migrate/20180731173147_add_poll_question_translations.rb
+++ b/db/migrate/20180731173147_add_poll_question_translations.rb
@@ -2,7 +2,8 @@ class AddPollQuestionTranslations < ActiveRecord::Migration
 
   def self.up
     Poll::Question.create_translation_table!(
-      title: :string
+      { title: :string },
+      { migrate_data: true }
     )
   end
 

--- a/db/migrate/20180801114529_add_poll_question_answer_translations.rb
+++ b/db/migrate/20180801114529_add_poll_question_answer_translations.rb
@@ -2,8 +2,11 @@ class AddPollQuestionAnswerTranslations < ActiveRecord::Migration
 
   def self.up
     Poll::Question::Answer.create_translation_table!(
-      title:       :string,
-      description: :text
+      {
+        title:       :string,
+        description: :text
+      },
+      { migrate_data: true }
     )
   end
 

--- a/db/migrate/20180801140800_add_collaborative_legislation_translations.rb
+++ b/db/migrate/20180801140800_add_collaborative_legislation_translations.rb
@@ -2,25 +2,33 @@ class AddCollaborativeLegislationTranslations < ActiveRecord::Migration
 
   def self.up
     Legislation::Process.create_translation_table!(
-      title:           :string,
-      summary:         :text,
-      description:     :text,
-      additional_info: :text,
+      {
+        title:           :string,
+        summary:         :text,
+        description:     :text,
+        additional_info: :text,
+      },
+      { migrate_data: true }
     )
 
     Legislation::Question.create_translation_table!(
-      title:           :text
+      { title: :text },
+      { migrate_data: true }
     )
 
     Legislation::DraftVersion.create_translation_table!(
-      title:           :string,
-      changelog:       :text,
-      body:            :text,
-      body_html:       :text,
-      toc_html:        :text
+      {
+        title:     :string,
+        changelog: :text,
+        body:      :text,
+        body_html: :text,
+        toc_html:  :text
+      },
+      { migrate_data: true }
     )
     Legislation::QuestionOption.create_translation_table!(
-      value:           :string
+      { value: :string },
+      { migrate_data: true }
     )
   end
 

--- a/db/migrate/20180924071722_add_translate_pages.rb
+++ b/db/migrate/20180924071722_add_translate_pages.rb
@@ -1,10 +1,14 @@
 class AddTranslatePages < ActiveRecord::Migration
   def self.up
-    SiteCustomization::Page.create_translation_table!({
-      title: :string,
-      subtitle: :string,
-      content: :text
-    })
+    SiteCustomization::Page.create_translation_table!(
+      {
+        title:    :string,
+        subtitle: :string,
+        content:  :text
+      },
+      { migrate_data: true }
+    )
+
     change_column :site_customization_pages, :title, :string, :null => true
   end
 

--- a/lib/tasks/globalize.rake
+++ b/lib/tasks/globalize.rake
@@ -22,8 +22,14 @@ namespace :globalize do
 
       model_class.find_each do |record|
         fields.each do |field|
-          if record.send(:"#{field}_#{I18n.locale}").blank?
-            record.send(:"#{field}_#{I18n.locale}=", record.untranslated_attributes[field.to_s])
+          locale = if model_class == SiteCustomization::Page && record.locale.present?
+                     record.locale
+                   else
+                     I18n.locale
+                   end
+
+          if record.send(:"#{field}_#{locale}").blank?
+            record.send(:"#{field}_#{locale}=", record.untranslated_attributes[field.to_s])
           end
         end
 

--- a/lib/tasks/globalize.rake
+++ b/lib/tasks/globalize.rake
@@ -1,0 +1,34 @@
+namespace :globalize do
+  desc "Migrates existing data to translation tables"
+  task migrate_data: :environment do
+    [
+      AdminNotification,
+      Banner,
+      Budget::Investment::Milestone,
+      I18nContent,
+      Legislation::DraftVersion,
+      Legislation::Process,
+      Legislation::Question,
+      Legislation::QuestionOption,
+      Poll,
+      Poll::Question,
+      Poll::Question::Answer,
+      SiteCustomization::Page,
+      Widget::Card
+    ].each do |model_class|
+      Logger.new(STDOUT).info "Migrating #{model_class} data"
+
+      fields = model_class.translated_attribute_names
+
+      model_class.find_each do |record|
+        fields.each do |field|
+          if record.send(:"#{field}_#{I18n.locale}").blank?
+            record.send(:"#{field}_#{I18n.locale}=", record.untranslated_attributes[field.to_s])
+          end
+        end
+
+        record.save!
+      end
+    end
+  end
+end

--- a/lib/tasks/globalize.rake
+++ b/lib/tasks/globalize.rake
@@ -33,8 +33,10 @@ namespace :globalize do
                      I18n.locale
                    end
 
-          if record.send(:"#{field}_#{locale}").blank?
-            record.send(:"#{field}_#{locale}=", record.untranslated_attributes[field.to_s])
+          translated_field = record.localized_attr_name_for(field, locale)
+
+          if record.send(translated_field).blank?
+            record.send(:"#{translated_field}=", record.untranslated_attributes[field.to_s])
           end
         end
 

--- a/lib/tasks/globalize.rake
+++ b/lib/tasks/globalize.rake
@@ -41,7 +41,7 @@ namespace :globalize do
         begin
           record.save!
         rescue ActiveRecord::RecordInvalid
-          logger.error "Failed to save #{model_class} with id #{record.id}"
+          logger.warn "Failed to save #{model_class} with id #{record.id}"
           @errored = true
         end
       end
@@ -68,17 +68,20 @@ namespace :globalize do
     end
 
     if errored?
-      logger.error "Simulation failed! Please check the errors and solve them before proceeding."
-      raise "Simulation failed!"
+      logger.warn "Some database records will not be migrated"
     else
       logger.info "Migrate data simulation ended successfully"
     end
   end
 
   desc "Migrates existing data to translation tables"
-  task migrate_data: :simulate_migrate_data do
+  task migrate_data: :environment do
     logger.info "Starting data migration"
     migrate_data
     logger.info "Finished data migration"
+
+    if errored?
+      logger.warn "Some database records couldn't be migrated; please check the log messages"
+    end
   end
 end

--- a/spec/lib/tasks/globalize_spec.rb
+++ b/spec/lib/tasks/globalize_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+require "rake"
+
+describe "Globalize tasks" do
+
+  describe "#migrate_data" do
+
+    before do
+      Rake.application.rake_require "tasks/globalize"
+      Rake::Task.define_task(:environment)
+    end
+
+    let :run_rake_task do
+      Rake::Task["globalize:migrate_data"].reenable
+      Rake.application.invoke_task "globalize:migrate_data"
+    end
+
+    context "Original data with no translated data" do
+      let(:poll) do
+        create(:poll).tap do |poll|
+          poll.translations.delete_all
+          poll.update_column(:name, "Original")
+          poll.reload
+        end
+      end
+
+      it "copies the original data" do
+        expect(poll.send(:"name_#{I18n.locale}")).to be nil
+        expect(poll.name).to eq("Original")
+
+        run_rake_task
+        poll.reload
+
+        expect(poll.name).to eq("Original")
+        expect(poll.send(:"name_#{I18n.locale}")).to eq("Original")
+      end
+    end
+
+    context "Original data with blank translated data" do
+      let(:banner) do
+        create(:banner).tap do |banner|
+          banner.update_column(:title, "Original")
+          banner.translations.first.update_column(:title, "")
+        end
+      end
+
+      it "copies the original data" do
+        expect(banner.title).to eq("")
+
+        run_rake_task
+        banner.reload
+
+        expect(banner.title).to eq("Original")
+        expect(banner.send(:"title_#{I18n.locale}")).to eq("Original")
+      end
+    end
+
+    context "Original data with translated data" do
+      let(:notification) do
+        create(:admin_notification, title: "Translated").tap do |notification|
+          notification.update_column(:title, "Original")
+        end
+      end
+
+      it "maintains the translated data" do
+        expect(notification.title).to eq("Translated")
+
+        run_rake_task
+        notification.reload
+
+        expect(notification.title).to eq("Translated")
+        expect(notification.send(:"title_#{I18n.locale}")).to eq("Translated")
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/globalize_spec.rb
+++ b/spec/lib/tasks/globalize_spec.rb
@@ -146,5 +146,23 @@ describe "Globalize tasks" do
         expect(invalid_process.reload.title).to eq ""
       end
     end
+
+    context "locale with non-underscored name" do
+      before { I18n.locale = :"pt-BR" }
+
+      let!(:milestone) do
+        create(:budget_investment_milestone).tap do |milestone|
+          milestone.translations.delete_all
+          milestone.update_column(:title, "Português")
+          milestone.reload
+        end
+      end
+
+      it "runs the migration successfully" do
+        run_rake_task
+
+        expect(milestone.reload.title).to eq "Português"
+      end
+    end
   end
 end

--- a/spec/lib/tasks/globalize_spec.rb
+++ b/spec/lib/tasks/globalize_spec.rb
@@ -11,7 +11,6 @@ describe "Globalize tasks" do
     end
 
     let :run_rake_task do
-      Rake::Task["globalize:simulate_migrate_data"].reenable
       Rake::Task["globalize:migrate_data"].reenable
       Rake.application.invoke_task "globalize:migrate_data"
     end
@@ -134,14 +133,16 @@ describe "Globalize tasks" do
         end
       end
 
-      it "simulates the task and aborts without creating any translations" do
+      it "ignores invalid data and migrates valid data" do
         expect(valid_process).to be_valid
         expect(invalid_process).not_to be_valid
 
-        expect { run_rake_task }.to raise_exception("Simulation failed!")
+        run_rake_task
 
-        expect(Legislation::Process::Translation.count).to eq 0
+        expect(valid_process.translations.count).to eq 1
         expect(valid_process.reload.title).to eq "Title"
+
+        expect(invalid_process.translations.count).to eq 0
         expect(invalid_process.reload.title).to eq ""
       end
     end


### PR DESCRIPTION
## References

* Backports pull request AyuntamientoMadrid#1657

## Background

We forgot to migrate existing data when we created the translations tables, and so when we edit translatable fields in the administration, they seem to be empty, increasing the risk of data loss.

## Objectives

Migrate existing data to the translation tables (unless we've already translated those records!) so contents show up when administrators edit contents.

## Notes

⚠️ **For release notes**:

In order to migrate existing data, execute:
`bin/rake globalize:migrate_data RAILS_ENV=production`

Although we believe it's completely safe to run this task, we recommend backing up the database before executing any task which modifies its data.

This task will not migrate records which contain invalid data (for example, a banner with a blank title), which might happen if the database content has been edited manually by system administrators. You can check which records aren't migrated by checking the warnings generated by executing:
`bin/rake globalize:simulate_migrate_data RAILS_ENV=production `

Most of the time no records contain invalid data and the task will run without any warnings.

Globalize developers recommend removing the original columns after migrating the data, since [having both original and translated columns is not supported](https://github.com/globalize/globalize/issues/429#issuecomment-250912403). We might add another task dealing with this issue.