### PR TITLE
[Backport] Show unfeasible and unselected investments for finished budgets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,6 +120,8 @@ class ApplicationController < ActionController::Base
     def set_default_budget_filter
       if @budget.try(:balloting?) || @budget.try(:publishing_prices?)
         params[:filter] ||= "selected"
+      elsif @budget.try(:finished?)
+        params[:filter] ||= "winners"
       end
     end
 

--- a/app/controllers/budgets/groups_controller.rb
+++ b/app/controllers/budgets/groups_controller.rb
@@ -4,7 +4,7 @@ module Budgets
     load_and_authorize_resource :group, class: "Budget::Group"
 
     before_action :set_default_budget_filter, only: :show
-    has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: [:show]
+    has_filters %w[not_unfeasible feasible unfeasible unselected selected winners], only: [:show]
 
     def show
     end

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -26,7 +26,9 @@ module Budgets
 
     has_orders %w{most_voted newest oldest}, only: :show
     has_orders ->(c) { c.instance_variable_get(:@budget).investments_orders }, only: :index
-    has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: [:index, :show, :suggest]
+
+    valid_filters = %w[not_unfeasible feasible unfeasible unselected selected winners]
+    has_filters valid_filters, only: [:index, :show, :suggest]
 
     invisible_captcha only: [:create, :update], honeypot: :subtitle, scope: :budget_investment
 
@@ -34,18 +36,10 @@ module Budgets
     respond_to :html, :js
 
     def index
-      all_investments = if @budget.finished?
-                          investments.winners
-                        else
-                          investments
-                        end
-
-      @investments = all_investments.page(params[:page]).per(10).for_render
+      @investments = investments.page(params[:page]).per(10).for_render
 
       @investment_ids = @investments.pluck(:id)
-      @investments_map_coordinates =  MapLocation.where(investment: all_investments).map do |loc|
-        loc.json_data
-      end
+      @investments_map_coordinates = MapLocation.where(investment: investments).map(&:json_data)
 
       load_investment_votes(@investments)
       @tag_cloud = tag_cloud

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -5,7 +5,7 @@ class BudgetsController < ApplicationController
 
   load_and_authorize_resource
   before_action :set_default_budget_filter, only: :show
-  has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: :show
+  has_filters %w[not_unfeasible feasible unfeasible unselected selected winners], only: :show
 
   respond_to :html, :js
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -519,6 +519,66 @@ feature 'Budget Investments' do
       expected_path = budget_investments_path(budget, heading_id: heading1.id, filter: "unfeasible")
       expect(page).to have_current_path(expected_path)
     end
+
+    context "Results Phase" do
+
+      before { budget.update(phase: "finished") }
+
+      scenario "show winners by default" do
+        investment1 = create(:budget_investment, :winner, heading: heading)
+        investment2 = create(:budget_investment, :selected, heading: heading)
+
+        visit budget_path(budget)
+        click_link "Health"
+
+        within("#budget-investments") do
+          expect(page).to have_css(".budget-investment", count: 1)
+          expect(page).to have_content(investment1.title)
+          expect(page).not_to have_content(investment2.title)
+        end
+
+        visit budget_results_path(budget)
+        click_link "List of all investment projects"
+        click_link "Health"
+
+        within("#budget-investments") do
+          expect(page).to have_css(".budget-investment", count: 1)
+          expect(page).to have_content(investment1.title)
+          expect(page).not_to have_content(investment2.title)
+        end
+      end
+
+      scenario "unfeasible", :js do
+        investment1 = create(:budget_investment, :unfeasible, heading: heading,
+                             valuation_finished: true)
+        investment2 = create(:budget_investment, :feasible, heading: heading)
+
+        visit budget_results_path(budget)
+        click_link "List of all unfeasible investment projects"
+        click_link "Health"
+
+        within("#budget-investments") do
+          expect(page).to have_css(".budget-investment", count: 1)
+          expect(page).to have_content(investment1.title)
+          expect(page).not_to have_content(investment2.title)
+        end
+      end
+
+      scenario "unselected" do
+        investment1 = create(:budget_investment, :unselected, heading: heading)
+        investment2 = create(:budget_investment, :selected, heading: heading)
+
+        visit budget_results_path(budget)
+        click_link "List of all investment projects not selected for balloting"
+        click_link "Health"
+
+        within("#budget-investments") do
+          expect(page).to have_css(".budget-investment", count: 1)
+          expect(page).to have_content(investment1.title)
+          expect(page).not_to have_content(investment2.title)
+        end
+      end
+    end
   end
 
   context "Orders" do
@@ -1161,20 +1221,6 @@ feature 'Budget Investments' do
 
     expect(page).not_to have_content("Unfeasibility explanation")
     expect(page).not_to have_content("Local government is not competent in this matter")
-  end
-
-  scenario "Only winner investments are show when budget is finished" do
-    3.times { create(:budget_investment, heading: heading) }
-
-    Budget::Investment.first.update(feasibility: 'feasible', selected: true, winner: true)
-    Budget::Investment.second.update(feasibility: 'feasible', selected: true, winner: true)
-    budget.update(phase: 'finished')
-
-    visit budget_investments_path(budget, heading_id: heading.id)
-
-    expect(page).to have_content("#{Budget::Investment.first.title}")
-    expect(page).to have_content("#{Budget::Investment.second.title}")
-    expect(page).not_to have_content("#{Budget::Investment.third.title}")
   end
 
   it_behaves_like "followable", "budget_investment", "budget_investment_path", { "budget_id": "budget_id", "id": "id" }


### PR DESCRIPTION
## References

This is a backport of PR https://github.com/AyuntamientoMadrid/consul/pull/1850

## Objectives

We want to show the list of `unfeasible` and `unselected` project although the budget is finished.