### PR TITLE
[Backport] Improve UX on admin section

### DIFF
--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -1,5 +1,14 @@
 <div class="admin-sidebar" data-equalizer-watch>
   <ul id="admin_menu" data-accordion-menu data-multi-open="false">
+    <% if feature?(:proposals) %>
+      <li class="section-title">
+        <%= link_to admin_proposals_path do %>
+          <span class="icon-proposals"></span>
+          <strong><%= t("admin.menu.proposals") %></strong>
+        <% end %>
+      </li>
+    <% end %>
+
     <% if feature?(:polls) %>
       <li class="section-title">
         <a href="#">
@@ -19,33 +28,6 @@
       </li>
     <% end %>
 
-    <li class="section-title">
-      <a href="#">
-        <span class="icon-box"></span>
-        <strong><%= t("admin.menu.title_booths") %></strong>
-      </a>
-      <ul id="booths_menu" <%= "class=is-active" if menu_booths? || controller_name == "polls" && action_name == "booth_assignments" %>>
-        <li <%= "class=is-active" if %w(officers officer_assignments).include?(controller_name) %>>
-          <%= link_to t("admin.menu.poll_officers"), admin_officers_path %>
-        </li>
-
-        <li <%= "class=is-active" if controller_name == "booths" &&
-                                  action_name != "available" %>>
-          <%= link_to t("admin.menu.poll_booths"), admin_booths_path %>
-        </li>
-
-        <li <%= "class=is-active" if (controller_name == "polls" && action_name == "booth_assignments") ||
-                                  controller_name == "booth_assignments" %>>
-          <%= link_to t("admin.menu.poll_booth_assignments"), booth_assignments_admin_polls_path %>
-        </li>
-
-        <li <%= "class=is-active" if %w(shifts booths).include?(controller_name) &&
-                                  %w(available new).include?(action_name) %>>
-          <%= link_to t("admin.menu.poll_shifts"), available_admin_booths_path %>
-        </li>
-      </ul>
-    </li>
-
     <% if feature?(:legislation) %>
       <li class="section-title <%= "is-active" if controller.class.parent == Admin::Legislation %>">
         <%= link_to admin_legislation_processes_path do %>
@@ -64,6 +46,35 @@
       </li>
     <% end %>
 
+    <li class="section-title">
+      <a href="#">
+        <span class="icon-box"></span>
+        <strong><%= t("admin.menu.title_booths") %></strong>
+      </a>
+      <ul id="booths_menu" <%= "class=is-active" if menu_booths? || controller_name == "polls" && action_name == "booth_assignments" %>>
+        <li <%= "class=is-active" if %w(officers officer_assignments).include?(controller_name) %>>
+          <%= link_to t("admin.menu.poll_officers"), admin_officers_path %>
+        </li>
+
+        <li <%= "class=is-active" if controller_name == "booths" &&
+                                  action_name != "available" %>>
+          <%= link_to t("admin.menu.poll_booths"), admin_booths_path %>
+        </li>
+
+        <li <%= "class=is-active" if (controller_name == "polls" &&
+                                      action_name == "booth_assignments") ||
+                                      controller_name == "booth_assignments" &&
+                                      action_name == "manage" %>>
+          <%= link_to t("admin.menu.poll_booth_assignments"), booth_assignments_admin_polls_path %>
+        </li>
+
+        <li <%= "class=is-active" if %w(shifts booths).include?(controller_name) &&
+                                  %w(available new).include?(action_name) %>>
+          <%= link_to t("admin.menu.poll_shifts"), available_admin_booths_path %>
+        </li>
+      </ul>
+    </li>
+
     <% if feature?(:spending_proposals) %>
       <li class="section-title">
         <a href="#">
@@ -75,15 +86,6 @@
             <%= link_to t("admin.menu.spending_proposals"), admin_spending_proposals_path %>
           </li>
         </ul>
-      </li>
-    <% end %>
-
-    <% if feature?(:proposals) %>
-      <li class="section-title">
-        <%= link_to admin_proposals_path do %>
-          <span class="icon-proposals"></span>
-          <strong><%= t("admin.menu.proposals") %></strong>
-        <% end %>
       </li>
     <% end %>
 

--- a/app/views/admin/budgets/index.html.erb
+++ b/app/views/admin/budgets/index.html.erb
@@ -23,7 +23,7 @@
       <% @budgets.each do |budget| %>
         <tr id="<%= dom_id(budget) %>" class="budget">
           <td>
-            <%= link_to budget.name, admin_budget_path(budget) %>
+            <%= budget.name %>
           </td>
           <td class="small">
             <%= t("budgets.phase.#{budget.phase}") %>

--- a/app/views/admin/poll/polls/booth_assignments.html.erb
+++ b/app/views/admin/poll/polls/booth_assignments.html.erb
@@ -11,7 +11,7 @@
       <% @polls.each do |poll| %>
         <tr id="<%= dom_id(poll) %>" class="poll">
           <td>
-            <strong><%= link_to poll.name, admin_poll_path(poll) %></strong>
+            <%= link_to poll.name, manage_admin_poll_booth_assignments_path(poll) %>
           </td>
           <td>
             <%= l poll.starts_at.to_date %> - <%= l poll.ends_at.to_date %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -438,7 +438,7 @@ en:
         index:
           create: New process
           delete: Delete
-          title: Legislation processes
+          title: Collaborative legislation
           filters:
             active: Active
             all: All

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -217,7 +217,7 @@ en:
       administration_menu: Admin
       administration: Administration
       available_locales: Available languages
-      collaborative_legislation: Legislation processes
+      collaborative_legislation: Collaborative legislation
       debates: Debates
       external_link_blog: Blog
       locale: 'Language:'

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -66,11 +66,11 @@ en:
         no_open_processes: There aren't open processes
         no_past_processes: There aren't past processes
         section_header:
-          icon_alt: Legislation processes icon
-          title: Legislation processes
-          help: Help about legislation processes
+          icon_alt: Collaborative legislation icon
+          title: Collaborative legislation
+          help: Help about collaborative legislation
         section_footer:
-          title: Help about legislation processes
+          title: Help about collaborative legislation
           description: Participate in the debates and processes prior to the approval of a ordinance or a municipal action. Your opinion will be considered by the City Council.
       phase_not_open:
         not_open: This phase is not open yet

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -217,7 +217,7 @@ es:
       administration_menu: Admin
       administration: Administración
       available_locales: Idiomas disponibles
-      collaborative_legislation: Procesos legislativos
+      collaborative_legislation: Legislación colaborativa
       debates: Debates
       external_link_blog: Blog
       locale: 'Idioma:'

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -66,11 +66,11 @@ es:
         no_open_processes: No hay procesos activos
         no_past_processes: No hay procesos terminados
         section_header:
-          icon_alt: Icono de Procesos legislativos
-          title: Procesos legislativos
-          help: Ayuda sobre procesos legislativos
+          icon_alt: Icono de legislación colaborativa
+          title: Legislación colaborativa
+          help: Ayuda sobre legislación colaborativa
         section_footer:
-          title: Ayuda sobre procesos legislativos
+          title: Ayuda sobre Legislación colaborativa
           description: Participa en los debates y procesos previos a la aprobación de una norma o de una actuación municipal. Tu opinión será tenida en cuenta por el Ayuntamiento.
       phase_not_open:
         not_open: Esta fase del proceso todavía no está abierta

--- a/config/locales/es/pages.yml
+++ b/config/locales/es/pages.yml
@@ -13,7 +13,7 @@ es:
         budgets: "Presupuestos participativos"
         polls: "Votaciones"
         other: "Otra información de interés"
-        processes: "Procesos legislativos"
+        processes: "Legislación colaborativa"
       debates:
         title: "Debates"
         description: "En la sección de %{link} puedes exponer y compartir tu opinión con otras personas sobre temas que te preocupan relacionados con la ciudad. También es un espacio donde generar ideas que a través de las otras secciones de %{org} lleven a actuaciones concretas por parte del Ayuntamiento."
@@ -41,9 +41,9 @@ es:
         feature_1: "Para participar en las votaciones tienes que %{link} y verificar tu cuenta."
         feature_1_link: "registrarte en %{org_name}"
       processes:
-        title: "Procesos legislativos"
+        title: "Legislación colaborativa"
         description: "En la sección de %{link} la ciudadanía participa en la elaboración y modificación de normativa que afecta a la ciudad y puede dar su opinión sobre las políticas municipales en debates previos."
-        link: "procesos legislativos"
+        link: "legislación colaborativa"
       faq:
         title: "¿Problemas técnicos?"
         description: "Lee las preguntas frecuentes y resuelve tus dudas."
@@ -122,7 +122,7 @@ es:
               page_column: Presupuestos participativos
             - 
               key_column: 5
-              page_column: Procesos legislativos
+              page_column: Legislación colaborativa
         browser_table:
           description: 'Dependiendo del sistema operativo y del navegador que se utilice, la combinación de teclas será la siguiente:'
           caption: Combinación de teclas dependiendo del sistema operativo y navegador

--- a/db/dev_seeds/legislation_processes.rb
+++ b/db/dev_seeds/legislation_processes.rb
@@ -1,4 +1,4 @@
-section "Creating legislation processes" do
+section "Creating collaborative legislation" do
   9.times do |i|
     Legislation::Process.create!(title: Faker::Lorem.sentence(3).truncate(60),
                                  description: Faker::Lorem.paragraphs.join("\n\n"),

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Admin legislation processes" do
+feature "Admin collaborative legislation" do
 
   background do
     admin = create(:administrator)
@@ -28,7 +28,7 @@ feature "Admin legislation processes" do
 
   context "Index" do
 
-    scenario "Displaying legislation processes" do
+    scenario "Displaying collaborative legislation" do
       process_1 = create(:legislation_process, title: "Process open")
       process_2 = create(:legislation_process, title: "Process for the future",
                                                start_date: Date.current + 5.days)

--- a/spec/features/admin/legislation/proposals_spec.rb
+++ b/spec/features/admin/legislation/proposals_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Admin legislation processes" do
+feature "Admin collaborative legislation" do
 
   background do
     admin = create(:administrator)

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -18,7 +18,7 @@ feature "Admin booths assignments" do
 
       visit booth_assignments_admin_polls_path
 
-      expect(page).to have_content(poll.name)
+      expect(page).to have_link(poll.name, href: manage_admin_poll_booth_assignments_path(poll))
       expect(page).to have_content(second_poll.name)
 
       within("#poll_#{second_poll.id}") do


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1893/.

## Objectives

Improve UX on admin section with the following changes:

- Replace poll name link in admin polls booth assignments: before link to poll and was a little confusing, now links to manage  admin poll booth assignments.

- Remove budget name link on admin budgets index: so the admin can use the actions on the table. 

- Reorder admin menu links with the same order of the front views.

- Replace legislation processes text to collaborative legislation to add consistency across all the app.
