### PR TITLE
[Backport] Fix flaky spec: Welcome screen is not shown to organizations 

### DIFF
--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -112,7 +112,7 @@ feature "Home" do
   end
 
   feature 'IE alert' do
-    scenario 'IE visitors are presented with an alert until they close it' do
+    scenario 'IE visitors are presented with an alert until they close it', :page_driver do
       # Selenium API does not include page request/response inspection methods
       # so we must use Capybara::RackTest driver to set the browser's headers
       Capybara.current_session.driver.header(
@@ -133,7 +133,7 @@ feature "Home" do
       expect(page.driver.request.cookies['ie_alert_closed']).to eq('true')
     end
 
-    scenario 'non-IE visitors are not bothered with IE alerts' do
+    scenario 'non-IE visitors are not bothered with IE alerts', :page_driver do
       visit root_path
       expect(page).not_to have_xpath(ie_alert_box_xpath, visible: false)
       expect(page.driver.request.cookies['ie_alert_closed']).to be_nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,10 @@ RSpec.configure do |config|
     end
   end
 
+  config.after(:each, :page_driver) do
+    page.driver.reset!
+  end
+
   config.before(:each, type: :feature) do
     Capybara.reset_sessions!
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,10 +64,6 @@ RSpec.configure do |config|
     page.driver.reset!
   end
 
-  config.before(:each, type: :feature) do
-    Capybara.reset_sessions!
-  end
-
   config.before do
     DatabaseCleaner.start
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'knapsack_pro'
 
 Dir["./spec/models/concerns/*.rb"].each { |f| require f }
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
-Dir["./spec/shared/**/*.rb"].sort.each { |f| require f }
+Dir["./spec/shared/**/*.rb"].sort.each  { |f| require f }
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = false
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   config.include(EmailSpec::Matchers)
   config.include(CommonActions)
   config.include(ActiveSupport::Testing::TimeHelpers)
+
   config.before(:suite) do
     DatabaseCleaner.clean_with :truncation
   end


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1624
* Closes AyuntamientoMadrid#1623

## Notes

* Part of the code changed in the original pull request doesn't exist in CONSUL, and so there was no need to change it
* The file `spec/spec_helper.rb` is now identical to the one in Madrid's fork