### PR TITLE
[Backport] Admin poll officers

### DIFF
--- a/app/controllers/admin/poll/officers_controller.rb
+++ b/app/controllers/admin/poll/officers_controller.rb
@@ -30,10 +30,4 @@ class Admin::Poll::OfficersController < Admin::Poll::BaseController
     redirect_to admin_officers_path
   end
 
-  def show
-  end
-
-  def edit
-  end
-
 end

--- a/app/views/admin/poll/officers/edit.html.erb
+++ b/app/views/admin/poll/officers/edit.html.erb
@@ -1,1 +1,0 @@
-officer edit

--- a/app/views/admin/poll/officers/show.html.erb
+++ b/app/views/admin/poll/officers/show.html.erb
@@ -1,1 +1,0 @@
-officer show

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -133,7 +133,7 @@ namespace :admin do
       resources :results, only: :index
     end
 
-    resources :officers do
+    resources :officers, only: [:index, :new, :create, :destroy] do
       get :search, on: :collection
     end
 


### PR DESCRIPTION
## References
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1711/

## Objectives

Removes unused admin poll officers views, routes and controller for `edit` and `show`.