### PR TITLE
[Backport] Remove before action not used

### DIFF
--- a/app/controllers/budgets/ballot/lines_controller.rb
+++ b/app/controllers/budgets/ballot/lines_controller.rb
@@ -2,7 +2,6 @@ module Budgets
   module Ballot
     class LinesController < ApplicationController
       before_action :authenticate_user!
-      #before_action :ensure_final_voting_allowed
       before_action :load_budget
       before_action :load_ballot
       before_action :load_tag_cloud
@@ -32,10 +31,6 @@ module Budgets
       end
 
       private
-
-        def ensure_final_voting_allowed
-          return head(:forbidden) unless @budget.balloting?
-        end
 
         def line_params
           params.permit(:investment_id, :budget_id)


### PR DESCRIPTION
## References

PR https://github.com/AyuntamientoMadrid/consul/pull/1793

## Objectives

Remove a `before_action` method not being used.