### PR TITLE
[Backport] Draft phase on legislation processes

### DIFF
--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -8,13 +8,15 @@ class Legislation::ProcessesController < Legislation::BaseController
 
   def index
     @current_filter ||= 'open'
-    @processes = ::Legislation::Process.send(@current_filter).published.not_in_draft.page(params[:page])
+    @processes = ::Legislation::Process.send(@current_filter).published
+                 .not_in_draft.page(params[:page])
   end
 
   def show
     draft_version = @process.draft_versions.published.last
+    allegations_phase = @process.allegations_phase
 
-    if @process.allegations_phase.enabled? && @process.allegations_phase.started? && draft_version.present?
+    if  allegations_phase.enabled? && allegations_phase.started? && draft_version.present?
       redirect_to legislation_process_draft_version_path(@process, draft_version)
     elsif @process.debate_phase.enabled?
       redirect_to debate_legislation_process_path(@process)

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -17,14 +17,19 @@ class Legislation::Process < ActiveRecord::Base
   translates :milestones_summary, touch: true
   include Globalizable
 
-  PHASES_AND_PUBLICATIONS = %i(draft_phase debate_phase allegations_phase proposals_phase draft_publication result_publication).freeze
+  PHASES_AND_PUBLICATIONS = %i[draft_phase debate_phase allegations_phase proposals_phase
+                               draft_publication result_publication].freeze
 
   has_many :draft_versions, -> { order(:id) }, class_name: 'Legislation::DraftVersion',
-                                               foreign_key: 'legislation_process_id', dependent: :destroy
-  has_one :final_draft_version, -> { where final_version: true, status: 'published' }, class_name: 'Legislation::DraftVersion',
-                                                                                       foreign_key: 'legislation_process_id'
-  has_many :questions, -> { order(:id) }, class_name: 'Legislation::Question', foreign_key: 'legislation_process_id', dependent: :destroy
-  has_many :proposals, -> { order(:id) }, class_name: 'Legislation::Proposal', foreign_key: 'legislation_process_id', dependent: :destroy
+                                               foreign_key: 'legislation_process_id',
+                                               dependent: :destroy
+  has_one :final_draft_version, -> { where final_version: true, status: 'published' },
+                                           class_name: 'Legislation::DraftVersion',
+                                           foreign_key: 'legislation_process_id'
+  has_many :questions, -> { order(:id) }, class_name: 'Legislation::Question',
+                                          foreign_key: 'legislation_process_id', dependent: :destroy
+  has_many :proposals, -> { order(:id) }, class_name: 'Legislation::Proposal',
+                                          foreign_key: 'legislation_process_id', dependent: :destroy
 
   validates_translation :title, presence: true
   validates :start_date, presence: true
@@ -38,12 +43,15 @@ class Legislation::Process < ActiveRecord::Base
   validates :proposals_phase_end_date, presence: true, if: :proposals_phase_start_date?
   validate :valid_date_ranges
 
-  scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current).order('id DESC') }
+  scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current)
+                    .order('id DESC') }
   scope :next, -> { where("start_date > ?", Date.current).order('id DESC') }
   scope :past, -> { where("end_date < ?", Date.current).order('id DESC') }
 
   scope :published, -> { where(published: true) }
-  scope :not_in_draft, -> { where("draft_phase_enabled = false or (draft_start_date IS NOT NULL and draft_end_date IS NOT NULL and (draft_start_date >= ? or draft_end_date <= ?))", Date.current, Date.current) }
+  scope :not_in_draft, -> { where("draft_phase_enabled = false or (draft_start_date IS NOT NULL and
+                                   draft_end_date IS NOT NULL and (draft_start_date >= ? or
+                                   draft_end_date <= ?))", Date.current, Date.current) }
 
   def draft_phase
     Legislation::Process::Phase.new(draft_start_date, draft_end_date, draft_phase_enabled)
@@ -54,11 +62,13 @@ class Legislation::Process < ActiveRecord::Base
   end
 
   def allegations_phase
-    Legislation::Process::Phase.new(allegations_start_date, allegations_end_date, allegations_phase_enabled)
+    Legislation::Process::Phase.new(allegations_start_date,
+                                    allegations_end_date, allegations_phase_enabled)
   end
 
   def proposals_phase
-    Legislation::Process::Phase.new(proposals_phase_start_date, proposals_phase_end_date, proposals_phase_enabled)
+    Legislation::Process::Phase.new(proposals_phase_start_date,
+                                    proposals_phase_end_date, proposals_phase_enabled)
   end
 
   def draft_publication
@@ -92,10 +102,17 @@ class Legislation::Process < ActiveRecord::Base
   private
 
     def valid_date_ranges
-      errors.add(:end_date, :invalid_date_range) if end_date && start_date && end_date < start_date
-      errors.add(:debate_end_date, :invalid_date_range) if debate_end_date && debate_start_date && debate_end_date < debate_start_date
-      errors.add(:draft_end_date, :invalid_date_range) if draft_end_date && draft_start_date && draft_end_date < draft_start_date
-      if allegations_end_date && allegations_start_date && allegations_end_date < allegations_start_date
+      if end_date && start_date && end_date < start_date
+        errors.add(:end_date, :invalid_date_range)
+      end
+      if debate_end_date && debate_start_date && debate_end_date < debate_start_date
+        errors.add(:debate_end_date, :invalid_date_range)
+      end
+      if draft_end_date && draft_start_date && draft_end_date < draft_start_date
+        errors.add(:draft_end_date, :invalid_date_range)
+      end
+      if allegations_end_date && allegations_start_date &&
+         allegations_end_date < allegations_start_date
         errors.add(:allegations_end_date, :invalid_date_range)
       end
     end

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -50,8 +50,8 @@ class Legislation::Process < ActiveRecord::Base
 
   scope :published, -> { where(published: true) }
   scope :not_in_draft, -> { where("draft_phase_enabled = false or (draft_start_date IS NOT NULL and
-                                   draft_end_date IS NOT NULL and (draft_start_date >= ? or
-                                   draft_end_date <= ?))", Date.current, Date.current) }
+                                   draft_end_date IS NOT NULL and (draft_start_date > ? or
+                                   draft_end_date < ?))", Date.current, Date.current) }
 
   def draft_phase
     Legislation::Process::Phase.new(draft_start_date, draft_end_date, draft_phase_enabled)

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -20,7 +20,8 @@ feature 'Admin legislation processes' do
 
     scenario 'Disabled with a feature flag' do
       Setting['feature.legislation'] = nil
-      expect{ visit admin_legislation_processes_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+      expect{ visit admin_legislation_processes_path }
+      .to raise_exception(FeatureFlags::FeatureDisabled)
     end
 
   end
@@ -55,14 +56,22 @@ feature 'Admin legislation processes' do
       fill_in 'legislation_process[start_date]', with: base_date.strftime("%d/%m/%Y")
       fill_in 'legislation_process[end_date]', with: (base_date + 5.days).strftime("%d/%m/%Y")
 
-      fill_in 'legislation_process[debate_start_date]', with: base_date.strftime("%d/%m/%Y")
-      fill_in 'legislation_process[debate_end_date]', with: (base_date + 2.days).strftime("%d/%m/%Y")
-      fill_in 'legislation_process[draft_start_date]', with: (base_date - 3.days).strftime("%d/%m/%Y")
-      fill_in 'legislation_process[draft_end_date]', with: (base_date - 1.days).strftime("%d/%m/%Y")
-      fill_in 'legislation_process[draft_publication_date]', with: (base_date + 3.days).strftime("%d/%m/%Y")
-      fill_in 'legislation_process[allegations_start_date]', with: (base_date + 3.days).strftime("%d/%m/%Y")
-      fill_in 'legislation_process[allegations_end_date]', with: (base_date + 5.days).strftime("%d/%m/%Y")
-      fill_in 'legislation_process[result_publication_date]', with: (base_date + 7.days).strftime("%d/%m/%Y")
+      fill_in 'legislation_process[debate_start_date]',
+               with: base_date.strftime("%d/%m/%Y")
+      fill_in 'legislation_process[debate_end_date]',
+               with: (base_date + 2.days).strftime("%d/%m/%Y")
+      fill_in 'legislation_process[draft_start_date]',
+               with: (base_date - 3.days).strftime("%d/%m/%Y")
+      fill_in 'legislation_process[draft_end_date]',
+               with: (base_date - 1.days).strftime("%d/%m/%Y")
+      fill_in 'legislation_process[draft_publication_date]',
+               with: (base_date + 3.days).strftime("%d/%m/%Y")
+      fill_in 'legislation_process[allegations_start_date]',
+               with: (base_date + 3.days).strftime("%d/%m/%Y")
+      fill_in 'legislation_process[allegations_end_date]',
+               with: (base_date + 5.days).strftime("%d/%m/%Y")
+      fill_in 'legislation_process[result_publication_date]',
+               with: (base_date + 7.days).strftime("%d/%m/%Y")
 
       click_button 'Create process'
 

--- a/spec/models/legislation/process/phase_spec.rb
+++ b/spec/models/legislation/process/phase_spec.rb
@@ -32,55 +32,67 @@ RSpec.describe Legislation::Process::Phase, type: :model do
   describe "#started?" do
     it "checks debate phase" do
       # future
-      process.update_attributes(debate_start_date: Date.current + 2.days, debate_end_date: Date.current + 3.days)
+      process.update_attributes(debate_start_date: Date.current + 2.days,
+                                debate_end_date: Date.current + 3.days)
       expect(process.debate_phase.started?).to be false
 
       # started
-      process.update_attributes(debate_start_date: Date.current - 2.days, debate_end_date: Date.current + 1.day)
+      process.update_attributes(debate_start_date: Date.current - 2.days,
+                                debate_end_date: Date.current + 1.day)
       expect(process.debate_phase.started?).to be true
 
       # starts today
-      process.update_attributes(debate_start_date: Date.current, debate_end_date: Date.current + 1.day)
+      process.update_attributes(debate_start_date: Date.current,
+                                debate_end_date: Date.current + 1.day)
       expect(process.debate_phase.started?).to be true
 
       # past
-      process.update_attributes(debate_start_date: Date.current - 2.days, debate_end_date: Date.current - 1.day)
+      process.update_attributes(debate_start_date: Date.current - 2.days,
+                                debate_end_date: Date.current - 1.day)
       expect(process.debate_phase.started?).to be true
     end
 
     it "checks draft phase" do
       # future
-      process.update_attributes(draft_start_date: Date.current + 2.days, draft_end_date: Date.current + 3.days, draft_phase_enabled: true)
+      process.update_attributes(draft_start_date: Date.current + 2.days,
+                                draft_end_date: Date.current + 3.days, draft_phase_enabled: true)
       expect(process.draft_phase.started?).to be false
 
       # started
-      process.update_attributes(draft_start_date: Date.current - 2.days, draft_end_date: Date.current + 1.day, draft_phase_enabled: true)
+      process.update_attributes(draft_start_date: Date.current - 2.days,
+                                draft_end_date: Date.current + 1.day, draft_phase_enabled: true)
       expect(process.draft_phase.started?).to be true
 
       # starts today
-      process.update_attributes(draft_start_date: Date.current, draft_end_date: Date.current + 1.day, draft_phase_enabled: true)
+      process.update_attributes(draft_start_date: Date.current,
+                                draft_end_date: Date.current + 1.day, draft_phase_enabled: true)
       expect(process.draft_phase.started?).to be true
 
       # past
-      process.update_attributes(draft_start_date: Date.current - 2.days, draft_end_date: Date.current - 1.day, draft_phase_enabled: true)
+      process.update_attributes(draft_start_date: Date.current - 2.days,
+                                draft_end_date: Date.current - 1.day, draft_phase_enabled: true)
       expect(process.draft_phase.started?).to be true
     end
 
     it "checks allegations phase" do
       # future
-      process.update_attributes(allegations_start_date: Date.current + 2.days, allegations_end_date: Date.current + 3.days)
+      process.update_attributes(allegations_start_date: Date.current + 2.days,
+                                allegations_end_date: Date.current + 3.days)
       expect(process.allegations_phase.started?).to be false
 
       # started
-      process.update_attributes(allegations_start_date: Date.current - 2.days, allegations_end_date: Date.current + 1.day)
+      process.update_attributes(allegations_start_date: Date.current - 2.days,
+                                allegations_end_date: Date.current + 1.day)
       expect(process.allegations_phase.started?).to be true
 
       # starts today
-      process.update_attributes(allegations_start_date: Date.current, allegations_end_date: Date.current + 1.day)
+      process.update_attributes(allegations_start_date: Date.current,
+                                allegations_end_date: Date.current + 1.day)
       expect(process.allegations_phase.started?).to be true
 
       # past
-      process.update_attributes(allegations_start_date: Date.current - 2.days, allegations_end_date: Date.current - 1.day)
+      process.update_attributes(allegations_start_date: Date.current - 2.days,
+                                allegations_end_date: Date.current - 1.day)
       expect(process.allegations_phase.started?).to be true
     end
   end
@@ -88,56 +100,68 @@ RSpec.describe Legislation::Process::Phase, type: :model do
   describe "#open?" do
     it "checks debate phase" do
       # future
-      process.update_attributes(debate_start_date: Date.current + 2.days, debate_end_date: Date.current + 3.days)
+      process.update_attributes(debate_start_date: Date.current + 2.days,
+                                debate_end_date: Date.current + 3.days)
       expect(process.debate_phase.open?).to be false
 
       # started
-      process.update_attributes(debate_start_date: Date.current - 2.days, debate_end_date: Date.current + 1.day)
+      process.update_attributes(debate_start_date: Date.current - 2.days,
+                                debate_end_date: Date.current + 1.day)
       expect(process.debate_phase.open?).to be true
 
       # starts today
-      process.update_attributes(debate_start_date: Date.current, debate_end_date: Date.current + 1.day)
+      process.update_attributes(debate_start_date: Date.current,
+                                debate_end_date: Date.current + 1.day)
       expect(process.debate_phase.open?).to be true
 
       # past
-      process.update_attributes(debate_start_date: Date.current - 2.days, debate_end_date: Date.current - 1.day)
+      process.update_attributes(debate_start_date: Date.current - 2.days,
+                                debate_end_date: Date.current - 1.day)
       expect(process.debate_phase.open?).to be false
     end
 
     it "checks draft phase" do
       # future
-      process.update_attributes(draft_start_date: Date.current + 2.days, draft_end_date: Date.current + 3.days, draft_phase_enabled: true)
+      process.update_attributes(draft_start_date: Date.current + 2.days,
+                                draft_end_date: Date.current + 3.days, draft_phase_enabled: true)
       expect(process.draft_phase.open?).to be false
 
       # started
-      process.update_attributes(draft_start_date: Date.current - 2.days, draft_end_date: Date.current + 1.day, draft_phase_enabled: true)
+      process.update_attributes(draft_start_date: Date.current - 2.days,
+                                draft_end_date: Date.current + 1.day, draft_phase_enabled: true)
       expect(process.draft_phase.open?).to be true
 
       # starts today
-      process.update_attributes(draft_start_date: Date.current, draft_end_date: Date.current + 1.day, draft_phase_enabled: true)
+      process.update_attributes(draft_start_date: Date.current,
+                                draft_end_date: Date.current + 1.day, draft_phase_enabled: true)
       expect(process.draft_phase.open?).to be true
 
       # past
-      process.update_attributes(draft_start_date: Date.current - 2.days, draft_end_date: Date.current - 1.day, draft_phase_enabled: true)
+      process.update_attributes(draft_start_date: Date.current - 2.days,
+                                draft_end_date: Date.current - 1.day, draft_phase_enabled: true)
       expect(process.draft_phase.open?).to be false
     end
 
     it "checks allegations phase" do
 
       # future
-      process.update_attributes(allegations_start_date: Date.current + 2.days, allegations_end_date: Date.current + 3.days)
+      process.update_attributes(allegations_start_date: Date.current + 2.days,
+                                allegations_end_date: Date.current + 3.days)
       expect(process.allegations_phase.open?).to be false
 
       # started
-      process.update_attributes(allegations_start_date: Date.current - 2.days, allegations_end_date: Date.current + 1.day)
+      process.update_attributes(allegations_start_date: Date.current - 2.days,
+                                allegations_end_date: Date.current + 1.day)
       expect(process.allegations_phase.open?).to be true
 
       # starts today
-      process.update_attributes(allegations_start_date: Date.current, allegations_end_date: Date.current + 1.day)
+      process.update_attributes(allegations_start_date: Date.current,
+                                allegations_end_date: Date.current + 1.day)
       expect(process.allegations_phase.open?).to be true
 
       # past
-      process.update_attributes(allegations_start_date: Date.current - 2.days, allegations_end_date: Date.current - 1.day)
+      process.update_attributes(allegations_start_date: Date.current - 2.days,
+                                allegations_end_date: Date.current - 1.day)
       expect(process.allegations_phase.open?).to be false
     end
   end

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -21,13 +21,15 @@ describe Legislation::Process do
     end
 
     it "is invalid if allegations_start_date is present but debate_end_date is not" do
-      process = build(:legislation_process, allegations_start_date: Date.current, allegations_end_date: "")
+      process = build(:legislation_process, allegations_start_date: Date.current,
+                                            allegations_end_date: "")
       expect(process).to be_invalid
       expect(process.errors.messages[:allegations_end_date]).to include("can't be blank")
     end
 
     it "is invalid if debate_end_date is present but allegations_start_date is not" do
-      process = build(:legislation_process, allegations_start_date: nil, allegations_end_date: Date.current)
+      process = build(:legislation_process, allegations_start_date: nil,
+                                            allegations_end_date: Date.current)
       expect(process).to be_invalid
       expect(process.errors.messages[:allegations_start_date]).to include("can't be blank")
     end
@@ -35,90 +37,107 @@ describe Legislation::Process do
 
   describe "date ranges validations" do
     it "is invalid if end_date is before start_date" do
-      process = build(:legislation_process, start_date: Date.current, end_date: Date.current - 1.day)
+      process = build(:legislation_process, start_date: Date.current,
+                                            end_date: Date.current - 1.day)
       expect(process).to be_invalid
       expect(process.errors.messages[:end_date]).to include("must be on or after the start date")
     end
 
     it "is valid if end_date is the same as start_date" do
-      process = build(:legislation_process, start_date: Date.current - 1.day, end_date: Date.current - 1.day)
+      process = build(:legislation_process, start_date: Date.current - 1.day,
+                                            end_date: Date.current - 1.day)
       expect(process).to be_valid
     end
 
     it "is valid if debate_end_date is the same as debate_start_date" do
-      process = build(:legislation_process, debate_start_date: Date.current - 1.day, debate_end_date: Date.current - 1.day)
+      process = build(:legislation_process, debate_start_date: Date.current - 1.day,
+                                            debate_end_date: Date.current - 1.day)
       expect(process).to be_valid
     end
 
     it "is invalid if debate_end_date is before debate_start_date" do
-      process = build(:legislation_process, debate_start_date: Date.current, debate_end_date: Date.current - 1.day)
+      process = build(:legislation_process, debate_start_date: Date.current,
+                                            debate_end_date: Date.current - 1.day)
       expect(process).to be_invalid
-      expect(process.errors.messages[:debate_end_date]).to include("must be on or after the debate start date")
+      expect(process.errors.messages[:debate_end_date])
+      .to include("must be on or after the debate start date")
     end
 
     it "is valid if draft_end_date is the same as draft_start_date" do
-      process = build(:legislation_process, draft_start_date: Date.current - 1.day, draft_end_date: Date.current - 1.day)
+      process = build(:legislation_process, draft_start_date: Date.current - 1.day,
+                                            draft_end_date: Date.current - 1.day)
       expect(process).to be_valid
     end
 
     it "is invalid if draft_end_date is before draft_start_date" do
-      process = build(:legislation_process, draft_start_date: Date.current, draft_end_date: Date.current - 1.day)
+      process = build(:legislation_process, draft_start_date: Date.current,
+                                            draft_end_date: Date.current - 1.day)
       expect(process).to be_invalid
-      expect(process.errors.messages[:draft_end_date]).to include("must be on or after the draft start date")
+      expect(process.errors.messages[:draft_end_date])
+      .to include("must be on or after the draft start date")
     end
 
     it "is invalid if allegations_end_date is before allegations_start_date" do
-      process = build(:legislation_process, allegations_start_date: Date.current, allegations_end_date: Date.current - 1.day)
+      process = build(:legislation_process, allegations_start_date: Date.current,
+                                            allegations_end_date: Date.current - 1.day)
       expect(process).to be_invalid
-      expect(process.errors.messages[:allegations_end_date]).to include("must be on or after the allegations start date")
+      expect(process.errors.messages[:allegations_end_date])
+      .to include("must be on or after the allegations start date")
     end
 
     it "is valid if allegations_end_date is the same as allegations_start_date" do
-      process = build(:legislation_process, allegations_start_date: Date.current - 1.day, allegations_end_date: Date.current - 1.day)
+      process = build(:legislation_process, allegations_start_date: Date.current - 1.day,
+                                              allegations_end_date: Date.current - 1.day)
       expect(process).to be_valid
     end
   end
 
   describe "filter scopes" do
-    before do
-      @process_1 = create(:legislation_process, start_date: Date.current - 2.days, end_date: Date.current + 1.day)
-      @process_2 = create(:legislation_process, start_date: Date.current + 1.day, end_date: Date.current + 3.days)
-      @process_3 = create(:legislation_process, start_date: Date.current - 4.days, end_date: Date.current - 3.days)
-      @process_4 = create(:legislation_process, draft_start_date: Date.current - 3.days, draft_end_date: Date.current - 2.days)
-      @process_5 = create(:legislation_process, draft_start_date: Date.current - 2.days, draft_end_date: Date.current + 2.days, draft_phase_enabled: false)
-      @process_6 = create(:legislation_process, draft_start_date: Date.current - 2.days, draft_end_date: Date.current + 2.days, draft_phase_enabled: true)
-    end
+    let!(:process_1) { create(:legislation_process, start_date: Date.current - 2.days,
+                                                   end_date: Date.current + 1.day) }
+    let!(:process_2) { create(:legislation_process, start_date: Date.current + 1.day,
+                                              end_date: Date.current + 3.days) }
+    let!(:process_3) { create(:legislation_process, start_date: Date.current - 4.days,
+                                              end_date: Date.current - 3.days) }
+    let!(:process_4) { create(:legislation_process, draft_start_date: Date.current - 3.days,
+                                              draft_end_date: Date.current - 2.days) }
+    let!(:process_5) { create(:legislation_process, draft_start_date: Date.current - 2.days,
+                                              draft_end_date: Date.current + 2.days,
+                                              draft_phase_enabled: false) }
+    let!(:process_6) { create(:legislation_process, draft_start_date: Date.current - 2.days,
+                                              draft_end_date: Date.current + 2.days,
+                                              draft_phase_enabled: true) }
 
     it "filters open" do
       open_processes = ::Legislation::Process.open
 
-      expect(open_processes).to include(@process_1)
-      expect(open_processes).not_to include(@process_2)
-      expect(open_processes).not_to include(@process_3)
+      expect(open_processes).to include(process_1)
+      expect(open_processes).not_to include(process_2)
+      expect(open_processes).not_to include(process_3)
     end
 
     it "filters draft phase" do
       draft_processes = ::Legislation::Process.not_in_draft
 
-      expect(draft_processes).to include(@process_4)
-      expect(draft_processes).to include(@process_5)
-      expect(draft_processes).not_to include(@process_6)
+      expect(draft_processes).to include(process_4)
+      expect(draft_processes).to include(process_5)
+      expect(draft_processes).not_to include(process_6)
     end
 
     it "filters next" do
       next_processes = ::Legislation::Process.next
 
-      expect(next_processes).to include(@process_2)
-      expect(next_processes).not_to include(@process_1)
-      expect(next_processes).not_to include(@process_3)
+      expect(next_processes).to include(process_2)
+      expect(next_processes).not_to include(process_1)
+      expect(next_processes).not_to include(process_3)
     end
 
     it "filters past" do
       past_processes = ::Legislation::Process.past
 
-      expect(past_processes).to include(@process_3)
-      expect(past_processes).not_to include(@process_2)
-      expect(past_processes).not_to include(@process_1)
+      expect(past_processes).to include(process_3)
+      expect(past_processes).not_to include(process_2)
+      expect(past_processes).not_to include(process_1)
     end
   end
 

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -99,14 +99,6 @@ describe Legislation::Process do
                                               end_date: Date.current + 3.days) }
     let!(:process_3) { create(:legislation_process, start_date: Date.current - 4.days,
                                               end_date: Date.current - 3.days) }
-    let!(:process_4) { create(:legislation_process, draft_start_date: Date.current - 3.days,
-                                              draft_end_date: Date.current - 2.days) }
-    let!(:process_5) { create(:legislation_process, draft_start_date: Date.current - 2.days,
-                                              draft_end_date: Date.current + 2.days,
-                                              draft_phase_enabled: false) }
-    let!(:process_6) { create(:legislation_process, draft_start_date: Date.current - 2.days,
-                                              draft_end_date: Date.current + 2.days,
-                                              draft_phase_enabled: true) }
 
     it "filters open" do
       open_processes = ::Legislation::Process.open
@@ -117,11 +109,39 @@ describe Legislation::Process do
     end
 
     it "filters draft phase" do
-      draft_processes = ::Legislation::Process.not_in_draft
+      process_before_draft = create(
+        :legislation_process,
+        draft_start_date: Date.current - 3.days,
+        draft_end_date: Date.current - 2.days
+      )
 
-      expect(draft_processes).to include(process_4)
-      expect(draft_processes).to include(process_5)
-      expect(draft_processes).not_to include(process_6)
+      process_with_draft_disabled = create(
+        :legislation_process,
+        draft_start_date: Date.current - 2.days,
+        draft_end_date: Date.current + 2.days,
+        draft_phase_enabled: false
+      )
+
+      process_with_draft_enabled = create(
+        :legislation_process,
+        draft_start_date: Date.current - 2.days,
+        draft_end_date: Date.current + 2.days,
+        draft_phase_enabled: true
+      )
+
+      process_with_draft_only_today = create(
+        :legislation_process,
+        draft_start_date: Date.current,
+        draft_end_date: Date.current,
+        draft_phase_enabled: true
+      )
+
+      processes_not_in_draft = ::Legislation::Process.not_in_draft
+
+      expect(processes_not_in_draft).to include(process_before_draft)
+      expect(processes_not_in_draft).to include(process_with_draft_disabled)
+      expect(processes_not_in_draft).not_to include(process_with_draft_enabled)
+      expect(processes_not_in_draft).not_to include(process_with_draft_only_today)
     end
 
     it "filters next" do


### PR DESCRIPTION
## References

This is a backport of part of https://github.com/AyuntamientoMadrid/consul/pull/1741/ and a backport of https://github.com/AyuntamientoMadrid/consul/pull/1750

## Objectives

- Fixes hound warnings on legislation processes.

- Hides process on index if draft dates match with date current. Before, on `scope :not_in_draft` if the `draft_start_date` or `draft_end_date` was matching with `Date.current` the process was showing on processes index page. We want to hide all processes with active draft phase.