### PR TITLE
[Backport] Change layout on homepage if feed debates and proposals are enabled

### DIFF
--- a/app/helpers/feeds_helper.rb
+++ b/app/helpers/feeds_helper.rb
@@ -12,8 +12,20 @@ module FeedsHelper
     feed.kind == "processes"
   end
 
+  def feed_debates_enabled?
+    Setting["feature.homepage.widgets.feeds.debates"].present?
+  end
+
+  def feed_proposals_enabled?
+    Setting["feature.homepage.widgets.feeds.proposals"].present?
+  end
+
   def feed_processes_enabled?
-    Setting['feature.homepage.widgets.feeds.processes'].present?
+    Setting["feature.homepage.widgets.feeds.processes"].present?
+  end
+
+  def feed_debates_and_proposals_enabled?
+    feed_debates_enabled? && feed_proposals_enabled?
   end
 
 end

--- a/app/views/welcome/_feeds.html.erb
+++ b/app/views/welcome/_feeds.html.erb
@@ -2,7 +2,8 @@
   <% @feeds.each do |feed| %>
 
     <% if feed_proposals?(feed) %>
-      <div class="small-12 medium-8 column margin-top">
+      <div id="feed_proposals" class="small-12 column margin-top
+                                      <%= 'medium-8' if feed_debates_and_proposals_enabled? %>">
         <div class="feed-content" data-equalizer-watch>
           <h3 class="title"><%= t("welcome.feed.most_active.#{feed.kind}") %></h3>
 
@@ -16,7 +17,8 @@
                   </div>
                 </div>
               <% end %>
-              <div class="feed-description small-12 column <%= 'large-9' if feature?(:allow_images) && item.image.present? %>">
+              <div class="feed-description small-12 column
+                          <%= 'large-9' if feature?(:allow_images) && item.image.present? %>">
                 <strong><%= link_to item.title, url_for(item) %></strong><br>
                 <p><%= item.summary %></p>
               </div>
@@ -29,7 +31,8 @@
     <% end %>
 
     <% if feed_debates?(feed) %>
-      <div class="small-12 medium-4 column margin-top">
+      <div id="feed_debates" class="small-12 column margin-top
+                                    <%= 'medium-4' if feed_debates_and_proposals_enabled? %>">
         <div class="feed-content" data-equalizer-watch>
           <h3 class="title"><%= t("welcome.feed.most_active.#{feed.kind}") %></h3>
 

--- a/spec/features/admin/homepage/homepage_spec.rb
+++ b/spec/features/admin/homepage/homepage_spec.rb
@@ -39,14 +39,18 @@ feature 'Homepage' do
       visit admin_homepage_path
 
       within("#widget_feed_#{proposals_feed.id}") do
-        select '1', from: 'widget_feed_limit'
+        select "1", from: "widget_feed_limit"
         accept_confirm { click_button "Enable" }
       end
 
       visit root_path
 
-      expect(page).to have_content "Most active proposals"
-      expect(page).to have_css(".proposal", count: 1)
+      within("#feed_proposals") do
+        expect(page).to have_content "Most active proposals"
+        expect(page).to have_css(".proposal", count: 1)
+      end
+
+      expect(page).not_to have_css("#feed_proposals.medium-8")
     end
 
     scenario "Debates", :js do
@@ -54,14 +58,50 @@ feature 'Homepage' do
 
       visit admin_homepage_path
       within("#widget_feed_#{debates_feed.id}") do
-        select '2', from: 'widget_feed_limit'
+        select "2", from: "widget_feed_limit"
         accept_confirm { click_button "Enable" }
       end
 
       visit root_path
 
-      expect(page).to have_content "Most active debates"
-      expect(page).to have_css(".debate", count: 2)
+      within("#feed_debates") do
+        expect(page).to have_content "Most active debates"
+        expect(page).to have_css(".debate", count: 2)
+      end
+
+      expect(page).not_to have_css("#feed_debates.medium-4")
+    end
+
+    scenario "Proposals and debates", :js do
+      3.times { create(:proposal) }
+      3.times { create(:debate) }
+
+      visit admin_homepage_path
+
+      within("#widget_feed_#{proposals_feed.id}") do
+        select "3", from: "widget_feed_limit"
+        accept_confirm { click_button "Enable" }
+      end
+
+      within("#widget_feed_#{debates_feed.id}") do
+        select "3", from: "widget_feed_limit"
+        accept_confirm { click_button "Enable" }
+      end
+
+      visit root_path
+
+      within("#feed_proposals") do
+        expect(page).to have_content "Most active proposals"
+        expect(page).to have_css(".proposal", count: 3)
+      end
+
+      within("#feed_debates") do
+        expect(page).to have_content "Most active debates"
+        expect(page).to have_css(".debate", count: 3)
+      end
+
+      expect(page).to have_css("#feed_proposals.medium-8")
+      expect(page).to have_css("#feed_debates.medium-4")
     end
 
     scenario "Processes", :js do


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1859/ 

## Background

Admin users can enable show proposals and debates feed on homepage from `/admin/homepage` but if only enable one the layout looks empty with too much blank space.

## Objectives

Change layout on homepage if feed debates and proposals are enabled. Now show the content with **100% width** if only proposals or debates are enabled.

## Visual Changes

**Feeds proposals and debates enabled (same layout)**
![proposals_debates](https://user-images.githubusercontent.com/631897/52274099-f7e86780-294b-11e9-96ff-8114dca375db.png)

**Only feed proposals, 100% width!**
![proposals](https://user-images.githubusercontent.com/631897/52274105-fa4ac180-294b-11e9-9ad9-6b6571d262d1.png)

**Only feed debates, 100% width!**
![debates](https://user-images.githubusercontent.com/631897/52274109-fcad1b80-294b-11e9-8116-bf15ab702711.png)