### PR TITLE
[Backport] Enable useless assignment rubocop rule

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -30,6 +30,9 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+Lint/UselessAssignment:
+  Enabled: true
+
 Metrics/LineLength:
   Max: 100
 


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1765

## Objectives

Help developers who don't run the ruby syntax check locally realize they might be involuntarily assigning a value to a local variable which is never used, and so they might want to check whether they need to refactor the code a bit.