### PR TITLE
[Backport] Show current phase as selected on phase select on admin budgets form

### DIFF
--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -6,7 +6,7 @@
 
   <div class="margin-top">
     <div class="small-12 medium-6 column">
-      <%= f.select :phase, budget_phases_select_options, selected: "drafting" %>
+      <%= f.select :phase, budget_phases_select_options %>
     </div>
     <div class="small-12 medium-3 column end">
       <%= f.select :currency_symbol, budget_currency_symbol_select_options %>

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -144,8 +144,12 @@ feature 'Admin budgets' do
     let!(:budget) { create(:budget) }
 
     scenario 'Show phases table' do
+      budget.update(phase: "selecting")
+
       visit admin_budgets_path
       click_link 'Edit budget'
+
+      expect(page).to have_select("budget_phase", selected: "Selecting projects")
 
       within '#budget-phases-table' do
 


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1840 

## Objectives

- Shows **current budget phase** as selected on phase select form on admin budgets form. Before always was showing "Draft" phase and was tedious change it every time.

## Visual Changes

**BEFORE always shows "Draft" phase**
![before](https://user-images.githubusercontent.com/631897/51546316-3538f980-1e64-11e9-982b-646b6021cf7f.png)

**AFTER shows the current phase**
![after](https://user-images.githubusercontent.com/631897/51546319-366a2680-1e64-11e9-8b5f-18e6f6858570.png)