### PR TITLE
Initialize graphql after application initialization

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,7 +48,10 @@ module Consul
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', 'custom', '**', '*.{rb,yml}')]
 
-    config.after_initialize { Globalize.set_fallbacks_to_all_available_locales }
+    config.after_initialize do
+      Globalize.set_fallbacks_to_all_available_locales
+      GraphQLApi::Loader.setup
+    end
 
     config.assets.paths << Rails.root.join("app", "assets", "fonts")
 

--- a/config/initializers/graphql.rb
+++ b/config/initializers/graphql.rb
@@ -1,4 +1,0 @@
-if ActiveRecord::Base.connection.tables.any?
-  api_config = YAML.load_file('./config/api.yml')
-  API_TYPE_DEFINITIONS = GraphQL::ApiTypesCreator::parse_api_config_file(api_config)
-end

--- a/config/initializers/graphql_api.rb
+++ b/config/initializers/graphql_api.rb
@@ -1,0 +1,11 @@
+module GraphQLApi
+  class Loader
+    def self.setup
+      if ActiveRecord::Base.connection.tables.any?
+        api_config = YAML.load_file('./config/api.yml')
+        GraphqlController.const_set "API_TYPE_DEFINITIONS",
+          GraphQL::ApiTypesCreator::parse_api_config_file(api_config)
+      end
+    end
+  end
+end

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-api_types  = GraphQL::ApiTypesCreator.create(API_TYPE_DEFINITIONS)
+api_types  = GraphQL::ApiTypesCreator.create(GraphqlController::API_TYPE_DEFINITIONS)
 query_type = GraphQL::QueryTypeCreator.create(api_types)
 ConsulSchema = GraphQL::Schema.define do
   query query_type


### PR DESCRIPTION
## References

> Related Issues: #3130 
> Related Pull Requests: #3156 

## Bug description

Proposals, Debates and Comments "globalize_accessors" class method were loaded before application available locales initialization because of graphql initializer. GraphQL initializer was loading mentioned models before I18n configuration loading was done so globalize_locales was returning an invalid set  of locales at this point.

Doing GraphQL initialization after application initialization should solve the problem for any translatable class.

## Objective
Load GraphQL after application initialization to get correct results of globalize_locales from any translatable model properly.

**No yet initialized available_locales**
```
(byebug) I18n.available_locales
[:en, :"ca-CAT", :uk, :"en-ZA", :"en-CA", :"en-NG", :"en-au-ocker", :"de-CH", :ca, :"pt-BR", :"de-AT", :"da-DK", :bg, :es, :ko, :id, :sk, :pt, :he, :de, :it, :pl, :fa, :sv, :ja, :"en-SG", :"en-GB", :ru, :"nb-NO", :"en-BORK", :fr, :"zh-TW", :"en-IND", :"en-UG", :"en-NZ", :"en-AU", :"es-MX", :nep, :tr, :"en-PAK", :"en-US", :vi, :"fi-FI", :"zh-CN", :nl, :"en-MS"]
```

**After application initialization**
```
2.3.2 :001 > I18n.available_locales
 => [:ar, :de, :en, :es, :fa, :fr, :gl, :he, :it, :nl, :pl, :"pt-BR", :sq, :sv, :val, :"zh-CN", :"zh-TW"] 
```

## Visual Changes
None

## Notes
None