### PR TITLE
[Backport] Set tags max length to 160

### DIFF
--- a/app/assets/javascripts/tags.js.coffee
+++ b/app/assets/javascripts/tags.js.coffee
@@ -8,7 +8,7 @@ App.Tags =
 
       unless $this.data('initialized') is 'yes'
         $this.on('click', ->
-          name = $(this).text()
+          name = '"' + $(this).text() + '"'
           current_tags = $tag_input.val().split(',').filter(Boolean)
 
           if $.inArray(name, current_tags) >= 0

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ActsAsTaggableOn::Tag
+end

--- a/db/migrate/20190205131722_increase_tag_name_limit.rb
+++ b/db/migrate/20190205131722_increase_tag_name_limit.rb
@@ -1,0 +1,9 @@
+class IncreaseTagNameLimit < ActiveRecord::Migration
+  def up
+    change_column :tags, :name, :string, limit: 160
+  end
+
+  def down
+    change_column :tags, :name, :string, limit: 40
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190131122858) do
+ActiveRecord::Schema.define(version: 20190205131722) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1311,15 +1311,15 @@ ActiveRecord::Schema.define(version: 20190131122858) do
   add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
 
   create_table "tags", force: :cascade do |t|
-    t.string  "name",                        limit: 40
-    t.integer "taggings_count",                         default: 0
-    t.integer "debates_count",                          default: 0
-    t.integer "proposals_count",                        default: 0
-    t.integer "spending_proposals_count",               default: 0
+    t.string  "name",                        limit: 160
+    t.integer "taggings_count",                          default: 0
+    t.integer "debates_count",                           default: 0
+    t.integer "proposals_count",                         default: 0
+    t.integer "spending_proposals_count",                default: 0
     t.string  "kind"
-    t.integer "budget/investments_count",               default: 0
-    t.integer "legislation/proposals_count",            default: 0
-    t.integer "legislation/processes_count",            default: 0
+    t.integer "budget/investments_count",                default: 0
+    t.integer "legislation/proposals_count",             default: 0
+    t.integer "legislation/processes_count",             default: 0
   end
 
   add_index "tags", ["debates_count"], name: "index_tags_on_debates_count", using: :btree

--- a/lib/tag_sanitizer.rb
+++ b/lib/tag_sanitizer.rb
@@ -1,10 +1,10 @@
 class TagSanitizer
-  DISALLOWED_STRINGS = %w(? < > = /)
+  DISALLOWED_STRINGS = %w[? < > = /]
 
   def sanitize_tag(tag)
     tag = tag.dup
     DISALLOWED_STRINGS.each do |s|
-      tag.gsub!(s, '')
+      tag.gsub!(s, "")
     end
     tag.truncate(TagSanitizer.tag_max_length)
   end
@@ -14,7 +14,7 @@ class TagSanitizer
   end
 
   def self.tag_max_length
-    40
+    160
   end
 
 end

--- a/spec/factories/classifications.rb
+++ b/spec/factories/classifications.rb
@@ -1,10 +1,16 @@
 FactoryBot.define do
-  factory :tag, class: 'ActsAsTaggableOn::Tag' do
+  factory :tag, class: "ActsAsTaggableOn::Tag" do
     sequence(:name) { |n| "Tag #{n} name" }
 
     trait :category do
       kind "category"
     end
+  end
+
+  factory :tagging, class: "ActsAsTaggableOn::Tagging" do
+    context "tags"
+    association :taggable, factory: :proposal
+    tag
   end
 
   factory :topic do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe Tag do
+
+  it "decreases tag_count when a debate is hidden" do
+    debate = create(:debate)
+    tag = create(:tag)
+    tagging = create(:tagging, tag: tag, taggable: debate)
+
+    expect(tag.taggings_count).to eq(1)
+
+    debate.update(hidden_at: Time.now)
+
+    tag.reload
+    expect(tag.taggings_count).to eq(0)
+  end
+
+  it "decreases tag_count when a proposal is hidden" do
+    proposal = create(:proposal)
+    tag = create(:tag)
+    tagging = create(:tagging, tag: tag, taggable: proposal)
+
+    expect(tag.taggings_count).to eq(1)
+
+    proposal.update(hidden_at: Time.now)
+
+    tag.reload
+    expect(tag.taggings_count).to eq(0)
+  end
+
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe Tag do
 
@@ -28,4 +28,10 @@ describe Tag do
     expect(tag.taggings_count).to eq(0)
   end
 
+  describe "name validation" do
+    it "160 char name should be valid" do
+      tag = build(:tag, name: Faker::Lorem.characters(160))
+      expect(tag).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
## References

We made this change on Madrid's fork on https://github.com/AyuntamientoMadrid/consul/commit/069c22a4ac02041bfe61a3bb115611b24dfd8280.

## Objectives

Now the users (and admins) can use **tags** with a max length of `160` characters.

## Notes

We already have a [`sets up a max length for each tag`](https://github.com/consul/consul/blob/master/spec/lib/tag_sanitizer_spec.rb#L16) spec covering this setting.

Also I included missing `models/tag.rb ` and `spec/models/tag_spec.rb` files added on:

https://github.com/AyuntamientoMadrid/consul/commit/1c6153ab7dfedcc924af082e0c7a38b3591e8036
https://github.com/AyuntamientoMadrid/consul/commit/6ad2fce3d3622f261890b5b2080b70cd0c79fbee