### PR TITLE
Adapt translatable shared specs

### DIFF
--- a/spec/shared/features/translatable.rb
+++ b/spec/shared/features/translatable.rb
@@ -31,9 +31,14 @@ shared_examples "translatable" do |factory_name, path_name, input_fields, textar
     fields - optional_fields
   end
 
+  let(:user) { create(:administrator).user }
   let(:translatable) { create(factory_name, attributes) }
   let(:path) { send(path_name, *resource_hierarchy_for(translatable)) }
-  before { login_as(create(:administrator).user) }
+
+  before do
+    login_as(user)
+    translatable.update(author: user) if front_end_path_to_visit?(path_name)
+  end
 
   context "Manage translations" do
     before do
@@ -332,4 +337,8 @@ def update_button_text
   else
     "Save changes"
   end
+end
+
+def front_end_path_to_visit?(path)
+  path[/admin|managment|valuation/].blank?
 end


### PR DESCRIPTION
## References

* Related Issues: #3130

## Objectives
Adapt translatable shared specs to define an owner when running at frontend feature specs.

## Visual Changes
None

## Notes
None