### PR TITLE
[Backport] Proposal create question

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1093,6 +1093,7 @@ form {
 
 .callout {
   font-size: $small-font-size;
+  overflow: hidden;
 
   a:not(.button) {
     font-weight: bold;
@@ -1131,6 +1132,10 @@ form {
 
   .close {
     text-decoration: none !important;
+  }
+
+  .button {
+    margin-bottom: 0;
   }
 }
 

--- a/app/views/admin/proposals/show.html.erb
+++ b/app/views/admin/proposals/show.html.erb
@@ -5,6 +5,18 @@
 <div class="proposal-show">
   <h2><%= @proposal.title %></h2>
 
+  <% if @proposal.successful? %>
+    <div class="callout success">
+      <%= t("proposals.proposal.successful") %>
+
+      <div class="float-right">
+        <%= link_to t("poll_questions.create_question"),
+                    new_admin_question_path(proposal_id: @proposal.id),
+                    class: "button medium" %>
+      </div>
+    </div>
+  <% end %>
+
   <%= render "proposals/info", proposal: @proposal %>
 </div>
 

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -66,18 +66,10 @@
            class="small-12 medium-3 column supports-container">
         <% if proposal.successful? %>
           <div class="padding text-center">
-
             <p>
               <%= t("proposals.proposal.successful") %>
             </p>
           </div>
-          <% if can? :create, Poll::Question %>
-            <p class="text-center">
-              <%= link_to t('poll_questions.create_question'),
-                          new_admin_question_path(proposal_id: proposal.id),
-                          class: "button hollow" %>
-            </p>
-          <% end %>
         <% elsif proposal.archived? %>
           <div class="padding text-center">
             <strong><%= t("proposals.proposal.supports", count: proposal.total_votes) %></strong>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -88,13 +88,6 @@
             <p>
               <%= t("proposals.proposal.successful") %>
             </p>
-            <% if can? :create, Poll::Question %>
-              <p class="text-center">
-                <%= link_to t('poll_questions.create_question'),
-                            new_admin_question_path(proposal_id: @proposal.id),
-                            class: "button hollow expanded" %>
-              </p>
-            <% end %>
           <% elsif @proposal.archived? %>
             <div class="padding text-center">
               <p>

--- a/spec/features/admin/poll/questions_spec.rb
+++ b/spec/features/admin/poll/questions_spec.rb
@@ -53,11 +53,12 @@ feature 'Admin poll questions' do
     expect(page).to have_content(title)
   end
 
-  scenario 'Create from successful proposal index' do
+  scenario 'Create from successful proposal' do
     poll = create(:poll, name: 'Proposals')
     proposal = create(:proposal, :successful)
 
-    visit proposals_path
+    visit admin_proposal_path(proposal)
+
     click_link "Create question"
 
     expect(page).to have_current_path(new_admin_question_path, ignore_query: true)
@@ -70,17 +71,6 @@ feature 'Admin poll questions' do
     expect(page).to have_content(proposal.title)
     expect(page).to have_link(proposal.title, href: proposal_path(proposal))
     expect(page).to have_link(proposal.author.name, href: user_path(proposal.author))
-  end
-
-  scenario "Create from successful proposal show" do
-    poll = create(:poll, name: 'Proposals')
-    proposal = create(:proposal, :successful)
-
-    visit proposal_path(proposal)
-    click_link "Create question"
-
-    expect(page).to have_current_path(new_admin_question_path, ignore_query: true)
-    expect(page).to have_field('Question', with: proposal.title)
   end
 
   scenario 'Update' do

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -28,12 +28,32 @@ feature "Admin proposals" do
     end
   end
 
-  scenario "Show" do
-    create(:proposal, title: "Create a chaotic future", summary: "Chaos isn't controlled")
+  context "Show" do
 
-    visit admin_proposals_path
-    click_link "Create a chaotic future"
+    scenario "View proposal" do
+      create(:proposal, title: "Create a chaotic future", summary: "Chaos isn't controlled")
 
-    expect(page).to have_content "Chaos isn't controlled"
+      visit admin_proposals_path
+      click_link "Create a chaotic future"
+
+      expect(page).to have_content "Chaos isn't controlled"
+      expect(page).not_to have_content "This proposal has reached the required supports"
+      expect(page).not_to have_link "Create question"
+    end
+
+    scenario "Successful proposals show create question button" do
+      successful_proposals = create_successful_proposals
+      admin = create(:administrator)
+
+      login_as(admin.user)
+
+      visit admin_proposals_path
+
+      successful_proposals.each do |proposal|
+        visit admin_proposal_path(proposal)
+        expect(page).to have_content "This proposal has reached the required supports"
+        expect(page).to have_link "Create question"
+      end
+    end
   end
 end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1789,8 +1789,11 @@ feature 'Successful proposals' do
     end
   end
 
-  scenario 'Successful proposals show create question button to admin users' do
+  scenario 'Successful proposals do not show create question button in index' do
     successful_proposals = create_successful_proposals
+    admin = create(:administrator)
+
+    login_as(admin.user)
 
     visit proposals_path
 
@@ -1799,17 +1802,20 @@ feature 'Successful proposals' do
         expect(page).not_to have_link "Create question"
       end
     end
+  end
 
-    login_as(create(:administrator).user)
+  scenario 'Successful proposals do not show create question button in show' do
+    successful_proposals = create_successful_proposals
+    admin = create(:administrator)
 
-    visit proposals_path
+    login_as(admin.user)
 
     successful_proposals.each do |proposal|
+      visit proposal_path(proposal)
       within("#proposal_#{proposal.id}_votes") do
-        expect(page).to have_link "Create question"
+        expect(page).not_to have_link "Create question"
       end
     end
-
   end
 
   context "Skip user verification" do


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1762

## Background

When a proposal reach the necessary number of supports become a ˝successful proposal" showing "This proposal has reached the required supports and will be voted in the next voting." message and a "Create question" button for admins.

## Objectives

Move this "Create question" button to admin proposals show view on `admin/proposals/N`.

## Visual Changes

**BEFORE**
**Proposal index & show**
![before_1](https://user-images.githubusercontent.com/631897/50152486-08714f80-02c4-11e9-81bb-fedd3e95b014.png)
![before_2](https://user-images.githubusercontent.com/631897/50152487-08714f80-02c4-11e9-9d5a-81f6da40a50a.png)
**Admin proposal show**
![before_3](https://user-images.githubusercontent.com/631897/50152488-08714f80-02c4-11e9-8194-65dacd58b904.png)


**AFTER**
**Proposal index & show**
![after_1](https://user-images.githubusercontent.com/631897/50152494-0c9d6d00-02c4-11e9-9f74-61cd8273b3fc.png)
![after_2](https://user-images.githubusercontent.com/631897/50152495-0c9d6d00-02c4-11e9-89b5-93bbd8d9ee37.png)
**Admin proposal show**
![after_3](https://user-images.githubusercontent.com/631897/50152496-0c9d6d00-02c4-11e9-8058-31109e7e54ee.png)