### PR TITLE
Add web sections to seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -132,3 +132,8 @@ Setting['feature.homepage.widgets.feeds.proposals'] = true
 Setting['feature.homepage.widgets.feeds.debates'] = true
 Setting['feature.homepage.widgets.feeds.processes'] = true
 
+WebSection.create(name: 'homepage')
+WebSection.create(name: 'debates')
+WebSection.create(name: 'proposals')
+WebSection.create(name: 'budgets')
+WebSection.create(name: 'help_page')


### PR DESCRIPTION
References
===================
> Add references to related Issues/Pull Requests/Travis Builds/Rollbar errors/etc...

Objectives
===================
Add web sections in the normal seeds so users can create banners and enable them on some sections

Visual Changes
===================
Before

![capture d ecran 2018-11-13 a 17 39 04](https://user-images.githubusercontent.com/7223028/48428485-69f54a00-e76b-11e8-844a-4f7fcdca25f0.png)

After

![capture d ecran 2018-11-13 a 17 41 32](https://user-images.githubusercontent.com/7223028/48428477-6661c300-e76b-11e8-97eb-16231351bed8.png)

Notes
===================
- This is just updating the seeds, not any code of the app.
- Those who want the same result without re-running the seeds can just run `rake web_sections:generate`.