### PR TITLE
[Backport] Add rubocop rule to indent private methods

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -18,6 +18,9 @@ AllCops:
 Layout/IndentationConsistency:
   EnforcedStyle: rails
 
+Layout/IndentationWidth:
+  Enabled: true
+
 Layout/EndOfLine:
   EnforcedStyle: lf
 


### PR DESCRIPTION
## References

Backports AyuntamientoMadrid#1785

## Objectives

Make the `EnforcedStyle: rails` defined in `Layout/IndentationConsistency` work properly.