### PR TITLE
[Backport] Reuse image attributes in legislation processes

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -1,5 +1,6 @@
 class Admin::Legislation::ProcessesController < Admin::Legislation::BaseController
   include Translatable
+  include ImageAttributes
 
   has_filters %w[open all], only: :index
 
@@ -71,7 +72,7 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         :font_color,
         translation_params(::Legislation::Process),
         documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
-        image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
+        image_attributes: image_attributes
       ]
     end
 


### PR DESCRIPTION
## References

* Backports commit AyuntamientoMadrid@fe9ffe9d from pull request AyuntamientoMadrid#1887
* Pull request 3170

## Notes

It wasn't originally added because legislation processes didn't have images at the time the original pull request was opened.