### PR TITLE
Update debates_spec.rb

### DIFF
--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -927,7 +927,7 @@ feature 'Debates' do
 
     scenario "Reorder by recommendations results maintaing search" do
       Setting['feature.user.recommendations'] = true
-      Setting['feature.user.recommendations_for_debates'] = true
+      Setting['feature.user.recommendations_on_debates'] = true
 
       user = create(:user, recommended_debates: true)
       login_as(user)
@@ -953,7 +953,7 @@ feature 'Debates' do
       end
 
       Setting['feature.user.recommendations'] = nil
-      Setting['feature.user.recommendations_for_debates'] = nil
+      Setting['feature.user.recommendations_on_debates'] = nil
     end
 
     scenario 'After a search do not show featured debates' do


### PR DESCRIPTION
Objectives
===================
> Fix an incorrect feature setting title in `debates_spec.rb` (I noticed it because it raised an error in my cloned project)

Notes
===================
If I trust https://github.com/consul/consul/blob/master/db/seeds.rb#L85, debates recommendations Setting title is `recommendations_on_debates`, and not `recommendations_for_debates`.
