### PR TITLE
i18n remove date.order key

### DIFF
--- a/config/locales/en/rails.yml
+++ b/config/locales/en/rails.yml
@@ -68,10 +68,6 @@ en:
     - October
     - November
     - December
-    order:
-    - :year
-    - :month
-    - :day
   datetime:
     distance_in_words:
       about_x_hours:


### PR DESCRIPTION
References
===================
**PR Crowdin bot**: https://github.com/consul/consul/pull/3005

Objectives
===================
Remove problematic key `date.order`.

People are translating the `date.order` key, however, this key is supposed to have the symbols `:year, :month, :day` and not be translated to for example `:año, :mes, :día` as that raises an exception.

These keys are only used for defining the order of [date selects](https://apidock.com/rails/ActionView/Helpers/DateHelper/date_select) which are not currently in use in CONSUL, so we can safely remove them for now.