### PR TITLE
Sort Legislation Processes by descending start date

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -6,7 +6,8 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
   load_and_authorize_resource :process, class: "Legislation::Process"
 
   def index
-    @processes = ::Legislation::Process.send(@current_filter).order('id DESC').page(params[:page])
+    @processes = ::Legislation::Process.send(@current_filter).order(start_date: :desc)
+                 .page(params[:page])
   end
 
   def create

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -9,7 +9,7 @@ class Legislation::ProcessesController < Legislation::BaseController
   def index
     @current_filter ||= 'open'
     @processes = ::Legislation::Process.send(@current_filter).published
-                 .not_in_draft.page(params[:page])
+                 .not_in_draft.order(start_date: :desc).page(params[:page])
   end
 
   def show

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -44,10 +44,9 @@ class Legislation::Process < ActiveRecord::Base
   validates :proposals_phase_end_date, presence: true, if: :proposals_phase_start_date?
   validate :valid_date_ranges
 
-  scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current)
-                    .order('id DESC') }
-  scope :next, -> { where("start_date > ?", Date.current).order('id DESC') }
-  scope :past, -> { where("end_date < ?", Date.current).order('id DESC') }
+  scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current) }
+  scope :next, -> { where("start_date > ?", Date.current) }
+  scope :past, -> { where("end_date < ?", Date.current) }
 
   scope :published, -> { where(published: true) }
   scope :not_in_draft, -> { where("draft_phase_enabled = false or (draft_start_date IS NOT NULL and

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -34,6 +34,18 @@ feature 'Admin legislation processes' do
 
       expect(page).to have_content(process.title)
     end
+
+    scenario "Processes are sorted by descending start date" do
+      create(:legislation_process, title: "Process 1", start_date: Date.yesterday)
+      create(:legislation_process, title: "Process 2", start_date: Date.today)
+      create(:legislation_process, title: "Process 3", start_date: Date.tomorrow)
+
+      visit admin_legislation_processes_path(filter: "all")
+
+      expect("Process 3").to appear_before("Process 2")
+      expect("Process 2").to appear_before("Process 1")
+    end
+
   end
 
   context 'Create' do

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -47,6 +47,17 @@ feature 'Legislation' do
       end
     end
 
+    scenario "Processes are sorted by descending start date", :js do
+      create(:legislation_process, title: "Process 1", start_date: 3.days.ago)
+      create(:legislation_process, title: "Process 2", start_date: 2.days.ago)
+      create(:legislation_process, title: "Process 3", start_date: Date.yesterday)
+
+      visit legislation_processes_path
+
+      expect("Process 3").to appear_before("Process 2")
+      expect("Process 2").to appear_before("Process 1")
+    end
+
     scenario 'Participation phases are displayed only if there is a phase enabled' do
       process = create(:legislation_process, :empty)
       process_debate = create(:legislation_process)


### PR DESCRIPTION
## References

This is a backport of PR https://github.com/AyuntamientoMadrid/consul/pull/1826

## Objectives

Sort Legislation Processes by descending start date