### PR TITLE
Maintains  orbit-wrapper div's height

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2380,7 +2380,7 @@ table {
       height: rem-calc(480);
 
       .orbit-wrapper {
-        max-height: rem-calc(450);
+        min-height: rem-calc(450);
       }
     }
 


### PR DESCRIPTION
References
===================
#3044 

Objectives
===================
While attempting to recreate the bug from #3044 I saw that if the recommended debate or proposal did not contain enough text to fill the orbit-wrapper div that the orbit-bullets div could move up.  This small change makes the orbit-wrapper a consistent size regardless of how much text is in the post so the orbit-bullets div won't move up.

Visual Changes
===================
![buttons](https://user-images.githubusercontent.com/26209735/48665951-2742b300-ea86-11e8-9959-2eaa26f8c0af.png)



Notes
===================
You will need to set `Setting['feature.user.recommendations']` in `spec/features/admin/homepage/homepage_spec.rb` to `true` to see the recommendation carousel 
