### PR TITLE
[Backport] Return a String in I18n method 'pluralize'

### DIFF
--- a/config/initializers/i18n_pluralize.rb
+++ b/config/initializers/i18n_pluralize.rb
@@ -10,7 +10,7 @@ module I18n
         return entry unless entry.is_a?(Hash) && count
 
         key = pluralization_key(entry, count)
-        return count unless entry.has_key?(key)
+        return "#{count}" unless entry.has_key?(key)
         entry[key]
       end
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,5 +16,6 @@
 # end
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.plural(/^(\d+)$/i, '\1')
   inflect.irregular 'organización', 'organizaciones'
 end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -56,9 +56,27 @@ describe 'I18n' do
       I18n.backend.store_translations(:en, { test_plural: keys })
 
       expect(I18n.t("test_plural", count: 0)).to eq("No comments")
-      expect(I18n.t("test_plural", count: 1)).to eq(1)
-      expect(I18n.t("test_plural", count: 2)).to eq(2)
+      expect(I18n.t("test_plural", count: 1)).to eq("1")
+      expect(I18n.t("test_plural", count: 2)).to eq("2")
     end
 
+    it "returns a String to avoid exception 'undefined method for Fixnum'" do
+      keys = { zero:  "No comments" }
+      I18n.backend.store_translations(:en, { test_plural: keys })
+
+      result = I18n.t("test_plural", count: 1)
+      expect(result.class).to be String
+      expect { result.pluralize }.not_to raise_error
+    end
+
+    it "returns the number not pluralized for missing translations" do
+      keys = { zero:  "No comments" }
+      I18n.backend.store_translations(:en, { test_plural: keys })
+
+      expect(I18n.t("test_plural", count: 1).pluralize).to eq "1"
+      expect(I18n.t("test_plural", count: 2).pluralize).to eq "2"
+      expect(I18n.t("test_plural", count: 1).pluralize).not_to eq "1s"
+      expect(I18n.t("test_plural", count: 2).pluralize).not_to eq "2s"
+    end
   end
 end


### PR DESCRIPTION
## References

This is a backport of the PR https://github.com/AyuntamientoMadrid/consul/pull/1864

## Objectives
If a translation was missing returning a `Fixnum` could cause to raise an exception "undefined method X for Fixnum".
For instance, we were getting the Exception "ActionView::Template::Error: undefined method 'pluralize' for 1:Fixnum" when calling `model_name.human` (used by the gem `kaminari` in the helper method `page_entries_info`).