### PR TITLE
Admin tables order - sorting [#2931]

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -215,10 +215,6 @@ $sidebar-active: #f4fcd0;
 
     thead {
       color: #fff;
-
-      a {
-        color: inherit;
-      }
     }
 
     th {
@@ -227,6 +223,10 @@ $sidebar-active: #f4fcd0;
 
       label {
         color: #fff;
+      }
+
+      a {
+        color: inherit;
       }
     }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -215,6 +215,10 @@ $sidebar-active: #f4fcd0;
 
     thead {
       color: #fff;
+
+      a {
+        color: inherit;
+      }
     }
 
     th {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -227,6 +227,7 @@ $sidebar-active: #f4fcd0;
 
       a {
         color: inherit;
+        white-space: nowrap;
       }
     }
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -77,7 +77,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
     def load_investments
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
-                                       .order_filter(params[:sort_by])
+                                       .order_filter(params[:sort_by], params[:direction])
+
       @investments = @investments.page(params[:page]) unless request.format.csv?
     end
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -80,6 +80,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
                                        .order_filter(params[:sort_by], params[:direction])
 
+      @investments = Budget::Investment.by_budget(@budget).all
       @investments = @investments.page(params[:page]) unless request.format.csv?
     end
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -76,6 +76,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_investments
+      params[:direction].present? ? params[:direction] : params[:direction] = "asc"
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
                                        .order_filter(params[:sort_by], params[:direction])
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -76,11 +76,9 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_investments
-      params[:direction].present? ? params[:direction] : params[:direction] = "asc"
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
-                                       .order_filter(params[:sort_by], params[:direction])
+                                       .order_filter(params)
 
-      @investments = Budget::Investment.by_budget(@budget).all
       @investments = @investments.page(params[:page]) unless request.format.csv?
     end
 
@@ -136,5 +134,4 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
         end
       end
     end
-
 end

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -6,8 +6,9 @@ module BudgetInvestmentsHelper
   def link_to_investments_sorted_by(column)
     sort_by = column.downcase
     default_direction = "desc"
+    current_direction = params[:direction].downcase if params[:direction]
 
-    direction = params[:direction] == default_direction ? default_direction : "asc"
+    direction = current_direction == default_direction ? default_direction : "asc"
 
     icon = direction == default_direction ? "icon-arrow-down" : "icon-arrow-top"
     icon = sort_by == params[:sort_by] ? icon : ""

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -12,7 +12,7 @@ module BudgetInvestmentsHelper
     translation = t("admin.budget_investments.index.list.#{column}")
 
     link_to(
-      "#{translation} <span class=\"#{icon}\"></span>".html_safe,
+      "#{translation} <span class='#{icon}'></span>".html_safe,
       admin_budget_budget_investments_path(sort_by: column, direction: direction)
     )
   end

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -5,13 +5,10 @@ module BudgetInvestmentsHelper
 
   def link_to_investments_sorted_by(column)
     sort_by = column.downcase
-    default_direction = "desc"
     current_direction = params[:direction].downcase if params[:direction]
 
-    direction = current_direction == default_direction ? "asc" : default_direction
-
-    icon = direction == default_direction ? "icon-arrow-top" : "icon-arrow-down"
-    icon = sort_by == params[:sort_by] ? icon : ""
+    direction = set_direction(current_direction)
+    icon = set_sorting_icon(direction, sort_by)
 
     translation = t("admin.budget_investments.index.sort_by.#{sort_by}")
 
@@ -19,6 +16,15 @@ module BudgetInvestmentsHelper
       "#{translation} <span class=\"#{icon}\"></span>".html_safe,
       admin_budget_budget_investments_path(sort_by: sort_by, direction: direction)
     )
+  end
+
+  def set_sorting_icon(direction, sort_by)
+    icon = direction == "desc" ? "icon-arrow-top" : "icon-arrow-down"
+    icon = sort_by == params[:sort_by] ? icon : ""
+  end
+
+  def set_direction(current_direction)
+    current_direction == "desc" ? "asc" : "desc"
   end
 
   def investments_minimal_view_path

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -4,9 +4,7 @@ module BudgetInvestmentsHelper
   end
 
   def link_to_investments_sorted_by(column)
-    current_direction = params[:direction].downcase if params[:direction]
-
-    direction = set_direction(current_direction)
+    direction = set_direction(params[:direction])
     icon = set_sorting_icon(direction, column)
 
     translation = t("admin.budget_investments.index.list.#{column}")

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -5,8 +5,9 @@ module BudgetInvestmentsHelper
 
   def link_to_investments_sorted_by(column)
     sorting_option = column.downcase
-    direction = sorting_option && params[:direction] == "asc" ? "desc" : "asc"
-    icon = direction == "asc" ? "icon-arrow-top" : "icon-arrow-down"
+    direction = params[:direction] ? params[:direction] : "desc"
+
+    icon = direction == "desc" ? "icon-arrow-down" : "icon-arrow-top"
     icon = sorting_option == params[:sort_by] ? icon : ""
 
     translation = t("admin.budget_investments.index.sort_by.#{sorting_option}")

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -8,9 +8,9 @@ module BudgetInvestmentsHelper
     default_direction = "desc"
     current_direction = params[:direction].downcase if params[:direction]
 
-    direction = current_direction == default_direction ? default_direction : "asc"
+    direction = current_direction == default_direction ? "asc" : default_direction
 
-    icon = direction == default_direction ? "icon-arrow-down" : "icon-arrow-top"
+    icon = direction == default_direction ? "icon-arrow-top" : "icon-arrow-down"
     icon = sort_by == params[:sort_by] ? icon : ""
 
     translation = t("admin.budget_investments.index.sort_by.#{sort_by}")

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -4,17 +4,26 @@ module BudgetInvestmentsHelper
   end
 
   def link_to_investments_sorted_by(column)
-    sorting_option = column.downcase
-    direction = params[:direction] ? params[:direction] : "desc"
+    sort_by = column.downcase
+    allowed_directions = %w[asc desc].freeze
+    default_direction = "desc"
+    current_direction = params[:direction]
 
-    icon = direction == "desc" ? "icon-arrow-down" : "icon-arrow-top"
-    icon = sorting_option == params[:sort_by] ? icon : ""
+    if allowed_directions.include?(current_direction)
+      #select opposite direction
+      direction = allowed_directions.reject { |dir| dir == current_direction }.first
+    else
+      direction = default_direction
+    end
 
-    translation = t("admin.budget_investments.index.sort_by.#{sorting_option}")
+    icon = direction == default_direction ? "icon-arrow-top" : "icon-arrow-down"
+    icon = sort_by == params[:sort_by] ? icon : ""
+
+    translation = t("admin.budget_investments.index.sort_by.#{sort_by}")
 
     link_to(
       "#{translation} <span class=\"#{icon}\"></span>".html_safe,
-      admin_budget_budget_investments_path(sort_by: sorting_option, direction: direction)
+      admin_budget_budget_investments_path(sort_by: sort_by, direction: direction)
     )
   end
 

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -5,9 +5,15 @@ module BudgetInvestmentsHelper
 
   def link_to_investments_sorted_by(column)
     sorting_option = column.downcase
+    direction = sorting_option && params[:direction] == "asc" ? "desc" : "asc"
+    icon = direction == "asc" ? "icon-arrow-top" : "icon-arrow-down"
+    icon = sorting_option == params[:sort_by] ? icon : ""
+
+    translation = t("admin.budget_investments.index.sort_by.#{sorting_option}")
+
     link_to(
-      t("admin.budget_investments.index.sort_by.#{sorting_option}"),
-      admin_budget_budget_investments_path(sort_by: sorting_option)
+      "#{translation} <span class=\"#{icon}\"></span>".html_safe,
+      admin_budget_budget_investments_path(sort_by: sorting_option, direction: direction)
     )
   end
 

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -1,17 +1,14 @@
 module BudgetInvestmentsHelper
-  def budget_investments_sorting_options
-    Budget::Investment::SORTING_OPTIONS.map do |so|
-      [t("admin.budget_investments.index.sort_by.#{so}"), so]
-    end
-  end
-
   def budget_investments_advanced_filters(params)
     params.map { |af| t("admin.budget_investments.index.filters.#{af}") }.join(', ')
   end
 
   def link_to_investments_sorted_by(column)
-    sorting_option = budget_investments_sorting_options.select { |so| so[1] == column.downcase }.flatten
-    link_to t(sorting_option[0]), admin_budget_budget_investments_path(sort_by: sorting_option[1])
+    sorting_option = column.downcase
+    link_to(
+      t("admin.budget_investments.index.sort_by.#{sorting_option}"),
+      admin_budget_budget_investments_path(sort_by: sorting_option)
+    )
   end
 
   def investments_minimal_view_path

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -16,8 +16,15 @@ module BudgetInvestmentsHelper
   end
 
   def set_sorting_icon(direction, sort_by)
-    icon = direction == "desc" ? "icon-arrow-top" : "icon-arrow-down"
-    icon = sort_by.to_s == params[:sort_by] ? icon : ""
+    if sort_by.to_s == params[:sort_by]
+      if direction == "desc"
+        "icon-arrow-top"
+      else
+        "icon-arrow-down"
+      end
+    else
+      ""
+    end
   end
 
   def set_direction(current_direction)

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -5,18 +5,11 @@ module BudgetInvestmentsHelper
 
   def link_to_investments_sorted_by(column)
     sort_by = column.downcase
-    allowed_directions = %w[asc desc].freeze
     default_direction = "desc"
-    current_direction = params[:direction]
 
-    if allowed_directions.include?(current_direction)
-      #select opposite direction
-      direction = allowed_directions.reject { |dir| dir == current_direction }.first
-    else
-      direction = default_direction
-    end
+    direction = params[:direction] == default_direction ? default_direction : "asc"
 
-    icon = direction == default_direction ? "icon-arrow-top" : "icon-arrow-down"
+    icon = direction == default_direction ? "icon-arrow-down" : "icon-arrow-top"
     icon = sort_by == params[:sort_by] ? icon : ""
 
     translation = t("admin.budget_investments.index.sort_by.#{sort_by}")

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -4,23 +4,22 @@ module BudgetInvestmentsHelper
   end
 
   def link_to_investments_sorted_by(column)
-    sort_by = column.downcase
     current_direction = params[:direction].downcase if params[:direction]
 
     direction = set_direction(current_direction)
-    icon = set_sorting_icon(direction, sort_by)
+    icon = set_sorting_icon(direction, column)
 
-    translation = t("admin.budget_investments.index.sort_by.#{sort_by}")
+    translation = t("admin.budget_investments.index.list.#{column}")
 
     link_to(
       "#{translation} <span class=\"#{icon}\"></span>".html_safe,
-      admin_budget_budget_investments_path(sort_by: sort_by, direction: direction)
+      admin_budget_budget_investments_path(sort_by: column, direction: direction)
     )
   end
 
   def set_sorting_icon(direction, sort_by)
     icon = direction == "desc" ? "icon-arrow-top" : "icon-arrow-down"
-    icon = sort_by == params[:sort_by] ? icon : ""
+    icon = sort_by.to_s == params[:sort_by] ? icon : ""
   end
 
   def set_direction(current_direction)

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -9,6 +9,11 @@ module BudgetInvestmentsHelper
     params.map { |af| t("admin.budget_investments.index.filters.#{af}") }.join(', ')
   end
 
+  def link_to_investments_sorted_by(column)
+    sorting_option = budget_investments_sorting_options.select { |so| so[1] == column.downcase }.flatten
+    link_to t(sorting_option[0]), admin_budget_budget_investments_path(sort_by: sorting_option[1])
+  end
+
   def investments_minimal_view_path
     budget_investments_path(id: @heading.group.to_param,
                             heading_id: @heading.to_param,

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,6 +1,6 @@
 class Budget
   class Investment < ActiveRecord::Base
-    SORTING_OPTIONS = [{"id": "id"}, {"title": "title"}, {"supports": "cached_votes_up"}].freeze
+    SORTING_OPTIONS = [{id: "id"}, {title: "title"}, {supports: "cached_votes_up"}].freeze
 
     include Rails.application.routes.url_helpers
     include Measurable

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -145,9 +145,10 @@ class Budget
 
       if allowed_sort_option.present?
         direction = params[:direction] == "desc" ? "desc" : "asc"
-        return order("#{allowed_sort_option} #{direction}")
+        order("#{allowed_sort_option} #{direction}")
+      else
+        order(cached_votes_up: :desc).order(id: :desc)
       end
-      order(cached_votes_up: :desc).order(id: :desc)
     end
 
     def self.limit_results(budget, params, results)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -143,7 +143,7 @@ class Budget
       sorting_key = sorting_param.to_sym if sorting_param
       allowed_sort_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
 
-      if sorting_param.present? && allowed_sort_option.present? then
+      if allowed_sort_option.present? then
         direction = %w[asc desc].include?(direction) ? direction : "asc"
         order("#{allowed_sort_option[sorting_key]} #{direction}")
       else

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -139,16 +139,15 @@ class Budget
       results.where("budget_investments.id IN (?)", ids)
     end
 
-    def self.order_filter(sorting_param, direction)
-      sorting_key = sorting_param.to_sym if sorting_param
-      allowed_sort_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
+    def self.order_filter(params)
+      sorting_key = params[:sort_by].to_sym if params[:sort_by]
+      allowed_sort_option = SORTING_OPTIONS.select { |so| so[sorting_key]}.reduce
 
-      if allowed_sort_option.present? then
-        direction = %w[asc desc].include?(direction) ? direction : "asc"
-        order("#{allowed_sort_option[sorting_key]} #{direction}")
-      else
-        order(cached_votes_up: :desc).order(id: :desc)
+      if allowed_sort_option.present?
+        direction = %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
+        return order("#{allowed_sort_option[sorting_key]} #{direction}")
       end
+      order(cached_votes_up: :desc).order(id: :desc)
     end
 
     def self.limit_results(budget, params, results)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,6 +1,6 @@
 class Budget
   class Investment < ActiveRecord::Base
-    SORTING_OPTIONS = [{id: "id"}, {title: "title"}, {supports: "cached_votes_up"}].freeze
+    SORTING_OPTIONS = {id: "id", title: "title", supports: "cached_votes_up"}.freeze
 
     include Rails.application.routes.url_helpers
     include Measurable
@@ -140,12 +140,12 @@ class Budget
     end
 
     def self.order_filter(params)
-      sorting_key = params[:sort_by].downcase.to_sym if params[:sort_by]
-      allowed_sort_option = SORTING_OPTIONS.select { |so| so[sorting_key]}.reduce
+      sorting_key = params[:sort_by]&.downcase&.to_sym
+      allowed_sort_option = SORTING_OPTIONS[sorting_key]
 
       if allowed_sort_option.present?
         direction = params[:direction] == "desc" ? "desc" : "asc"
-        return order("#{allowed_sort_option[sorting_key]} #{direction}")
+        return order("#{allowed_sort_option} #{direction}")
       end
       order(cached_votes_up: :desc).order(id: :desc)
     end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,6 +1,6 @@
 class Budget
   class Investment < ActiveRecord::Base
-    SORTING_OPTIONS = %w(id title supports).freeze
+    SORTING_OPTIONS = [{"id": "id"}, {"title": "title"}, {"supports": "cached_votes_up"}].freeze
 
     include Rails.application.routes.url_helpers
     include Measurable
@@ -139,9 +139,12 @@ class Budget
       results.where("budget_investments.id IN (?)", ids)
     end
 
-    def self.order_filter(sorting_param)
-      if sorting_param.present? && SORTING_OPTIONS.include?(sorting_param)
-        send("sort_by_#{sorting_param}")
+    def self.order_filter(sorting_param, direction)
+      sorting_key = sorting_param.to_sym
+      available_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
+      if sorting_param.present? && available_option.present? then
+        %w[asc desc].include?(direction) ? direction : "desc"
+        order("#{available_option[sorting_key]} #{direction}")
       else
         order(cached_votes_up: :desc).order(id: :desc)
       end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -140,7 +140,7 @@ class Budget
     end
 
     def self.order_filter(params)
-      sorting_key = params[:sort_by].to_sym if params[:sort_by]
+      sorting_key = params[:sort_by].downcase.to_sym if params[:sort_by]
       allowed_sort_option = SORTING_OPTIONS.select { |so| so[sorting_key]}.reduce
 
       if allowed_sort_option.present?

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -144,7 +144,7 @@ class Budget
       allowed_sort_option = SORTING_OPTIONS.select { |so| so[sorting_key]}.reduce
 
       if allowed_sort_option.present?
-        direction = %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
+        direction = params[:direction] == "desc" ? "desc" : "asc"
         return order("#{allowed_sort_option[sorting_key]} #{direction}")
       end
       order(cached_votes_up: :desc).order(id: :desc)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -140,10 +140,11 @@ class Budget
     end
 
     def self.order_filter(sorting_param, direction)
-      sorting_key = sorting_param.to_sym
+      sorting_key = sorting_param.to_sym if sorting_param
       available_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
+
       if sorting_param.present? && available_option.present? then
-        %w[asc desc].include?(direction) ? direction : "desc"
+        direction = %w[asc desc].include?(direction) ? direction : "asc"
         order("#{available_option[sorting_key]} #{direction}")
       else
         order(cached_votes_up: :desc).order(id: :desc)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -141,11 +141,11 @@ class Budget
 
     def self.order_filter(sorting_param, direction)
       sorting_key = sorting_param.to_sym if sorting_param
-      available_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
+      allowed_sort_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
 
-      if sorting_param.present? && available_option.present? then
+      if sorting_param.present? && allowed_sort_option.present? then
         direction = %w[asc desc].include?(direction) ? direction : "asc"
-        order("#{available_option[sorting_key]} #{direction}")
+        order("#{allowed_sort_option[sorting_key]} #{direction}")
       else
         order(cached_votes_up: :desc).order(id: :desc)
       end

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -26,9 +26,9 @@
   <table class="table-for-mobile">
     <thead>
       <tr>
-        <th><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.id")  %></th>
-        <th class="small-3"><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.title") %></th>
-        <th><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.supports") %></th>
+        <th><%= link_to_investments_sorted_by :id  %></th>
+        <th class="small-3"><%= link_to_investments_sorted_by :title %></th>
+        <th><%= link_to_investments_sorted_by :supports %></th>
         <th><%= t("admin.budget_investments.index.list.admin") %></th>
         <th>
           <%= t("admin.budget_investments.index.list.valuation_group") %>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -35,9 +35,9 @@
   <table class="table-for-mobile">
     <thead>
       <tr>
-        <th><%= link_to t("admin.budget_investments.index.list.id"), admin_budget_budget_investments_path(sort_by: "id")  %></th>
-        <th class="small-3"><%= link_to t("admin.budget_investments.index.list.title"), admin_budget_budget_investments_path(sort_by: "title") %></th>
-        <th><%= link_to t("admin.budget_investments.index.list.supports"), admin_budget_budget_investments_path(sort_by: "supports") %></th>
+        <th><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.id")  %></th>
+        <th class="small-3"><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.title") %></th>
+        <th><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.supports") %></th>
         <th><%= t("admin.budget_investments.index.list.admin") %></th>
         <th>
           <%= t("admin.budget_investments.index.list.valuation_group") %>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -35,9 +35,9 @@
   <table class="table-for-mobile">
     <thead>
       <tr>
-        <th><%= t("admin.budget_investments.index.list.id") %></th>
-        <th class="small-3"><%= t("admin.budget_investments.index.list.title") %></th>
-        <th><%= t("admin.budget_investments.index.list.supports") %></th>
+        <th><%= link_to t("admin.budget_investments.index.list.id"), admin_budget_budget_investments_path(sort_by: "id")  %></th>
+        <th class="small-3"><%= link_to t("admin.budget_investments.index.list.title"), admin_budget_budget_investments_path(sort_by: "title") %></th>
+        <th><%= link_to t("admin.budget_investments.index.list.supports"), admin_budget_budget_investments_path(sort_by: "supports") %></th>
         <th><%= t("admin.budget_investments.index.list.admin") %></th>
         <th>
           <%= t("admin.budget_investments.index.list.valuation_group") %>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -1,12 +1,3 @@
-<%= form_tag(admin_budget_budget_investments_path(budget: @budget), method: :get) do %>
-  <div class="small-12 medium-3 column">
-    <%= select_tag :sort_by, options_for_select(budget_investments_sorting_options, params[:sort_by]),
-                   { prompt: t("admin.budget_investments.index.sort_by.placeholder"),
-                     label: false,
-                     class: "js-submit-on-change" } %>
-  </div>
-<% end %>
-
 <%= link_to t("admin.budget_investments.index.download_current_selection"),
             admin_budget_budget_investments_path(csv_params),
             class: "float-right small clear" %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -176,11 +176,6 @@ en:
         tags_filter_all: All tags
         advanced_filters: Advanced filters
         placeholder: Search projects
-        sort_by:
-          placeholder: Sort by
-          id: ID
-          title: Title
-          supports: Supports
         filters:
           all: All
           without_admin: Without assigned admin

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -176,11 +176,6 @@ es:
         tags_filter_all: Todas las etiquetas
         advanced_filters: Filtros avanzados
         placeholder: Buscar proyectos
-        sort_by:
-          placeholder: Ordenar por
-          id: ID
-          title: Título
-          supports: Apoyos
         filters:
           all: Todos
           without_admin: Sin administrador

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -619,6 +619,9 @@ feature 'Admin budget investments' do
 
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
+        within('th', text: 'ID') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
 
       scenario 'Sort by title' do
@@ -626,6 +629,9 @@ feature 'Admin budget investments' do
 
         expect('A Second Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('C Third Investment')
+        within('th', text: 'Title') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
 
       scenario 'Sort by supports' do
@@ -633,6 +639,9 @@ feature 'Admin budget investments' do
 
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
+        within('th', text: 'Supports') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
     end
 
@@ -642,6 +651,9 @@ feature 'Admin budget investments' do
 
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
+        within('th', text: 'ID') do
+          expect(page).to have_css(".icon-arrow-down")
+        end
       end
 
       scenario 'Sort by title' do
@@ -649,6 +661,9 @@ feature 'Admin budget investments' do
 
         expect('C Third Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('A Second Investment')
+        within('th', text: 'Title') do
+          expect(page).to have_css(".icon-arrow-down")
+        end
       end
 
       scenario 'Sort by supports' do
@@ -656,6 +671,9 @@ feature 'Admin budget investments' do
 
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
+        within('th', text: 'Supports') do
+          expect(page).to have_css(".icon-arrow-down")
+        end
       end
     end
 
@@ -665,6 +683,9 @@ feature 'Admin budget investments' do
 
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
+        within('th', text: 'ID') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
 
       scenario 'Sort by title' do
@@ -672,6 +693,9 @@ feature 'Admin budget investments' do
 
         expect('A Second Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('C Third Investment')
+        within('th', text: 'Title') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
 
       scenario 'Sort by supports' do
@@ -679,10 +703,23 @@ feature 'Admin budget investments' do
 
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
+        within('th', text: 'Supports') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
     end
 
+    context 'With incorrect direction provided sorts ascending' do
+      scenario 'Sort by ID' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'incorrect')
 
+        expect('B First Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('C Third Investment')
+        within('th', text: 'ID') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
+      end
+    end
   end
 
   context 'Show' do

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -603,7 +603,7 @@ feature 'Admin budget investments' do
       create(:budget_investment, title: 'C Third Investment', cached_votes_up: 10, budget: budget)
     end
 
-    scenario "Default sorting" do
+    scenario "Default" do
       create(:budget_investment, title: 'D Fourth Investment', cached_votes_up: 50, budget: budget)
 
       visit admin_budget_budget_investments_path(budget)
@@ -613,26 +613,76 @@ feature 'Admin budget investments' do
       expect('A Second Investment').to appear_before('C Third Investment')
     end
 
-    scenario 'Sort by ID' do
-      visit admin_budget_budget_investments_path(budget, sort_by: 'id')
+    context 'Ascending' do
+      scenario 'Sort by ID' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'asc')
 
-      expect('C Third Investment').to appear_before('A Second Investment')
-      expect('A Second Investment').to appear_before('B First Investment')
+        expect('B First Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('C Third Investment')
+      end
+
+      scenario 'Sort by title' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'title', direction: 'asc')
+
+        expect('A Second Investment').to appear_before('B First Investment')
+        expect('B First Investment').to appear_before('C Third Investment')
+      end
+
+      scenario 'Sort by supports' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'supports', direction: 'asc')
+
+        expect('C Third Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('B First Investment')
+      end
     end
 
-    scenario 'Sort by title' do
-      visit admin_budget_budget_investments_path(budget, sort_by: 'title')
+    context 'Descending' do
+      scenario 'Sort by ID' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'desc')
 
-      expect('A Second Investment').to appear_before('B First Investment')
-      expect('B First Investment').to appear_before('C Third Investment')
+        expect('C Third Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('B First Investment')
+      end
+
+      scenario 'Sort by title' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'title', direction: 'desc')
+
+        expect('C Third Investment').to appear_before('B First Investment')
+        expect('B First Investment').to appear_before('A Second Investment')
+      end
+
+      scenario 'Sort by supports' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'supports', direction: 'desc')
+
+        expect('B First Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('C Third Investment')
+      end
     end
 
-    scenario 'Sort by supports' do
-      visit admin_budget_budget_investments_path(budget, sort_by: 'supports')
+    context 'With no direction provided sorts ascending' do
+      scenario 'Sort by ID' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'id')
 
-      expect('B First Investment').to appear_before('A Second Investment')
-      expect('A Second Investment').to appear_before('C Third Investment')
+        expect('B First Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('C Third Investment')
+      end
+
+      scenario 'Sort by title' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'title')
+
+        expect('A Second Investment').to appear_before('B First Investment')
+        expect('B First Investment').to appear_before('C Third Investment')
+      end
+
+      scenario 'Sort by supports' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'supports')
+
+        expect('C Third Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('B First Investment')
+      end
     end
+
+
   end
 
   context 'Show' do

--- a/spec/helpers/budget_investments_helper_spec.rb
+++ b/spec/helpers/budget_investments_helper_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe BudgetInvestmentsHelper, type: :helper do
+
+  describe "#set_direction" do
+
+    it "returns ASC if current_direction is DESC" do
+      expect(set_direction("desc")).to eq "asc"
+    end
+
+    it "returns DESC if current_direction is ASC" do
+      expect(set_direction("asc")).to eq "desc"
+    end
+
+    it "returns DESC if current_direction is nil" do
+      expect(set_direction(nil)).to eq "desc"
+    end
+  end
+
+  describe "#set_sorting_icon" do
+    let(:sort_by) { "title" }
+    let(:params)  { { sort_by: sort_by } }
+
+    it "returns arrow down if current direction is ASC" do
+      expect(set_sorting_icon("asc", sort_by)).to eq "icon-arrow-down"
+    end
+
+    it "returns arrow top if current direction is DESC" do
+      expect(set_sorting_icon("desc", sort_by)).to eq "icon-arrow-top"
+    end
+
+    it "returns arrow down if sort_by present, but no direction" do
+      expect(set_sorting_icon(nil, sort_by)).to eq "icon-arrow-down"
+    end
+
+    it "returns no icon if sort_by and direction is missing" do
+      params[:sort_by] = nil
+      expect(set_sorting_icon(nil, sort_by)).to eq ""
+    end
+
+    it "returns no icon if sort_by is incorrect" do
+      params[:sort_by] = "random"
+      expect(set_sorting_icon("asc", sort_by)).to eq ""
+    end
+  end
+
+end


### PR DESCRIPTION
## References

Issue: Admin tables order #2931

## Objectives

- remove sort select for Budget Investments
- implement sorting in columns: ID, Title, Supports
- submit first OSS PR :D 

## Visual Changes

- removed sort_by select
- added arrow icon to indicate sorting direction

![image](https://user-images.githubusercontent.com/2719923/50576457-749a9a00-0e12-11e9-9914-0ff2e4485b60.png)

## Notes

- modified tests to support new sorting rules
- fixed a bug with unsupported sort_by values (e.g. edited manually in the address field) - now the controller just ignores it and returns all investments
- I've created 3 helper methods for sorting in Budget Investments Helper for the sake of this PR, but eventually I think it should become a separate helper or module for sorting, which would also contain the model method self.order_filter - let me know which strategy you would like me to follow.

This is my first ever external commitment and I don't have commercial experience, so I figure there is a lot to refactor. I'd be happy to do that after code review :) Just point everything I could improve and I'll do my best :) I'd also would like to implement sorting for other tables as well so I'd appreciate any guidance towards making this more reusable.
