### PR TITLE
Configurable email interceptor by environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'unicorn', '~> 5.4.1'
 gem 'whenever', '~> 0.10.0', require: false
 gem 'globalize', '~> 5.0.0'
 gem 'globalize-accessors', '~> 0.2.1'
+gem 'recipient_interceptor', '~> 0.2.0'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-leaflet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,8 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (12.3.1)
+    recipient_interceptor (0.2.0)
+      mail
     redcarpet (3.4.0)
     referer-parser (0.3.0)
     request_store (1.3.2)
@@ -551,6 +553,7 @@ DEPENDENCIES
   rails (= 4.2.11)
   rails-assets-leaflet!
   rails-assets-markdown-it (~> 8.2.1)!
+  recipient_interceptor
   redcarpet (~> 3.4.0)
   responders (~> 2.4.0)
   rinku (~> 2.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,7 +553,7 @@ DEPENDENCIES
   rails (= 4.2.11)
   rails-assets-leaflet!
   rails-assets-markdown-it (~> 8.2.1)!
-  recipient_interceptor
+  recipient_interceptor (~> 0.2.0)
   redcarpet (~> 3.4.0)
   responders (~> 2.4.0)
   rinku (~> 2.0.2)

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -90,4 +90,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS'])
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -90,6 +90,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS'])
 end

--- a/config/initializers/recipient_interceptor.rb
+++ b/config/initializers/recipient_interceptor.rb
@@ -1,4 +1,6 @@
-if (recipients = Rails.application.secrets.interceptor_recipients)
+recipients = Rails.application.secrets.email_interceptor_recipients
+
+if recipients.present?
   interceptor = RecipientInterceptor.new(recipients)
   Mail.register_interceptor(interceptor)
 end

--- a/config/initializers/recipient_interceptor.rb
+++ b/config/initializers/recipient_interceptor.rb
@@ -1,0 +1,4 @@
+if (recipients = Rails.application.secrets.interceptor_recipients)
+  interceptor = RecipientInterceptor.new(recipients)
+  Mail.register_interceptor(interceptor)
+end

--- a/config/initializers/recipient_interceptor.rb
+++ b/config/initializers/recipient_interceptor.rb
@@ -1,6 +1,6 @@
 recipients = Rails.application.secrets.email_interceptor_recipients
 
 if recipients.present?
-  interceptor = RecipientInterceptor.new(recipients)
+  interceptor = RecipientInterceptor.new(recipients, subject_prefix: "[#{Rails.env}]")
   Mail.register_interceptor(interceptor)
 end

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,5 +1,6 @@
 default: &default
   secret_key_base: 56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4
+  email_interceptor_recipients: ""
 
 maps: &maps
   map_tiles_provider: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -6,6 +6,24 @@ feature 'Emails' do
     reset_mailer
   end
 
+  context "On Staging Environment" do
+
+    scenario "emails are delivered to configured recipient" do
+      interceptor = RecipientInterceptor.new("recipient@consul.dev", subject_prefix: "[staging]")
+      Mail.register_interceptor(interceptor)
+
+      sign_up
+
+      email = open_last_email
+      expect(email).to have_subject("[staging] Confirmation instructions")
+      expect(email).to deliver_to("recipient@consul.dev")
+      expect(email).not_to deliver_to("manuela@consul.dev")
+
+      Mail.unregister_interceptor(interceptor)
+    end
+
+  end
+
   scenario "Signup Email" do
     sign_up
 


### PR DESCRIPTION
## References

Isuue https://github.com/consul/consul/issues/2954

## Objectives

*Type*: Feature

To be able to configure the application to catch and forward emails to a specified email address depending on the environment.
Useful for staging environments where the data is a copy of production data.

## Notes
⚠️ For Release Notes:
To enable this feature a new key `email_interceptor_recipients ` needs to be added to your `secrets.yml` file in your staging server. Check the example in `config/secrets.yml.example` and replace the `""` to the addresses or list of emails you want to forward the emails. Note that for more than one address, they need to be separated by commas (,). Eg.
```
staging:
  email_interceptor_recipients: "address1@domain.com,address2@domain.com"
```