### PR TITLE
Dashboard actions attachments

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+rubocop:
+  config_file: .rubocop_basic.yml
+scss:
+  config_file: .scss-lint.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,35 +1,4 @@
-inherit_from: .rubocop_todo.yml
-require: rubocop-rspec
-
-AllCops:
-  DisplayCopNames: true
-  DisplayStyleGuide: true
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
-  Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'script/**/*'
-  TargetRubyVersion: 2.3
-  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
-  # to ignore them, so only the ones explicitly set in this file are enabled.
-  DisabledByDefault: true
-
-Metrics/LineLength:
-  Max: 100
-
-Layout/IndentationConsistency:
-  EnforcedStyle: rails
-
-Layout/EndOfLine:
-  EnforcedStyle: lf
-
-Layout/TrailingBlankLines:
-  Enabled: true
-
-Layout/TrailingWhitespace:
-  Enabled: true
+inherit_from: .rubocop_basic.yml
 
 Bundler/DuplicatedGem:
   Enabled: true
@@ -280,9 +249,6 @@ RSpec/DescribeMethod:
 RSpec/DescribeSymbol:
   Enabled: true
 
-RSpec/DescribedClass:
-  Enabled: true
-
 RSpec/EmptyExampleGroup:
   Enabled: true
 
@@ -366,9 +332,6 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Enabled: true
   Max: 4
-
-RSpec/NotToNot:
-  Enabled: true
 
 RSpec/OverwritingSetup:
   Enabled: true

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -1,0 +1,40 @@
+require: rubocop-rspec
+
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+  TargetRubyVersion: 2.3
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+
+Layout/IndentationConsistency:
+  EnforcedStyle: rails
+
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/EndOfLine:
+  EnforcedStyle: lf
+
+Layout/TrailingBlankLines:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Metrics/LineLength:
+  Max: 100
+
+RSpec/NotToNot:
+  Enabled: true
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -319,7 +319,8 @@
 .legislation-process-edit,
 .milestone-new,
 .milestone-edit,
-.image-form {
+.image-form,
+.dashboard-action-form {
   @include direct-uploads;
 }
 

--- a/app/models/dashboard/action.rb
+++ b/app/models/dashboard/action.rb
@@ -2,7 +2,11 @@ class Dashboard::Action < ActiveRecord::Base
   include Documentable
   documentable max_documents_allowed: 3,
                max_file_size: 3.megabytes,
-               accepted_content_types: [ 'application/pdf' ]
+               accepted_content_types: [ "application/pdf",
+                                         "image/jpeg",
+                                         "image/jpg",
+                                         "image/png",
+                                         "application/zip" ]
 
   include Linkable
 
@@ -14,7 +18,7 @@ class Dashboard::Action < ActiveRecord::Base
 
   enum action_type: [:proposed_action, :resource]
 
-  validates :title, 
+  validates :title,
             presence: true,
             allow_blank: false,
             length: { in: 4..80 }
@@ -40,7 +44,7 @@ class Dashboard::Action < ActiveRecord::Base
   scope :resources, -> { where(action_type: 1) }
   scope :proposed_actions, -> { where(action_type: 0) }
 
-  def self.active_for(proposal) 
+  def self.active_for(proposal)
     published_at = proposal.published_at&.to_date || Date.today
 
     active

--- a/app/views/admin/dashboard/actions/edit.html.erb
+++ b/app/views/admin/dashboard/actions/edit.html.erb
@@ -3,6 +3,8 @@
   <h2><%= t("admin.dashboard.actions.edit.editing") %></h2>
 </div>
 
-<%= form_for dashboard_action, url: { action: 'update' } do |f| %>
-  <%= render 'form', f: f %>
-<% end %>
+<div class="dashboard-action-form ">
+  <%= form_for dashboard_action, url: { action: 'update' } do |f| %>
+    <%= render 'form', f: f %>
+  <% end %>
+</div>

--- a/app/views/admin/dashboard/actions/new.html.erb
+++ b/app/views/admin/dashboard/actions/new.html.erb
@@ -3,6 +3,8 @@
   <h2><%= t("admin.dashboard.actions.new.creating") %></h2>
 </div>
 
-<%= form_for dashboard_action, url: { action: 'create' } do |f| %>
-  <%= render 'form', f: f %>
-<% end %>
+<div class="dashboard-action-form ">
+  <%= form_for dashboard_action, url: { action: 'create' } do |f| %>
+    <%= render 'form', f: f %>
+  <% end %>
+</div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -619,7 +619,7 @@ ActiveRecord::Schema.define(version: 20180924071722) do
     t.string   "locale",                       null: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
-    t.text     "title"
+    t.string   "title"
     t.text     "changelog"
     t.text     "body"
     t.text     "body_html"
@@ -1218,17 +1218,17 @@ ActiveRecord::Schema.define(version: 20180924071722) do
   add_index "site_customization_images", ["name"], name: "index_site_customization_images_on_name", unique: true, using: :btree
 
   create_table "site_customization_page_translations", force: :cascade do |t|
-      t.integer  "site_customization_page_id", null: false
-      t.string   "locale",                     null: false
-      t.datetime "created_at",                 null: false
-      t.datetime "updated_at",                 null: false
-      t.string   "title"
-      t.string   "subtitle"
-      t.text     "content"
-    end
+    t.integer  "site_customization_page_id", null: false
+    t.string   "locale",                     null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "title"
+    t.string   "subtitle"
+    t.text     "content"
+  end
 
-    add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
-    add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
+  add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
+  add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
 
   create_table "site_customization_pages", force: :cascade do |t|
     t.string   "slug",                                 null: false

--- a/spec/features/admin/dashboard/actions_spec.rb
+++ b/spec/features/admin/dashboard/actions_spec.rb
@@ -7,6 +7,15 @@ feature 'Admin dashboard actions' do
     login_as(admin.user)
   end
 
+  it_behaves_like "nested documentable",
+                  "administrator",
+                  "dashboard_action",
+                  "new_admin_dashboard_action_path",
+                  { },
+                  "documentable_fill_new_valid_dashboard_action",
+                  "Save",
+                  "Action created successfully"
+
   context 'when visiting index' do
     context 'and no actions defined' do
       before do

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -9,7 +9,11 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
   let!(:administrator)          { create(:user) }
   let!(:user)                   { create(:user, :level_two) }
   let!(:arguments)              { {} }
-  let!(:documentable)           { create(documentable_factory_name, author: user) }
+  if documentable_factory_name == "dashboard_action"
+    let!(:documentable)           { create(documentable_factory_name) }
+  else
+    let!(:documentable)           { create(documentable_factory_name, author: user) }
+  end
   let!(:user_to_login)          { send(login_as_name)}
 
   before do
@@ -133,7 +137,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       visit send(path, arguments)
 
       documentable_attach_new_file(
-        Rails.root.join('spec/fixtures/files/logo_header.png'),
+        Rails.root.join("spec/fixtures/files/logo_header.gif"),
         false
       )
 
@@ -154,7 +158,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       visit send(path, arguments)
 
       documentable_attach_new_file(
-        Rails.root.join('spec/fixtures/files/logo_header.png'),
+        Rails.root.join("spec/fixtures/files/logo_header.gif"),
         false
       )
 
@@ -208,6 +212,9 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
     end
 
     scenario "Should show new document after successful creation with one uploaded file", :js do
+      if documentable_factory_name == "dashboard_action"
+        skip("Not render Documents count on dashboard_actions")
+      end
       login_as user_to_login
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
@@ -227,6 +234,9 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
 
     scenario "Should show resource with new document after successful creation with
               maximum allowed uploaded files", :js do
+      if documentable_factory_name == "dashboard_action"
+        skip("Not render Documents count on dashboard_actions")
+      end
       login_as user_to_login
       visit send(path, arguments)
       FILENAMES ||= %w(clippy empty logo).freeze
@@ -357,6 +367,11 @@ def documentable_fill_new_valid_proposal
   fill_in :proposal_summary, with: "Proposal summary"
   fill_in :proposal_question, with: "Proposal question?"
   check :proposal_terms_of_service
+end
+
+def documentable_fill_new_valid_dashboard_action
+  fill_in :dashboard_action_title, with: "Dashboard title"
+  fill_in :dashboard_action_short_description, with: "Dashboard description"
 end
 
 def documentable_fill_new_valid_budget_investment


### PR DESCRIPTION
## References
[Dashboard: Allow zip, png and jpg on create action](https://github.com/Platoniq/consul/issues/19)

## Objectives
We want attach files on create new action from admin dashboard action with zip, png and jpg extensions.

## Visual Changes
![captura de pantalla 2019-01-08 a las 20 33 20](https://user-images.githubusercontent.com/16189/50854416-41fa1f80-1385-11e9-8df5-191232269409.png)
