### PR TITLE
[Backport] Budget executions

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1695,9 +1695,10 @@
 
     img {
       height: $line-height * 9;
+      min-width: 100%;
+      max-width: none;
       transition-duration: 0.3s;
       transition-property: transform;
-      width: 100%;
     }
 
     &:hover {

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -760,6 +760,10 @@
 
     &.past-budgets {
       min-height: 0;
+
+      .button ~ .button {
+        margin-left: $line-height / 2;
+      }
     }
   }
 

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -13,7 +13,7 @@ module Budgets
                       .joins(:milestones).includes(:milestones)
                       .select { |i| i.milestones.published.with_status
                                                 .order_by_publication_date.last
-                                                .status_id == params[:status].to_i }
+                                                .try(:status_id) == params[:status].to_i }
                       .uniq
                       .group_by(&:heading)
       else

--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -7,8 +7,8 @@ module BudgetExecutionsHelper
   end
 
   def first_milestone_with_image(investment)
-    investment.milestones.order(publication_date: :asc, created_at: :asc)
-                         .select{ |milestone| milestone.image.present? }.first
+    investment.milestones.order_by_publication_date
+                         .select{ |milestone| milestone.image.present? }.last
   end
 
 end

--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -6,4 +6,9 @@ module BudgetExecutionsHelper
                                       .last.status_id == status rescue false }.count
   end
 
+  def first_milestone_with_image(investment)
+    investment.milestones.order(publication_date: :asc, created_at: :asc)
+                         .select{ |milestone| milestone.image.present? }.first
+  end
+
 end

--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -17,7 +17,7 @@ class Budget
       validates :publication_date, presence: true
       validate :description_or_status_present?
 
-      scope :order_by_publication_date, -> { order(publication_date: :asc) }
+      scope :order_by_publication_date, -> { order(publication_date: :asc, created_at: :asc) }
       scope :published,                 -> { where("publication_date <= ?", Date.current) }
       scope :with_status,               -> { where("status_id IS NOT NULL") }
 

--- a/app/views/budgets/executions/_image.html.erb
+++ b/app/views/budgets/executions/_image.html.erb
@@ -1,0 +1,9 @@
+<% investment.milestones.order(publication_date: :desc).limit(1).each do |milestone| %>
+  <% if milestone.image.present? %>
+    <%= image_tag milestone.image_url(:large), alt: milestone.image.title %>
+  <% elsif investment.image.present? %>
+    <%= image_tag investment.image_url(:thumb), alt: investment.image.title %>
+  <% else %>
+    <%= image_tag "budget_execution_no_image.jpg", alt: investment.title %>
+  <% end %>
+<% end %>

--- a/app/views/budgets/executions/_image.html.erb
+++ b/app/views/budgets/executions/_image.html.erb
@@ -1,9 +1,9 @@
-<% investment.milestones.order(publication_date: :desc).limit(1).each do |milestone| %>
-  <% if milestone.image.present? %>
-    <%= image_tag milestone.image_url(:large), alt: milestone.image.title %>
-  <% elsif investment.image.present? %>
-    <%= image_tag investment.image_url(:thumb), alt: investment.image.title %>
-  <% else %>
-    <%= image_tag "budget_execution_no_image.jpg", alt: investment.title %>
-  <% end %>
+<% milestone = first_milestone_with_image(investment) %>
+
+<% if milestone&.image.present? %>
+  <%= image_tag milestone.image_url(:large), alt: milestone.image.title %>
+<% elsif investment.image.present? %>
+  <%= image_tag investment.image_url(:large), alt: investment.image.title %>
+<% else %>
+  <%= image_tag "budget_execution_no_image.jpg", alt: investment.title %>
 <% end %>

--- a/app/views/budgets/executions/_investments.html.erb
+++ b/app/views/budgets/executions/_investments.html.erb
@@ -7,15 +7,7 @@
         <div class="small-12 medium-6 large-4 column end margin-bottom">
           <div class="budget-execution">
             <%= link_to budget_investment_path(@budget, investment, anchor: "tab-milestones"), data: { 'equalizer-watch': true } do %>
-              <% investment.milestones.order(publication_date: :desc).limit(1).each do |milestone| %>
-                <% if milestone.image.present? %>
-                  <%= image_tag milestone.image_url(:large), alt: milestone.image.title %>
-                <% elsif investment.image.present? %>
-                  <%= image_tag investment.image_url(:thumb), alt: investment.image.title %>
-                <% else %>
-                  <%= image_tag "budget_execution_no_image.jpg", alt: investment.title %>
-                <% end %>
-              <% end %>
+              <%= render 'image', investment: investment %>
               <div class="budget-execution-info">
                 <div class="budget-execution-content">
                   <h5><%= investment.title %></h5>

--- a/app/views/budgets/executions/show.html.erb
+++ b/app/views/budgets/executions/show.html.erb
@@ -55,7 +55,7 @@
   <div class="small-12 medium-9 large-10 column">
     <%= form_tag(budget_executions_path(@budget), method: :get) do %>
       <div class="small-12 medium-3 column">
-        <%= label_tag t("budgets.executions.filters.label") %>
+        <%= label_tag :status, t("budgets.executions.filters.label") %>
         <%= select_tag :status,
                       options_from_collection_for_select(@statuses,
                       :id, lambda { |s| "#{s.name} (#{filters_select_counts(s.id)})" },

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -136,17 +136,20 @@
               <div class="budget-investment clear">
                 <div class="panel past-budgets">
                   <div class="row" data-equalizer data-equalizer-on="medium">
-                    <div class="small-12 medium-9 column table" data-equalizer-watch>
+                    <div class="small-12 medium-6 column table" data-equalizer-watch>
                       <div class="table-cell align-middle">
                         <h3><%= budget.name %></h3>
                       </div>
                     </div>
 
-                    <div class="small-12 medium-3 column table" data-equalizer-watch>
+                    <div class="small-12 medium-6 column table" data-equalizer-watch>
                       <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
                         <%= link_to t("budgets.index.see_results"),
                                     budget_results_path(budget.id),
-                                    class: "button expanded" %>
+                                    class: "button" %>
+                        <%= link_to t("budgets.index.milestones"),
+                                    budget_executions_path(budget.id),
+                                    class: "button" %>
                       </div>
                     </div>
                   </div>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -57,6 +57,7 @@ en:
       section_footer:
         title: Help with participatory budgets
         description: With the participatory budgets the citizens decide to which projects is destined a part of the budget.
+      milestones: Milestones
     investments:
       form:
         tag_category_label: "Categories"

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -57,6 +57,7 @@ es:
       section_footer:
         title: Ayuda sobre presupuestos participativos
         description: Con los presupuestos participativos la ciudadanía decide a qué proyectos va destinada una parte del presupuesto.
+      milestones: Seguimiento de proyectos
     investments:
       form:
         tag_category_label: "Categorías"

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -100,7 +100,7 @@ feature 'Executions' do
       expect(page).to have_css("img[alt='#{investment4.title}']")
     end
 
-    scenario "renders first milestone's image if investment has multiple milestones with images associated" do
+    scenario "renders last milestone's image if investment has multiple milestones with images associated" do
       milestone1 = create(:budget_investment_milestone, investment: investment1,
                                                         publication_date: Date.yesterday)
 
@@ -122,7 +122,7 @@ feature 'Executions' do
       click_link 'Milestones'
 
       expect(page).to have_content(investment1.title)
-      expect(page).to have_css("img[alt='#{milestone2.image.title}']")
+      expect(page).to have_css("img[alt='#{milestone3.image.title}']")
     end
 
   end

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -249,4 +249,18 @@ feature 'Executions' do
       expect(m_heading.name).to appear_before(z_heading.name)
     end
   end
+
+  context 'No milestones' do
+
+    scenario 'Milestone not yet published' do
+      status = create(:budget_investment_status)
+      unpublished_milestone = create(:budget_investment_milestone, investment: investment1,
+                                     status: status, publication_date: Date.tomorrow)
+
+      visit custom_budget_executions_path(budget, status: status.id)
+
+      expect(page).to have_content('No winner investments in this state')
+    end
+
+  end
 end

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -61,6 +61,7 @@ feature 'Executions' do
   end
 
   context 'Images' do
+
     scenario 'renders milestone image if available' do
       milestone1 = create(:budget_investment_milestone, investment: investment1)
       create(:image, imageable: milestone1)
@@ -99,15 +100,21 @@ feature 'Executions' do
       expect(page).to have_css("img[alt='#{investment4.title}']")
     end
 
-    scenario "renders last milestone's image if investment has multiple milestones with images associated" do
+    scenario "renders first milestone's image if investment has multiple milestones with images associated" do
       milestone1 = create(:budget_investment_milestone, investment: investment1,
-                                                        publication_date: 2.weeks.ago)
+                                                        publication_date: Date.yesterday)
 
       milestone2 = create(:budget_investment_milestone, investment: investment1,
                                                         publication_date: Date.yesterday)
 
-      create(:image, imageable: milestone1, title: 'First milestone image')
-      create(:image, imageable: milestone2, title: 'Second milestone image')
+      milestone3 = create(:budget_investment_milestone, investment: investment1,
+                                                        publication_date: Date.yesterday)
+
+      milestone4 = create(:budget_investment_milestone, investment: investment1,
+                                                        publication_date: Date.yesterday)
+
+      create(:image, imageable: milestone2, title: 'Image for first milestone with image')
+      create(:image, imageable: milestone3, title: 'Image for second milestone with image')
 
       visit budget_path(budget)
 
@@ -116,8 +123,8 @@ feature 'Executions' do
 
       expect(page).to have_content(investment1.title)
       expect(page).to have_css("img[alt='#{milestone2.image.title}']")
-      expect(page).not_to have_css("img[alt='#{milestone1.image.title}']")
     end
+
   end
 
   context 'Filters' do

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -264,7 +264,7 @@ feature 'Executions' do
       unpublished_milestone = create(:budget_investment_milestone, investment: investment1,
                                      status: status, publication_date: Date.tomorrow)
 
-      visit custom_budget_executions_path(budget, status: status.id)
+      visit budget_executions_path(budget, status: status.id)
 
       expect(page).to have_content('No winner investments in this state')
     end


### PR DESCRIPTION
References
===================
This is a backport of:

- Budget index milestones https://github.com/AyuntamientoMadrid/consul/pull/1632
- Display first image available for milestones https://github.com/AyuntamientoMadrid/consul/pull/1634
- Display last milestones image https://github.com/AyuntamientoMadrid/consul/pull/1636
- Budget executions label https://github.com/AyuntamientoMadrid/consul/pull/1650
- Budget executions images https://github.com/AyuntamientoMadrid/consul/pull/1656


Objectives
===================
- Adds a link to milestones on budgets index page.
- Sometimes a budget investment has some milestones created on the same date and the image is not displayed correctly. ~Now always display the first image available for milestones.~
- Always display last milestones image. Also adds a second order to ensure the order to display milestones with same publication date is always the same.
- Adds missing `for` atribute to **budget exections status label tag**.
- Improves styles to show budgets executions images. With this changes, all images adapt better to avoid big stretch or squeeze on images.

Visual Changes
===================
**Budget index**
![budget_index_milestones](https://user-images.githubusercontent.com/631897/45311982-2d1e9400-b52b-11e8-8408-026aa744c1e2.png)

**Incorrect `for`**
![for](https://user-images.githubusercontent.com/631897/45894828-d5f0ad00-bdcf-11e8-9bb3-5bbc808a281d.png)

**Fixed!**
![status](https://user-images.githubusercontent.com/631897/45894831-d7ba7080-bdcf-11e8-8827-cc2ce171f8f2.png)

![budget_executions_images](https://user-images.githubusercontent.com/631897/46209777-1354bd80-c32f-11e8-946a-2fbd416d78d8.jpg)