### PR TITLE
[Backport] Removes references to deleted general terms page

### DIFF
--- a/config/locales/es/pages.yml
+++ b/config/locales/es/pages.yml
@@ -4,7 +4,6 @@ es:
       title: Condiciones de uso
       subtitle: AVISO LEGAL SOBRE LAS CONDICIONES DE USO, PRIVACIDAD Y PROTECCIÓN DE DATOS PERSONALES DEL PORTAL DE GOBIERNO ABIERTO
       description: Página de información sobre las condiciones de uso, privacidad y protección de datos personales.
-    general_terms: Términos y Condiciones
     help:
       title: "%{org} es una plataforma de participación ciudadana"
       guide: "Esta guía explica para qué sirven y cómo funcionan cada una de las secciones de %{org}."

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -10,11 +10,6 @@ SitemapGenerator::Sitemap.default_host = Setting["url"]
 
 # sitemap generator
 SitemapGenerator::Sitemap.create do
-  pages = ["general_terms"]
-  pages.each do |page|
-    add page_path(id: page)
-  end
-
   add help_path
   add how_to_use_path
   add faq_path

--- a/spec/lib/tasks/sitemap_spec.rb
+++ b/spec/lib/tasks/sitemap_spec.rb
@@ -32,7 +32,6 @@ feature 'rake sitemap:create' do
     expect(sitemap).to include(faq_path)
     expect(sitemap).to include(help_path)
     expect(sitemap).to include(how_to_use_path)
-    expect(sitemap).to include(page_path(id: 'general_terms'))
 
     # Dynamic URLs
     expect(sitemap).to include(polls_path)


### PR DESCRIPTION
References
===================
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1723

Objectives
===================
Recently we add https://github.com/consul/consul/pull/3042 to remove some unnecessary empty pages.

This PR removes some references to deleted general terms page.
