### PR TITLE
[Backport] Add progress bars to milestones public view

### DIFF
--- a/app/assets/javascripts/forms.js.coffee
+++ b/app/assets/javascripts/forms.js.coffee
@@ -37,8 +37,10 @@ App.Forms =
 
         if this.value == "primary"
           title_field.hide()
+          $("#globalize_locales").hide()
         else
           title_field.show()
+          $("#globalize_locales").show()
 
     $("[name='progress_bar[kind]']").change()
 

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -60,7 +60,9 @@
     border: 1px solid $border;
     display: block;
     margin: rem-calc(-1) 0;
+    min-height: $line-height * 3;
     position: relative;
+    vertical-align: top;
 
     @include breakpoint(large down) {
 

--- a/app/assets/stylesheets/milestones.scss
+++ b/app/assets/stylesheets/milestones.scss
@@ -1,4 +1,4 @@
-.tab-milestones ul {
+.tab-milestones .timeline ul {
   margin-top: rem-calc(40);
   position: relative;
 }

--- a/app/assets/stylesheets/milestones.scss
+++ b/app/assets/stylesheets/milestones.scss
@@ -3,6 +3,53 @@
   position: relative;
 }
 
+.tab-milestones .progress-bars {
+  margin-top: $line-height / 2;
+
+  h5 {
+    font-size: rem-calc(25);
+  }
+
+  ul {
+    border-spacing: rem-calc(15) $line-height / 4;
+    display: table;
+    margin-top: $line-height / 2;
+
+    li {
+      display: table-row;
+
+      > * {
+        display: table-cell;
+        vertical-align: middle;
+      }
+    }
+  }
+
+  progress {
+    $background-color: #fef0e2;
+    $progress-color: #fea230;
+
+    background-color: $background-color;
+    color: $progress-color;
+
+    &.primary {
+      width: 100%;
+    }
+
+    &::-webkit-progress-bar {
+      background-color: $background-color;
+    }
+
+    &::-webkit-progress-value {
+      background-color: $progress-color;
+    }
+
+    &::-moz-progress-bar {
+      background-color: $progress-color;
+    }
+  }
+}
+
 .tab-milestones .timeline li {
   margin: 0 auto;
   position: relative;

--- a/app/assets/stylesheets/milestones.scss
+++ b/app/assets/stylesheets/milestones.scss
@@ -25,6 +25,21 @@
     }
   }
 
+  [data-text] {
+    display: block;
+    font-weight: bold;
+    position: relative;
+
+    &::after {
+      content: attr(data-text);
+      left: 0;
+      position: absolute;
+      text-align: right;
+      top: -0.1rem;
+      width: 100%;
+    }
+  }
+
   progress {
     $background-color: #fef0e2;
     $progress-color: #fea230;

--- a/app/assets/stylesheets/milestones.scss
+++ b/app/assets/stylesheets/milestones.scss
@@ -1,66 +1,36 @@
-.tab-milestones .timeline ul {
-  margin-top: rem-calc(40);
-  position: relative;
-}
+$progress-bar-background: #fef0e2;
+$progress-bar-color:      #fea230;
 
-.tab-milestones .progress-bars {
-  margin-top: $line-height / 2;
+.tab-milestones {
 
-  h5 {
-    font-size: rem-calc(25);
-  }
+  .progress-bars {
+    margin-bottom: $line-height * 2;
+    margin-top: $line-height;
 
-  ul {
-    border-spacing: rem-calc(15) $line-height / 4;
-    display: table;
-    margin-top: $line-height / 2;
-
-    li {
-      display: table-row;
-
-      > * {
-        display: table-cell;
-        vertical-align: middle;
-      }
+    h5 {
+      font-size: rem-calc(24);
     }
-  }
 
-  [data-text] {
-    display: block;
-    font-weight: bold;
-    position: relative;
+    .progress {
+      background: $progress-bar-background;
+      border-radius: rem-calc(6);
+      position: relative;
+    }
 
-    &::after {
-      content: attr(data-text);
-      left: 0;
-      position: absolute;
+    .progress-meter {
+      background: $progress-bar-color;
+      border-radius: rem-calc(6);
+    }
+
+    .progress-meter-text {
+      color: #000;
+      right: 12px;
       text-align: right;
-      top: -0.1rem;
-      width: 100%;
-    }
-  }
-
-  progress {
-    $background-color: #fef0e2;
-    $progress-color: #fea230;
-
-    background-color: $background-color;
-    color: $progress-color;
-
-    &.primary {
-      width: 100%;
+      transform: translate(0%, -50%);
     }
 
-    &::-webkit-progress-bar {
-      background-color: $background-color;
-    }
-
-    &::-webkit-progress-value {
-      background-color: $progress-color;
-    }
-
-    &::-moz-progress-bar {
-      background-color: $progress-color;
+    .milestone-progress .row {
+      margin-bottom: $line-height / 2;
     }
   }
 }

--- a/app/helpers/milestones_helper.rb
+++ b/app/helpers/milestones_helper.rb
@@ -1,9 +1,14 @@
 module MilestonesHelper
   def progress_tag_for(progress_bar)
-    content_tag :progress,
-                number_to_percentage(progress_bar.percentage, precision: 0),
-                class: progress_bar.primary? ? "primary" : "",
-                max: ProgressBar::RANGE.max,
-                value: progress_bar.percentage
+    text = number_to_percentage(progress_bar.percentage, precision: 0)
+
+    content_tag :span do
+      content_tag(:span, "", "data-text": text, style: "width: #{progress_bar.percentage}%;") +
+      content_tag(:progress,
+                  text,
+                  class: progress_bar.primary? ? "primary" : "",
+                  max: ProgressBar::RANGE.max,
+                  value: progress_bar.percentage)
+    end
   end
 end

--- a/app/helpers/milestones_helper.rb
+++ b/app/helpers/milestones_helper.rb
@@ -1,0 +1,9 @@
+module MilestonesHelper
+  def progress_tag_for(progress_bar)
+    content_tag :progress,
+                number_to_percentage(progress_bar.percentage, precision: 0),
+                class: progress_bar.primary? ? "primary" : "",
+                max: ProgressBar::RANGE.max,
+                value: progress_bar.percentage
+  end
+end

--- a/app/helpers/milestones_helper.rb
+++ b/app/helpers/milestones_helper.rb
@@ -2,13 +2,17 @@ module MilestonesHelper
   def progress_tag_for(progress_bar)
     text = number_to_percentage(progress_bar.percentage, precision: 0)
 
-    content_tag :span do
-      content_tag(:span, "", "data-text": text, style: "width: #{progress_bar.percentage}%;") +
-      content_tag(:progress,
-                  text,
-                  class: progress_bar.primary? ? "primary" : "",
-                  max: ProgressBar::RANGE.max,
-                  value: progress_bar.percentage)
+    content_tag :div, class: "progress",
+                      role:  "progressbar",
+                      "aria-valuenow": "#{progress_bar.percentage}",
+                      "aria-valuetext": "#{progress_bar.percentage}%",
+                      "aria-valuemax": ProgressBar::RANGE.max,
+                      "aria-valuemin":  "0",
+                      tabindex: "0" do
+      content_tag(:span, "",
+                  class: "progress-meter",
+                  style: "width: #{progress_bar.percentage}%;") +
+      content_tag(:p, text, class: "progress-meter-text")
     end
   end
 end

--- a/app/models/concerns/milestoneable.rb
+++ b/app/models/concerns/milestoneable.rb
@@ -7,5 +7,13 @@ module Milestoneable
     scope :with_milestones, -> { joins(:milestones).distinct }
 
     has_many :progress_bars, as: :progressable
+
+    def primary_progress_bar
+      progress_bars.primary.first
+    end
+
+    def secondary_progress_bars
+      progress_bars.secondary
+    end
   end
 end

--- a/app/views/admin/shared/_common_globalize_locales.html.erb
+++ b/app/views/admin/shared/_common_globalize_locales.html.erb
@@ -1,18 +1,20 @@
-<% I18n.available_locales.each do |locale| %>
-  <div class="text-right">
-    <%= link_to t("admin.translations.remove_language"), "#",
-                id: "js_delete_#{locale}",
-                style: display_translation_style(resource, locale),
-                class: 'delete js-delete-language',
-                data: { locale: locale } %>
+<div id="globalize_locales">
+  <% I18n.available_locales.each do |locale| %>
+    <div class="text-right">
+      <%= link_to t("admin.translations.remove_language"), "#",
+                  id: "js_delete_#{locale}",
+                  style: display_translation_style(resource, locale),
+                  class: 'delete js-delete-language',
+                  data: { locale: locale } %>
+    </div>
+  <% end %>
+
+  <%= render "admin/shared/globalize_tabs", resource: resource, display_style: display_style %>
+
+  <div class="small-12 medium-6">
+    <%= select_tag :translation_locale,
+                   options_for_locale_select,
+                   prompt: t("admin.translations.add_language"),
+                   class: "js-globalize-locale" %>
   </div>
-<% end %>
-
-<%= render "admin/shared/globalize_tabs", resource: resource, display_style: display_style %>
-
-<div class="small-12 medium-6">
-  <%= select_tag :translation_locale,
-                 options_for_locale_select,
-                 prompt: t("admin.translations.add_language"),
-                 class: "js-globalize-locale" %>
 </div>

--- a/app/views/admin/shared/_globalize_tabs.html.erb
+++ b/app/views/admin/shared/_globalize_tabs.html.erb
@@ -1,4 +1,4 @@
-<ul class="tabs" data-tabs id="globalize_locale">
+<ul class="tabs" data-tabs>
   <% I18n.available_locales.each do |locale| %>
     <li class="tabs-title">
       <%= link_to name_for_locale(locale), "#",

--- a/app/views/legislation/processes/_key_dates.html.erb
+++ b/app/views/legislation/processes/_key_dates.html.erb
@@ -42,11 +42,13 @@
           </li>
         <% end %>
 
-        <% if process.milestones.any? %>
+        <% if process.milestones.any? || process.progress_bars.any? %>
           <li class="milestones <%= "is-active" if phase == :milestones %>">
             <%= link_to milestones_legislation_process_path(process) do %>
               <h4><%= t("legislation.processes.shared.milestones_date") %></h4>
-              <span><%= format_date(process.milestones.order_by_publication_date.last.publication_date) %></span>
+              <% if process.milestones.any? %>
+                <span><%= format_date(process.milestones.order_by_publication_date.last.publication_date) %></span>
+              <% end %>
             <% end %>
           </li>
         <% end %>

--- a/app/views/milestones/_milestones_content.html.erb
+++ b/app/views/milestones/_milestones_content.html.erb
@@ -6,24 +6,7 @@
       </div>
     <% end %>
 
-    <% if milestoneable.primary_progress_bar %>
-      <section class="progress-bars">
-        <h5><%= t("milestones.index.progress") %></h5>
-
-        <%= progress_tag_for(milestoneable.primary_progress_bar) %>
-
-        <% if milestoneable.secondary_progress_bars.any? %>
-          <ul class="milestone-progress">
-            <% milestoneable.secondary_progress_bars.each do |progress_bar| %>
-              <li>
-                <%= progress_bar.title %>
-                <%= progress_tag_for(progress_bar) %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-      </section>
-    <% end %>
+    <%= render "milestones/progress_bars", milestoneable: milestoneable %>
 
     <section class="timeline">
       <ul class="no-bullet">

--- a/app/views/milestones/_milestones_content.html.erb
+++ b/app/views/milestones/_milestones_content.html.erb
@@ -5,6 +5,22 @@
         <%= t("milestones.index.no_milestones") %>
       </div>
     <% end %>
+
+    <% if milestoneable.primary_progress_bar %>
+      <%= progress_tag_for(milestoneable.primary_progress_bar) %>
+
+      <% if milestoneable.secondary_progress_bars.any? %>
+        <ul class="milestone-progress">
+          <% milestoneable.secondary_progress_bars.each do |progress_bar| %>
+            <li>
+              <%= progress_bar.title %>
+              <%= progress_tag_for(progress_bar) %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+
     <section class="timeline">
       <ul class="no-bullet">
         <% milestoneable.milestones.order_by_publication_date.each do |milestone| %>

--- a/app/views/milestones/_milestones_content.html.erb
+++ b/app/views/milestones/_milestones_content.html.erb
@@ -7,18 +7,22 @@
     <% end %>
 
     <% if milestoneable.primary_progress_bar %>
-      <%= progress_tag_for(milestoneable.primary_progress_bar) %>
+      <section class="progress-bars">
+        <h5><%= t("milestones.index.progress") %></h5>
 
-      <% if milestoneable.secondary_progress_bars.any? %>
-        <ul class="milestone-progress">
-          <% milestoneable.secondary_progress_bars.each do |progress_bar| %>
-            <li>
-              <%= progress_bar.title %>
-              <%= progress_tag_for(progress_bar) %>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
+        <%= progress_tag_for(milestoneable.primary_progress_bar) %>
+
+        <% if milestoneable.secondary_progress_bars.any? %>
+          <ul class="milestone-progress">
+            <% milestoneable.secondary_progress_bars.each do |progress_bar| %>
+              <li>
+                <%= progress_bar.title %>
+                <%= progress_tag_for(progress_bar) %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      </section>
     <% end %>
 
     <section class="timeline">

--- a/app/views/milestones/_milestones_content.html.erb
+++ b/app/views/milestones/_milestones_content.html.erb
@@ -1,12 +1,12 @@
 <div class="row">
   <div class="small-12 column">
+    <%= render "milestones/progress_bars", milestoneable: milestoneable %>
+
     <% if milestoneable.milestones.blank? %>
       <div class="callout primary text-center">
         <%= t("milestones.index.no_milestones") %>
       </div>
     <% end %>
-
-    <%= render "milestones/progress_bars", milestoneable: milestoneable %>
 
     <section class="timeline">
       <ul class="no-bullet">

--- a/app/views/milestones/_milestones_content.html.erb
+++ b/app/views/milestones/_milestones_content.html.erb
@@ -3,7 +3,7 @@
     <%= render "milestones/progress_bars", milestoneable: milestoneable %>
 
     <% if milestoneable.milestones.blank? %>
-      <div class="callout primary text-center">
+      <div class="callout primary text-center margin-top">
         <%= t("milestones.index.no_milestones") %>
       </div>
     <% end %>

--- a/app/views/milestones/_progress_bars.html.erb
+++ b/app/views/milestones/_progress_bars.html.erb
@@ -8,7 +8,7 @@
       <ul class="milestone-progress">
         <% milestoneable.secondary_progress_bars.each do |progress_bar| %>
           <li>
-            <%= progress_bar.title %>
+            <span class="title"><%= progress_bar.title %></span>
             <%= progress_tag_for(progress_bar) %>
           </li>
         <% end %>

--- a/app/views/milestones/_progress_bars.html.erb
+++ b/app/views/milestones/_progress_bars.html.erb
@@ -2,17 +2,23 @@
   <section class="progress-bars">
     <h5><%= t("milestones.index.progress") %></h5>
 
-    <%= progress_tag_for(milestoneable.primary_progress_bar) %>
+    <div class="margin">
+      <%= progress_tag_for(milestoneable.primary_progress_bar) %>
+    </div>
 
     <% if milestoneable.secondary_progress_bars.any? %>
-      <ul class="milestone-progress">
+      <div class="milestone-progress">
         <% milestoneable.secondary_progress_bars.each do |progress_bar| %>
-          <li>
-            <span class="title"><%= progress_bar.title %></span>
-            <%= progress_tag_for(progress_bar) %>
-          </li>
+          <div class="row margin-bottom">
+            <div class="small-12 medium-6 large-4 column">
+              <%= progress_bar.title %>
+            </div>
+            <div class="small-12 medium-6 large-8 column end">
+              <%= progress_tag_for(progress_bar) %>
+            </div>
+          </div>
         <% end %>
-      </ul>
+      </div>
     <% end %>
   </section>
 <% end %>

--- a/app/views/milestones/_progress_bars.html.erb
+++ b/app/views/milestones/_progress_bars.html.erb
@@ -1,0 +1,18 @@
+<% if milestoneable.primary_progress_bar %>
+  <section class="progress-bars">
+    <h5><%= t("milestones.index.progress") %></h5>
+
+    <%= progress_tag_for(milestoneable.primary_progress_bar) %>
+
+    <% if milestoneable.secondary_progress_bars.any? %>
+      <ul class="milestone-progress">
+        <% milestoneable.secondary_progress_bars.each do |progress_bar| %>
+          <li>
+            <%= progress_bar.title %>
+            <%= progress_tag_for(progress_bar) %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </section>
+<% end %>

--- a/config/locales/en/milestones.yml
+++ b/config/locales/en/milestones.yml
@@ -2,6 +2,7 @@ en:
   milestones:
     index:
       no_milestones: Don't have defined milestones
+      progress: Progress
     show:
       publication_date: "Published %{publication_date}"
       status_changed: Status changed to

--- a/config/locales/es/milestones.yml
+++ b/config/locales/es/milestones.yml
@@ -2,6 +2,7 @@ es:
   milestones:
     index:
       no_milestones: No hay hitos definidos
+      progress: Progreso
     show:
       publication_date: "Publicado el %{publication_date}"
       status_changed: El proyecto ha cambiado al estado

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -376,9 +376,9 @@ feature 'Legislation' do
     end
 
     context "Milestones" do
-      scenario "Without milestones" do
-        process = create(:legislation_process, :upcoming_proposals_phase)
+      let(:process) { create(:legislation_process, :upcoming_proposals_phase) }
 
+      scenario "Without milestones" do
         visit legislation_process_path(process)
 
         within(".legislation-process-list") do
@@ -387,7 +387,6 @@ feature 'Legislation' do
       end
 
       scenario "With milestones" do
-        process = create(:legislation_process, :upcoming_proposals_phase)
         create(:milestone,
                milestoneable:    process,
                description:      "Something important happened",
@@ -406,6 +405,39 @@ feature 'Legislation' do
 
         within(".tab-milestones") do
           expect(page).to have_content "Something important happened"
+        end
+      end
+
+      scenario "With main progress bar" do
+        create(:progress_bar, progressable: process)
+
+        visit milestones_legislation_process_path(process)
+
+        within(".tab-milestones") do
+          expect(page).to have_css "progress"
+        end
+      end
+
+      scenario "With main and secondary progress bar" do
+        create(:progress_bar, progressable: process)
+        create(:progress_bar, :secondary, progressable: process, title: "Build laboratory")
+
+        visit milestones_legislation_process_path(process)
+
+        within(".tab-milestones") do
+          expect(page).to have_css "progress"
+          expect(page).to have_content "Build laboratory"
+        end
+      end
+
+      scenario "No main progress bar" do
+        create(:progress_bar, :secondary, progressable: process, title: "Defeat Evil Lords")
+
+        visit milestones_legislation_process_path(process)
+
+        within(".tab-milestones") do
+          expect(page).not_to have_css "progress"
+          expect(page).not_to have_content "Defeat Evil Lords"
         end
       end
     end

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -414,7 +414,7 @@ feature 'Legislation' do
         visit milestones_legislation_process_path(process)
 
         within(".tab-milestones") do
-          expect(page).to have_css "progress"
+          expect(page).to have_content "Progress"
         end
       end
 
@@ -425,7 +425,7 @@ feature 'Legislation' do
         visit milestones_legislation_process_path(process)
 
         within(".tab-milestones") do
-          expect(page).to have_css "progress"
+          expect(page).to have_content "Progress"
           expect(page).to have_content "Build laboratory"
         end
       end
@@ -436,7 +436,7 @@ feature 'Legislation' do
         visit milestones_legislation_process_path(process)
 
         within(".tab-milestones") do
-          expect(page).not_to have_css "progress"
+          expect(page).not_to have_content "Progress"
           expect(page).not_to have_content "Defeat Evil Lords"
         end
       end

--- a/spec/shared/features/admin_milestoneable.rb
+++ b/spec/shared/features/admin_milestoneable.rb
@@ -1,5 +1,5 @@
 shared_examples "admin_milestoneable" do |factory_name, path_name|
-  it_behaves_like "progressable", factory_name, path_name
+  it_behaves_like "admin_progressable", factory_name, path_name
 
   feature "Admin milestones" do
     let!(:milestoneable) { create(factory_name) }

--- a/spec/shared/features/admin_progressable.rb
+++ b/spec/shared/features/admin_progressable.rb
@@ -1,0 +1,122 @@
+shared_examples "admin_progressable" do |factory_name, path_name|
+  let!(:progressable) { create(factory_name) }
+
+  feature "Manage progress bars" do
+    let(:progressable_path) { send(path_name, *resource_hierarchy_for(progressable)) }
+
+    let(:path) do
+      polymorphic_path([:admin, *resource_hierarchy_for(progressable.progress_bars.new)])
+    end
+
+    context "Index" do
+      scenario "Link to index path" do
+        create(:progress_bar, :secondary, progressable:  progressable,
+               title:      "Reading documents",
+               percentage: 20)
+
+        visit progressable_path
+        click_link "Manage progress bars"
+
+        expect(page).to have_content "Reading documents"
+      end
+
+      scenario "No progress bars" do
+        visit path
+
+        expect(page).to have_content("There are no progress bars")
+      end
+    end
+
+    context "New" do
+      scenario "Primary progress bar", :js do
+        visit path
+        click_link "Create new progress bar"
+
+        select "Primary", from: "Type"
+
+        expect(page).not_to have_field "Title"
+        expect(page).not_to have_content "Add language"
+
+        fill_in "Current progress", with: 43
+        click_button "Create Progress bar"
+
+        expect(page).to have_content "Progress bar created successfully"
+        expect(page).to have_content "43%"
+        expect(page).to have_content "Primary"
+        expect(page).to have_content "Primary progress bar"
+      end
+
+      scenario "Secondary progress bar", :js do
+        visit path
+        click_link "Create new progress bar"
+
+        select "Secondary", from: "Type"
+
+        expect(page).to have_content "Add language"
+
+        fill_in "Current progress", with: 36
+        fill_in "Title", with: "Plant trees"
+        click_button "Create Progress bar"
+
+        expect(page).to have_content "Progress bar created successfully"
+        expect(page).to have_content "36%"
+        expect(page).to have_content "Secondary"
+        expect(page).to have_content "Plant trees"
+      end
+    end
+
+    context "Edit" do
+      scenario "Primary progress bar", :js do
+        bar = create(:progress_bar, progressable: progressable)
+
+        visit path
+        within("#progress_bar_#{bar.id}") { click_link "Edit" }
+
+        expect(page).to have_field "Current progress"
+        expect(page).not_to have_field "Title"
+        expect(page).not_to have_content "Add language"
+
+        fill_in "Current progress", with: 44
+        click_button "Update Progress bar"
+
+        expect(page).to have_content "Progress bar updated successfully"
+
+        within("#progress_bar_#{bar.id}") do
+          expect(page).to have_content "44%"
+        end
+      end
+
+      scenario "Secondary progress bar", :js do
+        bar = create(:progress_bar, :secondary, progressable: progressable)
+
+        visit path
+        within("#progress_bar_#{bar.id}") { click_link "Edit" }
+
+        expect(page).to have_content "Add language"
+
+        fill_in "Current progress", with: 76
+        fill_in "Title", with: "Updated title"
+        click_button "Update Progress bar"
+
+        expect(page).to have_content "Progress bar updated successfully"
+
+        within("#progress_bar_#{bar.id}") do
+          expect(page).to have_content "76%"
+          expect(page).to have_content "Updated title"
+        end
+      end
+    end
+
+    context "Delete" do
+      scenario "Remove progress bar" do
+        bar = create(:progress_bar, progressable: progressable, percentage: 34)
+
+        visit path
+        within("#progress_bar_#{bar.id}") { click_link "Delete" }
+
+        expect(page).to have_content "Progress bar deleted successfully"
+        expect(page).not_to have_content "34%"
+      end
+    end
+  end
+end

--- a/spec/shared/features/milestoneable.rb
+++ b/spec/shared/features/milestoneable.rb
@@ -1,4 +1,6 @@
 shared_examples "milestoneable" do |factory_name, path_name|
+  it_behaves_like "progressable", factory_name, path_name
+
   let!(:milestoneable) { create(factory_name) }
 
   feature "Show milestones" do

--- a/spec/shared/features/progressable.rb
+++ b/spec/shared/features/progressable.rb
@@ -11,7 +11,7 @@ shared_examples "progressable" do |factory_name, path_name|
       find("#tab-milestones-label").click
 
       within("#tab-milestones") do
-        expect(page).to have_css "progress"
+        expect(page).to have_content "Progress"
       end
     end
 
@@ -24,7 +24,7 @@ shared_examples "progressable" do |factory_name, path_name|
       find("#tab-milestones-label").click
 
       within("#tab-milestones") do
-        expect(page).to have_css "progress"
+        expect(page).to have_content "Progress"
         expect(page).to have_content "Build laboratory"
       end
     end
@@ -37,6 +37,7 @@ shared_examples "progressable" do |factory_name, path_name|
       find("#tab-milestones-label").click
 
       within("#tab-milestones") do
+        expect(page).not_to have_content "Progress"
         expect(page).not_to have_content "Defeat Evil Lords"
       end
     end

--- a/spec/shared/features/progressable.rb
+++ b/spec/shared/features/progressable.rb
@@ -11,7 +11,7 @@ shared_examples "progressable" do |factory_name, path_name|
       find("#tab-milestones-label").click
 
       within("#tab-milestones") do
-        expect(page).to have_content "Progress"
+        expect(page).to have_css "progress"
       end
     end
 
@@ -24,7 +24,7 @@ shared_examples "progressable" do |factory_name, path_name|
       find("#tab-milestones-label").click
 
       within("#tab-milestones") do
-        expect(page).to have_content "Progress"
+        expect(page).to have_css "progress"
         expect(page).to have_content "Build laboratory"
       end
     end
@@ -37,7 +37,6 @@ shared_examples "progressable" do |factory_name, path_name|
       find("#tab-milestones-label").click
 
       within("#tab-milestones") do
-        expect(page).not_to have_content "Progress"
         expect(page).not_to have_content "Defeat Evil Lords"
       end
     end


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1813

This close consul#3135

## Objectives

* Display primary and secondary progress bars alongside milestones.

## Visual Changes

![proposals](https://user-images.githubusercontent.com/631897/51251501-c823f080-1999-11e9-9d17-0bee4c1abbb9.png)

![process](https://user-images.githubusercontent.com/631897/51251500-c78b5a00-1999-11e9-91bd-36e23bb40e0d.png)