### PR TITLE
Apply Rubocop not_to rule

### DIFF
--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -178,7 +178,7 @@ feature 'Legislation' do
         visit legislation_process_path(process)
 
         expect(page).to     have_content("This is the process homepage")
-        expect(page).to_not have_content("Participate in the debate")
+        expect(page).not_to have_content("Participate in the debate")
       end
 
       scenario 'disabled', :with_frozen_time do
@@ -190,7 +190,7 @@ feature 'Legislation' do
         visit legislation_process_path(process)
 
         expect(page).to have_content("This phase is not open yet")
-        expect(page).to_not have_content("This is the process homepage")
+        expect(page).not_to have_content("This is the process homepage")
       end
     end
 


### PR DESCRIPTION
## References

**PR:** https://github.com/consul/consul/pull/3091

## Objectives

Use `not_to` instead of `to_not` in specs