### PR TITLE
[Backport] Fix flaky specs: proposals and legislation Voting comments Update

### DIFF
--- a/spec/features/comments/legislation_questions_spec.rb
+++ b/spec/features/comments/legislation_questions_spec.rb
@@ -499,6 +499,11 @@ feature 'Commenting legislation questions' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -464,6 +464,11 @@ feature 'Commenting proposals' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1606

## Notes

Code affecting probe options and spending proposals hasn't been backported since those parts aren't present in CONSUL.