### PR TITLE
added heading as sidebar navigation to pages

### DIFF
--- a/app/controllers/admin/site_customization/pages_controller.rb
+++ b/app/controllers/admin/site_customization/pages_controller.rb
@@ -35,7 +35,7 @@ class Admin::SiteCustomization::PagesController < Admin::SiteCustomization::Base
   private
 
     def page_params
-      attributes = [:slug, :more_info_flag, :print_content_flag, :status]
+      attributes = [:slug, :more_info_flag, :print_content_flag, :status, :headings_as_sidebar_navigation]
 
       params.require(:site_customization_page).permit(*attributes,
         translation_params(SiteCustomization::Page)

--- a/app/views/admin/site_customization/pages/_form.html.erb
+++ b/app/views/admin/site_customization/pages/_form.html.erb
@@ -22,6 +22,7 @@
     <h3><%= t("admin.site_customization.pages.form.options") %></h3>
     <%= f.check_box :more_info_flag, class: "small" %>
     <%= f.check_box :print_content_flag %>
+    <%= f.check_box :headings_as_sidebar_navigation %>
   </div>
   <div class="small-12 medium-3 column">
     <%= f.label :status %>

--- a/app/views/pages/custom_page.html.erb
+++ b/app/views/pages/custom_page.html.erb
@@ -2,12 +2,21 @@
 
 <div class="row margin-top">
 
+  <% if @custom_page.headings_as_sidebar_navigation %>
+    <div class="jumbo" >
+      <h1><%= @custom_page.title %></h1>
+      <% if @custom_page.subtitle.present? %>
+          <h2><%= @custom_page.subtitle%></h2>
+      <% end %>
+    </div>
+  <% end %>
   <div class="small-12 medium-9 column">
-    <h1><%= @custom_page.title %></h1>
-    <% if @custom_page.subtitle.present? %>
-      <h2><%= @custom_page.subtitle%></h2>
+    <% unless @custom_page.headings_as_sidebar_navigation %>
+      <h1><%= @custom_page.title %></h1>
+      <% if @custom_page.subtitle.present? %>
+          <h2><%= @custom_page.subtitle%></h2>
+      <% end %>
     <% end %>
-
     <%= safe_html_with_links AdminWYSIWYGSanitizer.new.sanitize(@custom_page.content) %>
   </div>
 

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -208,6 +208,7 @@ en:
         more_info_flag: Show in help page
         print_content_flag: Print content button
         locale: Language
+        headings_as_sidebar_navigation: Show headings as sidebar navigation
       site_customization/page/translation:
         title: Title
         subtitle: Subtitle

--- a/db/migrate/20190112190324_add_headings_as_sidebar_navigation_to_site_customization_pages.rb
+++ b/db/migrate/20190112190324_add_headings_as_sidebar_navigation_to_site_customization_pages.rb
@@ -1,0 +1,5 @@
+class AddHeadingsAsSidebarNavigationToSiteCustomizationPages < ActiveRecord::Migration
+  def change
+    add_column :site_customization_pages, :headings_as_sidebar_navigation, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181206153510) do
+ActiveRecord::Schema.define(version: 20190112190324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1232,16 +1232,17 @@ ActiveRecord::Schema.define(version: 20181206153510) do
   add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
 
   create_table "site_customization_pages", force: :cascade do |t|
-    t.string   "slug",                                 null: false
+    t.string   "slug",                                             null: false
     t.string   "title"
     t.string   "subtitle"
     t.text     "content"
     t.boolean  "more_info_flag"
     t.boolean  "print_content_flag"
-    t.string   "status",             default: "draft"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.string   "status",                         default: "draft"
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
     t.string   "locale"
+    t.boolean  "headings_as_sidebar_navigation", default: false
   end
 
   create_table "spending_proposals", force: :cascade do |t|


### PR DESCRIPTION
## References

> Navigation sidebar on custom pages #3010

## Objectives

> nclude a new checkbox option to show headings as sidebar navigation of the content to users.

## Visual Changes

> The new custom page with the jumbo header
![48079911-b4ffe200-e1ec-11e8-901e-08f40ae1c155](https://user-images.githubusercontent.com/11414036/51078252-b1467b00-16c7-11e9-9500-7617c0ac1b83.jpg)

![48079917-b6c9a580-e1ec-11e8-9b7f-2c0edd1fb6d4](https://user-images.githubusercontent.com/11414036/51078242-6e84a300-16c7-11e9-9de1-cef95f82add6.png)


## Notes

> a migration to rub, `rake db:migrate`