### PR TITLE
[Backport] Delete Booth Shifts with associated data

### DIFF
--- a/app/controllers/admin/poll/shifts_controller.rb
+++ b/app/controllers/admin/poll/shifts_controller.rb
@@ -26,9 +26,14 @@ class Admin::Poll::ShiftsController < Admin::Poll::BaseController
 
   def destroy
     @shift = Poll::Shift.find(params[:id])
-    @shift.destroy
-    notice = t("admin.poll_shifts.flash.destroy")
-    redirect_to new_admin_booth_shift_path(@booth), notice: notice
+    if @shift.unable_to_destroy?
+      alert = t("admin.poll_shifts.flash.unable_to_destroy")
+      redirect_to new_admin_booth_shift_path(@booth), alert: alert
+    else
+      @shift.destroy
+      notice = t("admin.poll_shifts.flash.destroy")
+      redirect_to new_admin_booth_shift_path(@booth), notice: notice
+    end
   end
 
   def search_officers

--- a/app/models/poll/booth_assignment.rb
+++ b/app/models/poll/booth_assignment.rb
@@ -15,6 +15,10 @@ class Poll
       shifts.empty? ? false : true
     end
 
+    def unable_to_destroy?
+      (partial_results.count + recounts.count).positive?
+    end
+
     private
 
       def shifts

--- a/app/models/poll/shift.rb
+++ b/app/models/poll/shift.rb
@@ -35,6 +35,10 @@ class Poll
       end
     end
 
+    def unable_to_destroy?
+      booth.booth_assignments.map(&:unable_to_destroy?).any?
+    end
+
     def destroy_officer_assignments
       Poll::OfficerAssignment.where(booth_assignment: booth.booth_assignments,
                                     officer: officer,

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -872,6 +872,7 @@ en:
       flash:
         create: "Shift added"
         destroy: "Shift removed"
+        unable_to_destroy: "Shifts with associated results or recounts cannot be deleted"
         date_missing: "A date must be selected"
       vote_collection: Collect Votes
       recount_scrutiny: Recount & Scrutiny

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -872,6 +872,7 @@ es:
       flash:
         create: "Añadido turno de presidente de mesa"
         destroy: "Eliminado turno de presidente de mesa"
+        unable_to_destroy: "No se pueden eliminar turnos que tienen resultados o recuentos asociados"
         date_missing: "Debe seleccionarse una fecha"
       vote_collection: Recoger Votos
       recount_scrutiny: Recuento & Escrutinio

--- a/spec/features/admin/poll/shifts_spec.rb
+++ b/spec/features/admin/poll/shifts_spec.rb
@@ -165,6 +165,58 @@ feature 'Admin shifts' do
     expect(page).to have_css(".shift", count: 0)
   end
 
+  scenario "Try to destroy with associated recount" do
+    assignment = create(:poll_booth_assignment)
+    officer_assignment = create(:poll_officer_assignment, booth_assignment: assignment)
+    create(:poll_recount, booth_assignment: assignment, officer_assignment: officer_assignment)
+
+    officer = officer_assignment.officer
+    booth = assignment.booth
+    shift = create(:poll_shift, officer: officer, booth: booth)
+
+    visit available_admin_booths_path
+
+    within("#booth_#{booth.id}") do
+      click_link "Manage shifts"
+    end
+
+    expect(page).to have_css(".shift", count: 1)
+    within("#shift_#{shift.id}") do
+      click_link "Remove"
+    end
+
+    expect(page).not_to have_content "Shift removed"
+    expect(page).to have_content "Shifts with associated results or recounts cannot be deleted"
+    expect(page).to have_css(".shift", count: 1)
+  end
+
+  scenario "try to destroy with associated partial results" do
+    assignment = create(:poll_booth_assignment)
+    officer_assignment = create(:poll_officer_assignment, booth_assignment: assignment)
+    create(:poll_partial_result,
+           booth_assignment: assignment,
+           officer_assignment: officer_assignment)
+
+    officer = officer_assignment.officer
+    booth = assignment.booth
+    shift = create(:poll_shift, officer: officer, booth: booth)
+
+    visit available_admin_booths_path
+
+    within("#booth_#{booth.id}") do
+      click_link "Manage shifts"
+    end
+
+    expect(page).to have_css(".shift", count: 1)
+    within("#shift_#{shift.id}") do
+      click_link "Remove"
+    end
+
+    expect(page).not_to have_content "Shift removed"
+    expect(page).to have_content "Shifts with associated results or recounts cannot be deleted"
+    expect(page).to have_css(".shift", count: 1)
+  end
+
   scenario "Destroy an officer" do
     poll = create(:poll)
     booth = create(:poll_booth)


### PR DESCRIPTION
## References

This is a backport of PR https://github.com/AyuntamientoMadrid/consul/pull/1858

## Objectives

Show an alert message when trying to delete a Poll Booth Shift that has associated data like `partial_results` or `recounts`.

## Visual Changes
### ERROR RAISED BEFORE
![delete_poll_shift](https://user-images.githubusercontent.com/942995/52232067-d770cc80-28bb-11e9-9492-6e0eea7bb711.gif)

### ERROR MESSAGE AFTER
![poll_booth_after](https://user-images.githubusercontent.com/942995/52333829-80274500-29fe-11e9-8a33-4786317c22b3.gif)
