### PR TITLE
[Backport] Add cumulative totals to admin poll recounts list

### DIFF
--- a/app/controllers/admin/poll/recounts_controller.rb
+++ b/app/controllers/admin/poll/recounts_controller.rb
@@ -6,6 +6,10 @@ class Admin::Poll::RecountsController < Admin::Poll::BaseController
                               includes(:booth, :recounts, :voters).
                               order("poll_booths.name").
                               page(params[:page]).per(50)
+    @all_booths_counts = {
+      final: ::Poll::Recount.select(:total_amount).where(booth_assignment_id: @poll.booth_assignment_ids).sum(:total_amount),
+      system: ::Poll::Voter.where(booth_assignment_id: @poll.booth_assignment_ids).count
+    }
   end
 
   private

--- a/app/views/admin/poll/recounts/index.html.erb
+++ b/app/views/admin/poll/recounts/index.html.erb
@@ -9,6 +9,24 @@
       <%= t("admin.recounts.index.no_recounts") %>
     </div>
   <% else %>
+
+    <table id="totals">
+      <thead>
+        <tr>
+          <th class="text-center"></th>
+          <th class="text-center"><%= t("admin.recounts.index.total_final") %></th>
+          <th class="text-center"><%= t("admin.recounts.index.total_system") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong><%= t("admin.recounts.index.all_booths_total") %></strong></td>
+          <td class="text-center" id="total_final"><%=  @all_booths_counts[:final] %></td>
+          <td class="text-center" id="total_system"><%= @all_booths_counts[:system] %></td>
+        </tr>
+      </tbody>
+    </table>
+
     <table class="fixed margin">
       <thead>
         <th><%= t("admin.recounts.index.table_booth_name") %></th>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1049,6 +1049,9 @@ en:
       index:
         title: "Recounts"
         no_recounts: "There is nothing to be recounted"
+        all_booths_total: "Cumulative total from all booths:"
+        total_final: "Final recounts"
+        total_system: "Votes (automatic)"
         table_booth_name: "Booth"
         table_total_recount: "Total recount (by officer)"
         table_system_count: "Votes (automatic)"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1048,6 +1048,9 @@ es:
       index:
         title: "Recuentos"
         no_recounts: "No hay nada de lo que hacer recuento"
+        all_booths_total: "Acumulado en todas las urnas:"
+        total_final: "Recuentos finales"
+        total_system: "Votos (automático)"
         table_booth_name: "Urna"
         table_total_recount: "Recuento total (presidente de mesa)"
         table_system_count: "Votos (automático)"

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -239,6 +239,16 @@ feature 'Admin polls' do
 
         click_link "Recounting"
 
+        within("#totals") do
+          within("#total_final") do
+            expect(page).to have_content("#{55555 + 63}")
+          end
+
+          within("#total_system") do
+            expect(page).to have_content("2")
+          end
+        end
+
         expect(page).to have_css ".booth_recounts", count: 3
 
         within("#poll_booth_assignment_#{booth_assignment.id}_recounts") do


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#633
* Also backports parts of commits AyuntamientoMadrid@90638672, AyuntamientoMadrid@03371a71, AyuntamientoMadrid@fe3492a7, AyuntamientoMadrid@aa59d995 and AyuntamientoMadrid@c40e8d79

## Objectives

Show a table with cumulative total recounts in admin polls.

## Visual Changes

![Cumulative total recounts from all booths](https://user-images.githubusercontent.com/35156/53887189-0b0d5680-4022-11e9-833f-e6caaa9cbd2c.png)