### PR TITLE
[Backport] Bug Management Cannot create Budget Investment without a map location

### DIFF
--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -52,7 +52,8 @@ class Management::Budgets::InvestmentsController < Management::BaseController
     end
 
     def investment_params
-      params.require(:budget_investment).permit(:title, :description, :external_url, :heading_id, :tag_list, :organization_name, :location)
+      params.require(:budget_investment).permit(:title, :description, :external_url, :heading_id,
+                                                :tag_list, :organization_name, :location, :skip_map)
     end
 
     def only_verified_users

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -9,6 +9,15 @@ feature 'Budget Investments' do
     @heading = create(:budget_heading, group: @group, name: "Health")
   end
 
+  it_behaves_like "mappable",
+                  "budget_investment",
+                  "investment",
+                  "new_management_budget_investment_path",
+                  "",
+                  "management_budget_investment_path",
+                  { "budget_id": "budget_id" },
+                  management = true
+
   context "Create" do
     before { @budget.update(phase: 'accepting') }
 

--- a/spec/shared/features/mappable.rb
+++ b/spec/shared/features/mappable.rb
@@ -1,4 +1,10 @@
-shared_examples "mappable" do |mappable_factory_name, mappable_association_name, mappable_new_path, mappable_edit_path, mappable_show_path, mappable_path_arguments|
+shared_examples "mappable" do |mappable_factory_name,
+                               mappable_association_name,
+                               mappable_new_path,
+                               mappable_edit_path,
+                               mappable_show_path,
+                               mappable_path_arguments,
+                               management = false|
 
   include ActionView::Helpers
 
@@ -6,6 +12,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
   let!(:arguments)    { {} }
   let!(:mappable)     { create(mappable_factory_name.to_s.to_sym) }
   let!(:map_location) { create(:map_location, "#{mappable_factory_name}_map_location".to_sym, "#{mappable_association_name}": mappable) }
+  let(:management)    { management }
 
   before do
     Setting['feature.map'] = true
@@ -16,7 +23,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     before { set_arguments(arguments, mappable, mappable_path_arguments) }
 
     scenario "Should not show marker by default on create #{mappable_factory_name}", :js do
-      login_as user
+      do_login_for user
       visit send(mappable_new_path, arguments)
 
       send("fill_in_#{mappable_factory_name}_form")
@@ -27,7 +34,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario "Should show marker on create #{mappable_factory_name} when click on map", :js do
-      login_as user
+      do_login_for user
       visit send(mappable_new_path, arguments)
 
       send("fill_in_#{mappable_factory_name}_form")
@@ -39,7 +46,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario "Should create #{mappable_factory_name} with map", :js do
-      login_as user
+      do_login_for user
       visit send(mappable_new_path, arguments)
 
       send("fill_in_#{mappable_factory_name}_form")
@@ -50,7 +57,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario "Can not display map on #{mappable_factory_name} when not fill marker on map", :js do
-      login_as user
+      do_login_for user
       visit send(mappable_new_path, arguments)
 
       send("fill_in_#{mappable_factory_name}_form")
@@ -63,7 +70,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
     scenario "Can not display map on #{mappable_factory_name} when feature.map is disabled", :js do
       Setting['feature.map'] = false
-      login_as user
+      do_login_for user
       visit send(mappable_new_path, arguments)
 
       send("fill_in_#{mappable_factory_name}_form")
@@ -74,7 +81,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario 'Errors on create' do
-      login_as user
+      do_login_for user
       visit send(mappable_new_path, arguments)
 
       send("submit_#{mappable_factory_name}_form")
@@ -83,7 +90,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario 'Skip map', :js do
-      login_as user
+      do_login_for user
       visit send(mappable_new_path, arguments)
 
       send("fill_in_#{mappable_factory_name}_form")
@@ -94,7 +101,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario 'Toggle map', :js do
-      login_as user
+      do_login_for user
       visit send(mappable_new_path, arguments)
 
       check "#{mappable_factory_name}_skip_map"
@@ -115,7 +122,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     before { skip } if mappable_edit_path.blank?
 
     scenario "Should edit map on #{mappable_factory_name} and contain default values", :js do
-      login_as mappable.author
+      do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
 
@@ -124,7 +131,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario "Should edit default values from map on #{mappable_factory_name} edit page", :js do
-      login_as mappable.author
+      do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
       find(".map_location").click
@@ -137,7 +144,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario "Should edit mappable on #{mappable_factory_name} without change map", :js do
-      login_as mappable.author
+      do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
       fill_in "#{mappable_factory_name}_title", with: "New title"
@@ -150,7 +157,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario "Can not display map on #{mappable_factory_name} edit when remove map marker", :js do
-      login_as mappable.author
+      do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
       click_link "Remove map marker"
@@ -162,7 +169,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
     scenario "Can not display map on #{mappable_factory_name} edit when feature.map is disabled", :js do
       Setting['feature.map'] = false
-      login_as mappable.author
+      do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
       fill_in "#{mappable_factory_name}_title", with: "New title"
@@ -173,7 +180,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
     scenario 'No errors on update', :js do
       skip ""
-      login_as mappable.author
+      do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
       click_link "Remove map marker"
@@ -183,7 +190,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     scenario 'No need to skip map on update' do
-      login_as mappable.author
+      do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
       click_link "Remove map marker"
@@ -196,7 +203,10 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
   describe "At #{mappable_show_path}" do
 
-    before { set_arguments(arguments, mappable, mappable_path_arguments) }
+    before do
+      set_arguments(arguments, mappable, mappable_path_arguments)
+      do_login_for(user) if management
+    end
 
     scenario "Should display map on #{mappable_factory_name} show page", :js do
       arguments[:id] = mappable.id
@@ -227,6 +237,15 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
 
   end
 
+end
+
+def do_login_for(user)
+  if management
+    login_as_manager
+    login_managed_user(user)
+  else
+    login_as(user)
+  end
 end
 
 def fill_in_proposal_form


### PR DESCRIPTION
## References

PR https://github.com/AyuntamientoMadrid/consul/pull/1775

## Objectives
From the management console `/management/budgets/create_investments` it´s not possible to create a Budget Investment without a map location. 
Should be possible by checking the option "This investment doesn't have a concrete location or I'm not aware of it." 

## Visual Error
![captura de pantalla 2018-12-26 a las 11 41 13](https://user-images.githubusercontent.com/942995/50443778-21ea4b00-0905-11e9-9126-8b838abccff1.png)

![captura de pantalla 2018-12-26 a las 11 42 03](https://user-images.githubusercontent.com/942995/50443792-2ca4e000-0905-11e9-9745-7f6dce003b8d.png)
