### PR TITLE
Debate translations

### DIFF
--- a/app/controllers/admin/debates_controller.rb
+++ b/app/controllers/admin/debates_controller.rb
@@ -17,7 +17,7 @@ class Admin::DebatesController < Admin::BaseController
   end
 
   def restore
-    @debate.restore
+    @debate.restore!(recursive: true)
     @debate.ignore_flag
     Activity.log(current_user, :restore, @debate)
     redirect_to request.query_parameters.merge(action: :index)

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -2,6 +2,7 @@ class DebatesController < ApplicationController
   include FeatureFlags
   include CommentableActions
   include FlagActions
+  include Translatable
 
   before_action :parse_tag_filter, only: :index
   before_action :authenticate_user!, except: [:index, :show, :map]
@@ -55,7 +56,8 @@ class DebatesController < ApplicationController
   private
 
     def debate_params
-      params.require(:debate).permit(:title, :description, :tag_list, :terms_of_service)
+      attributes = [:tag_list, :terms_of_service]
+      params.require(:debate).permit(attributes, translation_params(Debate))
     end
 
     def resource_model

--- a/app/models/concerns/globalizable.rb
+++ b/app/models/concerns/globalizable.rb
@@ -20,6 +20,18 @@ module Globalizable
     if self.paranoid? && translation_class.attribute_names.include?("hidden_at")
       translation_class.send :acts_as_paranoid, column: :hidden_at
     end
+
+    private
+
+    def searchable_globalized_values
+      values = {}
+      translations.each do |translation|
+        Globalize.with_locale(translation.locale) do
+          values.merge! searchable_translations_definitions
+        end
+      end
+      values
+    end
   end
 
   class_methods do

--- a/app/models/concerns/globalizable.rb
+++ b/app/models/concerns/globalizable.rb
@@ -23,15 +23,15 @@ module Globalizable
 
     private
 
-    def searchable_globalized_values
-      values = {}
-      translations.each do |translation|
-        Globalize.with_locale(translation.locale) do
-          values.merge! searchable_translations_definitions
+      def searchable_globalized_values
+        values = {}
+        translations.each do |translation|
+          Globalize.with_locale(translation.locale) do
+            values.merge! searchable_translations_definitions
+          end
         end
+        values
       end
-      values
-    end
   end
 
   class_methods do

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -60,13 +60,17 @@ class Debate < ActiveRecord::Base
       .where("author_id != ?", user.id)
   end
 
+  def searchable_translations_definitions
+    { title       => "A",
+      description => "D" }
+  end
+
   def searchable_values
-    { title              => "A",
+    {
       author.username    => "B",
       tag_list.join(" ") => "B",
       geozone.try(:name) => "B",
-      description        => "D"
-    }
+    }.merge!(searchable_globalized_values)
   end
 
   def self.search(terms)
@@ -156,4 +160,16 @@ class Debate < ActiveRecord::Base
     orders << "recommendations" if Setting["feature.user.recommendations_on_debates"] && user&.recommended_debates
     return orders
   end
+
+  private
+
+    def searchable_globalized_values
+      values = {}
+      translations.each do |translation|
+        Globalize.with_locale(translation.locale) do
+          values.merge! searchable_translations_definitions
+        end
+      end
+      values
+    end
 end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -18,16 +18,17 @@ class Debate < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
+  translates :title, touch: true
+  translates :description, touch: true
+  include Globalizable
+
   belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
   belongs_to :geozone
   has_many :comments, as: :commentable
 
-  validates :title, presence: true
-  validates :description, presence: true
+  validates_translation :title, presence: true, length: { in: 4..Debate.title_max_length }
+  validates_translation :description, presence: true, length: { in: 10..Debate.description_max_length }
   validates :author, presence: true
-
-  validates :title, length: { in: 4..Debate.title_max_length }
-  validates :description, length: { in: 10..Debate.description_max_length }
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
 

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -160,16 +160,4 @@ class Debate < ActiveRecord::Base
     orders << "recommendations" if Setting["feature.user.recommendations_on_debates"] && user&.recommended_debates
     return orders
   end
-
-  private
-
-    def searchable_globalized_values
-      values = {}
-      translations.each do |translation|
-        Globalize.with_locale(translation.locale) do
-          values.merge! searchable_translations_definitions
-        end
-      end
-      values
-    end
 end

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -20,8 +20,7 @@
       <div class="ckeditor small-12 column">
         <%= translations_form.cktext_area :description,
               maxlength: Debate.description_max_length,
-              ckeditor: { language: I18n.locale },
-              label: t("debates.form.debate_text") %>
+              ckeditor: { language: I18n.locale } %>
       </div>
     <% end %>
 

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -12,10 +12,10 @@
               maxlength: Debate.title_max_length,
               placeholder: t("debates.form.debate_title"),
               data: { js_suggest_result: "js_suggest_result",
-                      js_suggest: "#js-suggest",
+                      js_suggest: ".js-suggest",
                       js_url: suggest_debates_path } %>
       </div>
-      <div id="js-suggest"></div>
+      <div class="js-suggest" data-locale="<%= translations_form.locale %>"></div>
 
       <div class="ckeditor small-12 column">
         <%= translations_form.cktext_area :description,

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -1,17 +1,29 @@
-<%= form_for(@debate) do |f| %>
+<%= render "admin/shared/globalize_locales", resource: @debate %>
+
+<%= translatable_form_for(@debate) do |f| %>
 
   <%= render "shared/errors", resource: @debate %>
 
   <div class="row">
-    <div class="small-12 column">
-      <%= f.label :title, t("debates.form.debate_title") %>
-      <%= f.text_field :title, maxlength: Debate.title_max_length, placeholder: t("debates.form.debate_title"), label: false, data: {js_suggest_result: "js_suggest_result", js_suggest: "#js-suggest", js_url: suggest_debates_path}%>
-    </div>
-    <div id="js-suggest"></div>
-    <div class="ckeditor small-12 column">
-      <%= f.label :description, t("debates.form.debate_text") %>
-      <%= f.cktext_area :description, maxlength: Debate.description_max_length, ckeditor: { language: I18n.locale }, label: false %>
-    </div>
+
+    <%= f.translatable_fields do |translations_form| %>
+      <div class="small-12 column">
+        <%= translations_form.text_field :title,
+              maxlength: Debate.title_max_length,
+              placeholder: t("debates.form.debate_title"),
+              data: { js_suggest_result: "js_suggest_result",
+                      js_suggest: "#js-suggest",
+                      js_url: suggest_debates_path } %>
+      </div>
+      <div id="js-suggest"></div>
+
+      <div class="ckeditor small-12 column">
+        <%= translations_form.cktext_area :description,
+              maxlength: Debate.description_max_length,
+              ckeditor: { language: I18n.locale },
+              label: t("debates.form.debate_text") %>
+      </div>
+    <% end %>
 
     <%= f.invisible_captcha :subtitle %>
 

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -162,7 +162,7 @@ en:
         author: "Author"
         description: "Opinion"
         terms_of_service: "Terms of service"
-        title: "Title"
+        title: "Debate title"
       proposal:
         author: "Author"
         title: "Title"

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -162,7 +162,10 @@ en:
         author: "Author"
         description: "Opinion"
         terms_of_service: "Terms of service"
+        title: "Title"
+      debate/translation:
         title: "Debate title"
+        description: "Initial debate text"
       proposal:
         author: "Author"
         title: "Title"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -93,7 +93,6 @@ en:
         submit_button: Save changes
       show_link: View debate
     form:
-      debate_text: Initial debate text
       debate_title: Debate title
       tags_instructions: Tag this debate.
       tags_label: Topics

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -163,6 +163,9 @@ es:
         description: "Opinión"
         terms_of_service: "Términos de servicio"
         title: "Título del debate"
+      debate/translation:
+        title: "Título del debate"
+        description: "Texto inicial del debate"
       proposal:
         author: "Autor"
         title: "Título"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -162,7 +162,7 @@ es:
         author: "Autor"
         description: "Opinión"
         terms_of_service: "Términos de servicio"
-        title: "Título"
+        title: "Título del debate"
       proposal:
         author: "Autor"
         title: "Título"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -93,7 +93,6 @@ es:
         submit_button: Guardar cambios
       show_link: Ver debate
     form:
-      debate_text: Texto inicial del debate
       debate_title: Título del debate
       tags_instructions: Etiqueta este debate.
       tags_label: Temas

--- a/db/dev_seeds/debates.rb
+++ b/db/dev_seeds/debates.rb
@@ -3,25 +3,40 @@ section "Creating Debates" do
   30.times do
     author = User.all.sample
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
-    Debate.create!(author: author,
-                   title: Faker::Lorem.sentence(3).truncate(60),
-                   created_at: rand((Time.current - 1.week)..Time.current),
-                   description: description,
-                   tag_list: tags.sample(3).join(","),
-                   geozone: Geozone.all.sample,
-                   terms_of_service: "1")
+    debate = Debate.create!(author: author,
+                            title: Faker::Lorem.sentence(3).truncate(60),
+                            created_at: rand((Time.current - 1.week)..Time.current),
+                            description: description,
+                            tag_list: tags.sample(3).join(","),
+                            geozone: Geozone.all.sample,
+                            terms_of_service: "1")
+    random_locales.map do |locale|
+      Globalize.with_locale(locale) do
+        debate.title = "Title for locale #{locale}"
+        debate.description = "<p>Description for locale #{locale}</p>"
+        debate.save!
+      end
+    end
   end
 
   tags = ActsAsTaggableOn::Tag.where(kind: "category")
   30.times do
     author = User.all.sample
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
-    Debate.create!(author: author,
-                   title: Faker::Lorem.sentence(3).truncate(60),
-                   created_at: rand((Time.current - 1.week)..Time.current),
-                   description: description,
-                   tag_list: tags.sample(3).join(","),
-                   geozone: Geozone.all.sample,
-                   terms_of_service: "1")
+
+    debate = Debate.create!(author: author,
+                            title: Faker::Lorem.sentence(3).truncate(60),
+                            created_at: rand((Time.current - 1.week)..Time.current),
+                            description: description,
+                            tag_list: tags.sample(3).join(","),
+                            geozone: Geozone.all.sample,
+                            terms_of_service: "1")
+    random_locales.map do |locale|
+      Globalize.with_locale(locale) do
+        debate.title = "Title for locale #{locale}"
+        debate.description = "<p>Description for locale #{locale}</p>"
+        debate.save!
+      end
+    end
   end
 end

--- a/db/migrate/20181130141019_add_debates_translations.rb
+++ b/db/migrate/20181130141019_add_debates_translations.rb
@@ -1,0 +1,15 @@
+class AddDebatesTranslations < ActiveRecord::Migration
+  def self.up
+    Debate.create_translation_table!(
+      {
+        title:               :string,
+        description:         :text
+       },
+      { migrate_data: true }
+    )
+  end
+
+  def self.down
+    Debate.drop_translation_table!
+  end
+end

--- a/db/migrate/20190123122752_add_hidden_at_to_debate_translations.rb
+++ b/db/migrate/20190123122752_add_hidden_at_to_debate_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToDebateTranslations < ActiveRecord::Migration
+  def change
+    add_column :debate_translations, :hidden_at, :datetime
+    add_index :debate_translations, :hidden_at
+  end
+end

--- a/db/migrate/20190213150434_rename_old_translatable_attibutes_in_debates.rb
+++ b/db/migrate/20190213150434_rename_old_translatable_attibutes_in_debates.rb
@@ -1,0 +1,8 @@
+class RenameOldTranslatableAttibutesInDebates < ActiveRecord::Migration
+  def change
+    remove_index :debates, :title
+
+    rename_column :debates, :title, :deprecated_title
+    rename_column :debates, :description, :deprecated_description
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -417,9 +417,11 @@ ActiveRecord::Schema.define(version: 20190325185550) do
     t.datetime "updated_at",  null: false
     t.string   "title"
     t.text     "description"
+    t.datetime "hidden_at"
   end
 
   add_index "debate_translations", ["debate_id"], name: "index_debate_translations_on_debate_id", using: :btree
+  add_index "debate_translations", ["hidden_at"], name: "index_debate_translations_on_hidden_at", using: :btree
   add_index "debate_translations", ["locale"], name: "index_debate_translations_on_locale", using: :btree
 
   create_table "debates", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -410,6 +410,18 @@ ActiveRecord::Schema.define(version: 20190325185550) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "debate_translations", force: :cascade do |t|
+    t.integer  "debate_id",   null: false
+    t.string   "locale",      null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.string   "title"
+    t.text     "description"
+  end
+
+  add_index "debate_translations", ["debate_id"], name: "index_debate_translations_on_debate_id", using: :btree
+  add_index "debate_translations", ["locale"], name: "index_debate_translations_on_locale", using: :btree
+
   create_table "debates", force: :cascade do |t|
     t.string   "title",                        limit: 80
     t.text     "description"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -423,8 +423,8 @@ ActiveRecord::Schema.define(version: 20190325185550) do
   add_index "debate_translations", ["locale"], name: "index_debate_translations_on_locale", using: :btree
 
   create_table "debates", force: :cascade do |t|
-    t.string   "title",                        limit: 80
-    t.text     "description"
+    t.string   "deprecated_title",             limit: 80
+    t.text     "deprecated_description"
     t.integer  "author_id"
     t.datetime "created_at",                                          null: false
     t.datetime "updated_at",                                          null: false
@@ -456,7 +456,6 @@ ActiveRecord::Schema.define(version: 20190325185550) do
   add_index "debates", ["geozone_id"], name: "index_debates_on_geozone_id", using: :btree
   add_index "debates", ["hidden_at"], name: "index_debates_on_hidden_at", using: :btree
   add_index "debates", ["hot_score"], name: "index_debates_on_hot_score", using: :btree
-  add_index "debates", ["title"], name: "index_debates_on_title", using: :btree
   add_index "debates", ["tsv"], name: "index_debates_on_tsv", using: :gin
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/controllers/debates_controller_spec.rb
+++ b/spec/controllers/debates_controller_spec.rb
@@ -12,10 +12,19 @@ describe DebatesController do
     end
 
     it "creates an ahoy event" do
-
+      debate_attributes = {
+        terms_of_service: "1",
+        translations_attributes: {
+          "0" => {
+            title: "A sample debate",
+            description: "this is a sample debate",
+            locale: "en"
+          }
+        }
+      }
       sign_in create(:user)
 
-      post :create, debate: { title: "A sample debate", description: "this is a sample debate", terms_of_service: 1 }
+      post :create, debate: debate_attributes
       expect(Ahoy::Event.where(name: :debate_created).count).to eq 1
       expect(Ahoy::Event.last.properties["debate_id"]).to eq Debate.last.id
     end

--- a/spec/features/admin/site_customization/information_texts_spec.rb
+++ b/spec/features/admin/site_customization/information_texts_spec.rb
@@ -98,10 +98,10 @@ feature "Admin custom information texts" do
                                            value_en: "Custom debate title",
                                            value_es: "Título personalizado de debate")
 
-      second_key = "debates.form.debate_text"
-      debate_text = create(:i18n_content, key: second_key,
-                                          value_en: "Custom debate text",
-                                          value_es: "Texto personalizado de debate")
+      second_key = "debates.new.start_new"
+      page_title = create(:i18n_content, key: second_key,
+                                          value_en: "Start a new debate",
+                                          value_es: "Empezar un debate")
 
       visit admin_site_customization_information_texts_path
 
@@ -112,15 +112,15 @@ feature "Admin custom information texts" do
       expect(page).not_to have_link "Español"
 
       click_link "English"
-      expect(page).to have_content "Custom debate text"
+      expect(page).to have_content "Start a new debate"
       expect(page).to have_content "Custom debate title"
 
       debate_title.reload
-      debate_text.reload
+      page_title.reload
 
-      expect(debate_text.value_es).to be(nil)
+      expect(page_title.value_es).to be(nil)
       expect(debate_title.value_es).to be(nil)
-      expect(debate_text.value_en).to eq("Custom debate text")
+      expect(page_title.value_en).to eq("Start a new debate")
       expect(debate_title.value_en).to eq("Custom debate title")
     end
   end

--- a/spec/features/ckeditor_spec.rb
+++ b/spec/features/ckeditor_spec.rb
@@ -8,12 +8,12 @@ feature "CKEditor" do
 
     visit new_debate_path
 
-    expect(page).to have_css "#cke_debate_description"
+    expect(page).to have_css ".translatable-fields[data-locale='en'] .cke_wysiwyg_frame"
 
     click_link "Debates"
     click_link "Start a debate"
 
-    expect(page).to have_css "#cke_debate_description"
+    expect(page).to have_css ".translatable-fields[data-locale='en'] .cke_wysiwyg_frame"
   end
 
 end

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -169,8 +169,8 @@ feature "Debates" do
     login_as(author)
 
     visit new_debate_path
-    fill_in "debate_title", with: "A title for a debate"
-    fill_in "debate_description", with: "This is very important because..."
+    fill_in "Debate title", with: "A title for a debate"
+    fill_in "Initial debate text", with: "This is very important because..."
     check "debate_terms_of_service"
 
     click_button "Start a debate"
@@ -187,9 +187,9 @@ feature "Debates" do
     login_as(author)
 
     visit new_debate_path
-    fill_in "debate_title", with: "I am a bot"
+    fill_in "Debate title", with: "I am a bot"
     fill_in "debate_subtitle", with: "This is a honeypot field"
-    fill_in "debate_description", with: "This is the description"
+    fill_in "Initial debate text", with: "This is the description"
     check "debate_terms_of_service"
 
     click_button "Start a debate"
@@ -206,8 +206,8 @@ feature "Debates" do
     login_as(author)
 
     visit new_debate_path
-    fill_in "debate_title", with: "I am a bot"
-    fill_in "debate_description", with: "This is the description"
+    fill_in "Debate title", with: "I am a bot"
+    fill_in "Initial debate text", with: "This is the description"
     check "debate_terms_of_service"
 
     click_button "Start a debate"
@@ -231,8 +231,8 @@ feature "Debates" do
     login_as(author)
 
     visit new_debate_path
-    fill_in "debate_title", with: "Testing an attack"
-    fill_in "debate_description", with: "<p>This is <script>alert('an attack');</script></p>"
+    fill_in "Debate title", with: "Testing an attack"
+    fill_in "Initial debate text", with: "<p>This is <script>alert('an attack');</script></p>"
     check "debate_terms_of_service"
 
     click_button "Start a debate"
@@ -249,8 +249,8 @@ feature "Debates" do
     login_as(author)
 
     visit new_debate_path
-    fill_in "debate_title", with: "Testing auto link"
-    fill_in "debate_description", with: "<p>This is a link www.example.org</p>"
+    fill_in "Debate title", with: "Testing auto link"
+    fill_in "Initial debate text", with: "<p>This is a link www.example.org</p>"
     check "debate_terms_of_service"
 
     click_button "Start a debate"
@@ -266,8 +266,8 @@ feature "Debates" do
     login_as(author)
 
     visit new_debate_path
-    fill_in "debate_title", with: "Testing auto link"
-    fill_in "debate_description", with: js_injection_string
+    fill_in "Debate title", with: "Testing auto link"
+    fill_in "Initial debate text", with: js_injection_string
     check "debate_terms_of_service"
 
     click_button "Start a debate"
@@ -318,8 +318,8 @@ feature "Debates" do
     visit edit_debate_path(debate)
     expect(page).to have_current_path(edit_debate_path(debate))
 
-    fill_in "debate_title", with: "End child poverty"
-    fill_in "debate_description", with: "Let's do something to end child poverty"
+    fill_in "Debate title", with: "End child poverty"
+    fill_in "Initial debate text", with: "Let's do something to end child poverty"
 
     click_button "Save changes"
 
@@ -333,7 +333,7 @@ feature "Debates" do
     login_as(debate.author)
 
     visit edit_debate_path(debate)
-    fill_in "debate_title", with: ""
+    fill_in "Debate title", with: ""
     click_button "Save changes"
 
     expect(page).to have_content error_message
@@ -1108,7 +1108,7 @@ feature "Debates" do
       debate7 = create(:debate, title: "This has seven votes, and is not suggest", description: "This is the seven", cached_votes_up: 7)
 
       visit new_debate_path
-      fill_in "debate_title", with: "debate"
+      fill_in "Debate title", with: "debate"
       check "debate_terms_of_service"
 
       within("div#js-suggest") do
@@ -1124,7 +1124,7 @@ feature "Debates" do
       debate2 = create(:debate, title: "Second debate has 2 votes", cached_votes_up: 2)
 
       visit new_debate_path
-      fill_in "debate_title", with: "proposal"
+      fill_in "Debate title", with: "proposal"
       check "debate_terms_of_service"
 
       within("div#js-suggest") do

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -11,6 +11,11 @@ feature "Debates" do
   context "Concerns" do
     it_behaves_like "notifiable in-app", Debate
     it_behaves_like "relationable", Debate
+    it_behaves_like "translatable",
+                    "debate",
+                    "edit_debate_path",
+                    %w[title],
+                    { "description" => :ckeditor }
   end
 
   scenario "Index" do

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -1116,7 +1116,7 @@ feature "Debates" do
       fill_in "Debate title", with: "debate"
       check "debate_terms_of_service"
 
-      within("div#js-suggest") do
+      within("div.js-suggest") do
         expect(page).to have_content "You are seeing 5 of 6 debates containing the term 'debate'"
       end
     end
@@ -1132,7 +1132,7 @@ feature "Debates" do
       fill_in "Debate title", with: "proposal"
       check "debate_terms_of_service"
 
-      within("div#js-suggest") do
+      within("div.js-suggest") do
         expect(page).not_to have_content "You are seeing"
       end
     end

--- a/spec/features/tags/debates_spec.rb
+++ b/spec/features/tags/debates_spec.rb
@@ -66,8 +66,8 @@ feature "Tags" do
     login_as(user)
 
     visit new_debate_path
-    fill_in "debate_title", with: "Title"
-    fill_in "debate_description", with: "Description"
+    fill_in "Debate title", with: "Title"
+    fill_in "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda"
@@ -85,8 +85,8 @@ feature "Tags" do
     login_as(user)
 
     visit new_debate_path
-    fill_in "debate_title", with: "Title"
-    fill_in "debate_description", with: "Description"
+    fill_in "Debate title", with: "Title"
+    fill_in "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
@@ -103,8 +103,8 @@ feature "Tags" do
 
     visit new_debate_path
 
-    fill_in "debate_title", with: "A test of dangerous strings"
-    fill_in "debate_description", with: "A description suitable for this test"
+    fill_in "Debate title", with: "A test of dangerous strings"
+    fill_in "Initial debate text", with: "A description suitable for this test"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "user_id=1, &a=3, <script>alert('hey');</script>"

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -59,8 +59,8 @@ feature "Tags" do
     login_as(user)
 
     visit new_debate_path
-    fill_in "debate_title", with: "Title"
-    fill_in "debate_description", with: "Description"
+    fill_in "Debate title", with: "Title"
+    fill_in "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda"
@@ -78,8 +78,8 @@ feature "Tags" do
     login_as(user)
 
     visit new_debate_path
-    fill_in "debate_title", with: "Title"
-    fill_in "debate_description", with: "Description"
+    fill_in "Debate title", with: "Title"
+    fill_in "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -479,7 +479,7 @@ describe Debate do
 
       it "searches by title across all languages translations" do
         debate = create(:debate, attributes)
-        results = described_class.search('salvar el mundo')
+        results = described_class.search("salvar el mundo")
         expect(results).to eq([debate])
       end
 
@@ -491,7 +491,7 @@ describe Debate do
 
       it "searches by description across all languages translations" do
         debate = create(:debate, attributes)
-        results = described_class.search('uno debe pensar')
+        results = described_class.search("uno debe pensar")
         expect(results).to eq([debate])
       end
 

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -465,15 +465,32 @@ describe Debate do
 
     context "attributes" do
 
+      let(:attributes) { { title: "save the world",
+                           description: "in order to save the world one must think about...",
+                           title_es: "para salvar el mundo uno debe pensar en...",
+                           description_es: "uno debe pensar" } }
+
       it "searches by title" do
-        debate = create(:debate, title: "save the world")
+        debate = create(:debate, attributes)
         results = described_class.search("save the world")
         expect(results).to eq([debate])
       end
 
+      it "searches by title across all languages translations" do
+        debate = create(:debate, attributes)
+        results = described_class.search('salvar el mundo')
+        expect(results).to eq([debate])
+      end
+
       it "searches by description" do
-        debate = create(:debate, description: "in order to save the world one must think about...")
+        debate = create(:debate, attributes)
         results = described_class.search("one must think")
+        expect(results).to eq([debate])
+      end
+
+      it "searches by description across all languages translations" do
+        debate = create(:debate, attributes)
+        results = described_class.search('uno debe pensar')
         expect(results).to eq([debate])
       end
 

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 describe Debate do
   let(:debate) { build(:debate) }
 
+  it_behaves_like "globalizable", :debate
+
   describe "Concerns" do
     it_behaves_like "has_public_author"
     it_behaves_like "notifiable"
@@ -36,6 +38,7 @@ describe Debate do
   end
 
   describe "#description" do
+
     it "is not valid without a description" do
       debate.description = nil
       expect(debate).not_to be_valid
@@ -43,13 +46,34 @@ describe Debate do
 
     it "is sanitized" do
       debate.description = "<script>alert('danger');</script>"
+
       debate.valid?
+
       expect(debate.description).to eq("alert('danger');")
     end
 
+    it "is sanitized using globalize accessors" do
+      debate.description_en = "<script>alert('danger');</script>"
+
+      debate.valid?
+
+      expect(debate.description_en).to eq("alert('danger');")
+    end
+
     it "is html_safe" do
-      debate.description = "<script>alert('danger');</script>"
-      expect(debate.description).to be_html_safe
+      debate.description_en = "<script>alert('danger');</script>"
+
+      debate.valid?
+
+      expect(debate.description_en).to be_html_safe
+    end
+
+    it "is html_safe using globalize accessors" do
+      debate.description_en = "<script>alert('danger');</script>"
+
+      debate.valid?
+
+      expect(debate.description_en).to be_html_safe
     end
 
     it "is not valid when very short" do

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -9,6 +9,7 @@ describe Debate do
   describe "Concerns" do
     it_behaves_like "has_public_author"
     it_behaves_like "notifiable"
+    it_behaves_like "sanitizable"
   end
 
   it "is valid" do
@@ -38,42 +39,9 @@ describe Debate do
   end
 
   describe "#description" do
-
     it "is not valid without a description" do
       debate.description = nil
       expect(debate).not_to be_valid
-    end
-
-    it "is sanitized" do
-      debate.description = "<script>alert('danger');</script>"
-
-      debate.valid?
-
-      expect(debate.description).to eq("alert('danger');")
-    end
-
-    it "is sanitized using globalize accessors" do
-      debate.description_en = "<script>alert('danger');</script>"
-
-      debate.valid?
-
-      expect(debate.description_en).to eq("alert('danger');")
-    end
-
-    it "is html_safe" do
-      debate.description_en = "<script>alert('danger');</script>"
-
-      debate.valid?
-
-      expect(debate.description_en).to be_html_safe
-    end
-
-    it "is html_safe using globalize accessors" do
-      debate.description_en = "<script>alert('danger');</script>"
-
-      debate.valid?
-
-      expect(debate.description_en).to be_html_safe
     end
 
     it "is not valid when very short" do
@@ -88,12 +56,6 @@ describe Debate do
   end
 
   describe "#tag_list" do
-    it "sanitizes the tag list" do
-      debate.tag_list = "user_id=1"
-      debate.valid?
-      expect(debate.tag_list).to eq(["user_id1"])
-    end
-
     it "is not valid with a tag list of more than 6 elements" do
       debate.tag_list = ["Hacienda", "Economía", "Medio Ambiente", "Corrupción", "Fiestas populares", "Prensa", "Huelgas"]
       expect(debate).not_to be_valid

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -10,6 +10,7 @@ describe Debate do
     it_behaves_like "has_public_author"
     it_behaves_like "notifiable"
     it_behaves_like "sanitizable"
+    it_behaves_like "acts as paranoid", :debate
   end
 
   it "is valid" do


### PR DESCRIPTION
## References

* Related Issues: #3130
* Related Pull Requests: This PR needs and includes these other PR's: #3240, #3241, #3242 

## Objectives

Add database translations to debates and :

* Include all existing translations at pg_search feature
* Fix suggest feature
* Add soft deletion of translations
* Include translation interface
* Update translations rake task to migrate data to translations table
* Add debate translations to dev_seeds

## Visual Changes
![debates new with translation interface](https://user-images.githubusercontent.com/15726/51849411-f2719880-231f-11e9-8d80-3d0072f6d1a7.png)
![debates new with translation interface mobile version](https://user-images.githubusercontent.com/15726/51849412-f2719880-231f-11e9-8d0f-e283d982e5d8.png)

## Notes
⚠️ For release notes:

Execute this command to migrate proposal data to new proposal translations table:
```bin/rake globalize:migrate_data RAILS_ENV=production```
