### PR TITLE
Fix failing spec: Budget::Investment Reclassification store_reclassified_votes stores the votes for a reclassified investment

### DIFF
--- a/app/models/budget/reclassification.rb
+++ b/app/models/budget/reclassification.rb
@@ -30,7 +30,7 @@ class Budget
     end
 
     def store_reclassified_votes(reason)
-      ballot_lines_for_investment.each do |line|
+      ballot_lines_for_investment.order(:id).each do |line|
         attrs = { user: line.ballot.user,
                   investment: self,
                   reason: reason }


### PR DESCRIPTION
References
===================
Issue https://github.com/consul/consul/issues/3051

Notes
===================
original PR was https://github.com/consul/consul/pull/3052/
closes https://github.com/consul/consul/issues/3051