### PR TITLE
[Backport] Admin poll questions index

### DIFF
--- a/app/views/admin/poll/questions/_questions.html.erb
+++ b/app/views/admin/poll/questions/_questions.html.erb
@@ -10,14 +10,22 @@
   <table class="fixed">
     <thead>
       <tr>
-        <th class="small-8"><%= t("admin.questions.index.table_question") %></th>
-        <th><%= t("admin.actions.actions") %></th>
+        <th><%= t("admin.questions.index.table_question") %></th>
+        <th><%= t("admin.questions.index.table_poll") %></th>
+        <th class="small-4"><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
     <tbody>
       <% @questions.each do |question| %>
         <tr id="<%= dom_id(question) %>">
           <td><%= link_to question.title, admin_question_path(question) %></td>
+          <td>
+            <% if question.poll.present? %>
+              <%= question.poll.name %>
+            <% else %>
+              <em><%= t("admin.questions.index.poll_not_assigned") %></em>
+            <% end %>
+          </td>
           <td>
             <div class="small-6 column">
               <%= link_to t("shared.edit"), edit_admin_question_path(question), class: "button hollow expanded" %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -924,6 +924,8 @@ en:
         create_question: "Create question"
         table_proposal: "Proposal"
         table_question: "Question"
+        table_poll: "Poll"
+        poll_not_assigned: "Poll not assigned"
       edit:
         title: "Edit Question"
       new:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -923,6 +923,8 @@ es:
         create_question: "Crear pregunta para votación"
         table_proposal: "Propuesta"
         table_question: "Pregunta"
+        table_poll: "Votación"
+        poll_not_assigned: "Votación no asignada"
       edit:
         title: "Editar pregunta ciudadana"
       new:

--- a/spec/features/admin/poll/questions_spec.rb
+++ b/spec/features/admin/poll/questions_spec.rb
@@ -12,13 +12,22 @@ feature 'Admin poll questions' do
                   %w[title]
 
   scenario 'Index' do
-    question1 = create(:poll_question)
-    question2 = create(:poll_question)
+    poll1 = create(:poll)
+    poll2 = create(:poll)
+    question1 = create(:poll_question, poll: poll1)
+    question2 = create(:poll_question, poll: poll2)
 
     visit admin_questions_path
 
-    expect(page).to have_content(question1.title)
-    expect(page).to have_content(question2.title)
+    within("#poll_question_#{question1.id}") do
+      expect(page).to have_content(question1.title)
+      expect(page).to have_content(poll1.name)
+    end
+
+    within("#poll_question_#{question2.id}") do
+      expect(page).to have_content(question2.title)
+      expect(page).to have_content(poll2.name)
+    end
   end
 
   scenario 'Show' do


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1764

## Objectives

Adds poll name on admin poll questions index. 

## Visual Changes

![screenshot 2018-12-18 at 19 27 41](https://user-images.githubusercontent.com/631897/50174723-3b830580-02fb-11e9-8ce3-2ea688f3f129.png)
