### PR TITLE
[Backport] Do not display alert when supporting in a group with a single heading

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -90,4 +90,10 @@ module BudgetsHelper
       t("admin.budgets.winners.recalculate")
     end
   end
+
+  def display_support_alert?(investment)
+    current_user &&
+    !current_user.voted_in_group?(investment.group) &&
+    investment.group.headings.count > 1
+  end
 end

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -18,8 +18,9 @@
           class: "button button-support small expanded",
           title: t('budgets.investments.investment.support_title'),
           method: "post",
-          remote: (current_user && current_user.voted_in_group?(investment.group) ? true : false),
-          data:   (current_user && current_user.voted_in_group?(investment.group) ? nil : { confirm: t('budgets.investments.investment.confirm_group', count: investment.group.max_votable_headings)} ),
+          remote: (display_support_alert?(investment) ? false: true ),
+          data:   (display_support_alert?(investment) ? {
+                  confirm: t("budgets.investments.investment.confirm_group")} : nil),
           "aria-hidden" => css_for_aria_hidden(reason) do %>
         <%= t("budgets.investments.investment.give_support") %>
       <% end %>

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1307,6 +1307,7 @@ feature 'Budget Investments' do
         carabanchel_investment = create(:budget_investment, :selected, heading: carabanchel)
         salamanca_investment   = create(:budget_investment, :selected, heading: salamanca)
 
+        login_as(author)
         visit budget_investments_path(budget, heading_id: carabanchel.id)
 
         within("#budget_investment_#{carabanchel_investment.id}") do
@@ -1332,19 +1333,33 @@ feature 'Budget Investments' do
       end
 
       scenario "When supporting in another group", :js do
-        carabanchel     = create(:budget_heading, group: group)
-        another_heading = create(:budget_heading, group: create(:budget_group, budget: budget))
+        heading = create(:budget_heading, group: group)
 
-        carabanchel_investment   = create(:budget_investment, heading: carabanchel)
-        another_group_investment = create(:budget_investment, heading: another_heading)
+        group2 = create(:budget_group, budget: budget)
+        another_heading1 = create(:budget_heading, group: group2)
+        another_heading2 = create(:budget_heading, group: group2)
 
-        create(:vote, votable: carabanchel_investment, voter: author)
+        heading_investment   = create(:budget_investment, heading: heading)
+        another_group_investment = create(:budget_investment, heading: another_heading1)
+
+        create(:vote, votable: heading_investment, voter: author)
 
         login_as(author)
-        visit budget_investments_path(budget, heading_id: another_heading.id)
+        visit budget_investments_path(budget, heading_id: another_heading1.id)
 
         within("#budget_investment_#{another_group_investment.id}") do
           expect(page).to have_css(".in-favor a[data-confirm]")
+        end
+      end
+
+      scenario "When supporting in a group with a single heading", :js do
+        all_city_investment = create(:budget_investment, heading: heading)
+
+        login_as(author)
+        visit budget_investments_path(budget, heading_id: heading.id)
+
+        within("#budget_investment_#{all_city_investment.id}") do
+          expect(page).not_to have_css(".in-favor a[data-confirm]")
         end
       end
     end

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -45,7 +45,7 @@ feature 'Votes' do
         visit budget_investments_path(budget, heading_id: heading.id)
 
         within('.supports') do
-          accept_confirm { find('.in-favor a').click }
+          find(".in-favor a").click
 
           expect(page).to have_content "1 support"
           expect(page).to have_content "You have already supported this investment project. Share it!"
@@ -67,7 +67,7 @@ feature 'Votes' do
         visit budget_investment_path(budget, @investment)
 
         within('.supports') do
-          accept_confirm { find('.in-favor a').click }
+          find(".in-favor a").click
           expect(page).to have_content "1 support"
 
           expect(page).not_to have_selector ".in-favor a"
@@ -78,7 +78,7 @@ feature 'Votes' do
         visit budget_investment_path(budget, @investment)
 
         within('.supports') do
-          accept_confirm { find('.in-favor a').click }
+          find(".in-favor a").click
 
           expect(page).to have_content "1 support"
           expect(page).to have_content "You have already supported this investment project. Share it!"

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -224,7 +224,7 @@ feature 'Budget Investments' do
       expect(page).to have_content(budget_investment.title)
 
       within("#budget-investments") do
-        accept_confirm { find('.js-in-favor a').click }
+        find(".js-in-favor a").click
 
         expect(page).to have_content "1 support"
         expect(page).to have_content "You have already supported this investment project. Share it!"


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/commit/3322439ecec9f8323c1d3534b854e16787cc982e

## Objectives

Do not display alert on budgets when supporting in a group with a single heading. Now, this alert only appears when the group have more than one heading.

## Visual Changes

**The alert**
![alert](https://user-images.githubusercontent.com/631897/52424091-9665fb80-2af9-11e9-8e9a-52c18433e5a6.png)