### PR TITLE
[Backport] Budget investment show

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -156,7 +156,7 @@
           <div class="callout success">
             <%= t("budgets.investments.show.project_selected_html") %>
           </div>
-        <% elsif !investment.selected? && @budget.balloting_or_later? %>
+        <% elsif @budget.balloting_or_later? %>
           <div class="callout warning">
             <%= t("budgets.investments.show.project_not_selected_html") %>
           </div>

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1063,6 +1063,25 @@ feature 'Budget Investments' do
     expect(page).to have_content("This investment project has not been selected for balloting phase")
   end
 
+  scenario "Show title (no message)" do
+    user = create(:user)
+    login_as(user)
+
+    investment = create(:budget_investment,
+                        :feasible,
+                        :finished,
+                        budget: budget,
+                        group: group,
+                        heading: heading)
+
+    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+
+    within("aside") do
+      expect(page).to have_content("Investment project")
+      expect(page).to have_css(".label-budget-investment")
+    end
+  end
+
   scenario "Show (unfeasible budget investment with valuation not finished)" do
     user = create(:user)
     login_as(user)


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1707/

Objectives
===================
This PR:

- Removes unnecessary condition when display unselected message. 
- Adds spec when no message is displayed. Should show only "Investment project" label.
