### PR TITLE
Change admin budget investments subfilters from tabs to advanced filter checkboxes

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1205,6 +1205,11 @@ table {
   .filter {
     display: inline-block;
     margin: 0 $line-height / 2;
+
+    label {
+      font-weight: normal;
+      margin: 0;
+    }
   }
 
   .button {

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -4,10 +4,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
   feature_flag :budgets
 
-  has_orders %w{oldest}, only: [:show, :edit]
-  has_filters(%w{all without_admin without_valuator under_valuation
-                 valuation_finished winners},
-                 only: [:index, :toggle_selection])
+  has_orders %w[oldest], only: [:show, :edit]
+  has_filters %w[all], only: [:index, :toggle_selection]
 
   before_action :load_budget
   before_action :load_investment, only: [:show, :edit, :update, :toggle_selection]

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -23,7 +23,9 @@ class Admin::BudgetsController < Admin::BaseController
   def calculate_winners
     return unless @budget.balloting_process?
     @budget.headings.each { |heading| Budget::Result.new(@budget, heading).delay.calculate_winners }
-    redirect_to admin_budget_budget_investments_path(budget_id: @budget.id, filter: "winners"),
+    redirect_to admin_budget_budget_investments_path(
+                  budget_id: @budget.id,
+                  advanced_filters: ["winners"]),
                 notice: I18n.t("admin.budgets.winners.calculated")
   end
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -117,7 +117,7 @@ class Budget
       results = Investment.by_budget(budget)
 
       results = results.where("cached_votes_up + physical_votes >= ?",
-                              params[:min_total_supports])                    if params[:min_total_supports].present?
+                              params[:min_total_supports])                 if params[:min_total_supports].present?
       results = results.where("cached_votes_up + physical_votes <= ?",
                               params[:max_total_supports])                 if params[:max_total_supports].present?
       results = results.where(group_id: params[:group_id])                 if params[:group_id].present?
@@ -134,12 +134,19 @@ class Budget
     end
 
     def self.advanced_filters(params, results)
+      results = results.without_admin      if params[:advanced_filters].include?("without_admin")
+      results = results.without_valuator   if params[:advanced_filters].include?("without_valuator")
+      results = results.under_valuation    if params[:advanced_filters].include?("under_valuation")
+      results = results.valuation_finished if params[:advanced_filters].include?("valuation_finished")
+      results = results.winners            if params[:advanced_filters].include?("winners")
+
       ids = []
       ids += results.valuation_finished_feasible.pluck(:id) if params[:advanced_filters].include?("feasible")
       ids += results.where(selected: true).pluck(:id)       if params[:advanced_filters].include?("selected")
       ids += results.undecided.pluck(:id)                   if params[:advanced_filters].include?("undecided")
       ids += results.unfeasible.pluck(:id)                  if params[:advanced_filters].include?("unfeasible")
-      results.where("budget_investments.id IN (?)", ids)
+      results = results.where("budget_investments.id IN (?)", ids) if ids.any?
+      results
     end
 
     def self.order_filter(params)

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -2,7 +2,7 @@
             admin_budget_budget_investments_path(csv_params),
             class: "float-right small clear" %>
 
-<% if params[:filter] == "winners" %>
+<% if params[:advanced_filters].include?("winners") %>
   <% if display_calculate_winners_button?(@budget) %>
     <%= link_to calculate_winner_button_text(@budget),
                 calculate_winners_admin_budget_path(@budget),

--- a/app/views/admin/budget_investments/_search_form.html.erb
+++ b/app/views/admin/budget_investments/_search_form.html.erb
@@ -11,10 +11,11 @@
   <div id="advanced_filters" class="<%= advanced_menu_visibility %>" data-toggler=".hide">
     <div class="small-12 column">
       <div class="advanced-filters-content">
-        <% ["feasible", "selected", "undecided", "unfeasible"].each do |option| %>
+        <% %w[feasible selected undecided unfeasible without_admin without_valuator under_valuation
+              valuation_finished winners].each do |filter| %>
           <div class="filter">
-            <%= check_box_tag "advanced_filters[]", option, params[:advanced_filters].index(option), id: "advanced_filters_#{option}" %>
-            <%= t("admin.budget_investments.index.filters.#{option}") %>
+            <%= check_box_tag "advanced_filters[]", filter, params[:advanced_filters].index(filter), id: "advanced_filters_#{filter}" %>
+            <%= label_tag "advanced_filters[#{filter}]", t("admin.budget_investments.index.filters.#{filter}") %>
           </div>
         <% end %>
         <div>

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -150,13 +150,17 @@ FactoryBot.define do
       valuation_finished true
     end
 
-     trait :hidden do
-       hidden_at { Time.current }
-     end
+    trait :hidden do
+      hidden_at { Time.current }
+    end
 
-     trait :with_ignored_flag do
-       ignored_flag_at { Time.current }
-     end
+    trait :with_ignored_flag do
+      ignored_flag_at { Time.current }
+    end
+
+    trait :with_administrator do
+      administrator
+    end
 
     trait :flagged do
        after :create do |investment|

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -281,7 +281,9 @@ feature "Admin budgets" do
       expect(page).not_to have_content "Calculate Winner Investments"
 
       visit admin_budget_budget_investments_path(budget)
-      click_link "Winners"
+      click_link "Advanced filters"
+      check "Winners"
+      click_button "Filter"
 
       expect(page).to have_content "Recalculate Winner Investments"
       expect(page).not_to have_content "Calculate Winner Investments"


### PR DESCRIPTION
## References

https://github.com/consul/consul/issues/3365

## Objectives

Change filters on /admin/budgets/:id/budget_investments . We want to move filters from tabs to checkboxes into advanced filters component to give admin the ability of join some of them as filters
- Change tab filters to checkboxes
- Filters can be combined

## Visual Changes

**Before:** 
![image](https://user-images.githubusercontent.com/1029265/54135978-252ca780-441b-11e9-9118-ee9419e4f297.png) 

**After:** 
![image](https://user-images.githubusercontent.com/1029265/55422278-96273100-557b-11e9-963b-77ad09b1c148.png)

