### PR TITLE
Dashboard actions for published proposals

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+rubocop:
+  config_file: .rubocop_basic.yml
+scss:
+  config_file: .scss-lint.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,35 +1,4 @@
-inherit_from: .rubocop_todo.yml
-require: rubocop-rspec
-
-AllCops:
-  DisplayCopNames: true
-  DisplayStyleGuide: true
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
-  Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'script/**/*'
-  TargetRubyVersion: 2.3
-  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
-  # to ignore them, so only the ones explicitly set in this file are enabled.
-  DisabledByDefault: true
-
-Metrics/LineLength:
-  Max: 100
-
-Layout/IndentationConsistency:
-  EnforcedStyle: rails
-
-Layout/EndOfLine:
-  EnforcedStyle: lf
-
-Layout/TrailingBlankLines:
-  Enabled: true
-
-Layout/TrailingWhitespace:
-  Enabled: true
+inherit_from: .rubocop_basic.yml
 
 Bundler/DuplicatedGem:
   Enabled: true
@@ -280,9 +249,6 @@ RSpec/DescribeMethod:
 RSpec/DescribeSymbol:
   Enabled: true
 
-RSpec/DescribedClass:
-  Enabled: true
-
 RSpec/EmptyExampleGroup:
   Enabled: true
 
@@ -366,9 +332,6 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Enabled: true
   Max: 4
-
-RSpec/NotToNot:
-  Enabled: true
 
 RSpec/OverwritingSetup:
   Enabled: true

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -1,0 +1,40 @@
+require: rubocop-rspec
+
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+  TargetRubyVersion: 2.3
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+
+Layout/IndentationConsistency:
+  EnforcedStyle: rails
+
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/EndOfLine:
+  EnforcedStyle: lf
+
+Layout/TrailingBlankLines:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Metrics/LineLength:
+  Max: 100
+
+RSpec/NotToNot:
+  Enabled: true
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/app/controllers/admin/dashboard/actions_controller.rb
+++ b/app/controllers/admin/dashboard/actions_controller.rb
@@ -25,7 +25,7 @@ class Admin::Dashboard::ActionsController < Admin::Dashboard::BaseController
   end
 
   def edit; end
-  
+
   def update
     if dashboard_action.update(dashboard_action_params)
       redirect_to admin_dashboard_actions_path
@@ -54,10 +54,10 @@ class Admin::Dashboard::ActionsController < Admin::Dashboard::BaseController
     params
       .require(:dashboard_action)
       .permit(
-        :title, :description, :short_description, :request_to_administrators, :day_offset, 
-        :required_supports, :order, :active, :action_type,
+        :title, :description, :short_description, :request_to_administrators, :day_offset,
+        :required_supports, :order, :active, :action_type, :published_proposal,
         documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
-        links_attributes: [:id, :label, :url, :open_in_new_tab, :_destroy] 
+        links_attributes: [:id, :label, :url, :open_in_new_tab, :_destroy]
       )
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -11,8 +11,8 @@ class DashboardController < Dashboard::BaseController
     proposal.publish
     redirect_to proposal_dashboard_path(proposal), notice: t('proposals.notice.published')
   end
-  
-  def progress 
+
+  def progress
     authorize! :dashboard, proposal
   end
 
@@ -21,9 +21,12 @@ class DashboardController < Dashboard::BaseController
   end
 
   private
-  
+
   def active_resources
-    @active_resources ||= Dashboard::Action.active.resources.order(required_supports: :asc, day_offset: :asc)
+    @active_resources ||= Dashboard::Action.active
+                                           .resources
+                                           .by_proposal(proposal)
+                                           .order(required_supports: :asc, day_offset: :asc)
   end
 
   def course

--- a/app/models/dashboard/action.rb
+++ b/app/models/dashboard/action.rb
@@ -14,7 +14,7 @@ class Dashboard::Action < ActiveRecord::Base
 
   enum action_type: [:proposed_action, :resource]
 
-  validates :title, 
+  validates :title,
             presence: true,
             allow_blank: false,
             length: { in: 4..80 }
@@ -39,13 +39,16 @@ class Dashboard::Action < ActiveRecord::Base
   scope :inactive, -> { where(active: false) }
   scope :resources, -> { where(action_type: 1) }
   scope :proposed_actions, -> { where(action_type: 0) }
+  scope :by_proposal, lambda { |proposal|
+    return where(published_proposal: false) if proposal.draft?
+  }
 
-  def self.active_for(proposal) 
+  def self.active_for(proposal)
     published_at = proposal.published_at&.to_date || Date.today
 
-    active
-      .where('required_supports <= ?', proposal.cached_votes_up)
-      .where('day_offset <= ?', (Date.today - published_at).to_i)
+    active.where('required_supports <= ?', proposal.cached_votes_up)
+          .where('day_offset <= ?', (Date.today - published_at).to_i)
+          .by_proposal(proposal)
   end
 
   def self.course_for(proposal)

--- a/app/views/admin/dashboard/actions/_form.html.erb
+++ b/app/views/admin/dashboard/actions/_form.html.erb
@@ -34,6 +34,13 @@
 </div>
 
 <div class="row expanded margin-top">
+  <div class="small-12 medium-12 column">
+    <%= f.check_box :published_proposal, label: t("admin.dashboard.actions.form.published_proposal") %>
+    <p class="help-text"><%= t("admin.dashboard.actions.form.published_proposal_help_text") %></p>
+  </div>
+</div>
+
+<div class="row expanded margin-top">
   <div class="small-12 medium-4 column">
     <%= f.label :day_offset %>
     <p class="help-text"><%= t("admin.dashboard.actions.form.day_offset_help_text") %></p>

--- a/app/views/admin/dashboard/actions/index.html.erb
+++ b/app/views/admin/dashboard/actions/index.html.erb
@@ -11,6 +11,7 @@
       <th><%= t("admin.dashboard.actions.index.action_title") %></th>
       <th><%= t("admin.dashboard.actions.index.action_type") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.action_active") %></th>
+      <th class="text-center"><%= t("admin.dashboard.actions.index.published_proposal") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.day_offset") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.required_supports") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.order") %></th>
@@ -30,6 +31,7 @@
         <td><%= action.title %></td>
         <td><%= t("admin.dashboard.actions.action_type.#{action.action_type}") %></td>
         <td class="text-center"><%= active_human_readable(action.active) %></td>
+        <td class="text-center"><%= active_human_readable(action.published_proposal) %></td>
         <td class="text-center"><%= number_with_delimiter(action.day_offset, delimiter: '.') %></td>
         <td class="text-center"><%= number_with_delimiter(action.required_supports, delimiter: '.') %></td>
         <td class="text-center"><%= action.order %></td>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -337,6 +337,7 @@ en:
           day_offset: Required days
           action_active: Active
           order: Order
+          published_proposal: Published proposal
         new:
           creating: New action for the proposals dashboard
           back: Back to list
@@ -352,6 +353,8 @@ en:
           day_offset_help_text: Enter 0 so that this value is not taken into account
           required_supports_help_text: Enter 0 so that this value is not taken into account
           order_help_text: Order to show to user
+          published_proposal: For published proposals?
+          published_proposal_help_text: Mark this checkbox to create the action only for published proposals
       administrator_tasks:
         index:
           title: Pending tasks

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -337,6 +337,7 @@ es:
           day_offset: Días necesarios
           action_active: Activo
           order: Orden
+          published_proposal: Propuesta publicada
         new:
           creating: Nueva acción para el dashboard de propuestas
           back: Volver a la lista
@@ -350,6 +351,8 @@ es:
           day_offset_help_text: Introduce 0 para que este valor no se tenga en cuenta
           required_supports_help_text: Introduce 0 para que este valor no se tenga en cuenta
           order_help_text: Orden para mostrar al usuario
+          published_proposal: ¿Para propuestas publicadas?
+          published_proposal_help_text: Marca este checkbox para crear la acción solo para propuestas publicadas
         delete:
           success: Acción borrada con éxito
       administrator_tasks:

--- a/db/migrate/20190108133246_add_published_proposal_to_dashboard_actions.rb
+++ b/db/migrate/20190108133246_add_published_proposal_to_dashboard_actions.rb
@@ -1,0 +1,5 @@
+class AddPublishedProposalToDashboardActions < ActiveRecord::Migration
+  def change
+    add_column :dashboard_actions, :published_proposal, :boolean, default: :false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -619,7 +619,7 @@ ActiveRecord::Schema.define(version: 20180924071722) do
     t.string   "locale",                       null: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
-    t.text     "title"
+    t.string   "title"
     t.text     "changelog"
     t.text     "body"
     t.text     "body_html"
@@ -1218,17 +1218,17 @@ ActiveRecord::Schema.define(version: 20180924071722) do
   add_index "site_customization_images", ["name"], name: "index_site_customization_images_on_name", unique: true, using: :btree
 
   create_table "site_customization_page_translations", force: :cascade do |t|
-      t.integer  "site_customization_page_id", null: false
-      t.string   "locale",                     null: false
-      t.datetime "created_at",                 null: false
-      t.datetime "updated_at",                 null: false
-      t.string   "title"
-      t.string   "subtitle"
-      t.text     "content"
-    end
+    t.integer  "site_customization_page_id", null: false
+    t.string   "locale",                     null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "title"
+    t.string   "subtitle"
+    t.text     "content"
+  end
 
-    add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
-    add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
+  add_index "site_customization_page_translations", ["locale"], name: "index_site_customization_page_translations_on_locale", using: :btree
+  add_index "site_customization_page_translations", ["site_customization_page_id"], name: "index_7fa0f9505738cb31a31f11fb2f4c4531fed7178b", using: :btree
 
   create_table "site_customization_pages", force: :cascade do |t|
     t.string   "slug",                                 null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180924071722) do
+ActiveRecord::Schema.define(version: 20190108133246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -370,6 +370,7 @@ ActiveRecord::Schema.define(version: 20180924071722) do
     t.string   "short_description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "published_proposal",                   default: false
   end
 
   create_table "dashboard_administrator_tasks", force: :cascade do |t|


### PR DESCRIPTION
## References
[Dashboard: Enhancement Resources/Actions Admin Page](https://github.com/Platoniq/consul/issues/4)

## Objectives
We want to publish actions for the same day the proposal is published.

## Visual Changes
- Index with new field "Published proposal"
![captura de pantalla 2019-01-11 a las 18 24 52](https://user-images.githubusercontent.com/16189/51049581-8debd500-15ce-11e9-92dc-d808f04efcab.png)

- Form with new field "Published proposal"
![captura de pantalla 2019-01-11 a las 18 25 10](https://user-images.githubusercontent.com/16189/51049586-93491f80-15ce-11e9-8502-bc900a820098.png)
