### PR TITLE
Fix poll results accuracy

### DIFF
--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -46,7 +46,7 @@ class Poll::Question::Answer < ActiveRecord::Base
   end
 
   def total_votes_percentage
-    question.answers_total_votes.zero? ? 0 : (total_votes * 100) / question.answers_total_votes
+    question.answers_total_votes.zero? ? 0 : (total_votes * 100.0) / question.answers_total_votes
   end
 
   def set_most_voted

--- a/spec/features/polls/results_spec.rb
+++ b/spec/features/polls/results_spec.rb
@@ -42,14 +42,14 @@ feature 'Poll Results' do
     expect(page).to have_content(question2.title)
 
     within("#question_#{question1.id}_results_table") do
-      expect(find("#answer_#{answer1.id}_result")).to have_content("2 (66.0%)")
-      expect(find("#answer_#{answer2.id}_result")).to have_content("1 (33.0%)")
+      expect(find("#answer_#{answer1.id}_result")).to have_content("2 (66.67%)")
+      expect(find("#answer_#{answer2.id}_result")).to have_content("1 (33.33%)")
     end
 
     within("#question_#{question2.id}_results_table") do
-      expect(find("#answer_#{answer3.id}_result")).to have_content("1 (33.0%)")
-      expect(find("#answer_#{answer4.id}_result")).to have_content("1 (33.0%)")
-      expect(find("#answer_#{answer5.id}_result")).to have_content("1 (33.0%)")
+      expect(find("#answer_#{answer3.id}_result")).to have_content("1 (33.33%)")
+      expect(find("#answer_#{answer4.id}_result")).to have_content("1 (33.33%)")
+      expect(find("#answer_#{answer5.id}_result")).to have_content("1 (33.33%)")
     end
   end
 end


### PR DESCRIPTION
Poll's questions results were returning integer instead of floats. This PR increase accuracy using a float value (as expected in the view).
This PR closes #3004