### PR TITLE
Fix failing spec: Poll::Shift officer_assignments creates and destroy corresponding officer_assignments

### DIFF
--- a/app/models/poll/shift.rb
+++ b/app/models/poll/shift.rb
@@ -24,7 +24,7 @@ class Poll
     end
 
     def create_officer_assignments
-      booth.booth_assignments.each do |booth_assignment|
+      booth.booth_assignments.order(:id).each do |booth_assignment|
         attrs = {
           officer_id:          officer_id,
           date:                date,


### PR DESCRIPTION
Hi @javierm I finally saw the failing spec you mentioned 🎉 

References
===================
Issue https://github.com/consul/consul/issues/3060

Notes
===================
closes https://github.com/consul/consul/issues/3060