### PR TITLE
Avoid exception on paranoid translations migrations

### DIFF
--- a/app/models/concerns/globalizable.rb
+++ b/app/models/concerns/globalizable.rb
@@ -13,7 +13,7 @@ module Globalizable
       self.read_attribute(:description).try :html_safe
     end
 
-    if self.paranoid?
+    if self.paranoid? && translation_class.attribute_names.include?("hidden_at")
       translation_class.send :acts_as_paranoid, column: :hidden_at
     end
   end


### PR DESCRIPTION
## References
* Related Issues: #3130
* Related PR's:  #3244, #3243, #3246

This also affect any globalized and paranoid model.

## Objectives
Translation classes are injected by Globalize and paranoia activation on translation classes is done through reflection from the parent class, this was throwing exceptions during database migrations because the code was trying to access `:hidden_at` column before to execute the migration.

## Visual Changes
None

# Specs
Here are specs created to warn us about this issue! But finally not include them in this PR, we think this could be confusing to other developers.

https://github.com/rockandror/consul/compare/activate-paranoia-on-translations-fix...rockandror:activate-paranoia-on-translations-fix-with-specs?expand=1

## Notes
**We should try this in pre-production environment to ensure we will run into problems.**
