### PR TITLE
Enable rubocop rules in config and seed files

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -7,9 +7,8 @@ AllCops:
     - "**/Rakefile"
     - "**/config.ru"
   Exclude:
-    - "db/**/*"
-    - "config/**/*"
-    - "script/**/*"
+    - "db/migrate/**/*"
+    - "db/schema.rb"
   TargetRubyVersion: 2.3
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1930

## Objectives

Follow Ruby code conventions in all files having ruby code.