### PR TITLE
Add missing feature spec: Admin poll questions Create from successful proposal show

### DIFF
--- a/spec/features/admin/poll/questions_spec.rb
+++ b/spec/features/admin/poll/questions_spec.rb
@@ -72,7 +72,16 @@ feature 'Admin poll questions' do
     expect(page).to have_link(proposal.author.name, href: user_path(proposal.author))
   end
 
-  pending "Create from successul proposal show"
+  scenario "Create from successful proposal show" do
+    poll = create(:poll, name: 'Proposals')
+    proposal = create(:proposal, :successful)
+
+    visit proposal_path(proposal)
+    click_link "Create question"
+
+    expect(page).to have_current_path(new_admin_question_path, ignore_query: true)
+    expect(page).to have_field('Question', with: proposal.title)
+  end
 
   scenario 'Update' do
     question1 = create(:poll_question)


### PR DESCRIPTION
Objectives
===================
I saw this feature spec wasn't implemented and I thought it was a good idea to have it.