### PR TITLE
Update globalize gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'turnout', '~> 2.4.0'
 gem 'uglifier', '~> 4.1.19'
 gem 'unicorn', '~> 5.4.1'
 gem 'whenever', '~> 0.10.0', require: false
-gem 'globalize', '~> 5.0.0'
+gem 'globalize', '~> 5.2.0'
 gem 'globalize-accessors', '~> 0.2.1'
 
 source 'https://rails-assets.org' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -175,9 +175,10 @@ GEM
     geocoder (1.4.4)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    globalize (5.0.1)
-      activemodel (>= 4.2.0, < 4.3)
-      activerecord (>= 4.2.0, < 4.3)
+    globalize (5.2.0)
+      activemodel (>= 4.2, < 5.3)
+      activerecord (>= 4.2, < 5.3)
+      request_store (~> 1.0)
     globalize-accessors (0.2.1)
       globalize (~> 5.0, >= 5.0.0)
     graphiql-rails (1.4.8)
@@ -522,7 +523,7 @@ DEPENDENCIES
   faker (~> 1.8.7)
   foundation-rails (~> 6.4.3.0)
   foundation_rails_helper (~> 2.0.0)
-  globalize (~> 5.0.0)
+  globalize (~> 5.2.0)
   globalize-accessors (~> 0.2.1)
   graphiql-rails (~> 1.4.1)
   graphql (~> 1.7.8)
@@ -576,4 +577,4 @@ DEPENDENCIES
   whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -9,9 +9,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   end
 
   def show
-    @poll = Poll.includes(:questions).
-                          order('poll_questions.title').
-                          find(params[:id])
+    @poll = Poll.find(params[:id])
   end
 
   def new
@@ -61,7 +59,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
 
     def poll_params
       image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
-      attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :results_enabled,
+      attributes = [:starts_at, :ends_at, :geozone_restricted, :results_enabled,
                     :stats_enabled, geozone_ids: [],
                     image_attributes: image_attributes]
       params.require(:poll).permit(*attributes, translation_params(Poll))

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -19,7 +19,7 @@ module Budgets
                   .group_by(&:heading)
         else
           @budget.investments.winners
-                  .joins(:milestones).includes(:milestones)
+                  .joins(milestones: :translations)
                   .distinct.group_by(&:heading)
         end
       end

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -9,7 +9,7 @@ class PollsController < ApplicationController
   ::Poll::Answer # trigger autoload
 
   def index
-    @polls = @polls.send(@current_filter).includes(:geozones).sort_for_list.page(params[:page])
+    @polls = @polls.send(@current_filter).sort_for_list.page(params[:page])
   end
 
   def show

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -12,7 +12,7 @@ module GlobalizeHelper
 
   def display_translation?(resource, locale)
     if !resource || resource.translations.blank? ||
-        resource.translations.map(&:locale).include?(I18n.locale)
+       resource.locales_not_marked_for_destruction.include?(I18n.locale)
       locale == I18n.locale
     else
       locale == resource.translations.first.locale

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -6,7 +6,13 @@ module TranslatableFormHelper
   end
 
   class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
+    attr_accessor :translations
+
     def translatable_fields(&block)
+      @translations = {}
+      @object.globalize_locales.map do |locale|
+        @translations[locale] = translation_for(locale)
+      end
       @object.globalize_locales.map do |locale|
         Globalize.with_locale(locale) { fields_for_locale(locale, &block) }
       end.join.html_safe
@@ -15,7 +21,7 @@ module TranslatableFormHelper
     private
 
       def fields_for_locale(locale, &block)
-        fields_for_translation(translation_for(locale)) do |translations_form|
+        fields_for_translation(@translations[locale]) do |translations_form|
           @template.content_tag :div, translations_options(translations_form.object, locale) do
             @template.concat translations_form.hidden_field(
               :_destroy,

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -343,7 +343,7 @@ class Budget
     end
 
     def self.with_milestone_status_id(status_id)
-      joins(:milestones).includes(:milestones).select do |investment|
+      includes(milestones: :translations).select do |investment|
         investment.milestone_status_id == status_id.to_i
       end
     end

--- a/app/models/concerns/globalizable.rb
+++ b/app/models/concerns/globalizable.rb
@@ -15,5 +15,9 @@ module Globalizable
       validates(method, options.merge(if: lambda { |resource| resource.translations.blank? }))
       translation_class.instance_eval { validates method, options }
     end
+
+    def translation_class_delegate(method)
+      translation_class.instance_eval { delegate method, to: :globalized_model }
+    end
   end
 end

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -7,6 +7,7 @@ class Milestone < ActiveRecord::Base
 
   translates :title, :description, touch: true
   include Globalizable
+  translation_class_delegate :status_id
 
   belongs_to :milestoneable, polymorphic: true
   belongs_to :status

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -14,7 +14,6 @@ class Milestone < ActiveRecord::Base
   validates :milestoneable, presence: true
   validates :publication_date, presence: true
 
-  before_validation :assign_milestone_to_translations
   validates_translation :description, presence: true, unless: -> { status_id.present? }
 
   scope :order_by_publication_date, -> { order(publication_date: :asc, created_at: :asc) }
@@ -24,10 +23,4 @@ class Milestone < ActiveRecord::Base
   def self.title_max_length
     80
   end
-
-  private
-
-    def assign_milestone_to_translations
-      translations.each { |translation| translation.globalized_model = self }
-    end
 end

--- a/app/models/milestone/translation.rb
+++ b/app/models/milestone/translation.rb
@@ -1,3 +1,0 @@
-class Milestone::Translation < Globalize::ActiveRecord::Translation
-  delegate :status_id, to: :globalized_model
-end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -35,7 +35,7 @@ class Poll < ActiveRecord::Base
   scope :by_geozone_id, ->(geozone_id) { where(geozones: {id: geozone_id}.joins(:geozones)) }
   scope :public_for_api, -> { all }
 
-  scope :sort_for_list, -> { order(:geozone_restricted, :starts_at, :name) }
+  scope :sort_for_list, -> { joins(:translations).order(:geozone_restricted, :starts_at, "poll_translations.name") }
 
   def title
     name

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -12,7 +12,7 @@ class Poll
     end
 
     def self.available
-      where(polls: { id: Poll.current_or_recounting_or_incoming }).includes(:polls)
+      where(polls: { id: Poll.current_or_recounting_or_incoming }).joins(polls: :translations)
     end
 
     def assignment_on_poll(poll)


### PR DESCRIPTION
## References

Related Issues: #3130
Related PR: #3156

## Objectives
Update globalize gem to the latest stable version v5.2.0 to get the latest fixes and improvements. We need this update to be able to finish #3156.

Keep deprecated columns to be able to run translations migration task from `lib/tasks/globalize.rake`. Once we remove these columns we no longer be able to run this task.

Here is a branch to remove deprecation warnings and translation data migration task: [update-globalize-fix-deprecation](https://github.com/consul/consul/compare/translations...rockandror:update-globalize-fix-deprecation?expand=1)

## Why?
Update globalize gem to the latest. There are two reasons to update:
1. Current version of globalize is 5.0.0 which is not ThreadSafe. This bug is fixed at v5.1.0 release.
Here is the globalize [CHANGELOG](https://github.com/globalize/globalize/blob/master/CHANGELOG.md). Here you can check ThreadSafe bug fix.
2. Latest version is v5.2.0 (this is the reason why i need to update), it works pretty good with paranoia gem and related translations simply adding hidden_at column to translations table. Without this update all translations will be destroyed (really) when calling destroy method of parent model, this will break restore feature because translation cannot be recovered.

As example:
```
class Banner < ActiveRecord::Base

  acts_as_paranoid column: :hidden_at
  include ActsAsParanoidAliases

  translates :title,       touch: true
  translates :description, touch: true
  include Globalizable

  ....
end
```
With current globalize version (v5.0.0) we are not able to recover soft_deleted Banner records because translations were really destroyed.

To make globalize models to work good with "paranoia" gem we will only need to add **hidden_at** column to Banner::Translation class as shown below (This feature es available only at v5.2.0 release):

```
class Banner::Translation < Globalize::ActiveRecord::Translation
  acts_as_paranoid column: :hidden_at
end
```

## Visual Changes
None

## Notes
This PR will introduce next deprecation warning for translatable models:

`You have defined one or more translated attributes with names that
conflict with column(s) on the model table. Globalize does not support
this configuration anymore, remove or rename column(s) on the model
table`