### PR TITLE
Enable double quotes rubocop rule

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -35,3 +35,6 @@ Metrics/LineLength:
 
 RSpec/NotToNot:
   Enabled: true
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes


### PR DESCRIPTION
## References

PR https://github.com/AyuntamientoMadrid/consul/pull/1814

## Objectives

Enable rubocop rule to always check for double quotes.