### PR TITLE
Fix scroll jump voting investments

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1581,7 +1581,6 @@
 }
 
 .progress-bar-nav {
-  padding: $line-height 0;
   position: relative;
   z-index: 3;
 


### PR DESCRIPTION
## References

* [Travis build 25381, job2](https://travis-ci.org/consul/consul/jobs/466662137), [Travis build 25378. job 1](https://travis-ci.org/consul/consul/jobs/466654534)
* [Debugging Scroll Event Issues in Capybara/Poltergeist](http://louissimoneau.com/2014/01/12/debugging-scroll-event-issues-in-capybara-slash-poltergeist/)
* [How To Create an On Scroll Fixed Header](https://www.w3schools.com/howto/howto_js_sticky_header.asp)

## Objectives

* Improve our usability by letting users scroll the page consistently
* Fix the flaky specs that appeared in `spec/features/budgets/ballots_spec.rb:112` ("Ballots Voting Adding and Removing Investments Add a investment"), `spec/features/budgets/ballots_spec.rb:282` ("Ballots Groups Change my heading") and `spec/features/budgets/ballots_spec.rb:615` ("Ballots Permissions Insufficient funds (removed after destroying from sidebar)")

### Explain why the test is flaky

When users scroll the page, the header nav bar changes its position on the screen to a fixed one, causing the space it was in to suddenly become empty, making the page scroll even further. If the user is a Capybara driver, that extra scroll might end on it not clicking the link it was trying to click.

![The mouse cursor jumps too much when scrolling](https://user-images.githubusercontent.com/35156/50155319-14610f80-02cc-11e9-9be8-6c9c3f91bac7.gif)

### Explain why your PR fixes it

Given the complexity of the elements surrounding our header nav bar and the CSS rules applied to it and its changes in height and font size, the easiest way to fix the problem is to remove the padding of this element, which is exactly the space which will be left empty when the element changes its position to a fixed one.

![The mouse cursor scrolls normally](https://user-images.githubusercontent.com/35156/50155344-22169500-02cc-11e9-9f1d-324fbc2ed0c9.gif)

I've tried more complex solutions like adding extra elements with a padding that compensates the empty space or manually adding extra padding, as suggested in the articles above. However, maybe because the header nav bar changes in height and font size, these solutions looked worse, with the scroll never being smooth enough and the header getting more padding than it has now.

On the other hand, the chosen solution might be fragile and we might have this issue again if we change the related CSS.

## Notes

There are other ways to make the affected tests pass without changing the code, like changing CSS rules for the test environment or increasing the window size of the Capybara driver so it doesn't need to scroll. However, IMHO these tests are failing because we've got a bug in our code (in this case, affecting usability). Changing the test so it passes without fixing the bug would make our test suite worse than it is now, since it wouldn't detect this usability issue.