### PR TITLE
[Backport] Add default order for admin budget investments list

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -77,7 +77,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
     def load_investments
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
-      @investments = @investments.order_filter(params[:sort_by]) if params[:sort_by].present?
+                                       .order_filter(params[:sort_by])
       @investments = @investments.page(params[:page]) unless request.format.csv?
     end
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -142,6 +142,8 @@ class Budget
     def self.order_filter(sorting_param)
       if sorting_param.present? && SORTING_OPTIONS.include?(sorting_param)
         send("sort_by_#{sorting_param}")
+      else
+        order(cached_votes_up: :desc).order(id: :desc)
       end
     end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -609,7 +609,7 @@ feature 'Admin budget investments' do
       visit admin_budget_budget_investments_path(budget)
 
       expect('D Fourth Investment').to appear_before('B First Investment')
-      expect('D Fourth Investment').to appear_before('A Second Investment')
+      expect('B First Investment').to appear_before('A Second Investment')
       expect('A Second Investment').to appear_before('C Third Investment')
     end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1126,18 +1126,22 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario "Pagination after unselecting an investment", :js do
-      create_list(:budget_investment, 30, budget: budget)
+    feature "Pagination" do
+      background { selected_bi.update(cached_votes_up: 50) }
 
-      visit admin_budget_budget_investments_path(budget)
+      scenario "After unselecting an investment", :js do
+        create_list(:budget_investment, 30, budget: budget)
 
-      within("#budget_investment_#{selected_bi.id}") do
-        click_link('Selected')
+        visit admin_budget_budget_investments_path(budget)
+
+        within("#budget_investment_#{selected_bi.id}") do
+          click_link('Selected')
+        end
+
+        click_link('Next')
+
+        expect(page).to have_link('Previous')
       end
-
-      click_link('Next')
-
-      expect(page).to have_link('Previous')
     end
   end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -603,6 +603,16 @@ feature 'Admin budget investments' do
       create(:budget_investment, title: 'C Third Investment', cached_votes_up: 10, budget: budget)
     end
 
+    scenario "Default sorting" do
+      create(:budget_investment, title: 'D Fourth Investment', cached_votes_up: 50, budget: budget)
+
+      visit admin_budget_budget_investments_path(budget)
+
+      expect('D Fourth Investment').to appear_before('B First Investment')
+      expect('D Fourth Investment').to appear_before('A Second Investment')
+      expect('A Second Investment').to appear_before('C Third Investment')
+    end
+
     scenario 'Sort by ID' do
       visit admin_budget_budget_investments_path(budget, sort_by: 'id')
 


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1426
* [Travis build 25371, job 2 ](https://travis-ci.org/consul/consul/jobs/466113109)

## Objectives

* Sort investments by supports when no sorting option is selected
* Fix a bug caused by not defining a default order which caused the spec `spec/features/admin/budget_investments_spec.rb:1279` ("Admin budget investments Selecting csv Downloading CSV file") to fail sometimes