### PR TITLE
[Backport] Admin menu link

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -9,11 +9,7 @@ module AdminHelper
   end
 
   def namespaced_root_path
-    if namespace == 'moderation/budgets'
-      "/moderation"
-    else
-      "/#{namespace}"
-    end
+    "/#{namespace}"
   end
 
   def namespaced_header_title
@@ -95,7 +91,7 @@ module AdminHelper
   private
 
     def namespace
-      controller.class.parent.name.downcase.gsub("::", "/")
+      controller.class.name.downcase.split("::").first
     end
 
 end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -27,7 +27,7 @@ module BudgetsHelper
 
   def namespaced_budget_investment_path(investment, options = {})
     case namespace
-    when "management/budgets"
+    when "management"
       management_budget_investment_path(investment.budget, investment, options)
     else
       budget_investment_path(investment.budget, investment, options)
@@ -36,7 +36,7 @@ module BudgetsHelper
 
   def namespaced_budget_investment_vote_path(investment, options = {})
     case namespace
-    when "management/budgets"
+    when "management"
       vote_management_budget_investment_path(investment.budget, investment, options)
     else
       vote_budget_investment_path(investment.budget, investment, options)

--- a/spec/features/admin/homepage/homepage_spec.rb
+++ b/spec/features/admin/homepage/homepage_spec.rb
@@ -19,7 +19,16 @@ feature 'Homepage' do
   let(:user_recommendations) { Setting.where(key: 'feature.user.recommendations').first }
   let(:user)                 { create(:user) }
 
-  scenario "Header" do
+  context "Header" do
+
+    scenario "Admin menu links to homepage path" do
+
+      visit new_admin_widget_card_path(header_card: true)
+
+      click_link Setting['org_name'] + " Administration"
+
+      expect(page).to have_current_path(admin_root_path)
+    end
   end
 
   context "Feeds" do


### PR DESCRIPTION
References
===================
This closes https://github.com/consul/consul/issues/2997

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1699

## Objectives

This PR fixes admin menu link when create a new widget avoiding the 404 error when clic on admin menu from `/admin/widget/cards/new`.

Now the header link redirects correctly to `/admin`.