### PR TITLE
Dashboard actions for published proposals

### DIFF
--- a/app/controllers/admin/dashboard/actions_controller.rb
+++ b/app/controllers/admin/dashboard/actions_controller.rb
@@ -25,7 +25,7 @@ class Admin::Dashboard::ActionsController < Admin::Dashboard::BaseController
   end
 
   def edit; end
-  
+
   def update
     if dashboard_action.update(dashboard_action_params)
       redirect_to admin_dashboard_actions_path
@@ -54,10 +54,10 @@ class Admin::Dashboard::ActionsController < Admin::Dashboard::BaseController
     params
       .require(:dashboard_action)
       .permit(
-        :title, :description, :short_description, :request_to_administrators, :day_offset, 
-        :required_supports, :order, :active, :action_type,
+        :title, :description, :short_description, :request_to_administrators, :day_offset,
+        :required_supports, :order, :active, :action_type, :published_proposal,
         documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
-        links_attributes: [:id, :label, :url, :open_in_new_tab, :_destroy] 
+        links_attributes: [:id, :label, :url, :open_in_new_tab, :_destroy]
       )
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -11,8 +11,8 @@ class DashboardController < Dashboard::BaseController
     proposal.publish
     redirect_to proposal_dashboard_path(proposal), notice: t('proposals.notice.published')
   end
-  
-  def progress 
+
+  def progress
     authorize! :dashboard, proposal
   end
 
@@ -21,9 +21,12 @@ class DashboardController < Dashboard::BaseController
   end
 
   private
-  
+
   def active_resources
-    @active_resources ||= Dashboard::Action.active.resources.order(required_supports: :asc, day_offset: :asc)
+    @active_resources ||= Dashboard::Action.active
+                                           .resources
+                                           .by_draft(proposal.draft?)
+                                           .order(required_supports: :asc, day_offset: :asc)
   end
 
   def course

--- a/app/views/admin/dashboard/actions/_form.html.erb
+++ b/app/views/admin/dashboard/actions/_form.html.erb
@@ -34,6 +34,13 @@
 </div>
 
 <div class="row expanded margin-top">
+  <div class="small-12 medium-12 column">
+    <%= f.check_box :published_proposal, label: t("admin.dashboard.actions.form.published_proposal") %>
+    <p class="help-text"><%= t("admin.dashboard.actions.form.published_proposal_help_text") %></p>
+  </div>
+</div>
+
+<div class="row expanded margin-top">
   <div class="small-12 medium-4 column">
     <%= f.label :day_offset %>
     <p class="help-text"><%= t("admin.dashboard.actions.form.day_offset_help_text") %></p>

--- a/app/views/admin/dashboard/actions/index.html.erb
+++ b/app/views/admin/dashboard/actions/index.html.erb
@@ -11,6 +11,7 @@
       <th><%= t("admin.dashboard.actions.index.action_title") %></th>
       <th><%= t("admin.dashboard.actions.index.action_type") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.action_active") %></th>
+      <th class="text-center"><%= t("admin.dashboard.actions.index.published_proposal") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.day_offset") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.required_supports") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.order") %></th>
@@ -30,6 +31,7 @@
         <td><%= action.title %></td>
         <td><%= t("admin.dashboard.actions.action_type.#{action.action_type}") %></td>
         <td class="text-center"><%= active_human_readable(action.active) %></td>
+        <td class="text-center"><%= active_human_readable(action.published_proposal) %></td>
         <td class="text-center"><%= number_with_delimiter(action.day_offset, delimiter: '.') %></td>
         <td class="text-center"><%= number_with_delimiter(action.required_supports, delimiter: '.') %></td>
         <td class="text-center"><%= action.order %></td>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -337,6 +337,7 @@ en:
           day_offset: Required days
           action_active: Active
           order: Order
+          published_proposal: Published proposal
         new:
           creating: New action for the proposals dashboard
           back: Back to list
@@ -352,6 +353,8 @@ en:
           day_offset_help_text: Enter 0 so that this value is not taken into account
           required_supports_help_text: Enter 0 so that this value is not taken into account
           order_help_text: Order to show to user
+          published_proposal: For published proposals?
+          published_proposal_help_text: Mark this checkbox to create the action only for published proposals
       administrator_tasks:
         index:
           title: Pending tasks

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -337,6 +337,7 @@ es:
           day_offset: Días necesarios
           action_active: Activo
           order: Orden
+          published_proposal: Propuesta publicada
         new:
           creating: Nueva acción para el dashboard de propuestas
           back: Volver a la lista
@@ -350,6 +351,8 @@ es:
           day_offset_help_text: Introduce 0 para que este valor no se tenga en cuenta
           required_supports_help_text: Introduce 0 para que este valor no se tenga en cuenta
           order_help_text: Orden para mostrar al usuario
+          published_proposal: ¿Para propuestas publicadas?
+          published_proposal_help_text: Marca este checkbox para crear la acción solo para propuestas publicadas
         delete:
           success: Acción borrada con éxito
       administrator_tasks:

--- a/db/migrate/20190108133246_add_published_proposal_to_dashboard_actions.rb
+++ b/db/migrate/20190108133246_add_published_proposal_to_dashboard_actions.rb
@@ -1,0 +1,5 @@
+class AddPublishedProposalToDashboardActions < ActiveRecord::Migration
+  def change
+    add_column :dashboard_actions, :published_proposal, :boolean, default: :false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -619,7 +619,7 @@ ActiveRecord::Schema.define(version: 20180924071722) do
     t.string   "locale",                       null: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
-    t.text     "title"
+    t.string   "title"
     t.text     "changelog"
     t.text     "body"
     t.text     "body_html"
@@ -1218,17 +1218,17 @@ ActiveRecord::Schema.define(version: 20180924071722) do
   add_index "site_customization_images", ["name"], name: "index_site_customization_images_on_name", unique: true, using: :btree
 
   create_table "site_customization_page_translations", force: :cascade do |t|
-      t.integer  "site_customization_page_id", null: false
-      t.string   "locale",                     null: false
-      t.datetime "created_at",                 null: false
-      t.datetime "updated_at",                 null: false
-      t.string   "title"
-      t.string   "subtitle"
-      t.text     "content"
-    end
+    t.integer  "site_customization_page_id", null: false
+    t.string   "locale",                     null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "title"
+    t.string   "subtitle"
+    t.text     "content"
+  end
 
-    add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
-    add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
+  add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
+  add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
 
   create_table "site_customization_pages", force: :cascade do |t|
     t.string   "slug",                                 null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180924071722) do
+ActiveRecord::Schema.define(version: 20190108133246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -370,6 +370,7 @@ ActiveRecord::Schema.define(version: 20180924071722) do
     t.string   "short_description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "published_proposal",                   default: false
   end
 
   create_table "dashboard_administrator_tasks", force: :cascade do |t|

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -56,7 +56,15 @@ feature "Proposal's dashboard" do
     expect(page).not_to have_selector(:css, "#dashboard_action_#{action.id}_execute")
   end
 
-  scenario 'Dashboard progress show available resources' do
+  scenario 'Dashboard progress dont show proposed actions with published_proposal: true' do
+    action = create(:dashboard_action, :proposed_action, :active, published_proposal: true)
+
+    visit progress_proposal_dashboard_path(proposal)
+
+    expect(page).not_to have_content(action.title)
+  end
+
+  scenario 'Dashboard progress show available resources for proposal draft' do
     available = create(:dashboard_action, :resource, :active)
 
     requested = create(:dashboard_action, :resource, :admin_request, :active)
@@ -94,6 +102,63 @@ feature "Proposal's dashboard" do
       within "div#dashboard_action_#{solved.id}" do
         expect(page).to have_link('See resource')
       end
+    end
+  end
+
+  scenario 'Dashboard progress show available resources for published proposal' do
+    proposal.update(published_at: Date.today)
+    available = create(:dashboard_action, :resource, :active)
+
+    requested = create(:dashboard_action, :resource, :admin_request, :active)
+    executed_action = create(:dashboard_executed_action, action: requested, proposal: proposal, executed_at: Time.current)
+    _task = create(:dashboard_administrator_task, :pending, source: executed_action)
+
+    solved = create(:dashboard_action, :resource, :admin_request, :active)
+    executed_solved_action = create(:dashboard_executed_action, action: solved, proposal: proposal, executed_at: Time.current)
+    _solved_task = create(:dashboard_administrator_task, :done, source: executed_solved_action)
+
+    unavailable = create(:dashboard_action, :resource, :active, required_supports: proposal.votes_for.size + 1_000)
+
+    visit progress_proposal_dashboard_path(proposal)
+    within 'div#available-resources-section' do
+      expect(page).to have_content('Polls')
+      expect(page).to have_content('E-mail')
+      expect(page).to have_content('Poster')
+      expect(page).to have_content(available.title)
+      expect(page).to have_content(unavailable.title)
+      expect(page).to have_content(requested.title)
+      expect(page).to have_content(solved.title)
+
+      within "div#dashboard_action_#{available.id}" do
+        expect(page).to have_link('Request resource')
+      end
+
+      within "div#dashboard_action_#{requested.id}" do
+        expect(page).to have_content('Resource already requested')
+      end
+
+      within "div#dashboard_action_#{unavailable.id}" do
+        expect(page).to have_content('1.000 supports required')
+      end
+
+      within "div#dashboard_action_#{solved.id}" do
+        expect(page).to have_link('See resource')
+      end
+    end
+  end
+
+  scenario 'Dashboard progress dont show resources with published_proposal: true' do
+    available = create(:dashboard_action, :resource, :active, published_proposal: true)
+    unavailable = create(:dashboard_action, :resource, :active, required_supports: proposal.votes_for.size + 1_000, published_proposal: true)
+
+    visit progress_proposal_dashboard_path(proposal)
+
+    within 'div#available-resources-section' do
+      expect(page).to have_content('Polls')
+      expect(page).to have_content('E-mail')
+      expect(page).to have_content('Poster')
+      expect(page).not_to have_content(available.title)
+      expect(page).not_to have_content(unavailable.title)
     end
   end
 

--- a/spec/models/dashboard/action_spec.rb
+++ b/spec/models/dashboard/action_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe Dashboard::Action do
-  subject do 
-    build :dashboard_action, 
-          title: title, 
+  subject do
+    build :dashboard_action,
+          title: title,
           description: description,
           day_offset: day_offset,
           required_supports: required_supports,
@@ -79,7 +79,7 @@ describe Dashboard::Action do
     it 'is active when published after day_offset' do
       action = build(:dashboard_action, required_supports: 0, day_offset: 10)
       proposal = build(:proposal, published_at: Time.current - 10.days)
-      
+
       expect(action).to be_active_for(proposal)
     end
 
@@ -93,7 +93,7 @@ describe Dashboard::Action do
     it 'is not active when not enough time published' do
       action = build(:dashboard_action, required_supports: 0, day_offset: 10)
       proposal = build(:proposal, published_at: Time.current - 9.days)
-      
+
       expect(action).not_to be_active_for(proposal)
     end
 
@@ -155,7 +155,10 @@ describe Dashboard::Action do
     let!(:not_enough_supports_action) { create :dashboard_action, :active, day_offset: 0, required_supports: 10_000 }
     let!(:inactive_action) { create :dashboard_action, :inactive }
     let!(:future_action) { create :dashboard_action, :active, day_offset: 300, required_supports: 0 }
+    let!(:action_for_published_proposal) { create :dashboard_action, :active, day_offset: 0, required_supports: 0, published_proposal: true }
+    let!(:action_for_draft_proposal) { create :dashboard_action, :active, day_offset: 0, required_supports: 0, published_proposal: false }
     let(:proposal) { create :proposal }
+    let(:draft_proposal) { create :proposal, :draft }
 
     it 'actions with enough supports or days are active' do
       expect(described_class.active_for(proposal)).to include(active_action)
@@ -171,7 +174,23 @@ describe Dashboard::Action do
 
     it 'actions planned to be active in the future are not active' do
       expect(described_class.active_for(proposal)).not_to include(future_action)
-    end 
+    end
+
+    it 'actions with published_proposal: true, are not included on draft proposal' do
+      expect(described_class.active_for(draft_proposal)).not_to include(action_for_published_proposal)
+    end
+
+    it 'actions with published_proposal: true, are included on published proposal' do
+      expect(described_class.active_for(proposal)).to include(action_for_published_proposal)
+    end
+
+    it 'actions with published_proposal: false, are included on draft proposal' do
+      expect(described_class.active_for(draft_proposal)).to include(action_for_draft_proposal)
+    end
+
+    it 'actions with published_proposal: false, are included on published proposal' do
+      expect(described_class.active_for(proposal)).to include(action_for_draft_proposal)
+    end
   end
 
   context '#course_for' do


### PR DESCRIPTION
## References
[Dashboard: Enhancement Resources/Actions Admin Page](https://github.com/Platoniq/consul/issues/4)

## Objectives
We want to publish actions for the same day the proposal is published.

## Visual Changes
- Index with new field "Published proposal"
![captura de pantalla 2019-01-11 a las 18 24 52](https://user-images.githubusercontent.com/16189/51049581-8debd500-15ce-11e9-92dc-d808f04efcab.png)

- Form with new field "Published proposal"
![captura de pantalla 2019-01-11 a las 18 25 10](https://user-images.githubusercontent.com/16189/51049586-93491f80-15ce-11e9-8502-bc900a820098.png)
