### PR TITLE
[Backport] Fix flaky spec checking price without currency symbol

### DIFF
--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1497,7 +1497,7 @@ feature 'Budget Investments' do
         expect(page).to have_content "€#{sp2.price}"
 
         expect(page).not_to have_content sp3.title
-        expect(page).not_to have_content "#{sp3.price}"
+        expect(page).not_to have_content "€#{sp3.price}"
       end
 
       within("#budget_group_#{group.id}") do


### PR DESCRIPTION
## References

PR https://github.com/AyuntamientoMadrid/consul/pull/1758

## Error message
``` bash
bin/rspec --seed 53044

Failures:

  1) Budget Investments Balloting Phase Confirm
     Failure/Error: expect(page).not_to have_content "#{sp3.price}"
       expected not to find text "100" in "Global Group - Global Heading You still have €999,989 to invest. Amount spent €11 Budget Investment 1006 title €10 Budget Investment 1005 title €1"
     # ./spec/features/budgets/investments_spec.rb:1466:in `block (4 levels) in <top (required)>'
     # ./spec/features/budgets/investments_spec.rb:1458:in `block (3 levels) in <top (required)>'
     # -e:1:in `<main>'

Failed examples:

rspec ./spec/features/budgets/investments_spec.rb:1419 # Budget Investments Balloting Phase Confirm
```

## Explain why the test is flaky
When we check the price not to appear we don't include the currency symbol, so if the number is anywhere else the test will fail.

## Explain why your PR fixes it
We will check the number doesn't appear, but with the currency symbol.