### PR TITLE
[Backport] Newsletter updates

### DIFF
--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -1,4 +1,5 @@
 class Newsletter < ActiveRecord::Base
+  has_many :activities, as: :actionable
 
   validates :subject, presence: true
   validates :segment_recipient, presence: true

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -26,6 +26,12 @@
       <%= segment_name(@newsletter.segment_recipient) %>
       <%= t("admin.newsletters.show.affected_users", n: recipients_count) %>
     </div>
+
+    <div class="small-12 column">
+      <strong>
+        <%= t("admin.newsletters.show.sent_emails", count: @newsletter.activities.count) %>
+      </strong>
+    </div>
   </div>
 
   <div class="small-12 column">

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -6,7 +6,7 @@ end
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 2
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 30.minutes
+Delayed::Worker.max_run_time = 1500.minutes
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.raise_signal_exceptions = :term

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -641,6 +641,9 @@ en:
         title: Newsletter preview
         send: Send
         affected_users: (%{n} affected users)
+        sent_emails:
+          one: 1 email sent
+          other: "%{count} emails sent"
         sent_at: Sent at
         subject: Subject
         segment_recipient: Recipients

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -637,6 +637,9 @@ es:
         title: Vista previa de newsletter
         send: Enviar
         affected_users: (%{n} usuarios afectados)
+        sent_emails:
+          one: 1 correo enviado
+          other: "%{count} correos enviados"
         sent_at: Enviado
         subject: Asunto
         segment_recipient: Destinatarios

--- a/spec/features/admin/emails/newsletters_spec.rb
+++ b/spec/features/admin/emails/newsletters_spec.rb
@@ -146,6 +146,20 @@ feature "Admin newsletter emails" do
     end
   end
 
+  context "Counter of emails sent", :js do
+    scenario "Display counter" do
+      newsletter = create(:newsletter, segment_recipient: "administrators")
+      visit admin_newsletter_path(newsletter)
+
+      accept_confirm { click_link "Send" }
+
+      expect(page).to have_content "Newsletter sent successfully"
+
+      expect(page).to have_content "1 affected users"
+      expect(page).to have_content "1 email sent"
+    end
+  end
+
   scenario "Select list of users to send newsletter" do
     UserSegments::SEGMENTS.each do |user_segment|
       visit new_admin_newsletter_path


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1691

## Objectives

* Add a counter of emails sent to newsletter previews so administrators know the status of the newsletter currently being sent
* Increase delayed job timeout to avoid large jobs being restarted