### PR TITLE
[Backport] Add a description for open polls

### DIFF
--- a/app/controllers/admin/poll/active_polls_controller.rb
+++ b/app/controllers/admin/poll/active_polls_controller.rb
@@ -1,0 +1,36 @@
+class Admin::Poll::ActivePollsController < Admin::Poll::BaseController
+  include Translatable
+
+  before_action :load_active_poll
+
+  def create
+    if @active_poll.update(active_poll_params)
+      redirect_to admin_polls_url, notice: t("flash.actions.update.active_poll")
+    else
+      render :edit
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @active_poll.update(active_poll_params)
+      redirect_to admin_polls_url, notice: t("flash.actions.update.active_poll")
+    else
+      render :edit
+    end
+  end
+
+
+  private
+
+    def load_active_poll
+      @active_poll = ::ActivePoll.first_or_initialize
+    end
+
+    def active_poll_params
+      params.require(:active_poll).permit(translation_params(ActivePoll))
+    end
+
+end

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,6 +1,8 @@
 class PollsController < ApplicationController
   include PollsHelper
 
+  before_action :load_active_poll, only: :index
+
   load_and_authorize_resource
 
   has_filters %w[current expired]
@@ -33,5 +35,11 @@ class PollsController < ApplicationController
 
   def results
   end
+
+  private
+
+    def load_active_poll
+      @active_poll = ActivePoll.first
+    end
 
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -37,8 +37,12 @@ module AdminHelper
     ["spending_proposals"].include?(controller_name)
   end
 
+  def menu_poll?
+    %w[polls active_polls recounts results].include?(controller_name)
+  end
+
   def menu_polls?
-    %w[polls questions answers recounts results].include?(controller_name)
+    menu_poll? || %w[questions answers].include?(controller_name)
   end
 
   def menu_booths?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,4 +60,11 @@ module ApplicationHelper
   def kaminari_path(url)
     "#{root_url.chomp("\/")}#{url}"
   end
+
+  def render_custom_partial(partial_name)
+    controller_action = @virtual_path.split("/").last
+    custom_partial_path = "custom/#{@virtual_path.remove(controller_action)}#{partial_name}"
+    render custom_partial_path if lookup_context.exists?(custom_partial_path, [], true)
+  end
+
 end

--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -64,4 +64,8 @@ module PollsHelper
   def info_menu?
     controller_name == "polls" && action_name == "show"
   end
+
+  def show_polls_description?
+    @active_poll.present? && @current_filter == "current"
+  end
 end

--- a/app/models/active_poll.rb
+++ b/app/models/active_poll.rb
@@ -1,0 +1,6 @@
+class ActivePoll < ActiveRecord::Base
+  include Measurable
+
+  translates :description, touch: true
+  include Globalizable
+end

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -7,7 +7,7 @@
           <strong><%= t("admin.menu.title_polls") %></strong>
         </a>
         <ul id="polls_menu" <%= "class=is-active" if menu_polls? || controller.class.parent == Admin::Poll::Questions::Answers %>>
-          <li <%= "class=is-active" if %w(polls recounts results).include?(controller_name) %>>
+          <li <%= "class=is-active" if menu_poll? %>>
             <%= link_to t("admin.menu.polls"), admin_polls_path %>
           </li>
 

--- a/app/views/admin/poll/active_polls/_form.html.erb
+++ b/app/views/admin/poll/active_polls/_form.html.erb
@@ -1,0 +1,20 @@
+<%= render "admin/shared/globalize_locales", resource: @active_poll %>
+
+<%= translatable_form_for(@active_poll, url: form_url) do |f| %>
+
+  <%= render 'shared/errors', resource: @active_poll %>
+
+  <%= f.translatable_fields do |translations_form| %>
+    <div class="ckeditor">
+      <span class="help-text"><%= t("admin.active_polls.form.description.help_text") %></span>
+      <%= translations_form.cktext_area :description,
+                                         maxlength: ActivePoll.description_max_length,
+                                         label: t("admin.active_polls.form.description.text") %>
+    </div>
+  <% end %>
+
+  <div class="small-12 medium-4 large-2 margin-top">
+    <%= f.submit(class: "button success", value: t("shared.save")) %>
+  </div>
+
+<% end %>

--- a/app/views/admin/poll/active_polls/edit.html.erb
+++ b/app/views/admin/poll/active_polls/edit.html.erb
@@ -1,0 +1,7 @@
+<%= back_link_to %>
+
+<h2><%= t("admin.active_polls.edit.title") %></h2>
+
+<div class="polls-form">
+  <%= render "form", form_url: admin_active_polls_url(@active_poll) %>
+</div>

--- a/app/views/admin/poll/polls/index.html.erb
+++ b/app/views/admin/poll/polls/index.html.erb
@@ -1,5 +1,9 @@
 <h2 class="inline-block"><%= t("admin.polls.index.title") %></h2>
 
+<%= link_to t("admin.active_polls.edit.title"),
+            edit_admin_active_polls_path,
+            class: "button hollow float-right" %>
+
 <%= link_to t("admin.polls.index.create"),
             new_admin_poll_path,
             class: "button float-right" %>

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -1,12 +1,23 @@
 <% provide :title do %><%= t("polls.index.title") %><% end %>
+
+<%= render_custom_partial "meta_description" %>
+
 <% content_for :canonical do %>
   <%= render "shared/canonical", href: polls_url %>
 <% end %>
+
+<%= render_custom_partial "social_meta_tags" %>
 
 <%= render "shared/section_header", i18n_namespace: "polls.index.section_header", image: "polls" %>
 
 <div class="row">
   <div class="small-12 column">
+    <% if show_polls_description? %>
+		  <div class="polls-description">
+        <%= safe_html_with_links WYSIWYGSanitizer.new.sanitize(@active_poll.description) %>
+      </div>
+		<% end %>
+
     <%= render 'shared/filter_subnav', i18n_namespace: "polls.index" %>
 
     <% if @polls.any? %>
@@ -38,6 +49,7 @@
         <strong><%= t("polls.index.section_footer.title") %></strong>
       </p>
       <p><%= t("polls.index.section_footer.description") %></p>
+      <%= render_custom_partial "footer" %>
     </div>
   </div>
 </div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -907,6 +907,13 @@ en:
         no_booths: "There are no booths assigned to this poll."
         table_name: "Name"
         table_location: "Location"
+    active_polls:
+      edit:
+        title: "Polls description"
+      form:
+        description:
+          text: "Description"
+          help_text: "This text will appear in the header of the polls page. It can be used to add a context to the open polls."
     polls:
       index:
         title: "List of polls"

--- a/config/locales/en/responders.yml
+++ b/config/locales/en/responders.yml
@@ -24,6 +24,7 @@ en:
         debate: "Debate updated successfully."
         poll: "Poll updated successfully."
         poll_booth: "Booth updated successfully."
+        active_poll: "Polls description updated successfully."
         proposal: "Proposal updated successfully."
         spending_proposal: "Investment project updated succesfully."
         budget_investment: "Investment project updated succesfully."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -906,6 +906,13 @@ es:
         no_booths: "No hay urnas asignadas a esta votación."
         table_name: "Nombre"
         table_location: "Ubicación"
+    active_polls:
+      edit:
+        title: "Descripción general de votaciones"
+      form:
+        description:
+          text: "Descripción"
+          help_text: "Este texto aparecerá en la cabecera de la página de votaciones. Puedes usarlo para añadir un contexto a las votaciones abiertas"
     polls:
       index:
         title: "Listado de votaciones"

--- a/config/locales/es/responders.yml
+++ b/config/locales/es/responders.yml
@@ -24,6 +24,7 @@ es:
         debate: "Debate actualizado correctamente."
         poll: "Votación actualizada correctamente."
         poll_booth: "Urna actualizada correctamente."
+        active_poll: "Descripción general de votaciones actualizada correctamente."
         proposal: "Propuesta actualizada correctamente."
         spending_proposal: "Propuesta de inversión actualizada correctamente."
         budget_investment: "Proyecto de gasto actualizado correctamente"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -159,6 +159,8 @@ namespace :admin do
       end
       post '/answers/order_answers', to: 'questions/answers#order_answers'
     end
+
+    resource :active_polls, only: [:create, :edit, :update]
   end
 
   resources :verifications, controller: :verifications, only: :index do

--- a/db/migrate/20190104160114_create_active_polls.rb
+++ b/db/migrate/20190104160114_create_active_polls.rb
@@ -1,0 +1,8 @@
+class CreateActivePolls < ActiveRecord::Migration
+  def change
+    create_table :active_polls do |t|
+      t.datetime   :created_at, null: false
+      t.datetime   :updated_at, null: false
+    end
+  end
+end

--- a/db/migrate/20190104170114_add_active_polls_translations.rb
+++ b/db/migrate/20190104170114_add_active_polls_translations.rb
@@ -1,0 +1,16 @@
+class AddActivePollsTranslations < ActiveRecord::Migration
+
+  def self.up
+    ActivePoll.create_translation_table!(
+      {
+        description: :text
+      },
+      { migrate_data: true }
+    )
+  end
+
+  def self.down
+    ActivePollPoll.drop_translation_table!
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,22 @@ ActiveRecord::Schema.define(version: 20190205131722) do
   enable_extension "unaccent"
   enable_extension "pg_trgm"
 
+  create_table "active_poll_translations", force: :cascade do |t|
+    t.integer  "active_poll_id", null: false
+    t.string   "locale",         null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.text     "description"
+  end
+
+  add_index "active_poll_translations", ["active_poll_id"], name: "index_active_poll_translations_on_active_poll_id", using: :btree
+  add_index "active_poll_translations", ["locale"], name: "index_active_poll_translations_on_locale", using: :btree
+
+  create_table "active_polls", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "activities", force: :cascade do |t|
     t.integer  "user_id"
     t.string   "action"

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -134,4 +134,7 @@ FactoryBot.define do
       year_of_birth { Time.current.year }
     end
   end
+
+  factory :active_poll do
+  end
 end

--- a/spec/features/admin/poll/active_polls_spec.rb
+++ b/spec/features/admin/poll/active_polls_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+feature "Admin Active polls" do
+
+  background do
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
+
+  it_behaves_like "translatable",
+                  "active_poll",
+                  "edit_admin_active_polls_path",
+                  [],
+                  { "description" => :ckeditor }
+
+  scenario "Add", :js do
+    expect(ActivePoll.first).to be nil
+
+    visit admin_polls_path
+    click_link "Polls description"
+
+    fill_in_ckeditor "Description", with: "Active polls description"
+    click_button "Save"
+
+    expect(page).to have_content "Polls description updated successfully."
+    expect(ActivePoll.first.description).to eq "<p>Active polls description</p>\r\n"
+  end
+
+  scenario "Edit", :js do
+    create(:active_poll, description_en: "Old description")
+
+    visit polls_path
+    within ".polls-description" do
+      expect(page).to have_content "Old description"
+    end
+
+    visit edit_admin_active_polls_path
+    fill_in_ckeditor "Description", with: "New description"
+    click_button "Save"
+
+    expect(page).to have_content "Polls description updated successfully."
+
+    visit polls_path
+    within ".polls-description" do
+      expect(page).not_to have_content "Old description"
+      expect(page).to have_content "New description"
+    end
+  end
+
+end

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -8,6 +8,19 @@ feature "Polls" do
 
   context "#index" do
 
+    scenario "Shows description for open polls" do
+      visit polls_path
+      expect(page).not_to have_content "Description for open polls"
+
+      create(:active_poll, description: "Description for open polls")
+
+      visit polls_path
+      expect(page).to have_content "Description for open polls"
+
+      click_link "Expired"
+      expect(page).not_to have_content "Description for open polls"
+    end
+
     scenario "Polls can be listed" do
       visit polls_path
       expect(page).to have_content("There are no open votings")

--- a/spec/shared/features/translatable.rb
+++ b/spec/shared/features/translatable.rb
@@ -339,7 +339,7 @@ def update_button_text
     "Update poll"
   when "Budget"
     "Update Budget"
-  when "Poll::Question", "Poll::Question::Answer"
+  when "Poll::Question", "Poll::Question::Answer", "ActivePoll"
     "Save"
   when "SiteCustomization::Page"
     "Update Custom page"


### PR DESCRIPTION
## References

This is a backport of PR https://github.com/AyuntamientoMadrid/consul/pull/1800

## Objectives

- Be able to add a description for the active polls
- Make it translatable

## Visual Changes
![captura de pantalla 2019-01-04 a las 17 12 28](https://user-images.githubusercontent.com/942995/50706319-c5520300-105d-11e9-9c04-59aa1dc80567.png)
![captura de pantalla 2019-01-04 a las 18 39 04](https://user-images.githubusercontent.com/942995/50706323-ca16b700-105d-11e9-930d-00d2a76aef8d.png)
![captura de pantalla 2019-01-04 a las 18 39 25](https://user-images.githubusercontent.com/942995/50706333-d26ef200-105d-11e9-9b55-b8a9b5f3ac42.png)

## Notes

closes https://github.com/consul/consul/issues/2784