### PR TITLE
[Backport] Widgets dev seeds

### DIFF
--- a/db/dev_seeds/widgets.rb
+++ b/db/dev_seeds/widgets.rb
@@ -22,7 +22,7 @@ section "Creating header and cards for the homepage" do
     label_es: 'Bienvenido a',
 
     link_url: 'http://consulproject.org/',
-    header: TRUE,
+    header: true,
     image_attributes: create_image_attachment('header')
   )
 
@@ -40,7 +40,7 @@ section "Creating header and cards for the homepage" do
     label_es: 'Debates',
 
     link_url: 'https://youtu.be/zU_0UN4VajY',
-    header: FALSE,
+    header: false,
     image_attributes: create_image_attachment('debate')
   )
 
@@ -58,7 +58,7 @@ section "Creating header and cards for the homepage" do
     label_es: 'Propuestas ciudadanas',
 
     link_url: 'https://youtu.be/ZHqBpT4uCoM',
-    header: FALSE,
+    header: false,
     image_attributes: create_image_attachment('proposal')
   )
 
@@ -76,7 +76,7 @@ section "Creating header and cards for the homepage" do
     label_es: 'Presupuestos participativos',
 
     link_url: 'https://youtu.be/igQ8KGZdk9c',
-    header: FALSE,
+    header: false,
     image_attributes: create_image_attachment('budget')
   )
 end


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1740

Objectives
===================
Updates deprecated constants on **dev_seed/widgets**. This change avoid warning message when run `rake db:dev_seed`

```console
Creating header and cards for the homepage
/app/db/dev_seeds/widgets.rb:25: warning: constant ::TRUE is deprecated
/app/db/dev_seeds/widgets.rb:43: warning: constant ::FALSE is deprecated
/app/db/dev_seeds/widgets.rb:61: warning: constant ::FALSE is deprecated
/app/db/dev_seeds/widgets.rb:79: warning: constant ::FALSE is deprecated
```

Notes
===================
[Ruby 2.4 has deprecated toplevel constants TRUE, FALSE and NIL](https://blog.bigbinary.com/2017/06/19/ruby-2-4-has-depecated-constants-true-false-and-nil.html)