### PR TITLE
[Backport] Add sorting icons to sortable tables

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -372,6 +372,44 @@ $sidebar-active: #f4fcd0;
   color: $text-medium;
 }
 
+.icon-sortable {
+  font-family: "icons";
+  font-size: $small-font-size;
+  padding-right: $line-height / 2;
+  position: relative;
+
+  &::before,
+  &::after {
+    left: 6px;
+    opacity: 0.25;
+    position: absolute;
+  }
+
+  &::before {
+    content: "\57";
+    top: -2px;
+  }
+
+  &::after {
+    content: "\52";
+    bottom: -10px;
+  }
+
+  &.asc {
+
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  &.desc {
+
+    &::before {
+      opacity: 1;
+    }
+  }
+}
+
 // 02. Sidebar
 // -----------
 

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -1,6 +1,6 @@
 module BudgetInvestmentsHelper
   def budget_investments_advanced_filters(params)
-    params.map { |af| t("admin.budget_investments.index.filters.#{af}") }.join(', ')
+    params.map { |af| t("admin.budget_investments.index.filters.#{af}") }.join(", ")
   end
 
   def link_to_investments_sorted_by(column)
@@ -10,7 +10,7 @@ module BudgetInvestmentsHelper
     translation = t("admin.budget_investments.index.list.#{column}")
 
     link_to(
-      "#{translation} <span class='#{icon}'></span>".html_safe,
+      "#{translation} <span class='icon-sortable #{icon}'></span>".html_safe,
       admin_budget_budget_investments_path(sort_by: column, direction: direction)
     )
   end
@@ -18,9 +18,9 @@ module BudgetInvestmentsHelper
   def set_sorting_icon(direction, sort_by)
     if sort_by.to_s == params[:sort_by]
       if direction == "desc"
-        "icon-arrow-top"
+        "desc"
       else
-        "icon-arrow-down"
+        "asc"
       end
     else
       ""

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1,10 +1,10 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Admin budget investments' do
+feature "Admin budget investments" do
 
   let(:budget) { create(:budget) }
   let(:administrator) do
-    create(:administrator, user: create(:user, username: 'Ana', email: 'ana@admins.org'))
+    create(:administrator, user: create(:user, username: "Ana", email: "ana@admins.org"))
   end
 
   it_behaves_like "admin_milestoneable",
@@ -19,14 +19,14 @@ feature 'Admin budget investments' do
   context "Feature flag" do
 
     background do
-      Setting['feature.budgets'] = nil
+      Setting["feature.budgets"] = nil
     end
 
     after do
-      Setting['feature.budgets'] = true
+      Setting["feature.budgets"] = true
     end
 
-    scenario 'Disabled with a feature flag' do
+    scenario "Disabled with a feature flag" do
       expect{ visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 
@@ -34,7 +34,7 @@ feature 'Admin budget investments' do
 
   context "Index" do
 
-    scenario 'Displaying investments' do
+    scenario "Displaying investments" do
       budget_investment = create(:budget_investment, budget: budget, cached_votes_up: 77)
       visit admin_budget_budget_investments_path(budget_id: budget.id)
       expect(page).to have_content(budget_investment.title)
@@ -43,7 +43,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content(budget_investment.total_votes)
     end
 
-    scenario 'If budget is finished do not show "Selected" button' do
+    scenario "If budget is finished do not show 'Selected' button" do
       finished_budget = create(:budget, :finished)
       budget_investment = create(:budget_investment, budget: finished_budget, cached_votes_up: 77)
 
@@ -58,14 +58,16 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario 'Display admin and valuator assignments' do
+    scenario "Display admin and valuator assignments" do
       budget_investment1 = create(:budget_investment, budget: budget)
       budget_investment2 = create(:budget_investment, budget: budget)
       budget_investment3 = create(:budget_investment, budget: budget)
 
-      valuator1 = create(:valuator, user: create(:user, username: 'Olga'), description: 'Valuator Olga')
-      valuator2 = create(:valuator, user: create(:user, username: 'Miriam'), description: 'Valuator Miriam')
-      admin = create(:administrator, user: create(:user, username: 'Gema'))
+      olga = create(:user, username: "Olga")
+      miriam = create(:user, username: "Miriam")
+      valuator1 = create(:valuator, user: olga, description: "Valuator Olga")
+      valuator2 = create(:valuator, user: miriam, description: "Valuator Miriam")
+      admin = create(:administrator, user: create(:user, username: "Gema"))
 
       budget_investment1.valuators << valuator1
       budget_investment2.valuators << valuator1
@@ -103,9 +105,12 @@ feature 'Admin budget investments' do
       group1_heading2 = create(:budget_heading, group: group1, name: "Mercy Street")
       group2_heading1 = create(:budget_heading, group: group2, name: "Central Park")
 
-      create(:budget_investment, title: "Realocate visitors", budget: budget, group: group1, heading: group1_heading1)
-      create(:budget_investment, title: "Change name", budget: budget, group: group1, heading: group1_heading2)
-      create(:budget_investment, title: "Plant trees", budget: budget, group: group2, heading: group2_heading1)
+      create(:budget_investment, title: "Realocate visitors", budget: budget, group: group1,
+                                                              heading: group1_heading1)
+      create(:budget_investment, title: "Change name", budget: budget, group: group1,
+                                                                       heading: group1_heading2)
+      create(:budget_investment, title: "Plant trees", budget: budget, group: group2,
+                                                                       heading: group2_heading1)
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
@@ -114,28 +119,28 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Plant trees")
 
       select "Central Park", from: "heading_id"
-      click_button 'Filter'
+      click_button "Filter"
 
       expect(page).not_to have_link("Realocate visitors")
       expect(page).not_to have_link("Change name")
       expect(page).to have_link("Plant trees")
 
       select "All headings", from: "heading_id"
-      click_button 'Filter'
+      click_button "Filter"
 
       expect(page).to have_link("Realocate visitors")
       expect(page).to have_link("Change name")
       expect(page).to have_link("Plant trees")
 
       select "Streets: Main Avenue", from: "heading_id"
-      click_button 'Filter'
+      click_button "Filter"
 
       expect(page).to have_link("Realocate visitors")
       expect(page).not_to have_link("Change name")
       expect(page).not_to have_link("Plant trees")
 
       select "Streets: Mercy Street", from: "heading_id"
-      click_button 'Filter'
+      click_button "Filter"
 
       expect(page).not_to have_link("Realocate visitors")
       expect(page).to have_link("Change name")
@@ -143,10 +148,11 @@ feature 'Admin budget investments' do
     end
 
     scenario "Filtering by admin", :js do
-      user = create(:user, username: 'Admin 1')
+      user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
 
-      create(:budget_investment, title: "Realocate visitors", budget: budget, administrator: administrator)
+      create(:budget_investment, title: "Realocate visitors", budget: budget,
+                                                              administrator: administrator)
       create(:budget_investment, title: "Destroy the city", budget: budget)
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
@@ -154,30 +160,30 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Destroy the city")
 
       select "Admin 1", from: "administrator_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
       expect(page).not_to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
 
       select "All administrators", from: "administrator_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There are 2 investments')
+      expect(page).to have_content("There are 2 investments")
       expect(page).to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
 
       select "Admin 1", from: "administrator_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
       expect(page).not_to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
     end
 
     scenario "Filtering by valuator", :js do
       user = create(:user)
-      valuator = create(:valuator, user: user, description: 'Valuator 1')
+      valuator = create(:valuator, user: user, description: "Valuator 1")
 
       budget_investment = create(:budget_investment, title: "Realocate visitors", budget: budget)
       budget_investment.valuators << valuator
@@ -189,28 +195,27 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Destroy the city")
 
       select "Valuator 1", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
       expect(page).not_to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
 
       select "All valuators", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There are 2 investments')
+      expect(page).to have_content("There are 2 investments")
       expect(page).to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
 
       select "Valuator 1", from: "valuator_or_group_id"
-      click_button 'Filter'
-      expect(page).to have_content('There is 1 investment')
+      click_button "Filter"
+      expect(page).to have_content("There is 1 investment")
       expect(page).not_to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
     end
 
     scenario "Filtering by valuator group", :js do
-      user = create(:user)
       health_group = create(:valuator_group, name: "Health")
       culture_group = create(:valuator_group, name: "Culture")
 
@@ -225,33 +230,33 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Build a theatre")
 
       select "Health", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
       expect(page).to have_link("Build a hospital")
       expect(page).not_to have_link("Build a theatre")
 
       select "All valuators", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There are 2 investments')
+      expect(page).to have_content("There are 2 investments")
       expect(page).to have_link("Build a hospital")
       expect(page).to have_link("Build a theatre")
 
       select "Culture", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
       expect(page).to have_link("Build a theatre")
       expect(page).not_to have_link("Build a hospital")
     end
 
     scenario "Current filter is properly highlighted" do
-      filters_links = { 'all' => 'All',
-                        'without_admin' => 'Without assigned admin',
-                        'without_valuator' => 'Without assigned valuator',
-                        'under_valuation' => 'Under valuation',
-                        'valuation_finished' => 'Valuation finished' }
+      filters_links = { "all" => "All",
+                        "without_admin" => "Without assigned admin",
+                        "without_valuator" => "Without assigned valuator",
+                        "under_valuation" => "Under valuation",
+                        "valuation_finished" => "Valuation finished" }
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
@@ -283,13 +288,13 @@ feature 'Admin budget investments' do
       expect(page).to have_content("Evaluating...")
       expect(page).to have_content("With group")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'without_admin')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "without_admin")
 
       expect(page).to have_content("Evaluating...")
       expect(page).to have_content("With group")
       expect(page).not_to have_content("Assigned idea")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'without_valuator')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "without_valuator")
 
       expect(page).to have_content("Assigned idea")
       expect(page).not_to have_content("Evaluating...")
@@ -297,52 +302,54 @@ feature 'Admin budget investments' do
     end
 
     scenario "Filtering by valuation status" do
-      valuating = create(:budget_investment, budget: budget, title: "Ongoing valuation", administrator: create(:administrator))
-      valuated = create(:budget_investment, budget: budget, title: "Old idea", valuation_finished: true)
+      valuating = create(:budget_investment, budget: budget, title: "Ongoing valuation",
+                                                             administrator: create(:administrator))
+      valuated = create(:budget_investment, budget: budget, title: "Old idea",
+                                                             valuation_finished: true)
       valuating.valuators.push(create(:valuator))
       valuated.valuators.push(create(:valuator))
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'under_valuation')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "under_valuation")
 
       expect(page).to have_content("Ongoing valuation")
       expect(page).not_to have_content("Old idea")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'valuation_finished')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "valuation_finished")
 
       expect(page).not_to have_content("Ongoing valuation")
       expect(page).to have_content("Old idea")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'all')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "all")
       expect(page).to have_content("Ongoing valuation")
       expect(page).to have_content("Old idea")
     end
 
     scenario "Filtering by tag" do
-      create(:budget_investment, budget: budget, title: 'Educate the children', tag_list: 'Education')
-      create(:budget_investment, budget: budget, title: 'More schools',         tag_list: 'Education')
-      create(:budget_investment, budget: budget, title: 'More hospitals',       tag_list: 'Health')
+      create(:budget_investment, budget: budget, title: "Educate children", tag_list: "Education")
+      create(:budget_investment, budget: budget, title: "More schools",     tag_list: "Education")
+      create(:budget_investment, budget: budget, title: "More hospitals",   tag_list: "Health")
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
       expect(page).to have_css(".budget_investment", count: 3)
-      expect(page).to have_content("Educate the children")
+      expect(page).to have_content("Educate children")
       expect(page).to have_content("More schools")
       expect(page).to have_content("More hospitals")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, tag_name: 'Education')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, tag_name: "Education")
 
       expect(page).not_to have_content("More hospitals")
       expect(page).to have_css(".budget_investment", count: 2)
-      expect(page).to have_content("Educate the children")
+      expect(page).to have_content("Educate children")
       expect(page).to have_content("More schools")
     end
 
     scenario "Filtering by tag, display only valuation tags" do
-      investment1 = create(:budget_investment, budget: budget, tag_list: 'Education')
-      investment2 = create(:budget_investment, budget: budget, tag_list: 'Health')
+      investment1 = create(:budget_investment, budget: budget, tag_list: "Education")
+      investment2 = create(:budget_investment, budget: budget, tag_list: "Health")
 
-      investment1.set_tag_list_on(:valuation, 'Teachers')
-      investment2.set_tag_list_on(:valuation, 'Hospitals')
+      investment1.set_tag_list_on(:valuation, "Teachers")
+      investment2.set_tag_list_on(:valuation, "Hospitals")
 
       investment1.save
       investment2.save
@@ -354,11 +361,11 @@ feature 'Admin budget investments' do
 
     scenario "Filtering by tag, display only valuation tags of the current budget" do
       new_budget = create(:budget)
-      investment1 = create(:budget_investment, budget: budget, tag_list: 'Roads')
-      investment2 = create(:budget_investment, budget: new_budget, tag_list: 'Accessibility')
+      investment1 = create(:budget_investment, budget: budget, tag_list: "Roads")
+      investment2 = create(:budget_investment, budget: new_budget, tag_list: "Accessibility")
 
-      investment1.set_tag_list_on(:valuation, 'Roads')
-      investment2.set_tag_list_on(:valuation, 'Accessibility')
+      investment1.set_tag_list_on(:valuation, "Roads")
+      investment2.set_tag_list_on(:valuation, "Accessibility")
 
       investment1.save
       investment2.save
@@ -403,44 +410,44 @@ feature 'Admin budget investments' do
       roads   = create(:budget_heading, group: group_2)
       streets = create(:budget_heading, group: group_2)
 
-      create(:budget_investment, heading: parks, cached_votes_up: 40, title: "Park with 40 supports")
-      create(:budget_investment, heading: parks, cached_votes_up: 99, title: "Park with 99 supports")
-      create(:budget_investment, heading: roads, cached_votes_up: 100, title: "Road with 100 supports")
-      create(:budget_investment, heading: roads, cached_votes_up: 199, title: "Road with 199 supports")
-      create(:budget_investment, heading: streets, cached_votes_up: 200, title: "Street with 200 supports")
-      create(:budget_investment, heading: streets, cached_votes_up: 300, title: "Street with 300 supports")
+      create(:budget_investment, heading: parks, cached_votes_up: 40, title: "Park 40 supports")
+      create(:budget_investment, heading: parks, cached_votes_up: 99, title: "Park 99 supports")
+      create(:budget_investment, heading: roads, cached_votes_up: 100, title: "Road 100 supports")
+      create(:budget_investment, heading: roads, cached_votes_up: 199, title: "Road 199 supports")
+      create(:budget_investment, heading: streets, cached_votes_up: 200, title: "St. 200 supports")
+      create(:budget_investment, heading: streets, cached_votes_up: 300, title: "St. 300 supports")
 
       visit admin_budget_budget_investments_path(budget)
 
-      expect(page).to have_link("Park with 40 supports")
-      expect(page).to have_link("Park with 99 supports")
-      expect(page).to have_link("Road with 100 supports")
-      expect(page).to have_link("Road with 199 supports")
-      expect(page).to have_link("Street with 200 supports")
-      expect(page).to have_link("Street with 300 supports")
+      expect(page).to have_link("Park 40 supports")
+      expect(page).to have_link("Park 99 supports")
+      expect(page).to have_link("Road 100 supports")
+      expect(page).to have_link("Road 199 supports")
+      expect(page).to have_link("St. 200 supports")
+      expect(page).to have_link("St. 300 supports")
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
       fill_in "min_total_supports", with: 180
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There are 3 investments')
-      expect(page).to have_link("Road with 199 supports")
-      expect(page).to have_link("Street with 200 supports")
-      expect(page).to have_link("Street with 300 supports")
-      expect(page).not_to have_link("Park with 40 supports")
-      expect(page).not_to have_link("Park with 99 supports")
-      expect(page).not_to have_link("Road with 100 supports")
+      expect(page).to have_content("There are 3 investments")
+      expect(page).to have_link("Road 199 supports")
+      expect(page).to have_link("St. 200 supports")
+      expect(page).to have_link("St. 300 supports")
+      expect(page).not_to have_link("Park 40 supports")
+      expect(page).not_to have_link("Park 99 supports")
+      expect(page).not_to have_link("Road 100 supports")
     end
 
     scenario "Combination of checkbox with text search", :js do
-      user = create(:user, username: 'Admin 1')
+      user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
 
-      create(:budget_investment, budget: budget, title: 'Educate the children',
+      create(:budget_investment, budget: budget, title: "Educate the children",
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More schools',
+      create(:budget_investment, budget: budget, title: "More schools",
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More hospitals')
+      create(:budget_investment, budget: budget, title: "More hospitals")
 
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
@@ -458,8 +465,8 @@ feature 'Admin budget investments' do
       expect(page).to have_content("More schools")
       expect(page).not_to have_content("More hospitals")
 
-      educate_children_investment = Budget::Investment.find_by(title: 'Educate the children')
-      fill_in 'title_or_id', with: educate_children_investment.id
+      educate_children_investment = Budget::Investment.find_by(title: "Educate the children")
+      fill_in "title_or_id", with: educate_children_investment.id
       click_button "Filter"
 
       expect(page).to have_css(".budget_investment", count: 1)
@@ -467,16 +474,16 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("More schools")
       expect(page).not_to have_content("More hospitals")
 
-      expect(page).to have_content('Selected')
+      expect(page).to have_content("Selected")
 
     end
 
     scenario "Combination of select with text search", :js do
-      create(:budget_investment, budget: budget, title: 'Educate the children',
-                                 feasibility: 'feasible', valuation_finished: true)
-      create(:budget_investment, budget: budget, title: 'More schools',
-                                 feasibility: 'feasible', valuation_finished: true)
-      create(:budget_investment, budget: budget, title: 'More hospitals')
+      create(:budget_investment, budget: budget, title: "Educate the children",
+                                 feasibility: "feasible", valuation_finished: true)
+      create(:budget_investment, budget: budget, title: "More schools",
+                                 feasibility: "feasible", valuation_finished: true)
+      create(:budget_investment, budget: budget, title: "More hospitals")
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
@@ -485,9 +492,9 @@ feature 'Admin budget investments' do
       expect(page).to have_content("More schools")
       expect(page).to have_content("More hospitals")
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      page.check('advanced_filters_feasible')
+      page.check("advanced_filters_feasible")
       click_button "Filter"
 
       expect(page).to have_css(".budget_investment", count: 2)
@@ -495,8 +502,8 @@ feature 'Admin budget investments' do
       expect(page).to have_content("More schools")
       expect(page).not_to have_content("More hospitals")
 
-      educate_children_investment = Budget::Investment.find_by(title: 'Educate the children')
-      fill_in 'title_or_id', with: educate_children_investment.id
+      educate_children_investment = Budget::Investment.find_by(title: "Educate the children")
+      fill_in "title_or_id", with: educate_children_investment.id
       click_button "Filter"
 
       expect(page).to have_css(".budget_investment", count: 1)
@@ -504,23 +511,23 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("More schools")
       expect(page).not_to have_content("More hospitals")
 
-      expect(page).to have_content('Selected')
+      expect(page).to have_content("Selected")
 
     end
 
     scenario "Combination of checkbox with text search and checkbox", :js do
-      user = create(:user, username: 'Admin 1')
+      user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
 
-      create(:budget_investment, budget: budget, title: 'Educate the children',
-                                 feasibility: 'feasible', valuation_finished: true,
+      create(:budget_investment, budget: budget, title: "Educate the children",
+                                 feasibility: "feasible", valuation_finished: true,
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More schools',
-                                 feasibility: 'feasible', valuation_finished: true,
+      create(:budget_investment, budget: budget, title: "More schools",
+                                 feasibility: "feasible", valuation_finished: true,
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More hospitals',
+      create(:budget_investment, budget: budget, title: "More hospitals",
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More hostals')
+      create(:budget_investment, budget: budget, title: "More hostals")
 
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
@@ -540,10 +547,10 @@ feature 'Admin budget investments' do
       expect(page).to have_content("More hospitals")
       expect(page).not_to have_content("More hostals")
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_feasible') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_feasible") }
+      click_button("Filter")
 
       expect(page).to have_css(".budget_investment", count: 2)
       expect(page).to have_content("Educate the children")
@@ -551,8 +558,8 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("More hospitals")
       expect(page).not_to have_content("More hostals")
 
-      educate_children_investment = Budget::Investment.find_by(title: 'Educate the children')
-      fill_in 'title_or_id', with: educate_children_investment.id
+      educate_children_investment = Budget::Investment.find_by(title: "Educate the children")
+      fill_in "title_or_id", with: educate_children_investment.id
       click_button "Filter"
 
       expect(page).to have_css(".budget_investment", count: 1)
@@ -561,7 +568,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("More hospitals")
       expect(page).not_to have_content("More hostals")
 
-      expect(page).to have_content('Selected')
+      expect(page).to have_content("Selected")
     end
 
     scenario "See results button appears when budget status is finished" do
@@ -581,177 +588,178 @@ feature 'Admin budget investments' do
 
   end
 
-  context 'Search' do
+  context "Search" do
     let!(:first_investment) do
-      create(:budget_investment, title: 'Some other investment', budget: budget)
+      create(:budget_investment, title: "Some other investment", budget: budget)
     end
 
     background do
-      create(:budget_investment, title: 'Some investment', budget: budget)
+      create(:budget_investment, title: "Some investment", budget: budget)
     end
 
     scenario "Search investments by title" do
       visit admin_budget_budget_investments_path(budget)
 
-      expect(page).to have_content('Some investment')
-      expect(page).to have_content('Some other investment')
+      expect(page).to have_content("Some investment")
+      expect(page).to have_content("Some other investment")
 
-      fill_in 'title_or_id', with: 'Some investment'
-      click_button 'Filter'
+      fill_in "title_or_id", with: "Some investment"
+      click_button "Filter"
 
-      expect(page).to have_content('Some investment')
-      expect(page).not_to have_content('Some other investment')
+      expect(page).to have_content("Some investment")
+      expect(page).not_to have_content("Some other investment")
     end
 
-    scenario 'Search investments by ID' do
+    scenario "Search investments by ID" do
       visit admin_budget_budget_investments_path(budget)
 
-      expect(page).to have_content('Some investment')
-      expect(page).to have_content('Some other investment')
+      expect(page).to have_content("Some investment")
+      expect(page).to have_content("Some other investment")
 
-      fill_in 'title_or_id', with: first_investment.id
-      click_button 'Filter'
+      fill_in "title_or_id", with: first_investment.id
+      click_button "Filter"
 
-      expect(page).to have_content('Some other investment')
-      expect(page).not_to have_content('Some investment')
+      expect(page).to have_content("Some other investment")
+      expect(page).not_to have_content("Some investment")
     end
   end
 
-  context 'Sorting' do
+  context "Sorting" do
     background do
-      create(:budget_investment, title: 'B First Investment', cached_votes_up: 50, budget: budget)
-      create(:budget_investment, title: 'A Second Investment', cached_votes_up: 25, budget: budget)
-      create(:budget_investment, title: 'C Third Investment', cached_votes_up: 10, budget: budget)
+      create(:budget_investment, title: "B First Investment", budget: budget, cached_votes_up: 50)
+      create(:budget_investment, title: "A Second Investment", budget: budget, cached_votes_up: 25)
+      create(:budget_investment, title: "C Third Investment", budget: budget, cached_votes_up: 10)
     end
 
     scenario "Default" do
-      create(:budget_investment, title: 'D Fourth Investment', cached_votes_up: 50, budget: budget)
+      create(:budget_investment, title: "D Fourth Investment", cached_votes_up: 50, budget: budget)
 
       visit admin_budget_budget_investments_path(budget)
 
-      expect('D Fourth Investment').to appear_before('B First Investment')
-      expect('B First Investment').to appear_before('A Second Investment')
-      expect('A Second Investment').to appear_before('C Third Investment')
+      expect("D Fourth Investment").to appear_before("B First Investment")
+      expect("B First Investment").to appear_before("A Second Investment")
+      expect("A Second Investment").to appear_before("C Third Investment")
     end
 
-    context 'Ascending' do
-      scenario 'Sort by ID' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'asc')
+    context "Ascending" do
+      scenario "Sort by ID" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "id", direction: "asc")
 
-        expect('B First Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('C Third Investment')
-        within('th', text: 'ID') do
+        expect("B First Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("C Third Investment")
+        within("th", text: "ID") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
-      scenario 'Sort by title' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'title', direction: 'asc')
+      scenario "Sort by title" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "title", direction: "asc")
 
-        expect('A Second Investment').to appear_before('B First Investment')
-        expect('B First Investment').to appear_before('C Third Investment')
-        within('th', text: 'Title') do
+        expect("A Second Investment").to appear_before("B First Investment")
+        expect("B First Investment").to appear_before("C Third Investment")
+        within("th", text: "Title") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
-      scenario 'Sort by supports' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'supports', direction: 'asc')
+      scenario "Sort by supports" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "supports", direction: "asc")
 
-        expect('C Third Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('B First Investment')
-        within('th', text: 'Supports') do
+        expect("C Third Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("B First Investment")
+        within("th", text: "Supports") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
 
-    context 'Descending' do
-      scenario 'Sort by ID' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'desc')
+    context "Descending" do
+      scenario "Sort by ID" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "id", direction: "desc")
 
-        expect('C Third Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('B First Investment')
-        within('th', text: 'ID') do
+        expect("C Third Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("B First Investment")
+        within("th", text: "ID") do
           expect(page).to have_css(".icon-sortable.asc")
         end
       end
 
-      scenario 'Sort by title' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'title', direction: 'desc')
+      scenario "Sort by title" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "title", direction: "desc")
 
-        expect('C Third Investment').to appear_before('B First Investment')
-        expect('B First Investment').to appear_before('A Second Investment')
-        within('th', text: 'Title') do
+        expect("C Third Investment").to appear_before("B First Investment")
+        expect("B First Investment").to appear_before("A Second Investment")
+        within("th", text: "Title") do
           expect(page).to have_css(".icon-sortable.asc")
         end
       end
 
-      scenario 'Sort by supports' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'supports', direction: 'desc')
+      scenario "Sort by supports" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "supports", direction: "desc")
 
-        expect('B First Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('C Third Investment')
-        within('th', text: 'Supports') do
+        expect("B First Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("C Third Investment")
+        within("th", text: "Supports") do
           expect(page).to have_css(".icon-sortable.asc")
         end
       end
     end
 
-    context 'With no direction provided sorts ascending' do
-      scenario 'Sort by ID' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'id')
+    context "With no direction provided sorts ascending" do
+      scenario "Sort by ID" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "id")
 
-        expect('B First Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('C Third Investment')
-        within('th', text: 'ID') do
+        expect("B First Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("C Third Investment")
+        within("th", text: "ID") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
-      scenario 'Sort by title' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'title')
+      scenario "Sort by title" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "title")
 
-        expect('A Second Investment').to appear_before('B First Investment')
-        expect('B First Investment').to appear_before('C Third Investment')
-        within('th', text: 'Title') do
+        expect("A Second Investment").to appear_before("B First Investment")
+        expect("B First Investment").to appear_before("C Third Investment")
+        within("th", text: "Title") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
-      scenario 'Sort by supports' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'supports')
+      scenario "Sort by supports" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "supports")
 
-        expect('C Third Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('B First Investment')
-        within('th', text: 'Supports') do
+        expect("C Third Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("B First Investment")
+        within("th", text: "Supports") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
 
-    context 'With incorrect direction provided sorts ascending' do
-      scenario 'Sort by ID' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'incorrect')
+    context "With incorrect direction provided sorts ascending" do
+      scenario "Sort by ID" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "id", direction: "incorrect")
 
-        expect('B First Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('C Third Investment')
-        within('th', text: 'ID') do
+        expect("B First Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("C Third Investment")
+        within("th", text: "ID") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
   end
 
-  context 'Show' do
+  context "Show" do
 
-    scenario 'Show the investment details' do
-      valuator = create(:valuator, user: create(:user, username: 'Rachel', email: 'rachel@valuators.org'))
+    scenario "Show the investment details" do
+      user = create(:user, username: "Rachel", email: "rachel@valuators.org")
+      valuator = create(:valuator, user: user)
       budget_investment = create(:budget_investment,
                                   price: 1234,
                                   price_first_year: 1000,
                                   feasibility: "unfeasible",
-                                  unfeasibility_explanation: 'It is impossible',
+                                  unfeasibility_explanation: "It is impossible",
                                   administrator: administrator)
       budget_investment.valuators << valuator
 
@@ -763,27 +771,27 @@ feature 'Admin budget investments' do
       expect(page).to have_content(budget_investment.description)
       expect(page).to have_content(budget_investment.author.name)
       expect(page).to have_content(budget_investment.heading.name)
-      expect(page).to have_content('Without image')
-      expect(page).to have_content('Without documents')
-      expect(page).to have_content('1234')
-      expect(page).to have_content('1000')
-      expect(page).to have_content('Unfeasible')
-      expect(page).to have_content('It is impossible')
-      expect(page).to have_content('Ana (ana@admins.org)')
+      expect(page).to have_content("Without image")
+      expect(page).to have_content("Without documents")
+      expect(page).to have_content("1234")
+      expect(page).to have_content("1000")
+      expect(page).to have_content("Unfeasible")
+      expect(page).to have_content("It is impossible")
+      expect(page).to have_content("Ana (ana@admins.org)")
 
-      within('#assigned_valuators') do
-        expect(page).to have_content('Rachel (rachel@valuators.org)')
+      within("#assigned_valuators") do
+        expect(page).to have_content("Rachel (rachel@valuators.org)")
       end
 
       expect(page).to have_button "Publish comment"
     end
 
-    scenario 'Show image and documents on investment details' do
+    scenario "Show image and documents on investment details" do
       budget_investment = create(:budget_investment,
                                   price: 1234,
                                   price_first_year: 1000,
                                   feasibility: "unfeasible",
-                                  unfeasibility_explanation: 'It is impossible',
+                                  unfeasibility_explanation: "It is impossible",
                                   administrator: administrator)
       create(:image, imageable: budget_investment)
       document = create(:document, documentable: budget_investment)
@@ -796,13 +804,13 @@ feature 'Admin budget investments' do
       expect(page).to have_content(budget_investment.description)
       expect(page).to have_content(budget_investment.author.name)
       expect(page).to have_content(budget_investment.heading.name)
-      expect(page).to have_content('See image')
-      expect(page).to have_content('See documents (1)')
-      expect(page).to have_content('1234')
-      expect(page).to have_content('1000')
-      expect(page).to have_content('Unfeasible')
-      expect(page).to have_content('It is impossible')
-      expect(page).to have_content('Ana (ana@admins.org)')
+      expect(page).to have_content("See image")
+      expect(page).to have_content("See documents (1)")
+      expect(page).to have_content("1234")
+      expect(page).to have_content("1000")
+      expect(page).to have_content("Unfeasible")
+      expect(page).to have_content("It is impossible")
+      expect(page).to have_content("Ana (ana@admins.org)")
     end
 
     scenario "If budget is finished, investment cannot be edited or valuation comments created" do
@@ -832,21 +840,21 @@ feature 'Admin budget investments' do
       create(:budget_heading, group: budget_investment.group, name: "Barbate")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit'
+      click_link "Edit"
 
-      fill_in 'budget_investment_title', with: 'Potatoes'
-      fill_in 'budget_investment_description', with: 'Carrots'
-      select "#{budget_investment.group.name}: Barbate", from: 'budget_investment[heading_id]'
+      fill_in "budget_investment_title", with: "Potatoes"
+      fill_in "budget_investment_description", with: "Carrots"
+      select "#{budget_investment.group.name}: Barbate", from: "budget_investment[heading_id]"
       uncheck "budget_investment_incompatible"
       check "budget_investment_selected"
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Potatoes'
-      expect(page).to have_content 'Carrots'
-      expect(page).to have_content 'Barbate'
-      expect(page).to have_content 'Compatibility: Compatible'
-      expect(page).to have_content 'Selected'
+      expect(page).to have_content "Potatoes"
+      expect(page).to have_content "Carrots"
+      expect(page).to have_content "Barbate"
+      expect(page).to have_content "Compatibility: Compatible"
+      expect(page).to have_content "Selected"
     end
 
     scenario "Compatible non-winner can't edit incompatibility" do
@@ -854,48 +862,53 @@ feature 'Admin budget investments' do
       create(:budget_heading, group: budget_investment.group, name: "Tetuan")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit'
+      click_link "Edit"
 
-      expect(page).not_to have_content 'Compatibility'
-      expect(page).not_to have_content 'Mark as incompatible'
+      expect(page).not_to have_content "Compatibility"
+      expect(page).not_to have_content "Mark as incompatible"
     end
 
     scenario "Add administrator" do
       budget_investment = create(:budget_investment)
-      administrator = create(:administrator, user: create(:user, username: 'Marta', email: 'marta@admins.org'))
+      user = create(:user, username: "Marta", email: "marta@admins.org")
+      create(:administrator, user: user)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
-      select 'Marta (marta@admins.org)', from: 'budget_investment[administrator_id]'
-      click_button 'Update'
+      select "Marta (marta@admins.org)", from: "budget_investment[administrator_id]"
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
-      expect(page).to have_content 'Assigned administrator: Marta'
+      expect(page).to have_content "Investment project updated succesfully."
+      expect(page).to have_content "Assigned administrator: Marta"
     end
 
     scenario "Add valuators" do
       budget_investment = create(:budget_investment)
 
-      valuator1 = create(:valuator, user: create(:user, username: 'Valentina', email: 'v1@valuators.org'))
-      valuator2 = create(:valuator, user: create(:user, username: 'Valerian',  email: 'v2@valuators.org'))
-      valuator3 = create(:valuator, user: create(:user, username: 'Val',       email: 'v3@valuators.org'))
+      user1 = create(:user, username: "Valentina", email: "v1@valuators.org")
+      user2 = create(:user, username: "Valerian",  email: "v2@valuators.org")
+      user3 = create(:user, username: "Val",       email: "v3@valuators.org")
+
+      valuator1 = create(:valuator, user: user1)
+      valuator3 = create(:valuator, user: user3)
+      create(:valuator, user: user2)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
       check "budget_investment_valuator_ids_#{valuator1.id}"
       check "budget_investment_valuator_ids_#{valuator3.id}"
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
-      within('#assigned_valuators') do
-        expect(page).to have_content('Valentina (v1@valuators.org)')
-        expect(page).to have_content('Val (v3@valuators.org)')
-        expect(page).not_to have_content('Undefined')
-        expect(page).not_to have_content('Valerian (v2@valuators.org)')
+      within("#assigned_valuators") do
+        expect(page).to have_content("Valentina (v1@valuators.org)")
+        expect(page).to have_content("Val (v3@valuators.org)")
+        expect(page).not_to have_content("Undefined")
+        expect(page).not_to have_content("Valerian (v2@valuators.org)")
       end
     end
 
@@ -903,24 +916,24 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       health_group = create(:valuator_group, name: "Health")
-      economy_group = create(:valuator_group, name: "Economy")
       culture_group = create(:valuator_group, name: "Culture")
+      create(:valuator_group, name: "Economy")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
       check "budget_investment_valuator_group_ids_#{health_group.id}"
       check "budget_investment_valuator_group_ids_#{culture_group.id}"
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
-      within('#assigned_valuator_groups') do
-        expect(page).to have_content('Health')
-        expect(page).to have_content('Culture')
-        expect(page).not_to have_content('Undefined')
-        expect(page).not_to have_content('Economy')
+      within("#assigned_valuator_groups") do
+        expect(page).to have_content("Health")
+        expect(page).to have_content("Culture")
+        expect(page).not_to have_content("Undefined")
+        expect(page).not_to have_content("Economy")
       end
     end
 
@@ -928,43 +941,43 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       health_group = create(:valuator_group, name: "Health")
-      user = create(:user, username: 'Valentina', email: 'v1@valuators.org')
+      user = create(:user, username: "Valentina", email: "v1@valuators.org")
       create(:valuator, user: user, valuator_group: health_group)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
       check "budget_investment_valuator_group_ids_#{health_group.id}"
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
-      within('#assigned_valuator_groups') { expect(page).to have_content('Health') }
-      within('#assigned_valuators') do
-        expect(page).to have_content('Undefined')
-        expect(page).not_to have_content('Valentina (v1@valuators.org)')
+      within("#assigned_valuator_groups") { expect(page).to have_content("Health") }
+      within("#assigned_valuators") do
+        expect(page).to have_content("Undefined")
+        expect(page).not_to have_content("Valentina (v1@valuators.org)")
       end
     end
 
     scenario "Adds existing valuation tags", :js do
       budget_investment1 = create(:budget_investment)
-      budget_investment1.set_tag_list_on(:valuation, 'Education, Health')
+      budget_investment1.set_tag_list_on(:valuation, "Education, Health")
       budget_investment1.save
 
       budget_investment2 = create(:budget_investment)
 
       visit edit_admin_budget_budget_investment_path(budget_investment2.budget, budget_investment2)
 
-      find('.js-add-tag-link', text: 'Education').click
+      find(".js-add-tag-link", text: "Education").click
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
       within "#tags" do
-        expect(page).to have_content 'Education'
-        expect(page).not_to have_content 'Health'
+        expect(page).to have_content "Education"
+        expect(page).not_to have_content "Health"
       end
     end
 
@@ -972,22 +985,22 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
-      fill_in 'budget_investment_valuation_tag_list', with: 'Refugees, Solidarity'
-      click_button 'Update'
+      fill_in "budget_investment_valuation_tag_list", with: "Refugees, Solidarity"
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
       within "#tags" do
-        expect(page).to have_content 'Refugees'
-        expect(page).to have_content 'Solidarity'
+        expect(page).to have_content "Refugees"
+        expect(page).to have_content "Solidarity"
       end
     end
 
     scenario "Changes valuation and user generated tags" do
-      budget_investment = create(:budget_investment, tag_list: 'Park')
-      budget_investment.set_tag_list_on(:valuation, 'Education')
+      budget_investment = create(:budget_investment, tag_list: "Park")
+      budget_investment.set_tag_list_on(:valuation, "Education")
       budget_investment.save
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -997,11 +1010,11 @@ feature 'Admin budget investments' do
         expect(page).to have_content "Park"
       end
 
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
-      fill_in 'budget_investment_tag_list', with: 'Park, Trees'
-      fill_in 'budget_investment_valuation_tag_list', with: 'Education, Environment'
-      click_button 'Update'
+      fill_in "budget_investment_tag_list", with: "Park, Trees"
+      fill_in "budget_investment_valuation_tag_list", with: "Education, Environment"
+      click_button "Update"
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
 
@@ -1019,16 +1032,16 @@ feature 'Admin budget investments' do
     end
 
     scenario "Maintains user tags" do
-      budget_investment = create(:budget_investment, tag_list: 'Park')
+      budget_investment = create(:budget_investment, tag_list: "Park")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
 
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
-      fill_in 'budget_investment_valuation_tag_list', with: 'Refugees, Solidarity'
-      click_button 'Update'
+      fill_in "budget_investment_valuation_tag_list", with: "Refugees, Solidarity"
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
       visit budget_investment_path(budget_investment.budget, budget_investment)
       expect(page).to have_content "Park"
@@ -1039,13 +1052,13 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit dossier'
+      click_link "Edit dossier"
 
-      expect(page).to have_content('Valuation finished')
+      expect(page).to have_content("Valuation finished")
 
-      accept_confirm { check('Valuation finished') }
+      accept_confirm { check("Valuation finished") }
 
-      expect(find('#js-investment-report-alert')).to be_checked
+      expect(find("#js-investment-report-alert")).to be_checked
     end
 
     # The feature tested in this scenario works as expected but some underlying reason
@@ -1054,11 +1067,11 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment, :unfeasible)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit dossier'
+      click_link "Edit dossier"
 
-      expect(page).to have_content('Valuation finished')
-      valuation = find_field('budget_investment[valuation_finished]')
-      accept_confirm { check('Valuation finished') }
+      expect(page).to have_content("Valuation finished")
+      valuation = find_field("budget_investment[valuation_finished]")
+      accept_confirm { check("Valuation finished") }
 
       expect(valuation).to be_checked
     end
@@ -1067,22 +1080,22 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit dossier'
+      click_link "Edit dossier"
 
-      dismiss_confirm { check('Valuation finished') }
+      dismiss_confirm { check("Valuation finished") }
 
-      expect(find('#js-investment-report-alert')).not_to be_checked
+      expect(find("#js-investment-report-alert")).not_to be_checked
     end
 
     scenario "Errors on update" do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit'
+      click_link "Edit"
 
-      fill_in 'budget_investment_title', with: ''
+      fill_in "budget_investment_title", with: ""
 
-      click_button 'Update'
+      click_button "Update"
 
       expect(page).to have_content "can't be blank"
     end
@@ -1091,27 +1104,33 @@ feature 'Admin budget investments' do
 
   context "Selecting" do
 
-    let!(:unfeasible_bi)  { create(:budget_investment, :unfeasible, budget: budget, title: "Unfeasible project") }
-    let!(:feasible_bi)    { create(:budget_investment, :feasible, budget: budget, title: "Feasible project") }
-    let!(:feasible_vf_bi) { create(:budget_investment, :feasible, :finished, budget: budget, title: "Feasible, VF project") }
-    let!(:selected_bi)    { create(:budget_investment, :selected, budget: budget, title: "Selected project") }
-    let!(:winner_bi)      { create(:budget_investment, :winner, budget: budget, title: "Winner project") }
-    let!(:undecided_bi)   { create(:budget_investment, :undecided, budget: budget, title: "Undecided project") }
+    let!(:unfeasible_bi)  { create(:budget_investment, :unfeasible, budget: budget,
+                                                                    title: "Unfeasible project") }
+    let!(:feasible_bi)    { create(:budget_investment, :feasible, budget: budget,
+                                                                  title: "Feasible project") }
+    let!(:feasible_vf_bi) { create(:budget_investment, :feasible, :finished, budget: budget,
+                                                                  title: "Feasible, VF project") }
+    let!(:selected_bi)    { create(:budget_investment, :selected, budget: budget,
+                                                                  title: "Selected project") }
+    let!(:winner_bi)      { create(:budget_investment, :winner, budget: budget,
+                                                                title: "Winner project") }
+    let!(:undecided_bi)   { create(:budget_investment, :undecided, budget: budget,
+                                                                   title: "Undecided project") }
 
     scenario "Filtering by valuation and selection", :js do
       visit admin_budget_budget_investments_path(budget)
 
-      within('#filter-subnav') { click_link 'Valuation finished' }
+      within("#filter-subnav") { click_link "Valuation finished" }
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
       expect(page).to have_content(feasible_vf_bi.title)
       expect(page).to have_content(selected_bi.title)
       expect(page).to have_content(winner_bi.title)
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_feasible') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_feasible") }
+      click_button("Filter")
 
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
@@ -1119,12 +1138,12 @@ feature 'Admin budget investments' do
       expect(page).to have_content(selected_bi.title)
       expect(page).to have_content(winner_bi.title)
 
-      within('#advanced_filters') do
-        check('advanced_filters_selected')
-        uncheck('advanced_filters_feasible')
+      within("#advanced_filters") do
+        check("advanced_filters_selected")
+        uncheck("advanced_filters_feasible")
       end
 
-      click_button('Filter')
+      click_button("Filter")
 
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
@@ -1132,7 +1151,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content(selected_bi.title)
       expect(page).to have_content(winner_bi.title)
 
-      within('#filter-subnav') { click_link 'Winners' }
+      within("#filter-subnav") { click_link "Winners" }
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
       expect(page).not_to have_content(feasible_vf_bi.title)
@@ -1143,10 +1162,10 @@ feature 'Admin budget investments' do
     scenario "Aggregating results", :js do
       visit admin_budget_budget_investments_path(budget)
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_undecided') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_undecided") }
+      click_button("Filter")
 
       expect(page).to have_content(undecided_bi.title)
       expect(page).not_to have_content(winner_bi.title)
@@ -1155,8 +1174,8 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_vf_bi.title)
 
-      within('#advanced_filters') { check('advanced_filters_unfeasible') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_unfeasible") }
+      click_button("Filter")
 
       expect(page).to have_content(undecided_bi.title)
       expect(page).to have_content(unfeasible_bi.title)
@@ -1170,23 +1189,23 @@ feature 'Admin budget investments' do
       visit admin_budget_budget_investments_path(budget)
 
       within("#budget_investment_#{unfeasible_bi.id}") do
-        expect(page).not_to have_link('Select')
-        expect(page).not_to have_link('Selected')
+        expect(page).not_to have_link("Select")
+        expect(page).not_to have_link("Selected")
       end
 
       within("#budget_investment_#{feasible_bi.id}") do
-        expect(page).not_to have_link('Select')
-        expect(page).not_to have_link('Selected')
+        expect(page).not_to have_link("Select")
+        expect(page).not_to have_link("Selected")
       end
 
       within("#budget_investment_#{feasible_vf_bi.id}") do
-        expect(page).to have_link('Select')
-        expect(page).not_to have_link('Selected')
+        expect(page).to have_link("Select")
+        expect(page).not_to have_link("Selected")
       end
 
       within("#budget_investment_#{selected_bi.id}") do
-        expect(page).not_to have_link('Select')
-        expect(page).to have_link('Selected')
+        expect(page).not_to have_link("Select")
+        expect(page).to have_link("Selected")
       end
     end
 
@@ -1194,43 +1213,43 @@ feature 'Admin budget investments' do
       visit admin_budget_budget_investments_path(budget)
 
       within("#budget_investment_#{feasible_vf_bi.id}") do
-        click_link('Select')
-        expect(page).to have_link('Selected')
+        click_link("Select")
+        expect(page).to have_link("Selected")
       end
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_selected') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_selected") }
+      click_button("Filter")
 
       within("#budget_investment_#{feasible_vf_bi.id}") do
-        expect(page).not_to have_link('Select')
-        expect(page).to have_link('Selected')
+        expect(page).not_to have_link("Select")
+        expect(page).to have_link("Selected")
       end
     end
 
     scenario "Unselecting an investment", :js do
       visit admin_budget_budget_investments_path(budget)
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_selected') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_selected") }
+      click_button("Filter")
 
-      expect(page).to have_content('There are 2 investments')
+      expect(page).to have_content("There are 2 investments")
 
       within("#budget_investment_#{selected_bi.id}") do
-        click_link('Selected')
+        click_link("Selected")
       end
 
-      click_button('Filter')
+      click_button("Filter")
       expect(page).not_to have_content(selected_bi.title)
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
 
       visit admin_budget_budget_investments_path(budget)
 
       within("#budget_investment_#{selected_bi.id}") do
-        expect(page).to have_link('Select')
-        expect(page).not_to have_link('Selected')
+        expect(page).to have_link("Select")
+        expect(page).not_to have_link("Selected")
       end
     end
 
@@ -1243,12 +1262,12 @@ feature 'Admin budget investments' do
         visit admin_budget_budget_investments_path(budget)
 
         within("#budget_investment_#{selected_bi.id}") do
-          click_link('Selected')
+          click_link("Selected")
         end
 
-        click_link('Next')
+        click_link("Next")
 
-        expect(page).to have_link('Previous')
+        expect(page).to have_link("Previous")
       end
     end
   end
@@ -1270,7 +1289,7 @@ feature 'Admin budget investments' do
       investment2.update(administrator: admin)
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
       expect(page).not_to have_link("Under valuation")
 
       within("#budget_investment_#{investment1.id}") do
@@ -1278,7 +1297,7 @@ feature 'Admin budget investments' do
       end
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
 
       within("#budget_investment_#{investment1.id}") do
         expect(find("#budget_investment_visible_to_valuators")).to be_checked
@@ -1308,7 +1327,7 @@ feature 'Admin budget investments' do
     end
 
     scenario "Unmark as visible to valuator", :js do
-      budget.update(phase: 'valuating')
+      budget.update(phase: "valuating")
 
       investment1.valuators << valuator
       investment2.valuators << valuator
@@ -1316,7 +1335,7 @@ feature 'Admin budget investments' do
       investment2.update(administrator: admin, visible_to_valuators: true)
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
       expect(page).not_to have_link("Under valuation")
 
       within("#budget_investment_#{investment1.id}") do
@@ -1324,7 +1343,7 @@ feature 'Admin budget investments' do
       end
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
 
       within("#budget_investment_#{investment1.id}") do
         expect(find("#budget_investment_visible_to_valuators")).not_to be_checked
@@ -1345,15 +1364,15 @@ feature 'Admin budget investments' do
 
       expect(page).to have_css("#budget_investment_visible_to_valuators")
 
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
 
       within("#budget_investment_#{investment1.id}") do
-        valuating_checkbox = find('#budget_investment_visible_to_valuators')
+        valuating_checkbox = find("#budget_investment_visible_to_valuators")
         expect(valuating_checkbox).to be_checked
       end
 
       within("#budget_investment_#{investment2.id}") do
-        valuating_checkbox = find('#budget_investment_visible_to_valuators')
+        valuating_checkbox = find("#budget_investment_visible_to_valuators")
         expect(valuating_checkbox).not_to be_checked
       end
     end
@@ -1362,8 +1381,8 @@ feature 'Admin budget investments' do
   context "Selecting csv" do
 
     scenario "Downloading CSV file" do
-      admin = create(:administrator, user: create(:user, username: 'Admin'))
-      valuator = create(:valuator, user: create(:user, username: 'Valuator'))
+      admin = create(:administrator, user: create(:user, username: "Admin"))
+      valuator = create(:valuator, user: create(:user, username: "Valuator"))
       valuator_group = create(:valuator_group, name: "Valuator Group")
       budget_group = create(:budget_group, name: "Budget Group", budget: budget)
       first_budget_heading = create(:budget_heading, group: budget_group, name: "Budget Heading")
@@ -1388,32 +1407,31 @@ feature 'Admin budget investments' do
 
       click_link "Download current selection"
 
-      header = page.response_headers['Content-Disposition']
+      header = page.response_headers["Content-Disposition"]
       expect(header).to match(/^attachment/)
       expect(header).to match(/filename="budget_investments.csv"$/)
 
       csv_contents = "ID,Title,Supports,Administrator,Valuator,Valuation Group,Scope of operation,"\
                      "Feasibility,Val. Fin.,Selected,Show to valuators,Author username\n"\
                      "#{first_investment.id},Le Investment,88,Admin,-,Valuator Group,"\
-                     "Budget Heading,Feasible (€99),Yes,Yes,Yes,#{first_investment.author.username}\n#{second_investment.id},"\
+                     "Budget Heading,Feasible (€99),Yes,Yes,Yes,"\
+                     "#{first_investment.author.username}\n#{second_investment.id},"\
                      "Alt Investment,66,No admin assigned,Valuator,-,Other Heading,"\
                      "Unfeasible,No,No,No,#{second_investment.author.username}\n"
       expect(page.body).to eq(csv_contents)
     end
 
     scenario "Downloading CSV file with applied filter" do
-      unfeasible_investment = create(:budget_investment, :unfeasible, budget: budget,
-                                                                      title: 'Unfeasible one')
-      finished_investment = create(:budget_investment, :finished, budget: budget,
-                                                                  title: 'Finished Investment')
+      create(:budget_investment, :unfeasible, budget: budget, title: "Unfeasible one")
+      create(:budget_investment, :finished, budget: budget, title: "Finished Investment")
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Valuation finished' }
+      within("#filter-subnav") { click_link "Valuation finished" }
 
       click_link "Download current selection"
 
-      expect(page).to have_content('Finished Investment')
-      expect(page).not_to have_content('Unfeasible one')
+      expect(page).to have_content("Finished Investment")
+      expect(page).not_to have_content("Unfeasible one")
     end
   end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -641,7 +641,7 @@ feature 'Admin budget investments' do
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
         within('th', text: 'ID') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
@@ -651,7 +651,7 @@ feature 'Admin budget investments' do
         expect('A Second Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('C Third Investment')
         within('th', text: 'Title') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
@@ -661,7 +661,7 @@ feature 'Admin budget investments' do
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
         within('th', text: 'Supports') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
@@ -673,7 +673,7 @@ feature 'Admin budget investments' do
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
         within('th', text: 'ID') do
-          expect(page).to have_css(".icon-arrow-down")
+          expect(page).to have_css(".icon-sortable.asc")
         end
       end
 
@@ -683,7 +683,7 @@ feature 'Admin budget investments' do
         expect('C Third Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('A Second Investment')
         within('th', text: 'Title') do
-          expect(page).to have_css(".icon-arrow-down")
+          expect(page).to have_css(".icon-sortable.asc")
         end
       end
 
@@ -693,7 +693,7 @@ feature 'Admin budget investments' do
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
         within('th', text: 'Supports') do
-          expect(page).to have_css(".icon-arrow-down")
+          expect(page).to have_css(".icon-sortable.asc")
         end
       end
     end
@@ -705,7 +705,7 @@ feature 'Admin budget investments' do
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
         within('th', text: 'ID') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
@@ -715,7 +715,7 @@ feature 'Admin budget investments' do
         expect('A Second Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('C Third Investment')
         within('th', text: 'Title') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
@@ -725,7 +725,7 @@ feature 'Admin budget investments' do
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
         within('th', text: 'Supports') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
@@ -737,7 +737,7 @@ feature 'Admin budget investments' do
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
         within('th', text: 'ID') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end

--- a/spec/helpers/budget_investments_helper_spec.rb
+++ b/spec/helpers/budget_investments_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe BudgetInvestmentsHelper, type: :helper do
 
@@ -22,15 +22,15 @@ RSpec.describe BudgetInvestmentsHelper, type: :helper do
     let(:params)  { { sort_by: sort_by } }
 
     it "returns arrow down if current direction is ASC" do
-      expect(set_sorting_icon("asc", sort_by)).to eq "icon-arrow-down"
+      expect(set_sorting_icon("asc", sort_by)).to eq "asc"
     end
 
     it "returns arrow top if current direction is DESC" do
-      expect(set_sorting_icon("desc", sort_by)).to eq "icon-arrow-top"
+      expect(set_sorting_icon("desc", sort_by)).to eq "desc"
     end
 
     it "returns arrow down if sort_by present, but no direction" do
-      expect(set_sorting_icon(nil, sort_by)).to eq "icon-arrow-down"
+      expect(set_sorting_icon(nil, sort_by)).to eq "asc"
     end
 
     it "returns no icon if sort_by and direction is missing" do


### PR DESCRIPTION
## References

* Backports commits AyuntamientoMadrid@6986c40b and AyuntamientoMadrid@ebb9f7c4 from pull request AyuntamientoMadrid#1888
* Issue #2931

## Objectives

* Add sorting icons to headings which allow sorting, to make it more intuitive for users to realize those headings can be used to sort the data in the table
* Use our coding conventions in the affected files