### PR TITLE
[WIP] Update globalize gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'turnout', '~> 2.4.0'
 gem 'uglifier', '~> 4.1.19'
 gem 'unicorn', '~> 5.4.1'
 gem 'whenever', '~> 0.10.0', require: false
-gem 'globalize', '~> 5.0.0'
+gem 'globalize', '~> 5.2.0'
 gem 'globalize-accessors', '~> 0.2.1'
 
 source 'https://rails-assets.org' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -175,9 +175,10 @@ GEM
     geocoder (1.4.4)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    globalize (5.0.1)
-      activemodel (>= 4.2.0, < 4.3)
-      activerecord (>= 4.2.0, < 4.3)
+    globalize (5.2.0)
+      activemodel (>= 4.2, < 5.3)
+      activerecord (>= 4.2, < 5.3)
+      request_store (~> 1.0)
     globalize-accessors (0.2.1)
       globalize (~> 5.0, >= 5.0.0)
     graphiql-rails (1.4.8)
@@ -522,7 +523,7 @@ DEPENDENCIES
   faker (~> 1.8.7)
   foundation-rails (~> 6.4.3.0)
   foundation_rails_helper (~> 2.0.0)
-  globalize (~> 5.0.0)
+  globalize (~> 5.2.0)
   globalize-accessors (~> 0.2.1)
   graphiql-rails (~> 1.4.1)
   graphql (~> 1.7.8)
@@ -576,4 +577,4 @@ DEPENDENCIES
   whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -9,9 +9,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   end
 
   def show
-    @poll = Poll.includes(:questions).
-                          order('poll_questions.title').
-                          find(params[:id])
+    @poll = Poll.find(params[:id])
   end
 
   def new
@@ -61,7 +59,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
 
     def poll_params
       image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
-      attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :results_enabled,
+      attributes = [:starts_at, :ends_at, :geozone_restricted, :results_enabled,
                     :stats_enabled, geozone_ids: [],
                     image_attributes: image_attributes]
       params.require(:poll).permit(*attributes, translation_params(Poll))

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -19,7 +19,7 @@ module Budgets
                   .group_by(&:heading)
         else
           @budget.investments.winners
-                  .joins(:milestones).includes(:milestones)
+                  .joins(milestones: :translations)
                   .distinct.group_by(&:heading)
         end
       end

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -9,7 +9,7 @@ class PollsController < ApplicationController
   ::Poll::Answer # trigger autoload
 
   def index
-    @polls = @polls.send(@current_filter).includes(:geozones).sort_for_list.page(params[:page])
+    @polls = @polls.send(@current_filter).sort_for_list.page(params[:page])
   end
 
   def show

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -6,7 +6,13 @@ module TranslatableFormHelper
   end
 
   class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
+    attr_accessor :translations
+
     def translatable_fields(&block)
+      @translations = {}
+      @object.globalize_locales.map do |locale|
+        @translations[locale] = translation_for(locale)
+      end
       @object.globalize_locales.map do |locale|
         Globalize.with_locale(locale) { fields_for_locale(locale, &block) }
       end.join.html_safe
@@ -15,7 +21,7 @@ module TranslatableFormHelper
     private
 
       def fields_for_locale(locale, &block)
-        fields_for_translation(translation_for(locale)) do |translations_form|
+        fields_for_translation(@translations[locale]) do |translations_form|
           @template.content_tag :div, translations_options(translations_form.object, locale) do
             @template.concat translations_form.hidden_field(
               :_destroy,

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -343,7 +343,7 @@ class Budget
     end
 
     def self.with_milestone_status_id(status_id)
-      joins(:milestones).includes(:milestones).select do |investment|
+      includes(milestones: :translations).select do |investment|
         investment.milestone_status_id == status_id.to_i
       end
     end

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -14,7 +14,6 @@ class Milestone < ActiveRecord::Base
   validates :milestoneable, presence: true
   validates :publication_date, presence: true
 
-  before_validation :assign_milestone_to_translations
   validates_translation :description, presence: true, unless: -> { status_id.present? }
 
   scope :order_by_publication_date, -> { order(publication_date: :asc, created_at: :asc) }
@@ -24,10 +23,4 @@ class Milestone < ActiveRecord::Base
   def self.title_max_length
     80
   end
-
-  private
-
-    def assign_milestone_to_translations
-      translations.each { |translation| translation.globalized_model = self }
-    end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -35,7 +35,7 @@ class Poll < ActiveRecord::Base
   scope :by_geozone_id, ->(geozone_id) { where(geozones: {id: geozone_id}.joins(:geozones)) }
   scope :public_for_api, -> { all }
 
-  scope :sort_for_list, -> { order(:geozone_restricted, :starts_at, :name) }
+  scope :sort_for_list, -> { joins(:translations).order(:geozone_restricted, :starts_at, "poll_translations.name") }
 
   def title
     name

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -12,7 +12,7 @@ class Poll
     end
 
     def self.available
-      where(polls: { id: Poll.current_or_recounting_or_incoming }).includes(:polls)
+      where(polls: { id: Poll.current_or_recounting_or_incoming }).joins(polls: :translations)
     end
 
     def assignment_on_poll(poll)

--- a/db/migrate/20190115131417_remove_translated_attributes_from_widget_cards.rb
+++ b/db/migrate/20190115131417_remove_translated_attributes_from_widget_cards.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromWidgetCards < ActiveRecord::Migration
+  def change
+    remove_columns :widget_cards, :label, :title, :description, :link_text
+  end
+end

--- a/db/migrate/20190115132754_remove_translated_attributes_from_site_customization_pages.rb
+++ b/db/migrate/20190115132754_remove_translated_attributes_from_site_customization_pages.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromSiteCustomizationPages < ActiveRecord::Migration
+  def change
+    remove_columns :site_customization_pages, :title, :subtitle, :content
+  end
+end

--- a/db/migrate/20190115133404_remove_translated_attributes_from_polls.rb
+++ b/db/migrate/20190115133404_remove_translated_attributes_from_polls.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromPolls < ActiveRecord::Migration
+  def change
+    remove_columns :polls, :name, :summary, :description
+  end
+end

--- a/db/migrate/20190115133846_remove_translated_attributes_from_admin_notifications.rb
+++ b/db/migrate/20190115133846_remove_translated_attributes_from_admin_notifications.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromAdminNotifications < ActiveRecord::Migration
+  def change
+    remove_columns :admin_notifications, :title, :body
+  end
+end

--- a/db/migrate/20190115134129_remove_translated_attributes_from_banners.rb
+++ b/db/migrate/20190115134129_remove_translated_attributes_from_banners.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromBanners < ActiveRecord::Migration
+  def change
+    remove_columns :banners, :title, :description
+  end
+end

--- a/db/migrate/20190115134459_remove_translated_attributes_from_legislation_questions.rb
+++ b/db/migrate/20190115134459_remove_translated_attributes_from_legislation_questions.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromLegislationQuestions < ActiveRecord::Migration
+  def change
+    remove_columns :legislation_questions, :title
+  end
+end

--- a/db/migrate/20190115142030_remove_translated_attributes_from_legislation_question_options.rb
+++ b/db/migrate/20190115142030_remove_translated_attributes_from_legislation_question_options.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromLegislationQuestionOptions < ActiveRecord::Migration
+  def change
+    remove_columns :legislation_question_options, :value
+  end
+end

--- a/db/migrate/20190115142648_remove_translated_attributes_from_legislation_draft_versions.rb
+++ b/db/migrate/20190115142648_remove_translated_attributes_from_legislation_draft_versions.rb
@@ -1,0 +1,6 @@
+class RemoveTranslatedAttributesFromLegislationDraftVersions < ActiveRecord::Migration
+  def change
+    remove_columns :legislation_draft_versions, :title, :changelog, :body,
+      :body_html, :toc_html
+  end
+end

--- a/db/migrate/20190115143151_remove_translated_attributes_from_legislation_processes.rb
+++ b/db/migrate/20190115143151_remove_translated_attributes_from_legislation_processes.rb
@@ -1,0 +1,6 @@
+class RemoveTranslatedAttributesFromLegislationProcesses < ActiveRecord::Migration
+  def change
+    remove_columns :legislation_processes, :title, :summary, :description,
+      :additional_info
+  end
+end

--- a/db/migrate/20190115143931_remove_translated_attributes_from_milestones.rb
+++ b/db/migrate/20190115143931_remove_translated_attributes_from_milestones.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromMilestones < ActiveRecord::Migration
+  def change
+    remove_columns :milestones, :title, :description
+  end
+end

--- a/db/migrate/20190115144213_remove_translated_attributes_from_poll_questions.rb
+++ b/db/migrate/20190115144213_remove_translated_attributes_from_poll_questions.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromPollQuestions < ActiveRecord::Migration
+  def change
+    remove_columns :poll_questions, :title
+  end
+end

--- a/db/migrate/20190115144450_remove_translated_attributes_from_poll_question_answers.rb
+++ b/db/migrate/20190115144450_remove_translated_attributes_from_poll_question_answers.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedAttributesFromPollQuestionAnswers < ActiveRecord::Migration
+  def change
+    remove_columns :poll_question_answers, :title, :description
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115142648) do
+ActiveRecord::Schema.define(version: 20190115143151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -629,9 +629,6 @@ ActiveRecord::Schema.define(version: 20190115142648) do
   add_index "legislation_process_translations", ["locale"], name: "index_legislation_process_translations_on_locale", using: :btree
 
   create_table "legislation_processes", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.text     "additional_info"
     t.date     "start_date"
     t.date     "end_date"
     t.date     "debate_start_date"
@@ -643,7 +640,6 @@ ActiveRecord::Schema.define(version: 20190115142648) do
     t.datetime "hidden_at"
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
-    t.text     "summary"
     t.boolean  "debate_phase_enabled",       default: false
     t.boolean  "allegations_phase_enabled",  default: false
     t.boolean  "draft_publication_enabled",  default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115133404) do
+ActiveRecord::Schema.define(version: 20190115133846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,8 +43,6 @@ ActiveRecord::Schema.define(version: 20190115133404) do
   add_index "admin_notification_translations", ["locale"], name: "index_admin_notification_translations_on_locale", using: :btree
 
   create_table "admin_notifications", force: :cascade do |t|
-    t.string   "title"
-    t.text     "body"
     t.string   "link"
     t.string   "segment_recipient"
     t.integer  "recipients_count"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115143931) do
+ActiveRecord::Schema.define(version: 20190115144213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -966,7 +966,6 @@ ActiveRecord::Schema.define(version: 20190115143931) do
     t.integer  "poll_id"
     t.integer  "author_id"
     t.string   "author_visible_name"
-    t.string   "title"
     t.integer  "comments_count"
     t.datetime "hidden_at"
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181206153510) do
+ActiveRecord::Schema.define(version: 20190115131417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1495,11 +1495,7 @@ ActiveRecord::Schema.define(version: 20181206153510) do
   add_index "widget_card_translations", ["widget_card_id"], name: "index_widget_card_translations_on_widget_card_id", using: :btree
 
   create_table "widget_cards", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.string   "link_text"
     t.string   "link_url"
-    t.string   "label"
     t.boolean  "header",      default: false
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115143151) do
+ActiveRecord::Schema.define(version: 20190115143931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -807,8 +807,6 @@ ActiveRecord::Schema.define(version: 20190115143151) do
   create_table "milestones", force: :cascade do |t|
     t.integer  "milestoneable_id"
     t.string   "milestoneable_type"
-    t.string   "title",              limit: 80
-    t.text     "description"
     t.datetime "publication_date"
     t.integer  "status_id"
     t.datetime "created_at",                    null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115133846) do
+ActiveRecord::Schema.define(version: 20190115134129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,8 +104,6 @@ ActiveRecord::Schema.define(version: 20190115133846) do
   add_index "banner_translations", ["locale"], name: "index_banner_translations_on_locale", using: :btree
 
   create_table "banners", force: :cascade do |t|
-    t.string   "title",            limit: 80
-    t.string   "description"
     t.string   "target_url"
     t.date     "post_started_at"
     t.date     "post_ended_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115134129) do
+ActiveRecord::Schema.define(version: 20190115134459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -745,7 +745,6 @@ ActiveRecord::Schema.define(version: 20190115134129) do
 
   create_table "legislation_questions", force: :cascade do |t|
     t.integer  "legislation_process_id"
-    t.text     "title"
     t.integer  "answers_count",          default: 0
     t.datetime "hidden_at"
     t.datetime "created_at",                         null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115134459) do
+ActiveRecord::Schema.define(version: 20190115142030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -722,7 +722,6 @@ ActiveRecord::Schema.define(version: 20190115134459) do
 
   create_table "legislation_question_options", force: :cascade do |t|
     t.integer  "legislation_question_id"
-    t.string   "value"
     t.integer  "answers_count",           default: 0
     t.datetime "hidden_at"
     t.datetime "created_at",                          null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115132754) do
+ActiveRecord::Schema.define(version: 20190115133404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1070,13 +1070,10 @@ ActiveRecord::Schema.define(version: 20190115132754) do
   add_index "poll_voters", ["user_id"], name: "index_poll_voters_on_user_id", using: :btree
 
   create_table "polls", force: :cascade do |t|
-    t.string   "name"
     t.datetime "starts_at"
     t.datetime "ends_at"
     t.boolean  "published",          default: false
     t.boolean  "geozone_restricted", default: false
-    t.text     "summary"
-    t.text     "description"
     t.integer  "comments_count",     default: 0
     t.integer  "author_id"
     t.datetime "hidden_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115142030) do
+ActiveRecord::Schema.define(version: 20190115142648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -601,16 +601,11 @@ ActiveRecord::Schema.define(version: 20190115142030) do
 
   create_table "legislation_draft_versions", force: :cascade do |t|
     t.integer  "legislation_process_id"
-    t.string   "title"
-    t.text     "changelog"
     t.string   "status",                 default: "draft"
     t.boolean  "final_version",          default: false
-    t.text     "body"
     t.datetime "hidden_at"
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
-    t.text     "body_html"
-    t.text     "toc_html"
   end
 
   add_index "legislation_draft_versions", ["hidden_at"], name: "index_legislation_draft_versions_on_hidden_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115144213) do
+ActiveRecord::Schema.define(version: 20190115144450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -941,8 +941,6 @@ ActiveRecord::Schema.define(version: 20190115144213) do
   add_index "poll_question_answer_videos", ["answer_id"], name: "index_poll_question_answer_videos_on_answer_id", using: :btree
 
   create_table "poll_question_answers", force: :cascade do |t|
-    t.string  "title"
-    t.text    "description"
     t.integer "question_id"
     t.integer "given_order", default: 1
     t.boolean "most_voted",  default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190115131417) do
+ActiveRecord::Schema.define(version: 20190115132754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1233,9 +1233,6 @@ ActiveRecord::Schema.define(version: 20190115131417) do
 
   create_table "site_customization_pages", force: :cascade do |t|
     t.string   "slug",                                 null: false
-    t.string   "title"
-    t.string   "subtitle"
-    t.text     "content"
     t.boolean  "more_info_flag"
     t.boolean  "print_content_flag"
     t.string   "status",             default: "draft"


### PR DESCRIPTION
## References

> Related Issues: #3130
> Related Pull Requests: #3156 

## Objectives
Update globalize gem to the latest. There are two reasons to update:
1. Current version of globalize is 5.0.0 which is not ThreadSafe. This bug is fixed at v5.1.0 release.
2. Latest version is v5.2.0 (this is the reason why i need to update), it works pretty good with paranoia gem and related translations simply adding hidden_at column to translations table. Without this update all translations will be destroyed (really) when calling destroy method of parent model, this will break restore feature because translation cannot be recovered.

Here is the globalize [CHANGELOG](https://github.com/globalize/globalize/blob/master/CHANGELOG.md). Here you can check ThreadSafe bug fix.

As example:
```
class Banner < ActiveRecord::Base

  acts_as_paranoid column: :hidden_at
  include ActsAsParanoidAliases

  translates :title,       touch: true
  translates :description, touch: true
  include Globalizable

  ....
end
```
With current globalize version (v5.0.0) we are not able to recover soft_deleted Banner records because translations were really destroyed.

To make globalize models to work good with "paranoia" gem we will only need to add **hidden_at** column to Banner::Translation class as shown below (This feature es available only at v5.2.0 release):

```
class Banner::Translation < Globalize::ActiveRecord::Translation
  acts_as_paranoid column: :hidden_at
end
```

## Visual Changes
Without visual changes

## Notes
None
