### PR TITLE
[Backport] Remove custom "toda la ciudad" code

### DIFF
--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -15,9 +15,7 @@ module Budgets
         if params[:status].present?
           @budget.investments.winners
                   .joins(:milestones).includes(:milestones)
-                  .select { |i| i.milestones.published.with_status
-                                            .order_by_publication_date.last
-                                            .try(:status_id) == params[:status].to_i }
+                  .select { |i| i.milestone_status_id == params[:status].to_i }
                   .uniq
                   .group_by(&:heading)
         else

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -7,7 +7,7 @@ module Budgets
     def show
       authorize! :read_executions, @budget
       @statuses = Milestone::Status.all
-      @investments_by_heading = investments_by_heading_ordered_alphabetically_with_city_heading_first.to_h
+      @investments_by_heading = investments_by_heading_ordered_alphabetically.to_h
     end
 
     private
@@ -31,16 +31,8 @@ module Budgets
         @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
       end
 
-      def investments_by_heading_ordered_alphabetically_with_city_heading_first
-        investments_by_heading.sort do |a, b|
-          if a[0].name == 'Toda la ciudad'
-            -1
-          elsif b[0].name == 'Toda la ciudad'
-            1
-          else
-            a[0].name <=> b[0].name
-          end
-        end
+      def investments_by_heading_ordered_alphabetically
+        investments_by_heading.sort { |a, b| a[0].name <=> b[0].name }
       end
   end
 end

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -14,8 +14,7 @@ module Budgets
       def investments_by_heading
         if params[:status].present?
           @budget.investments.winners
-                  .joins(:milestones).includes(:milestones)
-                  .select { |i| i.milestone_status_id == params[:status].to_i }
+                  .with_milestone_status_id(params[:status])
                   .uniq
                   .group_by(&:heading)
         else

--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -1,9 +1,9 @@
 module BudgetExecutionsHelper
 
   def filters_select_counts(status)
-    @budget.investments.winners.with_milestones.select { |i| i.milestones
-                                      .published.with_status.order_by_publication_date
-                                      .last.status_id == status rescue false }.count
+    @budget.investments.winners.with_milestones.select do |investment|
+      investment.milestone_status_id == status
+    end.count
   end
 
   def first_milestone_with_image(investment)

--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -1,9 +1,7 @@
 module BudgetExecutionsHelper
 
   def filters_select_counts(status)
-    @budget.investments.winners.with_milestones.select do |investment|
-      investment.milestone_status_id == status
-    end.count
+    @budget.investments.winners.with_milestone_status_id(status).count
   end
 
   def first_milestone_with_image(investment)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -342,6 +342,12 @@ class Budget
       self.valuator_groups.collect(&:name).compact.join(', ').presence
     end
 
+    def self.with_milestone_status_id(status_id)
+      joins(:milestones).includes(:milestones).select do |investment|
+        investment.milestone_status_id == status_id.to_i
+      end
+    end
+
     def milestone_status_id
       milestones.published.with_status.order_by_publication_date.last&.status_id
     end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -342,6 +342,10 @@ class Budget
       self.valuator_groups.collect(&:name).compact.join(', ').presence
     end
 
+    def milestone_status_id
+      milestones.published.with_status.order_by_publication_date.last&.status_id
+    end
+
     private
 
       def set_denormalized_ids

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -230,19 +230,6 @@ feature 'Executions' do
       heading
     end
 
-    scenario 'City heading is displayed first' do
-      heading.destroy!
-      other_heading1 = create_heading_with_investment_with_milestone(group: group, name: 'Other 1')
-      city_heading   = create_heading_with_investment_with_milestone(group: group, name: 'Toda la ciudad')
-      other_heading2 = create_heading_with_investment_with_milestone(group: group, name: 'Other 2')
-
-      visit budget_executions_path(budget)
-
-      expect(page).to have_css('.budget-execution', count: 3)
-      expect(city_heading.name).to appear_before(other_heading1.name)
-      expect(city_heading.name).to appear_before(other_heading2.name)
-    end
-
     scenario 'Non-city headings are displayed in alphabetical order' do
       heading.destroy!
       z_heading = create_heading_with_investment_with_milestone(group: group, name: 'Zzz')


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1704
* Pull request #2864

## Background

We had accidentally introduced custom code specific to Madrid's fork when backporting budget executions.

## Objectives

* Remove Madrid's custom code
* Refactor complex code in the budget executions controller