### PR TITLE
[Backport] Budget investments price explanation

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -80,7 +80,9 @@
         <% end %>
 
         <% if investment.should_show_price_explanation? %>
-          <h2><%= t('budgets.investments.show.price_explanation') %></h2>
+          <h2 id="price_explanation" data-magellan-target="price_explanation">
+            <%= t("budgets.investments.show.price_explanation") %>
+          </h2>
           <p><%= investment.price_explanation %></p>
         <% end %>
 
@@ -177,6 +179,12 @@
               <%= investment.formatted_price %>
             </p>
           </div>
+          <% if investment.should_show_price_explanation? %>
+            <div class="text-center" data-magellan>
+              <%= link_to t("budgets.investments.show.see_price_explanation"),
+                            "#price_explanation", class: "small" %>
+            </div>
+          <% end %>
         <% end %>
 
         <%= render 'shared/social_share',

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -127,6 +127,7 @@ en:
         project_selected_html: 'This investment project <strong>has been selected</strong> for balloting phase.'
         project_winner: 'Winning investment project'
         project_not_selected_html: 'This investment project <strong>has not been selected</strong> for balloting phase.'
+        see_price_explanation: See price explanation
       wrong_price_format: Only integer numbers
       investment:
         add: Vote

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -127,6 +127,7 @@ es:
         project_selected_html: 'Este proyecto de gasto <strong>ha sido seleccionado</strong> para la fase de votación.'
         project_winner: 'Proyecto de gasto ganador'
         project_not_selected_html: 'Este proyecto de gasto <strong>no ha sido seleccionado</strong> para la fase de votación.'
+        see_price_explanation: Ver informe de coste
       wrong_price_format: Solo puede incluir caracteres numéricos
       investment:
         add: Votar

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -902,6 +902,7 @@ feature 'Budget Investments' do
 
           expect(page).to have_content(investment.formatted_price)
           expect(page).to have_content(investment.price_explanation)
+          expect(page).to have_link("See price explanation")
 
           if budget.finished?
             investment.update(winner: true)
@@ -920,6 +921,7 @@ feature 'Budget Investments' do
 
           expect(page).not_to have_content(investment.formatted_price)
           expect(page).not_to have_content(investment.price_explanation)
+          expect(page).not_to have_link("See price explanation")
 
           visit budget_investments_path(budget)
 
@@ -941,6 +943,7 @@ feature 'Budget Investments' do
 
           expect(page).not_to have_content(investment.formatted_price)
           expect(page).not_to have_content(investment.price_explanation)
+          expect(page).not_to have_link("See price explanation")
 
           visit budget_investments_path(budget)
 


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1760

## Objectives

If budget investment have a price explanation shows "See price explanation" link after the price with an anchor link to Price explanation section.

I used [Foundation Magellan](https://foundation.zurb.com/sites/docs/magellan.html) for an awesome smooth scroll.

## Visual Changes

![screenshot 2018-12-18 at 11 41 18](https://user-images.githubusercontent.com/631897/50149282-1078c180-02bb-11e9-901b-28262ba8fad1.png)

![kapture 2018-12-18 at 11 42 28](https://user-images.githubusercontent.com/631897/50149299-18d0fc80-02bb-11e9-918f-6f84a8f68b02.gif)