### PR TITLE
Comments translations

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -14,7 +14,7 @@ class Admin::CommentsController < Admin::BaseController
   end
 
   def restore
-    @comment.restore
+    @comment.restore(recursive: true)
     @comment.ignore_flag
     Activity.log(current_user, :restore, @comment)
     redirect_to request.query_parameters.merge(action: :index)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -14,7 +14,10 @@ class Comment < ActiveRecord::Base
 
   attr_accessor :as_moderator, :as_administrator
 
-  validates :body, presence: true
+  translates :body, touch: true
+  include Globalizable
+
+  validates_translation :body, presence: true
   validates :user, presence: true
 
   validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }

--- a/db/migrate/20181205102153_add_comments_translations.rb
+++ b/db/migrate/20181205102153_add_comments_translations.rb
@@ -1,0 +1,14 @@
+class AddCommentsTranslations < ActiveRecord::Migration
+  def self.up
+    Comment.create_translation_table!(
+      {
+        body:               :text
+       },
+      { migrate_data: true }
+    )
+  end
+
+  def self.down
+    Comment.drop_translation_table!
+  end
+end

--- a/db/migrate/20190123122936_add_hidden_at_to_comment_translations.rb
+++ b/db/migrate/20190123122936_add_hidden_at_to_comment_translations.rb
@@ -1,0 +1,6 @@
+class AddHiddenAtToCommentTranslations < ActiveRecord::Migration
+  def change
+    add_column :comment_translations, :hidden_at, :datetime
+    add_index :comment_translations, :hidden_at
+  end
+end

--- a/db/migrate/20190218122530_rename_old_translatable_attibutes_in_comments.rb
+++ b/db/migrate/20190218122530_rename_old_translatable_attibutes_in_comments.rb
@@ -1,0 +1,5 @@
+class RenameOldTranslatableAttibutesInComments < ActiveRecord::Migration
+  def change
+    rename_column :comments, :body, :deprecated_body
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -388,7 +388,7 @@ ActiveRecord::Schema.define(version: 20190325185550) do
   create_table "comments", force: :cascade do |t|
     t.integer  "commentable_id"
     t.string   "commentable_type"
-    t.text     "body"
+    t.text     "deprecated_body"
     t.string   "subject"
     t.integer  "user_id",                            null: false
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -374,6 +374,17 @@ ActiveRecord::Schema.define(version: 20190325185550) do
 
   add_index "ckeditor_assets", ["type"], name: "index_ckeditor_assets_on_type", using: :btree
 
+  create_table "comment_translations", force: :cascade do |t|
+    t.integer  "comment_id", null: false
+    t.string   "locale",     null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text     "body"
+  end
+
+  add_index "comment_translations", ["comment_id"], name: "index_comment_translations_on_comment_id", using: :btree
+  add_index "comment_translations", ["locale"], name: "index_comment_translations_on_locale", using: :btree
+
   create_table "comments", force: :cascade do |t|
     t.integer  "commentable_id"
     t.string   "commentable_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -380,9 +380,11 @@ ActiveRecord::Schema.define(version: 20190325185550) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text     "body"
+    t.datetime "hidden_at"
   end
 
   add_index "comment_translations", ["comment_id"], name: "index_comment_translations_on_comment_id", using: :btree
+  add_index "comment_translations", ["hidden_at"], name: "index_comment_translations_on_hidden_at", using: :btree
   add_index "comment_translations", ["locale"], name: "index_comment_translations_on_locale", using: :btree
 
   create_table "comments", force: :cascade do |t|

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -5,6 +5,7 @@ describe Comment do
   let(:comment) { build(:comment) }
 
   it_behaves_like "has_public_author"
+  it_behaves_like "globalizable", :comment
 
   it "is valid" do
     expect(comment).to be_valid

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -6,6 +6,7 @@ describe Comment do
 
   it_behaves_like "has_public_author"
   it_behaves_like "globalizable", :comment
+  it_behaves_like "acts as paranoid", :comment
 
   it "is valid" do
     expect(comment).to be_valid


### PR DESCRIPTION
## References

* Related Issues: #3130
* Related Pull Requests: This PR needs and includes these other PR's: #3242 

## Objectives

Add database translations to proposals and :

* Add soft deletion of translations
* Include translation interface
* Update translations rake task to migrate data to translations table

We have not added translations interface to comments form because we want users to enter comments only in their preferred language. If users is browsing application in Italian language then his comment is stored as italian translation.

## Visual Changes
None

## Notes

Execute this command to migrate proposal data to new proposal translations table:
```bin/rake globalize:migrate_data RAILS_ENV=production```
