### PR TITLE
[Backport] Admin polls list

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -6,6 +6,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   before_action :load_geozones, only: [:new, :create, :edit, :update]
 
   def index
+    @polls = Poll.order(starts_at: :desc)
   end
 
   def show

--- a/app/views/admin/poll/polls/_poll.html.erb
+++ b/app/views/admin/poll/polls/_poll.html.erb
@@ -4,19 +4,19 @@
       <%= link_to poll.name, admin_poll_path(poll) %>
     </strong>
   </td>
-  <td>
-    <%= l poll.starts_at.to_date %> - <%= l poll.ends_at.to_date %>
+  <td class="text-center">
+    <%= l poll.starts_at.to_date %>
   </td>
-  <td class="text-right">
-    <div class="small-6 column">
+  <td class="text-center">
+    <%= l poll.ends_at.to_date %>
+  </td>
+  <td>
     <%= link_to t("admin.actions.edit"),
                 edit_admin_poll_path(poll),
-                class: "button hollow expanded" %>
-    </div>
-    <div class="small-6 column">
+                class: "button hollow" %>
+
     <%= link_to t("admin.actions.configure"),
                 admin_poll_path(poll),
-                class: "button hollow expanded" %>
-    </div>
+                class: "button hollow " %>
   </td>
 </tr>

--- a/app/views/admin/poll/polls/index.html.erb
+++ b/app/views/admin/poll/polls/index.html.erb
@@ -7,8 +7,9 @@
 <% if @polls.any? %>
   <table>
     <thead>
-      <th class="small-6"><%= t("admin.polls.index.name") %></th>
-      <th><%= t("admin.polls.index.dates") %></th>
+      <th class="small-5"><%= t("admin.polls.index.name") %></th>
+      <th class="text-center"><%= t("admin.polls.index.start_date") %></th>
+      <th class="text-center"><%= t("admin.polls.index.closing_date") %></th>
       <th><%= t("admin.actions.actions") %></th>
     </thead>
     <tbody>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -916,7 +916,7 @@ en:
         table_location: "Location"
     polls:
       index:
-        title: "List of active polls"
+        title: "List of polls"
         no_polls: "There are no polls coming up."
         create: "Create poll"
         name: "Name"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -921,6 +921,8 @@ en:
         create: "Create poll"
         name: "Name"
         dates: "Dates"
+        start_date: "Start Date"
+        closing_date: "Closing Date"
         geozone_restricted: "Restricted to districts"
       new:
         title: "New poll"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -916,7 +916,7 @@ es:
         table_location: "Ubicación"
     polls:
       index:
-        title: "Listado de votaciones activas"
+        title: "Listado de votaciones"
         no_polls: "No hay ninguna votación próximamente."
         create: "Crear votación"
         name: "Nombre"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -921,6 +921,8 @@ es:
         create: "Crear votación"
         name: "Nombre"
         dates: "Fechas"
+        start_date: "Fecha de apertura"
+        closing_date: "Fecha de cierre"
         geozone_restricted: "Restringida a los distritos"
       new:
         title: "Nueva votación"

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -23,13 +23,15 @@ feature 'Admin polls' do
     expect(page).to have_content "There are no polls"
   end
 
-  scenario 'Index', :js do
-    3.times { create(:poll) }
+  scenario "Index show polls list order by starts at date", :js do
+    poll_1 = create(:poll, name: "Poll first",  starts_at: 15.days.ago)
+    poll_2 = create(:poll, name: "Poll second", starts_at: 1.month.ago)
+    poll_3 = create(:poll, name: "Poll third",  starts_at: 2.days.ago)
 
     visit admin_root_path
 
     click_link "Polls"
-    within('#polls_menu') do
+    within("#polls_menu") do
       click_link "Polls"
     end
 
@@ -42,6 +44,9 @@ feature 'Admin polls' do
         expect(page).to have_content poll.name
       end
     end
+
+    expect(poll_3.name).to appear_before(poll_1.name)
+    expect(poll_1.name).to appear_before(poll_2.name)
     expect(page).not_to have_content "There are no polls"
   end
 

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -33,6 +33,7 @@ feature 'Admin polls' do
       click_link "Polls"
     end
 
+    expect(page).to have_content "List of polls"
     expect(page).to have_css ".poll", count: 3
 
     polls = Poll.all


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1837/
This closes: https://github.com/consul/consul/issues/3186

## Objectives

- Change admin poll list title from "List of active polls" to "List of polls"
- Order the polls list by starts_at date (from most recent to oldest).

## Visual Changes

![poll_index](https://user-images.githubusercontent.com/631897/51491772-b5515780-1daf-11e9-8092-3cac012e36f6.png)