### PR TITLE
Add price column in the admin budget investments table

### DIFF
--- a/app/models/budget/investment/exporter.rb
+++ b/app/models/budget/investment/exporter.rb
@@ -58,6 +58,10 @@ class Budget::Investment::Exporter
 
   def price(investment)
     price_string = "admin.budget_investments.index.feasibility.#{investment.feasibility}"
-    I18n.t(price_string, price: investment.formatted_price)
+    if investment.feasible?
+      "#{I18n.t(price_string)} (#{investment.formatted_price})"
+    else
+      I18n.t(price_string)
+    end
   end
 end

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -36,6 +36,7 @@
         </th>
         <th><%= t("admin.budget_investments.index.list.geozone") %></th>
         <th><%= t("admin.budget_investments.index.list.feasibility") %></th>
+        <th><%= t("admin.budget_investments.index.list.price") %></th>
         <th class="text-center"><%= t("admin.budget_investments.index.list.valuation_finished") %></th>
         <th class="text-center"><%= t("admin.budget_investments.index.list.visible_to_valuators") %></th>
         <th class="text-center"><%= t("admin.budget_investments.index.list.selected") %></th>

--- a/app/views/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/admin/budget_investments/_select_investment.html.erb
@@ -31,8 +31,10 @@
   <%= investment.heading.name %>
 </td>
 <td class="small">
-  <%= t("admin.budget_investments.index.feasibility.#{investment.feasibility}",
-        price: investment.formatted_price) %>
+  <%= t("admin.budget_investments.index.feasibility.#{investment.feasibility}") %>
+</td>
+<td class="small">
+  <%= investment.formatted_price %>
 </td>
 <td class="small text-center">
   <%= investment.valuation_finished? ? t("shared.yes"): t("shared.no") %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -206,7 +206,7 @@ en:
         no_valuators_assigned: No valuators assigned
         no_valuation_groups: No valuation groups assigned
         feasibility:
-          feasible: "Feasible (%{price})"
+          feasible: "Feasible"
           unfeasible: "Unfeasible"
           undecided: "Undecided"
         selected: "Selected"
@@ -225,6 +225,7 @@ en:
           visible_to_valuators: Show to valuators
           author_username: Author username
           incompatible: Incompatible
+          price: Price
         cannot_calculate_winners: The budget has to stay on phase "Balloting projects", "Reviewing Ballots" or "Finished budget" in order to calculate winners projects
         see_results: "See results"
       show:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -206,7 +206,7 @@ es:
         no_valuators_assigned: Sin evaluador
         no_valuation_groups: Sin grupos evaluadores
         feasibility:
-          feasible: "Viable (%{price})"
+          feasible: "Viable"
           unfeasible: "Inviable"
           undecided: "Sin decidir"
         selected: "Seleccionado"
@@ -225,6 +225,7 @@ es:
           visible_to_valuators: Mostrar a evaluadores
           author_username: Usuario autor
           incompatible: Incompatible
+          price: Precio
         cannot_calculate_winners: El presupuesto debe estar en las fases "Votación final", "Votación finalizada" o "Resultados" para poder calcular las propuestas ganadoras
         see_results: "Ver resultados"
       show:


### PR DESCRIPTION
## References

https://github.com/consul/consul/issues/3355

## Objectives

On admin investments page, we have a column "Feasibility" which display 2 different values: Feasibility and price.

- Add new column on table where display Price value
- Split current Feasibility information in two different columns, Feasibility and Price
- Add translations for new column

## Visual Changes

**Before:**
![image](https://user-images.githubusercontent.com/1029265/54264690-f249f700-4573-11e9-8663-ed0329b0b930.png)

**After:**
![image](https://user-images.githubusercontent.com/1029265/54264706-fb3ac880-4573-11e9-9d3b-ef927d5c2b50.png)

## Notes
This information can be exported as CSV. I'm not sure if someone uses that csv, so I keep the current implementation of that method