### PR TITLE
[Backport] Use find instead of find_by_id

### DIFF
--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -25,7 +25,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budgetid])
+        @budget = Budget.find_by_slug_or_id params[:budget_id]
       end
 
       def investments_by_heading_ordered_alphabetically

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -25,7 +25,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budgetid])
       end
 
       def investments_by_heading_ordered_alphabetically

--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -4,7 +4,6 @@ class Management::Budgets::InvestmentsController < Management::BaseController
   load_resource :investment, through: :budget, class: 'Budget::Investment'
 
   before_action :only_verified_users, except: :print
-  before_action :load_heading, only: [:index, :show, :print]
 
   def index
     @investments = @investments.apply_filters_and_search(@budget, params).page(params[:page])
@@ -59,10 +58,6 @@ class Management::Budgets::InvestmentsController < Management::BaseController
 
     def only_verified_users
       check_verified_user t("management.budget_investments.alert.unverified_user")
-    end
-
-    def load_heading
-      @heading = @budget.headings.find(params[:heading_id]) if params[:heading_id].present?
     end
 
     def load_categories

--- a/app/controllers/related_contents_controller.rb
+++ b/app/controllers/related_contents_controller.rb
@@ -31,7 +31,7 @@ class RelatedContentsController < ApplicationController
   private
 
   def score(action)
-    @related = RelatedContent.find_by(id: params[:id])
+    @related = RelatedContent.find params[:id]
     @related.send("score_#{action}", current_user)
 
     render template: 'relationable/_refresh_score_actions'

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -3,6 +3,10 @@ module Sluggable
 
   included do
     before_validation :generate_slug, if: :generate_slug?
+
+    def self.find_by_slug_or_id(slug_or_id)
+      find_by_slug(slug_or_id) || find_by_id(slug_or_id)
+    end
   end
 
   def generate_slug

--- a/spec/controllers/related_contents_controller_spec.rb
+++ b/spec/controllers/related_contents_controller_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe RelatedContentsController do
+
+  describe "#score" do
+    it "raises an error if related content does not exist" do
+      controller.params[:id] = 0
+
+      expect do
+        controller.send(:score, "action")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
+end


### PR DESCRIPTION
## References

https://github.com/AyuntamientoMadrid/consul/pull/1831

## Objectives

- Use correct param in controller 
- Remove unused before_action 
- Use find instead of find_by_id 
- Add method find_by_slug_or_id to Sluggable module