### PR TITLE
[Backport] Fix flaky spec: Legislation Proposals Each user has a different and consistent random proposals order

### DIFF
--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -118,9 +118,11 @@ class Legislation::ProcessesController < Legislation::BaseController
 
     def set_random_seed
       seed = (params[:random_seed] || session[:random_seed] || (rand(99) / 100.0)).to_f
+      seed = (-1..1).cover?(seed) ? seed : 1
+
       session[:random_seed] = seed
       params[:random_seed] = seed
-      seed = (-1..1).cover?(seed) ? seed : 1
+
       ::Legislation::Proposal.connection.execute "select setseed(#{seed})"
     end
 end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -117,12 +117,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     end
 
     def set_random_seed
-      seed = begin
-               Float(params[:random_seed] || session[:random_seed] || (rand(99) / 100.0))
-             rescue
-               0
-             end
-
+      seed = (params[:random_seed] || session[:random_seed] || (rand(99) / 100.0)).to_f
       session[:random_seed] = seed
       params[:random_seed] = seed
       seed = (-1..1).cover?(seed) ? seed : 1

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -122,7 +122,9 @@ class Legislation::ProcessesController < Legislation::BaseController
              rescue
                0
              end
-      session[:random_seed], params[:random_seed] = seed
+
+      session[:random_seed] = seed
+      params[:random_seed] = seed
       seed = (-1..1).cover?(seed) ? seed : 1
       ::Legislation::Proposal.connection.execute "select setseed(#{seed})"
     end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -117,7 +117,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     end
 
     def set_random_seed
-      seed = (params[:random_seed] || session[:random_seed] || (rand(99) / 100.0)).to_f
+      seed = (params[:random_seed] || session[:random_seed] || rand).to_f
       seed = (-1..1).cover?(seed) ? seed : 1
 
       session[:random_seed] = seed

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -29,7 +29,7 @@ feature 'Legislation Proposals' do
       )
     end
 
-    scenario 'Each user has a different and consistent random proposals order', :js do
+    scenario "Each user has a different and consistent random proposals order", :js do
       in_browser(:one) do
         login_as user
         visit legislation_process_proposals_path(process)
@@ -55,23 +55,23 @@ feature 'Legislation Proposals' do
       end
     end
 
-    scenario 'Random order maintained with pagination', :js do
+    scenario "Random order maintained with pagination", :js do
       login_as user
       visit legislation_process_proposals_path(process)
       first_page_proposals_order = legislation_proposals_order
 
-      click_link 'Next'
+      click_link "Next"
 
       expect(page).to have_content "You're on page 2"
       expect(first_page_proposals_order & legislation_proposals_order).to eq([])
 
-      click_link 'Previous'
+      click_link "Previous"
 
       expect(page).to have_content "You're on page 1"
       expect(legislation_proposals_order).to eq(first_page_proposals_order)
     end
 
-    scenario 'Does not crash when the seed is not a number' do
+    scenario "Does not crash when the seed is not a number" do
       login_as user
       visit legislation_process_proposals_path(process, random_seed: "Spoof")
 

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -61,11 +61,13 @@ feature 'Legislation Proposals' do
       first_page_proposals_order = legislation_proposals_order
 
       click_link 'Next'
+
       expect(page).to have_content "You're on page 2"
+      expect(first_page_proposals_order & legislation_proposals_order).to eq([])
 
       click_link 'Previous'
-      expect(page).to have_content "You're on page 1"
 
+      expect(page).to have_content "You're on page 1"
       expect(legislation_proposals_order).to eq(first_page_proposals_order)
     end
 

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -64,6 +64,19 @@ feature 'Legislation Proposals' do
     expect(legislation_proposals_order).to eq(first_page_proposals_order)
   end
 
+  scenario 'Does not crash when the seed is not a number' do
+    create_list(
+      :legislation_proposal,
+      (Legislation::Proposal.default_per_page + 2),
+      process: process
+    )
+
+    login_as user
+    visit legislation_process_proposals_path(process, random_seed: "Spoof")
+
+    expect(page).to have_content "You're on page 1"
+  end
+
   context 'Selected filter' do
     scenario 'apperars even if there are not any selected poposals' do
       create(:legislation_proposal, legislation_process_id: process.id)

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -22,6 +22,8 @@ feature 'Legislation Proposals' do
 
   feature "Random pagination" do
     before do
+      allow(Legislation::Proposal).to receive(:default_per_page).and_return(12)
+
       create_list(
         :legislation_proposal,
         (Legislation::Proposal.default_per_page + 2),

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -20,61 +20,61 @@ feature 'Legislation Proposals' do
     end
   end
 
-  scenario 'Each user has a different and consistent random proposals order', :js do
-    create_list(:legislation_proposal, 10, process: process)
+  feature "Random pagination" do
+    before do
+      create_list(
+        :legislation_proposal,
+        (Legislation::Proposal.default_per_page + 2),
+        process: process
+      )
+    end
 
-    in_browser(:one) do
+    scenario 'Each user has a different and consistent random proposals order', :js do
+      in_browser(:one) do
+        login_as user
+        visit legislation_process_proposals_path(process)
+        @first_user_proposals_order = legislation_proposals_order
+      end
+
+      in_browser(:two) do
+        login_as user2
+        visit legislation_process_proposals_path(process)
+        @second_user_proposals_order = legislation_proposals_order
+      end
+
+      expect(@first_user_proposals_order).not_to eq(@second_user_proposals_order)
+
+      in_browser(:one) do
+        visit legislation_process_proposals_path(process)
+        expect(legislation_proposals_order).to eq(@first_user_proposals_order)
+      end
+
+      in_browser(:two) do
+        visit legislation_process_proposals_path(process)
+        expect(legislation_proposals_order).to eq(@second_user_proposals_order)
+      end
+    end
+
+    scenario 'Random order maintained with pagination', :js do
       login_as user
       visit legislation_process_proposals_path(process)
-      @first_user_proposals_order = legislation_proposals_order
+      first_page_proposals_order = legislation_proposals_order
+
+      click_link 'Next'
+      expect(page).to have_content "You're on page 2"
+
+      click_link 'Previous'
+      expect(page).to have_content "You're on page 1"
+
+      expect(legislation_proposals_order).to eq(first_page_proposals_order)
     end
 
-    in_browser(:two) do
-      login_as user2
-      visit legislation_process_proposals_path(process)
-      @second_user_proposals_order = legislation_proposals_order
+    scenario 'Does not crash when the seed is not a number' do
+      login_as user
+      visit legislation_process_proposals_path(process, random_seed: "Spoof")
+
+      expect(page).to have_content "You're on page 1"
     end
-
-    expect(@first_user_proposals_order).not_to eq(@second_user_proposals_order)
-
-    in_browser(:one) do
-      visit legislation_process_proposals_path(process)
-      expect(legislation_proposals_order).to eq(@first_user_proposals_order)
-    end
-
-    in_browser(:two) do
-      visit legislation_process_proposals_path(process)
-      expect(legislation_proposals_order).to eq(@second_user_proposals_order)
-    end
-  end
-
-  scenario 'Random order maintained with pagination', :js do
-    create_list(:legislation_proposal, (Kaminari.config.default_per_page + 2), process: process)
-
-    login_as user
-    visit legislation_process_proposals_path(process)
-    first_page_proposals_order = legislation_proposals_order
-
-    click_link 'Next'
-    expect(page).to have_content "You're on page 2"
-
-    click_link 'Previous'
-    expect(page).to have_content "You're on page 1"
-
-    expect(legislation_proposals_order).to eq(first_page_proposals_order)
-  end
-
-  scenario 'Does not crash when the seed is not a number' do
-    create_list(
-      :legislation_proposal,
-      (Legislation::Proposal.default_per_page + 2),
-      process: process
-    )
-
-    login_as user
-    visit legislation_process_proposals_path(process, random_seed: "Spoof")
-
-    expect(page).to have_content "You're on page 1"
   end
 
   context 'Selected filter' do


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1660
* Pull request #3076 
* Closes AyuntamientoMadrid#1659