### PR TITLE
[Backport] Add progress bar dev seeds

### DIFF
--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -15,6 +15,10 @@ def log(msg)
   @logger.info "#{msg}\n"
 end
 
+def random_locales
+  [I18n.default_locale, *I18n.available_locales.sample(4)].uniq
+end
+
 require_relative 'dev_seeds/settings'
 require_relative 'dev_seeds/geozones'
 require_relative 'dev_seeds/users'

--- a/db/dev_seeds/milestones.rb
+++ b/db/dev_seeds/milestones.rb
@@ -22,7 +22,24 @@ section "Creating investment milestones" do
           end
         end
       end
+
+      if rand < 0.8
+        record.progress_bars.create!(kind: :primary, percentage: rand(ProgressBar::RANGE))
+      end
+
+      rand(0..3).times do
+        progress_bar = record.progress_bars.build(
+          kind:       :secondary,
+          percentage: rand(ProgressBar::RANGE)
+        )
+
+        random_locales.map do |locale|
+          Globalize.with_locale(locale) do
+            progress_bar.title = "Description for locale #{locale}"
+            progress_bar.save!
+          end
+        end
+      end
     end
   end
 end
-

--- a/db/dev_seeds/milestones.rb
+++ b/db/dev_seeds/milestones.rb
@@ -14,7 +14,7 @@ section "Creating investment milestones" do
           status_id: Milestone::Status.all.sample
         )
 
-        I18n.available_locales.map do |locale|
+        random_locales.map do |locale|
           Globalize.with_locale(locale) do
             milestone.description = "Description for locale #{locale}"
             milestone.title = I18n.l(Time.current, format: :datetime)

--- a/db/dev_seeds/milestones.rb
+++ b/db/dev_seeds/milestones.rb
@@ -6,7 +6,7 @@ section "Creating default Milestone Statuses" do
 end
 
 section "Creating investment milestones" do
-  [Budget::Investment, Proposal].each do |model|
+  [Budget::Investment, Proposal, Legislation::Process].each do |model|
     model.find_each do |record|
       rand(1..5).times do
         milestone = record.milestones.build(


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1827

Issue consul#3135

## Objectives

* Add progress bar dev seeds for proposals, budget investments and legislation processes
* Add milestone dev seeds for legislation processes, which were missing
* Reduce the amount of time it takes to create dev seeds for milestones and progress bars