### PR TITLE
[Backport] Show unfeasible budget investment messages only when valuation finished

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -146,7 +146,7 @@
           <% end %>
         <% end %>
 
-        <% if investment.unfeasible? %>
+        <% if investment.unfeasible? && investment.valuation_finished? %>
           <div class="callout warning">
             <%= t("budgets.investments.show.project_unfeasible_html") %>
           </div>

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1097,23 +1097,38 @@ feature 'Budget Investments' do
 
   end
 
-  scenario "Show (unfeasible budget investment)" do
+  scenario "Show (unfeasible budget investment) only when valuation finished" do
     user = create(:user)
     login_as(user)
 
     investment = create(:budget_investment,
                         :unfeasible,
+                        budget: budget,
+                        group: group,
+                        heading: heading,
+                        unfeasibility_explanation: "Local government is not competent in this")
+
+    investment_2 = create(:budget_investment,
+                        :unfeasible,
                         :finished,
                         budget: budget,
                         group: group,
                         heading: heading,
-                        unfeasibility_explanation: 'Local government is not competent in this matter')
+                        unfeasibility_explanation: "The unfeasible explanation")
 
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
 
+    expect(page).not_to have_content("Unfeasibility explanation")
+    expect(page).not_to have_content("Local government is not competent in this")
+    expect(page).not_to have_content("This investment project has been marked as not feasible "\
+                                     "and will not go to balloting phase")
+
+    visit budget_investment_path(budget_id: budget.id, id: investment_2.id)
+
     expect(page).to have_content("Unfeasibility explanation")
-    expect(page).to have_content("Local government is not competent in this matter")
-    expect(page).to have_content("This investment project has been marked as not feasible and will not go to balloting phase")
+    expect(page).to have_content("The unfeasible explanation")
+    expect(page).to have_content("This investment project has been marked as not feasible "\
+                                 "and will not go to balloting phase")
   end
 
   scenario "Show (selected budget investment)" do


### PR DESCRIPTION
## References

Backport of https://github.com/AyuntamientoMadrid/consul/pull/1903.

## Objectives

Show unfeasible budget investment messages only when valuation finished.

## Visual Changes

Now the message `This investment project has been marked as not feasible and will not go to balloting phase` only appears when valuation is marked as finished.

![screenshot 2019-03-06 at 10 07 45](https://user-images.githubusercontent.com/631897/53869146-e56b5780-3ff7-11e9-989d-27230a12ee15.png)

![screenshot 2019-03-06 at 10 07 30](https://user-images.githubusercontent.com/631897/53869151-e7351b00-3ff7-11e9-97de-9e9765692b9e.png)