### PR TITLE
[Backport] Include heading names in "headings limit reached" alert 

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -257,7 +257,7 @@ class Budget
     end
 
     def can_vote_in_another_heading?(user)
-      headings_voted_by_user(user).count < group.max_votable_headings
+      user.headings_voted_within_group(group).count < group.max_votable_headings
     end
 
     def headings_voted_by_user(user)
@@ -265,7 +265,7 @@ class Budget
     end
 
     def voted_in?(heading, user)
-      headings_voted_by_user(user).include?(heading.id)
+      user.headings_voted_within_group(group).where(id: heading.id).exists?
     end
 
     def ballotable_by?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -127,6 +127,11 @@ class User < ActiveRecord::Base
     votes.for_budget_investments(Budget::Investment.where(group: group)).exists?
   end
 
+  def headings_voted_within_group(group)
+    voted_investments = votes.for_budget_investments(Budget::Investment.by_group(group.id)).votables
+    Budget::Heading.where(id: voted_investments.map(&:heading_id).uniq)
+  end
+
   def administrator?
     administrator.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,7 +128,7 @@ class User < ActiveRecord::Base
   end
 
   def headings_voted_within_group(group)
-    Budget::Heading.where(id: voted_investments.by_group(group).pluck(:heading_id))
+    Budget::Heading.order("name").where(id: voted_investments.by_group(group).pluck(:heading_id))
   end
 
   def voted_investments

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,8 +128,13 @@ class User < ActiveRecord::Base
   end
 
   def headings_voted_within_group(group)
-    voted_investments = votes.for_budget_investments(Budget::Investment.by_group(group.id)).votables
-    Budget::Heading.where(id: voted_investments.map(&:heading_id).uniq)
+    Budget::Heading.where(id:
+      votes.where(votable_type: Budget::Investment)
+           .joins(:budget_investment)
+           .where(budget_investments: {group_id: group.id})
+           .distinct
+           .select('budget_investments.heading_id')
+    )
   end
 
   def administrator?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,13 +128,11 @@ class User < ActiveRecord::Base
   end
 
   def headings_voted_within_group(group)
-    Budget::Heading.where(id:
-      votes.where(votable_type: Budget::Investment)
-           .joins(:budget_investment)
-           .where(budget_investments: {group_id: group.id})
-           .distinct
-           .select('budget_investments.heading_id')
-    )
+    Budget::Heading.where(id: voted_investments.by_group(group).pluck(:heading_id))
+  end
+
+  def voted_investments
+    Budget::Investment.where(id: votes.for_budget_investments.pluck(:votable_id))
   end
 
   def administrator?

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -35,8 +35,9 @@
                 count: investment.group.max_votable_headings,
                 verify_account: link_to(t("votes.verify_account"), verification_path),
                 signin: link_to(t("votes.signin"), new_user_session_path),
-                signup: link_to(t("votes.signup"), new_user_registration_path)
-           ).html_safe %>
+                signup: link_to(t("votes.signup"), new_user_registration_path),
+                supported_headings: (current_user && current_user.headings_voted_within_group(investment.group).map(&:name).to_sentence)
+               ).html_safe %>
         </small>
       </p>
     </div>

--- a/config/initializers/vote_extensions.rb
+++ b/config/initializers/vote_extensions.rb
@@ -28,7 +28,7 @@ ActsAsVotable::Vote.class_eval do
     where(votable_type: 'SpendingProposal', votable_id: spending_proposals)
   end
 
-  def self.for_budget_investments(budget_investments)
+  def self.for_budget_investments(budget_investments=Budget::Investment.all)
     where(votable_type: 'Budget::Investment', votable_id: budget_investments)
   end
 

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -771,8 +771,8 @@ en:
       unfeasible: Unfeasible investment projects can not be supported
       not_voting_allowed: Voting phase is closed
       different_heading_assigned:
-        one: "You can only support investment projects in %{count} district"
-        other: "You can only support investment projects in %{count} districts"
+        one: "You can only support investment projects in %{count} district. You have already supported investments in %{supported_headings}."
+        other: "You can only support investment projects in %{count} districts. You have already supported investments in %{supported_headings}."
   welcome:
     feed:
       most_active:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -770,8 +770,8 @@ es:
       unfeasible: No se pueden votar propuestas inviables.
       not_voting_allowed: El periodo de votación está cerrado.
       different_heading_assigned:
-        one: "Sólo puedes apoyar proyectos de gasto de %{count} distrito"
-        other: "Sólo puedes apoyar proyectos de gasto de %{count} distritos"
+        one: "Sólo puedes apoyar proyectos de gasto de %{count} distrito. Ya has apoyado en %{supported_headings}."
+        other: "Sólo puedes apoyar proyectos de gasto de %{count} distritos. Ya has apoyado en %{supported_headings}."
   welcome:
     feed:
       most_active:

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -142,7 +142,10 @@ feature 'Votes' do
         within("#budget_investment_#{third_heading_investment.id}") do
           find('.in-favor a').click
 
-          expect(page).to have_content "You can only support investment projects in 2 districts. You have already supported investments in #{new_york.name} and #{san_francisco.name}"
+          expect(page).to have_content "You can only support investment projects in 2 districts. You have already supported investments in"
+
+          heading_names = find('.participation-not-allowed').text.match(/You have already supported investments in (.+) and (.+)\./)&.captures
+          expect(heading_names).to match_array [new_york.name, san_francisco.name]
 
           expect(page).not_to have_content "1 support"
           expect(page).not_to have_content "You have already supported this investment project. Share it!"
@@ -165,7 +168,10 @@ feature 'Votes' do
         visit budget_investment_path(budget, third_heading_investment)
 
         find('.in-favor a').click
-        expect(page).to have_content "You can only support investment projects in 2 districts. You have already supported investments in #{new_york.name} and #{san_francisco.name}"
+        expect(page).to have_content "You can only support investment projects in 2 districts. You have already supported investments in"
+
+        heading_names = find('.participation-not-allowed').text.match(/You have already supported investments in (.+) and (.+)\./)&.captures
+        expect(heading_names).to match_array [new_york.name, san_francisco.name]
 
         expect(page).not_to have_content "1 support"
         expect(page).not_to have_content "You have already supported this investment project. Share it!"

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -142,7 +142,7 @@ feature 'Votes' do
         within("#budget_investment_#{third_heading_investment.id}") do
           find('.in-favor a').click
 
-          expect(page).to have_content "You can only support investment projects in 2 districts"
+          expect(page).to have_content "You can only support investment projects in 2 districts. You have already supported investments in #{new_york.name} and #{san_francisco.name}"
 
           expect(page).not_to have_content "1 support"
           expect(page).not_to have_content "You have already supported this investment project. Share it!"
@@ -165,7 +165,7 @@ feature 'Votes' do
         visit budget_investment_path(budget, third_heading_investment)
 
         find('.in-favor a').click
-        expect(page).to have_content "You can only support investment projects in 2 districts"
+        expect(page).to have_content "You can only support investment projects in 2 districts. You have already supported investments in #{new_york.name} and #{san_francisco.name}"
 
         expect(page).not_to have_content "1 support"
         expect(page).not_to have_content "You have already supported this investment project. Share it!"

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -1,72 +1,70 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Votes' do
+feature "Votes" do
 
-  background do
-    @manuela = create(:user, verified_at: Time.current)
-  end
-
-  feature 'Investments' do
-
+  feature "Investments" do
+    let(:manuela) { create(:user, verified_at: Time.current) }
     let(:budget)  { create(:budget, phase: "selecting") }
     let(:group)   { create(:budget_group, budget: budget) }
     let(:heading) { create(:budget_heading, group: group) }
 
-    background { login_as(@manuela) }
+    background { login_as(manuela) }
 
-    feature 'Index' do
+    feature "Index" do
 
       scenario "Index shows user votes on proposals" do
         investment1 = create(:budget_investment, heading: heading)
         investment2 = create(:budget_investment, heading: heading)
         investment3 = create(:budget_investment, heading: heading)
-        create(:vote, voter: @manuela, votable: investment1, vote_flag: true)
+        create(:vote, voter: manuela, votable: investment1, vote_flag: true)
 
         visit budget_investments_path(budget, heading_id: heading.id)
 
         within("#budget-investments") do
           within("#budget_investment_#{investment1.id}_votes") do
-            expect(page).to have_content "You have already supported this investment project. Share it!"
+            expect(page).to have_content "You have already supported this investment project. "\
+                                         "Share it!"
           end
 
           within("#budget_investment_#{investment2.id}_votes") do
-            expect(page).not_to have_content "You have already supported this investment project. Share it!"
+            expect(page).not_to have_content "You have already supported this investment project. "\
+                                             "Share it!"
           end
 
           within("#budget_investment_#{investment3.id}_votes") do
-            expect(page).not_to have_content "You have already supported this investment project. Share it!"
+            expect(page).not_to have_content "You have already supported this investment project. "\
+                                             "Share it!"
           end
         end
       end
 
-      scenario 'Create from spending proposal index', :js do
-        investment = create(:budget_investment, heading: heading, budget: budget)
+      scenario "Create from spending proposal index", :js do
+        create(:budget_investment, heading: heading, budget: budget)
 
         visit budget_investments_path(budget, heading_id: heading.id)
 
-        within('.supports') do
+        within(".supports") do
           find(".in-favor a").click
 
           expect(page).to have_content "1 support"
-          expect(page).to have_content "You have already supported this investment project. Share it!"
+          expect(page).to have_content "You have already supported this investment project. "\
+                                       "Share it!"
         end
       end
     end
 
-    feature 'Single spending proposal' do
-      background do
-        @investment = create(:budget_investment, budget: budget, heading: heading)
-      end
+    feature "Single spending proposal" do
+      let(:investment) { create(:budget_investment, budget: budget, heading: heading)}
 
-      scenario 'Show no votes' do
-        visit budget_investment_path(budget, @investment)
+      scenario "Show no votes" do
+        visit budget_investment_path(budget, investment)
         expect(page).to have_content "No supports"
       end
 
-      scenario 'Trying to vote multiple times', :js do
-        visit budget_investment_path(budget, @investment)
+      scenario "Trying to vote multiple times", :js do
+        visit budget_investment_path(budget, investment)
 
-        within('.supports') do
+        within(".supports") do
           find(".in-favor a").click
           expect(page).to have_content "1 support"
 
@@ -74,20 +72,24 @@ feature 'Votes' do
         end
       end
 
-      scenario 'Create from proposal show', :js do
-        visit budget_investment_path(budget, @investment)
+      scenario "Create from proposal show", :js do
+        visit budget_investment_path(budget, investment)
 
-        within('.supports') do
+        within(".supports") do
           find(".in-favor a").click
 
           expect(page).to have_content "1 support"
-          expect(page).to have_content "You have already supported this investment project. Share it!"
+          expect(page).to have_content "You have already supported this investment project. "\
+                                       "Share it!"
         end
       end
     end
 
-    scenario 'Disable voting on spending proposals', :js do
-      login_as(@manuela)
+    scenario "Disable voting on spending proposals", :js do
+      manuela = create(:user, verified_at: Time.current)
+
+      login_as(manuela)
+
       budget.update(phase: "reviewing")
       investment = create(:budget_investment, budget: budget, heading: heading)
 
@@ -122,59 +124,71 @@ feature 'Votes' do
         visit budget_investments_path(budget, heading_id: new_york.id)
 
         within("#budget_investment_#{new_york_investment.id}") do
-          accept_confirm { find('.in-favor a').click }
+          accept_confirm { find(".in-favor a").click }
 
           expect(page).to have_content "1 support"
-          expect(page).to have_content "You have already supported this investment project. Share it!"
+          expect(page).to have_content "You have already supported this investment project. "\
+                                       "Share it!"
         end
 
         visit budget_investments_path(budget, heading_id: san_francisco.id)
 
         within("#budget_investment_#{san_francisco_investment.id}") do
-          find('.in-favor a').click
+          find(".in-favor a").click
 
           expect(page).to have_content "1 support"
-          expect(page).to have_content "You have already supported this investment project. Share it!"
+          expect(page).to have_content "You have already supported this investment project. "\
+                                       "Share it!"
         end
 
         visit budget_investments_path(budget, heading_id: third_heading.id)
 
         within("#budget_investment_#{third_heading_investment.id}") do
-          find('.in-favor a').click
+          find(".in-favor a").click
 
-          expect(page).to have_content "You can only support investment projects in 2 districts. You have already supported investments in"
+          expect(page).to have_content "You can only support investment projects in 2 districts. "\
+                                       "You have already supported investments in"
 
-          heading_names = find('.participation-not-allowed').text.match(/You have already supported investments in (.+) and (.+)\./)&.captures
-          expect(heading_names).to match_array [new_york.name, san_francisco.name]
+          participation = find(".participation-not-allowed")
+          headings = participation.text
+                     .match(/You have already supported investments in (.+) and (.+)\./)&.captures
+
+          expect(headings).to match_array [new_york.name, san_francisco.name]
 
           expect(page).not_to have_content "1 support"
-          expect(page).not_to have_content "You have already supported this investment project. Share it!"
+          expect(page).not_to have_content "You have already supported this investment project. "\
+                                           "Share it!"
         end
       end
 
       scenario "From show", :js do
         visit budget_investment_path(budget, new_york_investment)
 
-        accept_confirm { find('.in-favor a').click }
+        accept_confirm { find(".in-favor a").click }
         expect(page).to have_content "1 support"
         expect(page).to have_content "You have already supported this investment project. Share it!"
 
         visit budget_investment_path(budget, san_francisco_investment)
 
-        find('.in-favor a').click
+        find(".in-favor a").click
         expect(page).to have_content "1 support"
         expect(page).to have_content "You have already supported this investment project. Share it!"
 
         visit budget_investment_path(budget, third_heading_investment)
 
-        find('.in-favor a').click
-        expect(page).to have_content "You can only support investment projects in 2 districts. You have already supported investments in"
+        find(".in-favor a").click
+        expect(page).to have_content "You can only support investment projects in 2 districts. "\
+                                     "You have already supported investments in"
 
-        heading_names = find('.participation-not-allowed').text.match(/You have already supported investments in (.+) and (.+)\./)&.captures
-        expect(heading_names).to match_array [new_york.name, san_francisco.name]
+        participation = find(".participation-not-allowed")
+        headings = participation.text
+                   .match(/You have already supported investments in (.+) and (.+)\./)&.captures
+
+        expect(headings).to match_array [new_york.name, san_francisco.name]
 
         expect(page).not_to have_content "1 support"
-        expect(page).not_to have_content "You have already supported this investment project. Share it!"
+        expect(page).not_to have_content "You have already supported this investment project. "\
+                                         "Share it!"
       end
 
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,35 @@ require 'rails_helper'
 
 describe User do
 
+  describe '#headings_voted_within_group' do
+    it "returns the headings voted by a user" do
+      user1 = create(:user)
+      user2 = create(:user)
+
+      budget = create(:budget)
+      group = create(:budget_group, budget: budget)
+
+      new_york = create(:budget_heading, group: group)
+      san_franciso = create(:budget_heading, group: group)
+      another_heading = create(:budget_heading, group: group)
+
+      new_york_investment = create(:budget_investment, heading: new_york)
+      san_franciso_investment = create(:budget_investment, heading: san_franciso)
+      another_investment = create(:budget_investment, heading: san_franciso)
+
+      create(:vote, votable: new_york_investment, voter: user1)
+      create(:vote, votable: san_franciso_investment, voter: user1)
+
+      expect(user1.headings_voted_within_group(group)).to include(new_york)
+      expect(user1.headings_voted_within_group(group)).to include(san_franciso)
+      expect(user1.headings_voted_within_group(group)).to_not include(another_heading)
+
+      expect(user2.headings_voted_within_group(group)).to_not include(new_york)
+      expect(user2.headings_voted_within_group(group)).to_not include(san_franciso)
+      expect(user2.headings_voted_within_group(group)).to_not include(another_heading)
+    end
+  end
+
   describe "#debate_votes" do
     let(:user) { create(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,26 +3,33 @@ require "rails_helper"
 describe User do
 
   describe "#headings_voted_within_group" do
-    it "returns the headings voted by a user" do
+    it "returns the headings voted by a user ordered by name" do
       user1 = create(:user)
       user2 = create(:user)
 
       budget = create(:budget)
       group = create(:budget_group, budget: budget)
 
-      new_york = create(:budget_heading, group: group)
-      san_franciso = create(:budget_heading, group: group)
+      new_york = create(:budget_heading, group: group, name: "New york")
+      san_franciso = create(:budget_heading, group: group, name: "San Franciso")
+      wyoming = create(:budget_heading, group: group, name: "Wyoming")
       another_heading = create(:budget_heading, group: group)
 
       new_york_investment = create(:budget_investment, heading: new_york)
       san_franciso_investment = create(:budget_investment, heading: san_franciso)
+      wyoming_investment = create(:budget_investment, heading: wyoming)
 
-      create(:vote, votable: new_york_investment, voter: user1)
+      create(:vote, votable: wyoming_investment, voter: user1)
       create(:vote, votable: san_franciso_investment, voter: user1)
+      create(:vote, votable: new_york_investment, voter: user1)
+
+      headings_names = "#{new_york.name}, #{san_franciso.name}, and #{wyoming.name}"
 
       expect(user1.headings_voted_within_group(group)).to include(new_york)
       expect(user1.headings_voted_within_group(group)).to include(san_franciso)
+      expect(user1.headings_voted_within_group(group)).to include(wyoming)
       expect(user1.headings_voted_within_group(group)).not_to include(another_heading)
+      expect(user1.headings_voted_within_group(group).map(&:name).to_sentence).to eq(headings_names)
 
       expect(user2.headings_voted_within_group(group)).not_to include(new_york)
       expect(user2.headings_voted_within_group(group)).not_to include(san_franciso)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,8 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe User do
 
-  describe '#headings_voted_within_group' do
+  describe "#headings_voted_within_group" do
     it "returns the headings voted by a user" do
       user1 = create(:user)
       user2 = create(:user)
@@ -16,18 +16,17 @@ describe User do
 
       new_york_investment = create(:budget_investment, heading: new_york)
       san_franciso_investment = create(:budget_investment, heading: san_franciso)
-      another_investment = create(:budget_investment, heading: san_franciso)
 
       create(:vote, votable: new_york_investment, voter: user1)
       create(:vote, votable: san_franciso_investment, voter: user1)
 
       expect(user1.headings_voted_within_group(group)).to include(new_york)
       expect(user1.headings_voted_within_group(group)).to include(san_franciso)
-      expect(user1.headings_voted_within_group(group)).to_not include(another_heading)
+      expect(user1.headings_voted_within_group(group)).not_to include(another_heading)
 
-      expect(user2.headings_voted_within_group(group)).to_not include(new_york)
-      expect(user2.headings_voted_within_group(group)).to_not include(san_franciso)
-      expect(user2.headings_voted_within_group(group)).to_not include(another_heading)
+      expect(user2.headings_voted_within_group(group)).not_to include(new_york)
+      expect(user2.headings_voted_within_group(group)).not_to include(san_franciso)
+      expect(user2.headings_voted_within_group(group)).not_to include(another_heading)
     end
   end
 
@@ -101,39 +100,39 @@ describe User do
     end
   end
 
-  describe 'preferences' do
-    describe 'email_on_comment' do
-      it 'is false by default' do
+  describe "preferences" do
+    describe "email_on_comment" do
+      it "is false by default" do
         expect(subject.email_on_comment).to eq(false)
       end
     end
 
-    describe 'email_on_comment_reply' do
-      it 'is false by default' do
+    describe "email_on_comment_reply" do
+      it "is false by default" do
         expect(subject.email_on_comment_reply).to eq(false)
       end
     end
 
-    describe 'subscription_to_website_newsletter' do
-      it 'is true by default' do
+    describe "subscription_to_website_newsletter" do
+      it "is true by default" do
         expect(subject.newsletter).to eq(true)
       end
     end
 
-    describe 'email_digest' do
-      it 'is true by default' do
+    describe "email_digest" do
+      it "is true by default" do
         expect(subject.email_digest).to eq(true)
       end
     end
 
-    describe 'email_on_direct_message' do
-      it 'is true by default' do
+    describe "email_on_direct_message" do
+      it "is true by default" do
         expect(subject.email_on_direct_message).to eq(true)
       end
     end
 
-    describe 'official_position_badge' do
-      it 'is false by default' do
+    describe "official_position_badge" do
+      it "is false by default" do
         expect(subject.official_position_badge).to eq(false)
       end
     end
@@ -204,7 +203,7 @@ describe User do
       expect(subject.organization?).to be false
     end
 
-    describe 'when it is an organization' do
+    describe "when it is an organization" do
       before { create(:organization, user: subject) }
 
       it "is true when the user is an organization" do
@@ -222,7 +221,7 @@ describe User do
       expect(subject).not_to be_verified_organization
     end
 
-    describe 'when it is an organization' do
+    describe "when it is an organization" do
       before { create(:organization, user: subject) }
 
       it "is false when the user is not a verified organization" do
@@ -237,12 +236,12 @@ describe User do
   end
 
   describe "organization_attributes" do
-    before { subject.organization_attributes = {name: 'org', responsible_name: 'julia'} }
+    before { subject.organization_attributes = {name: "org", responsible_name: "julia"} }
 
     it "triggers the creation of an associated organization" do
       expect(subject.organization).to be
-      expect(subject.organization.name).to eq('org')
-      expect(subject.organization.responsible_name).to eq('julia')
+      expect(subject.organization.name).to eq("org")
+      expect(subject.organization.responsible_name).to eq("julia")
     end
 
     it "deactivates the validation of username, and activates the validation of organization" do
@@ -321,7 +320,7 @@ describe User do
       # We will use empleados.madrid.es as the officials' domain
       # Subdomains are also accepted
 
-      Setting['email_domain_for_officials'] = 'officials.madrid.es'
+      Setting["email_domain_for_officials"] = "officials.madrid.es"
       user1 = create(:user, email: "john@officials.madrid.es", confirmed_at: Time.current)
       user2 = create(:user, email: "john@yes.officials.madrid.es", confirmed_at: Time.current)
       user3 = create(:user, email: "john@unofficials.madrid.es", confirmed_at: Time.current)
@@ -333,7 +332,7 @@ describe User do
       expect(user4.has_official_email?).to eq(false)
 
       # We reset the officials' domain setting
-      Setting.find_by(key: 'email_domain_for_officials').update(value: '')
+      Setting.find_by(key: "email_domain_for_officials").update(value: "")
     end
   end
 
@@ -490,10 +489,10 @@ describe User do
                      reset_password_token: "token2",
                      email_verification_token: "token3")
 
-      user.erase('a test')
+      user.erase("a test")
       user.reload
 
-      expect(user.erase_reason).to eq('a test')
+      expect(user.erase_reason).to eq("a test")
       expect(user.erased_at).to    be
 
       expect(user.username).to be_nil
@@ -524,7 +523,7 @@ describe User do
       user = create(:user)
       identity = create(:identity, user: user)
 
-      user.erase('an identity test')
+      user.erase("an identity test")
 
       expect(Identity.exists?(identity.id)).not_to be
     end


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1558

This closes #2496

Objectives
===================
When the user is shown a "headings limit reached" alert, include the name of the relevant headings (where the user has already supported investments) in the message.

Also includes a small refactor to make the change easier and reduce the final amount of code.

Visual Changes
===================

__Before__
![selection_105](https://user-images.githubusercontent.com/7111622/42497803-c3d6ba9e-842a-11e8-9607-a47d16dc7453.png)

__After__
![selection_103](https://user-images.githubusercontent.com/7111622/42497119-76b4a5a2-8428-11e8-8acd-43836222792c.png)

![selection_104](https://user-images.githubusercontent.com/7111622/42497120-7b44f590-8428-11e8-9b16-ec332f18143e.png)