### PR TITLE
Keep images uploaded with CKEditor when deploying

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,7 +22,7 @@ set :pty, true
 set :use_sudo, false
 
 set :linked_files, %w{config/database.yml config/secrets.yml config/unicorn.rb config/environments/production.rb}
-set :linked_dirs, %w{log tmp public/system public/assets}
+set :linked_dirs, %w{log tmp public/system public/assets public/ckeditor_assets}
 
 set :keep_releases, 5
 


### PR DESCRIPTION
## References

This is a backport of PR https://github.com/AyuntamientoMadrid/consul/pull/1926

## Objectives

Images uploaded with CKEditor go to a folder that was not linked, so every new deploy with capistrano the reference to those images were lost.

By linking the directory the references to the images remain after a new deploy.

## Notes

After deploying this change, every image uploaded will remain with all consecutive deploys.