### PR TITLE
Custom fields on legislation proposals

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -35,6 +35,19 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
     end
   end
 
+  def update_proposal_fields
+    if @process.update(process_params)
+      set_tag_list
+
+      link = legislation_process_path(@process).html_safe
+      redirect_to(admin_legislation_process_proposals_path(@process),
+                  notice: t("admin.legislation.processes.update.notice", link: link))
+    else
+      flash.now[:error] = t("admin.legislation.processes.update.error")
+      render "admin/legislation/proposals/_form"
+    end
+  end
+
   def destroy
     @process.destroy
     notice = t("admin.legislation.processes.destroy.notice")
@@ -71,6 +84,20 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         :custom_list,
         :background_color,
         :font_color,
+        :title_label,
+        :summary_label,
+        :description_enabled,
+        :description_label,
+        :video_url_enabled,
+        :video_url_label,
+        :image_enabled,
+        :image_label,
+        :documents_enabled,
+        :documents_label,
+        :geozone_enabled,
+        :geozone_label,
+        :tags_enabled,
+        :tags_label,
         translation_params(::Legislation::Process),
         documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
         image_attributes: image_attributes

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -45,6 +45,14 @@ class Legislation::Process < ApplicationRecord
   validates :allegations_start_date, presence: true, if: :allegations_end_date?
   validates :allegations_end_date, presence: true, if: :allegations_start_date?
   validates :proposals_phase_end_date, presence: true, if: :proposals_phase_start_date?
+  validates :title_label, presence: true
+  validates :summary_label, presence: true
+  validates :description_label, presence:true, if: :description_enabled?
+  validates :video_url_label, presence: true, if: :video_url_enabled?
+  validates :image_label, presence: true, if: :image_enabled?
+  validates :documents_label, presence: true, if: :documents_enabled?
+  validates :geozone_label, presence: true, if: :geozone_enabled?
+  validates :tags_label, presence: true, if: :tags_enabled?
   validate :valid_date_ranges
   validates :background_color, format: { allow_blank: true, with: CSS_HEX_COLOR }
   validates :font_color, format: { allow_blank: true, with: CSS_HEX_COLOR }
@@ -110,6 +118,37 @@ class Legislation::Process < ApplicationRecord
     else
       :open
     end
+  end
+
+  def title_label
+    read_attribute(:title_label) || I18n.t("proposals.form.proposal_title")
+  end
+
+  def summary_label
+    read_attribute(:summary_label) || I18n.t("proposals.form.proposal_summary")  end
+
+  def description_label
+    read_attribute(:description_label) || I18n.t("proposals.form.proposal_text")
+  end
+
+  def video_url_label
+    read_attribute(:video_url_label) || I18n.t("proposals.form.proposal_video_url")
+  end
+
+  def image_label
+    read_attribute(:image_label) || I18n.t("images.form.title")
+  end
+
+  def documents_label
+    read_attribute(:documents_label) || I18n.t("documents.form.title")
+  end
+
+  def geozone_label
+    read_attribute(:geozone_label) || I18n.t("proposals.form.geozone")
+  end
+
+  def tags_label
+    read_attribute(:tags_label) || I18n.t("legislation.proposals.form.tags_label")
   end
 
   private

--- a/app/views/admin/legislation/proposals/_form.html.erb
+++ b/app/views/admin/legislation/proposals/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, @process], html: {data: {watch_changes: true}} do |f| %>
+<%= form_for [:admin, @process], url: update_proposal_fields_admin_legislation_process_path(@process), html: {method: :patch, data: {watch_changes: true}} do |f| %>
 
   <% if @process.errors.any? %>
 
@@ -23,6 +23,74 @@
                       placeholder: t("admin.legislation.proposals.form.custom_categories_placeholder"),
                       class: "js-tag-list",
                       aria: {describedby: "tag-list-help-text"} %>
+  </div>
+
+  <div class="small-12 medium-8 column">
+    <h4 class="inline-block"><%= t("proposals.form.form_title") %></h4>
+  </div>
+
+  <div class="small-12 medium-8 column">
+    <%= f.label :title_label, t("proposals.form.proposal_title") %>
+  </div>
+
+  <div class="small-12 column medium-8 column">
+    <%= f.text_field :title_label, value: @process.title_label, label: false %>
+  </div>
+
+  <div class="small-12 medium-8 column">
+    <%= f.label :summary_label, t("proposals.form.proposal_summary") %>
+  </div>
+
+  <div class="small-12 column medium-8 column">
+    <%= f.text_field :summary_label, value: @process.summary_label, label: false %>
+  </div>
+
+  <div class="small-12 medium-8 column">
+    <%= f.check_box :description_enabled, label: t("proposals.form.proposal_text") %>
+  </div>
+
+  <div class="small-12 column medium-8 column">
+    <%= f.text_field :description_label, value: @process.description_label, label: false %>
+  </div>
+
+  <div class="small-12 medium-8 column">
+    <%= f.check_box :video_url_enabled, label: t("proposals.form.proposal_video_url") %>
+  </div>
+
+  <div class="small-12 column medium-8 column">
+    <%= f.text_field :video_url_label, value: @process.video_url_label, label: false %>
+  </div>
+
+  <div class="small-12 medium-8 column">
+    <%= f.check_box :documents_enabled, label: t("documents.form.title") %>
+  </div>
+
+  <div class="small-12 column medium-8 column">
+    <%= f.text_field :documents_label, value: @process.documents_label, label: false %>
+  </div>
+
+  <div class="small-12 medium-8 column">
+    <%= f.check_box :image_enabled, label: t("images.form.title") %>
+  </div>
+
+  <div class="small-12 column medium-8 column">
+    <%= f.text_field :image_label, value: @process.image_label, label: false %>
+  </div>
+
+  <div class="small-12 medium-8 column">
+    <%= f.check_box :geozone_enabled, label: t("proposals.form.geozone") %>
+  </div>
+
+  <div class="small-12 column medium-8 column">
+    <%= f.text_field :geozone_label, value: @process.geozone_label, label: false %>
+  </div>
+
+  <div class="small-12 medium-8 column">
+    <%= f.check_box :tags_enabled, label: t("legislation.proposals.form.tags_label") %>
+  </div>
+
+  <div class="small-12 column medium-8 column">
+    <%= f.text_field :tags_label, value: @process.tags_label, label: false %>
   </div>
 
   <div class="small-12 medium-3 column clear end">

--- a/app/views/documents/_nested_documents.html.erb
+++ b/app/views/documents/_nested_documents.html.erb
@@ -1,5 +1,9 @@
 <div class="documents-list">
-  <%= f.label :documents, t("documents.form.title") %>
+  <% if local_assigns[:documents_label].present? %>
+    <%= f.label :documents, documents_label %>
+  <% else %>
+    <%= f.label :documents, t("documents.form.title") %>
+  <% end %>
   <p class="help-text"><%= documentables_note(documentable) %></p>
 
   <div id="nested-documents" data-max-documents-allowed="<%= documentable.class.max_documents_allowed%>">

--- a/app/views/images/_nested_image.html.erb
+++ b/app/views/images/_nested_image.html.erb
@@ -1,6 +1,10 @@
 <% image_fields ||= :image %>
 
-<%= f.label image_fields, t("images.form.title") %>
+<% if local_assigns[:image_label].present? %>
+  <%= f.label image_fields, image_label %>
+<% else %>
+  <%= f.label image_fields, t("images.form.title") %>
+<% end %>
 <p class="help-text"><%= imageables_note(imageable) %></p>
 
 <div id="nested-image">

--- a/app/views/legislation/proposals/_form.html.erb
+++ b/app/views/legislation/proposals/_form.html.erb
@@ -5,64 +5,74 @@
 
   <div class="row">
     <div class="small-12 column">
-      <%= f.label :title, t("proposals.form.proposal_title") %>
-      <%= f.text_field :title, maxlength: Legislation::Proposal.title_max_length, placeholder: t("proposals.form.proposal_title"), label: false %>
+      <%= f.label :title, @process.title_label %>
+      <%= f.text_field :title, maxlength: Legislation::Proposal.title_max_length, placeholder: @process.title_label, label: false %>
     </div>
 
     <%= f.invisible_captcha :subtitle %>
 
     <div class="small-12 column">
-      <%= f.label :summary, t("proposals.form.proposal_summary") %>
+      <%= f.label :summary, @process.summary_label %>
       <p class="help-text" id="summary-help-text"><%= t("proposals.form.proposal_summary_note") %></p>
       <%= f.text_area :summary, rows: 4, maxlength: 200, label: false,
-                      placeholder: t("proposals.form.proposal_summary"),
+                      placeholder: @process.summary_label,
                       aria: {describedby: "summary-help-text"} %>
     </div>
 
-    <div class="ckeditor small-12 column">
-      <%= f.label :description, t("proposals.form.proposal_text") %>
-      <%= f.cktext_area :description, maxlength: Legislation::Proposal.description_max_length, ckeditor: { language: I18n.locale }, label: false %>
-    </div>
-
-    <div class="small-12 column">
-      <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
-      <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
-      <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false,
-                                   aria: {describedby: "video-url-help-text"} %>
-    </div>
-
-    <% if feature?(:allow_images) %>
-      <div class="images small-12 column">
-        <%= render "images/nested_image", imageable: @proposal, f: f %>
+    <% if @process.description_enabled %>
+      <div class="ckeditor small-12 column">
+        <%= f.label :description, @process.description_label %>
+        <%= f.cktext_area :description, placeholder: @process.description_label, maxlength: Legislation::Proposal.description_max_length, ckeditor: { language: I18n.locale }, label: false %>
       </div>
     <% end %>
 
-    <div class="documents small-12 column" data-max-documents="<%= Legislation::Proposal.max_documents_allowed %>">
-      <%= render "documents/nested_documents", documentable: @proposal, f: f %>
-    </div>
-
-    <div class="small-12 medium-6 column">
-      <%= f.label :geozone_id,  t("proposals.form.geozone") %>
-      <%= f.select :geozone_id, geozone_select_options, {include_blank: t("geozones.none"), label: false} %>
-    </div>
-
-    <div class="small-12 column">
-      <%= f.label :tag_list, t("legislation.proposals.form.tags_label") %>
-      <p class="help-text" id="tag-list-help-text"><%= t("proposals.form.tags_instructions") %></p>
-
-      <div id="category_tags" class="tags">
-        <% @process.tag_list_on(:customs).each do |tag| %>
-          <a class="js-add-tag-link"><%= tag %></a>
-        <% end %>
+    <% if @process.video_url_enabled %>
+      <div class="small-12 column">
+        <%= f.label :video_url, @process.video_url_label %>
+        <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
+        <%= f.text_field :video_url, placeholder: @process.video_url_label, label: false,
+                                     aria: {describedby: "video-url-help-text"} %>
       </div>
+    <% end %>
 
-      <br>
-      <%= f.text_field :tag_list, value: @proposal.tag_list.to_s,
-                        label: false,
-                        placeholder: t("proposals.form.tags_placeholder"),
-                        class: "js-tag-list",
-                        aria: {describedby: "tag-list-help-text"} %>
-    </div>
+    <% if feature?(:allow_images) && @process.image_enabled %>
+      <div class="images small-12 column">
+        <%= render 'images/nested_image', imageable: @proposal, f: f, image_label: @process.image_label %>
+      </div>
+    <% end %>
+
+    <% if @process.documents_enabled %>
+      <div class="documents small-12 column" data-max-documents="<%= Legislation::Proposal.max_documents_allowed %>">
+        <%= render 'documents/nested_documents', documentable: @proposal, f: f, documents_label: @process.documents_label %>
+      </div>
+    <% end %>
+
+    <% if @process.geozone_enabled %>
+      <div class="small-12 medium-6 column">
+        <%= f.label :geozone_id, @process.geozone_label %>
+        <%= f.select :geozone_id, geozone_select_options, {include_blank: t("geozones.none"), label: false} %>
+      </div>
+    <% end %>
+
+    <% if @process.tags_enabled %>
+      <div class="small-12 column">
+        <%= f.label :tag_list, @process.tags_label %>
+        <p class="help-text" id="tag-list-help-text"><%= t("proposals.form.tags_instructions") %></p>
+
+        <div id="category_tags" class="tags">
+          <% @process.tag_list_on(:customs).each do |tag| %>
+            <a class="js-add-tag-link"><%= tag %></a>
+          <% end %>
+        </div>
+
+        <br>
+        <%= f.text_field :tag_list, value: @proposal.tag_list.to_s,
+                          label: false,
+                          placeholder: @process.tags_label,
+                          class: 'js-tag-list',
+                          aria: {describedby: "tag-list-help-text"} %>
+      </div>
+    <% end %>
 
     <div class="small-12 column">
       <% if @proposal.new_record? %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -344,6 +344,7 @@ en:
       proposal_summary_note: "(maximum 200 characters)"
       proposal_text: Proposal text
       proposal_title: Proposal title
+      form_title: Form input fields
       proposal_video_url: Link to external video
       proposal_video_url_note: You may add a link to YouTube or Vimeo
       tag_category_label: "Categories"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -213,6 +213,7 @@ namespace :admin do
       resources :milestones
       resources :progress_bars, except: :show
       resource :homepage, only: [:edit, :update]
+      member { patch :update_proposal_fields }
     end
   end
 

--- a/db/dev_seeds/legislation_processes.rb
+++ b/db/dev_seeds/legislation_processes.rb
@@ -20,7 +20,15 @@ section "Creating collaborative legislation" do
                                  draft_publication_enabled: true,
                                  result_publication_enabled: true,
                                  proposals_phase_enabled: true,
-                                 published: true)
+                                 published: true,
+                                 title_label: "Proposal title",
+                                 summary_label: "Proposal summary",
+                                 description_label: "Proposal text",
+                                 video_url_label: "Link to external video",
+                                 image_label: "Descriptive image",
+                                 documents_label: "Documents",
+                                 geozone_label: "Scope of operation",
+                                 tags_label: "Categories")
   end
 
   Legislation::Process.find_each do |process|

--- a/db/migrate/20190201002839_add_options_to_legislation_process.rb
+++ b/db/migrate/20190201002839_add_options_to_legislation_process.rb
@@ -1,0 +1,18 @@
+class AddOptionsToLegislationProcess < ActiveRecord::Migration
+  def change
+    add_column :legislation_processes, :title_label, :string
+    add_column :legislation_processes, :summary_label, :string
+    add_column :legislation_processes, :description_enabled, :boolean, default: true
+    add_column :legislation_processes, :description_label, :string
+    add_column :legislation_processes, :video_url_enabled, :boolean, default: true
+    add_column :legislation_processes, :video_url_label, :string
+    add_column :legislation_processes, :image_enabled, :boolean, default: true
+    add_column :legislation_processes, :image_label, :string
+    add_column :legislation_processes, :documents_enabled, :boolean, default: true
+    add_column :legislation_processes, :documents_label, :string
+    add_column :legislation_processes, :geozone_enabled, :boolean, default: true
+    add_column :legislation_processes, :geozone_label, :string
+    add_column :legislation_processes, :tags_enabled, :boolean, default: true
+    add_column :legislation_processes, :tags_label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -712,6 +712,20 @@ ActiveRecord::Schema.define(version: 20190429125842) do
     t.boolean  "homepage_enabled",           default: false
     t.text     "background_color"
     t.text     "font_color"
+    t.string   "title_label"
+    t.string   "summary_label"
+    t.boolean  "description_enabled",        default: true
+    t.string   "description_label"
+    t.boolean  "video_url_enabled",          default: true
+    t.string   "video_url_label"
+    t.boolean  "image_enabled",              default: true
+    t.string   "image_label"
+    t.boolean  "documents_enabled",          default: true
+    t.string   "documents_label"
+    t.boolean  "geozone_enabled",            default: true
+    t.string   "geozone_label"
+    t.boolean  "tags_enabled",               default: true
+    t.string   "tags_label"
     t.index ["allegations_end_date"], name: "index_legislation_processes_on_allegations_end_date", using: :btree
     t.index ["allegations_start_date"], name: "index_legislation_processes_on_allegations_start_date", using: :btree
     t.index ["debate_end_date"], name: "index_legislation_processes_on_debate_end_date", using: :btree

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -20,6 +20,14 @@ FactoryBot.define do
     draft_publication_enabled true
     result_publication_enabled true
     published true
+    title_label "Proposal title"
+    summary_label "Proposal summary"
+    description_label "Proposal text"
+    video_url_label "Link to external video"
+    image_label "Descriptive image"
+    documents_label "Documents"
+    geozone_label "Scope of operation"
+    tags_label "Categories"
 
     trait :past do
       start_date { Date.current - 12.days }

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -282,4 +282,80 @@ feature "Admin collaborative legislation" do
       expect(page).to have_content "There is still a long journey ahead of us"
     end
   end
+
+  context "Update proposal fields" do
+    let(:process) do
+      create(:legislation_process,
+             title: "An example legislation process",
+             summary: "Summarizing the process",
+             description: "Description of the process",
+             proposals_phase_start_date: Date.current - 2.days,
+             proposals_phase_end_date: Date.current + 2.days,
+             proposals_phase_enabled: true)
+    end
+
+    scenario "Change names of the fields" do
+      visit admin_legislation_process_proposals_path(process)
+
+      fill_in "legislation_process[title_label]", with: "New Proposal title"
+      fill_in "legislation_process[summary_label]", with: "New Proposal summary"
+      fill_in "legislation_process[description_label]", with: "New Proposal text"
+      fill_in "legislation_process[video_url_label]", with: "New Link to external video"
+      fill_in "legislation_process[image_label]", with: "New Descriptive image"
+      fill_in "legislation_process[documents_label]", with: "New Documents"
+      fill_in "legislation_process[geozone_label]", with: "New Scope of operation"
+      fill_in "legislation_process[tags_label]", with: "New Categories"
+
+      click_button "Save changes"
+
+      expect(page).to have_content "Process updated successfully"
+
+      visit new_legislation_process_proposal_path(process)
+
+      expect(page).to have_content "New Proposal title"
+      expect(page).to have_content "New Proposal summary"
+      expect(page).to have_content "New Proposal text"
+      expect(page).to have_content "New Link to external video"
+      expect(page).to have_content "New Descriptive image"
+      expect(page).to have_content "New Documents"
+      expect(page).to have_content "New Scope of operation"
+      expect(page).to have_content "New Categories"
+    end
+
+    scenario "Disable fields" do
+      visit admin_legislation_process_proposals_path(process)
+
+      uncheck "legislation_process[description_enabled]"
+      uncheck "legislation_process[video_url_enabled]"
+      uncheck "legislation_process[image_enabled]"
+      uncheck "legislation_process[documents_enabled]"
+      uncheck "legislation_process[geozone_enabled]"
+      uncheck "legislation_process[tags_enabled]"
+
+      click_button "Save changes"
+
+      expect(page).to have_content "Process updated successfully"
+
+      visit new_legislation_process_proposal_path(process)
+
+      expect(page).not_to have_content "Proposal text"
+      expect(page).not_to have_content "Link to external video"
+      expect(page).not_to have_content "Descriptive image"
+      expect(page).not_to have_content "Documents"
+      expect(page).not_to have_content "Scope of operation"
+      expect(page).not_to have_content "Categories"
+    end
+
+    scenario "Redirect to correct tab when error in fields" do
+      visit admin_legislation_process_proposals_path(process)
+
+      fill_in "legislation_process[description_label]", with: ""
+
+      click_button "Save changes"
+
+      expect(page).to have_content "Process couldn't be updated"
+      expect(page).to have_content "Proposal text"
+      expect(page).to have_content "can't be blank"
+    end
+  end
 end

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -194,4 +194,22 @@ describe Legislation::Process do
     end
   end
 
+  describe "proposal fields" do
+    it "is valid when label is nil but it is not enabled" do
+      process = build(:legislation_process,
+                       description_enabled: false,
+                       description_label: nil,
+                       video_url_enabled: false,
+                       video_url_label: nil,
+                       image_enabled: false,
+                       image_label: nil,
+                       documents_enabled: false,
+                       documents_label: nil,
+                       geozone_enabled: false,
+                       geozone_label: nil,
+                       tags_enabled: false,
+                       tags_label: nil)
+      expect(process).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
## References

Closes #3184 - Custom fields on legislation proposals

## Objectives

Enables admins to customize the fields of legislation proposals. It makes possible to select which fields are shown to the users and to change the label of the fields.

## Visual Changes

Changes in the admin view:

<img width="1061" alt="admin_view1" src="https://user-images.githubusercontent.com/253302/54249470-162f1d80-451f-11e9-88f1-5ed032c6985f.png">

<img width="1069" alt="admin_view2" src="https://user-images.githubusercontent.com/253302/54249486-1f1fef00-451f-11e9-8266-eba8dc40b1b7.png">

Changes in the users view:

<img width="835" alt="view" src="https://user-images.githubusercontent.com/253302/54249495-2810c080-451f-11e9-82ed-99903e8c8c9a.png">
