### PR TITLE
[Backport] Budgets UI minor fixes

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1253,16 +1253,12 @@
     display: inline-block;
     margin-bottom: $line-height / 2;
 
-    &:hover {
-      background: $highlight;
-      text-decoration: none;
-    }
-
     a {
       display: block;
       padding: $line-height / 2;
 
       &:hover {
+        background: $highlight;
         text-decoration: none;
       }
     }

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -48,8 +48,8 @@ module BudgetsHelper
   end
 
   def css_for_ballot_heading(heading)
-    return '' if current_ballot.blank?
-    current_ballot.has_lines_in_heading?(heading) ? 'is-active' : ''
+    return "" if current_ballot.blank? || @current_filter == "unfeasible"
+    current_ballot.has_lines_in_heading?(heading) ? "is-active" : ""
   end
 
   def current_ballot

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -62,8 +62,8 @@
     </div>
 
     <div class="float-right">
-      <% if @budget.balloting_process? %>
-        <%= link_to t("admin.budgets.winners.calculate"),
+      <% if display_calculate_winners_button?(@budget) %>
+        <%= link_to calculate_winner_button_text(@budget),
                     calculate_winners_admin_budget_path(@budget),
                     method: :put,
                     class: "button hollow" %>

--- a/app/views/budgets/groups/show.html.erb
+++ b/app/views/budgets/groups/show.html.erb
@@ -26,7 +26,7 @@
 <% end %>
 
 <div class="row margin">
-  <div id="select-district" class="small-12 medium-7 column select-district">
+  <div id="headings" class="small-12 medium-7 column select-district">
     <div class="row">
       <% @group.headings.order_by_group_name.each_slice(7) do |slice| %>
         <div class="small-6 medium-4 column end">

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -94,22 +94,28 @@
             <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
           </div>
 
-          <p>
+          <ul class="no-bullet margin-top">
             <% show_links = show_links_to_budget_investments(current_budget) %>
             <% if show_links %>
-              <%= link_to budget_url(current_budget) do %>
-                <small><%= t("budgets.index.investment_proyects") %></small>
-              <% end %><br>
+              <li>
+                <%= link_to budget_url(current_budget) do %>
+                  <small><%= t("budgets.index.investment_proyects") %></small>
+                <% end %>
+              </li>
             <% end %>
-            <%= link_to budget_url(current_budget, filter: 'unfeasible') do %>
-              <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
-            <% end %><br>
-            <% if show_links %>
-              <%= link_to budget_url(current_budget, filter: 'unselected') do %>
-                <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
+            <li>
+              <%= link_to budget_url(current_budget, filter: "unfeasible") do %>
+                <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
               <% end %>
+            </li>
+            <% if show_links %>
+              <li>
+                <%= link_to budget_url(current_budget, filter: "unselected") do %>
+                  <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
+                <% end %>
+              </li>
             <% end %>
-          </p>
+          </ul>
         <% end %>
 
         <div id="all_phases">

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -150,7 +150,7 @@
           <div class="callout warning">
             <%= t("budgets.investments.show.project_unfeasible_html") %>
           </div>
-        <% elsif investment.winner? %>
+        <% elsif investment.winner? && @budget.finished? %>
           <div class="callout success">
             <strong><%= t("budgets.investments.show.project_winner") %></strong>
           </div>

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -359,20 +359,30 @@ feature 'Admin budget investments' do
     end
 
     scenario "Disable 'Calculate winner' button if incorrect phase" do
-      budget.update(phase: 'reviewing_ballots')
+      budget.update(phase: "reviewing_ballots")
 
       visit admin_budget_budget_investments_path(budget)
-      click_link 'Winners'
+      click_link "Winners"
 
       expect(page).to have_link "Calculate Winner Investments"
 
-      budget.update(phase: 'accepting')
+      visit edit_admin_budget_path(budget)
+
+      expect(page).to have_link "Calculate Winner Investments"
+
+      budget.update(phase: "accepting")
 
       visit admin_budget_budget_investments_path(budget)
-      click_link 'Winners'
+      click_link "Winners"
 
       expect(page).not_to have_link "Calculate Winner Investments"
-      expect(page).to have_content 'The budget has to stay on phase "Balloting projects", "Reviewing Ballots" or "Finished budget" in order to calculate winners projects'
+      expect(page).to have_content 'The budget has to stay on phase "Balloting projects", '\
+                                   '"Reviewing Ballots" or "Finished budget" in order '\
+                                   "to calculate winners projects"
+
+      visit edit_admin_budget_path(budget)
+
+      expect(page).not_to have_link "Calculate Winner Investments"
     end
 
     scenario "Filtering by minimum number of votes", :js do

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -220,14 +220,33 @@ feature 'Admin budgets' do
       expect(page).to have_content 'See results'
     end
 
-    scenario 'For a finished Budget' do
-      budget = create(:budget, phase: 'finished')
-      allow_any_instance_of(Budget).to receive(:has_winning_investments?).and_return true
+    scenario "For a finished Budget" do
+      budget = create(:budget, phase: "finished")
+      allow_any_instance_of(Budget).to receive(:has_winning_investments?).and_return(true)
 
       visit edit_admin_budget_path(budget)
 
-      expect(page).not_to have_content 'Calculate Winner Investments'
-      expect(page).to have_content 'See results'
+      expect(page).to have_content "Calculate Winner Investments"
+      expect(page).to have_content "See results"
+    end
+
+    scenario "Recalculate for a finished Budget" do
+      budget = create(:budget, phase: "finished")
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+      create(:budget_investment, :winner, heading: heading)
+
+      visit edit_admin_budget_path(budget)
+
+      expect(page).to have_content "Recalculate Winner Investments"
+      expect(page).to have_content "See results"
+      expect(page).not_to have_content "Calculate Winner Investments"
+
+      visit admin_budget_budget_investments_path(budget)
+      click_link "Winners"
+
+      expect(page).to have_content "Recalculate Winner Investments"
+      expect(page).not_to have_content "Calculate Winner Investments"
     end
 
   end

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1073,7 +1073,8 @@ feature 'Budget Investments' do
     expect(page).to have_content("This investment project has been selected for balloting phase")
   end
 
-  scenario "Show (winner budget investment)" do
+  scenario "Show (winner budget investment) only if budget is finished" do
+    budget.update(phase: "balloting")
     user = create(:user)
     login_as(user)
 
@@ -1085,6 +1086,12 @@ feature 'Budget Investments' do
                         budget: budget,
                         group: group,
                         heading: heading)
+
+    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+
+    expect(page).not_to have_content("Winning investment project")
+
+    budget.update(phase: "finished")
 
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1513,6 +1513,39 @@ feature 'Budget Investments' do
       end
     end
 
+    scenario "Highlight voted heading except with unfeasible filter", :js do
+      budget.update(phase: "balloting")
+      user = create(:user, :level_two)
+
+      heading_1 = create(:budget_heading, group: group, name: "Heading 1")
+      heading_2 = create(:budget_heading, group: group, name: "Heading 2")
+      investment = create(:budget_investment, :selected, heading: heading_1)
+
+      login_as(user)
+      visit budget_path(budget)
+
+      click_link "Health"
+      click_link "Heading 1"
+
+      add_to_ballot(investment)
+
+      visit budget_group_path(budget, group)
+
+      expect(page).to have_css("#budget_heading_#{heading_1.id}.is-active")
+      expect(page).to have_css("#budget_heading_#{heading_2.id}")
+
+      visit budget_group_path(budget, group)
+
+      click_link "See unfeasible investments"
+      click_link "Health"
+
+      within("#headings") do
+        expect(page).to have_css("#budget_heading_#{heading_1.id}")
+        expect(page).to have_css("#budget_heading_#{heading_2.id}")
+        expect(page).not_to have_css(".is-active")
+      end
+    end
+
     scenario 'Ballot is visible' do
       login_as(author)
 


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1857

## Objectives


- Update calculate winners button on budgets form: now works the same way as the button on `/admin/budgets/N/budget_investments?filter=winners`. The button say "Calculate winner investments" (first time) and "Recalculate Winner Investments" the next one, and appears on ` balloting`,  `reviewing_ballots` and `finished` phases. 

- Hide hover background color on budget index if there is no heading link: now the hover effect effect appears only when the Headings are links (always except on `informing` and `finished` phases).

- Show `Winning investment project` label only if budget is finished on investment show.

- Hide voted group css class if current filter is unfeasible.

- Improve space for links on budget index, added a little extra space between map and links.

## Visual Changes
**Hover effect when Headings are links**
![hover](https://user-images.githubusercontent.com/631897/52226349-fae04b00-28ac-11e9-9127-b0f34b3acc6c.png)

**No links, no hover effect** 😎 
![no_hover](https://user-images.githubusercontent.com/631897/52226354-fcaa0e80-28ac-11e9-828a-4e62e4971687.png)

**This voted group (on `selecting` phase) css class disappears if current filter is unfeasible**
![heading](https://user-images.githubusercontent.com/631897/52226359-ffa4ff00-28ac-11e9-8708-c59635e6abc0.png)