### PR TITLE
Fix crash in valuation when there are no budgets

### DIFF
--- a/app/controllers/valuation/budgets_controller.rb
+++ b/app/controllers/valuation/budgets_controller.rb
@@ -7,7 +7,6 @@ class Valuation::BudgetsController < Valuation::BaseController
   def index
     @budget = current_budget
     if @budget.present?
-      @investments_with_valuation_open = {}
       @investments_with_valuation_open = @budget.investments
                                                 .by_valuator(current_user.valuator.try(:id))
                                                 .valuation_open

--- a/app/controllers/valuation/budgets_controller.rb
+++ b/app/controllers/valuation/budgets_controller.rb
@@ -7,10 +7,9 @@ class Valuation::BudgetsController < Valuation::BaseController
   def index
     @budget = current_budget
     if @budget.present?
-      @investments_with_valuation_open = @budget.investments
-                                                .by_valuator(current_user.valuator.try(:id))
-                                                .valuation_open
-                                                .count
+      @investments = @budget.investments
+                            .by_valuator(current_user.valuator)
+                            .valuation_open
     end
   end
 end

--- a/app/views/valuation/budgets/index.html.erb
+++ b/app/views/valuation/budgets/index.html.erb
@@ -18,7 +18,7 @@
         <%= t("budgets.phase.#{@budget.phase}") %>
       </td>
       <td>
-        <%= @investments_with_valuation_open %>
+        <%= @investments.count %>
       </td>
       <td>
         <%= link_to t("valuation.budgets.index.evaluate"),

--- a/app/views/valuation/budgets/index.html.erb
+++ b/app/views/valuation/budgets/index.html.erb
@@ -1,30 +1,36 @@
 <h2 class="inline-block"><%= t("valuation.budgets.index.title") %></h2>
 
-<table>
-  <thead>
-    <tr>
-      <th><%= t("valuation.budgets.index.table_name") %></th>
-      <th><%= t("valuation.budgets.index.table_phase") %></th>
-      <th><%= t("valuation.budgets.index.table_assigned_investments_valuation_open") %></th>
-      <th><%= t("valuation.budgets.index.table_actions") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr id="<%= dom_id(@budget) %>" class="budget">
-      <td>
-        <%= @budget.name %>
-      </td>
-      <td>
-        <%= t("budgets.phase.#{@budget.phase}") %>
-      </td>
-      <td>
-        <%= @investments.count %>
-      </td>
-      <td>
-        <%= link_to t("valuation.budgets.index.evaluate"),
-                    valuation_budget_budget_investments_path(budget_id: @budget.id),
-                    class: "button hollow expanded" %>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<% if @budget.present? %>
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("valuation.budgets.index.table_name") %></th>
+        <th><%= t("valuation.budgets.index.table_phase") %></th>
+        <th><%= t("valuation.budgets.index.table_assigned_investments_valuation_open") %></th>
+        <th><%= t("valuation.budgets.index.table_actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr id="<%= dom_id(@budget) %>" class="budget">
+        <td>
+          <%= @budget.name %>
+        </td>
+        <td>
+          <%= t("budgets.phase.#{@budget.phase}") %>
+        </td>
+        <td>
+          <%= @investments.count %>
+        </td>
+        <td>
+          <%= link_to t("valuation.budgets.index.evaluate"),
+                      valuation_budget_budget_investments_path(budget_id: @budget.id),
+                      class: "button hollow expanded" %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+<% else %>
+  <div class="callout primary clear">
+    <%= t("valuation.budgets.index.no_budgets") %>
+  </div>
+<% end %>

--- a/config/locales/en/valuation.yml
+++ b/config/locales/en/valuation.yml
@@ -17,6 +17,7 @@ en:
         table_assigned_investments_valuation_open: Investment projects assigned with valuation open
         table_actions: Actions
         evaluate: Evaluate
+        no_budgets: "There are no budgets"
     budget_investments:
       index:
         headings_filter_all: All headings

--- a/config/locales/es/valuation.yml
+++ b/config/locales/es/valuation.yml
@@ -17,6 +17,7 @@ es:
         table_assigned_investments_valuation_open: Prop. Inv. asignadas en evaluación
         table_actions: Acciones
         evaluate: Evaluar
+        no_budgets: "No hay presupuestos"
     budget_investments:
       index:
         headings_filter_all: Todas las partidas

--- a/spec/features/valuation/budgets_spec.rb
+++ b/spec/features/valuation/budgets_spec.rb
@@ -35,6 +35,11 @@ feature 'Valuation budgets' do
       expect(page).to have_content(budget3.name)
     end
 
+    scenario "With no budgets" do
+      visit valuation_budgets_path
+
+      expect(page).to have_content "There are no budgets"
+    end
   end
 
 end


### PR DESCRIPTION
## References

* Closes consul/installer#54

## Objectives

Fix a crash in the valuation section when there are no budgets.

## Visual Changes

After these changes:
![There are no budgets appears written in the valuation section](https://user-images.githubusercontent.com/35156/50352597-fdc5ed00-0545-11e9-9054-00e71ca7813c.png)