### PR TITLE
[Backport] Documents title

### DIFF
--- a/app/views/documents/_documents.html.erb
+++ b/app/views/documents/_documents.html.erb
@@ -1,9 +1,9 @@
-<div id="documents" class="documents">
-  <h2><%= t("documents.title") %>&nbsp;<span>(<%= documents.count %>)</span></h2>
+<% if documents.any? %>
+  <div id="documents" class="documents">
+    <h2><%= t("documents.title") %>&nbsp;<span>(<%= documents.count %>)</span></h2>
 
-  <% if documents.any? %>
     <ul class="no-bullet document-link">
       <%= render partial: "documents/document", collection: documents %>
     </ul>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -68,6 +68,33 @@ shared_examples "documentable" do |documentable_factory_name,
 
     end
 
+    describe "When allow attached documents setting is enabled" do
+      before do
+        Setting['feature.allow_attached_documents'] = true
+      end
+
+      after do
+        Setting['feature.allow_attached_documents'] = false
+      end
+
+      scenario "Documents list should be available" do
+        login_as(user)
+        visit send(documentable_path, arguments)
+
+        expect(page).to have_css("#documents")
+        expect(page).to have_content("Documents (1)")
+      end
+
+      scenario "Documents list increase documents number" do
+        create(:document, documentable: documentable, user: documentable.author)
+        login_as(user)
+        visit send(documentable_path, arguments)
+
+        expect(page).to have_css("#documents")
+        expect(page).to have_content("Documents (2)")
+      end
+    end
+
     describe "When allow attached documents setting is disabled" do
       before do
         Setting['feature.allow_attached_documents'] = false
@@ -101,7 +128,7 @@ shared_examples "documentable" do |documentable_factory_name,
       expect(page).to have_content "Document was deleted successfully."
     end
 
-    scenario "Should update documents tab count after successful deletion" do
+    scenario "Should hide documents tab if there is no documents" do
       login_as documentable.author
 
       visit send(documentable_path, arguments)
@@ -110,7 +137,7 @@ shared_examples "documentable" do |documentable_factory_name,
         click_on "Destroy document"
       end
 
-      expect(page).to have_content "Documents (0)"
+      expect(page).not_to have_content "Documents (0)"
     end
 
     scenario "Should redirect to documentable path after successful deletion" do


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1773

## Objectives

Shows documents title only if there is any document.

## Visual Changes

**BEFORE**
![screenshot 2018-12-20 at 14 59 32](https://user-images.githubusercontent.com/631897/50289043-fa5c3400-0467-11e9-873e-f4606966d309.png)

**AFTER**
![screenshot 2018-12-20 at 15 00 10](https://user-images.githubusercontent.com/631897/50289050-fcbe8e00-0467-11e9-81ce-0555f02e8a9b.png)

_With documents the title shows as before_
![screenshot 2018-12-20 at 14 59 42](https://user-images.githubusercontent.com/631897/50289053-ff20e800-0467-11e9-913c-158cfd1889b0.png)
