### PR TITLE
[Backport] checks for deleted proposals

### DIFF
--- a/app/views/admin/stats/proposal_notifications.html.erb
+++ b/app/views/admin/stats/proposal_notifications.html.erb
@@ -31,7 +31,13 @@
         <td>
           <h3>
             <%= notification.title %>
-            <small><%= link_to notification.proposal.title, proposal_path(notification.proposal) %></small>
+            <small>
+              <% if notification.proposal.present? %>
+                <%= link_to notification.proposal.title, proposal_path(notification.proposal) %>
+              <% else %>
+                <%= t("admin.stats.proposal_notifications.not_available") %><br>
+              <% end %>
+            </small>
           </h3>
           <p><%= notification.body %></p>
         </td>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1302,6 +1302,7 @@ en:
         title: Proposal notifications
         total: Total
         proposals_with_notifications: Proposals with notifications
+        not_available: "Proposal not available"
       polls:
         title: Poll Stats
         all: Polls

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1301,6 +1301,7 @@ es:
         title: Notificaciones de propuestas
         total: Total
         proposals_with_notifications: Propuestas con notificaciones
+        not_available: "Esta propuesta ya no está disponible"
       polls:
         title: Estadísticas de votaciones
         all: Votaciones

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -137,6 +137,20 @@ feature 'Stats' do
       end
     end
 
+    scenario "Deleted proposals" do
+      proposal_notification = create(:proposal_notification)
+      proposal_notification.proposal.destroy
+
+      visit admin_stats_path
+      click_link "Proposal notifications"
+
+      expect(page).to have_css(".proposal_notification", count: 1)
+
+      expect(page).to have_content proposal_notification.title
+      expect(page).to have_content proposal_notification.body
+      expect(page).to have_content "Proposal not available"
+    end
+
   end
 
   context "Direct messages" do


### PR DESCRIPTION
## References
Issue https://github.com/consul/consul/issues/3028
Backport AyuntamientoMadrid#330

## Objectives

Check for the deleted (hidden) proposals to avoid raising an error in `/admin/stats/proposal_notifications`.

## Notes
closes https://github.com/consul/consul/issues/3028