### PR TITLE
[Backport] Budget investments social share

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -179,13 +179,17 @@
           </div>
         <% end %>
 
-        <%= render partial: 'shared/social_share', locals: {
+        <%= render 'shared/social_share',
           share_title: t("budgets.investments.show.share"),
           title: investment.title,
           image_url: image_absolute_url(investment.image, :thumb),
           url: budget_investment_url(investment.budget, investment),
-          description: investment.title
-        } %>
+          description: t("budgets.investments.share.message",
+                          title: investment.title,
+                          org: setting['org_name']),
+          mobile: t("budgets.investments.share.message_mobile",
+                     title: investment.title,
+                     handle: setting['twitter_handle']) %>
 
         <% if current_user %>
           <div class="sidebar-divider"></div>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -105,6 +105,9 @@ en:
           random: random
           confidence_score: highest rated
           price: by price
+      share:
+        message: "I created the investment project %{title} in %{org}. Create an investment project you too!"
+        message_mobile: "I created the investment project %{title} in %{handle}. Create an investment project you too!"
       show:
         author_deleted: User deleted
         price_explanation: Price explanation

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -105,6 +105,9 @@ es:
           random: Aleatorios
           confidence_score: Mejor valorados
           price: Por coste
+      share:
+        message: "He presentado el proyecto %{title} en %{org}. ¡Presenta un proyecto tú también!"
+        message_mobile: "He presentado el proyecto %{title} en %{handle}. ¡Presenta un proyecto tú también!"
       show:
         author_deleted: Usuario eliminado
         price_explanation: Informe de coste


### PR DESCRIPTION
## References
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1709

## Objectives

Improves social share message to budget investments.

## Visual Changes

**BEFORE**
![before](https://user-images.githubusercontent.com/631897/48486885-fa3f9780-e81c-11e8-85e4-5f11682069df.png)

**AFTER**
![after](https://user-images.githubusercontent.com/631897/48486891-fca1f180-e81c-11e8-8145-0d16fa02abd2.png)
