### PR TITLE
[Backport] Fix accessibility and HTML warnings

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2655,6 +2655,17 @@ table {
   }
 }
 
+.leaflet-container {
+
+  .leaflet-control-attribution {
+    background: rgba(255, 255, 255, 0.9) !important;
+  }
+
+  a {
+    color: $link !important;
+  }
+}
+
 // 24. Homepage
 // ------------
 

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -128,15 +128,7 @@
     <% if @finished_budgets.present? %>
       <div class="row margin-top">
         <div class="small-12 medium-9 column">
-          <ul class="no-bullet submenu">
-            <li class="inline-block">
-              <%= link_to "#other_budgets", class: "is-active" do %>
-                <h2>
-                  <%= t("budgets.index.finished_budgets") %>
-                </h2>
-              <% end %>
-            </li>
-          </ul>
+          <h2><%= t("budgets.index.finished_budgets") %></h2>
 
           <div id="finished_budgets" class="budget-investments-list">
             <% @finished_budgets.each do |budget| %>

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -49,7 +49,8 @@
         title: investment.title,
         image_url: image_absolute_url(investment.image, :thumb),
         url: budget_investment_url(investment.budget, investment),
-        description: investment.title
+        description: investment.title,
+        mobile: investment.title
       } %>
     </div>
   <% end %>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -60,7 +60,8 @@
           share_title: t("debates.show.share"),
           title: @debate.title,
           url: debate_url(@debate),
-          description: @debate.title
+          description: @debate.title,
+          mobile: @debate.title
         } %>
       </aside>
     </div>

--- a/app/views/legislation/processes/_header.html.erb
+++ b/app/views/legislation/processes/_header.html.erb
@@ -40,7 +40,8 @@
         share_title: t("proposals.show.share"),
         title: @process.title,
         url: legislation_process_url(@process),
-        description: @process.title
+        description: @process.title,
+        mobile: @process.title
       } %>
 
       <% if @process.image.present? %>

--- a/app/views/legislation/proposals/_featured_votes.html.erb
+++ b/app/views/legislation/proposals/_featured_votes.html.erb
@@ -40,7 +40,8 @@
         <%= render partial: 'shared/social_share', locals: {
           title: proposal.title,
           url: proposal_url(proposal),
-          description: proposal.summary
+          description: proposal.summary,
+          mobile: proposal.title
         } %>
       </div>
     <% end %>

--- a/app/views/legislation/proposals/_votes.html.erb
+++ b/app/views/legislation/proposals/_votes.html.erb
@@ -73,7 +73,8 @@
       <%= render partial: 'shared/social_share', locals: {
           title: proposal.title,
           url: proposal_url(proposal),
-          description: proposal.summary
+          description: proposal.summary,
+          mobile: proposal.title
       } %>
     </div>
   <% end %>

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -108,7 +108,8 @@
           share_title: t("proposals.show.share"),
           title: @proposal.title,
           url: legislation_process_proposal_url(process_id: @process),
-          description: @proposal.summary
+          description: @proposal.summary,
+          mobile: @proposal.title
         } %>
       </aside>
     </div>

--- a/app/views/polls/_poll_header.html.erb
+++ b/app/views/polls/_poll_header.html.erb
@@ -21,7 +21,8 @@
         share_title: t("shared.share"),
         title: @poll.name,
         url: poll_url(@poll),
-        description: @poll.name
+        description: @poll.name,
+        mobile: @poll.name
       } %>
     </aside>
   </div>

--- a/app/views/proposals/_featured_votes.html.erb
+++ b/app/views/proposals/_featured_votes.html.erb
@@ -40,7 +40,8 @@
         <%= render partial: 'shared/social_share', locals: {
           title: proposal.title,
           url: proposal_url(proposal),
-          description: proposal.summary
+          description: proposal.summary,
+          mobile: proposal.title
         } %>
       </div>
     <% end %>

--- a/app/views/proposals/_info.html.erb
+++ b/app/views/proposals/_info.html.erb
@@ -60,10 +60,11 @@
     </p>
     <%= text_with_links @proposal.video_url %>
   </div>
-
 <% end %>
 
-<h4><%= @proposal.question %></h4>
+<% if @proposal.question.present? %>
+  <h4><%= @proposal.question %></h4>
+<% end %>
 
 <% if @proposal.retired? %>
   <div id="retired_explanation" class="callout">

--- a/app/views/proposals/_social_share.html.erb
+++ b/app/views/proposals/_social_share.html.erb
@@ -3,8 +3,8 @@
             title: proposal.title,
             url: proposal_url(proposal),
             description: t("proposals.share.message",
-                            summary: proposal.summary,
+                            title: proposal.title,
                             handle: setting['org_name']),
             mobile: t("proposals.share.message",
-                        summary: proposal.summary,
+                        title: proposal.title,
                         handle: setting['twitter_handle']) %>

--- a/app/views/proposals/share.html.erb
+++ b/app/views/proposals/share.html.erb
@@ -24,7 +24,8 @@
         <%= render partial: 'shared/social_share', locals: {
           title: @proposal.title,
           url: proposal_url(@proposal),
-          description: @proposal.summary
+          description: @proposal.summary,
+          mobile: @proposal.title
         } %>
 
         <div class="small margin-bottom">

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -2,8 +2,12 @@
   <h1 class="show-for-sr"><%= t("shared.outline.searcher") %></h1>
   <%= form_tag search_path, method: :get do %>
     <div class="input-group">
-      <label for="search_text" class="show-for-sr"><%= t("#{i18n_namespace}.title") %></label>
-      <input type="text" name="search" placeholder='<%= t("#{i18n_namespace}.placeholder") %>' class="input-group-field" value="<%= params[:search] %>" id="search_text">
+      <label for="search_text">
+        <span class="show-for-sr"><%= t("#{i18n_namespace}.title") %></span>
+        <input type="text" name="search" placeholder="<%= t("#{i18n_namespace}.placeholder") %>"
+                                         class="input-group-field"
+                                         value="<%= params[:search] %>" id="search_text">
+      </label>
       <div class="input-group-button">
         <button type="submit" class="button" title="<%= t("#{i18n_namespace}.button") %>">
           <span class="show-for-sr"><%= t("#{i18n_namespace}.button") %></span>

--- a/app/views/shared/_social_share.html.erb
+++ b/app/views/shared/_social_share.html.erb
@@ -1,5 +1,8 @@
 <% description = local_assigns.fetch(:description, '') %>
 <% description = truncate(ActionView::Base.full_sanitizer.sanitize(description), length: 140) %>
+<% mobile = local_assigns[:mobile] %>
+<% mobile_url = mobile.present? ? "#{mobile.gsub(/\s+/, '%20')}%20" : "" %>
+
 <% if local_assigns[:share_title].present? %>
   <div id="social-share" class="sidebar-divider"></div>
   <p class="sidebar-title"><%= share_title %></p>
@@ -11,7 +14,7 @@
                               desc: description,
                               'data-twitter-title': local_assigns[:mobile],
                               'data-telegram-title': local_assigns[:mobile])%>
-  <a href="whatsapp://send?text=<%= local_assigns[:mobile]%>&nbsp;<%= url %>"
+  <a href="whatsapp://send?text=<%= mobile_url %><%= url %>"
      class="show-for-small-only" data-action="share/whatsapp/share">
     <span class="icon-whatsapp whatsapp"></span>
     <span class="show-for-sr"><%= t("social.whatsapp") %></span>

--- a/app/views/users/_budget_investments.html.erb
+++ b/app/views/users/_budget_investments.html.erb
@@ -1,7 +1,9 @@
 <table id="budget_investments_list" class="margin-top">
   <thead>
-    <th scope="col"><%= t("users.show.budget_investments") %></th>
-    <th scope="col"><%= t("users.show.actions") %></th>
+    <tr>
+      <th scope="col"><%= t("users.show.budget_investments") %></th>
+      <th scope="col"><%= t("users.show.actions") %></th>
+    </tr>
   </thead>
   <tbody>
     <% @budget_investments.each do |budget_investment| %>

--- a/app/views/users/_comments.html.erb
+++ b/app/views/users/_comments.html.erb
@@ -1,6 +1,8 @@
 <table class="margin-top">
   <thead>
-    <th scope="col"><%= t("users.show.comments") %></th>
+    <tr>
+      <th scope="col"><%= t("users.show.comments") %></th>
+    </tr>
   </thead>
   <tbody>
     <% @comments.each do |comment| %>

--- a/app/views/users/_debates.html.erb
+++ b/app/views/users/_debates.html.erb
@@ -1,6 +1,8 @@
 <table class="margin-top">
   <thead>
-    <th scope="col"><%= t("users.show.debates") %></th>
+    <tr>
+      <th scope="col"><%= t("users.show.debates") %></th>
+    </tr>
   </thead>
   <tbody>
     <% @debates.each do |debate| %>

--- a/app/views/users/_proposals.html.erb
+++ b/app/views/users/_proposals.html.erb
@@ -1,7 +1,9 @@
 <table class="margin-top">
   <thead>
-    <th scope="col"><%= t("users.show.proposals") %></th>
-    <th scope="col" colspan="2"><%= t("users.show.actions") %></th>
+    <tr>
+      <th scope="col"><%= t("users.show.proposals") %></th>
+      <th scope="col" colspan="2"><%= t("users.show.actions") %></th>
+    </tr>
   </thead>
   <tbody>
     <% @proposals.each do |proposal| %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -443,7 +443,7 @@ en:
       form:
         submit_button: Save changes
     share:
-      message: "I supported the proposal %{summary} in %{handle}. If you're interested, support it too!"
+      message: "I supported the proposal %{title} in %{handle}. If you're interested, support it too!"
   polls:
     all: "All"
     no_dates: "no date assigned"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -443,7 +443,7 @@ es:
       form:
         submit_button: Guardar cambios
     share:
-      message: "He apoyado la propuesta %{summary} en %{handle}. Si te interesa, ¡apoya tú también!"
+      message: "He apoyado la propuesta %{title} en %{handle}. Si te interesa, ¡apoya tú también!"
   polls:
     all: "Todas"
     no_dates: "sin fecha asignada"


### PR DESCRIPTION
## References

Backport of https://github.com/AyuntamientoMadrid/consul/pull/1907/

We use [Rocket Validator](https://rocketvalidator.com) to check weekly HTML and A11y issues on code.

## Objectives

- Add missing `<tr>` tags on users views.
- Show proposal question only if it is present: this prevent render an empty `<h4>` tag.
- Change label for search text: label wraps input field to prevent error on missing label (hided by CSS).  
- Fix heading levels on custom welcome index.
- Improve color contrast on leaflet map.
- Remove unnecessary anchor link for finished budgets.
- Replace summary to title on proposals social share message.
- Replace spaces to `%20` on WhatsApp share url: this avoid have an invalid href with spaces.
- Add missing mobile social share message.
- Remove unnecessary type on script tags.

## Visual Changes

**Share on WhatsApp work as expected**
![whatsapp](https://user-images.githubusercontent.com/631897/53956752-c692c100-40dc-11e9-80e8-cd899e33160d.png)