### PR TITLE
[Backport] Use double quotes in CoffeeScript files

### DIFF
--- a/app/assets/javascripts/advanced_search.js.coffee
+++ b/app/assets/javascripts/advanced_search.js.coffee
@@ -1,42 +1,42 @@
 App.AdvancedSearch =
 
   advanced_search_terms: ->
-    $('#js-advanced-search').data('advanced-search-terms')
+    $("#js-advanced-search").data("advanced-search-terms")
 
   toggle_form: (event) ->
     event.preventDefault()
-    $('#js-advanced-search').slideToggle()
+    $("#js-advanced-search").slideToggle()
 
   toggle_date_options: ->
-    if $('#js-advanced-search-date-min').val() == 'custom'
-      $('#js-custom-date').show()
+    if $("#js-advanced-search-date-min").val() == "custom"
+      $("#js-custom-date").show()
       $( ".js-calendar" ).datepicker( "option", "disabled", false )
     else
-      $('#js-custom-date').hide()
+      $("#js-custom-date").hide()
       $( ".js-calendar" ).datepicker( "option", "disabled", true )
 
   init_calendar: ->
-    locale = $('#js-locale').data('current-locale')
-    if locale == 'en'
-      locale = ''
+    locale = $("#js-locale").data("current-locale")
+    if locale == "en"
+      locale = ""
 
-    $('.js-calendar').datepicker
+    $(".js-calendar").datepicker
       regional: locale
       maxDate: "+0d"
-    $('.js-calendar-full').datepicker
+    $(".js-calendar-full").datepicker
       regional: locale
 
   initialize: ->
     App.AdvancedSearch.init_calendar()
 
     if App.AdvancedSearch.advanced_search_terms()
-      $('#js-advanced-search').show()
+      $("#js-advanced-search").show()
       App.AdvancedSearch.toggle_date_options()
 
-    $('#js-advanced-search-title').on
+    $("#js-advanced-search-title").on
       click: (event) ->
         App.AdvancedSearch.toggle_form(event)
 
-    $('#js-advanced-search-date-min').on
+    $("#js-advanced-search-date-min").on
       change: ->
         App.AdvancedSearch.toggle_date_options()

--- a/app/assets/javascripts/allow_participation.js.coffee
+++ b/app/assets/javascripts/allow_participation.js.coffee
@@ -2,7 +2,7 @@ App.AllowParticipation =
 
   initialize: ->
     $(document).on {
-      'mouseenter focus': ->
+      "mouseenter focus": ->
         $(this).find(".js-participation-not-allowed").show()
         $(this).find(".js-participation-allowed").hide()
       mouseleave: ->

--- a/app/assets/javascripts/annotatable.js.coffee
+++ b/app/assets/javascripts/annotatable.js.coffee
@@ -2,18 +2,18 @@ _t = (key) -> new Gettext().gettext(key)
 
 App.Annotatable =
   initialize: ->
-    current_user_id = $('html').data('current-user-id')
+    current_user_id = $("html").data("current-user-id")
     if current_user_id == ""
       annotator.ui.editor.Editor.template = [
         '<div class="annotator-outer annotator-editor annotator-hide">',
         '  <form class="annotator-widget">',
-        "    #{_t('Unregistered')}",
+        "    #{_t("Unregistered")}",
         '    <div class="annotator-controls">',
-        "      <a href='#cancel' class='annotator-cancel'>#{_t('Cancel')}</a>",
-        '    </div>',
-        '  </form>',
-        '</div>'
-      ].join('\n')
+        "      <a href='#cancel' class='annotator-cancel'>#{_t("Cancel")}</a>",
+        "    </div>",
+        "  </form>",
+        "</div>"
+      ].join("\n")
 
     $("[data-annotatable-type]").each ->
       $this       = $(this)

--- a/app/assets/javascripts/annotatable.js.coffee
+++ b/app/assets/javascripts/annotatable.js.coffee
@@ -7,9 +7,9 @@ App.Annotatable =
       annotator.ui.editor.Editor.template = [
         '<div class="annotator-outer annotator-editor annotator-hide">',
         '  <form class="annotator-widget">',
-        '    ' + _t('Unregistered'),
+        "    #{_t('Unregistered')}",
         '    <div class="annotator-controls">',
-        '      <a href="#cancel" class="annotator-cancel">' + _t('Cancel') + '</a>',
+        "      <a href='#cancel' class='annotator-cancel'>#{_t('Cancel')}</a>",
         '    </div>',
         '  </form>',
         '</div>'
@@ -23,7 +23,7 @@ App.Annotatable =
       app = new annotator.App()
         .include ->
           beforeAnnotationCreated: (ann) ->
-            ann[ann_type + "_id"] = ann_id
+            ann["#{ann_type}_id"] = ann_id
             ann.permissions = ann.permissions || {}
             ann.permissions.admin = []
         .include(annotator.ui.main, { element: this })
@@ -34,5 +34,5 @@ App.Annotatable =
         app.ident.identity = current_user_id
 
         options = {}
-        options[ann_type + "_id"] = ann_id
+        options["#{ann_type}_id"] = ann_id
         app.annotations.load(options)

--- a/app/assets/javascripts/banners.js.coffee
+++ b/app/assets/javascripts/banners.js.coffee
@@ -8,19 +8,19 @@ App.Banners =
       .addClass(style, true)
 
   update_background_color: (selector, text_selector, background_color) ->
-    $(selector).css('background-color', background_color)
+    $(selector).css("background-color", background_color)
     $(text_selector).val(background_color)
 
   update_font_color: (selector, text_selector, font_color) ->
-    $(selector).css('color', font_color)
+    $(selector).css("color", font_color)
     $(text_selector).val(font_color)
 
   initialize: ->
-    $('[data-js-banner-title]').on
+    $("[data-js-banner-title]").on
       change: ->
         App.Banners.update_banner("#js-banner-title", $(this).val())
 
-    $('[data-js-banner-description]').on
+    $("[data-js-banner-description]").on
       change: ->
         App.Banners.update_banner("#js-banner-description", $(this).val())
 

--- a/app/assets/javascripts/check_all_none.js.coffee
+++ b/app/assets/javascripts/check_all_none.js.coffee
@@ -3,8 +3,8 @@ App.CheckAllNone =
   initialize: ->
     $('[data-check-all]').on 'click', ->
       target_name = $(this).data('check-all')
-      $("[name='" + target_name + "']").prop('checked', true)
+      $("[name='#{target_name}']").prop('checked', true)
 
     $('[data-check-none]').on 'click', ->
       target_name = $(this).data('check-none')
-      $("[name='" + target_name + "']").prop('checked', false)
+      $("[name='#{target_name}']").prop('checked', false)

--- a/app/assets/javascripts/check_all_none.js.coffee
+++ b/app/assets/javascripts/check_all_none.js.coffee
@@ -1,10 +1,10 @@
 App.CheckAllNone =
 
   initialize: ->
-    $('[data-check-all]').on 'click', ->
-      target_name = $(this).data('check-all')
-      $("[name='#{target_name}']").prop('checked', true)
+    $("[data-check-all]").on "click", ->
+      target_name = $(this).data("check-all")
+      $("[name='#{target_name}']").prop("checked", true)
 
-    $('[data-check-none]').on 'click', ->
-      target_name = $(this).data('check-none')
-      $("[name='#{target_name}']").prop('checked', false)
+    $("[data-check-none]").on "click", ->
+      target_name = $(this).data("check-none")
+      $("[name='#{target_name}']").prop("checked", false)

--- a/app/assets/javascripts/checkbox_toggle.js.coffee
+++ b/app/assets/javascripts/checkbox_toggle.js.coffee
@@ -1,10 +1,10 @@
 App.CheckboxToggle =
 
   initialize: ->
-    $('[data-checkbox-toggle]').on 'change', ->
+    $("[data-checkbox-toggle]").on "change", ->
       $this = $(this)
-      $target = $($this.data('checkbox-toggle'))
-      if $this.is(':checked')
+      $target = $($this.data("checkbox-toggle"))
+      if $this.is(":checked")
         $target.show()
       else
         $target.hide()

--- a/app/assets/javascripts/comments.js.coffee
+++ b/app/assets/javascripts/comments.js.coffee
@@ -21,12 +21,12 @@ App.Comments =
   reset_and_hide_form: (id) ->
     form_container = $("#js-comment-form-#{id}")
     input = form_container.find("form textarea")
-    input.val('')
+    input.val("")
     form_container.hide()
 
   reset_form: (id) ->
     input = $("#js-comment-form-#{id} form textarea")
-    input.val('')
+    input.val("")
 
   toggle_form: (id) ->
     $("#js-comment-form-#{id}").toggle()
@@ -39,21 +39,21 @@ App.Comments =
       $(arrow).removeClass("icon-arrow-down").addClass("icon-arrow-right")
 
   initialize: ->
-    $('body .js-add-comment-link').each ->
+    $("body .js-add-comment-link").each ->
       $this = $(this)
 
-      unless $this.data('initialized') is 'yes'
-        $this.on('click', ->
+      unless $this.data("initialized") is "yes"
+        $this.on("click", ->
           id = $(this).data().id
           App.Comments.toggle_form(id)
           false
-        ).data 'initialized', 'yes'
+        ).data "initialized", "yes"
 
-    $('body .js-toggle-children').each ->
-      $(this).on('click', ->
+    $("body .js-toggle-children").each ->
+      $(this).on("click", ->
         children_container_id = "#{$(this).data().id}_children"
-        $("##{children_container_id}").toggle('slow')
+        $("##{children_container_id}").toggle("slow")
         App.Comments.toggle_arrow(children_container_id)
-        $(this).children('.js-child-toggle').toggle()
+        $(this).children(".js-child-toggle").toggle()
         false
       )

--- a/app/assets/javascripts/documentable.js.coffee
+++ b/app/assets/javascripts/documentable.js.coffee
@@ -2,16 +2,16 @@ App.Documentable =
 
   initialize: ->
 
-    inputFiles = $('.js-document-attachment')
+    inputFiles = $(".js-document-attachment")
     $.each inputFiles, (index, input) ->
       App.Documentable.initializeDirectUploadInput(input)
 
-    $('#nested-documents').on 'cocoon:after-remove', (e, insertedItem) ->
+    $("#nested-documents").on "cocoon:after-remove", (e, insertedItem) ->
       App.Documentable.unlockUploads()
 
-    $('#nested-documents').on 'cocoon:after-insert', (e, nested_document) ->
-      input = $(nested_document).find('.js-document-attachment')
-      input["lockUpload"] = $(nested_document).closest('#nested-documents').find('.document:visible').length >= $('#nested-documents').data('max-documents-allowed')
+    $("#nested-documents").on "cocoon:after-insert", (e, nested_document) ->
+      input = $(nested_document).find(".js-document-attachment")
+      input["lockUpload"] = $(nested_document).closest("#nested-documents").find(".document:visible").length >= $("#nested-documents").data("max-documents-allowed")
       App.Documentable.initializeDirectUploadInput(input)
       App.Documentable.lockUploads() if input["lockUpload"]
 
@@ -30,7 +30,7 @@ App.Documentable =
       add: (e, data) ->
         data = App.Documentable.buildFileUploadData(e, data)
         App.Documentable.clearProgressBar(data)
-        App.Documentable.setProgressBar(data, 'uploading')
+        App.Documentable.setProgressBar(data, "uploading")
         data.submit()
 
       change: (e, data) ->
@@ -40,26 +40,26 @@ App.Documentable =
       fail: (e, data) ->
         $(data.cachedAttachmentField).val("")
         App.Documentable.clearFilename(data)
-        App.Documentable.setProgressBar(data, 'errors')
+        App.Documentable.setProgressBar(data, "errors")
         App.Documentable.clearInputErrors(data)
         App.Documentable.setInputErrors(data)
         $(data.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove()
-        $(data.addAttachmentLabel).addClass('error')
+        $(data.addAttachmentLabel).addClass("error")
         $(data.addAttachmentLabel).show()
 
       done: (e, data) ->
         $(data.cachedAttachmentField).val(data.result.cached_attachment)
         App.Documentable.setTitleFromFile(data, data.result.filename)
-        App.Documentable.setProgressBar(data, 'complete')
+        App.Documentable.setProgressBar(data, "complete")
         App.Documentable.setFilename(data, data.result.filename)
         App.Documentable.clearInputErrors(data)
         $(data.addAttachmentLabel).hide()
-        $(data.wrapper).find(".attachment-actions").removeClass('small-12').addClass('small-6 float-right')
-        $(data.wrapper).find(".attachment-actions .action-remove").removeClass('small-3').addClass('small-12')
+        $(data.wrapper).find(".attachment-actions").removeClass("small-12").addClass("small-6 float-right")
+        $(data.wrapper).find(".attachment-actions .action-remove").removeClass("small-3").addClass("small-12")
 
         destroyAttachmentLink = $(data.result.destroy_link)
         $(data.destroyAttachmentLinkContainer).html(destroyAttachmentLink)
-        $(destroyAttachmentLink).on 'click', (e) ->
+        $(destroyAttachmentLink).on "click", (e) ->
           e.preventDefault()
           e.stopPropagation()
           App.Documentable.doDeleteCachedAttachmentRequest(this.href, data)
@@ -69,7 +69,7 @@ App.Documentable =
 
       progress: (e, data) ->
         progress = parseInt(data.loaded / data.total * 100, 10)
-        $(data.progressBar).find('.loading-bar').css 'width', "#{progress}%"
+        $(data.progressBar).find(".loading-bar").css "width", "#{progress}%"
         return
 
   buildFileUploadData: (e, data) ->
@@ -77,35 +77,35 @@ App.Documentable =
     return data
 
   buildData: (data, input) ->
-    wrapper = $(input).closest('.direct-upload')
+    wrapper = $(input).closest(".direct-upload")
     data.input = input
     data.wrapper = wrapper
-    data.progressBar = $(wrapper).find('.progress-bar-placeholder')
-    data.errorContainer = $(wrapper).find('.attachment-errors')
-    data.fileNameContainer = $(wrapper).find('p.file-name')
-    data.destroyAttachmentLinkContainer = $(wrapper).find('.action-remove')
-    data.addAttachmentLabel = $(wrapper).find('.action-add label')
+    data.progressBar = $(wrapper).find(".progress-bar-placeholder")
+    data.errorContainer = $(wrapper).find(".attachment-errors")
+    data.fileNameContainer = $(wrapper).find("p.file-name")
+    data.destroyAttachmentLinkContainer = $(wrapper).find(".action-remove")
+    data.addAttachmentLabel = $(wrapper).find(".action-add label")
     data.cachedAttachmentField = $(wrapper).find("input[name$='[cached_attachment]']")
     data.titleField = $(wrapper).find("input[name$='[title]']")
-    $(wrapper).find('.progress-bar-placeholder').css('display', 'block')
+    $(wrapper).find(".progress-bar-placeholder").css("display", "block")
     return data
 
   clearFilename: (data) ->
-    $(data.fileNameContainer).text('')
+    $(data.fileNameContainer).text("")
     $(data.fileNameContainer).hide()
 
   clearInputErrors: (data) ->
-    $(data.errorContainer).find('small.error').remove()
+    $(data.errorContainer).find("small.error").remove()
 
   clearProgressBar: (data) ->
-    $(data.progressBar).find('.loading-bar').removeClass('complete errors uploading').css('width', "0px")
+    $(data.progressBar).find(".loading-bar").removeClass("complete errors uploading").css("width", "0px")
 
   setFilename: (data, file_name) ->
     $(data.fileNameContainer).text(file_name)
     $(data.fileNameContainer).show()
 
   setProgressBar: (data, klass) ->
-    $(data.progressBar).find('.loading-bar').addClass(klass)
+    $(data.progressBar).find(".loading-bar").addClass(klass)
 
   setTitleFromFile: (data, title) ->
     if $(data.titleField).val() == ""
@@ -116,14 +116,14 @@ App.Documentable =
     $(data.errorContainer).append(errors)
 
   lockUploads: ->
-    $('#new_document_link').addClass('hide')
+    $("#new_document_link").addClass("hide")
 
   unlockUploads: ->
-    $('#max-documents-notice').addClass('hide')
-    $('#new_document_link').removeClass('hide')
+    $("#max-documents-notice").addClass("hide")
+    $("#new_document_link").removeClass("hide")
 
   showNotice: ->
-    $('#max-documents-notice').removeClass('hide')
+    $("#max-documents-notice").removeClass("hide")
 
   doDeleteCachedAttachmentRequest: (url, data) ->
     $.ajax
@@ -140,18 +140,18 @@ App.Documentable =
         App.Documentable.clearProgressBar(data)
 
         App.Documentable.unlockUploads()
-        $(data.wrapper).find(".attachment-actions").addClass('small-12').removeClass('small-6 float-right')
-        $(data.wrapper).find(".attachment-actions .action-remove").addClass('small-3').removeClass('small-12')
+        $(data.wrapper).find(".attachment-actions").addClass("small-12").removeClass("small-6 float-right")
+        $(data.wrapper).find(".attachment-actions .action-remove").addClass("small-3").removeClass("small-12")
 
-        if $(data.input).data('nested-document') == true
+        if $(data.input).data("nested-document") == true
           $(data.wrapper).remove()
         else
-          $(data.wrapper).find('a.remove-cached-attachment').remove()
+          $(data.wrapper).find("a.remove-cached-attachment").remove()
 
   initializeRemoveCachedDocumentLink: (input, data) ->
     wrapper = $(input).closest(".direct-upload")
-    remove_document_link = $(wrapper).find('a.remove-cached-attachment')
-    $(remove_document_link).on 'click', (e) ->
+    remove_document_link = $(wrapper).find("a.remove-cached-attachment")
+    $(remove_document_link).on "click", (e) ->
       e.preventDefault()
       e.stopPropagation()
       App.Documentable.doDeleteCachedAttachmentRequest(this.href, data)

--- a/app/assets/javascripts/documentable.js.coffee
+++ b/app/assets/javascripts/documentable.js.coffee
@@ -69,7 +69,7 @@ App.Documentable =
 
       progress: (e, data) ->
         progress = parseInt(data.loaded / data.total * 100, 10)
-        $(data.progressBar).find('.loading-bar').css 'width', progress + '%'
+        $(data.progressBar).find('.loading-bar').css 'width', "#{progress}%"
         return
 
   buildFileUploadData: (e, data) ->
@@ -112,7 +112,7 @@ App.Documentable =
       $(data.titleField).val(title)
 
   setInputErrors: (data) ->
-    errors = '<small class="error">' + data.jqXHR.responseJSON.errors + '</small>'
+    errors = "<small class='error'>#{data.jqXHR.responseJSON.errors}</small>"
     $(data.errorContainer).append(errors)
 
   lockUploads: ->
@@ -157,4 +157,4 @@ App.Documentable =
       App.Documentable.doDeleteCachedAttachmentRequest(this.href, data)
 
   removeDocument: (id) ->
-    $('#' + id).remove()
+    $("##{id}").remove()

--- a/app/assets/javascripts/embed_video.js.coffee
+++ b/app/assets/javascripts/embed_video.js.coffee
@@ -1,6 +1,6 @@
 App.EmbedVideo =
 
   initialize: ->
-    $('#js-embedded-video').each ->
+    $("#js-embedded-video").each ->
       code = $(this).data("video-code")
-      $('#js-embedded-video').html(code)
+      $("#js-embedded-video").html(code)

--- a/app/assets/javascripts/fixed_bar.js.coffee
+++ b/app/assets/javascripts/fixed_bar.js.coffee
@@ -1,13 +1,13 @@
 App.FixedBar =
   initialize: ->
-    $('[data-fixed-bar]').each ->
+    $("[data-fixed-bar]").each ->
       $this = $(this)
       fixedBarTopPosition = $this.offset().top
 
-      $(window).on 'scroll', ->
+      $(window).on "scroll", ->
         if $(window).scrollTop() > fixedBarTopPosition
-          $this.addClass('is-fixed')
-          $("#check-ballot").css({ 'display': "inline-block" })
+          $this.addClass("is-fixed")
+          $("#check-ballot").css({ "display": "inline-block" })
         else
-          $this.removeClass('is-fixed')
+          $this.removeClass("is-fixed")
           $("#check-ballot").hide()

--- a/app/assets/javascripts/flaggable.js.coffee
+++ b/app/assets/javascripts/flaggable.js.coffee
@@ -1,4 +1,4 @@
 App.Flaggable =
 
   update: (resource_id, button) ->
-    $("#" + resource_id + " .js-flag-actions").html(button).foundation()
+    $("##{resource_id} .js-flag-actions").html(button).foundation()

--- a/app/assets/javascripts/followable.js.coffee
+++ b/app/assets/javascripts/followable.js.coffee
@@ -2,7 +2,7 @@ App.Followable =
 
   update: (followable_id, button, notice) ->
     $("##{followable_id} .js-follow").html(button)
-    if ($('[data-alert]').length > 0)
-      $('[data-alert]').replaceWith(notice)
+    if ($("[data-alert]").length > 0)
+      $("[data-alert]").replaceWith(notice)
     else
       $("body").append(notice)

--- a/app/assets/javascripts/followable.js.coffee
+++ b/app/assets/javascripts/followable.js.coffee
@@ -1,7 +1,7 @@
 App.Followable =
 
   update: (followable_id, button, notice) ->
-    $("#" + followable_id + " .js-follow").html(button)
+    $("##{followable_id} .js-follow").html(button)
     if ($('[data-alert]').length > 0)
       $('[data-alert]').replaceWith(notice)
     else

--- a/app/assets/javascripts/forms.js.coffee
+++ b/app/assets/javascripts/forms.js.coffee
@@ -1,24 +1,24 @@
 App.Forms =
 
   disableEnter: ->
-    $('form.js-enter-disabled').on('keyup keypress', (event) ->
+    $("form.js-enter-disabled").on("keyup keypress", (event) ->
       if event.which == 13
         e.preventDefault()
     )
 
   submitOnChange: ->
-    $('.js-submit-on-change').unbind('change').on('change', ->
-      $(this).closest('form').submit()
+    $(".js-submit-on-change").unbind("change").on("change", ->
+      $(this).closest("form").submit()
       false
     )
 
   toggleLink: ->
-    $('.js-toggle-link').unbind('click').on('click', ->
-      $($(this).data('toggle-selector')).toggle("down")
-      if $(this).data('toggle-text') isnt undefined
+    $(".js-toggle-link").unbind("click").on("click", ->
+      $($(this).data("toggle-selector")).toggle("down")
+      if $(this).data("toggle-text") isnt undefined
         toggle_txt = $(this).text()
-        $(this).text( $(this).data('toggle-text')  )
-        $(this).data('toggle-text', toggle_txt)
+        $(this).text( $(this).data("toggle-text")  )
+        $(this).data("toggle-text", toggle_txt)
 
       false
     )

--- a/app/assets/javascripts/gettext.js.coffee
+++ b/app/assets/javascripts/gettext.js.coffee
@@ -21,7 +21,7 @@ i18n = {
 
 window.Gettext = (key) ->
   gettext: (key) ->
-    locale_id = $('html').attr('lang')
+    locale_id = $("html").attr("lang")
     locale    = i18n[locale_id]
     if locale && locale[key]
       return locale[key]

--- a/app/assets/javascripts/globalize.js.coffee
+++ b/app/assets/javascripts/globalize.js.coffee
@@ -16,18 +16,18 @@ App.Globalize =
       else
         $(this).hide()
       $('.js-delete-language').hide()
-      $('#js_delete_' + locale).show()
+      $("#js_delete_#{locale}").show()
 
   highlight_locale: (element) ->
     $('.js-globalize-locale-link').removeClass('is-active')
     element.addClass('is-active')
 
   remove_language: (locale) ->
-    $(".js-globalize-attribute[data-locale=" + locale + "]").each ->
+    $(".js-globalize-attribute[data-locale=#{locale}]").each ->
       $(this).val('').hide()
       if CKEDITOR.instances[$(this).attr('id')]
         CKEDITOR.instances[$(this).attr('id')].setData('')
-    $(".js-globalize-locale-link[data-locale=" + locale + "]").hide()
+    $(".js-globalize-locale-link[data-locale=#{locale}]").hide()
     next = $(".js-globalize-locale-link:visible").first()
     App.Globalize.highlight_locale(next)
     App.Globalize.display_translations(next.data("locale"))
@@ -48,10 +48,10 @@ App.Globalize =
     )
 
   destroy_locale_field: (locale) ->
-    $("input[id$=_destroy][data-locale=" + locale + "]")
+    $("input[id$=_destroy][data-locale=#{locale}]")
 
   site_customization_enable_locale_field: (locale) ->
-    $("#enabled_translations_" + locale)
+    $("#enabled_translations_#{locale}")
 
   refresh_visible_translations: ->
     locale = $('.js-globalize-locale-link.is-active').data("locale")

--- a/app/assets/javascripts/globalize.js.coffee
+++ b/app/assets/javascripts/globalize.js.coffee
@@ -15,18 +15,18 @@ App.Globalize =
         $(this).show()
       else
         $(this).hide()
-      $('.js-delete-language').hide()
+      $(".js-delete-language").hide()
       $("#js_delete_#{locale}").show()
 
   highlight_locale: (element) ->
-    $('.js-globalize-locale-link').removeClass('is-active')
-    element.addClass('is-active')
+    $(".js-globalize-locale-link").removeClass("is-active")
+    element.addClass("is-active")
 
   remove_language: (locale) ->
     $(".js-globalize-attribute[data-locale=#{locale}]").each ->
-      $(this).val('').hide()
-      if CKEDITOR.instances[$(this).attr('id')]
-        CKEDITOR.instances[$(this).attr('id')].setData('')
+      $(this).val("").hide()
+      if CKEDITOR.instances[$(this).attr("id")]
+        CKEDITOR.instances[$(this).attr("id")].setData("")
     $(".js-globalize-locale-link[data-locale=#{locale}]").hide()
     next = $(".js-globalize-locale-link:visible").first()
     App.Globalize.highlight_locale(next)
@@ -54,20 +54,20 @@ App.Globalize =
     $("#enabled_translations_#{locale}")
 
   refresh_visible_translations: ->
-    locale = $('.js-globalize-locale-link.is-active').data("locale")
+    locale = $(".js-globalize-locale-link.is-active").data("locale")
     App.Globalize.display_translations(locale)
 
   initialize: ->
-    $('.js-globalize-locale').on 'change', ->
+    $(".js-globalize-locale").on "change", ->
       App.Globalize.display_translations($(this).val())
       App.Globalize.display_locale($(this).val())
 
-    $('.js-globalize-locale-link').on 'click', ->
+    $(".js-globalize-locale-link").on "click", ->
       locale = $(this).data("locale")
       App.Globalize.display_translations(locale)
       App.Globalize.highlight_locale($(this))
 
-    $('.js-delete-language').on 'click', ->
+    $(".js-delete-language").on "click", ->
       locale = $(this).data("locale")
       $(this).hide()
       App.Globalize.remove_language(locale)

--- a/app/assets/javascripts/ie_alert.js.coffee
+++ b/app/assets/javascripts/ie_alert.js.coffee
@@ -1,9 +1,9 @@
 App.IeAlert =
   set_cookie_and_hide: (event) ->
     event.preventDefault()
-    $.cookie('ie_alert_closed', 'true', { path: '/', expires: 365 })
-    $('.ie-callout').remove()
+    $.cookie("ie_alert_closed", "true", { path: "/", expires: 365 })
+    $(".ie-callout").remove()
 
   initialize: ->
-    $('.ie-callout-close-js').on 'click', (event) ->
+    $(".ie-callout-close-js").on "click", (event) ->
       App.IeAlert.set_cookie_and_hide(event)

--- a/app/assets/javascripts/imageable.js.coffee
+++ b/app/assets/javascripts/imageable.js.coffee
@@ -1,20 +1,20 @@
 App.Imageable =
 
   initialize: ->
-    inputFiles = $('.js-image-attachment')
+    inputFiles = $(".js-image-attachment")
     $.each inputFiles, (index, input) ->
       App.Imageable.initializeDirectUploadInput(input)
 
-    $('#nested-image').on 'cocoon:after-remove', (e, item) ->
-      $("#new_image_link").removeClass('hide')
+    $("#nested-image").on "cocoon:after-remove", (e, item) ->
+      $("#new_image_link").removeClass("hide")
 
-    $('#nested-image').on 'cocoon:before-insert', (e, nested_image) ->
+    $("#nested-image").on "cocoon:before-insert", (e, nested_image) ->
       if $(".js-image-attachment").length > 0
-        $(".js-image-attachment").closest('.image').remove()
+        $(".js-image-attachment").closest(".image").remove()
 
-    $('#nested-image').on 'cocoon:after-insert', (e, nested_image) ->
-      $("#new_image_link").addClass('hide')
-      input = $(nested_image).find('.js-image-attachment')
+    $("#nested-image").on "cocoon:after-insert", (e, nested_image) ->
+      $("#new_image_link").addClass("hide")
+      input = $(nested_image).find(".js-image-attachment")
       App.Imageable.initializeDirectUploadInput(input)
 
   initializeDirectUploadInput: (input) ->
@@ -32,7 +32,7 @@ App.Imageable =
       add: (e, data) ->
         data = App.Imageable.buildFileUploadData(e, data)
         App.Imageable.clearProgressBar(data)
-        App.Imageable.setProgressBar(data, 'uploading')
+        App.Imageable.setProgressBar(data, "uploading")
         data.submit()
 
       change: (e, data) ->
@@ -42,35 +42,35 @@ App.Imageable =
       fail: (e, data) ->
         $(data.cachedAttachmentField).val("")
         App.Imageable.clearFilename(data)
-        App.Imageable.setProgressBar(data, 'errors')
+        App.Imageable.setProgressBar(data, "errors")
         App.Imageable.clearInputErrors(data)
         App.Imageable.setInputErrors(data)
         App.Imageable.clearPreview(data)
         $(data.destroyAttachmentLinkContainer).find("a.delete:not(.remove-nested)").remove()
-        $(data.addAttachmentLabel).addClass('error')
+        $(data.addAttachmentLabel).addClass("error")
         $(data.addAttachmentLabel).show()
 
       done: (e, data) ->
         $(data.cachedAttachmentField).val(data.result.cached_attachment)
         App.Imageable.setTitleFromFile(data, data.result.filename)
-        App.Imageable.setProgressBar(data, 'complete')
+        App.Imageable.setProgressBar(data, "complete")
         App.Imageable.setFilename(data, data.result.filename)
         App.Imageable.clearInputErrors(data)
         $(data.addAttachmentLabel).hide()
-        $(data.wrapper).find(".attachment-actions").removeClass('small-12').addClass('small-6 float-right')
-        $(data.wrapper).find(".attachment-actions .action-remove").removeClass('small-3').addClass('small-12')
+        $(data.wrapper).find(".attachment-actions").removeClass("small-12").addClass("small-6 float-right")
+        $(data.wrapper).find(".attachment-actions .action-remove").removeClass("small-3").addClass("small-12")
         App.Imageable.setPreview(data)
 
         destroyAttachmentLink = $(data.result.destroy_link)
         $(data.destroyAttachmentLinkContainer).html(destroyAttachmentLink)
-        $(destroyAttachmentLink).on 'click', (e) ->
+        $(destroyAttachmentLink).on "click", (e) ->
           e.preventDefault()
           e.stopPropagation()
           App.Imageable.doDeleteCachedAttachmentRequest(this.href, data)
 
       progress: (e, data) ->
         progress = parseInt(data.loaded / data.total * 100, 10)
-        $(data.progressBar).find('.loading-bar').css 'width', "#{progress}%"
+        $(data.progressBar).find(".loading-bar").css "width", "#{progress}%"
         return
 
   buildFileUploadData: (e, data) ->
@@ -78,39 +78,39 @@ App.Imageable =
     return data
 
   buildData: (data, input) ->
-    wrapper = $(input).closest('.direct-upload')
+    wrapper = $(input).closest(".direct-upload")
     data.input = input
     data.wrapper = wrapper
-    data.progressBar = $(wrapper).find('.progress-bar-placeholder')
-    data.preview = $(wrapper).find('.image-preview')
-    data.errorContainer = $(wrapper).find('.attachment-errors')
-    data.fileNameContainer = $(wrapper).find('p.file-name')
-    data.destroyAttachmentLinkContainer = $(wrapper).find('.action-remove')
-    data.addAttachmentLabel = $(wrapper).find('.action-add label')
+    data.progressBar = $(wrapper).find(".progress-bar-placeholder")
+    data.preview = $(wrapper).find(".image-preview")
+    data.errorContainer = $(wrapper).find(".attachment-errors")
+    data.fileNameContainer = $(wrapper).find("p.file-name")
+    data.destroyAttachmentLinkContainer = $(wrapper).find(".action-remove")
+    data.addAttachmentLabel = $(wrapper).find(".action-add label")
     data.cachedAttachmentField = $(wrapper).find("input[name$='[cached_attachment]']")
     data.titleField = $(wrapper).find("input[name$='[title]']")
-    $(wrapper).find('.progress-bar-placeholder').css('display', 'block')
+    $(wrapper).find(".progress-bar-placeholder").css("display", "block")
     return data
 
   clearFilename: (data) ->
-    $(data.fileNameContainer).text('')
+    $(data.fileNameContainer).text("")
     $(data.fileNameContainer).hide()
 
   clearInputErrors: (data) ->
-    $(data.errorContainer).find('small.error').remove()
+    $(data.errorContainer).find("small.error").remove()
 
   clearProgressBar: (data) ->
-    $(data.progressBar).find('.loading-bar').removeClass('complete errors uploading').css('width', "0px")
+    $(data.progressBar).find(".loading-bar").removeClass("complete errors uploading").css("width", "0px")
 
   clearPreview: (data) ->
-    $(data.wrapper).find('.image-preview').remove()
+    $(data.wrapper).find(".image-preview").remove()
 
   setFilename: (data, file_name) ->
     $(data.fileNameContainer).text(file_name)
     $(data.fileNameContainer).show()
 
   setProgressBar: (data, klass) ->
-    $(data.progressBar).find('.loading-bar').addClass(klass)
+    $(data.progressBar).find(".loading-bar").addClass(klass)
 
   setTitleFromFile: (data, title) ->
     if $(data.titleField).val() == ""
@@ -126,7 +126,7 @@ App.Imageable =
       $(data.preview).replaceWith(image_preview)
     else
       $(image_preview).insertBefore($(data.wrapper).find(".attachment-actions"))
-      data.preview = $(data.wrapper).find('.image-preview')
+      data.preview = $(data.wrapper).find(".image-preview")
 
   doDeleteCachedAttachmentRequest: (url, data) ->
     $.ajax
@@ -143,24 +143,24 @@ App.Imageable =
         App.Imageable.clearProgressBar(data)
         App.Imageable.clearPreview(data)
 
-        $('#new_image_link').removeClass('hide')
+        $("#new_image_link").removeClass("hide")
 
-        $(data.wrapper).find(".attachment-actions").addClass('small-12').removeClass('small-6 float-right')
-        $(data.wrapper).find(".attachment-actions .action-remove").addClass('small-3').removeClass('small-12')
+        $(data.wrapper).find(".attachment-actions").addClass("small-12").removeClass("small-6 float-right")
+        $(data.wrapper).find(".attachment-actions .action-remove").addClass("small-3").removeClass("small-12")
 
-        if $(data.input).data('nested-image') == true
+        if $(data.input).data("nested-image") == true
           $(data.wrapper).remove()
         else
-          $(data.wrapper).find('a.remove-cached-attachment').remove()
+          $(data.wrapper).find("a.remove-cached-attachment").remove()
 
   initializeRemoveCachedImageLink: (input, data) ->
     wrapper = $(input).closest(".direct-upload")
-    remove_image_link = $(wrapper).find('a.remove-cached-attachment')
-    $(remove_image_link).on 'click', (e) ->
+    remove_image_link = $(wrapper).find("a.remove-cached-attachment")
+    $(remove_image_link).on "click", (e) ->
       e.preventDefault()
       e.stopPropagation()
       App.Imageable.doDeleteCachedAttachmentRequest(this.href, data)
 
   removeImage: (id) ->
     $("##{id}").remove()
-    $("#new_image_link").removeClass('hide')
+    $("#new_image_link").removeClass("hide")

--- a/app/assets/javascripts/imageable.js.coffee
+++ b/app/assets/javascripts/imageable.js.coffee
@@ -70,7 +70,7 @@ App.Imageable =
 
       progress: (e, data) ->
         progress = parseInt(data.loaded / data.total * 100, 10)
-        $(data.progressBar).find('.loading-bar').css 'width', progress + '%'
+        $(data.progressBar).find('.loading-bar').css 'width', "#{progress}%"
         return
 
   buildFileUploadData: (e, data) ->
@@ -117,11 +117,11 @@ App.Imageable =
       $(data.titleField).val(title)
 
   setInputErrors: (data) ->
-    errors = '<small class="error">' + data.jqXHR.responseJSON.errors + '</small>'
+    errors = "<small class='error'>#{data.jqXHR.responseJSON.errors}</small>"
     $(data.errorContainer).append(errors)
 
   setPreview: (data) ->
-    image_preview = '<div class="small-12 column text-center image-preview"><figure><img src="' + data.result.attachment_url + '" class="cached-image"/></figure></div>'
+    image_preview = "<div class='small-12 column text-center image-preview'><figure><img src='#{data.result.attachment_url}' class='cached-image'></figure></div>"
     if $(data.preview).length > 0
       $(data.preview).replaceWith(image_preview)
     else
@@ -162,5 +162,5 @@ App.Imageable =
       App.Imageable.doDeleteCachedAttachmentRequest(this.href, data)
 
   removeImage: (id) ->
-    $('#' + id).remove()
+    $("##{id}").remove()
     $("#new_image_link").removeClass('hide')

--- a/app/assets/javascripts/investment_report_alert.js.coffee
+++ b/app/assets/javascripts/investment_report_alert.js.coffee
@@ -1,7 +1,7 @@
 App.InvestmentReportAlert =
   initialize: ->
-    $('#js-investment-report-alert').on 'click', ->
-      if this.checked && $('#budget_investment_feasibility_unfeasible').is(':checked')
+    $("#js-investment-report-alert").on "click", ->
+      if this.checked && $("#budget_investment_feasibility_unfeasible").is(":checked")
         confirm("#{this.dataset.alert}\n#{this.dataset.notFeasibleAlert}")
       else if this.checked
         confirm(this.dataset.alert)

--- a/app/assets/javascripts/investment_report_alert.js.coffee
+++ b/app/assets/javascripts/investment_report_alert.js.coffee
@@ -2,6 +2,6 @@ App.InvestmentReportAlert =
   initialize: ->
     $('#js-investment-report-alert').on 'click', ->
       if this.checked && $('#budget_investment_feasibility_unfeasible').is(':checked')
-        confirm(this.dataset.alert + "\n" + this.dataset.notFeasibleAlert)
+        confirm("#{this.dataset.alert}\n#{this.dataset.notFeasibleAlert}")
       else if this.checked
         confirm(this.dataset.alert)

--- a/app/assets/javascripts/legislation.js.coffee
+++ b/app/assets/javascripts/legislation.js.coffee
@@ -1,12 +1,12 @@
 App.Legislation =
 
   initialize: ->
-    $('form#new_legislation_answer input.button').hide()
-    $('form#new_legislation_answer input[type=radio]').on
+    $("form#new_legislation_answer input.button").hide()
+    $("form#new_legislation_answer input[type=radio]").on
       click: ->
-        $('form#new_legislation_answer').submit()
+        $("form#new_legislation_answer").submit()
 
-    $('form#draft_version_go_to_version input.button').hide()
-    $('form#draft_version_go_to_version select').on
+    $("form#draft_version_go_to_version input.button").hide()
+    $("form#draft_version_go_to_version select").on
       change: ->
-        $('form#draft_version_go_to_version').submit()
+        $("form#draft_version_go_to_version").submit()

--- a/app/assets/javascripts/legislation_admin.js.coffee
+++ b/app/assets/javascripts/legislation_admin.js.coffee
@@ -4,10 +4,10 @@ App.LegislationAdmin =
     $("input[type='checkbox'][data-disable-date]").on
       change: ->
         checkbox = $(this)
-        parent = $(this).parents('.row:eq(0)')
-        date_selector = $(this).data('disable-date')
+        parent = $(this).parents(".row:eq(0)")
+        date_selector = $(this).data("disable-date")
         parent.find("input[type='text'][id^='#{date_selector}']").each ->
-          if checkbox.is(':checked')
+          if checkbox.is(":checked")
             $(this).removeAttr("disabled")
           else
             $(this).val("")

--- a/app/assets/javascripts/legislation_admin.js.coffee
+++ b/app/assets/javascripts/legislation_admin.js.coffee
@@ -6,7 +6,7 @@ App.LegislationAdmin =
         checkbox = $(this)
         parent = $(this).parents('.row:eq(0)')
         date_selector = $(this).data('disable-date')
-        parent.find("input[type='text'][id^='" + date_selector + "']").each ->
+        parent.find("input[type='text'][id^='#{date_selector}']").each ->
           if checkbox.is(':checked')
             $(this).removeAttr("disabled")
           else

--- a/app/assets/javascripts/legislation_allegations.js.coffee
+++ b/app/assets/javascripts/legislation_allegations.js.coffee
@@ -2,24 +2,24 @@ App.LegislationAllegations =
 
   toggle_comments: ->
     if !App.LegislationAnnotatable.isMobile()
-      $('.draft-allegation').toggleClass('comments-on')
-      $('#comments-box').html('').hide()
+      $(".draft-allegation").toggleClass("comments-on")
+      $("#comments-box").html("").hide()
 
   show_comments: ->
     if !App.LegislationAnnotatable.isMobile()
-      $('.draft-allegation').addClass('comments-on')
+      $(".draft-allegation").addClass("comments-on")
 
   initialize: ->
-    $('.js-toggle-allegations .draft-panel').on
+    $(".js-toggle-allegations .draft-panel").on
       click: (e) ->
         e.preventDefault()
         e.stopPropagation()
         if !App.LegislationAnnotatable.isMobile()
           App.LegislationAllegations.toggle_comments()
 
-    $('.js-toggle-allegations').on
+    $(".js-toggle-allegations").on
       click: (e) ->
         # Toggle comments when the section title is visible
         if !App.LegislationAnnotatable.isMobile()
-          if $(this).find('.draft-panel .panel-title:visible').length == 0
+          if $(this).find(".draft-panel .panel-title:visible").length == 0
             App.LegislationAllegations.toggle_comments()

--- a/app/assets/javascripts/legislation_annotatable.js.coffee
+++ b/app/assets/javascripts/legislation_annotatable.js.coffee
@@ -6,39 +6,39 @@ App.LegislationAnnotatable =
     sel = window.getSelection()
     if sel.rangeCount and sel.getRangeAt
       range = sel.getRangeAt(0)
-    document.designMode = 'on'
+    document.designMode = "on"
     if range
       sel.removeAllRanges()
       sel.addRange range
     # Use HiliteColor since some browsers apply BackColor to the whole block
-    if !document.execCommand('HiliteColor', false, colour)
-      document.execCommand 'BackColor', false, colour
-    document.designMode = 'off'
+    if !document.execCommand("HiliteColor", false, colour)
+      document.execCommand "BackColor", false, colour
+    document.designMode = "off"
     return
 
   highlight: (colour) ->
     if window.getSelection
       # IE9 and non-IE
       try
-        if !document.execCommand('BackColor', false, colour)
+        if !document.execCommand("BackColor", false, colour)
           App.LegislationAnnotatable.makeEditableAndHighlight colour
       catch ex
         App.LegislationAnnotatable.makeEditableAndHighlight colour
     else if document.selection and document.selection.createRange
       # IE <= 8 case
       range = document.selection.createRange()
-      range.execCommand 'BackColor', false, colour
+      range.execCommand "BackColor", false, colour
     return
 
   remove_highlight: ->
-    $('[data-legislation-draft-version-id] span[style]').replaceWith(->
+    $("[data-legislation-draft-version-id] span[style]").replaceWith(->
       return $(this).contents()
     )
     return
 
   renderAnnotationComments: (event) ->
     if event.offset
-      $("#comments-box").css({ top: event.offset - $('.calc-comments').offset().top })
+      $("#comments-box").css({ top: event.offset - $(".calc-comments").offset().top })
 
     if App.LegislationAnnotatable.isMobile()
       return
@@ -46,7 +46,7 @@ App.LegislationAnnotatable =
     $.ajax
       method: "GET"
       url: "#{event.annotation_url}/annotations/#{event.annotation_id}/comments"
-      dataType: 'script'
+      dataType: "script"
 
   onClick: (event) ->
     event.preventDefault()
@@ -54,21 +54,21 @@ App.LegislationAnnotatable =
 
     if App.LegislationAnnotatable.isMobile()
       annotation_url = $(event.target).closest(".legislation-annotatable").data("legislation-annotatable-base-url")
-      window.location.href = "#{annotation_url}/annotations/#{$(this).data('annotation-id')}"
+      window.location.href = "#{annotation_url}/annotations/#{$(this).data("annotation-id")}"
       return
 
-    $('[data-annotation-id]').removeClass('current-annotation')
+    $("[data-annotation-id]").removeClass("current-annotation")
 
     target = $(this)
 
-    parents = target.parents('.annotator-hl')
+    parents = target.parents(".annotator-hl")
     parents_ids = parents.map (_, elem) ->
       $(elem).data("annotation-id")
 
-    annotation_id = target.data('annotation-id')
-    $("[data-annotation-id='#{annotation_id}']").addClass('current-annotation')
+    annotation_id = target.data("annotation-id")
+    $("[data-annotation-id='#{annotation_id}']").addClass("current-annotation")
 
-    $('#comments-box').html('')
+    $("#comments-box").html("")
     App.LegislationAllegations.show_comments()
     $("#comments-box").show()
 
@@ -92,24 +92,24 @@ App.LegislationAnnotatable =
       return
 
   customShow: (position) ->
-    $(@element).html ''
+    $(@element).html ""
     # Clean comments section and open it
-    $('#comments-box').html ''
+    $("#comments-box").html ""
     App.LegislationAllegations.show_comments()
-    $('#comments-box').show()
+    $("#comments-box").show()
 
-    annotation_url = $('[data-legislation-annotatable-base-url]').data('legislation-annotatable-base-url')
+    annotation_url = $("[data-legislation-annotatable-base-url]").data("legislation-annotatable-base-url")
     $.ajax(
-      method: 'GET'
+      method: "GET"
       url: "#{annotation_url}/annotations/new"
-      dataType: 'script').done (->
-        $('#new_legislation_annotation #legislation_annotation_quote').val(@annotation.quote)
-        $('#new_legislation_annotation #legislation_annotation_ranges').val(JSON.stringify(@annotation.ranges))
-        $('#comments-box').css({ top: position.top - $('.calc-comments').offset().top })
+      dataType: "script").done (->
+        $("#new_legislation_annotation #legislation_annotation_quote").val(@annotation.quote)
+        $("#new_legislation_annotation #legislation_annotation_ranges").val(JSON.stringify(@annotation.ranges))
+        $("#comments-box").css({ top: position.top - $(".calc-comments").offset().top })
 
-        unless  $('[data-legislation-open-phase]').data('legislation-open-phase') == false
-          App.LegislationAnnotatable.highlight('#7fff9a')
-          $('#comments-box textarea').focus()
+        unless  $("[data-legislation-open-phase]").data("legislation-open-phase") == false
+          App.LegislationAnnotatable.highlight("#7fff9a")
+          $("#comments-box textarea").focus()
 
           $("#new_legislation_annotation").on("ajax:complete", (e, data, status, xhr) ->
             App.LegislationAnnotatable.app.destroy()
@@ -119,10 +119,10 @@ App.LegislationAnnotatable =
               $.ajax
                 method: "GET"
                 url: "#{annotation_url}/annotations/#{data.responseJSON.id}/comments"
-                dataType: 'script'
+                dataType: "script"
             else
-              $(e.target).find('label').addClass('error')
-              $("<small class='error'>#{data.responseJSON[0]}</small>").insertAfter($(e.target).find('textarea'))
+              $(e.target).find("label").addClass("error")
+              $("<small class='error'>#{data.responseJSON[0]}</small>").insertAfter($(e.target).find("textarea"))
             return true
           )
         return
@@ -133,17 +133,17 @@ App.LegislationAnnotatable =
 
   scrollToAnchor: ->
     annotationsLoaded: (annotations) ->
-      anchor = $(location).attr('hash')
-      if anchor && anchor.startsWith('#annotation')
+      anchor = $(location).attr("hash")
+      if anchor && anchor.startsWith("#annotation")
         ann_id = anchor.split("-")[-1..]
 
         checkExist = setInterval((->
           if $("span[data-annotation-id='#{ann_id}']").length
             el = $("span[data-annotation-id='#{ann_id}']")
-            el.addClass('current-annotation')
-            $('#comments-box').html('')
+            el.addClass("current-annotation")
+            $("#comments-box").html("")
             App.LegislationAllegations.show_comments()
-            $('html,body').animate({ scrollTop: el.offset().top })
+            $("html,body").animate({ scrollTop: el.offset().top })
             $.event.trigger
               type: "renderLegislationAnnotation"
               annotation_id: ann_id
@@ -175,16 +175,16 @@ App.LegislationAnnotatable =
 
   initialize: ->
     $(document).off("renderLegislationAnnotation").on("renderLegislationAnnotation", App.LegislationAnnotatable.renderAnnotationComments)
-    $(document).off('click', '[data-annotation-id]').on('click', '[data-annotation-id]', App.LegislationAnnotatable.onClick)
-    $(document).off('click', '[data-cancel-annotation]').on('click', '[data-cancel-annotation]', (e) ->
+    $(document).off("click", "[data-annotation-id]").on("click", "[data-annotation-id]", App.LegislationAnnotatable.onClick)
+    $(document).off("click", "[data-cancel-annotation]").on("click", "[data-cancel-annotation]", (e) ->
       e.preventDefault()
-      $('#comments-box').html('')
-      $('#comments-box').hide()
+      $("#comments-box").html("")
+      $("#comments-box").hide()
       App.LegislationAnnotatable.remove_highlight()
       return
     )
 
-    current_user_id = $('html').data('current-user-id')
+    current_user_id = $("html").data("current-user-id")
 
     $(".legislation-annotatable").each ->
       $this          = $(this)

--- a/app/assets/javascripts/legislation_annotatable.js.coffee
+++ b/app/assets/javascripts/legislation_annotatable.js.coffee
@@ -45,7 +45,7 @@ App.LegislationAnnotatable =
 
     $.ajax
       method: "GET"
-      url: event.annotation_url + "/annotations/" + event.annotation_id + "/comments"
+      url: "#{event.annotation_url}/annotations/#{event.annotation_id}/comments"
       dataType: 'script'
 
   onClick: (event) ->
@@ -54,7 +54,7 @@ App.LegislationAnnotatable =
 
     if App.LegislationAnnotatable.isMobile()
       annotation_url = $(event.target).closest(".legislation-annotatable").data("legislation-annotatable-base-url")
-      window.location.href = annotation_url + "/annotations/" + $(this).data('annotation-id')
+      window.location.href = "#{annotation_url}/annotations/#{$(this).data('annotation-id')}"
       return
 
     $('[data-annotation-id]').removeClass('current-annotation')
@@ -66,7 +66,7 @@ App.LegislationAnnotatable =
       $(elem).data("annotation-id")
 
     annotation_id = target.data('annotation-id')
-    $('[data-annotation-id="' + annotation_id + '"]').addClass('current-annotation')
+    $("[data-annotation-id='#{annotation_id}']").addClass('current-annotation')
 
     $('#comments-box').html('')
     App.LegislationAllegations.show_comments()
@@ -101,7 +101,7 @@ App.LegislationAnnotatable =
     annotation_url = $('[data-legislation-annotatable-base-url]').data('legislation-annotatable-base-url')
     $.ajax(
       method: 'GET'
-      url: annotation_url + '/annotations/new'
+      url: "#{annotation_url}/annotations/new"
       dataType: 'script').done (->
         $('#new_legislation_annotation #legislation_annotation_quote').val(@annotation.quote)
         $('#new_legislation_annotation #legislation_annotation_ranges').val(JSON.stringify(@annotation.ranges))
@@ -118,11 +118,11 @@ App.LegislationAnnotatable =
               $("#comments-box").html("").hide()
               $.ajax
                 method: "GET"
-                url: annotation_url + "/annotations/" + data.responseJSON.id + "/comments"
+                url: "#{annotation_url}/annotations/#{data.responseJSON.id}/comments"
                 dataType: 'script'
             else
               $(e.target).find('label').addClass('error')
-              $('<small class="error">' + data.responseJSON[0] + '</small>').insertAfter($(e.target).find('textarea'))
+              $("<small class='error'>#{data.responseJSON[0]}</small>").insertAfter($(e.target).find('textarea'))
             return true
           )
         return
@@ -138,8 +138,8 @@ App.LegislationAnnotatable =
         ann_id = anchor.split("-")[-1..]
 
         checkExist = setInterval((->
-          if $("span[data-annotation-id='" + ann_id + "']").length
-            el = $("span[data-annotation-id='" + ann_id + "']")
+          if $("span[data-annotation-id='#{ann_id}']").length
+            el = $("span[data-annotation-id='#{ann_id}']")
             el.addClass('current-annotation')
             $('#comments-box').html('')
             App.LegislationAllegations.show_comments()
@@ -164,11 +164,11 @@ App.LegislationAnnotatable =
       last_annotation = annotations[annotations.length - 1]
 
       checkExist = setInterval((->
-        if $("span[data-annotation-id='" + last_annotation.id + "']").length
+        if $("span[data-annotation-id='#{last_annotation.id}']").length
           for annotation in annotations
             ann_weight = App.LegislationAnnotatable.propotionalWeight(annotation.weight, max_weight)
-            el = $("span[data-annotation-id='" + annotation.id + "']")
-            el.addClass('weight-' + ann_weight)
+            el = $("span[data-annotation-id='#{annotation.id}']")
+            el.addClass("weight-#{ann_weight}")
           clearInterval checkExist
         return
       ), 100)

--- a/app/assets/javascripts/location_changer.js.coffee
+++ b/app/assets/javascripts/location_changer.js.coffee
@@ -1,5 +1,5 @@
 App.LocationChanger =
 
   initialize: ->
-    $('.js-location-changer').on 'change', ->
+    $(".js-location-changer").on "change", ->
       window.location.assign($(this).val())

--- a/app/assets/javascripts/managers.js.coffee
+++ b/app/assets/javascripts/managers.js.coffee
@@ -1,8 +1,8 @@
 App.Managers =
 
   generatePassword: ->
-    chars = 'aAbcdeEfghiJkmnpqrstuUvwxyz23456789'
-    pass = ''
+    chars = "aAbcdeEfghiJkmnpqrstuUvwxyz23456789"
+    pass = ""
     x = 0
     while x < 12
       i = Math.floor(Math.random() * chars.length)
@@ -11,15 +11,15 @@ App.Managers =
     return pass
 
   togglePassword: (type) ->
-    $('#user_password').prop 'type', type
+    $("#user_password").prop "type", type
 
   initialize: ->
     $(".generate-random-value").on "click", (event) ->
       password = App.Managers.generatePassword()
-      $('#user_password').val(password)
+      $("#user_password").val(password)
 
     $(".show-password").on "click", (event) ->
       if $("#user_password").is("input[type='password']")
-        App.Managers.togglePassword('text')
+        App.Managers.togglePassword("text")
       else
-        App.Managers.togglePassword('password')
+        App.Managers.togglePassword("password")

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -75,7 +75,7 @@ App.Map =
     openMarkerPopup = (e) ->
       marker = e.target
 
-      $.ajax '/investments/' + marker.options['id'] + '/json_data',
+      $.ajax "/investments/#{marker.options['id']}/json_data",
         type: 'GET'
         dataType: 'json'
         success: (data) ->

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -1,35 +1,35 @@
 App.Map =
 
   initialize: ->
-    maps = $('*[data-map]')
+    maps = $("*[data-map]")
 
     if maps.length > 0
       $.each maps, (index, map) ->
         App.Map.initializeMap map
 
-    $('.js-toggle-map').on
+    $(".js-toggle-map").on
       click: ->
         App.Map.toggleMap()
 
   initializeMap: (element) ->
     App.Map.cleanInvestmentCoordinates(element)
 
-    mapCenterLatitude        = $(element).data('map-center-latitude')
-    mapCenterLongitude       = $(element).data('map-center-longitude')
-    markerLatitude           = $(element).data('marker-latitude')
-    markerLongitude          = $(element).data('marker-longitude')
-    zoom                     = $(element).data('map-zoom')
-    mapTilesProvider         = $(element).data('map-tiles-provider')
-    mapAttribution           = $(element).data('map-tiles-provider-attribution')
-    latitudeInputSelector    = $(element).data('latitude-input-selector')
-    longitudeInputSelector   = $(element).data('longitude-input-selector')
-    zoomInputSelector        = $(element).data('zoom-input-selector')
-    removeMarkerSelector     = $(element).data('marker-remove-selector')
-    addMarkerInvestments     = $(element).data('marker-investments-coordinates')
-    editable                 = $(element).data('marker-editable')
+    mapCenterLatitude        = $(element).data("map-center-latitude")
+    mapCenterLongitude       = $(element).data("map-center-longitude")
+    markerLatitude           = $(element).data("marker-latitude")
+    markerLongitude          = $(element).data("marker-longitude")
+    zoom                     = $(element).data("map-zoom")
+    mapTilesProvider         = $(element).data("map-tiles-provider")
+    mapAttribution           = $(element).data("map-tiles-provider-attribution")
+    latitudeInputSelector    = $(element).data("latitude-input-selector")
+    longitudeInputSelector   = $(element).data("longitude-input-selector")
+    zoomInputSelector        = $(element).data("zoom-input-selector")
+    removeMarkerSelector     = $(element).data("marker-remove-selector")
+    addMarkerInvestments     = $(element).data("marker-investments-coordinates")
+    editable                 = $(element).data("marker-editable")
     marker                   = null
     markerIcon               = L.divIcon(
-      className: 'map-marker'
+      className: "map-marker"
       iconSize:     [30, 30]
       iconAnchor:   [15, 40]
       html: '<div class="map-icon"></div>'
@@ -39,7 +39,7 @@ App.Map =
       markerLatLng  = new (L.LatLng)(latitude, longitude)
       marker  = L.marker(markerLatLng, { icon: markerIcon, draggable: editable })
       if editable
-        marker.on 'dragend', updateFormfields
+        marker.on "dragend", updateFormfields
       marker.addTo(map)
       return marker
 
@@ -67,22 +67,22 @@ App.Map =
       return
 
     clearFormfields = ->
-      $(latitudeInputSelector).val ''
-      $(longitudeInputSelector).val ''
-      $(zoomInputSelector).val ''
+      $(latitudeInputSelector).val ""
+      $(longitudeInputSelector).val ""
+      $(zoomInputSelector).val ""
       return
 
     openMarkerPopup = (e) ->
       marker = e.target
 
-      $.ajax "/investments/#{marker.options['id']}/json_data",
-        type: 'GET'
-        dataType: 'json'
+      $.ajax "/investments/#{marker.options["id"]}/json_data",
+        type: "GET"
+        dataType: "json"
         success: (data) ->
           e.target.bindPopup(getPopupContent(data)).openPopup()
 
     getPopupContent = (data) ->
-      content = "<a href='/budgets/#{data['budget_id']}/investments/#{data['investment_id']}'>#{data['investment_title']}</a>"
+      content = "<a href='/budgets/#{data["budget_id"]}/investments/#{data["investment_id"]}'>#{data["investment_title"]}</a>"
       return content
 
     mapCenterLatLng  = new (L.LatLng)(mapCenterLatitude, mapCenterLongitude)
@@ -93,27 +93,27 @@ App.Map =
       marker  = createMarker(markerLatitude, markerLongitude)
 
     if editable
-      $(removeMarkerSelector).on 'click', removeMarker
-      map.on    'zoomend', updateFormfields
-      map.on    'click',   moveOrPlaceMarker
+      $(removeMarkerSelector).on "click", removeMarker
+      map.on    "zoomend", updateFormfields
+      map.on    "click",   moveOrPlaceMarker
 
     if addMarkerInvestments
       for i in addMarkerInvestments
         if App.Map.validCoordinates(i)
           marker = createMarker(i.lat, i.long)
-          marker.options['id'] = i.investment_id
+          marker.options["id"] = i.investment_id
 
-          marker.on 'click', openMarkerPopup
+          marker.on "click", openMarkerPopup
 
   toggleMap: ->
-    $('.map').toggle()
-    $('.js-location-map-remove-marker').toggle()
+    $(".map").toggle()
+    $(".js-location-map-remove-marker").toggle()
 
   cleanInvestmentCoordinates: (element) ->
-    markers = $(element).attr('data-marker-investments-coordinates')
+    markers = $(element).attr("data-marker-investments-coordinates")
     if markers?
       clean_markers = markers.replace(/-?(\*+)/g, null)
-      $(element).attr('data-marker-investments-coordinates', clean_markers)
+      $(element).attr("data-marker-investments-coordinates", clean_markers)
 
   validCoordinates: (coordinates) ->
     App.Map.isNumeric(coordinates.lat) && App.Map.isNumeric(coordinates.long)

--- a/app/assets/javascripts/markdown_editor.js.coffee
+++ b/app/assets/javascripts/markdown_editor.js.coffee
@@ -3,15 +3,15 @@ App.MarkdownEditor =
   refresh_preview: (element, md) ->
     textarea_content = App.MarkdownEditor.find_textarea(element).val()
     result = md.render(textarea_content)
-    element.find('.markdown-preview').html(result)
+    element.find(".markdown-preview").html(result)
 
   # Multi-locale (translatable) form fields work by hiding inputs of locales
   # which are not "active".
   find_textarea: (editor) ->
-    editor.find('textarea')
+    editor.find("textarea")
 
   initialize: ->
-    $('.markdown-editor').each ->
+    $(".markdown-editor").each ->
       md = window.markdownit({
         html: true,
         breaks: true,
@@ -20,25 +20,25 @@ App.MarkdownEditor =
 
       editor = $(this)
 
-      editor.on 'input', ->
+      editor.on "input", ->
         App.MarkdownEditor.refresh_preview($(this), md)
-        $('.legislation-draft-versions-edit .warning').show()
+        $(".legislation-draft-versions-edit .warning").show()
         return
 
-      editor.find('textarea').on 'scroll', ->
-        editor.find('.markdown-preview').scrollTop($(this).scrollTop())
+      editor.find("textarea").on "scroll", ->
+        editor.find(".markdown-preview").scrollTop($(this).scrollTop())
 
-      editor.find('.fullscreen-toggle').on 'click', ->
-        editor.toggleClass('fullscreen')
-        $('.fullscreen-container').toggleClass('medium-8', 'medium-12')
-        span = $(this).find('span')
+      editor.find(".fullscreen-toggle").on "click", ->
+        editor.toggleClass("fullscreen")
+        $(".fullscreen-container").toggleClass("medium-8", "medium-12")
+        span = $(this).find("span")
         current_html = span.html()
-        if(current_html == span.data('open-text'))
-          span.html(span.data('closed-text'))
+        if(current_html == span.data("open-text"))
+          span.html(span.data("closed-text"))
         else
-          span.html(span.data('open-text'))
+          span.html(span.data("open-text"))
 
-        if editor.hasClass('fullscreen')
+        if editor.hasClass("fullscreen")
           App.MarkdownEditor.find_textarea(editor).height($(window).height() - 100)
           App.MarkdownEditor.refresh_preview(editor, md)
         else

--- a/app/assets/javascripts/polls.js.coffee
+++ b/app/assets/javascripts/polls.js.coffee
@@ -23,7 +23,7 @@ App.Polls =
       click: =>
         token_message = $(".js-token-message")
         if !token_message.is(':visible')
-          token_message.html(token_message.html() + "<br><strong>" + @token + "</strong>")
+          token_message.html("#{token_message.html()}<br><strong>#{@token}</strong>")
           token_message.show()
     false
 

--- a/app/assets/javascripts/polls.js.coffee
+++ b/app/assets/javascripts/polls.js.coffee
@@ -1,7 +1,7 @@
 App.Polls =
   generateToken: ->
-    token = ''
-    rand = ''
+    token = ""
+    rand = ""
     for n in [0..5]
       rand = Math.random().toString(36).substr(2) # remove `0.`
       token = token + rand
@@ -10,7 +10,7 @@ App.Polls =
     return token
 
   replaceToken: ->
-    for link in $('.js-question-answer')
+    for link in $(".js-question-answer")
       token_param = link.search.slice(-6)
       if token_param == "token="
         link.href = link.href + @token
@@ -22,22 +22,22 @@ App.Polls =
     $(".js-question-answer").on
       click: =>
         token_message = $(".js-token-message")
-        if !token_message.is(':visible')
+        if !token_message.is(":visible")
           token_message.html("#{token_message.html()}<br><strong>#{@token}</strong>")
           token_message.show()
     false
 
     $(".zoom-link").on "click", (event) ->
       element = event.target
-      answer = $(element).closest('div.answer')
+      answer = $(element).closest("div.answer")
 
-      if $(answer).hasClass('medium-6')
+      if $(answer).hasClass("medium-6")
         $(answer).removeClass("medium-6")
         $(answer).addClass("answer-divider")
-        unless $(answer).hasClass('first')
-          $(answer).insertBefore($(answer).prev('div.answer'))
+        unless $(answer).hasClass("first")
+          $(answer).insertBefore($(answer).prev("div.answer"))
       else
         $(answer).addClass("medium-6")
         $(answer).removeClass("answer-divider")
-        unless $(answer).hasClass('first')
-          $(answer).insertAfter($(answer).next('div.answer'))
+        unless $(answer).hasClass("first")
+          $(answer).insertAfter($(answer).next("div.answer"))

--- a/app/assets/javascripts/polls_admin.js.coffee
+++ b/app/assets/javascripts/polls_admin.js.coffee
@@ -4,9 +4,9 @@ App.PollsAdmin =
     $("select[class='js-poll-shifts']").on
       change: ->
         switch ($(this).val())
-          when 'vote_collection'
+          when "vote_collection"
             $("select[class='js-shift-vote-collection-dates']").show()
             $("select[class='js-shift-recount-scrutiny-dates']").hide()
-          when 'recount_scrutiny'
+          when "recount_scrutiny"
             $("select[class='js-shift-recount-scrutiny-dates']").show()
             $("select[class='js-shift-vote-collection-dates']").hide()

--- a/app/assets/javascripts/prevent_double_submission.js.coffee
+++ b/app/assets/javascripts/prevent_double_submission.js.coffee
@@ -3,35 +3,35 @@ App.PreventDoubleSubmission =
     setTimeout ->
       buttons.each ->
         button = $(this)
-        unless button.hasClass('disabled')
-          loading = button.data('loading') ? '...'
-          button.addClass('disabled').attr('disabled', 'disabled')
-          button.data('text', button.val())
+        unless button.hasClass("disabled")
+          loading = button.data("loading") ? "..."
+          button.addClass("disabled").attr("disabled", "disabled")
+          button.data("text", button.val())
           button.val(loading)
     , 1
 
   reset_buttons: (buttons) ->
     buttons.each ->
       button = $(this)
-      if button.hasClass('disabled')
-        button_text = button.data('text')
-        button.removeClass('disabled').attr('disabled', null)
+      if button.hasClass("disabled")
+        button_text = button.data("text")
+        button.removeClass("disabled").attr("disabled", null)
         if button_text
           button.val(button_text)
-          button.data('text', null)
+          button.data("text", null)
 
   initialize: ->
-    $('form').on('submit', (event) ->
+    $("form").on("submit", (event) ->
       unless event.target.id == "new_officing_voter" ||
              event.target.id == "admin_download_emails"
 
-        buttons = $(this).find(':button, :submit')
+        buttons = $(this).find(":button, :submit")
         App.PreventDoubleSubmission.disable_buttons(buttons)
-    ).on('ajax:success', (event) ->
+    ).on("ajax:success", (event) ->
       unless event.target.id == "new_officing_voter" ||
              event.target.id == "admin_download_emails"
 
-        buttons = $(this).find(':button, :submit')
+        buttons = $(this).find(":button, :submit")
         App.PreventDoubleSubmission.reset_buttons(buttons)
     )
 

--- a/app/assets/javascripts/send_admin_notification_alert.js.coffee
+++ b/app/assets/javascripts/send_admin_notification_alert.js.coffee
@@ -1,4 +1,4 @@
 App.SendAdminNotificationAlert =
   initialize: ->
-    $('#js-send-admin_notification-alert').on 'click', ->
+    $("#js-send-admin_notification-alert").on "click", ->
       confirm(this.dataset.alert)

--- a/app/assets/javascripts/send_newsletter_alert.js.coffee
+++ b/app/assets/javascripts/send_newsletter_alert.js.coffee
@@ -1,4 +1,4 @@
 App.SendNewsletterAlert =
   initialize: ->
-    $('#js-send-newsletter-alert').on 'click', ->
+    $("#js-send-newsletter-alert").on "click", ->
       confirm(this.dataset.alert)

--- a/app/assets/javascripts/social_share.js.coffee
+++ b/app/assets/javascripts/social_share.js.coffee
@@ -3,5 +3,5 @@ App.SocialShare =
   initialize: ->
     $(".social-share-button a").each ->
       element = $(this)
-      site = element.data('site')
+      site = element.data("site")
       element.append("<span class='show-for-sr'>#{site}</span>")

--- a/app/assets/javascripts/sortable.js.coffee
+++ b/app/assets/javascripts/sortable.js.coffee
@@ -2,8 +2,8 @@ App.Sortable =
   initialize: ->
     $(".sortable").sortable
       update: (event, ui) ->
-        new_order = $(this).sortable('toArray', { attribute: 'data-answer-id' })
+        new_order = $(this).sortable("toArray", { attribute: "data-answer-id" })
         $.ajax
-          url: $('.sortable').data('js-url'),
+          url: $(".sortable").data("js-url"),
           data: { ordered_list: new_order },
-          type: 'POST'
+          type: "POST"

--- a/app/assets/javascripts/stats.js.coffee
+++ b/app/assets/javascripts/stats.js.coffee
@@ -2,8 +2,8 @@
 #----------------------------------------------------------------------
 
 buildGraph = (el) ->
-  url = $(el).data 'graph'
-  conf = bindto: el,  data: { x: 'x', url: url, mimeType: 'json' },  axis: { x: { type: 'timeseries', tick: { format: '%Y-%m-%d' } } }
+  url = $(el).data "graph"
+  conf = bindto: el,  data: { x: "x", url: url, mimeType: "json" },  axis: { x: { type: "timeseries", tick: { format: "%Y-%m-%d" } } }
   graph = c3.generate conf
 
 App.Stats =

--- a/app/assets/javascripts/suggest.js.coffee
+++ b/app/assets/javascripts/suggest.js.coffee
@@ -2,24 +2,24 @@ App.Suggest =
 
   initialize: ->
 
-    $('[data-js-suggest-result]').each ->
+    $("[data-js-suggest-result]").each ->
 
       $this = $(this)
 
       callback = ->
         $.ajax
-          url: $this.data('js-url')
+          url: $this.data("js-url")
           data: { search: $this.val() },
-          type: 'GET',
-          dataType: 'html'
+          type: "GET",
+          dataType: "html"
           success: (stHtml) ->
-            js_suggest_selector = $this.data('js-suggest')
+            js_suggest_selector = $this.data("js-suggest")
             $(js_suggest_selector).html(stHtml)
 
       timer = null
 
-      $this.on 'keyup', ->
+      $this.on "keyup", ->
         window.clearTimeout(timer)
         timer = window.setTimeout(callback, 1000)
 
-      $this.on 'change', callback
+      $this.on "change", callback

--- a/app/assets/javascripts/table_sortable.js.coffee
+++ b/app/assets/javascripts/table_sortable.js.coffee
@@ -1,6 +1,6 @@
 App.TableSortable =
   getCellValue: (row, index) ->
-    $(row).children('td').eq(index).text()
+    $(row).children("td").eq(index).text()
 
   comparer: (index) ->
     (a, b) ->
@@ -9,9 +9,9 @@ App.TableSortable =
       return if $.isNumeric(valA) and $.isNumeric(valB) then valA - valB else valA.localeCompare(valB)
 
   initialize: ->
-    $('table.sortable th').click ->
-      table = $(this).parents('table').eq(0)
-      rows = table.find('tr:gt(0)').not('tfoot tr').toArray().sort(App.TableSortable.comparer($(this).index()))
+    $("table.sortable th").click ->
+      table = $(this).parents("table").eq(0)
+      rows = table.find("tr:gt(0)").not("tfoot tr").toArray().sort(App.TableSortable.comparer($(this).index()))
       @asc = !@asc
       if !@asc
         rows = rows.reverse()

--- a/app/assets/javascripts/tag_autocomplete.js.coffee
+++ b/app/assets/javascripts/tag_autocomplete.js.coffee
@@ -7,13 +7,13 @@ App.TagAutocomplete =
     return (App.TagAutocomplete.split( term ).pop())
 
   init_autocomplete: ->
-    $('.tag-autocomplete').autocomplete
+    $(".tag-autocomplete").autocomplete
       source: (request, response) ->
         $.ajax
-          url: $('.tag-autocomplete').data('js-url'),
+          url: $(".tag-autocomplete").data("js-url"),
           data: { search: App.TagAutocomplete.extractLast( request.term ) },
-          type: 'GET',
-          dataType: 'json'
+          type: "GET",
+          dataType: "json"
           success: ( data ) ->
             response( data )
 

--- a/app/assets/javascripts/tags.js.coffee
+++ b/app/assets/javascripts/tags.js.coffee
@@ -1,21 +1,21 @@
 App.Tags =
 
   initialize: ->
-    $tag_input = $('input.js-tag-list')
+    $tag_input = $("input.js-tag-list")
 
-    $('body .js-add-tag-link').each ->
+    $("body .js-add-tag-link").each ->
       $this = $(this)
 
-      unless $this.data('initialized') is 'yes'
-        $this.on('click', ->
+      unless $this.data("initialized") is "yes"
+        $this.on("click", ->
           name = "\"#{$(this).text()}\""
-          current_tags = $tag_input.val().split(',').filter(Boolean)
+          current_tags = $tag_input.val().split(",").filter(Boolean)
 
           if $.inArray(name, current_tags) >= 0
             current_tags.splice($.inArray(name, current_tags), 1)
           else
             current_tags.push name
 
-          $tag_input.val(current_tags.join(','))
+          $tag_input.val(current_tags.join(","))
           false
-        ).data 'initialized', 'yes'
+        ).data "initialized", "yes"

--- a/app/assets/javascripts/tags.js.coffee
+++ b/app/assets/javascripts/tags.js.coffee
@@ -8,7 +8,7 @@ App.Tags =
 
       unless $this.data('initialized') is 'yes'
         $this.on('click', ->
-          name = '"' + $(this).text() + '"'
+          name = "\"#{$(this).text()}\""
           current_tags = $tag_input.val().split(',').filter(Boolean)
 
           if $.inArray(name, current_tags) >= 0

--- a/app/assets/javascripts/tracks.js.coffee
+++ b/app/assets/javascripts/tracks.js.coffee
@@ -4,25 +4,25 @@ App.Tracks =
     _paq?
 
   set_custom_var: (id, name, value, scope) ->
-    _paq.push(['setCustomVariable', id, name, value, scope])
-    _paq.push(['trackPageView'])
+    _paq.push(["setCustomVariable", id, name, value, scope])
+    _paq.push(["trackPageView"])
 
   track_event: ($this) ->
-    category = $this.data('track-event-category')
-    action   = $this.data('track-event-action')
-    _paq.push(['trackEvent', category, action])
+    category = $this.data("track-event-category")
+    action   = $this.data("track-event-action")
+    _paq.push(["trackEvent", category, action])
 
   initialize: ->
     if App.Tracks.tracking_enabled()
-      $('[data-track-usertype]').each ->
+      $("[data-track-usertype]").each ->
         $this = $(this)
-        usertype = $this.data('track-usertype')
+        usertype = $this.data("track-usertype")
         App.Tracks.set_custom_var(1, "usertype", usertype, "visit")
 
-      $('[data-track-event-category]').each ->
+      $("[data-track-event-category]").each ->
         $this = $(this)
         App.Tracks.track_event($this)
 
-      $('[data-track-click]').on 'click', ->
+      $("[data-track-click]").on "click", ->
         $this = $(this)
         App.Tracks.track_event($this)

--- a/app/assets/javascripts/tree_navigator.js.coffee
+++ b/app/assets/javascripts/tree_navigator.js.coffee
@@ -30,7 +30,7 @@ App.TreeNavigator =
           elem.siblings('ul').show()
 
     if anchor = $(location).attr('hash')
-      if link = elem.find('a[href="' + anchor + '"]')
+      if link = elem.find("a[href='#{anchor}']")
         link.parents('ul').each ->
           $(this).show()
           $(this).siblings('span').removeClass('closed').addClass('open')

--- a/app/assets/javascripts/tree_navigator.js.coffee
+++ b/app/assets/javascripts/tree_navigator.js.coffee
@@ -1,36 +1,36 @@
 App.TreeNavigator =
   setNodes: (nodes) ->
-    children = nodes.children('ul')
+    children = nodes.children("ul")
 
     if(children.length == 0)
       return
 
     children.each ->
-      link = $(this).prev('a')
+      link = $(this).prev("a")
       $('<span class="open"></span>').insertBefore(link)
       App.TreeNavigator.setNodes($(this).children())
 
   initialize: ->
-    elem = $('[data-tree-navigator]')
+    elem = $("[data-tree-navigator]")
     if(elem.length == 0)
       return
 
-    ul = elem.find('ul:eq(0)')
+    ul = elem.find("ul:eq(0)")
     if(ul.length && ul.children().length)
       App.TreeNavigator.setNodes(ul.children())
 
-    $('[data-tree-navigator] span').on
+    $("[data-tree-navigator] span").on
       click: (e) ->
         elem = $(this)
-        if(elem.hasClass('open'))
-          elem.removeClass('open').addClass('closed')
-          elem.siblings('ul').hide()
-        else if(elem.hasClass('closed'))
-          elem.removeClass('closed').addClass('open')
-          elem.siblings('ul').show()
+        if(elem.hasClass("open"))
+          elem.removeClass("open").addClass("closed")
+          elem.siblings("ul").hide()
+        else if(elem.hasClass("closed"))
+          elem.removeClass("closed").addClass("open")
+          elem.siblings("ul").show()
 
-    if anchor = $(location).attr('hash')
+    if anchor = $(location).attr("hash")
       if link = elem.find("a[href='#{anchor}']")
-        link.parents('ul').each ->
+        link.parents("ul").each ->
           $(this).show()
-          $(this).siblings('span').removeClass('closed').addClass('open')
+          $(this).siblings("span").removeClass("closed").addClass("open")

--- a/app/assets/javascripts/users.js.coffee
+++ b/app/assets/javascripts/users.js.coffee
@@ -1,5 +1,5 @@
 App.Users =
 
   initialize: ->
-    $('.initialjs-avatar').initial()
+    $(".initialjs-avatar").initial()
     false

--- a/app/assets/javascripts/valuation_budget_investment_form.js.coffee
+++ b/app/assets/javascripts/valuation_budget_investment_form.js.coffee
@@ -1,22 +1,22 @@
 App.ValuationBudgetInvestmentForm =
 
   showFeasibleFields: ->
-    $('#valuation_budget_investment_edit_form #unfeasible_fields').hide('down')
-    $('#valuation_budget_investment_edit_form #feasible_fields').show()
+    $("#valuation_budget_investment_edit_form #unfeasible_fields").hide("down")
+    $("#valuation_budget_investment_edit_form #feasible_fields").show()
 
   showNotFeasibleFields: ->
-    $('#valuation_budget_investment_edit_form #feasible_fields').hide('down')
-    $('#valuation_budget_investment_edit_form #unfeasible_fields').show()
+    $("#valuation_budget_investment_edit_form #feasible_fields").hide("down")
+    $("#valuation_budget_investment_edit_form #unfeasible_fields").show()
 
   showAllFields: ->
-    $('#valuation_budget_investment_edit_form #feasible_fields').show('down')
-    $('#valuation_budget_investment_edit_form #unfeasible_fields').show('down')
+    $("#valuation_budget_investment_edit_form #feasible_fields").show("down")
+    $("#valuation_budget_investment_edit_form #unfeasible_fields").show("down")
 
   showFeasibilityFields: ->
     feasibility = $("#valuation_budget_investment_edit_form input[type=radio][name='budget_investment[feasibility]']:checked").val()
-    if feasibility == 'feasible'
+    if feasibility == "feasible"
       App.ValuationBudgetInvestmentForm.showFeasibleFields()
-    else if feasibility == 'unfeasible'
+    else if feasibility == "unfeasible"
       App.ValuationBudgetInvestmentForm.showNotFeasibleFields()
 
 

--- a/app/assets/javascripts/valuation_spending_proposal_form.js.coffee
+++ b/app/assets/javascripts/valuation_spending_proposal_form.js.coffee
@@ -1,22 +1,22 @@
 App.ValuationSpendingProposalForm =
 
   showFeasibleFields: ->
-    $('#valuation_spending_proposal_edit_form #not_feasible_fields').hide('down')
-    $('#valuation_spending_proposal_edit_form #feasible_fields').show()
+    $("#valuation_spending_proposal_edit_form #not_feasible_fields").hide("down")
+    $("#valuation_spending_proposal_edit_form #feasible_fields").show()
 
   showNotFeasibleFields: ->
-    $('#valuation_spending_proposal_edit_form #feasible_fields').hide('down')
-    $('#valuation_spending_proposal_edit_form #not_feasible_fields').show()
+    $("#valuation_spending_proposal_edit_form #feasible_fields").hide("down")
+    $("#valuation_spending_proposal_edit_form #not_feasible_fields").show()
 
   showAllFields: ->
-    $('#valuation_spending_proposal_edit_form #feasible_fields').show('down')
-    $('#valuation_spending_proposal_edit_form #not_feasible_fields').show('down')
+    $("#valuation_spending_proposal_edit_form #feasible_fields").show("down")
+    $("#valuation_spending_proposal_edit_form #not_feasible_fields").show("down")
 
   showFeasibilityFields: ->
     feasible = $("#valuation_spending_proposal_edit_form input[type=radio][name='spending_proposal[feasible]']:checked").val()
-    if feasible == 'true'
+    if feasible == "true"
       App.ValuationSpendingProposalForm.showFeasibleFields()
-    else if feasible == 'false'
+    else if feasible == "false"
       App.ValuationSpendingProposalForm.showNotFeasibleFields()
 
 

--- a/app/assets/javascripts/votes.js.coffee
+++ b/app/assets/javascripts/votes.js.coffee
@@ -2,7 +2,7 @@ App.Votes =
 
   hoverize: (votes) ->
     $(document).on {
-      'mouseenter focus': ->
+      "mouseenter focus": ->
         $("div.participation-not-allowed", this).show()
         $("div.participation-allowed", this).hide()
       mouseleave: ->

--- a/app/assets/javascripts/watch_form_changes.js.coffee
+++ b/app/assets/javascripts/watch_form_changes.js.coffee
@@ -1,16 +1,16 @@
 App.WatchFormChanges =
   forms: ->
-    return $('form[data-watch-changes]')
+    return $("form[data-watch-changes]")
 
   msg: ->
-    if($('[data-watch-form-message]').length)
-      return $('[data-watch-form-message]').data('watch-form-message')
+    if($("[data-watch-form-message]").length)
+      return $("[data-watch-form-message]").data("watch-form-message")
 
   checkChanges: (event) ->
     changes = false
     App.WatchFormChanges.forms().each ->
       form = $(this)
-      if form.serialize() != form.data('watchChanges')
+      if form.serialize() != form.data("watchChanges")
         changes = true
     if changes
       return confirm(App.WatchFormChanges.msg())
@@ -21,10 +21,10 @@ App.WatchFormChanges =
     if App.WatchFormChanges.forms().length == 0 || App.WatchFormChanges.msg() == undefined
       return
 
-    $(document).off('page:before-change').on('page:before-change', (e) -> App.WatchFormChanges.checkChanges(e))
+    $(document).off("page:before-change").on("page:before-change", (e) -> App.WatchFormChanges.checkChanges(e))
 
     App.WatchFormChanges.forms().each ->
       form = $(this)
-      form.data('watchChanges', form.serialize())
+      form.data("watchChanges", form.serialize())
 
     false


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1900
* Pull request #3338

## Objectives

Use double quotes instead of single quotes in CoffeeScript files, just like we do in the rest of the application, in order to make the code more consistent and easier to read.

## Notes

* CoffeeLint doesn't a have a rule to enforce double quotes, so we won't get warnings when we use single quotes.
* This pull request depends on pull request #3338. Rebase against the `master` branch once #3338  is merged.