### PR TITLE
[Backport] Show documents on processes proposals phase

### DIFF
--- a/app/views/legislation/processes/proposals.html.erb
+++ b/app/views/legislation/processes/proposals.html.erb
@@ -2,6 +2,8 @@
 
 <%= render 'legislation/processes/header', process: @process, header: :full %>
 
+<%= render 'documents/additional_documents', documents: @process.documents %>
+
 <%= render 'key_dates', process: @process, phase: :proposals %>
 
 <%= render 'proposals_content', process: @process, proposals: @proposals %>

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -134,12 +134,21 @@ feature 'Legislation' do
     context "show" do
       include_examples "not published permissions", :legislation_process_path
 
-      scenario '#show view has document present' do
+      scenario 'show view has document present on all phases' do
         process = create(:legislation_process)
         document = create(:document, documentable: process)
+        phases = ["Debate", "Proposals", "Draft publication",
+                  "Comments", "Final result publication"]
+
         visit legislation_process_path(process)
 
-        expect(page).to have_content(document.title)
+        phases.each do |phase|
+          within(".legislation-process-list") do
+            find('li', :text => "#{phase}").click_link
+          end
+
+          expect(page).to have_content(document.title)
+        end
       end
 
       scenario 'show additional info button' do


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1781

## Objectives

- Adds documents list on legislation process proposals phase. Before the documents of the process didn't appear on this phase.

## Visual Changes

**AFTER**
![screenshot 2018-12-27 at 13 09 39](https://user-images.githubusercontent.com/631897/50479816-ba9dcb00-09d8-11e9-90cb-39384205f21c.png)