### PR TITLE
[Backport] Allow admins delete poll answer documents

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -11,7 +11,7 @@ class DocumentsController < ApplicationController
         else
           flash[:alert] = t "documents.actions.destroy.alert"
         end
-        redirect_to params[:from]
+        redirect_to request.referer
       end
       format.js do
         if @document.destroy

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -93,6 +93,7 @@ module Abilities
       cannot :comment_as_moderator, [::Legislation::Question, Legislation::Annotation, ::Legislation::Proposal]
 
       can [:create], Document
+      can [:destroy], Document, documentable_type: "Poll::Question::Answer"
       can [:create, :destroy], DirectUpload
 
       can [:deliver], Newsletter, hidden_at: nil

--- a/app/views/admin/poll/questions/answers/documents.html.erb
+++ b/app/views/admin/poll/questions/answers/documents.html.erb
@@ -14,18 +14,12 @@
 
     <%= render 'shared/errors', resource: @answer %>
 
-    <div class="row">
-      <div class="small-12 column">
-        <div class="documents small-12">
-          <%= render 'documents/nested_documents', documentable: @answer, f: f %>
-        </div>
+    <div class="documents">
+      <%= render 'documents/nested_documents', documentable: @answer, f: f %>
+    </div>
 
-        <div class="row">
-          <div class="actions small-12 medium-4 margin-top">
-            <%= f.submit(class: "button expanded", value: t("shared.save")) %>
-          </div>
-        </div>
-      </div>
+    <div class="small-12 medium-6 large-2">
+      <%= f.submit(class: "button expanded", value: t("shared.save")) %>
     </div>
   <% end %>
 
@@ -42,11 +36,17 @@
             <%= link_to document.title, document.attachment.url %>
           </td>
           <td class="text-right">
-            <%= link_to t('documents.buttons.download_document'),
+            <%= link_to t("documents.buttons.download_document"),
                         document.attachment.url,
                         target: "_blank",
                         rel: "nofollow",
-                        class: 'button hollow' %>
+                        class: "button hollow" %>
+
+            <%= link_to t("admin.shared.delete"),
+                          document_path(document),
+                          method: :delete,
+                          class: "button hollow alert",
+                          data: { confirm: t("admin.actions.confirm") } %>
           </td>
         </tr>
       <% end %>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -13,7 +13,8 @@
   <% if can?(:destroy, document) %>
     <br>
     <%= link_to t("documents.buttons.destroy_document"),
-                  document_path(document, from: request.url), method: :delete,
+                  document,
+                  method: :delete,
                   data: { confirm: t("documents.actions.destroy.confirm") },
                   class: "delete" %>
   <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1187,6 +1187,7 @@ en:
       author: Author
       content: Content
       created_at: Created at
+      delete: Delete
     spending_proposals:
       index:
         geozone_filter_all: All zones

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1187,6 +1187,7 @@ es:
       author: Autor
       content: Contenido
       created_at: Fecha de creación
+      delete: Eliminar
     spending_proposals:
       index:
         geozone_filter_all: Todos los ámbitos de actuación

--- a/spec/features/admin/poll/questions/answers/documents/documents_spec.rb
+++ b/spec/features/admin/poll/questions/answers/documents/documents_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+feature "Documents" do
+
+  background do
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
+
+  context "Index" do
+    scenario "Answer with no documents" do
+      answer = create(:poll_question_answer, question: create(:poll_question))
+      document = create(:document)
+
+      visit admin_answer_documents_path(answer)
+
+      expect(page).not_to have_content(document.title)
+    end
+
+    scenario "Answer with documents" do
+      answer = create(:poll_question_answer, question: create(:poll_question))
+      document = create(:document, documentable: answer)
+
+      visit admin_answer_documents_path(answer)
+
+      expect(page).to have_content(document.title)
+    end
+  end
+
+  scenario "Remove document from answer", :js do
+    answer = create(:poll_question_answer, question: create(:poll_question))
+    document = create(:document, documentable: answer)
+
+    visit admin_answer_documents_path(answer)
+    expect(page).to have_content(document.title)
+
+    accept_confirm "Are you sure?" do
+      click_link "Delete"
+    end
+
+    expect(page).not_to have_content(document.title)
+  end
+
+end


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1841

## Objectives

- Allow admins delete poll answer documents.
- Fix admin poll question answers documents layout, _see attached images_.

## Visual Changes

**BEFORE**
![before](https://user-images.githubusercontent.com/631897/51552884-e2663e80-1e71-11e9-8732-8f2ac4fa096c.png)

**AFTER**
![after](https://user-images.githubusercontent.com/631897/51552887-e4300200-1e71-11e9-85e4-9ba488391112.png)