### PR TITLE
Proposal translations

### DIFF
--- a/app/controllers/admin/hidden_proposals_controller.rb
+++ b/app/controllers/admin/hidden_proposals_controller.rb
@@ -18,7 +18,7 @@ class Admin::HiddenProposalsController < Admin::BaseController
   end
 
   def restore
-    @proposal.restore
+    @proposal.restore(recursive: true)
     @proposal.ignore_flag
     Activity.log(current_user, :restore, @proposal)
     redirect_to request.query_parameters.merge(action: :index)

--- a/app/controllers/concerns/translatable.rb
+++ b/app/controllers/concerns/translatable.rb
@@ -3,10 +3,13 @@ module Translatable
 
   private
 
-    def translation_params(resource_model)
-      {
-        translations_attributes: [:id, :_destroy, :locale] +
-                                 resource_model.translated_attribute_names
-      }
+    def translation_params(resource_model, options = {})
+      attributes = [:id, :locale, :_destroy]
+      if options[:only]
+        attributes += [*options[:only]]
+      else
+        attributes += resource_model.translated_attribute_names
+      end
+      { translations_attributes: attributes - [*options[:except]] }
     end
 end

--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -1,6 +1,7 @@
 class Management::ProposalsController < Management::BaseController
   include HasOrders
   include CommentableActions
+  include Translatable
 
   before_action :only_verified_users, except: :print
   before_action :set_proposal, only: [:vote, :show]
@@ -36,8 +37,9 @@ class Management::ProposalsController < Management::BaseController
     end
 
     def proposal_params
-      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
-                                       :responsible_name, :tag_list, :terms_of_service, :geozone_id)
+      attributes = [:external_url, :video_url, :responsible_name, :tag_list,
+                    :terms_of_service, :geozone_id]
+      params.require(:proposal).permit(attributes, translation_params(Proposal))
     end
 
     def resource_model

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -54,7 +54,7 @@ class ProposalsController < ApplicationController
   end
 
   def retire
-    if valid_retired_params? && @proposal.update(retired_params.merge(retired_at: Time.current))
+    if @proposal.update(retired_params.merge(retired_at: Time.current))
       redirect_to proposal_path(@proposal), notice: t("proposals.notice.retired")
     else
       render action: :retire_form
@@ -93,13 +93,8 @@ class ProposalsController < ApplicationController
     end
 
     def retired_params
-      params.require(:proposal).permit(:retired_reason, :retired_explanation)
-    end
-
-    def valid_retired_params?
-      @proposal.errors.add(:retired_reason, I18n.t("errors.messages.blank")) if params[:proposal][:retired_reason].blank?
-      @proposal.errors.add(:retired_explanation, I18n.t("errors.messages.blank")) if params[:proposal][:retired_explanation].blank?
-      @proposal.errors.empty?
+      attributes = [:retired_reason]
+      params.require(:proposal).permit(attributes, translation_params(Proposal))
     end
 
     def resource_model
@@ -151,5 +146,4 @@ class ProposalsController < ApplicationController
         @recommended_proposals = Proposal.recommendations(current_user).sort_by_random.limit(3)
       end
     end
-
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -3,6 +3,7 @@ class ProposalsController < ApplicationController
   include CommentableActions
   include FlagActions
   include ImageAttributes
+  include Translatable
 
   before_action :parse_tag_filter, only: :index
   before_action :load_categories, only: [:index, :new, :create, :edit, :map, :summary]
@@ -34,7 +35,6 @@ class ProposalsController < ApplicationController
 
   def create
     @proposal = Proposal.new(proposal_params.merge(author: current_user))
-
     if @proposal.save
       redirect_to share_proposal_path(@proposal), notice: I18n.t("flash.actions.create.proposal")
     else
@@ -85,11 +85,13 @@ class ProposalsController < ApplicationController
   private
 
     def proposal_params
-      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
-                                       :responsible_name, :tag_list, :terms_of_service, :geozone_id, :skip_map,
-                                       image_attributes: image_attributes,
-                                       documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
-                                       map_location_attributes: [:latitude, :longitude, :zoom])
+      attributes = [:external_url, :video_url,:responsible_name, :tag_list,
+                    :terms_of_service, :geozone_id, :skip_map,
+                    image_attributes: image_attributes,
+                    documents_attributes: [:id, :title, :attachment, :cached_attachment,
+                                           :user_id, :_destroy],
+                    map_location_attributes: [:latitude, :longitude, :zoom]]
+      params.require(:proposal).permit(attributes, translation_params(Proposal))
     end
 
     def retired_params

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -91,12 +91,14 @@ class ProposalsController < ApplicationController
                     documents_attributes: [:id, :title, :attachment, :cached_attachment,
                                            :user_id, :_destroy],
                     map_location_attributes: [:latitude, :longitude, :zoom]]
-      params.require(:proposal).permit(attributes, translation_params(Proposal))
+      translations_attributes = translation_params(Proposal, except: :retired_explanation)
+      params.require(:proposal).permit(attributes, translations_attributes)
     end
 
     def retired_params
       attributes = [:retired_reason]
-      params.require(:proposal).permit(attributes, translation_params(Proposal))
+      translations_attributes = translation_params(Proposal, only: :retired_explanation)
+      params.require(:proposal).permit(attributes, translations_attributes)
     end
 
     def resource_model

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -64,4 +64,12 @@ module ProposalsHelper
     proposals_current_view == "default" ? "minimal" : "default"
   end
 
+  def question_help_text_id(translations_form)
+    "question-help-text-#{translations_form.locale}"
+  end
+
+  def summary_help_text_id(translations_form)
+    "summary-help-text-#{translations_form.locale}"
+  end
+
 end

--- a/app/models/concerns/globalizable.rb
+++ b/app/models/concerns/globalizable.rb
@@ -20,6 +20,18 @@ module Globalizable
     if self.paranoid? && translation_class.attribute_names.include?("hidden_at")
       translation_class.send :acts_as_paranoid, column: :hidden_at
     end
+
+    private
+
+      def searchable_globalized_values
+        values = {}
+        translations.each do |translation|
+          Globalize.with_locale(translation.locale) do
+            values.merge! searchable_translations_definitions
+          end
+        end
+        values
+      end
   end
 
   class_methods do

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -29,22 +29,30 @@ class Proposal < ActiveRecord::Base
 
   RETIRE_OPTIONS = %w(duplicated started unfeasible done other)
 
+  translates :title, touch: true
+  translates :description, touch: true
+  translates :question, touch: true
+  translates :summary, touch: true
+  translates :retired_explanation, touch: true
+  include Globalizable
+  translation_class_delegate :retired_at
+
   belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
   belongs_to :geozone
   has_many :comments, as: :commentable, dependent: :destroy
   has_many :proposal_notifications, dependent: :destroy
 
-  validates :title, presence: true
-  validates :question, presence: true
-  validates :summary, presence: true
+  validates_translation :title, presence: true, length: { in: 4..Proposal.title_max_length }
+  validates_translation :description, length: { maximum: Proposal.description_max_length }
+  validates_translation :question, presence: true, length: { in: 10..Proposal.question_max_length }
+  validates_translation :summary, presence: true
+  validates_translation :retired_explanation, presence: true, unless: -> { retired_at.blank? }
+
   validates :author, presence: true
   validates :responsible_name, presence: true, unless: :skip_user_verification?
 
-  validates :title, length: { in: 4..Proposal.title_max_length }
-  validates :description, length: { maximum: Proposal.description_max_length }
-  validates :question, length: { in: 10..Proposal.question_max_length }
   validates :responsible_name, length: { in: 6..Proposal.responsible_name_max_length }, unless: :skip_user_verification?
-  validates :retired_reason, inclusion: { in: RETIRE_OPTIONS, allow_nil: true }
+  validates :retired_reason, presence: true, inclusion: { in: RETIRE_OPTIONS }, unless: -> { retired_at.blank? }
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
 
@@ -223,5 +231,4 @@ class Proposal < ActiveRecord::Base
         self.responsible_name = author.document_number
       end
     end
-
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -102,15 +102,19 @@ class Proposal < ActiveRecord::Base
     "#{id}-#{title}".parameterize
   end
 
+  def searchable_translations_definitions
+    { title       => "A",
+      question    => "B",
+      summary     => "C",
+      description => "D" }
+  end
+
   def searchable_values
-    { title              => "A",
-      question           => "B",
-      author.username    => "B",
-      tag_list.join(" ") => "B",
-      geozone.try(:name) => "B",
-      summary            => "C",
-      description        => "D"
-    }
+    {
+      author.username       => "B",
+      tag_list.join(" ")    => "B",
+      geozone.try(:name)    => "B"
+    }.merge!(searchable_globalized_values)
   end
 
   def self.search(terms)
@@ -231,4 +235,5 @@ class Proposal < ActiveRecord::Base
         self.responsible_name = author.document_number
       end
     end
+
 end

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -5,7 +5,6 @@
   <%= render "shared/errors", resource: @proposal %>
 
   <div class="row">
-
     <%= f.translatable_fields do |translations_form| %>
       <div class="small-12 column">
         <%= translations_form.text_field :title,
@@ -13,10 +12,10 @@
               placeholder: t("proposals.form.proposal_title"),
               label: t("proposals.form.proposal_title"),
               data: { js_suggest_result: "js_suggest_result",
-                      js_suggest: "#js-suggest",
+                      js_suggest: ".js-suggest",
                       js_url: suggest_proposals_path } %>
       </div>
-      <div id="js-suggest"></div>
+      <div class="js-suggest" data-locale="<%= translations_form.locale %>"></div>
 
       <div class="small-12 column">
         <%= translations_form.label :question %>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -1,43 +1,62 @@
-<%= form_for(@proposal, url: form_url) do |f| %>
+<%= render "admin/shared/globalize_locales", resource: @proposal %>
+
+<%= translatable_form_for(@proposal, url: form_url) do |f| %>
+
   <%= render "shared/errors", resource: @proposal %>
 
   <div class="row">
-    <div class="small-12 column">
-      <%= f.label :title, t("proposals.form.proposal_title") %>
-      <%= f.text_field :title, maxlength: Proposal.title_max_length, placeholder: t("proposals.form.proposal_title"), label: false, data: {js_suggest_result: "js_suggest_result", js_suggest: "#js-suggest", js_url: suggest_proposals_path}%>
-    </div>
-    <div id="js-suggest"></div>
+
+    <%= f.translatable_fields do |translations_form| %>
+      <div class="small-12 column">
+        <%= translations_form.text_field :title,
+              maxlength: Proposal.title_max_length,
+              placeholder: t("proposals.form.proposal_title"),
+              label: t("proposals.form.proposal_title"),
+              data: { js_suggest_result: "js_suggest_result",
+                      js_suggest: "#js-suggest",
+                      js_url: suggest_proposals_path } %>
+      </div>
+      <div id="js-suggest"></div>
+
+      <div class="small-12 column">
+        <%= translations_form.label :question %>
+        <p class="help-text" id=<%= question_help_text_id(translations_form) %>>
+          <%= t("proposals.form.proposal_question_example_html") %>
+        </p>
+        <%= translations_form.text_field :question,
+              maxlength: Proposal.question_max_length,
+              placeholder: t("proposals.form.proposal_question"),
+              label: false,
+              aria: { describedby: question_help_text_id(translations_form) } %>
+      </div>
+
+      <div class="small-12 column">
+        <%= translations_form.label :summary %>
+        <p class="help-text" id=<%= summary_help_text_id(translations_form) %>>
+          <%= t("proposals.form.proposal_summary_note") %>
+        </p>
+        <%= translations_form.text_area :summary,
+                                        rows: 4, maxlength: 200,
+                                        label: false,
+                                        placeholder: t("proposals.form.proposal_summary"),
+                                        aria: {describedby: summary_help_text_id(translations_form)} %>
+      </div>
+
+      <div class="ckeditor small-12 column">
+        <%= translations_form.cktext_area :description,
+                                          maxlength: Proposal.description_max_length,
+                                          ckeditor: { language: I18n.locale },
+                                          label: t("proposals.form.proposal_text") %>
+      </div>
+    <% end %>
 
     <%= f.invisible_captcha :subtitle %>
 
     <div class="small-12 column">
-      <%= f.label :question, t("proposals.form.proposal_question") %>
-      <p class="help-text" id="question-help-text">
-        <%= t("proposals.form.proposal_question_example_html") %>
-      </p>
-      <%= f.text_field :question, maxlength: Proposal.question_max_length,
-                                  placeholder: t("proposals.form.proposal_question"),
-                                  label: false,
-                                  aria: {describedby: "question-help-text"} %>
-    </div>
-
-    <div class="small-12 column">
-      <%= f.label :summary, t("proposals.form.proposal_summary") %>
-      <p class="help-text" id="summary-help-text"><%= t("proposals.form.proposal_summary_note") %></p>
-      <%= f.text_area :summary, rows: 4, maxlength: 200, label: false,
-                      placeholder: t("proposals.form.proposal_summary"),
-                      aria: {describedby: "summary-help-text"} %>
-    </div>
-
-    <div class="ckeditor small-12 column">
-      <%= f.label :description, t("proposals.form.proposal_text") %>
-      <%= f.cktext_area :description, maxlength: Proposal.description_max_length, ckeditor: { language: I18n.locale }, label: false %>
-    </div>
-
-    <div class="small-12 column">
       <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
       <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
-      <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false,
+      <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"),
+                                   label: false,
                                    aria: {describedby: "video-url-help-text"} %>
     </div>
 

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -10,7 +10,6 @@
         <%= translations_form.text_field :title,
               maxlength: Proposal.title_max_length,
               placeholder: t("proposals.form.proposal_title"),
-              label: t("proposals.form.proposal_title"),
               data: { js_suggest_result: "js_suggest_result",
                       js_suggest: ".js-suggest",
                       js_url: suggest_proposals_path } %>
@@ -44,8 +43,7 @@
       <div class="ckeditor small-12 column">
         <%= translations_form.cktext_area :description,
                                           maxlength: Proposal.description_max_length,
-                                          ckeditor: { language: I18n.locale },
-                                          label: t("proposals.form.proposal_text") %>
+                                          ckeditor: { language: I18n.locale } %>
       </div>
     <% end %>
 

--- a/app/views/proposals/retire_form.html.erb
+++ b/app/views/proposals/retire_form.html.erb
@@ -23,10 +23,9 @@
 
       <div class="row">
         <%= f.translatable_fields do |translations_form| %>
-          <div class="small-12 medium-9 column">
+          <div class="small-12 medium-9 column float-left">
             <%= translations_form.text_area :retired_explanation,
                   rows: 4, maxlength: 500,
-                  label:  t("proposals.retire_form.retired_explanation_label"),
                   placeholder: t("proposals.retire_form.retired_explanation_placeholder") %>
           </div>
         <% end %>

--- a/app/views/proposals/retire_form.html.erb
+++ b/app/views/proposals/retire_form.html.erb
@@ -10,7 +10,9 @@
      <%= t("proposals.retire_form.warning") %>
     </div>
 
-    <%= form_for(@proposal, url: retire_proposal_path(@proposal)) do |f| %>
+    <%= render "admin/shared/globalize_locales", resource: @proposal %>
+
+    <%= translatable_form_for(@proposal, url: retire_proposal_path(@proposal)) do |f| %>
       <%= render "shared/errors", resource: @proposal %>
       <div class="row">
         <div class="small-12 medium-6 large-4 column">
@@ -20,11 +22,14 @@
       </div>
 
       <div class="row">
-        <div class="small-12 medium-9 column">
-          <%= f.label :retired_explanation, t("proposals.retire_form.retired_explanation_label") %>
-          <%= f.text_area :retired_explanation, rows: 4, maxlength: 500, label: false,
-                          placeholder: t("proposals.retire_form.retired_explanation_placeholder") %>
-        </div>
+        <%= f.translatable_fields do |translations_form| %>
+          <div class="small-12 medium-9 column">
+            <%= translations_form.text_area :retired_explanation,
+                  rows: 4, maxlength: 500,
+                  label:  t("proposals.retire_form.retired_explanation_label"),
+                  placeholder: t("proposals.retire_form.retired_explanation_placeholder") %>
+          </div>
+        <% end %>
       </div>
 
       <div class="row">

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -169,6 +169,12 @@ en:
         question: "Question"
         description: "Description"
         terms_of_service: "Terms of service"
+      proposal/translation:
+        title: "Proposal title"
+        description: "Proposal text"
+        question: "Proposal question"
+        summary: "Proposal summary"
+        retired_explanation: "Explanation"
       user:
         login: "Email or username"
         email: "Email"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -301,7 +301,6 @@ en:
       warning: "If you retire the proposal it would still accept supports, but will be removed from the main list and a message will be visible to all users stating that the author considers the proposal should not be supported anymore"
       retired_reason_label: Reason to retire the proposal
       retired_reason_blank: Choose an option
-      retired_explanation_label: Explanation
       retired_explanation_placeholder: Explain shortly why you think this proposal should not receive more supports
       submit_button: Retire proposal
     retire_options:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -169,6 +169,12 @@ es:
         question: "Pregunta"
         description: "Descripción"
         terms_of_service: "Términos de servicio"
+      proposal/translation:
+        title: "Título de la propuesta"
+        description: "Texto desarrollado de la propuesta"
+        question: "Pregunta de la propuesta"
+        summary: "Resumen de la propuesta"
+        retired_explanation: "Explicación"
       user:
         login: "Email o nombre de usuario"
         email: "Email"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -301,7 +301,6 @@ es:
       warning: "Si sigues adelante tu propuesta podrá seguir recibiendo apoyos, pero dejará de ser listada en la lista principal, y aparecerá un mensaje para todos los usuarios avisándoles de que el autor considera que esta propuesta no debe seguir recogiendo apoyos."
       retired_reason_label: Razón por la que se retira la propuesta
       retired_reason_blank: Selecciona una opción
-      retired_explanation_label: Explicación
       retired_explanation_placeholder: Explica brevemente por que consideras que esta propuesta no debe recoger más apoyos
       submit_button: Retirar propuesta
     retire_options:

--- a/db/dev_seeds/proposals.rb
+++ b/db/dev_seeds/proposals.rb
@@ -24,20 +24,33 @@ end
 section "Creating Proposals" do
   tags = Faker::Lorem.words(25)
   30.times do
-    author = User.all.sample
+    title = Faker::Lorem.sentence(3).truncate(60)
+    question = Faker::Lorem.sentence(3) + "?"
+    summary = Faker::Lorem.sentence(3)
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
+    author = User.all.sample
+
     proposal = Proposal.create!(author: author,
-                                title: Faker::Lorem.sentence(3).truncate(60),
-                                question: Faker::Lorem.sentence(3) + "?",
-                                summary: Faker::Lorem.sentence(3),
+                                title: title,
+                                question: question,
+                                summary: summary,
+                                description: description,
                                 responsible_name: Faker::Name.name,
                                 external_url: Faker::Internet.url,
-                                description: description,
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(","),
                                 geozone: Geozone.all.sample,
                                 skip_map: "1",
                                 terms_of_service: "1")
+    random_locales.map do |locale|
+      Globalize.with_locale(locale) do
+        proposal.title = "Title for locale #{locale}"
+        proposal.question = "Question for locale #{locale}?"
+        proposal.summary = "Summary for locale #{locale}"
+        proposal.description = "<p>Description for locale #{locale}</p>"
+        proposal.save!
+      end
+    end
     add_image_to proposal
   end
 end
@@ -59,6 +72,15 @@ section "Creating Archived Proposals" do
                                 skip_map: "1",
                                 terms_of_service: "1",
                                 created_at: Setting["months_to_archive_proposals"].to_i.months.ago)
+    random_locales.map do |locale|
+      Globalize.with_locale(locale) do
+        proposal.title = "Archived proposal title for locale #{locale}"
+        proposal.question = "Archived proposal question for locale #{locale}?"
+        proposal.summary = "Archived proposal title summary for locale #{locale}"
+        proposal.description = "<p>Archived proposal description for locale #{locale}</p>"
+        proposal.save!
+      end
+    end
     add_image_to proposal
   end
 end
@@ -81,6 +103,15 @@ section "Creating Successful Proposals" do
                                 skip_map: "1",
                                 terms_of_service: "1",
                                 cached_votes_up: Setting["votes_for_proposal_success"])
+    random_locales.map do |locale|
+      Globalize.with_locale(locale) do
+        proposal.title = "Successful proposal title for locale #{locale}"
+        proposal.question = "Successful proposal question for locale #{locale}?"
+        proposal.summary = "Successful proposal title summary for locale #{locale}"
+        proposal.description = "<p>Successful proposal description for locale #{locale}</p>"
+        proposal.save!
+      end
+    end
     add_image_to proposal
   end
 
@@ -100,6 +131,15 @@ section "Creating Successful Proposals" do
                                 geozone: Geozone.all.sample,
                                 skip_map: "1",
                                 terms_of_service: "1")
+    random_locales.map do |locale|
+      Globalize.with_locale(locale) do
+        proposal.title = "Tagged proposal title for locale #{locale}"
+        proposal.question = "Tagged proposal question for locale #{locale}?"
+        proposal.summary = "Tagged proposal title summary for locale #{locale}"
+        proposal.description = "<p>Tagged proposal description for locale #{locale}</p>"
+        proposal.save!
+      end
+    end
     add_image_to proposal
   end
 end

--- a/db/migrate/20181129115006_add_proposals_translations.rb
+++ b/db/migrate/20181129115006_add_proposals_translations.rb
@@ -1,0 +1,18 @@
+class AddProposalsTranslations < ActiveRecord::Migration
+  def self.up
+    Proposal.create_translation_table!(
+      {
+        title:               :string,
+        description:         :text,
+        question:            :string,
+        summary:             :text,
+        retired_explanation: :text
+      },
+      { migrate_data: true }
+    )
+  end
+
+  def self.down
+    Proposal.drop_translation_table!
+  end
+end

--- a/db/migrate/20190123122511_add_hidden_at_to_proposal_translations.rb
+++ b/db/migrate/20190123122511_add_hidden_at_to_proposal_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToProposalTranslations < ActiveRecord::Migration
+  def change
+    add_column :proposal_translations, :hidden_at, :datetime
+    add_index :proposal_translations, :hidden_at
+  end
+end

--- a/db/migrate/20190215152236_rename_old_translatable_attibutes_in_proposals.rb
+++ b/db/migrate/20190215152236_rename_old_translatable_attibutes_in_proposals.rb
@@ -1,0 +1,13 @@
+class RenameOldTranslatableAttibutesInProposals < ActiveRecord::Migration
+  def change
+    remove_index :proposals, :title
+    remove_index :proposals, :question
+    remove_index :proposals, :summary
+
+    rename_column :proposals, :title, :deprecated_title
+    rename_column :proposals, :description, :deprecated_description
+    rename_column :proposals, :question, :deprecated_question
+    rename_column :proposals, :summary, :deprecated_summary
+    rename_column :proposals, :retired_explanation, :deprecated_retired_explanation
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1152,6 +1152,21 @@ ActiveRecord::Schema.define(version: 20190325185550) do
     t.datetime "confirmed_hide_at"
   end
 
+  create_table "proposal_translations", force: :cascade do |t|
+    t.integer  "proposal_id",         null: false
+    t.string   "locale",              null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.string   "title"
+    t.text     "description"
+    t.string   "question"
+    t.text     "summary"
+    t.text     "retired_explanation"
+  end
+
+  add_index "proposal_translations", ["locale"], name: "index_proposal_translations_on_locale", using: :btree
+  add_index "proposal_translations", ["proposal_id"], name: "index_proposal_translations_on_proposal_id", using: :btree
+
   create_table "proposals", force: :cascade do |t|
     t.string   "title",               limit: 80
     t.text     "description"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1162,8 +1162,10 @@ ActiveRecord::Schema.define(version: 20190325185550) do
     t.string   "question"
     t.text     "summary"
     t.text     "retired_explanation"
+    t.datetime "hidden_at"
   end
 
+  add_index "proposal_translations", ["hidden_at"], name: "index_proposal_translations_on_hidden_at", using: :btree
   add_index "proposal_translations", ["locale"], name: "index_proposal_translations_on_locale", using: :btree
   add_index "proposal_translations", ["proposal_id"], name: "index_proposal_translations_on_proposal_id", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1168,9 +1168,9 @@ ActiveRecord::Schema.define(version: 20190325185550) do
   add_index "proposal_translations", ["proposal_id"], name: "index_proposal_translations_on_proposal_id", using: :btree
 
   create_table "proposals", force: :cascade do |t|
-    t.string   "title",               limit: 80
-    t.text     "description"
-    t.string   "question"
+    t.string   "deprecated_title",               limit: 80
+    t.text     "deprecated_description"
+    t.string   "deprecated_question"
     t.string   "external_url"
     t.integer  "author_id"
     t.datetime "hidden_at"
@@ -1184,13 +1184,13 @@ ActiveRecord::Schema.define(version: 20190325185550) do
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
     t.string   "responsible_name",    limit: 60
-    t.text     "summary"
+    t.text     "deprecated_summary"
     t.string   "video_url"
     t.tsvector "tsv"
     t.integer  "geozone_id"
     t.datetime "retired_at"
     t.string   "retired_reason"
-    t.text     "retired_explanation"
+    t.text     "deprecated_retired_explanation"
     t.integer  "community_id"
   end
 
@@ -1202,9 +1202,6 @@ ActiveRecord::Schema.define(version: 20190325185550) do
   add_index "proposals", ["geozone_id"], name: "index_proposals_on_geozone_id", using: :btree
   add_index "proposals", ["hidden_at"], name: "index_proposals_on_hidden_at", using: :btree
   add_index "proposals", ["hot_score"], name: "index_proposals_on_hot_score", using: :btree
-  add_index "proposals", ["question"], name: "index_proposals_on_question", using: :btree
-  add_index "proposals", ["summary"], name: "index_proposals_on_summary", using: :btree
-  add_index "proposals", ["title"], name: "index_proposals_on_title", using: :btree
   add_index "proposals", ["tsv"], name: "index_proposals_on_tsv", using: :gin
 
   create_table "related_content_scores", force: :cascade do |t|

--- a/lib/tasks/proposals.rake
+++ b/lib/tasks/proposals.rake
@@ -11,10 +11,14 @@ namespace :proposals do
       print "Move external_url to description for #{model}s"
       model.find_each do |resource|
         if resource.external_url.present?
-          resource.update_columns(description: "#{resource.description} "\
-                                  "<p>#{text_with_links(resource.external_url)}</p>",
-                                  external_url: "", updated_at: Time.current)
-          print "."
+          Globalize.with_locale(I18n.default_locale) do
+            new_description = "#{resource.description} <p>#{text_with_links(resource.external_url)}</p>"
+            resource.description = new_description
+            resource.external_url = ""
+            resource.updated_at = Time.current
+            resource.save(validate: false)
+            print "."
+          end
         end
       end
       puts " ✅ "

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -51,6 +51,12 @@ FactoryBot.define do
     trait :successful do
       cached_votes_up { Proposal.votes_needed_for_success + 100 }
     end
+
+    trait :retired do
+      retired_at { Time.current }
+      retired_reason "unfeasible"
+      retired_explanation "Retired explanation"
+    end
   end
 
   factory :proposal_notification do

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -21,10 +21,10 @@ feature "Proposals" do
         expect(page).to have_content user.document_number.to_s
       end
 
-      fill_in "proposal_title", with: "Help refugees"
-      fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-      fill_in "proposal_summary", with: "In summary, what we want is..."
-      fill_in "proposal_description", with: "This is very important because..."
+      fill_in "Proposal title", with: "Help refugees"
+      fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+      fill_in "Proposal summary", with: "In summary, what we want is..."
+      fill_in "Proposal text", with: "This is very important because..."
       fill_in "proposal_external_url", with: "http://rescue.org/refugees"
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yRYFKcMa_Ek"
       check "proposal_terms_of_service"

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -217,14 +217,14 @@ feature "Proposals" do
     login_as(author)
 
     visit new_proposal_path
-    fill_in "proposal_title", with: "Help refugees"
-    fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-    fill_in "proposal_summary", with: "In summary, what we want is..."
-    fill_in "proposal_description", with: "This is very important because..."
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
-    fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
+    fill_in "Proposal title", with: "Help refugees"
+    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in "Proposal text", with: "This is very important because..."
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_tag_list", with: "Refugees, Solidarity"
+    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
+    fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
     check "proposal_terms_of_service"
 
     click_button "Create proposal"
@@ -247,17 +247,45 @@ feature "Proposals" do
     expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)
   end
 
+  scenario "Create with proposal improvement info link" do
+    Setting["proposal_improvement_path"] = "/more-information/proposal-improvement"
+    author = create(:user)
+    login_as(author)
+
+    visit new_proposal_path
+    fill_in "Proposal title", with: "Help refugees"
+    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in "Proposal text", with: "This is very important because..."
+    fill_in "proposal_responsible_name", with: "Isabel Garcia"
+    fill_in "proposal_tag_list", with: "Refugees, Solidarity"
+    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
+    fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
+    check "proposal_terms_of_service"
+
+    click_button "Create proposal"
+
+    expect(page).to have_content "Proposal created successfully."
+    expect(page).to have_content "Improve your campaign and get more supports"
+
+    click_link "Not now, go to my proposal"
+
+    expect(page).to have_content "Help refugees"
+
+    Setting["proposal_improvement_path"] = nil
+  end
+
   scenario "Create with invisible_captcha honeypot field" do
     author = create(:user)
     login_as(author)
 
     visit new_proposal_path
-    fill_in "proposal_title", with: "I am a bot"
+    fill_in "Proposal title", with: "I am a bot"
     fill_in "proposal_subtitle", with: "This is the honeypot field"
-    fill_in "proposal_question", with: "This is a question"
-    fill_in "proposal_summary", with: "This is the summary"
-    fill_in "proposal_description", with: "This is the description"
     fill_in "proposal_external_url", with: "http://google.com/robots.txt"
+    fill_in "Proposal question", with: "This is a question"
+    fill_in "Proposal summary", with: "This is the summary"
+    fill_in "Proposal text", with: "This is the description"
     fill_in "proposal_responsible_name", with: "Some other robot"
     check "proposal_terms_of_service"
 
@@ -275,12 +303,12 @@ feature "Proposals" do
     login_as(author)
 
     visit new_proposal_path
-    fill_in "proposal_title", with: "I am a bot"
-    fill_in "proposal_question", with: "This is a question"
-    fill_in "proposal_summary", with: "This is the summary"
-    fill_in "proposal_description", with: "This is the description"
-    fill_in "proposal_external_url", with: "http://google.com/robots.txt"
+    fill_in "Proposal title", with: "I am a bot"
+    fill_in "Proposal question", with: "This is a question"
+    fill_in "Proposal summary", with: "This is the summary"
+    fill_in "Proposal text", with: "This is the description"
     fill_in "proposal_responsible_name", with: "Some other robot"
+    fill_in "proposal_external_url", with: "http://google.com/robots.txt"
     check "proposal_terms_of_service"
 
     click_button "Create proposal"
@@ -295,13 +323,14 @@ feature "Proposals" do
     login_as(author)
 
     visit new_proposal_path
-    fill_in "proposal_title", with: "Help refugees"
-    fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-    fill_in "proposal_summary", with: "In summary, what we want is..."
-    fill_in "proposal_description", with: "This is very important because..."
+
+    fill_in "Proposal title", with: "Help refugees"
+    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in "Proposal text", with: "This is very important because..."
+    fill_in "proposal_responsible_name", with: "Isabel Garcia"
+    fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_external_url", with: "http://rescue.org/refugees"
-    fill_in "proposal_responsible_name", with: "Isabel Garcia"
-    fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"
 
     click_button "Create proposal"
@@ -320,10 +349,10 @@ feature "Proposals" do
     visit new_proposal_path
     expect(page).not_to have_selector("#proposal_responsible_name")
 
-    fill_in "proposal_title", with: "Help refugees"
-    fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-    fill_in "proposal_summary", with: "In summary, what we want is..."
-    fill_in "proposal_description", with: "This is very important because..."
+    fill_in "Proposal title", with: "Help refugees"
+    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in "Proposal text", with: "This is very important because..."
     fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     check "proposal_terms_of_service"
 
@@ -350,12 +379,12 @@ feature "Proposals" do
     login_as(author)
 
     visit new_proposal_path
-    fill_in "proposal_title", with: "Testing an attack"
-    fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-    fill_in "proposal_summary", with: "In summary, what we want is..."
-    fill_in "proposal_description", with: "<p>This is <script>alert('an attack');</script></p>"
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
+    fill_in "Proposal title", with: "Testing an attack"
+    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in "Proposal text", with: "<p>This is <script>alert(\"an attack\");</script></p>"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
+    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     check "proposal_terms_of_service"
 
     click_button "Create proposal"
@@ -375,10 +404,10 @@ feature "Proposals" do
     login_as(author)
 
     visit new_proposal_path
-    fill_in "proposal_title", with: "Testing auto link"
-    fill_in "proposal_question", with: "Should I stay or should I go?"
-    fill_in "proposal_summary", with: "In summary, what we want is..."
-    fill_in "proposal_description", with: "<p>This is a link www.example.org</p>"
+    fill_in "Proposal title", with: "Testing auto link"
+    fill_in "Proposal question", with: "Should I stay or should I go?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in "Proposal text", with: "<p>This is a link www.example.org</p>"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"
 
@@ -398,10 +427,10 @@ feature "Proposals" do
     login_as(author)
 
     visit new_proposal_path
-    fill_in "proposal_title", with: "Testing auto link"
-    fill_in "proposal_question", with: "Should I stay or should I go?"
-    fill_in "proposal_summary", with: "In summary, what we want is..."
-    fill_in "proposal_description", with: js_injection_string
+    fill_in "Proposal title", with: "Testing auto link"
+    fill_in "Proposal question", with: "Should I stay or should I go?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in "Proposal text", with: js_injection_string
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"
 
@@ -431,13 +460,13 @@ feature "Proposals" do
 
       visit new_proposal_path
 
-      fill_in "proposal_title", with: "Help refugees"
-      fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-      fill_in "proposal_summary", with: "In summary, what we want is..."
-      fill_in "proposal_description", with: "This is very important because..."
+      fill_in "Proposal title", with: "Help refugees"
+      fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+      fill_in "Proposal summary", with: "In summary, what we want is..."
+      fill_in "Proposal text", with: "This is very important because..."
+      fill_in "proposal_responsible_name", with: "Isabel Garcia"
       fill_in "proposal_external_url", with: "http://rescue.org/refugees"
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
-      fill_in "proposal_responsible_name", with: "Isabel Garcia"
       check "proposal_terms_of_service"
 
       click_button "Create proposal"
@@ -459,13 +488,13 @@ feature "Proposals" do
 
       visit new_proposal_path
 
-      fill_in "proposal_title", with: "Help refugees"
-      fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-      fill_in "proposal_summary", with: "In summary, what we want is..."
-      fill_in "proposal_description", with: "This is very important because..."
+      fill_in "Proposal title", with: "Help refugees"
+      fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+      fill_in "Proposal summary", with: "In summary, what we want is..."
+      fill_in "Proposal text", with: "This is very important because..."
+      fill_in "proposal_responsible_name", with: "Isabel Garcia"
       fill_in "proposal_external_url", with: "http://rescue.org/refugees"
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
-      fill_in "proposal_responsible_name", with: "Isabel Garcia"
       check "proposal_terms_of_service"
 
       select("California", from: "proposal_geozone_id")
@@ -611,12 +640,12 @@ feature "Proposals" do
     visit edit_proposal_path(proposal)
     expect(page).to have_current_path(edit_proposal_path(proposal))
 
-    fill_in "proposal_title", with: "End child poverty"
-    fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-    fill_in "proposal_summary", with: "Basically..."
-    fill_in "proposal_description", with: "Let's do something to end child poverty"
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
+    fill_in "Proposal title", with: "End child poverty"
+    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+    fill_in "Proposal summary", with: "Basically..."
+    fill_in "Proposal text", with: "Let's do something to end child poverty"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
+    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
 
     click_button "Save changes"
 
@@ -631,7 +660,7 @@ feature "Proposals" do
     login_as(proposal.author)
 
     visit edit_proposal_path(proposal)
-    fill_in "proposal_title", with: ""
+    fill_in "Proposal title", with: ""
     click_button "Save changes"
 
     expect(page).to have_content error_message
@@ -1620,7 +1649,7 @@ feature "Proposals" do
       create(:proposal, title: "Seventh proposal, has search term")
 
       visit new_proposal_path
-      fill_in "proposal_title", with: "search"
+      fill_in "Proposal title", with: "search"
       check "proposal_terms_of_service"
 
       within("div#js-suggest") do
@@ -1636,7 +1665,7 @@ feature "Proposals" do
       create(:proposal, title: "Second proposal").update_column(:confidence_score, 8)
 
       visit new_proposal_path
-      fill_in "proposal_title", with: "debate"
+      fill_in "Proposal title", with: "debate"
       check "proposal_terms_of_service"
 
       within("div#js-suggest") do
@@ -1814,13 +1843,13 @@ feature "Successful proposals" do
 
       expect(current_path).to eq(new_proposal_path)
 
-      fill_in "proposal_title", with: "Help refugees"
-      fill_in "proposal_summary", with: "In summary what we want is..."
-      fill_in "proposal_question", with: "Would you like to?"
-      fill_in "proposal_description", with: "This is very important because..."
+      fill_in "Proposal title", with: "Help refugees"
+      fill_in "Proposal question", with: "Would you like to?"
+      fill_in "Proposal summary", with: "In summary what we want is..."
+      fill_in "Proposal text", with: "This is very important because..."
+      fill_in "proposal_tag_list", with: "Refugees, Solidarity"
       fill_in "proposal_external_url", with: "http://rescue.org/refugees"
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
-      fill_in "proposal_tag_list", with: "Refugees, Solidarity"
       check "proposal_terms_of_service"
 
       click_button "Create proposal"

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -15,6 +15,11 @@ feature "Proposals" do
   context "Concerns" do
     it_behaves_like "notifiable in-app", Proposal
     it_behaves_like "relationable", Proposal
+    it_behaves_like "translatable",
+                    "proposal",
+                    "edit_proposal_path",
+                    %w[title question summary],
+                    { "description" => :ckeditor }
   end
 
   context "Index" do

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1657,7 +1657,7 @@ feature "Proposals" do
       fill_in "Proposal title", with: "search"
       check "proposal_terms_of_service"
 
-      within("div#js-suggest") do
+      within("div.js-suggest") do
         expect(page).to have_content "You are seeing 5 of 6 proposals containing the term 'search'"
       end
     end
@@ -1673,7 +1673,7 @@ feature "Proposals" do
       fill_in "Proposal title", with: "debate"
       check "proposal_terms_of_service"
 
-      within("div#js-suggest") do
+      within("div.js-suggest") do
         expect(page).not_to have_content "You are seeing"
       end
     end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -252,34 +252,6 @@ feature "Proposals" do
     expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)
   end
 
-  scenario "Create with proposal improvement info link" do
-    Setting["proposal_improvement_path"] = "/more-information/proposal-improvement"
-    author = create(:user)
-    login_as(author)
-
-    visit new_proposal_path
-    fill_in "Proposal title", with: "Help refugees"
-    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
-    fill_in "Proposal summary", with: "In summary, what we want is..."
-    fill_in "Proposal text", with: "This is very important because..."
-    fill_in "proposal_responsible_name", with: "Isabel Garcia"
-    fill_in "proposal_tag_list", with: "Refugees, Solidarity"
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
-    fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
-    check "proposal_terms_of_service"
-
-    click_button "Create proposal"
-
-    expect(page).to have_content "Proposal created successfully."
-    expect(page).to have_content "Improve your campaign and get more supports"
-
-    click_link "Not now, go to my proposal"
-
-    expect(page).to have_content "Help refugees"
-
-    Setting["proposal_improvement_path"] = nil
-  end
-
   scenario "Create with invisible_captcha honeypot field" do
     author = create(:user)
     login_as(author)
@@ -387,7 +359,7 @@ feature "Proposals" do
     fill_in "Proposal title", with: "Testing an attack"
     fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
     fill_in "Proposal summary", with: "In summary, what we want is..."
-    fill_in "Proposal text", with: "<p>This is <script>alert(\"an attack\");</script></p>"
+    fill_in "Proposal text", with: "<p>This is <script>alert('an attack');</script></p>"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     check "proposal_terms_of_service"

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -494,7 +494,7 @@ feature "Proposals" do
       expect(page).to have_current_path(retire_form_proposal_path(proposal))
 
       select "Duplicated", from: "proposal_retired_reason"
-      fill_in "proposal_retired_explanation", with: "There are three other better proposals with the same subject"
+      fill_in "Explanation", with: "There are three other better proposals with the same subject"
       click_button "Retire proposal"
 
       expect(page).to have_content "Proposal retired"
@@ -507,7 +507,7 @@ feature "Proposals" do
       expect(page).to have_content "There are three other better proposals with the same subject"
     end
 
-    scenario "Fields are mandatory" do
+    scenario "Fields are mandatory", :js do
       proposal = create(:proposal)
       login_as(proposal.author)
 
@@ -523,7 +523,7 @@ feature "Proposals" do
       Setting["feature.featured_proposals"] = true
       create_featured_proposals
       not_retired = create(:proposal)
-      retired = create(:proposal, retired_at: Time.current)
+      retired = create(:proposal, :retired)
 
       visit proposals_path
 
@@ -537,7 +537,7 @@ feature "Proposals" do
     scenario "Index has a link to retired proposals list" do
       create_featured_proposals
       not_retired = create(:proposal)
-      retired = create(:proposal, retired_at: Time.current)
+      retired = create(:proposal, :retired)
 
       visit proposals_path
 
@@ -557,8 +557,8 @@ feature "Proposals" do
     end
 
     scenario "Retired proposals index has links to filter by retired_reason" do
-      unfeasible = create(:proposal, retired_at: Time.current, retired_reason: "unfeasible")
-      duplicated = create(:proposal, retired_at: Time.current, retired_reason: "duplicated")
+      unfeasible = create(:proposal, :retired, retired_reason: "unfeasible")
+      duplicated = create(:proposal, :retired, retired_reason: "duplicated")
 
       visit proposals_path(retired: "all")
 

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -69,10 +69,10 @@ feature "Tags" do
     login_as(user)
 
     visit new_proposal_path
-    fill_in "proposal_title", with: "Help refugees"
-    fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-    fill_in "proposal_summary", with: "In summary, what we want is..."
-    fill_in "proposal_description", with: "This is very important because..."
+    fill_in "Proposal title", with: "Help refugees"
+    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in "Proposal text", with: "This is very important because..."
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_tag_list", with: "Economía, Hacienda"
     check "proposal_terms_of_service"
@@ -96,10 +96,10 @@ feature "Tags" do
 
     visit new_proposal_path
 
-    fill_in "proposal_title", with: "Help refugees"
-    fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-    fill_in "proposal_summary", with: "In summary, what we want is..."
-    fill_in_ckeditor "proposal_description", with: "A description with enough characters"
+    fill_in "Proposal title", with: "Help refugees"
+    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in_ckeditor "Proposal text", with: "A description with enough characters"
     fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=Ae6gQmhaMn4"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
@@ -123,8 +123,8 @@ feature "Tags" do
     login_as(user)
 
     visit new_proposal_path
-    fill_in "proposal_title", with: "Title"
-    fill_in "proposal_description", with: "Description"
+    fill_in "Proposal title", with: "Title"
+    fill_in "Proposal text", with: "Description"
     check "proposal_terms_of_service"
 
     fill_in "proposal_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
@@ -141,10 +141,10 @@ feature "Tags" do
 
     visit new_proposal_path
 
-    fill_in "proposal_title", with: "A test of dangerous strings"
-    fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-    fill_in "proposal_summary", with: "In summary, what we want is..."
-    fill_in "proposal_description", with: "A description suitable for this test"
+    fill_in "Proposal title", with: "A test of dangerous strings"
+    fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+    fill_in "Proposal summary", with: "In summary, what we want is..."
+    fill_in "Proposal text", with: "A description suitable for this test"
     fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"

--- a/spec/models/proposal_notification_spec.rb
+++ b/spec/models/proposal_notification_spec.rb
@@ -146,7 +146,9 @@ describe ProposalNotification do
       it "returns false if the resource is retired" do
         notification = create(:notification, notifiable: notifiable)
 
-        notifiable.proposal.update(retired_at: Time.current)
+        notifiable.proposal.update(retired_at: Time.current,
+          retired_explanation: "Unfeasible reason explanation",
+          retired_reason: "unfeasible")
         expect(notification.check_availability(proposal)).to be(false)
       end
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -503,27 +503,60 @@ describe Proposal do
 
     context "attributes" do
 
+      let(:attributes) { { title: "save the world",
+                           question: "to be or not to be",
+                           summary: "basically",
+                           description: "in order to save the world one must think about...",
+                           title_es: "para salvar el mundo uno debe pensar en...",
+                           question_es: "ser o no ser",
+                           summary_es: "basicamente",
+                           description_es: "uno debe pensar" } }
+
       it "searches by title" do
-        proposal = create(:proposal, title: "save the world")
+        proposal = create(:proposal, attributes)
         results = described_class.search("save the world")
         expect(results).to eq([proposal])
       end
 
+      it "searches by title across all languages translations" do
+        proposal = create(:proposal, attributes)
+        results = described_class.search("salvar el mundo")
+        expect(results).to eq([proposal])
+      end
+
       it "searches by summary" do
-        proposal = create(:proposal, summary: "basically...")
+        proposal = create(:proposal, attributes)
         results = described_class.search("basically")
         expect(results).to eq([proposal])
       end
 
+      it "searches by summary across all languages translations" do
+        proposal = create(:proposal, attributes)
+        results = described_class.search("basicamente")
+        expect(results).to eq([proposal])
+      end
+
       it "searches by description" do
-        proposal = create(:proposal, description: "in order to save the world one must think about...")
+        proposal = create(:proposal, attributes)
         results = described_class.search("one must think")
         expect(results).to eq([proposal])
       end
 
+      it "searches by description across all languages translations" do
+        proposal = create(:proposal, attributes)
+        results = described_class.search("uno debe pensar")
+        expect(results).to eq([proposal])
+      end
+
       it "searches by question" do
-        proposal = create(:proposal, question: "to be or not to be")
+        proposal = create(:proposal, attributes)
         results = described_class.search("to be or not to be")
+        expect(results).to eq([proposal])
+      end
+
+      it "searches by question across all languages translations" do
+        proposal = create(:proposal, attributes)
+        results = described_class.search("ser o no ser")
         expect(results).to eq([proposal])
       end
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -9,6 +9,7 @@ describe Proposal do
     it_behaves_like "notifiable"
     it_behaves_like "map validations"
     it_behaves_like "globalizable", :proposal
+    it_behaves_like "sanitizable"
   end
 
   it "is valid" do
@@ -43,38 +44,6 @@ describe Proposal do
   end
 
   describe "#description" do
-    it "is sanitized" do
-      proposal.description = "<script>alert('danger');</script>"
-
-      proposal.valid?
-
-      expect(proposal.description).to eq("alert('danger');")
-    end
-
-    it "is sanitized using globalize accessors" do
-      proposal.description_en = "<script>alert('danger');</script>"
-
-      proposal.valid?
-
-      expect(proposal.description_en).to eq("alert('danger');")
-    end
-
-    it "is html_safe" do
-      proposal.description = "<script>alert('danger');</script>"
-
-      proposal.valid?
-
-      expect(proposal.description).to be_html_safe
-    end
-
-    it "is html_safe using globalize accessors" do
-      proposal.description_en = "<script>alert('danger');</script>"
-
-      proposal.valid?
-
-      expect(proposal.description_en).to be_html_safe
-    end
-
     it "is not valid when very long" do
       proposal.description = "a" * 6001
       expect(proposal).not_to be_valid
@@ -157,12 +126,6 @@ describe Proposal do
   end
 
   describe "tag_list" do
-    it "sanitizes the tag list" do
-      proposal.tag_list = "user_id=1"
-      proposal.valid?
-      expect(proposal.tag_list).to eq(["user_id1"])
-    end
-
     it "is not valid with a tag list of more than 6 elements" do
       proposal.tag_list = ["Hacienda", "Economía", "Medio Ambiente", "Corrupción", "Fiestas populares", "Prensa", "Huelgas"]
       expect(proposal).not_to be_valid

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -10,6 +10,7 @@ describe Proposal do
     it_behaves_like "map validations"
     it_behaves_like "globalizable", :proposal
     it_behaves_like "sanitizable"
+    it_behaves_like "acts as paranoid", :proposal
   end
 
   it "is valid" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -8,6 +8,7 @@ describe Proposal do
     it_behaves_like "has_public_author"
     it_behaves_like "notifiable"
     it_behaves_like "map validations"
+    it_behaves_like "globalizable", :proposal
   end
 
   it "is valid" do
@@ -44,8 +45,34 @@ describe Proposal do
   describe "#description" do
     it "is sanitized" do
       proposal.description = "<script>alert('danger');</script>"
+
       proposal.valid?
+
       expect(proposal.description).to eq("alert('danger');")
+    end
+
+    it "is sanitized using globalize accessors" do
+      proposal.description_en = "<script>alert('danger');</script>"
+
+      proposal.valid?
+
+      expect(proposal.description_en).to eq("alert('danger');")
+    end
+
+    it "is html_safe" do
+      proposal.description = "<script>alert('danger');</script>"
+
+      proposal.valid?
+
+      expect(proposal.description).to be_html_safe
+    end
+
+    it "is html_safe using globalize accessors" do
+      proposal.description_en = "<script>alert('danger');</script>"
+
+      proposal.valid?
+
+      expect(proposal.description_en).to be_html_safe
     end
 
     it "is not valid when very long" do
@@ -158,6 +185,46 @@ describe Proposal do
     expect(proposal.code).to eq "TEST-#{proposal.created_at.strftime('%Y-%m')}-#{proposal.id}"
 
     Setting["proposal_code_prefix"] = "MAD"
+  end
+
+  describe "#retired_explanation" do
+    it "is valid when retired timestamp is present and retired explanation is defined" do
+      proposal.retired_at = Time.current
+      proposal.retired_explanation = "Duplicated of ..."
+      proposal.retired_reason = "duplicated"
+      expect(proposal).to be_valid
+    end
+
+    it "is not valid when retired_at is present and retired explanation is empty" do
+      proposal.retired_at = Time.current
+      proposal.retired_explanation = nil
+      proposal.retired_reason = "duplicated"
+      expect(proposal).not_to be_valid
+    end
+  end
+
+  describe "#retired_reason" do
+    it "is valid when retired timestamp is present and retired reason is defined" do
+      proposal.retired_at = Time.current
+      proposal.retired_explanation = "Duplicated of ..."
+      proposal.retired_reason = "duplicated"
+      expect(proposal).to be_valid
+    end
+
+    it "is not valid when retired timestamp is present but defined retired reason
+        is not included in retired reasons" do
+      proposal.retired_at = Time.current
+      proposal.retired_explanation = "Duplicated of ..."
+      proposal.retired_reason = "duplicate"
+      expect(proposal).not_to be_valid
+    end
+
+    it "is not valid when retired_at is present and retired reason is empty" do
+      proposal.retired_at = Time.current
+      proposal.retired_explanation = "Duplicated of ..."
+      proposal.retired_reason = nil
+      expect(proposal).not_to be_valid
+    end
   end
 
   describe "#editable?" do
@@ -845,7 +912,7 @@ describe Proposal do
 
   describe "retired" do
     let!(:proposal1) { create(:proposal) }
-    let!(:proposal2) { create(:proposal, retired_at: Time.current) }
+    let!(:proposal2) { create(:proposal, :retired) }
 
     it "retired? is true" do
       expect(proposal1.retired?).to eq false

--- a/spec/shared/features/mappable.rb
+++ b/spec/shared/features/mappable.rb
@@ -147,7 +147,7 @@ shared_examples "mappable" do |mappable_factory_name,
       do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
-      fill_in "#{mappable_factory_name}_title", with: "New title"
+      fill_in "#{mappable_factory_name.camelize} title", with: "New title"
       click_on("Save changes")
       mappable.reload
 
@@ -172,7 +172,7 @@ shared_examples "mappable" do |mappable_factory_name,
       do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
-      fill_in "#{mappable_factory_name}_title", with: "New title"
+      fill_in "#{mappable_factory_name.camelize} title", with: "New title"
       click_on("Save changes")
 
       expect(page).not_to have_css(".map_location")
@@ -249,9 +249,9 @@ def do_login_for(user)
 end
 
 def fill_in_proposal_form
-  fill_in "proposal_title", with: "Help refugees"
-  fill_in "proposal_question", with: "¿Would you like to give assistance to war refugees?"
-  fill_in "proposal_summary", with: "In summary, what we want is..."
+  fill_in "Proposal title", with: "Help refugees"
+  fill_in "Proposal question", with: "¿Would you like to give assistance to war refugees?"
+  fill_in "Proposal summary", with: "In summary, what we want is..."
 end
 
 def submit_proposal_form

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -353,9 +353,9 @@ def expect_document_has_cached_attachment(index, extension)
 end
 
 def documentable_fill_new_valid_proposal
-  fill_in :proposal_title, with: "Proposal title #{rand(9999)}"
-  fill_in :proposal_summary, with: "Proposal summary"
-  fill_in :proposal_question, with: "Proposal question?"
+  fill_in "Proposal title", with: "Proposal title #{rand(9999)}"
+  fill_in "Proposal summary", with: "Proposal summary"
+  fill_in "Proposal question", with: "Proposal question?"
   check :proposal_terms_of_service
 end
 

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -289,9 +289,9 @@ def imageable_attach_new_file(_imageable_factory_name, path, success = true)
 end
 
 def imageable_fill_new_valid_proposal
-  fill_in :proposal_title, with: "Proposal title"
-  fill_in :proposal_summary, with: "Proposal summary"
-  fill_in :proposal_question, with: "Proposal question?"
+  fill_in "Proposal title", with: "Proposal title"
+  fill_in "Proposal summary", with: "Proposal summary"
+  fill_in "Proposal question", with: "Proposal question?"
   check :proposal_terms_of_service
 end
 

--- a/spec/shared/models/notifiable.rb
+++ b/spec/shared/models/notifiable.rb
@@ -78,7 +78,8 @@ shared_examples "notifiable" do
       notification = create(:notification, notifiable: notifiable)
 
       if notifiable.respond_to?(:retired_at)
-        notifiable.update(retired_at: Time.current)
+        notifiable.update(retired_at: Time.current, retired_reason: "unfeasible",
+          retired_explanation: "Unfeasibility explanation ...")
         expect(notification.check_availability(notifiable)).to be(false)
       end
     end


### PR DESCRIPTION
## References

* Related Issues: #3130
* Related Pull Requests: This PR needs and includes these other PR's: #3240, #3241, #3242 

## Objectives

Add database translations to proposals and :

* Include all existing translations at pg_search feature
* Fix suggest feature
* Add soft deletion of translations
* Include translation interface
* Update translations rake task to migrate data to translations table
* Add proposal translations to dev_seeds

**The visually improved translation interface and new feature setting will be added in next PR's.**

## Visual Changes

![captura de pantalla 2018-12-05 a las 11 46 09](https://user-images.githubusercontent.com/15726/49509210-f388cb00-f884-11e8-9747-aad70a90f7c3.png)

![screen shot 2018-12-05 at 11 52 54](https://user-images.githubusercontent.com/15726/49509244-0ac7b880-f885-11e8-8417-d9f0aaa88087.png)

![screen shot 2018-12-05 at 11 50 40](https://user-images.githubusercontent.com/15726/49509245-0b604f00-f885-11e8-875b-d12e2e3b4c38.png)

![captura de pantalla 2018-12-05 a las 12 00 04](https://user-images.githubusercontent.com/15726/49510152-ad813680-f887-11e8-9fe2-d3dbe7e164e1.png)

## Notes
⚠️ For release notes:

Execute this command to migrate proposal data to new proposal translations table:
```bin/rake globalize:migrate_data RAILS_ENV=production```
