### PR TITLE
Remote translations structure

### DIFF
--- a/app/controllers/concerns/remotely_translatable.rb
+++ b/app/controllers/concerns/remotely_translatable.rb
@@ -11,9 +11,9 @@ module RemotelyTranslatable
     end
 
     def remote_translation_for(resource)
-      { 'remote_translatable_id' => resource.id.to_s,
-        'remote_translatable_type' => resource.class.to_s,
-        'locale' => I18n.locale }
+      { "remote_translatable_id" => resource.id.to_s,
+        "remote_translatable_type" => resource.class.to_s,
+        "locale" => I18n.locale }
     end
 
     def translation_empty?(resource)

--- a/app/controllers/concerns/remotely_translatable.rb
+++ b/app/controllers/concerns/remotely_translatable.rb
@@ -1,0 +1,29 @@
+module RemotelyTranslatable
+
+  private
+
+    def detect_remote_translations(*args)
+      return [] unless Setting["feature.remote_translations"].present?
+
+      resources_groups(*args).flatten.select { |resource| translation_empty?(resource) }.map do |resource|
+        remote_translation_for(resource)
+      end
+    end
+
+    def remote_translation_for(resource)
+      { 'remote_translatable_id' => resource.id.to_s,
+        'remote_translatable_type' => resource.class.to_s,
+        'locale' => I18n.locale }
+    end
+
+    def translation_empty?(resource)
+      resource.translations.where(locale: I18n.locale).empty?
+    end
+
+    def resources_groups(*args)
+      feeds = args.detect { |arg| arg&.first.class == Widget::Feed } || []
+
+      args.compact - [feeds] + feeds.map(&:items)
+    end
+
+end

--- a/app/controllers/remote_translations_controller.rb
+++ b/app/controllers/remote_translations_controller.rb
@@ -1,0 +1,32 @@
+class RemoteTranslationsController < ApplicationController
+  skip_authorization_check
+  respond_to :html, :js
+
+  before_action :set_remote_translations, only: :create
+
+  def create
+    @remote_translations.each do |remote_translation|
+      RemoteTranslation.create(remote_translation) unless translations_enqueued?(remote_translation)
+    end
+    redirect_to request.referer, notice: t('remote_translations.create.enqueue_remote_translation')
+  end
+
+  private
+
+  def remote_translations_params
+    params.permit(:remote_translations)
+  end
+
+  def set_remote_translations
+    decoded_remote_translations = ActiveSupport::JSON.decode(remote_translations_params["remote_translations"])
+    @remote_translations = decoded_remote_translations.map{ |remote_translation|
+                            remote_translation.slice("remote_translatable_id","remote_translatable_type","locale")
+                          }
+  end
+
+
+  def translations_enqueued?(remote_translation)
+    RemoteTranslation.remote_translation_enqueued?(remote_translation)
+  end
+
+end

--- a/app/controllers/remote_translations_controller.rb
+++ b/app/controllers/remote_translations_controller.rb
@@ -8,25 +8,27 @@ class RemoteTranslationsController < ApplicationController
     @remote_translations.each do |remote_translation|
       RemoteTranslation.create(remote_translation) unless translations_enqueued?(remote_translation)
     end
-    redirect_to request.referer, notice: t('remote_translations.create.enqueue_remote_translation')
+    redirect_to request.referer, notice: t("remote_translations.create.enqueue_remote_translation")
   end
 
   private
 
-  def remote_translations_params
-    params.permit(:remote_translations)
-  end
+    def remote_translations_params
+      params.permit(:remote_translations)
+    end
 
-  def set_remote_translations
-    decoded_remote_translations = ActiveSupport::JSON.decode(remote_translations_params["remote_translations"])
-    @remote_translations = decoded_remote_translations.map{ |remote_translation|
-                            remote_translation.slice("remote_translatable_id","remote_translatable_type","locale")
-                          }
-  end
+    def set_remote_translations
+      remote_translations = remote_translations_params["remote_translations"]
+      decoded_remote_translations = ActiveSupport::JSON.decode(remote_translations)
+      @remote_translations = decoded_remote_translations.map{ |remote_translation|
+                              remote_translation.slice("remote_translatable_id",
+                                                       "remote_translatable_type",
+                                                       "locale")
+                            }
+    end
 
-
-  def translations_enqueued?(remote_translation)
-    RemoteTranslation.remote_translation_enqueued?(remote_translation)
-  end
+    def translations_enqueued?(remote_translation)
+      RemoteTranslation.remote_translation_enqueued?(remote_translation)
+    end
 
 end

--- a/app/models/concerns/globalizable.rb
+++ b/app/models/concerns/globalizable.rb
@@ -35,7 +35,19 @@ module Globalizable
   class_methods do
     def validates_translation(method, options = {})
       validates(method, options.merge(if: lambda { |resource| resource.translations.blank? }))
-      translation_class.instance_eval { validates method, options }
+      if options.include?(:length)
+        lenght_validate = { length: options[:length] }
+        translation_class.instance_eval do
+          validates method, lenght_validate.merge(if: lambda { |translation| translation.locale == I18n.default_locale })
+        end
+        if options.count > 1
+          translation_class.instance_eval do
+            validates method, options.reject { |key| key == :length }
+          end
+        end
+      else
+        translation_class.instance_eval { validates method, options }
+      end
     end
 
     def translation_class_delegate(method)

--- a/app/models/remote_translation.rb
+++ b/app/models/remote_translation.rb
@@ -11,4 +11,10 @@ class RemoteTranslation < ActiveRecord::Base
   def enqueue_remote_translation
   end
 
+  def self.remote_translation_enqueued?(remote_translation)
+    where(remote_translatable_id: remote_translation["remote_translatable_id"],
+          remote_translatable_type: remote_translation["remote_translatable_type"],
+          locale: remote_translation["locale"],
+          error_message: nil).any?
+  end
 end

--- a/app/models/remote_translation.rb
+++ b/app/models/remote_translation.rb
@@ -1,0 +1,14 @@
+class RemoteTranslation < ActiveRecord::Base
+
+  belongs_to :remote_translatable, polymorphic: true
+
+  validates :remote_translatable_id, presence: true
+  validates :remote_translatable_type, presence: true
+  validates :locale, presence: true
+
+  after_create :enqueue_remote_translation
+
+  def enqueue_remote_translation
+  end
+
+end

--- a/app/models/remote_translation.rb
+++ b/app/models/remote_translation.rb
@@ -9,6 +9,7 @@ class RemoteTranslation < ActiveRecord::Base
   after_create :enqueue_remote_translation
 
   def enqueue_remote_translation
+    RemoteTranslationsCaller.new(self).delay.call
   end
 
   def self.remote_translation_enqueued?(remote_translation)

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -838,3 +838,6 @@ en:
       text_sign_in: login
       text_sign_up: sign up
       title: How I can comment this document?
+  remote_translations:
+    create:
+      enqueue_remote_translation: Translations have been correctly requested.

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -104,6 +104,8 @@ en:
       public_stats_description: "Display public stats in the Administration panel"
       help_page: "Help page"
       help_page_description: 'Displays a Help menu that contains a page with an info section about each enabled feature. Also custom pages and menus can be created in the "Custom pages" and  "Custom content blocks" sections'
+      remote_translations: "Remote translation"
+      remote_translations_description: "Displays a button that allows users to request a translation when there are not contents in their language."
     map:
       latitude: "Latitude"
       latitude_description: "Latitude to show the map position"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -837,3 +837,6 @@ es:
       text_sign_in: iniciar sesión
       text_sign_up: registrarte
       title: '¿Cómo puedo comentar este documento?'
+  remote_translations:
+    create:
+      enqueue_remote_translation: Se han solicitado correctamente las traducciones.

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -104,6 +104,8 @@ es:
       public_stats_description: "Muestra las estadísticas públicas en el panel de Administración"
       help_page: "Página de ayuda"
       help_page_description: 'Muestra un menú Ayuda que contiene una página con una sección de información sobre cada funcionalidad habilitada. También se pueden crear páginas y menús personalizados en las secciones "Personalizar páginas" y "Personalizar bloques"'
+      remote_translations: "Traducciones remotas"
+      remote_translations_description: "Muestra un botón que permite a los usuarios solicitar una traducción de una página no traducida en su idioma."
     map:
       latitude: "Latitud"
       latitude_description: "Latitud para mostrar la posición del mapa"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   resources :images, only: [:destroy]
   resources :documents, only: [:destroy]
   resources :follows, only: [:create, :destroy]
+  resources :remote_translations, only: [:create]
 
   # More info pages
   get "help",             to: "pages#show", id: "help/index",             as: "help"

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -50,7 +50,7 @@ section "Creating Settings" do
   Setting.create(key: "feature.allow_attached_documents", value: "true")
   Setting.create(key: "feature.public_stats", value: "true")
   Setting.create(key: "feature.help_page", value: "true")
-  Setting.create(key: 'feature.remote_translations', value: nil)
+  Setting.create(key: "feature.remote_translations", value: nil)
 
   Setting.create(key: "html.per_page_code_head", value: "")
   Setting.create(key: "html.per_page_code_body", value: "")

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -50,6 +50,7 @@ section "Creating Settings" do
   Setting.create(key: "feature.allow_attached_documents", value: "true")
   Setting.create(key: "feature.public_stats", value: "true")
   Setting.create(key: "feature.help_page", value: "true")
+  Setting.create(key: 'feature.remote_translations', value: nil)
 
   Setting.create(key: "html.per_page_code_head", value: "")
   Setting.create(key: "html.per_page_code_body", value: "")

--- a/db/migrate/20181205191300_create_remote_translations.rb
+++ b/db/migrate/20181205191300_create_remote_translations.rb
@@ -1,0 +1,12 @@
+class CreateRemoteTranslations < ActiveRecord::Migration
+  def change
+    create_table :remote_translations do |t|
+      t.string :locale
+      t.integer :remote_translatable_id
+      t.string  :remote_translatable_type
+      t.text :error_message
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1275,6 +1275,15 @@ ActiveRecord::Schema.define(version: 20190325185550) do
   add_index "related_contents", ["parent_relationable_type", "parent_relationable_id"], name: "index_related_contents_on_parent_relationable", using: :btree
   add_index "related_contents", ["related_content_id"], name: "opposite_related_content", using: :btree
 
+  create_table "remote_translations", force: :cascade do |t|
+    t.string   "locale"
+    t.integer  "remote_translatable_id"
+    t.string   "remote_translatable_type"
+    t.text     "error_message"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
   create_table "settings", force: :cascade do |t|
     t.string "key"
     t.string "value"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,6 +89,7 @@ Setting["feature.map"] = nil
 Setting["feature.allow_images"] = true
 Setting["feature.allow_attached_documents"] = true
 Setting["feature.help_page"] = true
+Setting['feature.remote_translations'] = nil
 
 # Spending proposals feature flags
 Setting["feature.spending_proposal_features.voting_allowed"] = nil

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,7 +89,7 @@ Setting["feature.map"] = nil
 Setting["feature.allow_images"] = true
 Setting["feature.allow_attached_documents"] = true
 Setting["feature.help_page"] = true
-Setting['feature.remote_translations'] = nil
+Setting["feature.remote_translations"] = nil
 
 # Spending proposals feature flags
 Setting["feature.spending_proposal_features.voting_allowed"] = nil

--- a/lib/remote_translations_caller.rb
+++ b/lib/remote_translations_caller.rb
@@ -1,0 +1,49 @@
+class RemoteTranslationsCaller
+  attr_reader :remote_translation
+
+  def initialize(remote_translation)
+    @remote_translation = remote_translation
+  end
+
+  def call
+    update_resource
+    destroy_remote_translation
+  end
+
+  private
+
+    def update_resource
+      Globalize.with_locale(locale) do
+        resource.translated_attribute_names.each_with_index do |field, index|
+          resource.send(:"#{field}=", translations[index])
+        end
+      end
+      resource.save
+    end
+
+    def destroy_remote_translation
+      if resource.valid?
+        remote_translation.destroy
+      else
+        remote_translation.update(error_message: resource.errors.messages)
+      end
+    end
+
+    def resource
+      @resource ||= remote_translation.remote_translatable
+    end
+
+    def translations
+      @translations ||= MicrosoftTranslateClient.new.call(fields_values, locale)
+    end
+
+    def fields_values
+      resource.translated_attribute_names.map do |field|
+        resource.send(field)
+      end
+    end
+
+    def locale
+      remote_translation.locale
+    end
+end

--- a/lib/remote_translations_caller.rb
+++ b/lib/remote_translations_caller.rb
@@ -27,6 +27,7 @@ class RemoteTranslationsCaller
       else
         remote_translation.update(error_message: resource.errors.messages)
       end
+      resource.save
     end
 
     def resource

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -75,4 +75,9 @@ namespace :settings do
     Setting.rename_key from: "feature.homepage.widgets.feeds.processes", to: "homepage.widgets.feeds.processes"
   end
 
+  desc "Create remote translations setting"
+  task create_remote_translations_setting: :environment do
+    Setting["feature.remote_translations"] = nil
+  end
+
 end

--- a/spec/controllers/concerns/remotely_translatable_spec.rb
+++ b/spec/controllers/concerns/remotely_translatable_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+include RemotelyTranslatable
+
+describe RemotelyTranslatable do
+
+  before do
+    Setting["feature.remote_translations"] = true
+  end
+
+  after do
+    Setting["feature.remote_translations"] = nil
+  end
+
+  describe "#detect_remote_translations" do
+
+    describe "Should detect remote_translations" do
+
+      it "When collections and featured_proposals are not defined in current locale" do
+        proposals = create_list(:proposal, 3)
+        featured_proposals = create_featured_proposals
+
+        I18n.with_locale(:es) do
+          expect(detect_remote_translations(proposals, featured_proposals).count).to eq 6
+        end
+      end
+
+      it "When we have nil as argument and collections are not defined in current locale" do
+        proposals = create_list(:proposal, 3)
+
+        I18n.with_locale(:es) do
+          expect(detect_remote_translations(proposals, nil).count).to eq 3
+        end
+      end
+
+      it "When we have [] as argument and collections are not defined in current locale" do
+        proposals = create_list(:proposal, 3)
+
+        I18n.with_locale(:es) do
+          expect(detect_remote_translations(proposals, []).count).to eq 3
+        end
+      end
+
+      it "When widget feeds are not defined in current locale" do
+        create_list(:proposal, 3)
+        create_list(:debate, 3)
+        create_list(:legislation_process, 3)
+        create(:widget_feed, kind: "proposals")
+        create(:widget_feed, kind: "debates")
+        create(:widget_feed, kind: "processes")
+        widget_feeds = Widget::Feed.active
+
+        I18n.with_locale(:es) do
+          expect(detect_remote_translations(widget_feeds).count).to eq 9
+        end
+      end
+
+    end
+
+    it "When defined in current locale should not detect remote_translations" do
+      proposal = create(:proposal)
+      comment = create(:comment, commentable: proposal)
+
+      expect(detect_remote_translations([proposal, comment])).to eq []
+    end
+  end
+end

--- a/spec/controllers/remote_translation_controller_spec.rb
+++ b/spec/controllers/remote_translation_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe RemoteTranslationsController do
+
+  describe 'POST create' do
+    before do
+      @debate = create(:debate)
+      @remote_translations_params = [{ remote_translatable_id: @debate.id.to_s,
+                                      remote_translatable_type: @debate.class.to_s,
+                                      locale: :es }].to_json
+      allow(controller.request).to receive(:referer).and_return('any_path')
+      Delayed::Worker.delay_jobs = true
+    end
+
+    after do
+      Delayed::Worker.delay_jobs = false
+    end
+
+    it 'set_remote_translations parse correctly remote_translations_params' do
+      post :create, remote_translations: @remote_translations_params
+
+      expect(assigns(:remote_translations).count).to eq(1)
+    end
+
+    it 'create correctly remote translation' do
+      post :create, remote_translations: @remote_translations_params
+
+      expect(RemoteTranslation.count).to eq(1)
+    end
+
+    it 'create remote translation when same remote translation with error_message is enqueued' do
+      create(:remote_translation, remote_translatable: @debate, locale: :es, error_message: "Has errors")
+
+      post :create, remote_translations: @remote_translations_params
+
+      expect(RemoteTranslation.count).to eq(2)
+    end
+
+    it 'not create remote translation when same remote translation is enqueued' do
+      create(:remote_translation, remote_translatable: @debate, locale: :es)
+
+      post :create, remote_translations: @remote_translations_params
+
+      expect(RemoteTranslation.count).to eq(1)
+    end
+
+    it 'redirect_to request referer after create' do
+      post :create, remote_translations: @remote_translations_params
+
+      expect(subject).to redirect_to('any_path')
+    end
+
+  end
+end

--- a/spec/controllers/remote_translation_controller_spec.rb
+++ b/spec/controllers/remote_translation_controller_spec.rb
@@ -1,14 +1,15 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe RemoteTranslationsController do
 
-  describe 'POST create' do
+  describe "POST create" do
+    let(:debate)             { create(:debate) }
+
     before do
-      @debate = create(:debate)
-      @remote_translations_params = [{ remote_translatable_id: @debate.id.to_s,
-                                      remote_translatable_type: @debate.class.to_s,
-                                      locale: :es }].to_json
-      allow(controller.request).to receive(:referer).and_return('any_path')
+      @remote_translations_params = [{ remote_translatable_id: debate.id.to_s,
+                                       remote_translatable_type: debate.class.to_s,
+                                       locale: :es }].to_json
+      allow(controller.request).to receive(:referer).and_return("any_path")
       Delayed::Worker.delay_jobs = true
     end
 
@@ -16,38 +17,38 @@ describe RemoteTranslationsController do
       Delayed::Worker.delay_jobs = false
     end
 
-    it 'set_remote_translations parse correctly remote_translations_params' do
+    it "set_remote_translations parse correctly remote_translations_params" do
       post :create, remote_translations: @remote_translations_params
 
       expect(assigns(:remote_translations).count).to eq(1)
     end
 
-    it 'create correctly remote translation' do
+    it "create correctly remote translation" do
       post :create, remote_translations: @remote_translations_params
 
       expect(RemoteTranslation.count).to eq(1)
     end
 
-    it 'create remote translation when same remote translation with error_message is enqueued' do
-      create(:remote_translation, remote_translatable: @debate, locale: :es, error_message: "Has errors")
+    it "create remote translation when same remote translation with error_message is enqueued" do
+      create(:remote_translation, remote_translatable: debate, locale: :es, error_message: "Has errors")
 
       post :create, remote_translations: @remote_translations_params
 
       expect(RemoteTranslation.count).to eq(2)
     end
 
-    it 'not create remote translation when same remote translation is enqueued' do
-      create(:remote_translation, remote_translatable: @debate, locale: :es)
+    it "not create remote translation when same remote translation is enqueued" do
+      create(:remote_translation, remote_translatable: debate, locale: :es)
 
       post :create, remote_translations: @remote_translations_params
 
       expect(RemoteTranslation.count).to eq(1)
     end
 
-    it 'redirect_to request referer after create' do
+    it "redirect_to request referer after create" do
       post :create, remote_translations: @remote_translations_params
 
-      expect(subject).to redirect_to('any_path')
+      expect(subject).to redirect_to("any_path")
     end
 
   end

--- a/spec/factories/remote_translations.rb
+++ b/spec/factories/remote_translations.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :remote_translation do
+    association :remote_translatable, factory: :debate
+  end
+end

--- a/spec/lib/remote_translations_caller_spec.rb
+++ b/spec/lib/remote_translations_caller_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe RemoteTranslationsCaller do
 
@@ -6,18 +6,18 @@ describe RemoteTranslationsCaller do
     RemoteTranslation.skip_callback(:create, :after, :enqueue_remote_translation)
   end
 
-  describe '#call' do
+  describe "#call" do
 
-    context 'Debates' do
+    context "Debates" do
 
       let(:debate)             { create(:debate) }
       let(:remote_translation) { create(:remote_translation,
                                         remote_translatable: debate, locale: :es) }
       let(:remote_translation_caller) { described_class.new(remote_translation) }
 
-      it 'returns the resource with new translation persisted' do
-        microsoft_translate_client_response = ["Título traducido", "Descripción traducida"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+      it "returns the resource with new translation persisted" do
+        response = ["Título traducido", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -25,8 +25,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "when new translation locale is distinct to default_locale skip length validations" do
-        microsoft_translate_client_response = ["TT", "Descripción traducida"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["TT", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -36,8 +36,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "when new translation locale is distinct to default_locale not skip presence validations" do
-        microsoft_translate_client_response = ["", "Descripción traducida"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -47,8 +47,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "destroy remote translation instance" do
-        microsoft_translate_client_response = ["Título traducido", "Descripción traducida"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["Título traducido", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -56,16 +56,17 @@ describe RemoteTranslationsCaller do
       end
     end
 
-    context 'Proposals' do
+    context "Proposals" do
 
       let!(:proposal)          { create(:proposal) }
       let(:remote_translation) { create(:remote_translation,
                                         remote_translatable: proposal, locale: :es) }
       let(:remote_translation_caller) { described_class.new(remote_translation) }
 
-      it 'returns the resource with new translation persisted' do
-        microsoft_translate_client_response = ["Título traducido", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+      it "returns the resource with new translation persisted" do
+        response = ["Título traducido", "Descripción traducida", "Pregunta traducida",
+                    "Resumen traducido", nil]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -73,8 +74,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "when new translation locale is distinct to default_locale skip lenght validations" do
-        microsoft_translate_client_response = ["TT", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["TT", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -84,8 +85,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "when new translation locale is distinct to default_locale do not skip presence validations" do
-        microsoft_translate_client_response = ["", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -95,8 +96,9 @@ describe RemoteTranslationsCaller do
       end
 
       it "destroy remote translation instance" do
-        microsoft_translate_client_response = ["Título traducido", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["Título traducido", "Descripción traducida", "Pregunta traducida",
+                    "Resumen traducido", nil]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -104,7 +106,7 @@ describe RemoteTranslationsCaller do
       end
     end
 
-    context 'Budget Investments' do
+    context "Budget Investments" do
 
       let(:budget_investment)  { create(:budget_investment) }
       let(:remote_translation) { create(:remote_translation,
@@ -112,9 +114,9 @@ describe RemoteTranslationsCaller do
                                         locale: :es) }
       let(:remote_translation_caller) { described_class.new(remote_translation) }
 
-      it 'returns the resource with new translation persisted' do
-        microsoft_translate_client_response = ["Título traducido", "Descripción traducida"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+      it "returns the resource with new translation persisted" do
+        response = ["Título traducido", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -122,8 +124,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "when new translation locale is distinct to default_locale skip lenght validations" do
-        microsoft_translate_client_response = ["TT", "Descripción traducida"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["TT", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -133,8 +135,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "when new translation locale is distinct to default_locale not skip presence validations" do
-        microsoft_translate_client_response = ["", "Descripción traducida"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -144,8 +146,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "destroy remote translation instance" do
-        microsoft_translate_client_response = ["Título traducido", "Descripción traducida"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["Título traducido", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -153,16 +155,16 @@ describe RemoteTranslationsCaller do
       end
     end
 
-    context 'Comments' do
+    context "Comments" do
 
       let(:comment)            { create(:comment) }
       let(:remote_translation) { create(:remote_translation,
                                         remote_translatable: comment, locale: :es) }
       let(:remote_translation_caller) { described_class.new(remote_translation) }
 
-      it 'returns the resource with new translation persisted' do
-        microsoft_translate_client_response = ["Body traducido"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+      it "returns the resource with new translation persisted" do
+        response = ["Body traducido"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -170,8 +172,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "when new translation locale is distinct to default_locale skip lenght validations" do
-        microsoft_translate_client_response = ["BT"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["BT"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -181,8 +183,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "when new translation locale is distinct to default_locale not skip presence validations" do
-        microsoft_translate_client_response = [""]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = [""]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 
@@ -192,8 +194,8 @@ describe RemoteTranslationsCaller do
       end
 
       it "destroy remote translation instance" do
-        microsoft_translate_client_response = ["Body traducido"]
-        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+        response = ["Body traducido"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(response)
 
         remote_translation_caller.call
 

--- a/spec/lib/remote_translations_caller_spec.rb
+++ b/spec/lib/remote_translations_caller_spec.rb
@@ -1,0 +1,206 @@
+require 'rails_helper'
+
+describe RemoteTranslationsCaller do
+
+  before do
+    RemoteTranslation.skip_callback(:create, :after, :enqueue_remote_translation)
+  end
+
+  describe '#call' do
+
+    context 'Debates' do
+
+      let(:debate)             { create(:debate) }
+      let(:remote_translation) { create(:remote_translation,
+                                        remote_translatable: debate, locale: :es) }
+      let(:remote_translation_caller) { described_class.new(remote_translation) }
+
+      it 'returns the resource with new translation persisted' do
+        microsoft_translate_client_response = ["Título traducido", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(debate.translations.count).to eq(2)
+      end
+
+      it "when new translation locale is distinct to default_locale skip length validations" do
+        microsoft_translate_client_response = ["TT", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(remote_translation.error_message).to eq nil
+        expect(debate.translations.count).to eq(2)
+        expect(debate.valid?).to eq true
+      end
+
+      it "when new translation locale is distinct to default_locale not skip presence validations" do
+        microsoft_translate_client_response = ["", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(remote_translation.error_message).to include("can't be blank")
+        expect(debate.translations.count).to eq(1)
+        expect(debate.valid?).to eq false
+      end
+
+      it "destroy remote translation instance" do
+        microsoft_translate_client_response = ["Título traducido", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(RemoteTranslation.count).to eq(0)
+      end
+    end
+
+    context 'Proposals' do
+
+      let!(:proposal)          { create(:proposal) }
+      let(:remote_translation) { create(:remote_translation,
+                                        remote_translatable: proposal, locale: :es) }
+      let(:remote_translation_caller) { described_class.new(remote_translation) }
+
+      it 'returns the resource with new translation persisted' do
+        microsoft_translate_client_response = ["Título traducido", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(proposal.translations.count).to eq(2)
+      end
+
+      it "when new translation locale is distinct to default_locale skip lenght validations" do
+        microsoft_translate_client_response = ["TT", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(remote_translation.error_message).to eq nil
+        expect(proposal.translations.count).to eq(2)
+        expect(proposal.valid?).to eq true
+      end
+
+      it "when new translation locale is distinct to default_locale do not skip presence validations" do
+        microsoft_translate_client_response = ["", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(remote_translation.error_message).to include("can't be blank")
+        expect(proposal.translations.count).to eq(1)
+        expect(proposal.valid?).to eq false
+      end
+
+      it "destroy remote translation instance" do
+        microsoft_translate_client_response = ["Título traducido", "Descripción traducida", "Pregunta traducida", "Resumen traducido", nil]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(RemoteTranslation.count).to eq(0)
+      end
+    end
+
+    context 'Budget Investments' do
+
+      let(:budget_investment)  { create(:budget_investment) }
+      let(:remote_translation) { create(:remote_translation,
+                                        remote_translatable: budget_investment,
+                                        locale: :es) }
+      let(:remote_translation_caller) { described_class.new(remote_translation) }
+
+      it 'returns the resource with new translation persisted' do
+        microsoft_translate_client_response = ["Título traducido", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(budget_investment.translations.count).to eq(2)
+      end
+
+      it "when new translation locale is distinct to default_locale skip lenght validations" do
+        microsoft_translate_client_response = ["TT", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(remote_translation.error_message).to eq nil
+        expect(budget_investment.translations.count).to eq(2)
+        expect(budget_investment.valid?).to eq true
+      end
+
+      it "when new translation locale is distinct to default_locale not skip presence validations" do
+        microsoft_translate_client_response = ["", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(remote_translation.error_message).to include("can't be blank")
+        expect(budget_investment.translations.count).to eq(1)
+        expect(budget_investment.valid?).to eq false
+      end
+
+      it "destroy remote translation instance" do
+        microsoft_translate_client_response = ["Título traducido", "Descripción traducida"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(RemoteTranslation.count).to eq(0)
+      end
+    end
+
+    context 'Comments' do
+
+      let(:comment)            { create(:comment) }
+      let(:remote_translation) { create(:remote_translation,
+                                        remote_translatable: comment, locale: :es) }
+      let(:remote_translation_caller) { described_class.new(remote_translation) }
+
+      it 'returns the resource with new translation persisted' do
+        microsoft_translate_client_response = ["Body traducido"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(comment.translations.count).to eq(2)
+      end
+
+      it "when new translation locale is distinct to default_locale skip lenght validations" do
+        microsoft_translate_client_response = ["BT"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(remote_translation.error_message).to eq nil
+        expect(comment.translations.count).to eq(2)
+        expect(comment.valid?).to eq true
+      end
+
+      it "when new translation locale is distinct to default_locale not skip presence validations" do
+        microsoft_translate_client_response = [""]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(remote_translation.error_message).to include("can't be blank")
+        expect(comment.translations.count).to eq(1)
+        expect(comment.valid?).to eq false
+      end
+
+      it "destroy remote translation instance" do
+        microsoft_translate_client_response = ["Body traducido"]
+        expect_any_instance_of(MicrosoftTranslateClient).to receive(:call).and_return(microsoft_translate_client_response)
+
+        remote_translation_caller.call
+
+        expect(RemoteTranslation.count).to eq(0)
+      end
+    end
+
+  end
+
+end

--- a/spec/lib/remote_translations_caller_spec.rb
+++ b/spec/lib/remote_translations_caller_spec.rb
@@ -6,6 +6,10 @@ describe RemoteTranslationsCaller do
     RemoteTranslation.skip_callback(:create, :after, :enqueue_remote_translation)
   end
 
+  after do
+    RemoteTranslation.set_callback(:create, :after, :enqueue_remote_translation)
+  end
+
   describe "#call" do
 
     context "Debates" do

--- a/spec/models/remote_translation_spec.rb
+++ b/spec/models/remote_translation_spec.rb
@@ -30,12 +30,16 @@ describe RemoteTranslation do
 
   describe "#enqueue_remote_translation" do
 
-    it "after create enqueue Delayed Job" do
+    before do
       Delayed::Worker.delay_jobs = true
+    end
 
-      expect { remote_translation.save }.to change { Delayed::Job.count }.by(1)
-
+    after do
       Delayed::Worker.delay_jobs = false
+    end
+
+    it "after create enqueue Delayed Job" do
+      expect { remote_translation.save }.to change { Delayed::Job.count }.by(1)
     end
 
   end

--- a/spec/models/remote_translation_spec.rb
+++ b/spec/models/remote_translation_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe RemoteTranslation do
+
+  let(:remote_translation) { build(:remote_translation, locale: :es) }
+
+  it "is valid" do
+    expect(remote_translation).to be_valid
+  end
+
+  it "is valid without error_message" do
+    remote_translation.error_message = nil
+    expect(remote_translation).to be_valid
+  end
+
+  it "is not valid without to" do
+    remote_translation.locale = nil
+    expect(remote_translation).not_to be_valid
+  end
+
+  it "is not valid without a remote_translatable_id" do
+    remote_translation.remote_translatable_id = nil
+    expect(remote_translation).not_to be_valid
+  end
+
+  it "is not valid without a remote_translatable_type" do
+    remote_translation.remote_translatable_type = nil
+    expect(remote_translation).not_to be_valid
+  end
+  end
+
+end

--- a/spec/models/remote_translation_spec.rb
+++ b/spec/models/remote_translation_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe RemoteTranslation do
 
@@ -28,9 +28,9 @@ describe RemoteTranslation do
     expect(remote_translation).not_to be_valid
   end
 
-  describe '#enqueue_remote_translation' do
+  describe "#enqueue_remote_translation" do
 
-    it 'after create enqueue Delayed Job' do
+    it "after create enqueue Delayed Job" do
       Delayed::Worker.delay_jobs = true
 
       expect { remote_translation.save }.to change { Delayed::Job.count }.by(1)

--- a/spec/models/remote_translation_spec.rb
+++ b/spec/models/remote_translation_spec.rb
@@ -27,6 +27,17 @@ describe RemoteTranslation do
     remote_translation.remote_translatable_type = nil
     expect(remote_translation).not_to be_valid
   end
+
+  describe '#enqueue_remote_translation' do
+
+    it 'after create enqueue Delayed Job' do
+      Delayed::Worker.delay_jobs = true
+
+      expect { remote_translation.save }.to change { Delayed::Job.count }.by(1)
+
+      Delayed::Worker.delay_jobs = false
+    end
+
   end
 
 end


### PR DESCRIPTION
## References
Related issues: #3157 
Related PR: #3235 #3156 

## Objectives
1. Detect missing translations: 
Create concern to reuse the logic of detection of non-existent translations in Controllers.

2. Create RemoteTranslations Controller and RemoteTranslation model:
Receive resources without translations and create RemoteTranslation instances when theirs translations are not enqueued. After create a remote translation order missing translations via DelayedJobs.

3. Create RemoteTranslations Caller:
  - extracting resources associated from RemoteTranslation and preparing its fields to be sent to the MicrosoftTranslateClient.
  - receive the response from MicrosoftTranslateClient and update resource with her translates

4. Add feature setting to enable/disable:
  - detect missing translations
  - send request to translate

## Visual Changes
Without visual changes

## Notes
⚠️ For Release notes:
Create Remote Translations Settings: Setting["feature.remote_translations"]. Execute this command to create: `bin/rake settings:create_remote_translations_setting RAILS_ENV=production`

- This PR start from #3235. When PR #3235 will be merged on consul/translations branch we can rebase it to this PR and all their commits will disappear.
- This PR need Proposal, Debate, Comment and BudgetInvestment as Globalize models. The PR #3156 include these changes. When PR #3156 will be merged on consult/translations branch we can rebase it to this PR and all specs will be fixed.
- For ease of review these are the commits that the PR should include:
  - Create RemotelyTranslatable concern controller (dd0f7d2)
  - Create RemoteTranslation model (1181fd6)
  - Create RemoteTranslations Controller (1186c49)
  - Create Remote Translations Caller (dfa2104)
  - Add Remote Translations Settings (40b55eb)
  - Create rake task for enable Remote Translation Settings (c66a7d1)
  - Allow create translations without length validation (3f02a15)