### PR TITLE
[Backport] New algorithm for filter 'most active'

### DIFF
--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -122,14 +122,11 @@ class Debate < ActiveRecord::Base
   end
 
   def after_commented
-    save # updates the hot_score because there is a before_save
+    save # update cache when it has a new comment
   end
 
   def calculate_hot_score
-    self.hot_score = ScoreCalculator.hot_score(created_at,
-                                               cached_votes_total,
-                                               cached_votes_up,
-                                               comments_count)
+    self.hot_score = ScoreCalculator.hot_score(self)
   end
 
   def calculate_confidence_score

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -121,14 +121,11 @@ class Legislation::Proposal < ActiveRecord::Base
   end
 
   def after_commented
-    save # updates the hot_score because there is a before_save
+    save # update cache when it has a new comment
   end
 
   def calculate_hot_score
-    self.hot_score = ScoreCalculator.hot_score(created_at,
-                                               total_votes,
-                                               total_votes,
-                                               comments_count)
+    self.hot_score = ScoreCalculator.hot_score(self)
   end
 
   def calculate_confidence_score

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -166,14 +166,11 @@ class Proposal < ActiveRecord::Base
   end
 
   def after_commented
-    save # updates the hot_score because there is a before_save
+    save # update cache when it has a new comment
   end
 
   def calculate_hot_score
-    self.hot_score = ScoreCalculator.hot_score(created_at,
-                                               total_votes,
-                                               total_votes,
-                                               comments_count)
+    self.hot_score = ScoreCalculator.hot_score(self)
   end
 
   def calculate_confidence_score

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -52,6 +52,8 @@ en:
     place_name_description: "Name of your city"
     related_content_score_threshold: "Related content score threshold"
     related_content_score_threshold_description: "Hides content that users mark as unrelated"
+    hot_score_period_in_days: "Period (days) used by the filter 'most active'"
+    hot_score_period_in_days_description: "The filter 'most active' used in multiple sections will be based on the votes during the last X days"
     map_latitude: "Latitude"
     map_latitude_description: "Latitude to show the map position"
     map_longitude: "Longitude"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -106,7 +106,7 @@ es:
       orders:
         confidence_score: Mejor valorados
         created_at: Nuevos
-        hot_score: Más activos hoy
+        hot_score: Más activos
         most_commented: Más comentados
         relevance: Más relevantes
         recommendations: Recomendaciones
@@ -346,7 +346,7 @@ es:
       orders:
         confidence_score: Más apoyadas
         created_at: Nuevas
-        hot_score: Más activas hoy
+        hot_score: Más activas
         most_commented: Más comentadas
         relevance: Más relevantes
         archival_date: Archivadas

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -52,6 +52,8 @@ es:
     place_name_description: "Nombre de tu ciudad"
     related_content_score_threshold: "Umbral de puntuación de contenido relacionado"
     related_content_score_threshold_description: "Oculta el contenido que los usuarios marquen como no relacionado"
+    hot_score_period_in_days: "Periodo (días) usado para el filtro 'Más Activos'"
+    hot_score_period_in_days_description: "El filtro 'Más Activos' usado en diferentes secciones se basará en los votos de los últimos X días"
     map_latitude: "Latitud"
     map_latitude_description: "Latitud para mostrar la posición del mapa"
     map_longitude: "Longitud"

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -69,6 +69,7 @@ section "Creating Settings" do
   Setting.create(key: 'featured_proposals_number', value: 3)
 
   Setting.create(key: 'related_content_score_threshold', value: -0.3)
+  Setting.create(key: 'hot_score_period_in_days', value: 31)
 
   Setting['feature.homepage.widgets.feeds.proposals'] = true
   Setting['feature.homepage.widgets.feeds.debates'] = true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -136,6 +136,9 @@ Setting['feature.homepage.widgets.feeds.proposals'] = true
 Setting['feature.homepage.widgets.feeds.debates'] = true
 Setting['feature.homepage.widgets.feeds.processes'] = true
 
+# Votes hot_score configuration
+Setting['hot_score_period_in_days'] = 31
+
 WebSection.create(name: 'homepage')
 WebSection.create(name: 'debates')
 WebSection.create(name: 'proposals')

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -31,4 +31,9 @@ namespace :settings do
     Setting['featured_proposals_number'] = 3
   end
 
+  desc "Create new period to calculate hot_score"
+  task create_hot_score_period_setting: :environment do
+    Setting['hot_score_period_in_days'] = 31
+  end
+
 end

--- a/lib/tasks/votes.rake
+++ b/lib/tasks/votes.rake
@@ -13,4 +13,15 @@ namespace :votes do
 
   end
 
+  desc "Resets hot_score to its new value"
+  task reset_hot_score: :environment do
+    models = [Debate, Proposal, Legislation::Proposal]
+
+    models.each do |model|
+      model.find_each do |resource|
+        resource.save
+        print "."
+      end
+    end
+  end
 end

--- a/spec/models/legislation/proposal_spec.rb
+++ b/spec/models/legislation/proposal_spec.rb
@@ -27,4 +27,82 @@ describe Legislation::Proposal do
     expect(proposal).not_to be_valid
   end
 
+  describe '#hot_score' do
+    let(:now) { Time.current }
+
+    it "period is correctly calculated to get exact votes per day" do
+      new_proposal = create(:legislation_proposal, created_at: 23.hours.ago)
+      2.times { new_proposal.vote_by(voter: create(:user), vote: "yes") }
+      expect(new_proposal.hot_score).to be 2
+
+      old_proposal = create(:legislation_proposal, created_at: 25.hours.ago)
+      2.times { old_proposal.vote_by(voter: create(:user), vote: "yes") }
+      expect(old_proposal.hot_score).to be 1
+
+      older_proposal = create(:legislation_proposal, created_at: 49.hours.ago)
+      3.times { older_proposal.vote_by(voter: create(:user), vote: "yes") }
+      expect(old_proposal.hot_score).to be 1
+    end
+
+    it "remains the same for not voted proposals" do
+      new = create(:legislation_proposal, created_at: now)
+      old = create(:legislation_proposal, created_at: 1.day.ago)
+      older = create(:legislation_proposal, created_at: 2.month.ago)
+      expect(new.hot_score).to be 0
+      expect(old.hot_score).to be 0
+      expect(older.hot_score).to be 0
+    end
+
+    it "increases for proposals with more positive votes" do
+      more_positive_votes = create(:legislation_proposal)
+      2.times { more_positive_votes.vote_by(voter: create(:user), vote: "yes") }
+
+      less_positive_votes = create(:legislation_proposal)
+      less_positive_votes.vote_by(voter: create(:user), vote: "yes")
+
+      expect(more_positive_votes.hot_score).to be > less_positive_votes.hot_score
+    end
+
+    it "increases for proposals with the same amount of positive votes within less days" do
+      newer_proposal = create(:legislation_proposal, created_at: now)
+      5.times { newer_proposal.vote_by(voter: create(:user), vote: "yes") }
+
+      older_proposal = create(:legislation_proposal, created_at: 1.day.ago)
+      5.times { older_proposal.vote_by(voter: create(:user), vote: "yes") }
+
+      expect(newer_proposal.hot_score).to be > older_proposal.hot_score
+    end
+
+    it "increases for proposals voted within the period (last month by default)" do
+      newer_proposal = create(:legislation_proposal, created_at: 2.months.ago)
+      20.times { create(:vote, votable: newer_proposal, created_at: 3.days.ago) }
+
+      older_proposal = create(:legislation_proposal, created_at: 2.months.ago)
+      20.times { create(:vote, votable: older_proposal, created_at: 40.days.ago) }
+
+      expect(newer_proposal.hot_score).to be > older_proposal.hot_score
+    end
+
+    describe 'actions which affect it' do
+
+      let(:proposal) { create(:legislation_proposal) }
+
+      before do
+        5.times { proposal.vote_by(voter: create(:user), vote: "yes") }
+        2.times { proposal.vote_by(voter: create(:user), vote: "no") }
+      end
+
+      it "increases with positive votes" do
+        previous = proposal.hot_score
+        3.times { proposal.vote_by(voter: create(:user), vote: "yes") }
+        expect(previous).to be < proposal.hot_score
+      end
+
+      it "decreases with negative votes" do
+        previous = proposal.hot_score
+        3.times { proposal.vote_by(voter: create(:user), vote: "no") }
+        expect(previous).to be > proposal.hot_score
+      end
+    end
+  end
 end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -254,49 +254,78 @@ describe Proposal do
   describe '#hot_score' do
     let(:now) { Time.current }
 
-    it "increases for newer proposals" do
-      old = create(:proposal, :with_hot_score, created_at: now - 1.day)
-      new = create(:proposal, :with_hot_score, created_at: now)
-      expect(new.hot_score).to be > old.hot_score
+    it "period is correctly calculated to get exact votes per day" do
+      new_proposal = create(:proposal, created_at: 23.hours.ago)
+      2.times { new_proposal.vote_by(voter: create(:user), vote: "yes") }
+      expect(new_proposal.hot_score).to be 2
+
+      old_proposal = create(:proposal, created_at: 25.hours.ago)
+      2.times { old_proposal.vote_by(voter: create(:user), vote: "yes") }
+      expect(old_proposal.hot_score).to be 1
+
+      older_proposal = create(:proposal, created_at: 49.hours.ago)
+      3.times { older_proposal.vote_by(voter: create(:user), vote: "yes") }
+      expect(old_proposal.hot_score).to be 1
     end
 
-    it "increases for proposals with more comments" do
-      more_comments = create(:proposal, :with_hot_score, created_at: now, comments_count: 25)
-      less_comments = create(:proposal, :with_hot_score, created_at: now, comments_count: 1)
-      expect(more_comments.hot_score).to be > less_comments.hot_score
+    it "remains the same for not voted proposals" do
+      new = create(:proposal, created_at: now)
+      old = create(:proposal, created_at: 1.day.ago)
+      older = create(:proposal, created_at: 2.month.ago)
+      expect(new.hot_score).to be 0
+      expect(old.hot_score).to be 0
+      expect(older.hot_score).to be 0
     end
 
     it "increases for proposals with more positive votes" do
-      more_likes = create(:proposal, :with_hot_score, created_at: now, cached_votes_up: 5)
-      less_likes = create(:proposal, :with_hot_score, created_at: now, cached_votes_up: 1)
-      expect(more_likes.hot_score).to be > less_likes.hot_score
+      more_positive_votes = create(:proposal)
+      2.times { more_positive_votes.vote_by(voter: create(:user), vote: "yes") }
+
+      less_positive_votes = create(:proposal)
+      less_positive_votes.vote_by(voter: create(:user), vote: "yes")
+
+      expect(more_positive_votes.hot_score).to be > less_positive_votes.hot_score
     end
 
-    it "increases for proposals with more confidence" do
-      more_confidence = create(:proposal, :with_hot_score, created_at: now, cached_votes_up: 700)
-      less_confidence = create(:proposal, :with_hot_score, created_at: now, cached_votes_up: 9)
-      expect(more_confidence.hot_score).to be > less_confidence.hot_score
+    it "increases for proposals with the same amount of positive votes within less days" do
+      newer_proposal = create(:proposal, created_at: now)
+      5.times { newer_proposal.vote_by(voter: create(:user), vote: "yes") }
+
+      older_proposal = create(:proposal, created_at: 1.day.ago)
+      5.times { older_proposal.vote_by(voter: create(:user), vote: "yes") }
+
+      expect(newer_proposal.hot_score).to be > older_proposal.hot_score
     end
 
-    it "decays in older proposals, even if they have more votes" do
-      older_more_voted = create(:proposal, :with_hot_score, created_at: now - 5.days, cached_votes_up: 900)
-      new_less_voted   = create(:proposal, :with_hot_score, created_at: now, cached_votes_up: 9)
-      expect(new_less_voted.hot_score).to be > older_more_voted.hot_score
+    it "increases for proposals voted within the period (last month by default)" do
+      newer_proposal = create(:proposal, created_at: 2.months.ago)
+      20.times { create(:vote, votable: newer_proposal, created_at: 3.days.ago) }
+
+      older_proposal = create(:proposal, created_at: 2.months.ago)
+      20.times { create(:vote, votable: older_proposal, created_at: 40.days.ago) }
+
+      expect(newer_proposal.hot_score).to be > older_proposal.hot_score
     end
 
     describe 'actions which affect it' do
-      let(:proposal) { create(:proposal, :with_hot_score) }
 
-      it "increases with votes" do
-        previous = proposal.hot_score
-        5.times { proposal.register_vote(create(:user, verified_at: Time.current), true) }
-        expect(previous).to be < proposal.reload.hot_score
+      let(:proposal) { create(:proposal) }
+
+      before do
+        5.times { proposal.vote_by(voter: create(:user), vote: "yes") }
+        2.times { proposal.vote_by(voter: create(:user), vote: "no") }
       end
 
-      it "increases with comments" do
+      it "increases with positive votes" do
         previous = proposal.hot_score
-        25.times{ Comment.create(user: create(:user), commentable: proposal, body: 'foobarbaz') }
-        expect(previous).to be < proposal.reload.hot_score
+        3.times { proposal.vote_by(voter: create(:user), vote: "yes") }
+        expect(previous).to be < proposal.hot_score
+      end
+
+      it "decreases with negative votes" do
+        previous = proposal.hot_score
+        3.times { proposal.vote_by(voter: create(:user), vote: "no") }
+        expect(previous).to be > proposal.hot_score
       end
     end
   end


### PR DESCRIPTION
## References

Backports https://github.com/AyuntamientoMadrid/consul/pull/1742

## Objectives
With the new algorithm that calculates the `hot_score` we try to prioritize the Debates/Proposals that has received more positive votes per day within the recent period. This period is configurable in settings and is set to 1 month/31 days by default.

It will also have in consideration the negative votes (if applicable), so a Debate with same positive votes and less negative votes will have higher score.

## Notes

⚠️ For Release Notes:
A new Admin Setting has been added, execute the following rake task to add the Admin Setting to your existing DB. 
```
bin/rake settings:create_hot_score_period_setting RAILS_ENV=production
```
And the following rake task to recalculate the `hot_score` for all resources.

```
bin/rake votes:reset_hot_score RAILS_ENV=production
```