### PR TITLE
[Backport] Help feature

### DIFF
--- a/app/views/debates/new.html.erb
+++ b/app/views/debates/new.html.erb
@@ -7,8 +7,11 @@
     <div data-alert class="callout primary">
       <%= t("debates.new.info",
       info_link: link_to(t("debates.new.info_link"), new_proposal_path )).html_safe %>
-      <%= link_to help_path, title: t('shared.target_blank_html'), target: "_blank" do %>
-        <strong><%= t("debates.new.more_info") %></strong>
+
+      <% if feature?(:help_page) %>
+        <%= link_to help_path, title: t("shared.target_blank_html"), target: "_blank" do %>
+          <strong><%= t("debates.new.more_info") %></strong>
+        <% end %>
       <% end %>
     </div>
     <%= render "form" %>

--- a/app/views/pages/help/how_to_use/index.html.erb
+++ b/app/views/pages/help/how_to_use/index.html.erb
@@ -4,7 +4,9 @@
 
 <div class="row margin-top">
   <div class="text small-12 column">
-    <%= back_link_to help_path %>
+    <% if feature?(:help_page) %>
+      <%= back_link_to help_path %>
+    <% end %>
 
     <h1><%= t('pages.help.titles.how_to_use') %></h1>
 

--- a/app/views/welcome/welcome.html.erb
+++ b/app/views/welcome/welcome.html.erb
@@ -40,7 +40,11 @@
     <%= link_to(t("welcome.welcome.user_permission_verify_my_account"), verification_path, class: "button success radius expand") %>
   <% end %>
 
-  <p class="text-center">
-    <%= link_to t("welcome.welcome.go_to_index"), proposals_path %>
+  <p>
+    <% if feature?(:help_page) %>
+      <%= link_to t("welcome.welcome.go_to_index"), help_path %>
+    <% else %>
+      <%= link_to t("welcome.welcome.go_to_index"), root_path %>
+    <% end  %>
   </p>
 </div>

--- a/db/dev_seeds/widgets.rb
+++ b/db/dev_seeds/widgets.rb
@@ -21,7 +21,7 @@ section "Creating header and cards for the homepage" do
     label_en: 'Welcome to',
     label_es: 'Bienvenido a',
 
-    link_url: 'help_path',
+    link_url: 'http://consulproject.org/',
     header: TRUE,
     image_attributes: create_image_attachment('header')
   )


### PR DESCRIPTION
## References
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1705/commits

## Objectives

There is some `help_path` links by default on the code. Whit this PR these links only shows if feature `:help_page` is enabled.

Also updates link url on dev seed widgets because `help_path` was generating a nonexistent  url `https://localhost:3000/help_path`.