### PR TITLE
Add officing booths

### DIFF
--- a/app/controllers/officing/base_controller.rb
+++ b/app/controllers/officing/base_controller.rb
@@ -26,9 +26,13 @@ class Officing::BaseController < ApplicationController
     end
 
     def verify_booth
-      if session[:booth_id].blank?
+      if current_booth.blank?
         redirect_to new_officing_booth_path
       end
+    end
+
+    def current_booth
+      Poll::Booth.where(id: session[:booth_id]).first
     end
 
 end

--- a/app/controllers/officing/base_controller.rb
+++ b/app/controllers/officing/base_controller.rb
@@ -27,13 +27,24 @@ class Officing::BaseController < ApplicationController
     end
 
     def verify_booth
-      if current_booth.blank?
+      return unless current_booth.blank?
+      booths = todays_booths_for_officer(current_user.poll_officer)
+      case booths.count
+      when 0
+        redirect_to officing_root_path
+      when 1
+        session[:booth_id] = booths.first.id
+      else
         redirect_to new_officing_booth_path
       end
     end
 
     def current_booth
       Poll::Booth.where(id: session[:booth_id]).first
+    end
+
+    def todays_booths_for_officer(officer)
+      officer.officer_assignments.by_date(Date.today).map(&:booth).uniq
     end
 
 end

--- a/app/controllers/officing/base_controller.rb
+++ b/app/controllers/officing/base_controller.rb
@@ -28,7 +28,7 @@ class Officing::BaseController < ApplicationController
 
     def verify_booth
       return unless current_booth.blank?
-      booths = todays_booths_for_officer(current_user.poll_officer)
+      booths = current_user.poll_officer.todays_booths
       case booths.count
       when 0
         redirect_to officing_root_path
@@ -41,10 +41,6 @@ class Officing::BaseController < ApplicationController
 
     def current_booth
       Poll::Booth.where(id: session[:booth_id]).first
-    end
-
-    def todays_booths_for_officer(officer)
-      officer.officer_assignments.by_date(Date.today).map(&:booth).uniq
     end
 
 end

--- a/app/controllers/officing/base_controller.rb
+++ b/app/controllers/officing/base_controller.rb
@@ -6,7 +6,29 @@ class Officing::BaseController < ApplicationController
 
   skip_authorization_check
 
-  def verify_officer
-    raise CanCan::AccessDenied unless current_user.try(:poll_officer?)
-  end
+  private
+
+    def verify_officer
+      raise CanCan::AccessDenied unless current_user.try(:poll_officer?)
+    end
+
+    def load_officer_assignment
+      @officer_assignments ||= current_user.poll_officer.
+                               officer_assignments.
+                               voting_days.
+                               where(date: Time.current.to_date)
+    end
+
+    def verify_officer_assignment
+      if @officer_assignments.blank?
+        redirect_to officing_root_path, notice: t("officing.residence.flash.not_allowed")
+      end
+    end
+
+    def verify_booth
+      if session[:booth_id].blank?
+        redirect_to new_officing_booth_path
+      end
+    end
+
 end

--- a/app/controllers/officing/base_controller.rb
+++ b/app/controllers/officing/base_controller.rb
@@ -1,5 +1,6 @@
 class Officing::BaseController < ApplicationController
   layout "admin"
+  helper_method :current_booth
 
   before_action :authenticate_user!
   before_action :verify_officer

--- a/app/controllers/officing/booth_controller.rb
+++ b/app/controllers/officing/booth_controller.rb
@@ -7,14 +7,14 @@ class Officing::BoothController < Officing::BaseController
 
     if only_one_booth?
       set_booth(@booths.first)
-      redirect_to officing_root_path, notice: t("officing.booth.new.success", booth: @booths.first.name)
+      redirect_to officing_root_path, notice: t("officing.booth.new.success", booth: @booths.first.location)
     end
   end
 
   def create
     find_booth
     set_booth(@booth)
-    redirect_to officing_root_path, notice: t("officing.booth.new.success", booth: @booth.name)
+    redirect_to officing_root_path, notice: t("officing.booth.new.success", booth: @booth.location)
   end
 
   private

--- a/app/controllers/officing/booth_controller.rb
+++ b/app/controllers/officing/booth_controller.rb
@@ -3,7 +3,7 @@ class Officing::BoothController < Officing::BaseController
   before_action :verify_officer_assignment
 
   def new
-    @booths = todays_booths_for_officer(current_user.poll_officer)
+    @booths = current_user.poll_officer.todays_booths
   end
 
   def create

--- a/app/controllers/officing/booth_controller.rb
+++ b/app/controllers/officing/booth_controller.rb
@@ -7,14 +7,14 @@ class Officing::BoothController < Officing::BaseController
 
     if only_one_booth?
       set_booth(@booths.first)
-      redirect_to officing_root_path, notice: t("officing.booth.new.success", booth: @booths.first.location)
+      redirect_to officing_root_path
     end
   end
 
   def create
     find_booth
     set_booth(@booth)
-    redirect_to officing_root_path, notice: t("officing.booth.new.success", booth: @booth.location)
+    redirect_to officing_root_path
   end
 
   private

--- a/app/controllers/officing/booth_controller.rb
+++ b/app/controllers/officing/booth_controller.rb
@@ -25,7 +25,7 @@ class Officing::BoothController < Officing::BaseController
 
   def load_booths
     officer = current_user.poll_officer
-    @booths = officer.officer_assignments.by_date(Date.today).map(&:booth)
+    @booths = officer.officer_assignments.by_date(Date.today).map(&:booth).uniq
   end
 
   def only_one_booth?

--- a/app/controllers/officing/booth_controller.rb
+++ b/app/controllers/officing/booth_controller.rb
@@ -1,0 +1,43 @@
+class Officing::BoothController < Officing::BaseController
+  before_action :load_officer_assignment
+  before_action :verify_officer_assignment
+
+  def new
+    load_booths
+
+    if only_one_booth?
+      set_booth(@booths.first)
+      redirect_to officing_root_path, notice: t("officing.booth.new.success", booth: @booths.first.name)
+    end
+  end
+
+  def create
+    find_booth
+    set_booth(@booth)
+    redirect_to officing_root_path, notice: t("officing.booth.new.success", booth: @booth.name)
+  end
+
+  private
+
+  def booth_params
+    params.require(:booth).permit(:id)
+  end
+
+  def load_booths
+    officer = current_user.poll_officer
+    @booths = officer.officer_assignments.by_date(Date.today).map(&:booth)
+  end
+
+  def only_one_booth?
+    @booths.count == 1
+  end
+
+  def find_booth
+    @booth = Poll::Booth.find(booth_params[:id])
+  end
+
+  def set_booth(booth)
+    session[:booth_id] = booth.id
+  end
+
+end

--- a/app/controllers/officing/booth_controller.rb
+++ b/app/controllers/officing/booth_controller.rb
@@ -3,17 +3,11 @@ class Officing::BoothController < Officing::BaseController
   before_action :verify_officer_assignment
 
   def new
-    load_booths
-
-    if only_one_booth?
-      set_booth(@booths.first)
-      redirect_to officing_root_path
-    end
+    @booths = todays_booths_for_officer(current_user.poll_officer)
   end
 
   def create
-    find_booth
-    set_booth(@booth)
+    set_booth(Poll::Booth.find(booth_params[:id]))
     redirect_to officing_root_path
   end
 
@@ -21,19 +15,6 @@ class Officing::BoothController < Officing::BaseController
 
   def booth_params
     params.require(:booth).permit(:id)
-  end
-
-  def load_booths
-    officer = current_user.poll_officer
-    @booths = officer.officer_assignments.by_date(Date.today).map(&:booth).uniq
-  end
-
-  def only_one_booth?
-    @booths.count == 1
-  end
-
-  def find_booth
-    @booth = Poll::Booth.find(booth_params[:id])
   end
 
   def set_booth(booth)

--- a/app/controllers/officing/polls_controller.rb
+++ b/app/controllers/officing/polls_controller.rb
@@ -1,4 +1,5 @@
 class Officing::PollsController < Officing::BaseController
+  before_action :verify_booth
 
   def index
     @polls = current_user.poll_officer? ? current_user.poll_officer.voting_days_assigned_polls : []

--- a/app/controllers/officing/residence_controller.rb
+++ b/app/controllers/officing/residence_controller.rb
@@ -1,7 +1,6 @@
 class Officing::ResidenceController < Officing::BaseController
 
-  before_action :load_officer_assignment
-  before_action :validate_officer_assignment, only: :create
+  before_action :validate_officer_assignment
 
   def new
     @residence = Officing::Residence.new
@@ -23,13 +22,14 @@ class Officing::ResidenceController < Officing::BaseController
     end
 
     def load_officer_assignment
-      @officer_assignments = current_user.poll_officer.
+      @officer_assignments ||= current_user.poll_officer.
                                officer_assignments.
                                voting_days.
                                where(date: Date.current)
     end
 
     def validate_officer_assignment
+      load_officer_assignment
       if @officer_assignments.blank?
         redirect_to officing_root_path, notice: t("officing.residence.flash.not_allowed")
       end

--- a/app/controllers/officing/residence_controller.rb
+++ b/app/controllers/officing/residence_controller.rb
@@ -1,6 +1,8 @@
 class Officing::ResidenceController < Officing::BaseController
 
-  before_action :validate_officer_assignment
+  before_action :load_officer_assignment
+  before_action :verify_officer_assignment
+  before_action :verify_booth
 
   def new
     @residence = Officing::Residence.new
@@ -21,17 +23,4 @@ class Officing::ResidenceController < Officing::BaseController
       params.require(:residence).permit(:document_number, :document_type, :year_of_birth)
     end
 
-    def load_officer_assignment
-      @officer_assignments ||= current_user.poll_officer.
-                               officer_assignments.
-                               voting_days.
-                               where(date: Date.current)
-    end
-
-    def validate_officer_assignment
-      load_officer_assignment
-      if @officer_assignments.blank?
-        redirect_to officing_root_path, notice: t("officing.residence.flash.not_allowed")
-      end
-    end
 end

--- a/app/controllers/officing/results_controller.rb
+++ b/app/controllers/officing/results_controller.rb
@@ -8,6 +8,8 @@ class Officing::ResultsController < Officing::BaseController
   before_action :check_officer_assignment, only: :create
   before_action :build_results, only: :create
 
+  before_action :verify_booth
+
   def new
   end
 

--- a/app/controllers/officing/results_controller.rb
+++ b/app/controllers/officing/results_controller.rb
@@ -7,7 +7,6 @@ class Officing::ResultsController < Officing::BaseController
   before_action :load_officer_assignment, only: :create
   before_action :check_officer_assignment, only: :create
   before_action :build_results, only: :create
-
   before_action :verify_booth
 
   def new

--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -38,8 +38,4 @@ class Officing::VotersController < Officing::BaseController
                              .first
     end
 
-    def current_booth
-      Poll::Booth.find(session[:booth_id])
-    end
-
 end

--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -15,7 +15,8 @@ class Officing::VotersController < Officing::BaseController
                              user: @user,
                              poll: @poll,
                              origin: "booth",
-                             officer: current_user.poll_officer)
+                             officer: current_user.poll_officer,
+                             officer_assignment: officer_assignment(@poll))
     @voter.save!
   end
 
@@ -25,4 +26,10 @@ class Officing::VotersController < Officing::BaseController
       params.require(:voter).permit(:poll_id, :user_id)
     end
 
+    def officer_assignment(poll)
+      Poll::OfficerAssignment.by_officer(current_user.poll_officer)
+                             .by_poll(poll)
+                             .by_date(Date.current)
+                             .first
+    end
 end

--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -20,6 +20,7 @@ class Officing::VotersController < Officing::BaseController
                              poll: @poll,
                              origin: "booth",
                              officer: current_user.poll_officer,
+                             booth_assignment: Poll::BoothAssignment.where(poll: @poll, booth: current_booth).first,
                              officer_assignment: officer_assignment(@poll))
     @voter.save!
   end
@@ -35,6 +36,7 @@ class Officing::VotersController < Officing::BaseController
                              .by_poll(poll)
                              .by_booth(current_booth)
                              .by_date(Date.current)
+                             .where(final: false)
                              .first
     end
 

--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -1,6 +1,10 @@
 class Officing::VotersController < Officing::BaseController
   respond_to :html, :js
 
+  before_action :load_officer_assignment
+  before_action :verify_officer_assignment
+  before_action :verify_booth
+
   def new
     @user = User.find(params[:id])
     booths = current_user.poll_officer.shifts.current.vote_collection.pluck(:booth_id).uniq
@@ -29,7 +33,13 @@ class Officing::VotersController < Officing::BaseController
     def officer_assignment(poll)
       Poll::OfficerAssignment.by_officer(current_user.poll_officer)
                              .by_poll(poll)
+                             .by_booth(current_booth)
                              .by_date(Date.current)
                              .first
     end
+
+    def current_booth
+      Poll::Booth.find(session[:booth_id])
+    end
+
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,7 +3,9 @@ class Users::SessionsController < Devise::SessionsController
   private
 
     def after_sign_in_path_for(resource)
-      if !verifying_via_email? && resource.show_welcome_screen?
+      if current_user.poll_officer?
+        new_officing_booth_path
+      elsif !verifying_via_email? && resource.show_welcome_screen?
         welcome_path
       else
         super

--- a/app/helpers/officers_helper.rb
+++ b/app/helpers/officers_helper.rb
@@ -5,7 +5,7 @@ module OfficersHelper
   end
 
   def vote_collection_shift?
-    current_user.poll_officer.officer_assignments.where(date: Time.current.to_date).any?
+    current_user.poll_officer.officer_assignments.voting_days.where(date: Time.current.to_date).any?
   end
 
   def final_recount_shift?

--- a/app/helpers/officers_helper.rb
+++ b/app/helpers/officers_helper.rb
@@ -12,4 +12,8 @@ module OfficersHelper
     current_user.poll_officer.officer_assignments.final.where(date: Time.current.to_date).any?
   end
 
+  def no_shifts?
+    current_user.poll_officer.officer_assignments.where(date: Time.current.to_date).blank?
+  end
+
 end

--- a/app/models/poll/officer.rb
+++ b/app/models/poll/officer.rb
@@ -23,5 +23,9 @@ class Poll
                                sort {|x, y| y.ends_at <=> x.ends_at}
     end
 
+    def todays_booths
+      officer_assignments.by_date(Date.current).map(&:booth).uniq
+    end
+
   end
 end

--- a/app/models/poll/officer_assignment.rb
+++ b/app/models/poll/officer_assignment.rb
@@ -17,6 +17,9 @@ class Poll
     scope :by_officer_and_poll, ->(officer_id, poll_id) do
       where("officer_id = ? AND poll_booth_assignments.poll_id = ?", officer_id, poll_id)
     end
+    scope :by_officer, ->(officer){ where(officer_id: officer.id) }
+    scope :by_poll, ->(poll){ joins(:booth_assignment).where("poll_booth_assignments.poll_id" => poll.id) }
+    scope :by_date, ->(date){ where(date: date) }
 
     before_create :log_user_data
 

--- a/app/models/poll/officer_assignment.rb
+++ b/app/models/poll/officer_assignment.rb
@@ -18,7 +18,8 @@ class Poll
       where("officer_id = ? AND poll_booth_assignments.poll_id = ?", officer_id, poll_id)
     end
     scope :by_officer, ->(officer){ where(officer_id: officer.id) }
-    scope :by_poll, ->(poll){ joins(:booth_assignment).where("poll_booth_assignments.poll_id" => poll.id) }
+    scope :by_poll,  ->(poll){ joins(:booth_assignment).where("poll_booth_assignments.poll_id" => poll.id) }
+    scope :by_booth, ->(booth){ joins(:booth_assignment).where("poll_booth_assignments.booth_id" => booth.id) }
     scope :by_date, ->(date){ where(date: date) }
 
     before_create :log_user_data
@@ -26,5 +27,10 @@ class Poll
     def log_user_data
       self.user_data_log = "#{officer.user_id} - #{officer.user.name_and_email}"
     end
+
+    def booth
+      booth_assignment.booth
+    end
+
   end
 end

--- a/app/models/poll/voter.rb
+++ b/app/models/poll/voter.rb
@@ -12,6 +12,8 @@ class Poll
 
     validates :poll_id, presence: true
     validates :user_id, presence: true
+    validates :booth_assignment_id, presence: true, if: ->(voter) { voter.origin == "booth" }
+    validates :officer_assignment_id, presence: true, if: ->(voter) { voter.origin == "booth" }
 
     validates :document_number, presence: true, uniqueness: { scope: [:poll_id, :document_type], message: :has_voted }
     validates :origin, inclusion: { in: VALID_ORIGINS }

--- a/app/models/poll/voter.rb
+++ b/app/models/poll/voter.rb
@@ -16,7 +16,7 @@ class Poll
     validates :document_number, presence: true, uniqueness: { scope: [:poll_id, :document_type], message: :has_voted }
     validates :origin, inclusion: { in: VALID_ORIGINS }
 
-    before_validation :set_demographic_info, :set_document_info
+    before_validation :set_demographic_info, :set_document_info, :set_denormalized_booth_assignment_id
 
     scope :web,   -> { where(origin: "web") }
     scope :booth, -> { where(origin: "booth") }
@@ -37,6 +37,10 @@ class Poll
     end
 
     private
+
+      def set_denormalized_booth_assignment_id
+        self.booth_assignment_id ||= officer_assignment.try(:booth_assignment_id)
+      end
 
       def in_census?
         census_api_response.valid?

--- a/app/views/admin/poll/recounts/index.html.erb
+++ b/app/views/admin/poll/recounts/index.html.erb
@@ -43,14 +43,14 @@
                 <%= link_to booth_assignment.booth.name, admin_poll_booth_assignment_path(@poll, booth_assignment, anchor: "tab-recounts") %>
               </strong>
             </td>
-            <td class="text-center <%= "count-error" if total_recounts.to_i != system_count %>">
+            <td class="text-center <%= "count-error" if total_recounts.to_i != system_count %>" id="<%= dom_id(booth_assignment) %>_recount">
               <% if total_recounts.present? %>
                 <strong><%= total_recounts %></strong>
               <% else %>
                 <span>-</span>
               <% end %>
             </td>
-            <td class="text-center">
+            <td class="text-center" id="<%= dom_id(booth_assignment) %>_system">
               <% if system_count.present? %>
                 <strong><%= system_count %></strong>
               <% else %>

--- a/app/views/layouts/_officing_booth.html.erb
+++ b/app/views/layouts/_officing_booth.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.poll_officer? %>
+  <div id="officing-booth" class="callout info">
+    <%= t("admin.officing_booth.title", booth: current_booth.try(:location)) %>
+  </div>
+<% end %>

--- a/app/views/layouts/_officing_booth.html.erb
+++ b/app/views/layouts/_officing_booth.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.poll_officer? %>
   <div id="officing-booth" class="callout info">
-    <%= t("admin.officing_booth.title", booth: current_booth.try(:location)) %>
+    <%= t("admin.officing_booth.title", booth: try(:current_booth).try(:location)) %>
   </div>
 <% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -33,6 +33,7 @@
 
             <div class="admin-content small-12 medium-9 column" data-equalizer-watch>
               <%= render "layouts/flash" %>
+              <%= render "layouts/officing_booth" %>
               <%= yield %>
             </div>
           </div>

--- a/app/views/officing/booth/new.html.erb
+++ b/app/views/officing/booth/new.html.erb
@@ -11,7 +11,7 @@
         <div class="row">
           <div class="small-12 column">
             <%= f.select :id,
-                         @booths.collect { |booth| [booth.name, booth.id] },
+                         @booths.collect { |booth| [booth.location, booth.id] },
                          selected: @booths.first,
                          label: false,
                          tabindex: "1" %>

--- a/app/views/officing/booth/new.html.erb
+++ b/app/views/officing/booth/new.html.erb
@@ -1,0 +1,25 @@
+<div class="row margin-top">
+  <div class="small-12 medium-6 column small-centered">
+    <div class="panel margin-top">
+      <h1 class="text-center">
+        <%= t("officing.booth.new.title") %>
+      </h1>
+      <%= form_for Poll::Booth.new,
+                   as: :booth,
+                   url: officing_booth_path,
+                   method: :post do |f| %>
+        <div class="row">
+          <div class="small-12 column">
+            <%= f.select :id,
+                         @booths.collect { |booth| [booth.name, booth.id] },
+                         selected: @booths.first,
+                         label: false,
+                         tabindex: "1" %>
+
+            <%= f.submit(t("devise_views.sessions.new.submit"), class: "button expanded") %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/officing/dashboard/index.html.erb
+++ b/app/views/officing/dashboard/index.html.erb
@@ -3,7 +3,7 @@
 
   <p><%= t("officing.dashboard.index.info") %></p>
 
-  <% unless final_recount_shift? && vote_collection_shift? %>
+  <% if no_shifts? %>
     <div class="callout warning">
       <%= t("officing.dashboard.index.no_shifts") %>
     </div>

--- a/app/views/officing/residence/new.html.erb
+++ b/app/views/officing/residence/new.html.erb
@@ -1,32 +1,25 @@
 <h2><%= t("officing.residence.new.title") %></h2>
 
-<% if @officer_assignments.present? %>
-  <div class="row verification account">
-    <div class="small-12 medium-8 column">
-      <%= form_for @residence, as: "residence", url: officing_residence_path do |f| %>
-        <%= render "errors" %>
+<div class="row verification account">
+  <div class="small-12 medium-8 column">
+    <%= form_for @residence, as: "residence", url: officing_residence_path do |f| %>
+      <%= render "errors" %>
 
-        <div class="small-12 medium-6">
-          <%= f.select :document_type, document_types, prompt: "" %>
+      <div class="small-12 medium-6">
+        <%= f.select :document_type, document_types, prompt: "" %>
 
-
-          <%= f.text_field :document_number,
+        <%= f.text_field :document_number,
                          placeholder: t("officing.residence.new.document_number"),
                          autocomplete: "off" %>
-        </div>
+      </div>
 
-        <div class="date-of-birth small-12 medium-6">
-          <%= f.text_field :year_of_birth, type: "number", autocomplete: "off" %>
-        </div>
+      <div class="date-of-birth small-12 medium-6">
+        <%= f.text_field :year_of_birth, type: "number", autocomplete: "off" %>
+      </div>
 
-        <div class="small-12 medium-6">
-          <input type="submit" value="<%= t("officing.residence.new.submit") %>" class="button expanded">
-        </div>
-      <% end %>
-    </div>
+      <div class="small-12 medium-6">
+        <input type="submit" value="<%= t("officing.residence.new.submit") %>" class="button expanded">
+      </div>
+    <% end %>
   </div>
-<% else %>
-  <div class="callout primary">
-    <%= t("officing.residence.new.no_assignments") %>
-  </div>
-<% end %>
+</div>

--- a/app/views/officing/voters/create.js.erb
+++ b/app/views/officing/voters/create.js.erb
@@ -1,3 +1,4 @@
 $("#<%= dom_id(@poll) %> #actions").html("<%= j render("voted") %>");
 $("#<%= dom_id(@poll) %> #can_vote_callout").hide();
+$("#not_voted").hide();
 $(".js-vote-collection").removeClass("is-hidden");

--- a/app/views/officing/voters/new.html.erb
+++ b/app/views/officing/voters/new.html.erb
@@ -28,4 +28,8 @@
   </table>
 <% end %>
 
-<%= link_to t("officing.voters.new.not_to_vote"), namespaced_root_path, class: "button" %>
+<% if Poll.votable_by(@user).any? %>
+  <div id="not_voted">
+    <%= link_to t("officing.voters.new.not_to_vote"), namespaced_root_path, class: "button" %>
+  </div>
+<% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -14,6 +14,8 @@ en:
       edit: Edit
       configure: Configure
       delete: Delete
+    officing_booth:
+      title: "You are officing the booth located at %{booth}. If this is not correct, do not continue and call the help phone number. Thank you."
     banners:
       index:
         title: Banners

--- a/config/locales/en/officing.yml
+++ b/config/locales/en/officing.yml
@@ -19,7 +19,7 @@ en:
     booth:
       new:
         title: "Choose your booth"
-        success: "You are officing booth %{booth}"
+        success: "You are officing the booth located at %{booth}. If this is not correct, do not continue and call the help phone number. Thank you."
     results:
       flash:
         create: "Results saved"

--- a/config/locales/en/officing.yml
+++ b/config/locales/en/officing.yml
@@ -19,7 +19,6 @@ en:
     booth:
       new:
         title: "Choose your booth"
-        success: "You are officing the booth located at %{booth}. If this is not correct, do not continue and call the help phone number. Thank you."
     results:
       flash:
         create: "Results saved"

--- a/config/locales/en/officing.yml
+++ b/config/locales/en/officing.yml
@@ -51,7 +51,6 @@ en:
         submit: Validate document
         error_verifying_census: "The Census was unable to verify this document."
         form_errors: prevented the verification of this document
-        no_assignments: "You don't have officing shifts today"
     voters:
       new:
         title: Polls

--- a/config/locales/en/officing.yml
+++ b/config/locales/en/officing.yml
@@ -16,6 +16,10 @@ en:
         no_polls: You are not officing final recounts in any active poll
         select_poll: Select poll
         add_results: Add results
+    booth:
+      new:
+        title: "Choose your booth"
+        success: "You are officing booth %{booth}"
     results:
       flash:
         create: "Results saved"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -14,6 +14,8 @@ es:
       edit: Editar
       configure: Configurar
       delete: Borrar
+    officing_booth:
+      title: "Estás ahora mismo en la mesa ubicada en %{booth}. Si esto no es correcto no sigas adelante y llama al teléfono de incidencias. Gracias."
     banners:
       index:
         title: Banners

--- a/config/locales/es/officing.yml
+++ b/config/locales/es/officing.yml
@@ -51,7 +51,6 @@ es:
         submit: Validar documento
         error_verifying_census: "El Padrón no pudo verificar este documento."
         form_errors: evitaron verificar este documento
-        no_assignments: "Hoy no tienes turno de presidente de mesa"
     voters:
       new:
         title: Votaciones

--- a/config/locales/es/officing.yml
+++ b/config/locales/es/officing.yml
@@ -19,7 +19,7 @@ es:
     booth:
       new:
         title: "Escoge tu urna"
-        success: "Estás presidiendo la urna %{booth}"
+        success: "Estás ahora mismo en la mesa ubicada en %{booth}. Si esto no es correcto no sigas adelante y llama al teléfono de incidencias. Gracias."
     results:
       flash:
         create: "Datos guardados"

--- a/config/locales/es/officing.yml
+++ b/config/locales/es/officing.yml
@@ -19,7 +19,6 @@ es:
     booth:
       new:
         title: "Escoge tu urna"
-        success: "Estás ahora mismo en la mesa ubicada en %{booth}. Si esto no es correcto no sigas adelante y llama al teléfono de incidencias. Gracias."
     results:
       flash:
         create: "Datos guardados"

--- a/config/locales/es/officing.yml
+++ b/config/locales/es/officing.yml
@@ -16,6 +16,10 @@ es:
         no_polls: No tienes permiso para recuento final en ninguna votación reciente
         select_poll: Selecciona votación
         add_results: Añadir resultados
+    booth:
+      new:
+        title: "Escoge tu urna"
+        success: "Estás presidiendo la urna %{booth}"
     results:
       flash:
         create: "Datos guardados"

--- a/config/routes/officing.rb
+++ b/config/routes/officing.rb
@@ -4,6 +4,7 @@ namespace :officing do
     resources :results, only: [:new, :create, :index]
   end
 
+  resource :booth, controller: "booth", only: [:new, :create]
   resource :residence, controller: "residence", only: [:new, :create]
   resources :voters, only: [:new, :create]
   root to: "dashboard#index"

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -146,11 +146,11 @@ section "Creating Poll Voters" do
   end
 
   (Poll.expired + Poll.current + Poll.recounting).uniq.each do |poll|
-    level_two_verified_users = User.level_two_verified
+    verified_users = User.level_two_or_three_verified
     if poll.geozone_restricted?
-      level_two_verified_users = level_two_verified_users.where(geozone_id: poll.geozone_ids)
+      verified_users = verified_users.where(geozone_id: poll.geozone_ids)
     end
-    user_groups = level_two_verified_users.in_groups(2)
+    user_groups = verified_users.in_groups(2)
     user_groups.first.each { |user| vote_poll_on_booth(user, poll) }
     user_groups.second.compact.each { |user| vote_poll_on_web(user, poll) }
   end

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -162,13 +162,23 @@ section "Creating Poll Recounts" do
       officer_assignment = poll.officer_assignments.first
       author = Poll::Officer.first.user
 
+      total_amount = white_amount = null_amount = 0
+
+      booth_assignment.voters.count.times do
+        case rand
+        when 0...0.1 then null_amount += 1
+        when 0.1...0.2 then white_amount += 1
+        else total_amount += 1
+        end
+      end
+
       Poll::Recount.create!(officer_assignment: officer_assignment,
                             booth_assignment: booth_assignment,
                             author: author,
                             date: poll.ends_at,
-                            white_amount: rand(0..10),
-                            null_amount: rand(0..10),
-                            total_amount: rand(100..9999),
+                            white_amount: white_amount,
+                            null_amount: null_amount,
+                            total_amount: total_amount,
                             origin: "booth")
     end
   end

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -114,12 +114,16 @@ end
 section "Creating Poll Voters" do
 
   def vote_poll_on_booth(user, poll)
+    officer = Poll::Officer.all.sample
+
     Poll::Voter.create!(document_type: user.document_type,
                         document_number: user.document_number,
                         user: user,
                         poll: poll,
                         origin: "booth",
-                        officer: Poll::Officer.all.sample)
+                        officer: officer,
+                        officer_assignment: officer.officer_assignments.sample,
+                        booth_assignment: poll.booth_assignments.sample)
   end
 
   def vote_poll_on_web(user, poll)

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -42,24 +42,24 @@ end
 section "Creating Poll Questions & Answers" do
   Poll.find_each do |poll|
     (1..4).to_a.sample.times do
-      title = Faker::Lorem.sentence(3).truncate(60) + "?"
+      question_title = Faker::Lorem.sentence(3).truncate(60) + "?"
       question = Poll::Question.new(author: User.all.sample,
-                                    title: title,
+                                    title: question_title,
                                     poll: poll)
       I18n.available_locales.map do |locale|
         Globalize.with_locale(locale) do
-          question.title = "#{title} (#{locale})"
+          question.title = "#{question_title} (#{locale})"
         end
       end
       question.save!
-      Faker::Lorem.words((2..4).to_a.sample).each do |title|
+      Faker::Lorem.words((2..4).to_a.sample).each do |answer_title|
         description = "<p>#{Faker::Lorem.paragraphs.join("</p><p>")}</p>"
         answer = Poll::Question::Answer.new(question: question,
-                                            title: title.capitalize,
+                                            title: answer_title.capitalize,
                                             description: description)
         I18n.available_locales.map do |locale|
           Globalize.with_locale(locale) do
-            answer.title = "#{title} (#{locale})"
+            answer.title = "#{answer_title} (#{locale})"
             answer.description = "#{description} (#{locale})"
           end
         end

--- a/db/dev_seeds/users.rb
+++ b/db/dev_seeds/users.rb
@@ -8,7 +8,7 @@ section "Creating Users" do
       password_confirmation:  password,
       confirmed_at:           Time.current,
       terms_of_service:       "1",
-      gender:                 ["Male", "Female"].sample,
+      gender:                 %w[male female].sample,
       date_of_birth:          rand((Time.current - 80.years)..(Time.current - 16.years)),
       public_activity:        (rand(1..100) > 30)
     )

--- a/spec/features/budget_polls/officing_spec.rb
+++ b/spec/features/budget_polls/officing_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "Budget Poll Officing" do
 
-  scenario "Show sidebar menu if officer has shifts assigned" do
+  scenario "Show sidebar menus if officer has shifts assigned" do
     poll = create(:poll)
     booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
@@ -10,13 +10,21 @@ feature "Budget Poll Officing" do
     user = create(:user)
     officer = create(:poll_officer, user: user)
 
+    create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
+
+    login_as user
+    visit officing_root_path
+
+    expect(page).not_to have_content("You don't have officing shifts today")
+    expect(page).to have_content("Validate document")
+    expect(page).not_to have_content("Total recounts and results")
+
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :recount_scrutiny)
 
     officer_assignment = create(:poll_officer_assignment,
                                  booth_assignment: booth_assignment,
                                  officer: officer)
 
-    login_as user
     visit officing_root_path
 
     expect(page).not_to have_content("You don't have officing shifts today")
@@ -24,7 +32,7 @@ feature "Budget Poll Officing" do
     expect(page).to have_content("Total recounts and results")
   end
 
-  scenario "Do not show sidebar menu if officer has no shifts assigned" do
+  scenario "Do not show sidebar menus if officer has no shifts assigned" do
     user = create(:user)
     officer = create(:poll_officer, user: user)
 

--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -5,7 +5,7 @@ feature "Booth" do
   scenario "Officer with no booth assignments today" do
     officer = create(:poll_officer)
 
-    login_through_form_as(officer.user)
+    login_through_form_as_officer(officer.user)
 
     expect(page).to have_content "You don't have officing shifts today"
   end
@@ -14,7 +14,7 @@ feature "Booth" do
     officer = create(:poll_officer)
     create(:poll_officer_assignment, officer: officer, date: 1.day.from_now)
 
-    login_through_form_as(officer.user)
+    login_through_form_as_officer(officer.user)
 
     expect(page).to have_content "You don't have officing shifts today"
   end
@@ -28,7 +28,7 @@ feature "Booth" do
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
     create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.today)
 
-    login_through_form_as(officer.user)
+    login_through_form_as_officer(officer.user)
 
     within("#officing-booth") do
       expect(page).to have_content "You are officing the booth located at #{booth.location}."
@@ -48,9 +48,8 @@ feature "Booth" do
     create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.today)
     create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.today)
 
-    login_through_form_as(officer.user)
+    login_through_form_as_officer(officer.user)
 
-    expect(page).to have_content "You have been signed in successfully."
     expect(page).to have_content "Choose your booth"
 
     select booth2.location, from: "booth_id"
@@ -78,9 +77,8 @@ feature "Booth" do
     create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.today)
     create(:poll_officer_assignment, officer: officer, booth_assignment: ba3, date: Date.today)
 
-    login_through_form_as(officer.user)
+    login_through_form_as_officer(officer.user)
 
-    expect(page).to have_content "You have been signed in successfully."
     expect(page).to have_content "Choose your booth"
 
     expect(page).to have_select("booth_id", options: [booth1.location, booth2.location])

--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -57,4 +57,29 @@ feature "Booth" do
     expect(page).to have_content "You are officing the booth located at #{booth2.name}."
   end
 
+  scenario "Display single booth for any number of polls" do
+    officer = create(:poll_officer)
+
+    booth1 = create(:poll_booth)
+    booth2 = create(:poll_booth)
+
+    poll1 = create(:poll)
+    poll2 = create(:poll)
+
+    ba1 = create(:poll_booth_assignment, poll: poll1, booth: booth1)
+    ba2 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
+    ba3 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
+
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.today)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.today)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba3, date: Date.today)
+
+    login_through_form_as(officer.user)
+
+    expect(page).to have_content "You have been signed in successfully."
+    expect(page).to have_content "Choose your booth"
+
+    expect(page).to have_select("booth_id", options: [booth1.name, booth2.name])
+  end
+
 end

--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+feature "Booth" do
+
+  scenario "Officer with no booth assignments today" do
+    officer = create(:poll_officer)
+
+    login_through_form_as(officer.user)
+
+    expect(page).to have_content "You don't have officing shifts today"
+  end
+
+  scenario "Officer with booth assignments another day" do
+    officer = create(:poll_officer)
+    create(:poll_officer_assignment, officer: officer, date: 1.day.from_now)
+
+    login_through_form_as(officer.user)
+
+    expect(page).to have_content "You don't have officing shifts today"
+  end
+
+  scenario "Officer with single booth assignment today" do
+    officer = create(:poll_officer)
+    poll = create(:poll)
+
+    booth = create(:poll_booth)
+
+    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.today)
+
+    login_through_form_as(officer.user)
+
+    expect(page).to have_content "You are officing booth #{booth.name}"
+  end
+
+  scenario "Officer with multiple booth assignments today" do
+    officer = create(:poll_officer)
+    poll = create(:poll)
+
+    booth1 = create(:poll_booth)
+    booth2 = create(:poll_booth)
+
+    ba1 = create(:poll_booth_assignment, poll: poll, booth: booth1)
+    ba2 = create(:poll_booth_assignment, poll: poll, booth: booth2)
+
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.today)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.today)
+
+    login_through_form_as(officer.user)
+
+    expect(page).to have_content "You have been signed in successfully."
+    expect(page).to have_content "Choose your booth"
+
+    select booth2.name, from: "booth_id"
+    click_button "Enter"
+
+    expect(page).to have_content "You are officing booth #{booth2.name}"
+  end
+
+end

--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -30,7 +30,7 @@ feature "Booth" do
 
     login_through_form_as(officer.user)
 
-    expect(page).to have_content "You are officing booth #{booth.name}"
+    expect(page).to have_content "You are officing the booth located at #{booth.name}."
   end
 
   scenario "Officer with multiple booth assignments today" do
@@ -54,7 +54,7 @@ feature "Booth" do
     select booth2.name, from: "booth_id"
     click_button "Enter"
 
-    expect(page).to have_content "You are officing booth #{booth2.name}"
+    expect(page).to have_content "You are officing the booth located at #{booth2.name}."
   end
 
 end

--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -30,7 +30,9 @@ feature "Booth" do
 
     login_through_form_as(officer.user)
 
-    expect(page).to have_content "You are officing the booth located at #{booth.location}."
+    within("#officing-booth") do
+      expect(page).to have_content "You are officing the booth located at #{booth.location}."
+    end
   end
 
   scenario "Officer with multiple booth assignments today" do
@@ -54,7 +56,9 @@ feature "Booth" do
     select booth2.location, from: "booth_id"
     click_button "Enter"
 
-    expect(page).to have_content "You are officing the booth located at #{booth2.location}."
+    within("#officing-booth") do
+      expect(page).to have_content "You are officing the booth located at #{booth2.location}."
+    end
   end
 
   scenario "Display single booth for any number of polls" do

--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Booth" do
+feature "Booth", :with_frozen_time do
 
   scenario "Officer with no booth assignments today" do
     officer = create(:poll_officer)
@@ -12,7 +12,7 @@ feature "Booth" do
 
   scenario "Officer with booth assignments another day" do
     officer = create(:poll_officer)
-    create(:poll_officer_assignment, officer: officer, date: 1.day.from_now)
+    create(:poll_officer_assignment, officer: officer, date: Date.current + 1.day)
 
     login_through_form_as_officer(officer.user)
 
@@ -26,7 +26,7 @@ feature "Booth" do
     booth = create(:poll_booth)
 
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.today)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.current)
 
     login_through_form_as_officer(officer.user)
 
@@ -45,8 +45,8 @@ feature "Booth" do
     ba1 = create(:poll_booth_assignment, poll: poll, booth: booth1)
     ba2 = create(:poll_booth_assignment, poll: poll, booth: booth2)
 
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.today)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.today)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.current)
 
     login_through_form_as_officer(officer.user)
 
@@ -73,9 +73,9 @@ feature "Booth" do
     ba2 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
     ba3 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
 
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.today)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.today)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba3, date: Date.today)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba3, date: Date.current)
 
     login_through_form_as_officer(officer.user)
 

--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -30,7 +30,7 @@ feature "Booth" do
 
     login_through_form_as(officer.user)
 
-    expect(page).to have_content "You are officing the booth located at #{booth.name}."
+    expect(page).to have_content "You are officing the booth located at #{booth.location}."
   end
 
   scenario "Officer with multiple booth assignments today" do
@@ -51,10 +51,10 @@ feature "Booth" do
     expect(page).to have_content "You have been signed in successfully."
     expect(page).to have_content "Choose your booth"
 
-    select booth2.name, from: "booth_id"
+    select booth2.location, from: "booth_id"
     click_button "Enter"
 
-    expect(page).to have_content "You are officing the booth located at #{booth2.name}."
+    expect(page).to have_content "You are officing the booth located at #{booth2.location}."
   end
 
   scenario "Display single booth for any number of polls" do
@@ -79,7 +79,7 @@ feature "Booth" do
     expect(page).to have_content "You have been signed in successfully."
     expect(page).to have_content "Choose your booth"
 
-    expect(page).to have_select("booth_id", options: [booth1.name, booth2.name])
+    expect(page).to have_select("booth_id", options: [booth1.location, booth2.location])
   end
 
 end

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -93,4 +93,28 @@ feature "Residence", :with_frozen_time do
 
   end
 
+  scenario "Verify booth", :js do
+    booth = create(:poll_booth)
+    poll = create(:poll)
+
+    ba = create(:poll_booth_assignment, poll: poll, booth: booth )
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba)
+
+    login_as(officer.user)
+
+    # User somehow skips setting session[:booth_id]
+    # set_officing_booth(booth)
+
+    visit new_officing_residence_path
+    expect(page).to have_content "You are officing booth #{booth.name}"
+
+    visit new_officing_residence_path
+    officing_verify_residence
+
+    expect(page).to have_content poll.name
+    click_button "Confirm vote"
+
+    expect(page).to have_content "Vote introduced!"
+  end
+
 end

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -25,7 +25,7 @@ feature "Residence", :with_frozen_time do
 
     background do
       create(:poll_officer_assignment, officer: officer)
-      login_as(officer.user)
+      login_through_form_as(officer.user)
       visit officing_root_path
     end
 

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -106,7 +106,9 @@ feature "Residence", :with_frozen_time do
     # set_officing_booth(booth)
 
     visit new_officing_residence_path
-    expect(page).to have_content "You are officing booth #{booth.name}"
+    within("#officing-booth") do
+      expect(page).to have_content "You are officing the booth located at #{booth.location}."
+    end
 
     visit new_officing_residence_path
     officing_verify_residence

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -97,20 +97,17 @@ feature "Residence", :with_frozen_time do
     booth = create(:poll_booth)
     poll = create(:poll)
 
-    ba = create(:poll_booth_assignment, poll: poll, booth: booth )
+    ba = create(:poll_booth_assignment, poll: poll, booth: booth)
     create(:poll_officer_assignment, officer: officer, booth_assignment: ba)
+    create(:poll_shift, officer: officer, booth: booth, date: Time.zone.today)
 
     login_as(officer.user)
-
-    # User somehow skips setting session[:booth_id]
-    # set_officing_booth(booth)
 
     visit new_officing_residence_path
     within("#officing-booth") do
       expect(page).to have_content "You are officing the booth located at #{booth.location}."
     end
 
-    visit new_officing_residence_path
     officing_verify_residence
 
     expect(page).to have_content poll.name

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -25,7 +25,7 @@ feature "Residence", :with_frozen_time do
 
     background do
       create(:poll_officer_assignment, officer: officer)
-      login_through_form_as(officer.user)
+      login_through_form_as_officer(officer.user)
       visit officing_root_path
     end
 

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -99,7 +99,7 @@ feature "Residence", :with_frozen_time do
 
     ba = create(:poll_booth_assignment, poll: poll, booth: booth)
     create(:poll_officer_assignment, officer: officer, booth_assignment: ba)
-    create(:poll_shift, officer: officer, booth: booth, date: Time.zone.today)
+    create(:poll_shift, officer: officer, booth: booth, date: Date.current)
 
     login_as(officer.user)
 

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -16,6 +16,7 @@ feature "Officing Results", :with_frozen_time do
     create(:poll_question_answer, title: "Tomorrow", question: @question_2)
 
     login_as(@poll_officer.user)
+    set_officing_booth(@officer_assignment.booth)
   end
 
   scenario "Only polls where user is officer for results are accessible" do
@@ -31,8 +32,6 @@ feature "Officing Results", :with_frozen_time do
     click_link "Polling officers"
 
     expect(page).to have_content("Poll officing")
-
-    set_officing_booth(@officer_assignment.booth)
 
     within("#side_menu") do
       click_link "Total recounts and results"

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -5,6 +5,7 @@ feature "Officing Results", :with_frozen_time do
   background do
     @poll_officer = create(:poll_officer)
     @officer_assignment = create(:poll_officer_assignment, :final, officer: @poll_officer)
+    create(:poll_shift, officer: @poll_officer, booth: @officer_assignment.booth, date: Time.zone.today)
     @poll = @officer_assignment.booth_assignment.poll
     @poll.update(ends_at: 1.day.ago)
     @question_1 = create(:poll_question, poll: @poll)
@@ -30,6 +31,9 @@ feature "Officing Results", :with_frozen_time do
     click_link "Polling officers"
 
     expect(page).to have_content("Poll officing")
+
+    set_officing_booth(@officer_assignment.booth)
+
     within("#side_menu") do
       click_link "Total recounts and results"
     end

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -5,7 +5,7 @@ feature "Officing Results", :with_frozen_time do
   background do
     @poll_officer = create(:poll_officer)
     @officer_assignment = create(:poll_officer_assignment, :final, officer: @poll_officer)
-    create(:poll_shift, officer: @poll_officer, booth: @officer_assignment.booth, date: Time.zone.today)
+    create(:poll_shift, officer: @poll_officer, booth: @officer_assignment.booth, date: Date.current)
     @poll = @officer_assignment.booth_assignment.poll
     @poll.update(ends_at: 1.day.ago)
     @question_1 = create(:poll_question, poll: @poll)

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -59,6 +59,10 @@ feature "Voters" do
     user = create(:user, residence_verified_at: Time.current, document_type: "1", document_number: "12345678Z")
     expect(user).not_to be_level_two_verified
 
+    visit root_path
+    click_link "Sign out"
+    login_through_form_as(officer.user)
+
     visit new_officing_residence_path
     officing_verify_residence
 
@@ -97,7 +101,7 @@ feature "Voters" do
   end
 
   scenario "Store officer and booth information", :js do
-    create(:user, :in_census, id: rand(9999))
+    create(:user, :in_census, id: rand(9999999))
     poll1 = create(:poll, name: "¿Quieres que XYZ sea aprobado?")
     poll2 = create(:poll, name: "Pregunta de votación de prueba")
 

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -15,6 +15,8 @@ feature "Voters" do
   end
 
   scenario "Can vote", :js do
+    create(:poll_officer_assignment, officer: officer)
+
     visit new_officing_residence_path
     officing_verify_residence
 

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -61,7 +61,7 @@ feature "Voters" do
 
     visit root_path
     click_link "Sign out"
-    login_through_form_as(officer.user)
+    login_through_form_as_officer(officer.user)
 
     visit new_officing_residence_path
     officing_verify_residence

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -75,7 +75,7 @@ feature "Voters" do
     poll_current = create(:poll, :current)
     second_booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll_current, booth: second_booth)
-    officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
     create(:poll_shift, officer: officer, booth: second_booth, date: Date.current, task: :recount_scrutiny)
     create(:poll_shift, officer: officer, booth: second_booth, date: Date.tomorrow, task: :vote_collection)
 
@@ -90,7 +90,7 @@ feature "Voters" do
     booth_assignment = create(:poll_booth_assignment, poll: poll_geozone_restricted_out, booth: booth)
     create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
 
-    set_officing_booth(officer_assignment.booth)
+    set_officing_booth(second_booth)
     visit new_officing_residence_path
     officing_verify_residence
 

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -135,10 +135,10 @@ feature "Voters" do
     voter1 = Poll::Voter.first
 
     expect(voter1.booth_assignment).to eq(ba1)
-    expect(voter1.officer_assignment).not_to be_nil
+    expect(voter1.officer_assignment).to eq(ba1.officer_assignments.first)
 
     voter2 = Poll::Voter.last
     expect(voter2.booth_assignment).to eq(ba2)
-    expect(voter2.officer_assignment).not_to be_nil
+    expect(voter2.officer_assignment).to eq(ba2.officer_assignments.first)
   end
 end

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -93,4 +93,42 @@ feature "Voters" do
     expect(page).to have_content poll_geozone_restricted_in.name
     expect(page).not_to have_content poll_geozone_restricted_out.name
   end
+
+  scenario "Store officer and booth information", :js do
+    create(:user, :in_census, id: rand(9999))
+    poll1 = create(:poll, name: "¿Quieres que XYZ sea aprobado?")
+    poll2 = create(:poll, name: "Pregunta de votación de prueba")
+
+    ba1 = create(:poll_booth_assignment, poll: poll1)
+    ba2 = create(:poll_booth_assignment, poll: poll2)
+    oa1 = create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.current)
+    oa2 = create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.current)
+
+    validate_officer
+    visit new_officing_residence_path
+    officing_verify_residence
+
+    within("#poll_#{poll1.id}") do
+      click_button "Confirm vote"
+
+      expect(page).to have_content "Vote introduced!"
+    end
+
+    within("#poll_#{poll2.id}") do
+      click_button "Confirm vote"
+
+      expect(page).to have_content "Vote introduced!"
+    end
+
+    expect(Poll::Voter.count).to eq(2)
+
+    voter1 = Poll::Voter.first
+
+    expect(voter1.booth_assignment).to eq(ba1)
+    expect(voter1.officer_assignment).to eq(oa1)
+
+    voter2 = Poll::Voter.last
+    expect(voter2.booth_assignment).to eq(ba2)
+    expect(voter2.officer_assignment).to eq(oa2)
+  end
 end

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -107,13 +107,15 @@ feature "Voters" do
     poll1 = create(:poll, name: "¿Quieres que XYZ sea aprobado?")
     poll2 = create(:poll, name: "Pregunta de votación de prueba")
 
-    ba1 = create(:poll_booth_assignment, poll: poll1)
-    ba2 = create(:poll_booth_assignment, poll: poll2)
-    oa1 = create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.current)
-    oa2 = create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.current)
+    second_booth = create(:poll_booth)
+
+    ba1 = create(:poll_booth_assignment, poll: poll1, booth: second_booth )
+    ba2 = create(:poll_booth_assignment, poll: poll2, booth: second_booth )
+    create(:poll_shift, officer: officer, booth: second_booth, date: Date.current, task: :vote_collection)
 
     validate_officer
     visit new_officing_residence_path
+    set_officing_booth(second_booth)
     officing_verify_residence
 
     within("#poll_#{poll1.id}") do
@@ -133,10 +135,10 @@ feature "Voters" do
     voter1 = Poll::Voter.first
 
     expect(voter1.booth_assignment).to eq(ba1)
-    expect(voter1.officer_assignment).to eq(oa1)
+    expect(voter1.officer_assignment).not_to be_nil
 
     voter2 = Poll::Voter.last
     expect(voter2.booth_assignment).to eq(ba2)
-    expect(voter2.officer_assignment).to eq(oa2)
+    expect(voter2.officer_assignment).not_to be_nil
   end
 end

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -17,6 +17,8 @@ feature "Voters" do
   scenario "Can vote", :js do
     create(:poll_officer_assignment, officer: officer)
 
+    officer_assignment = create(:poll_officer_assignment, officer: officer)
+    set_officing_booth(officer_assignment.booth)
     visit new_officing_residence_path
     officing_verify_residence
 
@@ -38,10 +40,11 @@ feature "Voters" do
   scenario "Already voted", :js do
     poll2 = create(:poll, :current)
     booth_assignment = create(:poll_booth_assignment, poll: poll2, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+    officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
 
     user = create(:user, :level_two)
     voter = create(:poll_voter, poll: poll, user: user)
+    set_officing_booth(officer_assignment.booth)
 
     visit new_officing_voter_path(id: voter.user.id)
 
@@ -74,7 +77,7 @@ feature "Voters" do
     poll_current = create(:poll, :current)
     second_booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll_current, booth: second_booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+    officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
     create(:poll_shift, officer: officer, booth: second_booth, date: Date.current, task: :recount_scrutiny)
     create(:poll_shift, officer: officer, booth: second_booth, date: Date.tomorrow, task: :vote_collection)
 
@@ -89,6 +92,7 @@ feature "Voters" do
     booth_assignment = create(:poll_booth_assignment, poll: poll_geozone_restricted_out, booth: booth)
     create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
 
+    set_officing_booth(officer_assignment.booth)
     visit new_officing_residence_path
     officing_verify_residence
 

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -12,13 +12,12 @@ feature "Voters" do
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
     create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+    set_officing_booth(booth)
   end
 
   scenario "Can vote", :js do
     create(:poll_officer_assignment, officer: officer)
 
-    officer_assignment = create(:poll_officer_assignment, officer: officer)
-    set_officing_booth(officer_assignment.booth)
     visit new_officing_residence_path
     officing_verify_residence
 
@@ -40,11 +39,10 @@ feature "Voters" do
   scenario "Already voted", :js do
     poll2 = create(:poll, :current)
     booth_assignment = create(:poll_booth_assignment, poll: poll2, booth: booth)
-    officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
 
     user = create(:user, :level_two)
     voter = create(:poll_voter, poll: poll, user: user)
-    set_officing_booth(officer_assignment.booth)
 
     visit new_officing_voter_path(id: voter.user.id)
 

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -97,6 +97,7 @@ feature "Poll Officing" do
   end
 
   scenario "Poll officer access links" do
+    create(:poll)
     create(:poll_officer, user: user)
     login_as(user)
     visit root_path

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -8,6 +8,7 @@ feature "Voter" do
     let(:question) { create(:poll_question, poll: poll) }
     let(:booth) { create(:poll_booth) }
     let(:officer) { create(:poll_officer) }
+    let(:admin) { create(:administrator) }
     let!(:answer_yes) { create(:poll_question_answer, question: question, title: "Yes") }
     let!(:answer_no) { create(:poll_question_answer, question: question, title: "No") }
 
@@ -71,6 +72,19 @@ feature "Voter" do
 
       expect(Poll::Voter.count).to eq(1)
       expect(Poll::Voter.first.origin).to eq("booth")
+
+      visit root_path
+      click_link "Sign out"
+      login_as(admin.user)
+      visit admin_poll_recounts_path(poll)
+
+      within("#total_system") do
+        expect(page).to have_content "1"
+      end
+
+      within("#poll_booth_assignment_#{Poll::BoothAssignment.where(poll: poll, booth: booth).first.id}_recounts") do
+        expect(page).to have_content "1"
+      end
     end
 
     context "Trying to vote the same poll in booth and web" do
@@ -107,6 +121,19 @@ feature "Voter" do
         expect(page).not_to have_link(answer_yes.title)
         expect(page).to have_content "You have already participated in a physical booth. You can not participate again."
         expect(Poll::Voter.count).to eq(1)
+
+        visit root_path
+        click_link "Sign out"
+        login_as(admin.user)
+        visit admin_poll_recounts_path(poll)
+
+        within("#total_system") do
+          expect(page).to have_content "1"
+        end
+
+        within("#poll_booth_assignment_#{Poll::BoothAssignment.where(poll: poll, booth: booth).first.id}_recounts") do
+          expect(page).to have_content "1"
+        end
       end
 
       scenario "Trying to vote in web again", :js do
@@ -162,6 +189,19 @@ feature "Voter" do
       expect(page).not_to have_link(answer_yes.title)
       expect(page).to have_content "You have already participated in a physical booth. You can not participate again."
       expect(Poll::Voter.count).to eq(1)
+
+      visit root_path
+      click_link "Sign out"
+      login_as(admin.user)
+      visit admin_poll_recounts_path(poll)
+
+      within("#total_system") do
+        expect(page).to have_content "1"
+      end
+
+      within("#poll_booth_assignment_#{Poll::BoothAssignment.where(poll: poll, booth: booth).first.id}_recounts") do
+        expect(page).to have_content "1"
+      end
     end
 
     context "Side menu" do

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -87,6 +87,43 @@ feature "Voter" do
       end
     end
 
+    context "The person has decided not to vote at this time" do
+      let!(:user) { create(:user, :in_census) }
+
+      scenario "Show not to vote at this time button" do
+        login_through_form_as_officer(officer.user)
+
+        visit new_officing_residence_path
+        officing_verify_residence
+
+        expect(page).to have_content poll.name
+        expect(page).to have_button "Confirm vote"
+        expect(page).to have_content "Can vote"
+        expect(page).to have_link "The person has decided not to vote at this time"
+      end
+
+      scenario "Hides not to vote at this time button if already voted", :js do
+        login_through_form_as_officer(officer.user)
+
+        visit new_officing_residence_path
+        officing_verify_residence
+
+        within("#poll_#{poll.id}") do
+          click_button("Confirm vote")
+          expect(page).not_to have_button("Confirm vote")
+          expect(page).to have_content "Vote introduced!"
+          expect(page).not_to have_content "The person has decided not to vote at this time"
+        end
+
+        visit new_officing_residence_path
+        officing_verify_residence
+
+        expect(page).to have_content "Has already participated in this poll"
+        expect(page).not_to have_content "The person has decided not to vote at this time"
+      end
+
+    end
+
     context "Trying to vote the same poll in booth and web" do
       let!(:user) { create(:user, :in_census) }
 

--- a/spec/models/poll/officer_spec.rb
+++ b/spec/models/poll/officer_spec.rb
@@ -121,4 +121,21 @@ describe Poll::Officer do
       expect(assigned_polls.last).to eq(poll_3)
     end
   end
+
+  describe "todays_booths" do
+    let(:officer) { create(:poll_officer) }
+
+    it "returns booths for the application's time zone date", :with_different_time_zone do
+      assignment_with_local_time_zone = create(:poll_officer_assignment,
+                                               date:    Date.today,
+                                               officer: officer)
+
+      assignment_with_application_time_zone = create(:poll_officer_assignment,
+                                                     date:    Date.current,
+                                                     officer: officer)
+
+      expect(officer.todays_booths).to include(assignment_with_application_time_zone.booth)
+      expect(officer.todays_booths).not_to include(assignment_with_local_time_zone.booth)
+    end
+  end
 end

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -6,6 +6,7 @@ describe Poll::Voter do
   let(:booth) { create(:poll_booth) }
   let(:booth_assignment) { create(:poll_booth_assignment, poll: poll, booth: booth) }
   let(:voter) { create(:poll_voter) }
+  let(:officer_assignment) { create(:poll_officer_assignment) }
 
   describe "validations" do
 
@@ -97,6 +98,7 @@ describe Poll::Voter do
 
       it "is valid with a booth origin" do
         voter.origin = "booth"
+        voter.officer_assignment = officer_assignment
         expect(voter).to be_valid
       end
 
@@ -104,7 +106,27 @@ describe Poll::Voter do
         voter.origin = "web"
         expect(voter).to be_valid
       end
+    end
 
+    context "assignments" do
+      it "should not be valid without a booth_assignment_id when origin is booth" do
+        voter.origin = "booth"
+        voter.booth_assignment_id = nil
+        expect(voter).not_to be_valid
+      end
+
+      it "should not be valid without an officer_assignment_id when origin is booth" do
+        voter.origin = "booth"
+        voter.officer_assignment_id = nil
+        expect(voter).not_to be_valid
+      end
+
+      it "should be valid without assignments when origin is web" do
+        voter.origin = "web"
+        voter.booth_assignment_id = nil
+        voter.officer_assignment_id = nil
+        expect(voter).to be_valid
+      end
     end
 
   end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -23,7 +23,13 @@ module CommonActions
 
   def validate_officer
     allow_any_instance_of(Officing::ResidenceController).
-    to receive(:validate_officer_assignment).and_return(true)
+    to receive(:verify_officer_assignment).and_return(true)
   end
 
+  def set_officing_booth(booth=nil)
+    booth = create(:poll_booth) if booth.blank?
+
+    allow_any_instance_of(Officing::VotersController).
+    to receive(:current_booth).and_return(booth)
+  end
 end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -22,14 +22,14 @@ module CommonActions
   end
 
   def validate_officer
-    allow_any_instance_of(Officing::ResidenceController).
+    allow_any_instance_of(Officing::BaseController).
     to receive(:verify_officer_assignment).and_return(true)
   end
 
   def set_officing_booth(booth=nil)
     booth = create(:poll_booth) if booth.blank?
 
-    allow_any_instance_of(Officing::VotersController).
+    allow_any_instance_of(Officing::BaseController).
     to receive(:current_booth).and_return(booth)
   end
 end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -21,4 +21,9 @@ module CommonActions
     check "user_terms_of_service"
   end
 
+  def validate_officer
+    allow_any_instance_of(Officing::ResidenceController).
+    to receive(:validate_officer_assignment).and_return(true)
+  end
+
 end


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#578
* Backports commits AyuntamientoMadrid@79bad0913 and AyuntamientoMadrid@51e37a2b from AyuntamientoMadrid#593
* Backports AyuntamientoMadrid#600
* Backports AyuntamientoMadrid#623
* Backports AyuntamientoMadrid#624
* Backports AyuntamientoMadrid#724
* Backports AyuntamientoMadrid#944
* Backports AyuntamientoMadrid#960
* Backports the relevent part of commit AyuntamientoMadrid@74faec0c
* Backports commit AyuntamientoMadrid@33d555ab from AyuntamientoMadrid#1046
* Backports commit AyuntamientoMadrid@193197ae5 from AyuntamientoMadrid#1119
* Backports AyuntamientoMadrid#1343
* Backports AyuntamientoMadrid#1531
* Backports the parts of AyuntamientoMadrid#1625 which hadn't already been backported
* Backports AyuntamientoMadrid#1755
* Backports commit AyuntamientoMadrid@b738c804
* Closes #2080

## Objectives

* Store the officing assignment and the booth assignment on each vote and voter, when they are available
* Stores officer and booth for voter in a physical booth
* Use officer booth in session to find correct officer assigment