### PR TITLE
[Backport] Removes next/incoming filters

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -1,7 +1,7 @@
 class Admin::Legislation::ProcessesController < Admin::Legislation::BaseController
   include Translatable
 
-  has_filters %w{open next past all}, only: :index
+  has_filters %w[open past all], only: :index
 
   load_and_authorize_resource :process, class: "Legislation::Process"
 

--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -1,7 +1,7 @@
 class Admin::Legislation::ProcessesController < Admin::Legislation::BaseController
   include Translatable
 
-  has_filters %w[open past all], only: :index
+  has_filters %w[open all], only: :index
 
   load_and_authorize_resource :process, class: "Legislation::Process"
 

--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -51,7 +51,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   end
 
   def booth_assignments
-    @polls = Poll.current_or_incoming
+    @polls = Poll.current
   end
 
   private

--- a/app/controllers/admin/poll/shifts_controller.rb
+++ b/app/controllers/admin/poll/shifts_controller.rb
@@ -6,8 +6,8 @@ class Admin::Poll::ShiftsController < Admin::Poll::BaseController
   def new
     load_shifts
     @shift = ::Poll::Shift.new
-    @voting_polls = @booth.polls.current_or_incoming
-    @recount_polls = @booth.polls.current_or_recounting_or_incoming
+    @voting_polls = @booth.polls.current
+    @recount_polls = @booth.polls.current_or_recounting
   end
 
   def create

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -1,5 +1,5 @@
 class Legislation::ProcessesController < Legislation::BaseController
-  has_filters %w[open next past], only: :index
+  has_filters %w[open past], only: :index
   has_filters %w[random winners], only: :proposals
 
   load_and_authorize_resource

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -3,7 +3,7 @@ class PollsController < ApplicationController
 
   load_and_authorize_resource
 
-  has_filters %w{current expired incoming}
+  has_filters %w[current expired]
   has_orders %w{most_voted newest oldest}, only: :show
 
   ::Poll::Answer # trigger autoload

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -50,7 +50,6 @@ class Legislation::Process < ActiveRecord::Base
   validates :font_color, format: { allow_blank: true, with: CSS_HEX_COLOR }
 
   scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current) }
-  scope :next, -> { where("start_date > ?", Date.current) }
   scope :past, -> { where("end_date < ?", Date.current) }
 
   scope :published, -> { where(published: true) }

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -28,7 +28,6 @@ class Poll < ActiveRecord::Base
   validate :date_range
 
   scope :current,  -> { where('starts_at <= ? and ? <= ends_at', Date.current.beginning_of_day, Date.current.beginning_of_day) }
-  scope :incoming, -> { where('? < starts_at', Date.current.beginning_of_day) }
   scope :expired,  -> { where('ends_at < ?', Date.current.beginning_of_day) }
   scope :recounting, -> { Poll.where(ends_at: (Date.current.beginning_of_day - RECOUNT_DURATION)..Date.current.beginning_of_day) }
   scope :published, -> { where('published = ?', true) }
@@ -45,20 +44,12 @@ class Poll < ActiveRecord::Base
     starts_at <= timestamp && timestamp <= ends_at
   end
 
-  def incoming?(timestamp = Date.current.beginning_of_day)
-    timestamp < starts_at
-  end
-
   def expired?(timestamp = Date.current.beginning_of_day)
     ends_at < timestamp
   end
 
-  def self.current_or_incoming
-    current + incoming
-  end
-
-  def self.current_or_recounting_or_incoming
-    current + recounting + incoming
+  def self.current_or_recounting
+    current + recounting
   end
 
   def answerable_by?(user)

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -12,7 +12,7 @@ class Poll
     end
 
     def self.available
-      where(polls: { id: Poll.current_or_recounting_or_incoming }).includes(:polls)
+      where(polls: { id: Poll.current_or_recounting }).includes(:polls)
     end
 
     def assignment_on_poll(poll)

--- a/app/views/polls/_callout.html.erb
+++ b/app/views/polls/_callout.html.erb
@@ -10,10 +10,6 @@
       <%= t('polls.show.cant_answer_verify_html',
             verify_link: link_to(t('polls.show.verify_link'), verification_path)) %>
     </div>
-  <% elsif @poll.incoming? %>
-    <div class="callout primary">
-      <%= t('polls.show.cant_answer_incoming') %>
-    </div>
   <% elsif @poll.expired? %>
     <div class="callout alert">
       <%= t('polls.show.cant_answer_expired') %>

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -75,8 +75,6 @@
           <%= link_to poll, class: "button hollow expanded" do %>
             <% if poll.expired? %>
               <%= t("polls.index.participate_button_expired") %>
-            <% elsif poll.incoming? %>
-              <%= t("polls.index.participate_button_incoming") %>
             <% else %>
               <%= t("polls.index.participate_button") %>
             <% end %>

--- a/config/locales/ar/admin.yml
+++ b/config/locales/ar/admin.yml
@@ -134,7 +134,6 @@ ar:
           delete: حذف
           filters:
             open: فتح
-            next: التالي
             past: السابق
         new:
           back: عودة

--- a/config/locales/ar/admin.yml
+++ b/config/locales/ar/admin.yml
@@ -134,7 +134,6 @@ ar:
           delete: حذف
           filters:
             open: فتح
-            past: السابق
         new:
           back: عودة
           submit_button: إنشاء عملية

--- a/config/locales/ar/seeds.yml
+++ b/config/locales/ar/seeds.yml
@@ -49,7 +49,6 @@ ar:
     polls:
       current_poll: "الاستطلاع الحالي"
       current_poll_geozone_restricted: "الاستطلاع الجغرافي الاحالي مقيد"
-      incoming_poll: "الاقتراع الوارد"
       recounting_poll: "اعادة حساب الاستطلاع"
       expired_poll_without_stats: "انتهاء مدة صلاحية الاستطلاع دون احصائيات و النتائج"
       expired_poll_with_stats: "انتهاء مدة صلاحية الاستطلاع مع الاحصائيات و النتائج"

--- a/config/locales/de-DE/admin.yml
+++ b/config/locales/de-DE/admin.yml
@@ -386,7 +386,6 @@ de:
           title: Kollaborative Gesetzgebungsprozesse
           filters:
             open: Offen
-            past: Vorherige
             all: Alle
         new:
           back: Zurück

--- a/config/locales/de-DE/admin.yml
+++ b/config/locales/de-DE/admin.yml
@@ -386,7 +386,6 @@ de:
           title: Kollaborative Gesetzgebungsprozesse
           filters:
             open: Offen
-            next: Nächste/r
             past: Vorherige
             all: Alle
         new:

--- a/config/locales/de-DE/general.yml
+++ b/config/locales/de-DE/general.yml
@@ -456,11 +456,9 @@ de:
     index:
       filters:
         current: "Offen"
-        incoming: "Demnächst"
         expired: "Abgelaufen"
       title: "Umfragen"
       participate_button: "An dieser Umfrage teilnehmen"
-      participate_button_incoming: "Weitere Informationen"
       participate_button_expired: "Umfrage beendet"
       no_geozone_restricted: "Ganze Stadt"
       geozone_restricted: "Bezirke"
@@ -484,7 +482,6 @@ de:
       signup: Registrierung
       cant_answer_verify_html: "Sie müssen %{verify_link}, um zu antworten."
       verify_link: "verifizieren Sie Ihr Konto"
-      cant_answer_incoming: "Diese Umfrage hat noch nicht begonnen."
       cant_answer_expired: "Diese Umfrage wurde beendet."
       cant_answer_wrong_geozone: "Diese Frage ist nicht in ihrem Gebiet verfügbar."
       more_info_title: "Weitere Informationen"

--- a/config/locales/de-DE/legislation.yml
+++ b/config/locales/de-DE/legislation.yml
@@ -62,10 +62,8 @@ de:
         filter: Filter
         filters:
           open: Laufende Verfahren
-          next: Geplante
           past: Vorherige
         no_open_processes: Es gibt keine offenen Verfahren
-        no_next_processes: Es gibt keine geplanten Prozesse
         no_past_processes: Es gibt keine vergangene Prozesse
         section_header:
           icon_alt: Gesetzgebungsverfahren Icon

--- a/config/locales/de-DE/seeds.yml
+++ b/config/locales/de-DE/seeds.yml
@@ -49,7 +49,6 @@ de:
     polls:
       current_poll: "Aktuelle Umfrage"
       current_poll_geozone_restricted: "Aktuelle Umfrage eingeschränkt auf Geo-Zone"
-      incoming_poll: "Eingehende Umfrage"
       recounting_poll: "Umfrage wiederholen"
       expired_poll_without_stats: "Abgelaufene Umfrage ohne Statistiken und Ergebnisse"
       expired_poll_with_stats: "Abgelaufene Umfrage mit Statistiken und Ergebnisse"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -446,7 +446,6 @@ en:
           title: Legislation processes
           filters:
             open: Open
-            next: Next
             past: Past
             all: All
         new:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -446,7 +446,6 @@ en:
           title: Legislation processes
           filters:
             open: Open
-            past: Past
             all: All
         new:
           back: Back

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -462,11 +462,9 @@ en:
     index:
       filters:
         current: "Open"
-        incoming: "Incoming"
         expired: "Expired"
       title: "Polls"
       participate_button: "Participate in this poll"
-      participate_button_incoming: "More information"
       participate_button_expired: "Poll ended"
       no_geozone_restricted: "All city"
       geozone_restricted: "Districts"
@@ -494,7 +492,6 @@ en:
       signup: Sign up
       cant_answer_verify_html: "You must %{verify_link} in order to answer."
       verify_link: "verify your account"
-      cant_answer_incoming: "This poll has not yet started."
       cant_answer_expired: "This poll has finished."
       cant_answer_wrong_geozone: "This question is not available on your geozone."
       more_info_title: "More information"

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -62,10 +62,8 @@ en:
         filter: Filter
         filters:
           open: Open processes
-          next: Next
           past: Past
         no_open_processes: There aren't open processes
-        no_next_processes: There aren't planned processes
         no_past_processes: There aren't past processes
         section_header:
           icon_alt: Legislation processes icon

--- a/config/locales/en/seeds.yml
+++ b/config/locales/en/seeds.yml
@@ -49,7 +49,6 @@ en:
     polls:
       current_poll: "Current Poll"
       current_poll_geozone_restricted: "Current Poll Geozone Restricted"
-      incoming_poll: "Incoming Poll"
       recounting_poll: "Recounting Poll"
       expired_poll_without_stats: "Expired Poll without Stats & Results"
       expired_poll_with_stats: "Expired Poll with Stats & Results"

--- a/config/locales/es-AR/admin.yml
+++ b/config/locales/es-AR/admin.yml
@@ -350,7 +350,6 @@ es-AR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-AR/admin.yml
+++ b/config/locales/es-AR/admin.yml
@@ -350,7 +350,6 @@ es-AR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-AR/general.yml
+++ b/config/locales/es-AR/general.yml
@@ -431,11 +431,9 @@ es-AR:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -459,7 +457,6 @@ es-AR:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-AR/legislation.yml
+++ b/config/locales/es-AR/legislation.yml
@@ -54,10 +54,8 @@ es-AR:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-BO/admin.yml
+++ b/config/locales/es-BO/admin.yml
@@ -261,7 +261,6 @@ es-BO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-BO/admin.yml
+++ b/config/locales/es-BO/admin.yml
@@ -261,7 +261,6 @@ es-BO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-BO/general.yml
+++ b/config/locales/es-BO/general.yml
@@ -406,11 +406,9 @@ es-BO:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-BO:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-BO/legislation.yml
+++ b/config/locales/es-BO/legislation.yml
@@ -54,10 +54,8 @@ es-BO:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-CL/admin.yml
+++ b/config/locales/es-CL/admin.yml
@@ -344,7 +344,6 @@ es-CL:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-CL/admin.yml
+++ b/config/locales/es-CL/admin.yml
@@ -344,7 +344,6 @@ es-CL:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-CL/general.yml
+++ b/config/locales/es-CL/general.yml
@@ -406,11 +406,9 @@ es-CL:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-CL:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-CL/legislation.yml
+++ b/config/locales/es-CL/legislation.yml
@@ -54,10 +54,8 @@ es-CL:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-CO/admin.yml
+++ b/config/locales/es-CO/admin.yml
@@ -261,7 +261,6 @@ es-CO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-CO/admin.yml
+++ b/config/locales/es-CO/admin.yml
@@ -261,7 +261,6 @@ es-CO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-CO/general.yml
+++ b/config/locales/es-CO/general.yml
@@ -406,11 +406,9 @@ es-CO:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-CO:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-CO/legislation.yml
+++ b/config/locales/es-CO/legislation.yml
@@ -54,10 +54,8 @@ es-CO:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-CR/admin.yml
+++ b/config/locales/es-CR/admin.yml
@@ -261,7 +261,6 @@ es-CR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-CR/admin.yml
+++ b/config/locales/es-CR/admin.yml
@@ -261,7 +261,6 @@ es-CR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-CR/general.yml
+++ b/config/locales/es-CR/general.yml
@@ -406,11 +406,9 @@ es-CR:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-CR:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-CR/legislation.yml
+++ b/config/locales/es-CR/legislation.yml
@@ -54,10 +54,8 @@ es-CR:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-DO/admin.yml
+++ b/config/locales/es-DO/admin.yml
@@ -261,7 +261,6 @@ es-DO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-DO/admin.yml
+++ b/config/locales/es-DO/admin.yml
@@ -261,7 +261,6 @@ es-DO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-DO/general.yml
+++ b/config/locales/es-DO/general.yml
@@ -406,11 +406,9 @@ es-DO:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-DO:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-DO/legislation.yml
+++ b/config/locales/es-DO/legislation.yml
@@ -54,10 +54,8 @@ es-DO:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-EC/admin.yml
+++ b/config/locales/es-EC/admin.yml
@@ -261,7 +261,6 @@ es-EC:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-EC/admin.yml
+++ b/config/locales/es-EC/admin.yml
@@ -261,7 +261,6 @@ es-EC:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-EC/general.yml
+++ b/config/locales/es-EC/general.yml
@@ -406,11 +406,9 @@ es-EC:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-EC:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-EC/legislation.yml
+++ b/config/locales/es-EC/legislation.yml
@@ -54,10 +54,8 @@ es-EC:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-GT/admin.yml
+++ b/config/locales/es-GT/admin.yml
@@ -261,7 +261,6 @@ es-GT:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-GT/admin.yml
+++ b/config/locales/es-GT/admin.yml
@@ -261,7 +261,6 @@ es-GT:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-GT/general.yml
+++ b/config/locales/es-GT/general.yml
@@ -406,11 +406,9 @@ es-GT:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-GT:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-GT/legislation.yml
+++ b/config/locales/es-GT/legislation.yml
@@ -54,10 +54,8 @@ es-GT:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-HN/admin.yml
+++ b/config/locales/es-HN/admin.yml
@@ -261,7 +261,6 @@ es-HN:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-HN/admin.yml
+++ b/config/locales/es-HN/admin.yml
@@ -261,7 +261,6 @@ es-HN:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-HN/general.yml
+++ b/config/locales/es-HN/general.yml
@@ -406,11 +406,9 @@ es-HN:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-HN:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-HN/legislation.yml
+++ b/config/locales/es-HN/legislation.yml
@@ -54,10 +54,8 @@ es-HN:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-MX/admin.yml
+++ b/config/locales/es-MX/admin.yml
@@ -261,7 +261,6 @@ es-MX:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-MX/admin.yml
+++ b/config/locales/es-MX/admin.yml
@@ -261,7 +261,6 @@ es-MX:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-MX/general.yml
+++ b/config/locales/es-MX/general.yml
@@ -406,11 +406,9 @@ es-MX:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-MX:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-MX/legislation.yml
+++ b/config/locales/es-MX/legislation.yml
@@ -54,10 +54,8 @@ es-MX:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-NI/admin.yml
+++ b/config/locales/es-NI/admin.yml
@@ -261,7 +261,6 @@ es-NI:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-NI/admin.yml
+++ b/config/locales/es-NI/admin.yml
@@ -261,7 +261,6 @@ es-NI:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-NI/general.yml
+++ b/config/locales/es-NI/general.yml
@@ -406,11 +406,9 @@ es-NI:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-NI:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-NI/legislation.yml
+++ b/config/locales/es-NI/legislation.yml
@@ -54,10 +54,8 @@ es-NI:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-PA/admin.yml
+++ b/config/locales/es-PA/admin.yml
@@ -261,7 +261,6 @@ es-PA:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-PA/admin.yml
+++ b/config/locales/es-PA/admin.yml
@@ -261,7 +261,6 @@ es-PA:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-PA/general.yml
+++ b/config/locales/es-PA/general.yml
@@ -406,11 +406,9 @@ es-PA:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-PA:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-PA/legislation.yml
+++ b/config/locales/es-PA/legislation.yml
@@ -54,10 +54,8 @@ es-PA:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-PE/admin.yml
+++ b/config/locales/es-PE/admin.yml
@@ -261,7 +261,6 @@ es-PE:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-PE/admin.yml
+++ b/config/locales/es-PE/admin.yml
@@ -261,7 +261,6 @@ es-PE:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-PE/general.yml
+++ b/config/locales/es-PE/general.yml
@@ -406,11 +406,9 @@ es-PE:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-PE:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-PE/legislation.yml
+++ b/config/locales/es-PE/legislation.yml
@@ -54,10 +54,8 @@ es-PE:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-PR/admin.yml
+++ b/config/locales/es-PR/admin.yml
@@ -261,7 +261,6 @@ es-PR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-PR/admin.yml
+++ b/config/locales/es-PR/admin.yml
@@ -261,7 +261,6 @@ es-PR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-PR/general.yml
+++ b/config/locales/es-PR/general.yml
@@ -406,11 +406,9 @@ es-PR:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-PR:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-PR/legislation.yml
+++ b/config/locales/es-PR/legislation.yml
@@ -54,10 +54,8 @@ es-PR:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-PY/admin.yml
+++ b/config/locales/es-PY/admin.yml
@@ -261,7 +261,6 @@ es-PY:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-PY/admin.yml
+++ b/config/locales/es-PY/admin.yml
@@ -261,7 +261,6 @@ es-PY:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-PY/general.yml
+++ b/config/locales/es-PY/general.yml
@@ -406,11 +406,9 @@ es-PY:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-PY:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-PY/legislation.yml
+++ b/config/locales/es-PY/legislation.yml
@@ -54,10 +54,8 @@ es-PY:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-SV/admin.yml
+++ b/config/locales/es-SV/admin.yml
@@ -261,7 +261,6 @@ es-SV:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-SV/admin.yml
+++ b/config/locales/es-SV/admin.yml
@@ -261,7 +261,6 @@ es-SV:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-SV/general.yml
+++ b/config/locales/es-SV/general.yml
@@ -415,11 +415,9 @@ es-SV:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -446,7 +444,6 @@ es-SV:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-SV/legislation.yml
+++ b/config/locales/es-SV/legislation.yml
@@ -54,10 +54,8 @@ es-SV:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-UY/admin.yml
+++ b/config/locales/es-UY/admin.yml
@@ -261,7 +261,6 @@ es-UY:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-UY/admin.yml
+++ b/config/locales/es-UY/admin.yml
@@ -261,7 +261,6 @@ es-UY:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-UY/general.yml
+++ b/config/locales/es-UY/general.yml
@@ -406,11 +406,9 @@ es-UY:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-UY:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-UY/legislation.yml
+++ b/config/locales/es-UY/legislation.yml
@@ -54,10 +54,8 @@ es-UY:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-VE/admin.yml
+++ b/config/locales/es-VE/admin.yml
@@ -306,7 +306,6 @@ es-VE:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-VE/admin.yml
+++ b/config/locales/es-VE/admin.yml
@@ -306,7 +306,6 @@ es-VE:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-VE/general.yml
+++ b/config/locales/es-VE/general.yml
@@ -422,11 +422,9 @@ es-VE:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -449,7 +447,6 @@ es-VE:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-VE/legislation.yml
+++ b/config/locales/es-VE/legislation.yml
@@ -54,10 +54,8 @@ es-VE:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -447,7 +447,6 @@ es:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -447,7 +447,6 @@ es:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -462,11 +462,9 @@ es:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -494,7 +492,6 @@ es:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -62,10 +62,8 @@ es:
         filter: Filtro
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es/seeds.yml
+++ b/config/locales/es/seeds.yml
@@ -49,7 +49,6 @@ es:
     polls:
       current_poll: "Votación Abierta"
       current_poll_geozone_restricted: "Votación Abierta restringida por geozona"
-      incoming_poll: "Siguiente Votación"
       recounting_poll: "Votación en Recuento"
       expired_poll_without_stats: "Votación Finalizada (sin Estadísticas o Resultados)"
       expired_poll_with_stats: "Votación Finalizada (con Estadísticas y Resultado)"

--- a/config/locales/fa-IR/admin.yml
+++ b/config/locales/fa-IR/admin.yml
@@ -322,7 +322,6 @@ fa:
           title: فرآیندهای قانونی
           filters:
             open: بازکردن
-            past: گذشته
             all: همه
         new:
           back: برگشت

--- a/config/locales/fa-IR/admin.yml
+++ b/config/locales/fa-IR/admin.yml
@@ -322,7 +322,6 @@ fa:
           title: فرآیندهای قانونی
           filters:
             open: بازکردن
-            next: بعدی
             past: گذشته
             all: همه
         new:

--- a/config/locales/fa-IR/legislation.yml
+++ b/config/locales/fa-IR/legislation.yml
@@ -59,10 +59,8 @@ fa:
         filter: فیلتر
         filters:
           open: فرآیندهای باز
-          next: بعدی
           past: گذشته
         no_open_processes: فرایندهای باز وجود ندارد
-        no_next_processes: فرایندها برنامه ریزی نشده است
         no_past_processes: فرآیندهای گذشته وجود ندارد
         section_header:
           icon_alt: آیکون قوانین پردازش 

--- a/config/locales/fa-IR/seeds.yml
+++ b/config/locales/fa-IR/seeds.yml
@@ -33,7 +33,6 @@ fa:
     polls:
       current_poll: "نظرسنجی کنونی"
       current_poll_geozone_restricted: "نظرسنجی کنونی Geozone محصور"
-      incoming_poll: "نظرسنجی ورودی"
       recounting_poll: "بازپرداخت نظرسنجی"
       expired_poll_without_stats: "نظرسنجی منقضی شده بدون آمار & نتیجه "
       expired_poll_with_stats: "نظرسنجی منقضی شده با آمار & نتیجه "

--- a/config/locales/fr/admin.yml
+++ b/config/locales/fr/admin.yml
@@ -385,7 +385,6 @@ fr:
           title: Processus législatifs
           filters:
             open: Ouvert
-            next: Suivant
             past: Passé
             all: Tous
         new:

--- a/config/locales/fr/admin.yml
+++ b/config/locales/fr/admin.yml
@@ -385,7 +385,6 @@ fr:
           title: Processus législatifs
           filters:
             open: Ouvert
-            past: Passé
             all: Tous
         new:
           back: Retour

--- a/config/locales/fr/general.yml
+++ b/config/locales/fr/general.yml
@@ -458,11 +458,9 @@ fr:
     index:
       filters:
         current: "Ouvert"
-        incoming: "Entrants"
         expired: "Expirés"
       title: "Votes"
       participate_button: "Participer à ce vote"
-      participate_button_incoming: "Plus d'informations"
       participate_button_expired: "Vote terminé"
       no_geozone_restricted: "Toute la ville"
       geozone_restricted: "Quartiers"
@@ -487,7 +485,6 @@ fr:
       signup: S'inscrire
       cant_answer_verify_html: "Vous devez %{verify_link} pour répondre."
       verify_link: "vérifier votre compte"
-      cant_answer_incoming: "Ce vote n'a pas encore commencé."
       cant_answer_expired: "Ce vote est terminé."
       cant_answer_wrong_geozone: "Cette question n'est pas disponible pour votre zone géographique."
       more_info_title: "Plus d'informations"

--- a/config/locales/fr/legislation.yml
+++ b/config/locales/fr/legislation.yml
@@ -59,10 +59,8 @@ fr:
         filter: Filtrer
         filters:
           open: Processus ouverts
-          next: À venir
           past: Passés
         no_open_processes: Il n'y a pas de processus ouverts
-        no_next_processes: Il n'y a pas de processus à venir
         no_past_processes: Il n'y a pas de processus passés
         section_header:
           icon_alt: Icône des processus législatifs

--- a/config/locales/fr/seeds.yml
+++ b/config/locales/fr/seeds.yml
@@ -49,7 +49,6 @@ fr:
     polls:
       current_poll: "Vote en cours"
       current_poll_geozone_restricted: "Géozone du vote en cours restreinte"
-      incoming_poll: "Vote entrant"
       recounting_poll: "Re-dépouillement du vote"
       expired_poll_without_stats: "Vote terminé sans statistiques ni résultats"
       expired_poll_with_stats: "Vote terminé avec statistiques et résultats"

--- a/config/locales/gl/admin.yml
+++ b/config/locales/gl/admin.yml
@@ -388,7 +388,6 @@ gl:
           title: Procesos lexislativos
           filters:
             open: Abertos
-            next: Proximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/gl/admin.yml
+++ b/config/locales/gl/admin.yml
@@ -388,7 +388,6 @@ gl:
           title: Procesos lexislativos
           filters:
             open: Abertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/gl/general.yml
+++ b/config/locales/gl/general.yml
@@ -461,11 +461,9 @@ gl:
     index:
       filters:
         current: "Abertas"
-        incoming: "Proximamente"
         expired: "Rematadas"
       title: "Votacións"
       participate_button: "Participar nesta votación"
-      participate_button_incoming: "Máis información"
       participate_button_expired: "Votación rematada"
       no_geozone_restricted: "Toda a cidade"
       geozone_restricted: "Zonas"
@@ -493,7 +491,6 @@ gl:
       signup: rexistrarte
       cant_answer_verify_html: "Debes %{verify_link} para poder responder."
       verify_link: "verificar a túa conta"
-      cant_answer_incoming: "Esta votación aínda non comezou."
       cant_answer_expired: "A votación rematou."
       cant_answer_wrong_geozone: "Esta pregunta non está dispoñible na túa zona."
       more_info_title: "Máis información"

--- a/config/locales/gl/legislation.yml
+++ b/config/locales/gl/legislation.yml
@@ -62,10 +62,8 @@ gl:
         filter: Filtro
         filters:
           open: Procesos abertos
-          next: Proximamente
           past: Rematados
         no_open_processes: Non hai ningún proceso activo
-        no_next_processes: Non hai ningún proceso planeado
         no_past_processes: Non hai procesos rematados
         section_header:
           icon_alt: Icona de procesos lexislativos

--- a/config/locales/gl/seeds.yml
+++ b/config/locales/gl/seeds.yml
@@ -49,7 +49,6 @@ gl:
     polls:
       current_poll: "Votación aberta"
       current_poll_geozone_restricted: "Votación aberta restrinxida por zona xeográfica"
-      incoming_poll: "Seguinte votación"
       recounting_poll: "Votación en escrutinio"
       expired_poll_without_stats: "Votación pechada sen Estatísticas e Resultados"
       expired_poll_with_stats: "Votación pechada con Estatísticas e Resultados"

--- a/config/locales/he/general.yml
+++ b/config/locales/he/general.yml
@@ -321,11 +321,9 @@ he:
     index:
       filters:
         current: "פתיחה"
-        incoming: "מתקרב"
         expired: "לא בתוקף"
       title: "הצבעות"
       participate_button: "השתתפות בהצבעה זו"
-      participate_button_incoming: "מידע נוסף"
       participate_button_expired: "ההצבעה הסתיימה"
       no_geozone_restricted: "בכל הערים/הרשויות"
       geozone_restricted: "מחוזות"
@@ -337,7 +335,6 @@ he:
       signup: הרשמה
       cant_answer_verify_html: "נדרש %{verify_link}על מנת להצביע."
       verify_link: "לאמת את חשבונך"
-      cant_answer_incoming: "הצבעה זו טרם התחילה"
       cant_answer_expired: "הצבעה זו הסתיימה"
   poll_questions:
     create_question: "יצירת שאלה חדשה"

--- a/config/locales/id-ID/admin.yml
+++ b/config/locales/id-ID/admin.yml
@@ -306,7 +306,6 @@ id:
           title: Proses undang-undang
           filters:
             open: Buka
-            past: Yang lalu
             all: Semua
         new:
           back: Kembali

--- a/config/locales/id-ID/admin.yml
+++ b/config/locales/id-ID/admin.yml
@@ -306,7 +306,6 @@ id:
           title: Proses undang-undang
           filters:
             open: Buka
-            next: Lanjut
             past: Yang lalu
             all: Semua
         new:

--- a/config/locales/id-ID/general.yml
+++ b/config/locales/id-ID/general.yml
@@ -409,11 +409,9 @@ id:
     index:
       filters:
         current: "Buka"
-        incoming: "Masuk"
         expired: "Kadaluarsa"
       title: "Jajak pendapat"
       participate_button: "Berpartisipasi dalam jajak pendapat ini"
-      participate_button_incoming: "Informasi lebih lanjut"
       participate_button_expired: "Jajak pendapat terakhir"
       no_geozone_restricted: "Semua kota"
       geozone_restricted: "Kabupaten"
@@ -436,7 +434,6 @@ id:
       signup: Daftar
       cant_answer_verify_html: "Anda harus %{verify_link} dalam rangka untuk menjawab."
       verify_link: "verivikasi akun anda"
-      cant_answer_incoming: "Jajak pendapat ini belum dimulai."
       cant_answer_expired: "Jajak pendapat ini telah selesai."
       cant_answer_wrong_geozone: "Pertanyaan ini tidak tersedia pada geozone."
       more_info_title: "Informasi lebih lanjut"

--- a/config/locales/id-ID/legislation.yml
+++ b/config/locales/id-ID/legislation.yml
@@ -51,10 +51,8 @@ id:
       index:
         filters:
           open: Proses yang terbuka
-          next: Selanjutnya
           past: Sebelumnya
         no_open_processes: Tidak ada proses yang terbuka
-        no_next_processes: Tidak ada proses yang direncanakan
         no_past_processes: Tidak ada masa lalu proses
         section_header:
           icon_alt: Undang-undang proses ikon

--- a/config/locales/it/admin.yml
+++ b/config/locales/it/admin.yml
@@ -385,7 +385,6 @@ it:
           title: Procedimenti legislativi
           filters:
             open: Aperti
-            past: Precedente
             all: Tutti
         new:
           back: Indietro

--- a/config/locales/it/admin.yml
+++ b/config/locales/it/admin.yml
@@ -385,7 +385,6 @@ it:
           title: Procedimenti legislativi
           filters:
             open: Aperti
-            next: Successivo
             past: Precedente
             all: Tutti
         new:

--- a/config/locales/it/general.yml
+++ b/config/locales/it/general.yml
@@ -458,11 +458,9 @@ it:
     index:
       filters:
         current: "Aperte"
-        incoming: "In arrivo"
         expired: "Scadute"
       title: "Votazioni"
       participate_button: "Partecipa a questa votazione"
-      participate_button_incoming: "Più informazioni"
       participate_button_expired: "Votazione conclusa"
       no_geozone_restricted: "Tutta la città"
       geozone_restricted: "Distretti"
@@ -490,7 +488,6 @@ it:
       signup: Registrati
       cant_answer_verify_html: "È necessario %{verify_link} per rispondere."
       verify_link: "verifica il tuo account"
-      cant_answer_incoming: "Questa votazione non è ancora iniziata."
       cant_answer_expired: "Questa votazione è conclusa."
       cant_answer_wrong_geozone: "Questo quesito non è disponibile nella tua zona."
       more_info_title: "Più informazioni"

--- a/config/locales/it/legislation.yml
+++ b/config/locales/it/legislation.yml
@@ -59,10 +59,8 @@ it:
         filter: Filtra
         filters:
           open: Procedimenti aperti
-          next: Successivo
           past: Passato
         no_open_processes: Non ci sono procedimenti aperti
-        no_next_processes: Non ci sono procedimenti in programma
         no_past_processes: Non ci sono procedimenti passati
         section_header:
           icon_alt: Icona dei procedimenti legislativi

--- a/config/locales/it/seeds.yml
+++ b/config/locales/it/seeds.yml
@@ -49,7 +49,6 @@ it:
     polls:
       current_poll: "Votazione Corrente"
       current_poll_geozone_restricted: "Votazione Corrente Geograficamente Ristretta"
-      incoming_poll: "Votazione Imminente"
       recounting_poll: "Votazione a Scrutinio"
       expired_poll_without_stats: "Votazione Scaduta senza Statistiche & Risultati"
       expired_poll_with_stats: "Votazione Scaduta con Statistiche & Risultati"

--- a/config/locales/nl/admin.yml
+++ b/config/locales/nl/admin.yml
@@ -386,7 +386,6 @@ nl:
           title: Plannen
           filters:
             open: Open
-            next: Volgende
             past: Verleden
             all: Alle
         new:

--- a/config/locales/nl/admin.yml
+++ b/config/locales/nl/admin.yml
@@ -386,7 +386,6 @@ nl:
           title: Plannen
           filters:
             open: Open
-            past: Verleden
             all: Alle
         new:
           back: Terug

--- a/config/locales/nl/general.yml
+++ b/config/locales/nl/general.yml
@@ -458,11 +458,9 @@ nl:
     index:
       filters:
         current: "Open"
-        incoming: "Binnenkort"
         expired: "Verlopen"
       title: "Stemmen"
       participate_button: "Neem deel aan deze stemronde"
-      participate_button_incoming: "Meer informatie"
       participate_button_expired: "Stemronde is voorbij"
       no_geozone_restricted: "Gehele gemeente"
       geozone_restricted: "Regio's"
@@ -487,7 +485,6 @@ nl:
       signup: Registreren
       cant_answer_verify_html: "Je moet %{verify_link} om te kunnen antwoorden."
       verify_link: "je account verifieren"
-      cant_answer_incoming: "Deze stemronde is nog niet gestart."
       cant_answer_expired: "Deze stemronde is afgesloten."
       cant_answer_wrong_geozone: "Deze vraag wordt niet behandeld in jouw regio."
       more_info_title: "Meer informatie"

--- a/config/locales/nl/legislation.yml
+++ b/config/locales/nl/legislation.yml
@@ -59,10 +59,8 @@ nl:
         filter: Filter
         filters:
           open: Open processen
-          next: Toekomstige
           past: Vorige
         no_open_processes: Er zijn geen open processen
-        no_next_processes: Er zijn geen toekomstige plannen
         no_past_processes: Er zijn geen afgesloten plannen
         section_header:
           icon_alt: Plannen icoon

--- a/config/locales/nl/seeds.yml
+++ b/config/locales/nl/seeds.yml
@@ -49,7 +49,6 @@ nl:
     polls:
       current_poll: "Huidige peiling"
       current_poll_geozone_restricted: "Huidige peiling is gebiedsgebonden"
-      incoming_poll: "Inkomende peiling"
       recounting_poll: "Hertellen peiling"
       expired_poll_without_stats: "Verlopen peiling zonder statistieken en resultaten"
       expired_poll_with_stats: "Verlopen peilingen met statistieken en resultaten"

--- a/config/locales/pl-PL/admin.yml
+++ b/config/locales/pl-PL/admin.yml
@@ -391,7 +391,6 @@ pl:
           title: Procesy legislacyjne
           filters:
             open: Otwórz
-            next: Następny
             past: Ubiegły
             all: Wszystko
         new:

--- a/config/locales/pl-PL/admin.yml
+++ b/config/locales/pl-PL/admin.yml
@@ -391,7 +391,6 @@ pl:
           title: Procesy legislacyjne
           filters:
             open: Otwórz
-            past: Ubiegły
             all: Wszystko
         new:
           back: Wstecz

--- a/config/locales/pl-PL/general.yml
+++ b/config/locales/pl-PL/general.yml
@@ -484,11 +484,9 @@ pl:
     index:
       filters:
         current: "Otwórz"
-        incoming: "Przychodzące"
         expired: "Przedawnione"
       title: "Ankiety"
       participate_button: "Weź udział w tej sondzie"
-      participate_button_incoming: "Więcej informacji"
       participate_button_expired: "Sonda zakończyła się"
       no_geozone_restricted: "Wszystkie miasta"
       geozone_restricted: "Dzielnice"
@@ -516,7 +514,6 @@ pl:
       signup: Zarejestruj się
       cant_answer_verify_html: "Aby odpowiedzieć, musisz %{verify_link}."
       verify_link: "zweryfikuj swoje konto"
-      cant_answer_incoming: "Ta sonda jeszcze się nie rozpoczęła."
       cant_answer_expired: "Ta sonda została zakończona."
       cant_answer_wrong_geozone: "To pytanie nie jest dostępne w Twojej strefie geograficznej."
       more_info_title: "Więcej informacji"

--- a/config/locales/pl-PL/legislation.yml
+++ b/config/locales/pl-PL/legislation.yml
@@ -60,10 +60,8 @@ pl:
         filter: Filtr
         filters:
           open: Otwarte procesy
-          next: Następny
           past: Ubiegły
         no_open_processes: Nie ma otwartych procesów
-        no_next_processes: Nie ma zaplanowanych procesów
         no_past_processes: Brak ubiegłych procesów
         section_header:
           icon_alt: Ikona procesów legislacyjnych

--- a/config/locales/pl-PL/seeds.yml
+++ b/config/locales/pl-PL/seeds.yml
@@ -49,7 +49,6 @@ pl:
     polls:
       current_poll: "Aktualna Ankieta"
       current_poll_geozone_restricted: "Obecna Ankieta Ograniczona przez Geostrefę"
-      incoming_poll: "Nadchodząca ankieta"
       recounting_poll: "Przeliczanie ankiety"
       expired_poll_without_stats: "Ankieta Wygasła bez Statystyk i Wyników"
       expired_poll_with_stats: "Ankieta Wygasła ze Statystykami i Wynikami"

--- a/config/locales/pt-BR/admin.yml
+++ b/config/locales/pt-BR/admin.yml
@@ -387,7 +387,6 @@ pt-BR:
           title: Processos legislativos
           filters:
             open: Abertos
-            next: Próximo
             past: Passados
             all: Todos
         new:

--- a/config/locales/pt-BR/admin.yml
+++ b/config/locales/pt-BR/admin.yml
@@ -387,7 +387,6 @@ pt-BR:
           title: Processos legislativos
           filters:
             open: Abertos
-            past: Passados
             all: Todos
         new:
           back: Voltar

--- a/config/locales/pt-BR/general.yml
+++ b/config/locales/pt-BR/general.yml
@@ -458,11 +458,9 @@ pt-BR:
     index:
       filters:
         current: "Abrir"
-        incoming: "Entrada"
         expired: "Expirado"
       title: "Votações"
       participate_button: "Participar desta votação"
-      participate_button_incoming: "Mais informações"
       participate_button_expired: "Votação encerrada"
       no_geozone_restricted: "Toda a cidade"
       geozone_restricted: "Distritos"
@@ -490,7 +488,6 @@ pt-BR:
       signup: Inscrever-se
       cant_answer_verify_html: "Você deve %{verify_link} para poder responder."
       verify_link: "verificar sua conta"
-      cant_answer_incoming: "Esta votação ainda não iniciou."
       cant_answer_expired: "Esta votação já foi encerrada."
       cant_answer_wrong_geozone: "Esta questão não está disponível na sua geozona."
       more_info_title: "Mais informações"

--- a/config/locales/pt-BR/legislation.yml
+++ b/config/locales/pt-BR/legislation.yml
@@ -59,10 +59,8 @@ pt-BR:
         filter: Filtro
         filters:
           open: Processos abertos
-          next: Próximo
           past: Passado
         no_open_processes: Não existem processos abertos
-        no_next_processes: Não existem processos planejados
         no_past_processes: Não existem processos terminados
         section_header:
           icon_alt: Ícone de processos legislativos

--- a/config/locales/pt-BR/seeds.yml
+++ b/config/locales/pt-BR/seeds.yml
@@ -49,7 +49,6 @@ pt-BR:
     polls:
       current_poll: "Votação atual"
       current_poll_geozone_restricted: "Votação atual restrita por geozona"
-      incoming_poll: "Votação próxima"
       recounting_poll: "Votação em recontagem"
       expired_poll_without_stats: "Votação expirada sem estatísticas e resultados"
       expired_poll_with_stats: "Votação expirada com estatísticas e resultados"

--- a/config/locales/sq-AL/admin.yml
+++ b/config/locales/sq-AL/admin.yml
@@ -387,7 +387,6 @@ sq:
           title: Proceset legjislative
           filters:
             open: Hapur
-            next: Tjetër
             past: E kaluara
             all: Të gjithë
         new:

--- a/config/locales/sq-AL/admin.yml
+++ b/config/locales/sq-AL/admin.yml
@@ -387,7 +387,6 @@ sq:
           title: Proceset legjislative
           filters:
             open: Hapur
-            past: E kaluara
             all: Të gjithë
         new:
           back: Pas

--- a/config/locales/sq-AL/general.yml
+++ b/config/locales/sq-AL/general.yml
@@ -458,11 +458,9 @@ sq:
     index:
       filters:
         current: "Hapur"
-        incoming: "Hyrës"
         expired: "Ka skaduar"
       title: "Sondazhet"
       participate_button: "Merrni pjesë në këtë sondazh"
-      participate_button_incoming: "Më shumë informacion"
       participate_button_expired: "Sondazhi përfundoi"
       no_geozone_restricted: "I gjithë qyteti"
       geozone_restricted: "Zonë"
@@ -490,7 +488,6 @@ sq:
       signup: Rregjistrohu
       cant_answer_verify_html: "Ju duhet të %{verify_link}për t'u përgjigjur."
       verify_link: "verifikoni llogarinë tuaj"
-      cant_answer_incoming: "Ky sondazh ende nuk ka filluar."
       cant_answer_expired: "Ky sondazh ka përfunduar."
       cant_answer_wrong_geozone: "Kjo pyetje nuk është e disponueshme në gjeozonën tuaj"
       more_info_title: "Më shumë informacion"

--- a/config/locales/sq-AL/legislation.yml
+++ b/config/locales/sq-AL/legislation.yml
@@ -62,10 +62,8 @@ sq:
         filter: Filtër
         filters:
           open: "\nProceset e hapura"
-          next: Tjetra
           past: E kaluara
         no_open_processes: Nuk ka procese të hapura
-        no_next_processes: Nuk ka procese të planifikuar
         no_past_processes: Nuk ka procese të kaluara
         section_header:
           icon_alt: Ikona e proceseve të legjilacionit

--- a/config/locales/sq-AL/seeds.yml
+++ b/config/locales/sq-AL/seeds.yml
@@ -49,7 +49,6 @@ sq:
     polls:
       current_poll: "Sondazhi aktual"
       current_poll_geozone_restricted: "Sondazhi aktual Gjeozone i kufizuar"
-      incoming_poll: "Sondazhi i ardhur"
       recounting_poll: "Rinumërimi sondazhit"
       expired_poll_without_stats: "Sondazh i skaduar pa statistika dhe rezultate"
       expired_poll_with_stats: "Sondazh i skaduar me statistika dhe rezultate"

--- a/config/locales/sv-SE/admin.yml
+++ b/config/locales/sv-SE/admin.yml
@@ -386,7 +386,6 @@ sv:
           title: Dialoger
           filters:
             open: Pågående
-            past: Avslutade
             all: Alla
         new:
           back: Tillbaka

--- a/config/locales/sv-SE/admin.yml
+++ b/config/locales/sv-SE/admin.yml
@@ -386,7 +386,6 @@ sv:
           title: Dialoger
           filters:
             open: Pågående
-            next: Kommande
             past: Avslutade
             all: Alla
         new:

--- a/config/locales/sv-SE/general.yml
+++ b/config/locales/sv-SE/general.yml
@@ -458,11 +458,9 @@ sv:
     index:
       filters:
         current: "Pågående"
-        incoming: "Kommande"
         expired: "Avslutade"
       title: "Omröstningar"
       participate_button: "Delta i omröstningen"
-      participate_button_incoming: "Mer information"
       participate_button_expired: "Omröstningen är avslutad"
       no_geozone_restricted: "Hela staden"
       geozone_restricted: "Stadsdelar"
@@ -487,7 +485,6 @@ sv:
       signup: Registrera dig
       cant_answer_verify_html: "Du måste %{verify_link} för att svara."
       verify_link: "verifiera ditt konto"
-      cant_answer_incoming: "Omröstningen har inte börjat än."
       cant_answer_expired: "Omröstningen är avslutad."
       cant_answer_wrong_geozone: "Den här frågan är inte tillgänglig i ditt område."
       more_info_title: "Mer information"

--- a/config/locales/sv-SE/legislation.yml
+++ b/config/locales/sv-SE/legislation.yml
@@ -59,10 +59,8 @@ sv:
         filter: Filtrera
         filters:
           open: Pågående processer
-          next: Kommande
           past: Avslutade
         no_open_processes: Det finns inga pågående processer
-        no_next_processes: Det finns inga planerade processer
         no_past_processes: Det finns inga avslutade processer
         section_header:
           icon_alt: Ikon för dialoger

--- a/config/locales/sv-SE/seeds.yml
+++ b/config/locales/sv-SE/seeds.yml
@@ -49,7 +49,6 @@ sv:
     polls:
       current_poll: "Aktuell omröstning"
       current_poll_geozone_restricted: "Omröstningen är begränsad till ett geografiskt område"
-      incoming_poll: "Kommande omröstning"
       recounting_poll: "Rösträkning"
       expired_poll_without_stats: "Avslutad omröstning (utan statistik eller resultat)"
       expired_poll_with_stats: "Avslutad omröstning (med statistik och resultat)"

--- a/config/locales/tr-TR/seeds.yml
+++ b/config/locales/tr-TR/seeds.yml
@@ -33,7 +33,6 @@ tr:
     polls:
       current_poll: "Geçerli Anket"
       current_poll_geozone_restricted: "Geçerli Anket Geozone sınırlı"
-      incoming_poll: "Gelen anket"
       recounting_poll: "Anket anlatırken"
       expired_poll_without_stats: "İstatistikler ve sonuçları olmadan anket süresi"
       expired_poll_with_stats: "İstatistikler ve sonuçları olmadan anket süresi"

--- a/config/locales/val/admin.yml
+++ b/config/locales/val/admin.yml
@@ -382,7 +382,6 @@ val:
           title: Processos de legislació col·laborativa
           filters:
             open: Oberts
-            next: Pròximament
             past: Finalitzats
             all: Tots
         new:

--- a/config/locales/val/admin.yml
+++ b/config/locales/val/admin.yml
@@ -382,7 +382,6 @@ val:
           title: Processos de legislació col·laborativa
           filters:
             open: Oberts
-            past: Finalitzats
             all: Tots
         new:
           back: Tornar

--- a/config/locales/val/general.yml
+++ b/config/locales/val/general.yml
@@ -456,11 +456,9 @@ val:
     index:
       filters:
         current: "Obertes"
-        incoming: "Pròximament"
         expired: "Acabades"
       title: "Votacions"
       participate_button: "Participar en esta votació"
-      participate_button_incoming: "Més informació"
       participate_button_expired: "Votació finalitzada"
       no_geozone_restricted: "Tota la ciutat"
       geozone_restricted: "Districtes"
@@ -484,7 +482,6 @@ val:
       signup: Registrar-te
       cant_answer_verify_html: "Si us plau %{verify_link} per a poder respondre."
       verify_link: "verifica el teu compte"
-      cant_answer_incoming: "Esta votació encara no ha començat."
       cant_answer_expired: "Esta votació ha acabat."
       cant_answer_wrong_geozone: "Esta votació no està disponible en la teua zona."
       more_info_title: "Més informació"

--- a/config/locales/val/legislation.yml
+++ b/config/locales/val/legislation.yml
@@ -59,10 +59,8 @@ val:
         filter: Filtre
         filters:
           open: Processos actius
-          next: Pròximament
           past: Finalitzats
         no_open_processes: No hi ha processos actius
-        no_next_processes: No hi ha processos planejats
         no_past_processes: No hi ha processos finalitzats
         section_header:
           icon_alt: Icona de Processos legislatius

--- a/config/locales/val/seeds.yml
+++ b/config/locales/val/seeds.yml
@@ -43,7 +43,6 @@ val:
     polls:
       current_poll: "Votació Oberta"
       current_poll_geozone_restricted: "Votació Oberta restringida per geozona"
-      incoming_poll: "Següent Votació"
       recounting_poll: "Votació en Recompte"
       expired_poll_without_stats: "Votació Finalitzada sense Estadístiques ni Resultats"
       expired_poll_with_stats: "Votació Finalitzada amb Estadístiques i Resultats"

--- a/config/locales/zh-CN/admin.yml
+++ b/config/locales/zh-CN/admin.yml
@@ -384,7 +384,6 @@ zh-CN:
           title: 立法进程
           filters:
             open: 打开
-            past: 过去的
             all: 所有
         new:
           back: 返回

--- a/config/locales/zh-CN/admin.yml
+++ b/config/locales/zh-CN/admin.yml
@@ -384,7 +384,6 @@ zh-CN:
           title: 立法进程
           filters:
             open: 打开
-            next: 下一个
             past: 过去的
             all: 所有
         new:

--- a/config/locales/zh-CN/general.yml
+++ b/config/locales/zh-CN/general.yml
@@ -441,11 +441,9 @@ zh-CN:
     index:
       filters:
         current: "打开"
-        incoming: "传入"
         expired: "过期的"
       title: "投票"
       participate_button: "参与此投票"
-      participate_button_incoming: "更多信息"
       participate_button_expired: "投票已结束"
       no_geozone_restricted: "所有城市"
       geozone_restricted: "地区"
@@ -473,7 +471,6 @@ zh-CN:
       signup: 注册
       cant_answer_verify_html: "您必须%{verify_link} 才能回答。"
       verify_link: "验证您的账户"
-      cant_answer_incoming: "此投票还没有开始。"
       cant_answer_expired: "此投票已经结束。"
       cant_answer_wrong_geozone: "此问题在您的地理区域里不可用。"
       more_info_title: "更多信息"

--- a/config/locales/zh-CN/legislation.yml
+++ b/config/locales/zh-CN/legislation.yml
@@ -59,10 +59,8 @@ zh-CN:
         filter: 过滤器
         filters:
           open: 开启进程
-          next: 下一个
           past: 过去的
         no_open_processes: 没有已开放的进程
-        no_next_processes: 没有已计划的进程
         no_past_processes: 没有已去过的进程
         section_header:
           icon_alt: 立法进程图标

--- a/config/locales/zh-CN/seeds.yml
+++ b/config/locales/zh-CN/seeds.yml
@@ -49,7 +49,6 @@ zh-CN:
     polls:
       current_poll: "当前的投票"
       current_poll_geozone_restricted: "当前投票地理区域的限制"
-      incoming_poll: "进来的投票"
       recounting_poll: "重新计票"
       expired_poll_without_stats: "已过期的投票，没有统计数据&结果"
       expired_poll_with_stats: "已过期的投票，有统计数据&结果"

--- a/config/locales/zh-TW/admin.yml
+++ b/config/locales/zh-TW/admin.yml
@@ -385,7 +385,6 @@ zh-TW:
           title: 立法進程
           filters:
             open: 打開
-            next: 下一個
             past: 過去的
             all: 所有
         new:

--- a/config/locales/zh-TW/admin.yml
+++ b/config/locales/zh-TW/admin.yml
@@ -385,7 +385,6 @@ zh-TW:
           title: 立法進程
           filters:
             open: 打開
-            past: 過去的
             all: 所有
         new:
           back: 返回

--- a/config/locales/zh-TW/general.yml
+++ b/config/locales/zh-TW/general.yml
@@ -441,11 +441,9 @@ zh-TW:
     index:
       filters:
         current: "開"
-        incoming: "傳入"
         expired: "已過期"
       title: "投票"
       participate_button: "參與此投票"
-      participate_button_incoming: "更多資訊"
       participate_button_expired: "投票結束"
       no_geozone_restricted: "所有城市"
       geozone_restricted: "地區"
@@ -473,7 +471,6 @@ zh-TW:
       signup: 登記
       cant_answer_verify_html: "您必須%{verify_link} 才能回答。"
       verify_link: "核實您的帳戶"
-      cant_answer_incoming: "此投票項尚未開始。"
       cant_answer_expired: "此投票項已結束。"
       cant_answer_wrong_geozone: "此問題並不適用於您的地理區域。"
       more_info_title: "更多資訊"

--- a/config/locales/zh-TW/legislation.yml
+++ b/config/locales/zh-TW/legislation.yml
@@ -56,10 +56,8 @@ zh-TW:
         filter: 篩選器
         filters:
           open: 開啟進程
-          next: 下一個
           past: 過去的
         no_open_processes: 沒有已開啟的進程
-        no_next_processes: 沒有已計劃的進程
         no_past_processes: 沒有過去的進程
         section_header:
           icon_alt: 立法進程圖標

--- a/config/locales/zh-TW/seeds.yml
+++ b/config/locales/zh-TW/seeds.yml
@@ -49,7 +49,6 @@ zh-TW:
     polls:
       current_poll: "當前的投票"
       current_poll_geozone_restricted: "當前投票地理區域的限制"
-      incoming_poll: "傳入投票"
       recounting_poll: "重新計票"
       expired_poll_without_stats: "已過期的投票項目，沒有統計數據和結果"
       expired_poll_with_stats: "已過期的投票項目，連帶統計數據和結果"

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -11,10 +11,6 @@ section "Creating polls" do
               geozone_restricted: true,
               geozones: Geozone.reorder("RANDOM()").limit(3))
 
-  Poll.create(name: I18n.t('seeds.polls.incoming_poll'),
-              starts_at: 1.month.from_now,
-              ends_at:   2.months.from_now)
-
   Poll.create(name: I18n.t('seeds.polls.recounting_poll'),
               starts_at: 15.days.ago,
               ends_at:   2.days.ago)

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -34,17 +34,6 @@ FactoryBot.define do
     result_publication_enabled true
     published true
 
-    trait :next do
-      start_date { Date.current + 2.days }
-      end_date { Date.current + 8.days }
-      debate_start_date { Date.current + 2.days }
-      debate_end_date { Date.current + 4.days }
-      draft_publication_date { Date.current + 5.days }
-      allegations_start_date { Date.current + 5.days }
-      allegations_end_date { Date.current + 7.days }
-      result_publication_date { Date.current + 8.days }
-    end
-
     trait :past do
       start_date { Date.current - 12.days }
       end_date { Date.current - 2.days }

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -10,11 +10,6 @@ FactoryBot.define do
       ends_at { 2.days.from_now }
     end
 
-    trait :incoming do
-      starts_at { 2.days.from_now }
-      ends_at { 1.month.from_now }
-    end
-
     trait :expired do
       starts_at { 1.month.ago }
       ends_at { 15.days.ago }

--- a/spec/features/admin/poll/booths_spec.rb
+++ b/spec/features/admin/poll/booths_spec.rb
@@ -38,27 +38,23 @@ feature 'Admin booths' do
 
   scenario "Available" do
     booth_for_current_poll  = create(:poll_booth)
-    booth_for_incoming_poll = create(:poll_booth)
     booth_for_expired_poll  = create(:poll_booth)
 
     current_poll  = create(:poll, :current)
-    incoming_poll = create(:poll, :incoming)
     expired_poll  = create(:poll, :expired)
 
     create(:poll_booth_assignment, poll: current_poll,  booth: booth_for_current_poll)
-    create(:poll_booth_assignment, poll: incoming_poll, booth: booth_for_incoming_poll)
     create(:poll_booth_assignment, poll: expired_poll,  booth: booth_for_expired_poll)
 
     visit admin_root_path
 
-    within('#side_menu') do
+    within("#side_menu") do
       click_link "Manage shifts"
     end
 
-    expect(page).to have_css(".booth", count: 2)
+    expect(page).to have_css(".booth", count: 1)
 
     expect(page).to have_content booth_for_current_poll.name
-    expect(page).to have_content booth_for_incoming_poll.name
     expect(page).not_to have_content booth_for_expired_poll.name
     expect(page).not_to have_link "Edit booth"
   end

--- a/spec/features/admin/poll/shifts_spec.rb
+++ b/spec/features/admin/poll/shifts_spec.rb
@@ -32,7 +32,6 @@ feature 'Admin shifts' do
 
   scenario "Create Vote Collection Shift and Recount & Scrutiny Shift on same date", :js do
     create(:poll)
-    create(:poll, :incoming)
     poll = create(:poll, :current)
     booth = create(:poll_booth)
     create(:poll_booth_assignment, poll: poll, booth: booth)

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -29,6 +29,9 @@ feature 'Legislation' do
     scenario "No processes to be listed" do
       visit legislation_processes_path
       expect(page).to have_text "There aren't open processes"
+
+      visit legislation_processes_path(filter: "past")
+      expect(page).to have_text "There aren't past processes"
     end
 
     scenario 'Processes can be listed' do

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -26,15 +26,9 @@ feature 'Legislation' do
 
   context 'processes home page' do
 
-    scenario 'No processes to be listed' do
+    scenario "No processes to be listed" do
       visit legislation_processes_path
       expect(page).to have_text "There aren't open processes"
-
-      visit legislation_processes_path(filter: 'next')
-      expect(page).to have_text "There aren't planned processes"
-
-      visit legislation_processes_path(filter: 'past')
-      expect(page).to have_text "There aren't past processes"
     end
 
     scenario 'Processes can be listed' do
@@ -90,24 +84,16 @@ feature 'Legislation' do
 
     scenario 'Filtering processes' do
       create(:legislation_process, title: "Process open")
-      create(:legislation_process, :next, title: "Process next")
       create(:legislation_process, :past, title: "Process past")
       create(:legislation_process, :in_draft_phase, title: "Process in draft phase")
 
       visit legislation_processes_path
       expect(page).to have_content('Process open')
-      expect(page).not_to have_content('Process next')
       expect(page).not_to have_content('Process past')
       expect(page).not_to have_content('Process in draft phase')
 
-      visit legislation_processes_path(filter: 'next')
-      expect(page).not_to have_content('Process open')
-      expect(page).to have_content('Process next')
-      expect(page).not_to have_content('Process past')
-
       visit legislation_processes_path(filter: 'past')
       expect(page).not_to have_content('Process open')
-      expect(page).not_to have_content('Process next')
       expect(page).to have_content('Process past')
     end
 
@@ -115,10 +101,8 @@ feature 'Legislation' do
       before do
         create(:legislation_process, title: "published")
         create(:legislation_process, :not_published, title: "not published")
-        [:next, :past].each do |trait|
-          create(:legislation_process, trait, title: "#{trait} published")
-          create(:legislation_process, :not_published, trait, title: "#{trait} not published")
-        end
+        create(:legislation_process, :past, title: "past published")
+        create(:legislation_process, :not_published, :past, title: "past not published")
       end
 
       it "aren't listed" do
@@ -130,17 +114,6 @@ feature 'Legislation' do
         visit legislation_processes_path
         expect(page).not_to have_content('not published')
         expect(page).to have_content('published')
-      end
-
-      it "aren't listed with next filter" do
-        visit legislation_processes_path(filter: 'next')
-        expect(page).not_to have_content('not published')
-        expect(page).to have_content('next published')
-
-        login_as(administrator)
-        visit legislation_processes_path(filter: 'next')
-        expect(page).not_to have_content('not published')
-        expect(page).to have_content('next published')
       end
 
       it "aren't listed with past filter" do

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -75,9 +75,6 @@ feature 'Voters' do
     poll_expired = create(:poll, :expired)
     create(:poll_officer_assignment, officer: officer, booth_assignment: create(:poll_booth_assignment, poll: poll_expired, booth: booth))
 
-    poll_incoming = create(:poll, :incoming)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: create(:poll_booth_assignment, poll: poll_incoming, booth: booth))
-
     poll_geozone_restricted_in = create(:poll, :current, geozone_restricted: true, geozones: [Geozone.first])
     booth_assignment = create(:poll_booth_assignment, poll: poll_geozone_restricted_in, booth: booth)
     create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
@@ -93,7 +90,6 @@ feature 'Voters' do
     expect(page).to have_content poll.name
     expect(page).not_to have_content poll_current.name
     expect(page).not_to have_content poll_expired.name
-    expect(page).not_to have_content poll_incoming.name
     expect(page).to have_content poll_geozone_restricted_in.name
     expect(page).not_to have_content poll_geozone_restricted_out.name
   end

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -28,24 +28,15 @@ feature 'Polls' do
 
     scenario 'Filtering polls' do
       create(:poll, name: "Current poll")
-      create(:poll, :incoming, name: "Incoming poll")
       create(:poll, :expired, name: "Expired poll")
 
       visit polls_path
       expect(page).to have_content('Current poll')
       expect(page).to have_link('Participate in this poll')
-      expect(page).not_to have_content('Incoming poll')
-      expect(page).not_to have_content('Expired poll')
-
-      visit polls_path(filter: 'incoming')
-      expect(page).not_to have_content('Current poll')
-      expect(page).to have_content('Incoming poll')
-      expect(page).to have_link('More information')
       expect(page).not_to have_content('Expired poll')
 
       visit polls_path(filter: 'expired')
       expect(page).not_to have_content('Current poll')
-      expect(page).not_to have_content('Incoming poll')
       expect(page).to have_content('Expired poll')
       expect(page).to have_link('Poll ended')
     end
@@ -53,17 +44,10 @@ feature 'Polls' do
     scenario "Current filter is properly highlighted" do
       visit polls_path
       expect(page).not_to have_link('Open')
-      expect(page).to have_link('Incoming')
-      expect(page).to have_link('Expired')
-
-      visit polls_path(filter: 'incoming')
-      expect(page).to have_link('Open')
-      expect(page).not_to have_link('Incoming')
       expect(page).to have_link('Expired')
 
       visit polls_path(filter: 'expired')
       expect(page).to have_link('Open')
-      expect(page).to have_link('Incoming')
       expect(page).not_to have_link('Expired')
     end
 
@@ -202,26 +186,6 @@ feature 'Polls' do
 
       expect(page).to have_link('Han Solo', href: verification_path)
       expect(page).to have_link('Chewbacca', href: verification_path)
-    end
-
-    scenario 'Level 2 users in an incoming poll' do
-      incoming_poll = create(:poll, :incoming, geozone_restricted: true)
-      incoming_poll.geozones << geozone
-
-      question = create(:poll_question, poll: incoming_poll)
-      answer1 = create(:poll_question_answer, question: question, title: 'Rey')
-      answer2 = create(:poll_question_answer, question: question, title: 'Finn')
-
-      login_as(create(:user, :level_two, geozone: geozone))
-
-      visit poll_path(incoming_poll)
-
-      expect(page).to have_content('Rey')
-      expect(page).to have_content('Finn')
-      expect(page).not_to have_link('Rey')
-      expect(page).not_to have_link('Finn')
-
-      expect(page).to have_content('This poll has not yet started')
     end
 
     scenario 'Level 2 users in an expired poll' do

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -33,9 +33,6 @@ describe Abilities::Common do
   let(:ballot_in_balloting_budget) { create(:budget_ballot, budget: balloting_budget) }
 
   let(:current_poll)  { create(:poll) }
-  let(:incoming_poll) { create(:poll, :incoming) }
-  let(:incoming_poll_from_own_geozone) { create(:poll, :incoming, geozone_restricted: true, geozones: [geozone]) }
-  let(:incoming_poll_from_other_geozone) { create(:poll, :incoming, geozone_restricted: true, geozones: [create(:geozone)]) }
   let(:expired_poll) { create(:poll, :expired) }
   let(:expired_poll_from_own_geozone) { create(:poll, :expired, geozone_restricted: true, geozones: [geozone]) }
   let(:expired_poll_from_other_geozone) { create(:poll, :expired, geozone_restricted: true, geozones: [create(:geozone)]) }
@@ -50,10 +47,6 @@ describe Abilities::Common do
   let(:expired_poll_question_from_own_geozone)   { create(:poll_question, poll: expired_poll_from_own_geozone) }
   let(:expired_poll_question_from_other_geozone) { create(:poll_question, poll: expired_poll_from_other_geozone) }
   let(:expired_poll_question_from_all_geozones)  { create(:poll_question, poll: expired_poll) }
-
-  let(:incoming_poll_question_from_own_geozone)   { create(:poll_question, poll: incoming_poll_from_own_geozone) }
-  let(:incoming_poll_question_from_other_geozone) { create(:poll_question, poll: incoming_poll_from_other_geozone) }
-  let(:incoming_poll_question_from_all_geozones)  { create(:poll_question, poll: incoming_poll) }
 
   let(:own_proposal_document)          { build(:document, documentable: own_proposal) }
   let(:proposal_document)              { build(:document, documentable: proposal) }
@@ -188,7 +181,6 @@ describe Abilities::Common do
     describe "Poll" do
       it { should     be_able_to(:answer, current_poll)  }
       it { should_not be_able_to(:answer, expired_poll)  }
-      it { should_not be_able_to(:answer, incoming_poll) }
 
       it { should     be_able_to(:answer, poll_question_from_own_geozone)   }
       it { should     be_able_to(:answer, poll_question_from_all_geozones)  }
@@ -197,10 +189,6 @@ describe Abilities::Common do
       it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
       it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
       it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-      it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
 
       context "without geozone" do
         before { user.geozone = nil }
@@ -212,10 +200,6 @@ describe Abilities::Common do
         it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
         it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
         it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-        it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-        it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-        it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
       end
     end
 
@@ -270,7 +254,6 @@ describe Abilities::Common do
 
     it { should     be_able_to(:answer, current_poll)  }
     it { should_not be_able_to(:answer, expired_poll)  }
-    it { should_not be_able_to(:answer, incoming_poll) }
 
     it { should     be_able_to(:answer, poll_question_from_own_geozone)   }
     it { should     be_able_to(:answer, poll_question_from_all_geozones)  }
@@ -279,10 +262,6 @@ describe Abilities::Common do
     it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
     it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
     it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-    it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-    it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-    it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
 
     context "without geozone" do
       before { user.geozone = nil }
@@ -293,10 +272,6 @@ describe Abilities::Common do
       it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
       it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
       it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-      it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
     end
   end
 

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -144,14 +144,6 @@ describe Legislation::Process do
       expect(processes_not_in_draft).not_to include(process_with_draft_only_today)
     end
 
-    it "filters next" do
-      next_processes = ::Legislation::Process.next
-
-      expect(next_processes).to include(process_2)
-      expect(next_processes).not_to include(process_1)
-      expect(next_processes).not_to include(process_3)
-    end
-
     it "filters past" do
       past_processes = ::Legislation::Process.past
 

--- a/spec/models/poll/booth_spec.rb
+++ b/spec/models/poll/booth_spec.rb
@@ -26,21 +26,17 @@ describe Poll::Booth do
 
   describe "#available" do
 
-    it "returns booths associated to current or incoming polls" do
+    it "returns booths associated to current polls" do
       booth_for_current_poll  = create(:poll_booth)
-      booth_for_incoming_poll = create(:poll_booth)
       booth_for_expired_poll  = create(:poll_booth)
 
       current_poll  = create(:poll, :current)
-      incoming_poll = create(:poll, :incoming)
       expired_poll  = create(:poll, :expired)
 
       create(:poll_booth_assignment, poll: current_poll,  booth: booth_for_current_poll)
-      create(:poll_booth_assignment, poll: incoming_poll, booth: booth_for_incoming_poll)
       create(:poll_booth_assignment, poll: expired_poll,  booth: booth_for_expired_poll)
 
       expect(described_class.available).to include(booth_for_current_poll)
-      expect(described_class.available).to include(booth_for_incoming_poll)
       expect(described_class.available).not_to include(booth_for_expired_poll)
     end
 

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -36,24 +36,14 @@ describe Poll do
   end
 
   describe "#opened?" do
-    it "returns true only when it isn't too early or too late" do
-      expect(create(:poll, :incoming)).not_to be_current
+    it "returns true only when it isn't too late" do
       expect(create(:poll, :expired)).not_to be_current
       expect(create(:poll)).to be_current
     end
   end
 
-  describe "#incoming?" do
-    it "returns true only when it is too early" do
-      expect(create(:poll, :incoming)).to be_incoming
-      expect(create(:poll, :expired)).not_to be_incoming
-      expect(create(:poll)).not_to be_incoming
-    end
-  end
-
   describe "#expired?" do
     it "returns true only when it is too late" do
-      expect(create(:poll, :incoming)).not_to be_expired
       expect(create(:poll, :expired)).to be_expired
       expect(create(:poll)).not_to be_expired
     end
@@ -66,49 +56,31 @@ describe Poll do
     end
   end
 
-  describe "#current_or_incoming" do
-    it "returns current or incoming polls" do
-      current = create(:poll, :current)
-      incoming = create(:poll, :incoming)
-      expired = create(:poll, :expired)
-
-      current_or_incoming = described_class.current_or_incoming
-
-      expect(current_or_incoming).to include(current)
-      expect(current_or_incoming).to include(incoming)
-      expect(current_or_incoming).not_to include(expired)
-    end
-  end
-
   describe "#recounting" do
     it "returns polls in recount & scrutiny phase" do
       current = create(:poll, :current)
-      incoming = create(:poll, :incoming)
       expired = create(:poll, :expired)
       recounting = create(:poll, :recounting)
 
       recounting_polls = described_class.recounting
 
       expect(recounting_polls).not_to include(current)
-      expect(recounting_polls).not_to include(incoming)
       expect(recounting_polls).not_to include(expired)
       expect(recounting_polls).to include(recounting)
     end
   end
 
-  describe "#current_or_recounting_or_incoming" do
-    it "returns current or recounting or incoming polls" do
+  describe "#current_or_recounting" do
+    it "returns current or recounting polls" do
       current = create(:poll, :current)
-      incoming = create(:poll, :incoming)
       expired = create(:poll, :expired)
       recounting = create(:poll, :recounting)
 
-      current_or_recounting_or_incoming = described_class.current_or_recounting_or_incoming
+      current_or_recounting = described_class.current_or_recounting
 
-      expect(current_or_recounting_or_incoming).to include(current)
-      expect(current_or_recounting_or_incoming).to include(recounting)
-      expect(current_or_recounting_or_incoming).to include(incoming)
-      expect(current_or_recounting_or_incoming).not_to include(expired)
+      expect(current_or_recounting).to include(current)
+      expect(current_or_recounting).to include(recounting)
+      expect(current_or_recounting).not_to include(expired)
     end
   end
 
@@ -117,12 +89,12 @@ describe Poll do
 
     let!(:current_poll) { create(:poll) }
     let!(:expired_poll) { create(:poll, :expired) }
-    let!(:incoming_poll) { create(:poll, :incoming) }
+
     let!(:current_restricted_poll) { create(:poll, geozone_restricted: true, geozones: [geozone]) }
     let!(:expired_restricted_poll) { create(:poll, :expired, geozone_restricted: true, geozones: [geozone]) }
-    let!(:incoming_restricted_poll) { create(:poll, :incoming, geozone_restricted: true, geozones: [geozone]) }
-    let!(:all_polls) { [current_poll, expired_poll, incoming_poll, current_poll, expired_restricted_poll, incoming_restricted_poll] }
-    let(:non_current_polls) { [expired_poll, incoming_poll, expired_restricted_poll, incoming_restricted_poll] }
+
+    let!(:all_polls) { [current_poll, expired_poll, current_poll, expired_restricted_poll] }
+    let(:non_current_polls) { [expired_poll, expired_restricted_poll] }
 
     let(:non_user) { nil }
     let(:level1)   { create(:user) }


### PR DESCRIPTION
## References

This closes https://github.com/consul/consul/issues/3181

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1861/ and https://github.com/AyuntamientoMadrid/consul/pull/1862

## Objectives

Remove **incoming polls filter**: now there are only to filters `Open` and `Expired`.

Remove **next legislation processes filter**: now there are only two filters `Open processes` and `Past`. Also remove  `Past` legislation processes filter on **Admin panel**. 

## Visual Changes
**No more incoming polls**
![no incoming polls](https://user-images.githubusercontent.com/631897/52344549-53355b00-2a1b-11e9-9cae-cef158ce296e.png)

**Legislation processes view**
<img width="376" alt="process front" src="https://user-images.githubusercontent.com/631897/52359396-1e84cc00-2a3a-11e9-94c6-07c50c2649f2.png">

**Legislation processes admin**
<img width="327" alt="process admin" src="https://user-images.githubusercontent.com/631897/52359404-20e72600-2a3a-11e9-91dc-9a0f4f00ad1b.png">
