### PR TITLE
[Backport] Honeypot on users sign up form

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,7 +2,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :authenticate_scope!, only: [:edit, :update, :destroy, :finish_signup, :do_finish_signup]
   before_filter :configure_permitted_parameters
 
-  invisible_captcha only: [:create], honeypot: :family_name, scope: :user
+  invisible_captcha only: [:create], honeypot: :address, scope: :user
 
   def new
     super do |user|

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -24,7 +24,7 @@
                                    label: false,
                                    aria: {describedby: "username-help-text"} %>
 
-      <%= f.invisible_captcha :family_name %>
+      <%= f.invisible_captcha :address %>
 
       <%= f.email_field :email,     placeholder: t("devise_views.users.registrations.new.email_label") %>
 

--- a/spec/features/registration_form_spec.rb
+++ b/spec/features/registration_form_spec.rb
@@ -47,7 +47,7 @@ feature 'Registration form' do
     visit new_user_registration_path
 
     fill_in 'user_username',              with: "robot"
-    fill_in 'user_family_name',           with: 'This is the honeypot field'
+    fill_in 'user_address',               with: 'This is the honeypot field'
     fill_in 'user_email',                 with: 'robot@robot.com'
     fill_in 'user_password',              with: 'destroyallhumans'
     fill_in 'user_password_confirmation', with: 'destroyallhumans'
@@ -65,7 +65,7 @@ feature 'Registration form' do
     visit new_user_registration_path
 
     fill_in 'user_username',              with: "robot"
-    fill_in 'user_family_name',           with: 'This is the honeypot field'
+    fill_in 'user_address',               with: 'This is the honeypot field'
     fill_in 'user_email',                 with: 'robot@robot.com'
     fill_in 'user_password',              with: 'destroyallhumans'
     fill_in 'user_password_confirmation', with: 'destroyallhumans'


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1772

## Objectives

Changes honeypot `:family_name` to `:address` on users sign up form. This prevent a real user fill this honeypot hidden field when use "autofill" browser feature. 

We use `HTML <input> autocomplete = "off"` in some fields in this form (honeypot included) but it seems new browsers are ignoring this value.

## Visual Changes
_The honeypot field is hidden but I change styles to show it and view the changes_

**BEFORE**
![before](https://user-images.githubusercontent.com/631897/50287623-99326180-0463-11e9-8b2c-a681aadfb5db.gif)


**AFTER**
![after](https://user-images.githubusercontent.com/631897/50287626-9b94bb80-0463-11e9-9e9c-1453adf4cfe3.gif)

## Notes

Some info about HTML <input> autocomplete = "off":

[HTML <input> autocomplete Attribute](https://www.w3schools.com/tags/att_input_autocomplete.asp)
[AutoComplete=Off” not working on Google Chrome Browser](https://stackoverflow.com/questions/18306052/autocomplete-off-not-working-on-google-chrome-browser)
[Chrome ignores autocomplete=“off”](https://stackoverflow.com/questions/12374442/chrome-ignores-autocomplete-off)

