### PR TITLE
Pananoid translations (Translations soft deletion)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'turnout', '~> 2.4.0'
 gem 'uglifier', '~> 4.1.19'
 gem 'unicorn', '~> 5.4.1'
 gem 'whenever', '~> 0.10.0', require: false
-gem 'globalize', '~> 5.0.0'
+gem 'globalize', '~> 5.2.0'
 gem 'globalize-accessors', '~> 0.2.1'
 
 source 'https://rails-assets.org' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -175,9 +175,10 @@ GEM
     geocoder (1.4.4)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    globalize (5.0.1)
-      activemodel (>= 4.2.0, < 4.3)
-      activerecord (>= 4.2.0, < 4.3)
+    globalize (5.2.0)
+      activemodel (>= 4.2, < 5.3)
+      activerecord (>= 4.2, < 5.3)
+      request_store (~> 1.0)
     globalize-accessors (0.2.1)
       globalize (~> 5.0, >= 5.0.0)
     graphiql-rails (1.4.8)
@@ -522,7 +523,7 @@ DEPENDENCIES
   faker (~> 1.8.7)
   foundation-rails (~> 6.4.3.0)
   foundation_rails_helper (~> 2.0.0)
-  globalize (~> 5.0.0)
+  globalize (~> 5.2.0)
   globalize-accessors (~> 0.2.1)
   graphiql-rails (~> 1.4.1)
   graphql (~> 1.7.8)
@@ -576,4 +577,4 @@ DEPENDENCIES
   whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -9,9 +9,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   end
 
   def show
-    @poll = Poll.includes(:questions).
-                          order('poll_questions.title').
-                          find(params[:id])
+    @poll = Poll.find(params[:id])
   end
 
   def new
@@ -61,7 +59,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
 
     def poll_params
       image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
-      attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :results_enabled,
+      attributes = [:starts_at, :ends_at, :geozone_restricted, :results_enabled,
                     :stats_enabled, geozone_ids: [],
                     image_attributes: image_attributes]
       params.require(:poll).permit(*attributes, translation_params(Poll))

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -19,7 +19,7 @@ module Budgets
                   .group_by(&:heading)
         else
           @budget.investments.winners
-                  .joins(:milestones).includes(:milestones)
+                  .joins(milestones: :translations)
                   .distinct.group_by(&:heading)
         end
       end

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -9,7 +9,7 @@ class PollsController < ApplicationController
   ::Poll::Answer # trigger autoload
 
   def index
-    @polls = @polls.send(@current_filter).includes(:geozones).sort_for_list.page(params[:page])
+    @polls = @polls.send(@current_filter).sort_for_list.page(params[:page])
   end
 
   def show

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -12,7 +12,7 @@ module GlobalizeHelper
 
   def display_translation?(resource, locale)
     if !resource || resource.translations.blank? ||
-        resource.translations.map(&:locale).include?(I18n.locale)
+       resource.locales_not_marked_for_destruction.include?(I18n.locale)
       locale == I18n.locale
     else
       locale == resource.translations.first.locale

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -6,7 +6,13 @@ module TranslatableFormHelper
   end
 
   class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
+    attr_accessor :translations
+
     def translatable_fields(&block)
+      @translations = {}
+      @object.globalize_locales.map do |locale|
+        @translations[locale] = translation_for(locale)
+      end
       @object.globalize_locales.map do |locale|
         Globalize.with_locale(locale) { fields_for_locale(locale, &block) }
       end.join.html_safe
@@ -15,7 +21,7 @@ module TranslatableFormHelper
     private
 
       def fields_for_locale(locale, &block)
-        fields_for_translation(translation_for(locale)) do |translations_form|
+        fields_for_translation(@translations[locale]) do |translations_form|
           @template.content_tag :div, translations_options(translations_form.object, locale) do
             @template.concat translations_form.hidden_field(
               :_destroy,

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -343,7 +343,7 @@ class Budget
     end
 
     def self.with_milestone_status_id(status_id)
-      joins(:milestones).includes(:milestones).select do |investment|
+      includes(milestones: :translations).select do |investment|
         investment.milestone_status_id == status_id.to_i
       end
     end

--- a/app/models/concerns/globalizable.rb
+++ b/app/models/concerns/globalizable.rb
@@ -8,6 +8,10 @@ module Globalizable
     def locales_not_marked_for_destruction
       translations.reject(&:_destroy).map(&:locale)
     end
+
+    if self.paranoid?
+      translation_class.send :acts_as_paranoid, column: :hidden_at
+    end
   end
 
   class_methods do

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -14,7 +14,6 @@ class Milestone < ActiveRecord::Base
   validates :milestoneable, presence: true
   validates :publication_date, presence: true
 
-  before_validation :assign_milestone_to_translations
   validates_translation :description, presence: true, unless: -> { status_id.present? }
 
   scope :order_by_publication_date, -> { order(publication_date: :asc, created_at: :asc) }
@@ -24,10 +23,4 @@ class Milestone < ActiveRecord::Base
   def self.title_max_length
     80
   end
-
-  private
-
-    def assign_milestone_to_translations
-      translations.each { |translation| translation.globalized_model = self }
-    end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -35,7 +35,7 @@ class Poll < ActiveRecord::Base
   scope :by_geozone_id, ->(geozone_id) { where(geozones: {id: geozone_id}.joins(:geozones)) }
   scope :public_for_api, -> { all }
 
-  scope :sort_for_list, -> { order(:geozone_restricted, :starts_at, :name) }
+  scope :sort_for_list, -> { joins(:translations).order(:geozone_restricted, :starts_at, "poll_translations.name") }
 
   def title
     name

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -12,7 +12,7 @@ class Poll
     end
 
     def self.available
-      where(polls: { id: Poll.current_or_recounting_or_incoming }).includes(:polls)
+      where(polls: { id: Poll.current_or_recounting_or_incoming }).joins(polls: :translations)
     end
 
     def assignment_on_poll(poll)

--- a/db/migrate/20190121121420_add_hidden_at_to_legislation_draft_version_translations.rb
+++ b/db/migrate/20190121121420_add_hidden_at_to_legislation_draft_version_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToLegislationDraftVersionTranslations < ActiveRecord::Migration
+  def change
+    add_column :legislation_draft_version_translations, :hidden_at, :datetime
+    add_index :legislation_draft_version_translations, :hidden_at
+  end
+end

--- a/db/migrate/20190121121823_add_hidden_at_to_legislation_process_translations.rb
+++ b/db/migrate/20190121121823_add_hidden_at_to_legislation_process_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToLegislationProcessTranslations < ActiveRecord::Migration
+  def change
+    add_column :legislation_process_translations, :hidden_at, :datetime
+    add_index :legislation_process_translations, :hidden_at
+  end
+end

--- a/db/migrate/20190121122302_add_hidden_at_to_legislation_question_option_translations.rb
+++ b/db/migrate/20190121122302_add_hidden_at_to_legislation_question_option_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToLegislationQuestionOptionTranslations < ActiveRecord::Migration
+  def change
+    add_column :legislation_question_option_translations, :hidden_at, :datetime
+    add_index :legislation_question_option_translations, :hidden_at
+  end
+end

--- a/db/migrate/20190121122546_add_hidden_at_to_legislation_question_translations.rb
+++ b/db/migrate/20190121122546_add_hidden_at_to_legislation_question_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToLegislationQuestionTranslations < ActiveRecord::Migration
+  def change
+    add_column :legislation_question_translations, :hidden_at, :datetime
+    add_index :legislation_question_translations, :hidden_at
+  end
+end

--- a/db/migrate/20190121122946_add_hidden_at_to_poll_translations.rb
+++ b/db/migrate/20190121122946_add_hidden_at_to_poll_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToPollTranslations < ActiveRecord::Migration
+  def change
+    add_column :poll_translations, :hidden_at, :datetime
+    add_index :poll_translations, :hidden_at
+  end
+end

--- a/db/migrate/20190121123230_add_hidden_at_to_poll_question_translations.rb
+++ b/db/migrate/20190121123230_add_hidden_at_to_poll_question_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToPollQuestionTranslations < ActiveRecord::Migration
+  def change
+    add_column :poll_question_translations, :hidden_at, :datetime
+    add_index :poll_question_translations, :hidden_at
+  end
+end

--- a/db/migrate/20190122133850_add_hidden_at_to_banner_translations.rb
+++ b/db/migrate/20190122133850_add_hidden_at_to_banner_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToBannerTranslations < ActiveRecord::Migration
+  def change
+    add_column :banner_translations, :hidden_at, :datetime
+    add_index :banner_translations, :hidden_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190121121420) do
+ActiveRecord::Schema.define(version: 20190121121823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -634,8 +634,10 @@ ActiveRecord::Schema.define(version: 20190121121420) do
     t.text     "additional_info"
     t.text     "milestones_summary"
     t.text     "homepage"
+    t.datetime "hidden_at"
   end
 
+  add_index "legislation_process_translations", ["hidden_at"], name: "index_legislation_process_translations_on_hidden_at", using: :btree
   add_index "legislation_process_translations", ["legislation_process_id"], name: "index_199e5fed0aca73302243f6a1fca885ce10cdbb55", using: :btree
   add_index "legislation_process_translations", ["locale"], name: "index_legislation_process_translations_on_locale", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190121121823) do
+ActiveRecord::Schema.define(version: 20190121122302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -723,8 +723,10 @@ ActiveRecord::Schema.define(version: 20190121121823) do
     t.datetime "created_at",                     null: false
     t.datetime "updated_at",                     null: false
     t.string   "value"
+    t.datetime "hidden_at"
   end
 
+  add_index "legislation_question_option_translations", ["hidden_at"], name: "index_legislation_question_option_translations_on_hidden_at", using: :btree
   add_index "legislation_question_option_translations", ["legislation_question_option_id"], name: "index_61bcec8729110b7f8e1e9e5ce08780878597a209", using: :btree
   add_index "legislation_question_option_translations", ["locale"], name: "index_legislation_question_option_translations_on_locale", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190121122946) do
+ActiveRecord::Schema.define(version: 20190121123230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -981,8 +981,10 @@ ActiveRecord::Schema.define(version: 20190121122946) do
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
     t.string   "title"
+    t.datetime "hidden_at"
   end
 
+  add_index "poll_question_translations", ["hidden_at"], name: "index_poll_question_translations_on_hidden_at", using: :btree
   add_index "poll_question_translations", ["locale"], name: "index_poll_question_translations_on_locale", using: :btree
   add_index "poll_question_translations", ["poll_question_id"], name: "index_poll_question_translations_on_poll_question_id", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190121122302) do
+ActiveRecord::Schema.define(version: 20190121122546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -748,8 +748,10 @@ ActiveRecord::Schema.define(version: 20190121122302) do
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
     t.text     "title"
+    t.datetime "hidden_at"
   end
 
+  add_index "legislation_question_translations", ["hidden_at"], name: "index_legislation_question_translations_on_hidden_at", using: :btree
   add_index "legislation_question_translations", ["legislation_question_id"], name: "index_d34cc1e1fe6d5162210c41ce56533c5afabcdbd3", using: :btree
   add_index "legislation_question_translations", ["locale"], name: "index_legislation_question_translations_on_locale", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190121123230) do
+ActiveRecord::Schema.define(version: 20190122133850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,9 +100,11 @@ ActiveRecord::Schema.define(version: 20190121123230) do
     t.datetime "updated_at",  null: false
     t.string   "title"
     t.text     "description"
+    t.datetime "hidden_at"
   end
 
   add_index "banner_translations", ["banner_id"], name: "index_banner_translations_on_banner_id", using: :btree
+  add_index "banner_translations", ["hidden_at"], name: "index_banner_translations_on_hidden_at", using: :btree
   add_index "banner_translations", ["locale"], name: "index_banner_translations_on_locale", using: :btree
 
   create_table "banners", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190121122546) do
+ActiveRecord::Schema.define(version: 20190121122946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1047,8 +1047,10 @@ ActiveRecord::Schema.define(version: 20190121122546) do
     t.string   "name"
     t.text     "summary"
     t.text     "description"
+    t.datetime "hidden_at"
   end
 
+  add_index "poll_translations", ["hidden_at"], name: "index_poll_translations_on_hidden_at", using: :btree
   add_index "poll_translations", ["locale"], name: "index_poll_translations_on_locale", using: :btree
   add_index "poll_translations", ["poll_id"], name: "index_poll_translations_on_poll_id", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181206153510) do
+ActiveRecord::Schema.define(version: 20190121121420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -598,8 +598,10 @@ ActiveRecord::Schema.define(version: 20181206153510) do
     t.text     "body"
     t.text     "body_html"
     t.text     "toc_html"
+    t.datetime "hidden_at"
   end
 
+  add_index "legislation_draft_version_translations", ["hidden_at"], name: "index_legislation_draft_version_translations_on_hidden_at", using: :btree
   add_index "legislation_draft_version_translations", ["legislation_draft_version_id"], name: "index_900e5ba94457606e69e89193db426e8ddff809bc", using: :btree
   add_index "legislation_draft_version_translations", ["locale"], name: "index_legislation_draft_version_translations_on_locale", using: :btree
 

--- a/lib/acts_as_paranoid_aliases.rb
+++ b/lib/acts_as_paranoid_aliases.rb
@@ -28,7 +28,7 @@ module ActsAsParanoidAliases
       def restore(opts = {})
         return false unless hidden?
         super(opts)
-        update_attribute(:confirmed_hide_at, nil)
+        update_attribute(:confirmed_hide_at, nil) if self.class.column_names.include? "confirmed_hide_at"
         after_restore
       end
 

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Banner do
+
+  let(:banner) { build(:banner) }
+
+  describe "Concerns" do
+    it_behaves_like "acts as paranoid", :banner
+  end
+
+  it "is valid" do
+    expect(banner).to be_valid
+  end
+
+end

--- a/spec/models/legislation/draft_version_spec.rb
+++ b/spec/models/legislation/draft_version_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe Legislation::DraftVersion, type: :model do
-    let(:legislation_draft_version) { build(:legislation_draft_version) }
+describe Legislation::DraftVersion do
+  let(:legislation_draft_version) { build(:legislation_draft_version) }
+
+  it_behaves_like "acts as paranoid", :legislation_draft_version
 
   it "is valid" do
     expect(legislation_draft_version).to be_valid

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe Legislation::Process do
   let(:process) { create(:legislation_process) }
 
+  it_behaves_like "acts as paranoid", :legislation_process
+
   it "is valid" do
     expect(process).to be_valid
   end

--- a/spec/models/legislation/question_option_spec.rb
+++ b/spec/models/legislation/question_option_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe Legislation::QuestionOption, type: :model do
+describe Legislation::QuestionOption do
   let(:legislation_question_option) { build(:legislation_question_option) }
+
+  it_behaves_like "acts as paranoid", :legislation_question_option
 
   it "is valid" do
     expect(legislation_question_option).to be_valid

--- a/spec/models/legislation/question_spec.rb
+++ b/spec/models/legislation/question_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe Legislation::Question do
   let(:question) { create(:legislation_question) }
 
+  it_behaves_like "acts as paranoid", :legislation_question
+
   describe "Concerns" do
     it_behaves_like "notifiable"
   end

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -6,6 +6,7 @@ describe Poll do
 
   describe "Concerns" do
     it_behaves_like "notifiable"
+    it_behaves_like "acts as paranoid", :poll
   end
 
   describe "validations" do

--- a/spec/models/poll/question_spec.rb
+++ b/spec/models/poll/question_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Poll::Question, type: :model do
   let(:poll_question) { build(:poll_question) }
 
+  describe "Concerns" do
+    it_behaves_like "acts as paranoid", :poll_question
+  end
+
   describe "#poll_question_id" do
     it "is invalid if a poll is not selected" do
       poll_question.poll_id = nil

--- a/spec/shared/models/acts_as_paranoid.rb
+++ b/spec/shared/models/acts_as_paranoid.rb
@@ -1,0 +1,65 @@
+shared_examples "acts as paranoid" do |factory_name|
+  let!(:resource) { create(factory_name) }
+
+  it "#{described_class} can be recovered after soft deletion" do
+    resource.destroy
+    resource.reload
+
+    expect(resource.hidden_at).not_to be_blank
+    resource.restore!
+    resource.reload
+
+    expect(resource.hidden_at).to be_blank
+  end
+
+  describe "#{described_class} translations" do
+
+    it "should be hidden after parent resource destroy" do
+      resource.destroy
+      resource.reload
+
+      expect(resource.translations.with_deleted.first.hidden_at).not_to be_blank
+    end
+
+    it "should be destroyed after parent resource really_destroy" do
+      expect{ resource.really_destroy! }.to change { resource.translations.with_deleted.count }.from(1).to(0)
+    end
+
+    it "cannot be recovered through non recursive restore" do
+      resource.destroy
+      resource.reload
+
+      expect{ resource.restore }.not_to change { resource.translations.with_deleted.first.hidden_at }
+    end
+
+    it "can be recovered through recursive restore after non-recursive restore" do
+      resource.destroy
+      resource.restore
+      resource.destroy
+      resource.reload
+
+      expect{ resource.restore(recursive: true) }.to change { resource.translations.with_deleted.first.hidden_at }
+    end
+
+    it "can be recovered after soft deletion through recursive restore" do
+      original_translation = resource.translations.first
+      new_translation = resource.translations.build
+      described_class.translated_attribute_names.each do |translated_attribute_name|
+        new_translation.send("#{translated_attribute_name}=", original_translation.send(translated_attribute_name))
+      end
+      new_translation.locale = :fr
+      new_translation.save
+
+      expect(resource.translations.with_deleted.count).to eq(2)
+      resource.destroy
+      resource.reload
+      expect(resource.translations.with_deleted.count).to eq(2)
+      expect(resource.translations.with_deleted.first.hidden_at).not_to be_blank
+      expect(resource.translations.with_deleted.second.hidden_at).not_to be_blank
+      resource.restore!(recursive: true)
+      resource.reload
+      expect(resource.translations.with_deleted.first.hidden_at).to be_blank
+      expect(resource.translations.with_deleted.second.hidden_at).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
## References

Related Issues: #3156 
Related PR's: This PR contains this another one #3194 commits 

## Objectives
Add soft deletion behavior to translations records.

## Why?
All translations were being lost after soft deletion of parent models. We want to keep these translations in database until they are really destroyed through parent model record destroy method.

## Visual Changes
None

## Notes
None
