### PR TITLE
[Backport] Use votes score instead of total votes on debates and legislation proposals

### DIFF
--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -88,6 +88,10 @@ class Debate < ActiveRecord::Base
     cached_votes_total
   end
 
+  def votes_score
+    cached_votes_score
+  end
+
   def total_anonymous_votes
     cached_anonymous_votes_total
   end

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -47,7 +47,7 @@ class Legislation::Proposal < ActiveRecord::Base
   scope :sort_by_most_commented,   -> { reorder(comments_count: :desc) }
   scope :sort_by_title,            -> { reorder(title: :asc) }
   scope :sort_by_id,               -> { reorder(id: :asc) }
-  scope :sort_by_supports,         -> { reorder(cached_votes_up: :desc) }
+  scope :sort_by_supports,         -> { reorder(cached_votes_score: :desc) }
   scope :sort_by_random,           -> { reorder("RANDOM()") }
   scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
   scope :last_week,                -> { where("proposals.created_at >= ?", 7.days.ago)}

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -96,6 +96,10 @@ class Legislation::Proposal < ActiveRecord::Base
     cached_votes_total
   end
 
+  def votes_score
+    cached_votes_score
+  end
+
   def voters
     User.active.where(id: votes_for.voters)
   end

--- a/app/views/admin/legislation/proposals/_proposals.html.erb
+++ b/app/views/admin/legislation/proposals/_proposals.html.erb
@@ -18,7 +18,7 @@
         <tr id="<%= dom_id(proposal) %>" class="legislation_proposal">
           <td class="text-center"><%= proposal.id %></td>
           <td><%= proposal.title %></td>
-          <td class="text-center"><%= proposal.cached_votes_up %></td>
+          <td class="text-center"><%= proposal.votes_score %></td>
           <td class="select"><%= render "select_proposal", proposal: proposal %></td>
         </tr>
       <% end %>

--- a/app/views/debates/_votes.html.erb
+++ b/app/views/debates/_votes.html.erb
@@ -40,7 +40,7 @@
   </div>
 
   <span class="total-votes">
-    <%= t("debates.debate.votes", count: debate.total_votes) %>
+    <%= t("debates.debate.votes", count: debate.votes_score) %>
   </span>
 
   <% if user_signed_in? && current_user.organization? %>

--- a/app/views/legislation/proposals/_votes.html.erb
+++ b/app/views/legislation/proposals/_votes.html.erb
@@ -42,7 +42,7 @@
   <% end %>
 
   <span class="total-votes">
-    <%= t("proposals.proposal.votes", count: proposal.total_votes) %>
+    <%= t("proposals.proposal.votes", count: proposal.votes_score) %>
   </span>
 
   <% if user_signed_in? && current_user.organization? %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -456,7 +456,7 @@ en:
           orders:
             id: Id
             title: Title
-            supports: Supports
+            supports: Total supports
         process:
           title: Process
           comments: Comments
@@ -481,7 +481,7 @@ en:
           back: Back
           id: Id
           title: Title
-          supports: Supports
+          supports: Total supports
           select: Select
           selected: Selected
         form:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -457,7 +457,7 @@ es:
           orders:
             id: Id
             title: Título
-            supports: Apoyos
+            supports: Apoyos totales
         process:
           title: Proceso
           comments: Comentarios
@@ -481,7 +481,7 @@ es:
           title: Título
           back: Volver
           id: Id
-          supports: Apoyos
+          supports: Apoyos totales
           select: Seleccionar
           selected: Seleccionada
         form:

--- a/db/migrate/20190118115237_add_cached_votes_score_to_legislation_proposals.rb
+++ b/db/migrate/20190118115237_add_cached_votes_score_to_legislation_proposals.rb
@@ -1,0 +1,7 @@
+class AddCachedVotesScoreToLegislationProposals < ActiveRecord::Migration
+  def change
+    add_column :legislation_proposals, :cached_votes_score, :integer, default: 0
+
+    add_index :legislation_proposals, :cached_votes_score
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -691,8 +691,10 @@ ActiveRecord::Schema.define(version: 20190205131722) do
     t.integer  "cached_votes_total",                default: 0
     t.integer  "cached_votes_down",                 default: 0
     t.boolean  "selected"
+    t.integer  "cached_votes_score",                default: 0
   end
 
+  add_index "legislation_proposals", ["cached_votes_score"], name: "index_legislation_proposals_on_cached_votes_score", using: :btree
   add_index "legislation_proposals", ["legislation_process_id"], name: "index_legislation_proposals_on_legislation_process_id", using: :btree
 
   create_table "legislation_question_option_translations", force: :cascade do |t|

--- a/lib/tasks/legislation_proposals.rake
+++ b/lib/tasks/legislation_proposals.rake
@@ -1,0 +1,10 @@
+namespace :legislation_proposals do
+  desc "Calculate cached votes score for existing legislation proposals"
+  task calculate_cached_votes_score: :environment do
+    Legislation::Proposal.find_each do |p|
+      p.update_column(:cached_votes_score, p.cached_votes_up - p.cached_votes_down)
+      print "."
+    end
+    puts "\nTask finished 🎉"
+  end
+end

--- a/spec/features/admin/legislation/proposals_spec.rb
+++ b/spec/features/admin/legislation/proposals_spec.rb
@@ -10,20 +10,20 @@ feature 'Admin legislation processes' do
   context "Index" do
 
     scenario 'Displaying legislation proposals' do
-      proposal = create(:legislation_proposal, cached_votes_up: 10)
+      proposal = create(:legislation_proposal, cached_votes_score: 10)
 
       visit admin_legislation_process_proposals_path(proposal.legislation_process_id)
 
       within "#legislation_proposal_#{proposal.id}" do
         expect(page).to have_content(proposal.title)
         expect(page).to have_content(proposal.id)
-        expect(page).to have_content(proposal.cached_votes_up)
+        expect(page).to have_content(proposal.cached_votes_score)
         expect(page).to have_content('Select')
       end
     end
 
     scenario 'Selecting legislation proposals', :js do
-      proposal = create(:legislation_proposal, cached_votes_up: 10)
+      proposal = create(:legislation_proposal, cached_votes_score: 10)
 
       visit admin_legislation_process_proposals_path(proposal.legislation_process_id)
       click_link 'Select'
@@ -51,12 +51,12 @@ feature 'Admin legislation processes' do
 
     scenario 'Sorting legislation proposals by supports', js: true do
       process = create(:legislation_process)
-      create(:legislation_proposal, cached_votes_up: 10, legislation_process_id: process.id)
-      create(:legislation_proposal, cached_votes_up: 30, legislation_process_id: process.id)
-      create(:legislation_proposal, cached_votes_up: 20, legislation_process_id: process.id)
+      create(:legislation_proposal, cached_votes_score: 10, legislation_process_id: process.id)
+      create(:legislation_proposal, cached_votes_score: 30, legislation_process_id: process.id)
+      create(:legislation_proposal, cached_votes_score: 20, legislation_process_id: process.id)
 
       visit admin_legislation_process_proposals_path(process.id)
-      select "Supports", from: "order-selector-participation"
+      select "Total supports", from: "order-selector-participation"
 
       within('#legislation_proposals_list') do
         within all('.legislation_proposal')[0] { expect(page).to have_content('30') }

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -128,6 +128,43 @@ feature 'Debates' do
     end
   end
 
+  scenario "Show votes score on index and show" do
+    debate_positive = create(:debate, title: "Debate positive")
+    debate_zero = create(:debate, title: "Debate zero")
+    debate_negative = create(:debate, title: "Debate negative")
+
+    10.times { create(:vote, votable: debate_positive, vote_flag: true) }
+    3.times  { create(:vote, votable: debate_positive, vote_flag: false) }
+
+    5.times { create(:vote, votable: debate_zero, vote_flag: true) }
+    5.times  { create(:vote, votable: debate_zero, vote_flag: false) }
+
+    6.times  { create(:vote, votable: debate_negative, vote_flag: false) }
+
+    visit debates_path
+
+    within "#debate_#{debate_positive.id}" do
+      expect(page).to have_content("7 votes")
+    end
+
+    within "#debate_#{debate_zero.id}" do
+      expect(page).to have_content("No votes")
+    end
+
+    within "#debate_#{debate_negative.id}" do
+      expect(page).to have_content("-6 votes")
+    end
+
+    visit debate_path(debate_positive)
+    expect(page).to have_content("7 votes")
+
+    visit debate_path(debate_zero)
+    expect(page).to have_content("No votes")
+
+    visit debate_path(debate_negative)
+    expect(page).to have_content("-6 votes")
+  end
+
   scenario 'Create' do
     author = create(:user)
     login_as(author)

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -145,4 +145,49 @@ feature 'Legislation Proposals' do
     expect(page).to have_content 'Including an image on a legislation proposal'
     expect(page).to have_css("img[alt='#{Legislation::Proposal.last.image.title}']")
   end
+
+  scenario "Show votes score on index and show" do
+    legislation_proposal_positive = create(:legislation_proposal,
+                                           legislation_process_id: process.id,
+                                           title: "Legislation proposal positive")
+
+    legislation_proposal_zero = create(:legislation_proposal,
+                                       legislation_process_id: process.id,
+                                       title: "Legislation proposal zero")
+
+    legislation_proposal_negative = create(:legislation_proposal,
+                                           legislation_process_id: process.id,
+                                           title: "Legislation proposal negative")
+
+    10.times { create(:vote, votable: legislation_proposal_positive, vote_flag: true) }
+    3.times  { create(:vote, votable: legislation_proposal_positive, vote_flag: false) }
+
+    5.times { create(:vote, votable: legislation_proposal_zero, vote_flag: true) }
+    5.times  { create(:vote, votable: legislation_proposal_zero, vote_flag: false) }
+
+    6.times  { create(:vote, votable: legislation_proposal_negative, vote_flag: false) }
+
+    visit legislation_process_proposals_path(process)
+
+    within "#legislation_proposal_#{legislation_proposal_positive.id}" do
+      expect(page).to have_content("7 votes")
+    end
+
+    within "#legislation_proposal_#{legislation_proposal_zero.id}" do
+      expect(page).to have_content("No votes")
+    end
+
+    within "#legislation_proposal_#{legislation_proposal_negative.id}" do
+      expect(page).to have_content("-6 votes")
+    end
+
+    visit legislation_process_proposal_path(process, legislation_proposal_positive)
+    expect(page).to have_content("7 votes")
+
+    visit legislation_process_proposal_path(process, legislation_proposal_zero)
+    expect(page).to have_content("No votes")
+
+    visit legislation_process_proposal_path(process, legislation_proposal_negative)
+    expect(page).to have_content("-6 votes")
+  end
 end

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -128,7 +128,7 @@ feature 'Votes' do
 
         visit debate_path(debate)
 
-        expect(page).to have_content "2 votes"
+        expect(page).to have_content "No votes"
 
         within('.in-favor') do
           expect(page).to have_content "50%"


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1835

## Objectives

Use *votes_score* instead of *total_votes* on **debates** and **legislation proposals**. 

The main change it's now the votes number is the result of `cached_votes_up` minus `cached_votes_down`.

**BEFORE**
```
1 cached_votes_up + 0 cached_votes_down = 1 vote
1 cached_votes_up + 1 cached_votes_down = 2 votes
0 cached_votes_up + 1 cached_votes_down = 1 vote
```

**NOW**
```
1 cached_votes_up + 0 cached_votes_down = 1 vote
1 cached_votes_up + 1 cached_votes_down = No votes
0 cached_votes_up + 1 cached_votes_down = -1 vote
```
So this PR:

- Replace total votes to cached_votes_score on debates: this show votes_score as result of votes_up minus votes_down.
- Add cached_votes_score to legislation proposals.
- Replace total votes to cached_votes_score on legislation proposals: this show votes_score as result of votes_up minus votes_down.
- Show cached_votes_score on admin legislation proposals.

## Visual Changes
**Voting debates**
![debates](https://user-images.githubusercontent.com/631897/51388424-ab1e2780-1b29-11e9-9b89-88ab6f07c382.gif)

**Voting legislation proposals**
![legislation_proposals](https://user-images.githubusercontent.com/631897/51388428-ace7eb00-1b29-11e9-8d55-680f42ce5f4c.gif)

**Legislation proposals admin show "Total supports" (cached_votes_score)**
![admin](https://user-images.githubusercontent.com/631897/51388435-b3766280-1b29-11e9-98cc-d30224f5ff99.png)

## For release notes ⚠️ 

In case you have existing legislation proposals in DB run: 
`bin/rake legislation_proposals:calculate_cached_votes_score RAILS_ENV=production`
to calculate **cached_votes_score**.