### PR TITLE
Dashboard wrong calculate week

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+rubocop:
+  config_file: .rubocop_basic.yml
+scss:
+  config_file: .scss-lint.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,35 +1,4 @@
-inherit_from: .rubocop_todo.yml
-require: rubocop-rspec
-
-AllCops:
-  DisplayCopNames: true
-  DisplayStyleGuide: true
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
-  Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'script/**/*'
-  TargetRubyVersion: 2.3
-  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
-  # to ignore them, so only the ones explicitly set in this file are enabled.
-  DisabledByDefault: true
-
-Metrics/LineLength:
-  Max: 100
-
-Layout/IndentationConsistency:
-  EnforcedStyle: rails
-
-Layout/EndOfLine:
-  EnforcedStyle: lf
-
-Layout/TrailingBlankLines:
-  Enabled: true
-
-Layout/TrailingWhitespace:
-  Enabled: true
+inherit_from: .rubocop_basic.yml
 
 Bundler/DuplicatedGem:
   Enabled: true
@@ -280,9 +249,6 @@ RSpec/DescribeMethod:
 RSpec/DescribeSymbol:
   Enabled: true
 
-RSpec/DescribedClass:
-  Enabled: true
-
 RSpec/EmptyExampleGroup:
   Enabled: true
 
@@ -366,9 +332,6 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Enabled: true
   Max: 4
-
-RSpec/NotToNot:
-  Enabled: true
 
 RSpec/OverwritingSetup:
   Enabled: true

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -1,0 +1,40 @@
+require: rubocop-rspec
+
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+  TargetRubyVersion: 2.3
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+
+Layout/IndentationConsistency:
+  EnforcedStyle: rails
+
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/EndOfLine:
+  EnforcedStyle: lf
+
+Layout/TrailingBlankLines:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Metrics/LineLength:
+  Max: 100
+
+RSpec/NotToNot:
+  Enabled: true
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/app/controllers/concerns/dashboard/group_supports.rb
+++ b/app/controllers/concerns/dashboard/group_supports.rb
@@ -7,8 +7,8 @@ module Dashboard::GroupSupports
     end
 
     def grouping_key_for(date)
-      return "#{date.cweek}/#{date.year}" if params[:group_by] == 'week'
-      return "#{date.year}-#{date.month}" if params[:group_by] == 'month'
+      return calculate_week(date) if params[:group_by] == "week"
+      return "#{date.year}-#{date.month}" if params[:group_by] == "month"
 
       date
     end
@@ -50,4 +50,29 @@ module Dashboard::GroupSupports
       1.day
     end
   end
+  private
+
+    def calculate_week(date)
+      week = date.cweek
+      year = calculate_year_of_week(date)
+      "#{week}/#{year}"
+    end
+
+    def calculate_year_of_week(date)
+      year =  date.year
+      if first_week_of_year?(date) && date.end_of_week.year != date.year
+        year = year + 1
+      elsif last_week_of_year?(date) && date.beginning_of_week.year != date.year
+        year = year - 1
+      end
+      year
+    end
+
+    def first_week_of_year?(date)
+      date.cweek == 1
+    end
+
+    def last_week_of_year?(date)
+      date.cweek == 52 || date.cweek == 53
+    end
 end

--- a/app/controllers/concerns/dashboard/group_supports.rb
+++ b/app/controllers/concerns/dashboard/group_supports.rb
@@ -3,7 +3,7 @@ module Dashboard::GroupSupports
 
   included do
     def grouped_supports(attribute)
-      supports.group_by { |v| grouping_key_for(v[attribute].to_date) }
+      supports.group_by { |v| grouping_key_for(v[attribute].in_time_zone.to_date) }
     end
 
     def grouping_key_for(date)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -619,7 +619,7 @@ ActiveRecord::Schema.define(version: 20180924071722) do
     t.string   "locale",                       null: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
-    t.text     "title"
+    t.string   "title"
     t.text     "changelog"
     t.text     "body"
     t.text     "body_html"
@@ -1218,17 +1218,17 @@ ActiveRecord::Schema.define(version: 20180924071722) do
   add_index "site_customization_images", ["name"], name: "index_site_customization_images_on_name", unique: true, using: :btree
 
   create_table "site_customization_page_translations", force: :cascade do |t|
-      t.integer  "site_customization_page_id", null: false
-      t.string   "locale",                     null: false
-      t.datetime "created_at",                 null: false
-      t.datetime "updated_at",                 null: false
-      t.string   "title"
-      t.string   "subtitle"
-      t.text     "content"
-    end
+    t.integer  "site_customization_page_id", null: false
+    t.string   "locale",                     null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "title"
+    t.string   "subtitle"
+    t.text     "content"
+  end
 
-    add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
-    add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
+  add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
+  add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
 
   create_table "site_customization_pages", force: :cascade do |t|
     t.string   "slug",                                 null: false


### PR DESCRIPTION
## References
[Dashboard: Fix successful supports specs ](https://github.com/Platoniq/consul/issues/20)

## Objectives
- Detect the wrong code so that the spec will pass again without errors:
  -  Improve method `grouping_key_for(date)` when `params[:group_by] == "month"` on module `Dashboard::GroupSupports`

## Notes
1. A bad iteration of dates has been detected. 
In the method:
```
    def grouped_supports(attribute)
      supports.group_by { |v| grouping_key_for(v[attribute].to_date) }
    end
```
I.e:
supports.first = `#<Vote id: 1, votable_id: 1, votable_type: "Proposal", voter_id: 2, voter_type: "User", vote_flag: nil, vote_scope: nil, vote_weight: 1, created_at: "2018-12-30 23:00:00", updated_at: "2018-12-30 23:00:00", signature_id: nil>`
supports.first.created_at = `Mon, 31 Dec 2018 00:00:00 CET +01:00`
When extract the date on method `supports.group_by { |v| grouping_key_for(v[attribute].to_date) }`, we extract the value 30/12/2018 and I suppose that we want 31/12/2018.
Added `grouping_key_for(v[attribute].in_time_zone.to_date` to fix it.

2. The method `fill_holes(grouped_votes)` seems to be trying to contemplate new groups of votes not previously contemplated. But grouped_supports method is less restrictive  than fill_holes method.  ❓ 
```
  def accumulated_grouped_supports
    grouped_votes = grouped_supports(:voted_at)
    grouped_votes = fill_holes(grouped_votes)
    accumulate_supports(grouped_votes)
  end
```