### PR TITLE
Remove help and recommendations on legislation proposal new form

### DIFF
--- a/app/views/legislation/proposals/new.html.erb
+++ b/app/views/legislation/proposals/new.html.erb
@@ -1,24 +1,10 @@
 <div class="proposal-form row">
 
-  <div class="small-12 medium-9 column">
+  <div class="small-12 column">
     <%= back_link_to %>
 
     <h1><%= t("proposals.new.start_new") %></h1>
-    <div data-alert class="callout primary">
-      <%= link_to help_path(anchor: "proposals"), title: t('shared.target_blank_html'), target: "_blank" do %>
-        <%= t("proposals.new.more_info")%>
-      <% end %>
-    </div>
-    <%= render "legislation/proposals/form", form_url: legislation_process_proposals_url, id: @proposal.id %>
-  </div>
 
-  <div class="small-12 medium-3 column">
-    <span class="icon-proposals float-right"></span>
-    <h2><%= t("proposals.new.recommendations_title") %></h2>
-    <ul class="recommendations">
-      <li><%= t("proposals.new.recommendation_one") %></li>
-      <li><%= t("proposals.new.recommendation_two") %></li>
-      <li><%= t("proposals.new.recommendation_three") %></li>
-    </ul>
+    <%= render "legislation/proposals/form", form_url: legislation_process_proposals_url, id: @proposal.id %>
   </div>
 </div>


### PR DESCRIPTION
## Objectives

- Remove help link and recommendations sidebar on legislation proposal new form. This help and recommendations are related with **proposals** and can be a little confusing on **legislation proposals** context.

## Visual Changes

**New legislation proposal form BEFORE**
![before](https://user-images.githubusercontent.com/631897/51530990-7e755300-1e3c-11e9-9ffa-44c8b34eb251.png)

**New legislation proposal form AFTER**
![after](https://user-images.githubusercontent.com/631897/51530994-80d7ad00-1e3c-11e9-8c1a-12c69e57bfb4.png)
