### PR TITLE
Maintain translations for other languages after updatin main language

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,7 @@
 files:
   - source: /config/locales/en/**.yml
     translation: /config/locales/%locale%/%original_file_name%
+    update_option: update_without_changes
     languages_mapping:
       locale:
         ar: ar


### PR DESCRIPTION
References
===================
**PR Crowdin bot**: https://github.com/consul/consul/pull/3019

Objectives
===================
When [updating the translation for an English key](https://github.com/consul/consul/pull/3011/files#diff-76ed21d657018eb0c7461bab305d06edR341) (the base language) Crowdin was [removing that key](https://github.com/consul/consul/pull/3019/files#diff-2dfa07ac78be4dc2732fed2bd9a7f873L120) from all other languages.

As suggested by the Crowdin Support Team, with the [update_option](https://support.crowdin.com/api/update-file/) configuration, translations for other languages should be maintained.
