### PR TITLE
Dashboard recommended actions page

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+rubocop:
+  config_file: .rubocop_basic.yml
+scss:
+  config_file: .scss-lint.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,35 +1,4 @@
-inherit_from: .rubocop_todo.yml
-require: rubocop-rspec
-
-AllCops:
-  DisplayCopNames: true
-  DisplayStyleGuide: true
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
-  Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'script/**/*'
-  TargetRubyVersion: 2.3
-  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
-  # to ignore them, so only the ones explicitly set in this file are enabled.
-  DisabledByDefault: true
-
-Metrics/LineLength:
-  Max: 100
-
-Layout/IndentationConsistency:
-  EnforcedStyle: rails
-
-Layout/EndOfLine:
-  EnforcedStyle: lf
-
-Layout/TrailingBlankLines:
-  Enabled: true
-
-Layout/TrailingWhitespace:
-  Enabled: true
+inherit_from: .rubocop_basic.yml
 
 Bundler/DuplicatedGem:
   Enabled: true
@@ -280,9 +249,6 @@ RSpec/DescribeMethod:
 RSpec/DescribeSymbol:
   Enabled: true
 
-RSpec/DescribedClass:
-  Enabled: true
-
 RSpec/EmptyExampleGroup:
   Enabled: true
 
@@ -366,9 +332,6 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Enabled: true
   Max: 4
-
-RSpec/NotToNot:
-  Enabled: true
 
 RSpec/OverwritingSetup:
   Enabled: true

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -1,0 +1,40 @@
+require: rubocop-rspec
+
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+  TargetRubyVersion: 2.3
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+
+Layout/IndentationConsistency:
+  EnforcedStyle: rails
+
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/EndOfLine:
+  EnforcedStyle: lf
+
+Layout/TrailingBlankLines:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Metrics/LineLength:
+  Max: 100
+
+RSpec/NotToNot:
+  Enabled: true
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/app/assets/javascripts/globalize.js.coffee
+++ b/app/assets/javascripts/globalize.js.coffee
@@ -58,3 +58,6 @@ App.Globalize =
       $(this).hide()
       App.Globalize.remove_language(locale)
 
+    $('.action-content a').click (event), ->
+      $(this).next('div').toggleClass('hide');
+      event.preventDefault()

--- a/app/assets/javascripts/globalize.js.coffee
+++ b/app/assets/javascripts/globalize.js.coffee
@@ -57,7 +57,3 @@ App.Globalize =
       locale = $(this).data("locale")
       $(this).hide()
       App.Globalize.remove_language(locale)
-
-    $('.action-content a').click (event), ->
-      $(this).next('div').toggleClass('hide');
-      event.preventDefault()

--- a/app/controllers/dashboard/actions_controller.rb
+++ b/app/controllers/dashboard/actions_controller.rb
@@ -1,4 +1,4 @@
-class Dashboard::ActionsController < Dashboard::BaseController 
+class Dashboard::ActionsController < Dashboard::BaseController
   helper_method :dashboard_action
 
   def new_request
@@ -10,8 +10,8 @@ class Dashboard::ActionsController < Dashboard::BaseController
     authorize! :dashboard, proposal
 
     source_params = {
-      proposal: proposal, 
-      action: dashboard_action, 
+      proposal: proposal,
+      action: dashboard_action,
       executed_at: Time.now
     }
 
@@ -30,7 +30,7 @@ class Dashboard::ActionsController < Dashboard::BaseController
     authorize! :dashboard, proposal
 
     Dashboard::ExecutedAction.create(proposal: proposal, action: dashboard_action, executed_at: Time.now)
-    redirect_to progress_proposal_dashboard_path(proposal.to_param)
+    redirect_to request.referer
   end
 
   private
@@ -39,4 +39,3 @@ class Dashboard::ActionsController < Dashboard::BaseController
     @dashboard_action ||= Dashboard::Action.find(params[:id])
   end
 end
-

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,6 @@
 class DashboardController < Dashboard::BaseController
   helper_method :dashboard_action, :active_resources, :course
+  before_action :set_done_and_pending_actions, only: [:recommended_actions, :progress]
 
   def show
     authorize! :dashboard, proposal
@@ -11,8 +12,8 @@ class DashboardController < Dashboard::BaseController
     proposal.publish
     redirect_to proposal_dashboard_path(proposal), notice: t('proposals.notice.published')
   end
-  
-  def progress 
+
+  def progress
     authorize! :dashboard, proposal
   end
 
@@ -21,12 +22,17 @@ class DashboardController < Dashboard::BaseController
   end
 
   private
-  
+
   def active_resources
     @active_resources ||= Dashboard::Action.active.resources.order(required_supports: :asc, day_offset: :asc)
   end
 
   def course
     @course ||= Dashboard::Action.course_for(proposal)
+  end
+
+  def set_done_and_pending_actions
+    @done_actions = proposed_actions.joins(:proposals).where("proposals.id = ?", proposal.id)
+    @pending_actions = proposed_actions - @done_actions
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -21,6 +21,10 @@ class DashboardController < Dashboard::BaseController
     authorize! :dashboard, proposal
   end
 
+  def recommended_actions
+    authorize! :dashboard, proposal
+  end
+
   private
 
   def active_resources

--- a/app/helpers/proposals_dashboard_helper.rb
+++ b/app/helpers/proposals_dashboard_helper.rb
@@ -11,6 +11,10 @@ module ProposalsDashboardHelper
     is_proposed_action_request? || (controller_name == 'dashboard' && action_name == 'progress')
   end
 
+  def recommended_actions_menu_active?
+    controller_name == "dashboard" && action_name == "recommended_actions"
+  end
+
   def resources_menu_visible?(proposal, resources)
     can?(:manage_polls, proposal) || resources.any?
   end

--- a/app/views/dashboard/_menu.html.erb
+++ b/app/views/dashboard/_menu.html.erb
@@ -13,6 +13,13 @@
     <% end %>
   </li>
 
+  <li class="section-title <%= 'is-active' if recommended_actions_menu_active? %>">
+    <span class="icon-checkmark-circle"></span>
+    <%= link_to recommended_actions_proposal_dashboard_path(proposal.to_param) do %>
+      <strong><%= t("dashboard.menu.recommended_actions") %></strong>
+    <% end %>
+  </li>
+
   <% if resources_menu_visible?(proposal, resources) %>
     <li class="section-title <%= 'is-active' if resources_menu_active? %>">
       <span class="icon-zip"></span>

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -17,8 +17,8 @@
       <% if proposed_action.proposals.where(id: proposal.id).any? %>
         <p><%= l(proposed_action.executed_actions.find_by(proposal: proposal).executed_at.to_date) %></p>
       <% else %>
-        <% if proposed_action.short_description.present? %>
-          <p><%= proposed_action.short_description %></p>
+        <% if proposed_action.description.present? %>
+          <p><%= proposed_action.description.html_safe %></p>
         <% end %>
 
         <% proposed_action.links.each do |link| %>

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -16,6 +16,7 @@
 
       <% if proposed_action.proposals.where(id: proposal.id).any? %>
         <p><%= l(proposed_action.executed_actions.find_by(proposal: proposal).executed_at.to_date) %></p>
+        <%= proposed_action.description.html_safe %>
       <% else %>
         <% if proposed_action.description.present? %>
           <p><%= proposed_action.description.html_safe %></p>

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -10,38 +10,30 @@
         <span class="unchecked"></span>
       <% end %>
     <% end %>
-
     <div class="action-content">
       <h4><%= proposed_action.title %></h4>
-
       <% if proposed_action.proposals.where(id: proposal.id).any? %>
-
         <p class="inline">
           <%= l(proposed_action.executed_actions.find_by(proposal: proposal).executed_at.to_date) %>
         </p>
-
-        <%= link_to do %>
+        <a data-toggle="proposed_action_description_<%= dom_id(proposed_action) %>">
           <small><%= t("dashboard.recommended_actions.show_description") %></small>
-        <% end %>
-
-        <div class="hide">
+        </a>
+        <div id="proposed_action_description_<%= dom_id(proposed_action) %>" class="hide" data-toggler=".hide">
           <%= proposed_action.description.html_safe %>
         </div>
-
       <% else %>
         <% if proposed_action.description.present? %>
-        <%= link_to do %>
-          <small><%= t("dashboard.recommended_actions.show_description") %></small>
-        <% end %>
-          <div class="hide">
+          <a data-toggle="proposed_action_description_<%= dom_id(proposed_action) %>">
+            <small><%= t("dashboard.recommended_actions.show_description") %></small>
+          </a>
+          <div id="proposed_action_description_<%= dom_id(proposed_action) %>" class="hide" data-toggler=".hide">
             <%= proposed_action.description.html_safe %>
           </div>
         <% end %>
-
         <% proposed_action.links.each do |link| %>
           <p><%= link_to link.label, link.url, target: "_blank" %></p>
         <% end %>
-
         <%= render partial: 'document', collection: proposed_action.documents %>
       <% end %>
     </div>

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -21,7 +21,7 @@
         </p>
 
         <%= link_to do %>
-          <small>Mostrar Description</small>
+          <small><%= t("dashboard.recommended_actions.show_description") %></small>
         <% end %>
 
         <div class="hide">
@@ -31,7 +31,7 @@
       <% else %>
         <% if proposed_action.description.present? %>
         <%= link_to do %>
-          <small>Mostrar Description</small>
+          <small><%= t("dashboard.recommended_actions.show_description") %></small>
         <% end %>
           <div class="hide">
             <%= proposed_action.description.html_safe %>

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -15,11 +15,27 @@
       <h4><%= proposed_action.title %></h4>
 
       <% if proposed_action.proposals.where(id: proposal.id).any? %>
-        <p><%= l(proposed_action.executed_actions.find_by(proposal: proposal).executed_at.to_date) %></p>
-        <%= proposed_action.description.html_safe %>
+
+        <p class="inline">
+          <%= l(proposed_action.executed_actions.find_by(proposal: proposal).executed_at.to_date) %>
+        </p>
+
+        <%= link_to do %>
+          <small>Mostrar Description</small>
+        <% end %>
+
+        <div class="hide">
+          <%= proposed_action.description.html_safe %>
+        </div>
+
       <% else %>
         <% if proposed_action.description.present? %>
-          <p><%= proposed_action.description.html_safe %></p>
+        <%= link_to do %>
+          <small>Mostrar Description</small>
+        <% end %>
+          <div class="hide">
+            <%= proposed_action.description.html_safe %>
+          </div>
         <% end %>
 
         <% proposed_action.links.each do |link| %>

--- a/app/views/dashboard/_recommended_actions.html.erb
+++ b/app/views/dashboard/_recommended_actions.html.erb
@@ -1,5 +1,0 @@
-<% if proposed_actions.any? %>
-  <h3 class="title"><%= t("dashboard.recommended_actions.title") %></h3>
-
-  <%= render partial: 'proposed_action', collection: proposed_actions %>
-<% end %>

--- a/app/views/dashboard/_recommended_actions_by_status.html.erb
+++ b/app/views/dashboard/_recommended_actions_by_status.html.erb
@@ -8,12 +8,11 @@
       <div class="margin small">
         <% if toggle == true %>
           <a id="see_proposed_actions_link_<%= status %>" data-toggle="last_proposed_actions_<%= status %> proposed_actions_<%= status %>">
-            <%#= t("dashboard.recommended_actions.see_proposed_actions") %>
-            Mostrar todas las acciones recomendadas
+            <%= t("dashboard.recommended_actions.see_proposed_actions") %>
           </a>
         <% else %>
           <%= link_to recommended_actions_proposal_dashboard_path(proposal.to_param) do %>
-            <strong><%= t("dashboard.recommended_actions.see_proposed_actions") %></strong>
+            <strong><%= t("dashboard.recommended_actions.goto_proposed_actions") %></strong>
           <% end %>
         <% end %>
       </div>

--- a/app/views/dashboard/_recommended_actions_by_status.html.erb
+++ b/app/views/dashboard/_recommended_actions_by_status.html.erb
@@ -1,17 +1,36 @@
 <h2 class="title"><%= t("dashboard.recommended_actions.#{status}_title") %></h2>
 <% if actions.any? %>
-  <div id="proposed_actions" data-toggler=".hide">
+  <div id="proposed_actions_<%= status %>" data-toggler=".hide">
     <% actions.first(4).each do |proposed_action| %>
       <%= render 'proposed_action', proposed_action: proposed_action %>
     <% end %>
     <% if actions.count > 4 %>
       <div class="margin small">
+        <% if toggle == true %>
+          <a id="see_proposed_actions_link_<%= status %>" data-toggle="last_proposed_actions_<%= status %> proposed_actions_<%= status %>">
+            <%= t("dashboard.recommended_actions.see_proposed_actions") %>
+          </a>
+        <% else %>
           <%= link_to recommended_actions_proposal_dashboard_path(proposal.to_param) do %>
             <strong><%= t("dashboard.recommended_actions.see_proposed_actions") %></strong>
           <% end %>
+        <% end %>
       </div>
     <% end %>
   </div>
+  <% if toggle == true %>
+    <% if actions.count > 4 %>
+      <div id="last_proposed_actions_<%= status %>" class="hide" data-toggler=".hide">
+        <%= render partial: 'proposed_action', collection: actions %>
+
+        <div class="margin small">
+          <a data-toggle="last_proposed_actions_<%= status %> proposed_actions_<%= status %>">
+            <%= t("dashboard.recommended_actions.hide_proposed_actions") %>
+          </a>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
 <% else %>
   <%= t("dashboard.recommended_actions.without_#{status}_actions") %>
 <% end %>

--- a/app/views/dashboard/_recommended_actions_by_status.html.erb
+++ b/app/views/dashboard/_recommended_actions_by_status.html.erb
@@ -8,7 +8,8 @@
       <div class="margin small">
         <% if toggle == true %>
           <a id="see_proposed_actions_link_<%= status %>" data-toggle="last_proposed_actions_<%= status %> proposed_actions_<%= status %>">
-            <%= t("dashboard.recommended_actions.see_proposed_actions") %>
+            <%#= t("dashboard.recommended_actions.see_proposed_actions") %>
+            Mostrar todas las acciones recomendadas
           </a>
         <% else %>
           <%= link_to recommended_actions_proposal_dashboard_path(proposal.to_param) do %>

--- a/app/views/dashboard/_recommended_actions_by_status.html.erb
+++ b/app/views/dashboard/_recommended_actions_by_status.html.erb
@@ -1,4 +1,4 @@
-<h2 class="title"><%= t("dashboard.recommended_actions.#{status}_title") %></h2>
+<h3 class="title"><%= t("dashboard.recommended_actions.#{status}_title") %></h3>
 <% if actions.any? %>
   <div id="proposed_actions_<%= status %>" data-toggler=".hide">
     <% actions.first(4).each do |proposed_action| %>

--- a/app/views/dashboard/_recommended_actions_by_status.html.erb
+++ b/app/views/dashboard/_recommended_actions_by_status.html.erb
@@ -1,14 +1,14 @@
 <h3 class="title"><%= t("dashboard.recommended_actions.#{status}_title") %></h3>
 <% if actions.any? %>
-  <div id="proposed_actions_<%= status %>" data-toggler=".hide">
+  <div id="proposed_actions_<%= status %>">
     <% actions.first(4).each do |proposed_action| %>
       <%= render 'proposed_action', proposed_action: proposed_action %>
     <% end %>
     <% if actions.count > 4 %>
-      <div class="margin small">
+      <div class="margin small" id="proposed_actions_<%= status %>_link" data-toggler=".hide">
         <% if toggle == true %>
-          <a id="see_proposed_actions_link_<%= status %>" data-toggle="last_proposed_actions_<%= status %> proposed_actions_<%= status %>">
-            <%= t("dashboard.recommended_actions.see_proposed_actions") %>
+          <a id="see_proposed_actions_link_<%= status %>" data-toggle="last_proposed_actions_<%= status %> proposed_actions_<%= status %>_link">
+            <strong><%= t("dashboard.recommended_actions.see_proposed_actions") %></strong>
           </a>
         <% else %>
           <%= link_to recommended_actions_proposal_dashboard_path(proposal.to_param) do %>
@@ -21,11 +21,10 @@
   <% if toggle == true %>
     <% if actions.count > 4 %>
       <div id="last_proposed_actions_<%= status %>" class="hide" data-toggler=".hide">
-        <%= render partial: 'proposed_action', collection: actions %>
-
+        <%= render partial: 'proposed_action', collection: actions - actions.first(4) %>
         <div class="margin small">
-          <a data-toggle="last_proposed_actions_<%= status %> proposed_actions_<%= status %>">
-            <%= t("dashboard.recommended_actions.hide_proposed_actions") %>
+          <a data-toggle="last_proposed_actions_<%= status %> proposed_actions_<%= status %>_link">
+            <strong><%= t("dashboard.recommended_actions.hide_proposed_actions") %></strong>
           </a>
         </div>
       </div>

--- a/app/views/dashboard/_recommended_actions_by_status.html.erb
+++ b/app/views/dashboard/_recommended_actions_by_status.html.erb
@@ -1,0 +1,17 @@
+<h2 class="title"><%= t("dashboard.recommended_actions.#{status}_title") %></h2>
+<% if actions.any? %>
+  <div id="proposed_actions" data-toggler=".hide">
+    <% actions.first(4).each do |proposed_action| %>
+      <%= render 'proposed_action', proposed_action: proposed_action %>
+    <% end %>
+    <% if actions.count > 4 %>
+      <div class="margin small">
+          <%= link_to recommended_actions_proposal_dashboard_path(proposal.to_param) do %>
+            <strong><%= t("dashboard.recommended_actions.see_proposed_actions") %></strong>
+          <% end %>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <%= t("dashboard.recommended_actions.without_#{status}_actions") %>
+<% end %>

--- a/app/views/dashboard/_summary_recommended_actions.html.erb
+++ b/app/views/dashboard/_summary_recommended_actions.html.erb
@@ -1,4 +1,4 @@
-<h3 class="title"><%= t("dashboard.recommended_actions.title") %></h3>
+<h2 class="title"><%= t("dashboard.recommended_actions.title") %></h2>
 
 <%= render 'recommended_actions_by_status', status: 'pending', actions: @pending_actions, toggle: false %>
 <%= render 'recommended_actions_by_status', status: 'done', actions: @done_actions, toggle: false %>

--- a/app/views/dashboard/_summary_recommended_actions.html.erb
+++ b/app/views/dashboard/_summary_recommended_actions.html.erb
@@ -1,0 +1,4 @@
+<h3 class="title"><%= t("dashboard.recommended_actions.title") %></h3>
+
+<%= render 'recommended_actions_by_status', status: 'pending', actions: @pending_actions, toggle: false %>
+<%= render 'recommended_actions_by_status', status: 'done', actions: @done_actions, toggle: false %>

--- a/app/views/dashboard/progress.html.erb
+++ b/app/views/dashboard/progress.html.erb
@@ -33,5 +33,5 @@
 <% end %>
 
 <%= render 'next_goal' %>
-<%= render 'recommended_actions' %>
+<%= render 'summary_recommended_actions' %>
 <%= render 'resources' %>

--- a/app/views/dashboard/recommended_actions.html.erb
+++ b/app/views/dashboard/recommended_actions.html.erb
@@ -1,4 +1,4 @@
-<h3 class="title"><%= t("dashboard.recommended_actions.title") %></h3>
+<h2 class="title"><%= t("dashboard.recommended_actions.title") %></h3>
 
 <%= render 'recommended_actions_by_status', status: 'pending', actions: @pending_actions, toggle: true  %>
 <%= render 'recommended_actions_by_status', status: 'done', actions: @done_actions, toggle: true  %>

--- a/app/views/dashboard/recommended_actions.html.erb
+++ b/app/views/dashboard/recommended_actions.html.erb
@@ -1,0 +1,4 @@
+<h3 class="title"><%= t("dashboard.recommended_actions.title") %></h3>
+
+<%= render 'recommended_actions_by_status', status: 'pending', actions: @pending_actions, toggle: true  %>
+<%= render 'recommended_actions_by_status', status: 'done', actions: @done_actions, toggle: true  %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -167,6 +167,7 @@ ignore_unused:
   - 'polls.index.filters.*'
   - 'polls.index.section_header.*'
   - 'polls.index.orders.*'
+  - 'dashboard.recommended_actions.*'
   - 'debates.index.select_order'
   - 'debates.index.orders.*'
   - 'debates.index.section_header.*'

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -484,6 +484,7 @@ en:
       polls: Polls
       mailing: E-mail
       poster: Poster
+      recommended_actions: Recommended actions
     form:
       request: Request
     create_request:
@@ -518,7 +519,9 @@ en:
       see_proposed_actions: Check out recommended actions
       hide_proposed_actions: Hide recommended actions
       pending_title: Recommended actions pending
+      without_pending_actions: No recommended actions pending
       done_title: Recommended actions done
+      without_done_actions: No recommended actions done
     next_goal:
       title: Goal
       see_complete_course: Check out the complete course

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -515,6 +515,10 @@ en:
       resource_locked: Resource locked
     recommended_actions:
       title: Recommended actions
+      see_proposed_actions: Check out recommended actions
+      hide_proposed_actions: Hide recommended actions
+      pending_title: Recommended actions pending
+      done_title: Recommended actions done
     next_goal:
       title: Goal
       see_complete_course: Check out the complete course

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -516,11 +516,13 @@ en:
       resource_locked: Resource locked
     recommended_actions:
       title: Recommended actions
+      goto_proposed_actions: Go to recommended actions
       see_proposed_actions: Check out recommended actions
       hide_proposed_actions: Hide recommended actions
-      pending_title: Recommended actions pending
+      pending_title: Pending
+      show_description: Show description
       without_pending_actions: No recommended actions pending
-      done_title: Recommended actions done
+      done_title: Done
       without_done_actions: No recommended actions done
     next_goal:
       title: Goal

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -515,6 +515,10 @@ es:
       resource_locked: Recurso bloqueado
     recommended_actions:
       title: Acciones recomendadas
+      see_proposed_actions: Ver todas las acciones recomendadas
+      hide_proposed_actions: Ocultar acciones recomendadas
+      pending_title: Acciones recomendadas pendientes
+      done_title: Acciones recomendadas realizadas
     next_goal:
       title: Meta
       see_complete_course: Ver ruta completa

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -484,6 +484,7 @@ es:
       polls: Encuestas
       mailing: Correo electrónico
       poster: Póster
+      recommended_actions: Acciones recomendadas
     form:
       request: Solicitar
     create_request:
@@ -518,7 +519,9 @@ es:
       see_proposed_actions: Ver todas las acciones recomendadas
       hide_proposed_actions: Ocultar acciones recomendadas
       pending_title: Acciones recomendadas pendientes
+      without_pending_actions: No hay acciones recomendadas pendientes
       done_title: Acciones recomendadas realizadas
+      without_done_actions: No hay acciones recomendadas realizadas
     next_goal:
       title: Meta
       see_complete_course: Ver ruta completa

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -516,9 +516,11 @@ es:
       resource_locked: Recurso bloqueado
     recommended_actions:
       title: Acciones recomendadas
+      goto_proposed_actions: Ir a las acciones recomendadas
       see_proposed_actions: Ver todas las acciones recomendadas
       hide_proposed_actions: Ocultar acciones recomendadas
       pending_title: Pendientes
+      show_description: Mostrar descripción
       without_pending_actions: No hay acciones recomendadas pendientes
       done_title: Realizadas
       without_done_actions: No hay acciones recomendadas realizadas

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -518,9 +518,9 @@ es:
       title: Acciones recomendadas
       see_proposed_actions: Ver todas las acciones recomendadas
       hide_proposed_actions: Ocultar acciones recomendadas
-      pending_title: Acciones recomendadas pendientes
+      pending_title: Pendientes
       without_pending_actions: No hay acciones recomendadas pendientes
-      done_title: Acciones recomendadas realizadas
+      done_title: Realizadas
       without_done_actions: No hay acciones recomendadas realizadas
     next_goal:
       title: Meta

--- a/config/routes/proposal.rb
+++ b/config/routes/proposal.rb
@@ -4,6 +4,7 @@ resources :proposals do
       patch :publish
       get :progress
       get :community
+      get :recommended_actions
     end
 
     resources :resources, only: [:index], controller: 'dashboard/resources'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -619,7 +619,7 @@ ActiveRecord::Schema.define(version: 20180924071722) do
     t.string   "locale",                       null: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
-    t.text     "title"
+    t.string   "title"
     t.text     "changelog"
     t.text     "body"
     t.text     "body_html"
@@ -1218,17 +1218,17 @@ ActiveRecord::Schema.define(version: 20180924071722) do
   add_index "site_customization_images", ["name"], name: "index_site_customization_images_on_name", unique: true, using: :btree
 
   create_table "site_customization_page_translations", force: :cascade do |t|
-      t.integer  "site_customization_page_id", null: false
-      t.string   "locale",                     null: false
-      t.datetime "created_at",                 null: false
-      t.datetime "updated_at",                 null: false
-      t.string   "title"
-      t.string   "subtitle"
-      t.text     "content"
-    end
+    t.integer  "site_customization_page_id", null: false
+    t.string   "locale",                     null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "title"
+    t.string   "subtitle"
+    t.text     "content"
+  end
 
-    add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
-    add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
+  add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
+  add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
 
   create_table "site_customization_pages", force: :cascade do |t|
     t.string   "slug",                                 null: false

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -63,7 +63,8 @@ feature "Proposal's dashboard" do
     expect(page).not_to have_content(action_5.title)
   end
 
-  scenario "Dashboard progress display link to new page for proposed actions when there are more than four proposed actions", js: true do
+  scenario "Dashboard progress display link to new page for proposed actions when
+            there are more than four proposed actions", js: true do
     create_list(:dashboard_action, 4, :proposed_action, :active)
     action_5 = create(:dashboard_action, :proposed_action, :active)
 
@@ -72,7 +73,8 @@ feature "Proposal's dashboard" do
     expect(page).to have_link("Check out recommended actions")
   end
 
-  scenario "Dashboard progress do not display link to new page for proposed actions when there are less than five proposed actions", js: true do
+  scenario "Dashboard progress do not display link to new page for proposed actions
+            when there are less than five proposed actions", js: true do
     create_list(:dashboard_action, 4, :proposed_action, :active)
 
     visit progress_proposal_dashboard_path(proposal)
@@ -90,7 +92,8 @@ feature "Proposal's dashboard" do
     end
   end
 
-  scenario "Dashboard progress display no results text when there are not proposed_actions pending" do
+  scenario "Dashboard progress display contains no results text when there are not
+            proposed_actions pending" do
     visit progress_proposal_dashboard_path(proposal)
 
     expect(page).to have_content("No recommended actions pending")
@@ -107,7 +110,8 @@ feature "Proposal's dashboard" do
     end
   end
 
-  scenario "Dashboard progress display no results text when there are not proposed_actions pending" do
+  scenario "Dashboard progress display contains no results text when there are not
+            proposed_actions pending" do
     visit progress_proposal_dashboard_path(proposal)
 
     expect(page).to have_content("No recommended actions done")
@@ -223,4 +227,88 @@ feature "Proposal's dashboard" do
     expect(page).to have_content('Comments')
     expect(page).to have_link('Access the community')
   end
+
+  scenario "Dashboard has a link to recommended_actions", js: true do
+    expect(page).to have_link("Recommended actions")
+    click_link "Recommended actions"
+
+    expect(page).to have_content("Recommended actions")
+    expect(page).to have_content("Recommended actions pending")
+    expect(page).to have_content("Recommended actions done")
+  end
+
+  scenario "On recommended actions section display from the fourth proposed actions
+            when click see_proposed_actions_link", js: true do
+    create_list(:dashboard_action, 4, :proposed_action, :active)
+    action_5 = create(:dashboard_action, :proposed_action, :active)
+
+    visit recommended_actions_proposal_dashboard_path(proposal.to_param)
+    find(:css, "#see_proposed_actions_link_pending").click
+
+    expect(page).to have_content(action_5.title)
+  end
+
+  scenario "On recommended actions section do not display from the fourth proposed actions", js: true do
+    create_list(:dashboard_action, 4, :proposed_action, :active)
+    action_5 = create(:dashboard_action, :proposed_action, :active)
+
+    visit recommended_actions_proposal_dashboard_path(proposal.to_param)
+
+    expect(page).not_to have_content(action_5.title)
+  end
+
+  scenario "On recommended actions section display link for toggle when there are
+            more than four proposed actions", js: true do
+    create_list(:dashboard_action, 4, :proposed_action, :active)
+    action_5 = create(:dashboard_action, :proposed_action, :active)
+
+    visit recommended_actions_proposal_dashboard_path(proposal.to_param)
+
+    expect(page).to have_content("Check out recommended actions")
+  end
+
+  scenario "On recommended actions section do not display link for toggle when
+            there are less than five proposed actions", js: true do
+    create_list(:dashboard_action, 4, :proposed_action, :active)
+
+    visit recommended_actions_proposal_dashboard_path(proposal.to_param)
+
+    expect(page).not_to have_link("Check out recommended actions")
+  end
+
+  scenario "On recommended actions section display proposed_action pending on his section" do
+    action = create(:dashboard_action, :proposed_action, :active)
+
+    visit recommended_actions_proposal_dashboard_path(proposal.to_param)
+
+    within "#proposed_actions_pending" do
+      expect(page).to have_content(action.title)
+    end
+  end
+
+  scenario "On recommended actions section contains no_results_text when there are
+            not proposed_actions pending" do
+    visit recommended_actions_proposal_dashboard_path(proposal.to_param)
+
+    expect(page).to have_content("No recommended actions pending")
+  end
+
+  scenario "On recommended actions section display proposed_action done on his section" do
+    action = create(:dashboard_action, :proposed_action, :active)
+
+    visit recommended_actions_proposal_dashboard_path(proposal.to_param)
+    find(:css, "#dashboard_action_#{action.id}_execute").click
+
+    within "#proposed_actions_done" do
+      expect(page).to have_content(action.title)
+    end
+  end
+
+  scenario "On recommended actions section contains no_results_text when there are
+            not proposed_actions pending" do
+    visit progress_proposal_dashboard_path(proposal)
+
+    expect(page).to have_content("No recommended actions done")
+  end
+
 end

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -50,6 +50,73 @@ feature "Proposal's dashboard" do
     action = create(:dashboard_action, :proposed_action, :active)
 
     visit progress_proposal_dashboard_path(proposal)
+
+    expect(page).to have_content(action.title)
+  end
+
+  scenario "Dashboard progress do not display from the fourth proposed actions", js: true do
+    create_list(:dashboard_action, 4, :proposed_action, :active)
+    action_5 = create(:dashboard_action, :proposed_action, :active)
+
+    visit progress_proposal_dashboard_path(proposal)
+
+    expect(page).not_to have_content(action_5.title)
+  end
+
+  scenario "Dashboard progress display link to new page for proposed actions when there are more than four proposed actions", js: true do
+    create_list(:dashboard_action, 4, :proposed_action, :active)
+    action_5 = create(:dashboard_action, :proposed_action, :active)
+
+    visit progress_proposal_dashboard_path(proposal)
+
+    expect(page).to have_link("Check out recommended actions")
+  end
+
+  scenario "Dashboard progress do not display link to new page for proposed actions when there are less than five proposed actions", js: true do
+    create_list(:dashboard_action, 4, :proposed_action, :active)
+
+    visit progress_proposal_dashboard_path(proposal)
+
+    expect(page).not_to have_link("Check out recommended actions")
+  end
+
+  scenario "Dashboard progress display proposed_action pending on his section" do
+    action = create(:dashboard_action, :proposed_action, :active)
+
+    visit progress_proposal_dashboard_path(proposal)
+
+    within "#proposed_actions_pending" do
+      expect(page).to have_content(action.title)
+    end
+  end
+
+  scenario "Dashboard progress display no results text when there are not proposed_actions pending" do
+    visit progress_proposal_dashboard_path(proposal)
+
+    expect(page).to have_content("No recommended actions pending")
+  end
+
+  scenario "Dashboard progress display proposed_action done on his section" do
+    action = create(:dashboard_action, :proposed_action, :active)
+
+    visit progress_proposal_dashboard_path(proposal)
+    find(:css, "#dashboard_action_#{action.id}_execute").click
+
+    within "#proposed_actions_done" do
+      expect(page).to have_content(action.title)
+    end
+  end
+
+  scenario "Dashboard progress display no results text when there are not proposed_actions pending" do
+    visit progress_proposal_dashboard_path(proposal)
+
+    expect(page).to have_content("No recommended actions done")
+  end
+
+  scenario "Dashboard progress can execute proposed action" do
+    action = create(:dashboard_action, :proposed_action, :active)
+
+    visit progress_proposal_dashboard_path(proposal)
     expect(page).to have_content(action.title)
 
     find(:css, "#dashboard_action_#{action.id}_execute").click

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -70,7 +70,7 @@ feature "Proposal's dashboard" do
 
     visit progress_proposal_dashboard_path(proposal)
 
-    expect(page).to have_link("Check out recommended actions")
+    expect(page).to have_link("Go to recommended actions")
   end
 
   scenario "Dashboard progress do not display link to new page for proposed actions
@@ -233,8 +233,8 @@ feature "Proposal's dashboard" do
     click_link "Recommended actions"
 
     expect(page).to have_content("Recommended actions")
-    expect(page).to have_content("Recommended actions pending")
-    expect(page).to have_content("Recommended actions done")
+    expect(page).to have_content("Pending")
+    expect(page).to have_content("Done")
   end
 
   scenario "On recommended actions section display from the fourth proposed actions


### PR DESCRIPTION
## References
[Dashboard: Enhancement Progress page (Actions List)](https://github.com/Platoniq/consul/issues/9)

## Objectives
- On progress page we want to have a summary from recommended actions.
- Create a new page for display all recommended actions informations.
- Create two list for recommended actions for progress page and new recommended actions page:
  - Recommended actions done.
  - Recommended actions pending.
- Display recommended actions as goals on new page with a toggle for display from the fourth recommended action.
- Add toggle button to display long descriptión for recommended actions.

## Visual Changes
- Progress page (summary recommended actions) with link to new page "recommended actions", and with two lists (pending, done).
![captura de pantalla 2019-01-14 a las 14 25 50](https://user-images.githubusercontent.com/16189/51115404-7e57d080-1808-11e9-9970-92d7eb78df76.png)

- New Recommended actions page with toggle for display all other recommended actions. Add two lists (pending, done) recommended actions. 
![captura de pantalla 2019-01-14 a las 14 26 36](https://user-images.githubusercontent.com/16189/51115692-4ac97600-1809-11e9-8d28-0d4290f1db25.png)

![captura de pantalla 2019-01-14 a las 14 27 01](https://user-images.githubusercontent.com/16189/51115698-4f8e2a00-1809-11e9-8aba-da45ff61b3fa.png)



