### PR TITLE
[Backport] Processes key dates

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -121,14 +121,6 @@
     background: $highlight;
     position: relative;
 
-    @include breakpoint(large down) {
-
-      &::after {
-        content: '\61';
-        color: $link;
-      }
-    }
-
     @include breakpoint(large) {
       background: none;
       border: 1px solid $border;
@@ -137,11 +129,14 @@
       &::after {
         border-bottom: 1px solid #fefefe;
         bottom: -1px;
-        content: '';
         left: 0;
         position: absolute;
         width: 100%;
       }
+    }
+
+    &::after {
+      content: '';
     }
   }
 }

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -44,68 +44,98 @@
 // 02. Legislation process navigation
 // ----------------------------------
 
-.legislation-process-categories {
-  position: relative;
+.legislation-process-list {
+  border-bottom: 1px solid $border;
+}
 
-  .legislation-process-list {
-    border-bottom: 1px solid $medium-gray;
-    margin: 0 rem-calc(16) rem-calc(16);
+.key-dates {
+  list-style-type: none;
+  margin: 0 rem-calc(-10);
 
-    ul {
-      list-style: none;
-      margin: 0 auto;
+  @include breakpoint(medium) {
+    margin: 0;
+  }
+
+  li {
+    border: 1px solid $border;
+    display: block;
+    margin: rem-calc(-1) 0;
+    position: relative;
+
+    @include breakpoint(medium) {
+      background: #fafafa;
+      display: inline-block;
+      border-bottom: 0;
+      border-top-left-radius: rem-calc(6);
+      border-top-right-radius: rem-calc(6);
       margin-bottom: 0;
-      padding-left: 0;
+      margin-right: $line-height / 4;
+      margin-top: 0;
+
+      &:hover:not(.is-active) {
+        background: $highlight;
+      }
+
+      &::after {
+        content: '' !important;
+      }
     }
 
-    li {
-      border-bottom: 2px solid transparent;
-      cursor: pointer;
-      display: inline-block;
-      margin-bottom: $line-height;
-      margin-right: $line-height;
-      transition: all 0.4s;
-
-      @include breakpoint(medium) {
-        margin-bottom: 0;
-      }
-
-      &:hover,
-      &:active,
-      &:focus {
-        border-bottom: 2px solid $brand;
-      }
-
-      a,
-      h4 {
-        display: block;
-        color: #6d6d6d;
-        margin-bottom: 0;
-      }
+    &::after {
+      content: '\63';
+      font-family: "icons" !important;
+      font-size: rem-calc(24);
+      pointer-events: none;
+      position: absolute;
+      right: 12px;
+      top: 12px;
     }
 
     a {
-      &:hover,
-      &:active {
+      display: block;
+      padding: $line-height / 4 $line-height / 2;
+
+      @include breakpoint(medium) {
+        display: inline-block;
+      }
+
+      &:hover {
         text-decoration: none;
       }
 
-      p {
+      h4 {
         margin-bottom: 0;
+      }
+    }
+  }
 
-        @include breakpoint(medium) {
-          margin-bottom: rem-calc(16);
-        }
+  span {
+    color: $text-medium;
+    font-size: $small-font-size;
+  }
+
+  .is-active {
+    background: $highlight;
+    position: relative;
+
+    @include breakpoint(medium) {
+      background: none;
+      border: 1px solid $border;
+      border-bottom: 0;
+
+      &::after {
+        border-bottom: 1px solid #fefefe;
+        bottom: -1px;
+        content: '' !important;
+        left: 0;
+        position: absolute;
+        width: 100%;
       }
     }
 
-    .is-active {
-      border-bottom: 2px solid $brand;
-
-      a,
-      h4 {
-        color: $brand;
-      }
+    &::after {
+      content: '\61';
+      color: $link;
     }
   }
 }

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -52,7 +52,7 @@
   list-style-type: none;
   margin: 0 rem-calc(-10);
 
-  @include breakpoint(medium) {
+  @include breakpoint(large) {
     margin: 0;
   }
 
@@ -62,7 +62,20 @@
     margin: rem-calc(-1) 0;
     position: relative;
 
-    @include breakpoint(medium) {
+    @include breakpoint(large down) {
+
+      &::after {
+        content: '\63';
+        font-family: "icons" !important;
+        font-size: rem-calc(24);
+        pointer-events: none;
+        position: absolute;
+        right: 12px;
+        top: 12px;
+      }
+    }
+
+    @include breakpoint(large) {
       background: #fafafa;
       display: inline-block;
       border-bottom: 0;
@@ -77,25 +90,15 @@
       }
 
       &::after {
-        content: '' !important;
+        content: '';
       }
-    }
-
-    &::after {
-      content: '\63';
-      font-family: "icons" !important;
-      font-size: rem-calc(24);
-      pointer-events: none;
-      position: absolute;
-      right: 12px;
-      top: 12px;
     }
 
     a {
       display: block;
       padding: $line-height / 4 $line-height / 2;
 
-      @include breakpoint(medium) {
+      @include breakpoint(large) {
         display: inline-block;
       }
 
@@ -118,7 +121,15 @@
     background: $highlight;
     position: relative;
 
-    @include breakpoint(medium) {
+    @include breakpoint(large down) {
+
+      &::after {
+        content: '\61';
+        color: $link;
+      }
+    }
+
+    @include breakpoint(large) {
       background: none;
       border: 1px solid $border;
       border-bottom: 0;
@@ -126,16 +137,11 @@
       &::after {
         border-bottom: 1px solid #fefefe;
         bottom: -1px;
-        content: '' !important;
+        content: '';
         left: 0;
         position: absolute;
         width: 100%;
       }
-    }
-
-    &::after {
-      content: '\61';
-      color: $link;
     }
   }
 }

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -80,6 +80,10 @@ class Legislation::Process < ActiveRecord::Base
     Legislation::Process::Publication.new(result_publication_date, result_publication_enabled)
   end
 
+  def enabled_phases?
+    PHASES_AND_PUBLICATIONS.any? { |process| send(process).enabled? }
+  end
+
   def enabled_phases_and_publications_count
     PHASES_AND_PUBLICATIONS.count { |process| send(process).enabled? }
   end

--- a/app/views/admin/legislation/homepages/_form.html.erb
+++ b/app/views/admin/legislation/homepages/_form.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <%= f.translatable_fields do |translations_form| %>
-    <div class="small-12 column end">
+    <div class="small-12 column">
       <div class="ckeditor">
         <%= translations_form.cktext_area :homepage,
                                           language: I18n.locale,
@@ -22,7 +22,7 @@
     </div>
   <% end %>
 
-  <div class="small-12 medium-3 column clear end">
+  <div class="small-12 medium-3 column end margin-top">
     <%= f.submit(class: "button success expanded", value: t("admin.legislation.processes.#{admin_submit_action(@process)}.submit_button")) %>
   </div>
 <% end %>

--- a/app/views/legislation/processes/_key_dates.html.erb
+++ b/app/views/legislation/processes/_key_dates.html.erb
@@ -1,65 +1,65 @@
-<nav class="legislation-process-categories">
-  <div class="legislation-process-list">
-    <div class="row">
-      <div class="small-12 column">
+<nav class="<%= 'legislation-process-list' if process.enabled_phases? %>">
+  <div class="row">
+    <div class="small-12 column">
+      <% if process.enabled_phases? %>
         <h3><%= t("legislation.processes.shared.key_dates") %></h3>
+      <% end %>
 
-        <ul>
-          <% if process.debate_phase.enabled? %>
-            <li <%= 'class=is-active' if phase.to_sym == :debate_phase %>>
-              <%= link_to debate_legislation_process_path(process) do %>
-                <h4><%= t('legislation.processes.shared.debate_dates') %></h4>
-                <p><%= format_date(process.debate_start_date) %> - <%= format_date(process.debate_end_date) %></p>
-              <% end %>
-            </li>
-          <% end %>
+      <ul class="key-dates">
+        <% if process.debate_phase.enabled? %>
+          <li <%= 'class=is-active' if phase.to_sym == :debate_phase %>>
+            <%= link_to debate_legislation_process_path(process) do %>
+              <h4><%= t("legislation.processes.shared.debate_dates") %></h4>
+              <span><%= format_date(process.debate_start_date) %> - <%= format_date(process.debate_end_date) %></span>
+            <% end %>
+          </li>
+        <% end %>
 
-          <% if process.proposals_phase.enabled? %>
-            <li <%= 'class=is-active' if phase.to_sym == :proposals %>>
-              <%= link_to proposals_legislation_process_path(process) do %>
-                <h4><%= t('legislation.processes.shared.proposals_dates') %></h4>
-                <p><%= format_date(process.proposals_phase_start_date) %> - <%= format_date(process.proposals_phase_end_date) %></p>
-              <% end %>
-            </li>
-          <% end %>
+        <% if process.proposals_phase.enabled? %>
+          <li <%= 'class=is-active' if phase.to_sym == :proposals %>>
+            <%= link_to proposals_legislation_process_path(process) do %>
+              <h4><%= t("legislation.processes.shared.proposals_dates") %></h4>
+              <span><%= format_date(process.proposals_phase_start_date) %> - <%= format_date(process.proposals_phase_end_date) %></span>
+            <% end %>
+          </li>
+        <% end %>
 
-          <% if process.draft_publication.enabled? %>
-            <li <%= 'class=is-active' if phase.to_sym == :draft_publication %>>
-              <%= link_to draft_publication_legislation_process_path(process) do %>
-                <h4><%= t('legislation.processes.shared.draft_publication_date') %></h4>
-                <p><%= format_date(process.draft_publication_date) %></p>
-              <% end %>
-            </li>
-          <% end %>
+        <% if process.draft_publication.enabled? %>
+          <li <%= 'class=is-active' if phase.to_sym == :draft_publication %>>
+            <%= link_to draft_publication_legislation_process_path(process) do %>
+              <h4><%= t("legislation.processes.shared.draft_publication_date") %></h4>
+              <span><%= format_date(process.draft_publication_date) %></span>
+            <% end %>
+          </li>
+        <% end %>
 
-          <% if process.allegations_phase.enabled? %>
-            <li <%= 'class=is-active' if phase.to_sym == :allegations_phase %>>
-              <%= link_to allegations_legislation_process_path(process) do %>
-                <h4><%= t('legislation.processes.shared.allegations_dates') %></h4>
-                <p><%= format_date(process.allegations_start_date) %> - <%= format_date(process.allegations_end_date) %></p>
-              <% end %>
-            </li>
-          <% end %>
+        <% if process.allegations_phase.enabled? %>
+          <li <%= 'class=is-active' if phase.to_sym == :allegations_phase %>>
+            <%= link_to allegations_legislation_process_path(process) do %>
+              <h4><%= t("legislation.processes.shared.allegations_dates") %></h4>
+              <span><%= format_date(process.allegations_start_date) %> - <%= format_date(process.allegations_end_date) %></span>
+            <% end %>
+          </li>
+        <% end %>
 
-          <% if process.result_publication.enabled? %>
-            <li <%= 'class=is-active' if phase.to_sym == :result_publication %>>
-              <%= link_to result_publication_legislation_process_path(process) do %>
-                <h4><%= t('legislation.processes.shared.result_publication_date') %></h4>
-                <p><%= format_date(process.result_publication_date) %></p>
-              <% end %>
-            </li>
-          <% end %>
+        <% if process.result_publication.enabled? %>
+          <li <%= 'class=is-active' if phase.to_sym == :result_publication %>>
+            <%= link_to result_publication_legislation_process_path(process) do %>
+              <h4><%= t("legislation.processes.shared.result_publication_date") %></h4>
+              <span><%= format_date(process.result_publication_date) %></span>
+            <% end %>
+          </li>
+        <% end %>
 
-          <% if process.milestones.any? %>
-            <li class="milestones <%= "is-active" if phase == :milestones %>">
-              <%= link_to milestones_legislation_process_path(process) do %>
-                <h4><%= t("legislation.processes.shared.milestones_date") %></h4>
-                <p><%= format_date(process.milestones.order_by_publication_date.last.publication_date) %></p>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
+        <% if process.milestones.any? %>
+          <li class="milestones <%= "is-active" if phase == :milestones %>">
+            <%= link_to milestones_legislation_process_path(process) do %>
+              <h4><%= t("legislation.processes.shared.milestones_date") %></h4>
+              <span><%= format_date(process.milestones.order_by_publication_date.last.publication_date) %></span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
     </div>
   </div>
 </nav>

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -82,7 +82,7 @@ en:
         see_latest_comments: See latest comments
         see_latest_comments_title: Comment on this process
       shared:
-        key_dates: Key dates
+        key_dates: Participation phases
         debate_dates: Debate
         draft_publication_date: Draft publication
         allegations_dates: Comments

--- a/config/locales/es-AR/legislation.yml
+++ b/config/locales/es-AR/legislation.yml
@@ -73,7 +73,7 @@ es-AR:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-BO/legislation.yml
+++ b/config/locales/es-BO/legislation.yml
@@ -73,7 +73,7 @@ es-BO:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-CL/legislation.yml
+++ b/config/locales/es-CL/legislation.yml
@@ -73,7 +73,7 @@ es-CL:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-CO/legislation.yml
+++ b/config/locales/es-CO/legislation.yml
@@ -73,7 +73,7 @@ es-CO:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-CR/legislation.yml
+++ b/config/locales/es-CR/legislation.yml
@@ -73,7 +73,7 @@ es-CR:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-DO/legislation.yml
+++ b/config/locales/es-DO/legislation.yml
@@ -73,7 +73,7 @@ es-DO:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-EC/legislation.yml
+++ b/config/locales/es-EC/legislation.yml
@@ -73,7 +73,7 @@ es-EC:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-GT/legislation.yml
+++ b/config/locales/es-GT/legislation.yml
@@ -73,7 +73,7 @@ es-GT:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-HN/legislation.yml
+++ b/config/locales/es-HN/legislation.yml
@@ -73,7 +73,7 @@ es-HN:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-MX/legislation.yml
+++ b/config/locales/es-MX/legislation.yml
@@ -73,7 +73,7 @@ es-MX:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-NI/legislation.yml
+++ b/config/locales/es-NI/legislation.yml
@@ -73,7 +73,7 @@ es-NI:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-PA/legislation.yml
+++ b/config/locales/es-PA/legislation.yml
@@ -73,7 +73,7 @@ es-PA:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-PE/legislation.yml
+++ b/config/locales/es-PE/legislation.yml
@@ -73,7 +73,7 @@ es-PE:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-PR/legislation.yml
+++ b/config/locales/es-PR/legislation.yml
@@ -73,7 +73,7 @@ es-PR:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-PY/legislation.yml
+++ b/config/locales/es-PY/legislation.yml
@@ -73,7 +73,7 @@ es-PY:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-SV/legislation.yml
+++ b/config/locales/es-SV/legislation.yml
@@ -73,7 +73,7 @@ es-SV:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-UY/legislation.yml
+++ b/config/locales/es-UY/legislation.yml
@@ -73,7 +73,7 @@ es-UY:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es-VE/legislation.yml
+++ b/config/locales/es-VE/legislation.yml
@@ -73,7 +73,7 @@ es-VE:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         result_publication_date: Publicación resultados

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -82,7 +82,7 @@ es:
         see_latest_comments: Ver últimas aportaciones
         see_latest_comments_title: Aportar a este proceso
       shared:
-        key_dates: Fechas clave
+        key_dates: Fases de participación
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         allegations_dates: Comentarios

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -100,6 +100,25 @@ FactoryBot.define do
       end_date   { 1.week.from_now }
     end
 
+    trait :empty do
+      start_date { Date.current - 5.days }
+      end_date { Date.current + 5.days }
+      debate_start_date nil
+      debate_end_date nil
+      draft_publication_date nil
+      allegations_start_date nil
+      allegations_end_date nil
+      proposals_phase_start_date nil
+      proposals_phase_end_date nil
+      result_publication_date nil
+      debate_phase_enabled false
+      allegations_phase_enabled false
+      proposals_phase_enabled false
+      draft_publication_enabled false
+      result_publication_enabled false
+      published true
+    end
+
   end
 
   factory :legislation_draft_version, class: 'Legislation::DraftVersion' do

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -47,17 +47,32 @@ feature 'Legislation' do
       end
     end
 
-    scenario 'Key dates are displayed on current locale' do
+    scenario 'Participation phases are displayed only if there is a phase enabled' do
+      process = create(:legislation_process, :empty)
+      process_debate = create(:legislation_process)
+
+      visit legislation_process_path(process)
+
+      expect(page).not_to have_content("Participation phases")
+
+      visit legislation_process_path(process_debate)
+
+      expect(page).to have_content("Participation phases")
+    end
+
+    scenario 'Participation phases are displayed on current locale' do
       process = create(:legislation_process, proposals_phase_start_date: Date.new(2018, 01, 01),
                                              proposals_phase_end_date: Date.new(2018, 12, 01))
 
       visit legislation_process_path(process)
 
+      expect(page).to have_content("Participation phases")
       expect(page).to have_content("Proposals")
       expect(page).to have_content("01 Jan 2018 - 01 Dec 2018")
 
       visit legislation_process_path(process, locale: "es")
 
+      expect(page).to have_content("Fases de participación")
       expect(page).to have_content("Propuestas")
       expect(page).to have_content("01 ene 2018 - 01 dic 2018")
     end


### PR DESCRIPTION
## References
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1780 and https://github.com/AyuntamientoMadrid/consul/pull/1788/

## Objectives

To improve UX, this PR changes styles (to tabs style) on processes key dates.

## Visual Changes

**Before** _(some users didn't understand the key dates was links)_ 
![before](https://user-images.githubusercontent.com/631897/50452502-b02cf400-093a-11e9-8b61-3c5fd1f603cd.png)

**After** _(the new style as tabs it's easier to understand)_
![after](https://user-images.githubusercontent.com/631897/50452506-b327e480-093a-11e9-8533-2aae714a6446.gif)

**Mobile version**
![mobile](https://user-images.githubusercontent.com/631897/50487907-58f15700-0a00-11e9-902d-54e7b5ca215c.gif)

**UPDATE** 
_Finally on mobile sizes we remove arrow on `is-active` process phase._
![screenshot 2018-12-28 at 19 36 33](https://user-images.githubusercontent.com/631897/50524864-7265d200-0ad8-11e9-8179-e2154d217edb.png)
