### PR TITLE
[Backport] Legislation dates

### DIFF
--- a/app/helpers/legislation_helper.rb
+++ b/app/helpers/legislation_helper.rb
@@ -1,6 +1,6 @@
 module LegislationHelper
   def format_date(date)
-    l(date, format: "%d %h %Y") if date
+    l(date, format: "%d %b %Y") if date
   end
 
   def format_date_for_calendar_form(date)

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -47,6 +47,21 @@ feature 'Legislation' do
       end
     end
 
+    scenario 'Key dates are displayed on current locale' do
+      process = create(:legislation_process, proposals_phase_start_date: Date.new(2018, 01, 01),
+                                             proposals_phase_end_date: Date.new(2018, 12, 01))
+
+      visit legislation_process_path(process)
+
+      expect(page).to have_content("Proposals")
+      expect(page).to have_content("01 Jan 2018 - 01 Dec 2018")
+
+      visit legislation_process_path(process, locale: "es")
+
+      expect(page).to have_content("Propuestas")
+      expect(page).to have_content("01 ene 2018 - 01 dic 2018")
+    end
+
     scenario 'Filtering processes' do
       create(:legislation_process, title: "Process open")
       create(:legislation_process, :next, title: "Process next")


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1702

## Objectives

This PR fixes date format on legislation helper.
Changing `format: "%d %h %Y"` to `format: "%d %b %Y"`

## Visual Changes
Before _key dates_ were shown always on `en` format:
![screenshot 2018-11-13 at 11 15 07](https://user-images.githubusercontent.com/631897/48406874-dce3ce00-e735-11e8-9da4-2ebae34058c2.png)

With this changes when the locale is `es` displays dates correctly:
![screenshot 2018-11-13 at 11 15 18](https://user-images.githubusercontent.com/631897/48407029-2cc29500-e736-11e8-9fe0-96bea5b7f314.png)

## Notes

On [apidock strftime docs](https://apidock.com/ruby/DateTime/strftime) it seems `%h` is equivalent to `%b` but the first option doesn't work correctly when change locale because [I18n translates %b but not %h](https://github.com/svenfuchs/i18n/blob/master/lib/i18n/backend/base.rb#L249).