### PR TITLE
[Backport] Send newsletter emails in order

### DIFF
--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -50,7 +50,7 @@ class UserSegments
   end
 
   def self.user_segment_emails(users_segment)
-    UserSegments.send(users_segment).newsletter.pluck(:email).compact
+    UserSegments.send(users_segment).newsletter.order(:created_at).pluck(:email).compact
   end
 
   private

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -190,4 +190,15 @@ describe UserSegments do
     end
   end
 
+  describe "#user_segment_emails" do
+    it "returns list of emails sorted by user creation date" do
+      create(:user, email: "first@email.com", created_at: 1.day.ago)
+      create(:user, email: "last@email.com")
+
+      emails = described_class.user_segment_emails(:all_users)
+      expect(emails.first).to eq "first@email.com"
+      expect(emails.last).to eq "last@email.com"
+    end
+  end
+
 end


### PR DESCRIPTION
## References

This is a backport of the PR https://github.com/AyuntamientoMadrid/consul/pull/1858
Original issue https://github.com/AyuntamientoMadrid/consul/issues/1854

## Objectives
Order all newsletter emails by a user's `created_at` attribute