### PR TITLE
[Backport] Hide polls results and stats to admins

### DIFF
--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -49,4 +49,19 @@ module PollsHelper
     question.answers.where(author: current_user).any? { |vote| current_user.current_sign_in_at > vote.updated_at }
   end
 
+  def show_stats_or_results?
+    @poll.expired? && (@poll.results_enabled? || @poll.stats_enabled?)
+  end
+
+  def results_menu?
+    controller_name == "polls" && action_name == "results"
+  end
+
+  def stats_menu?
+    controller_name == "polls" && action_name == "stats"
+  end
+
+  def info_menu?
+    controller_name == "polls" && action_name == "show"
+  end
 end

--- a/app/views/polls/_poll_subnav.html.erb
+++ b/app/views/polls/_poll_subnav.html.erb
@@ -1,8 +1,9 @@
+<% if show_stats_or_results? %>
   <div class="row margin-top">
     <div class="small-12 column">
       <ul class="menu simple clear">
-          <% if controller_name == "polls" && action_name == "results" %>
         <% if @poll.results_enabled? %>
+          <% if results_menu? %>
             <li class="is-active">
               <h2><%= t("polls.show.results_menu") %></h2>
             </li>
@@ -11,8 +12,8 @@
           <% end %>
         <% end %>
 
-          <% if controller_name == "polls" && action_name == "stats" %>
         <% if @poll.stats_enabled? %>
+          <% if stats_menu? %>
             <li class="is-active">
               <h2><%= t("polls.show.stats_menu") %></h2>
             </li>
@@ -21,7 +22,7 @@
           <% end %>
         <% end %>
 
-        <% if controller_name == "polls" && action_name == "show" %>
+        <% if info_menu? %>
           <li class="is-active">
             <h2><%= t("polls.show.info_menu") %></h2>
           </li>

--- a/app/views/polls/_poll_subnav.html.erb
+++ b/app/views/polls/_poll_subnav.html.erb
@@ -1,10 +1,8 @@
-<% if current_user && current_user.administrator? ||
-  (@poll.expired? && (@poll.results_enabled? || @poll.stats_enabled?)) %>
   <div class="row margin-top">
     <div class="small-12 column">
       <ul class="menu simple clear">
-        <% if current_user && current_user.administrator? || @poll.results_enabled? %>
           <% if controller_name == "polls" && action_name == "results" %>
+        <% if @poll.results_enabled? %>
             <li class="is-active">
               <h2><%= t("polls.show.results_menu") %></h2>
             </li>
@@ -13,8 +11,8 @@
           <% end %>
         <% end %>
 
-        <% if current_user && current_user.administrator? || @poll.stats_enabled? %>
           <% if controller_name == "polls" && action_name == "stats" %>
+        <% if @poll.stats_enabled? %>
             <li class="is-active">
               <h2><%= t("polls.show.stats_menu") %></h2>
             </li>

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -474,21 +474,28 @@ feature 'Polls' do
       expect(page).to have_content("You do not have permission to carry out the action 'stats' on poll.")
     end
 
-    scenario "Show poll results and stats if user is administrator" do
-      poll = create(:poll, :current, results_enabled: false, stats_enabled: false)
-      user = create(:administrator).user
+    scenario "Do not show poll results or stats if are disabled" do
+      poll = create(:poll, :expired, results_enabled: false, stats_enabled: false)
+      question1 = create(:poll_question, poll: poll)
+      create(:poll_question_answer, question: question1, title: "Han Solo")
+      create(:poll_question_answer, question: question1, title: "Chewbacca")
+      question2 = create(:poll_question, poll: poll)
+      create(:poll_question_answer, question: question2, title: "Leia")
+      create(:poll_question_answer, question: question2, title: "Luke")
+      user = create(:user)
+      admin = create(:administrator).user
 
       login_as user
       visit poll_path(poll)
 
-      expect(page).to have_content("Poll results")
-      expect(page).to have_content("Participation statistics")
+      expect(page).not_to have_content("Poll results")
+      expect(page).not_to have_content("Participation statistics")
 
-      visit results_poll_path(poll)
-      expect(page).to have_content("Questions")
+      login_as admin
+      visit poll_path(poll)
 
-      visit stats_poll_path(poll)
-      expect(page).to have_content("Participation data")
+      expect(page).not_to have_content("Poll results")
+      expect(page).not_to have_content("Participation statistics")
     end
   end
 end


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1838

## Objectives

- Hide poll results and stats to admins: only shows the sub navigation to users if poll is expired and poll results or poll stats are enabled.
- Create helper for active menus on poll sub navigation.