### PR TITLE
Simplify poll factories

### DIFF
--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -91,12 +91,11 @@ FactoryBot.define do
     origin "web"
 
     trait :from_booth do
-      association :booth_assignment, factory: :poll_booth_assignment
       origin "booth"
-      before :create do |voter|
-        voter.officer_assignment = create(:poll_officer_assignment,
-                                          officer: voter.officer,
-                                          booth_assignment: voter.booth_assignment)
+      association :booth_assignment, factory: :poll_booth_assignment
+
+      officer_assignment do
+        association :poll_officer_assignment, booth_assignment: booth_assignment, officer: officer
       end
     end
 

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -88,7 +88,12 @@ FactoryBot.define do
     poll
     association :user, :level_two
     association :officer, factory: :poll_officer
-    origin "web"
+    from_web
+
+    trait :from_web do
+      origin "web"
+      token SecureRandom.hex(32)
+    end
 
     trait :from_booth do
       origin "booth"
@@ -129,6 +134,16 @@ FactoryBot.define do
   factory :poll_recount, class: "Poll::Recount" do
     association :author, factory: :user
     origin "web"
+
+    trait :from_booth do
+      origin "booth"
+
+      transient { poll nil }
+
+      booth_assignment do
+        association :poll_booth_assignment, poll: poll
+      end
+    end
   end
 
   factory :officing_residence, class: "Officing::Residence" do

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -87,7 +87,6 @@ FactoryBot.define do
   factory :poll_voter, class: "Poll::Voter" do
     poll
     association :user, :level_two
-    association :officer, factory: :poll_officer
     from_web
 
     trait :from_web do
@@ -103,7 +102,9 @@ FactoryBot.define do
       end
 
       officer_assignment do
-        association :poll_officer_assignment, booth_assignment: booth_assignment, officer: officer
+        association :poll_officer_assignment,
+          booth_assignment: booth_assignment,
+          officer: officer || association(:poll_officer)
       end
     end
 

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -92,7 +92,10 @@ FactoryBot.define do
 
     trait :from_booth do
       origin "booth"
-      association :booth_assignment, factory: :poll_booth_assignment
+
+      booth_assignment do
+        association :poll_booth_assignment, poll: poll
+      end
 
       officer_assignment do
         association :poll_officer_assignment, booth_assignment: booth_assignment, officer: officer

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -222,7 +222,9 @@ feature "Admin polls" do
                  total_amount: 21)
         end
 
-        2.times { create(:poll_voter, booth_assignment: booth_assignment_final_recounted) }
+        2.times do
+          create(:poll_voter, poll: poll, booth_assignment: booth_assignment_final_recounted)
+        end
 
         create(:poll_recount,
                booth_assignment: booth_assignment_final_recounted,

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -318,10 +318,7 @@ feature "Admin polls" do
         unvoted_poll = create(:poll)
 
         voted_poll = create(:poll)
-        booth_assignment = create(:poll_booth_assignment, poll: voted_poll)
-        create(:poll_voter, :from_booth, :valid_document,
-               booth_assignment: booth_assignment,
-               poll: voted_poll)
+        create(:poll_voter, :from_booth, :valid_document, poll: voted_poll)
 
         visit admin_poll_results_path(unvoted_poll)
 

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -235,7 +235,7 @@ describe Poll do
       user = create(:user, :level_two)
       poll = create(:poll)
 
-      create(:poll_voter, poll: poll, user: user, origin: "booth")
+      create(:poll_voter, :from_booth, poll: poll, user: user)
 
       expect(poll.voted_in_booth?(user)).to be
     end
@@ -251,7 +251,7 @@ describe Poll do
       user = create(:user, :level_two)
       poll = create(:poll)
 
-      create(:poll_voter, poll: poll, user: user, origin: "web")
+      create(:poll_voter, :from_web, poll: poll, user: user)
 
       expect(poll.voted_in_booth?(user)).not_to be
     end

--- a/spec/models/poll/stats_spec.rb
+++ b/spec/models/poll/stats_spec.rb
@@ -2,16 +2,15 @@ require "rails_helper"
 
 describe Poll::Stats do
 
-  describe "Calculate stats" do
-    it "Generate the correct stats" do
+  describe "#generate" do
+    it "generates the correct stats" do
       poll = create(:poll)
-      booth = create(:poll_booth)
-      booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-      create(:poll_voter, poll: poll, origin: "web")
-      3.times {create(:poll_voter, poll: poll, origin: "booth")}
-      create(:poll_voter, poll: poll)
-      create(:poll_recount, origin: "booth", white_amount: 1, null_amount: 0, total_amount: 2, booth_assignment_id: booth_assignment.id)
-      stats = described_class.new(poll).generate
+      2.times { create(:poll_voter, :from_web, poll: poll) }
+      3.times { create(:poll_voter, :from_booth, poll: poll) }
+      create(:poll_recount, :from_booth, poll: poll,
+             white_amount: 1, null_amount: 0, total_amount: 2)
+
+      stats = Poll::Stats.new(poll).generate
 
       expect(stats[:total_participants]).to eq(5)
       expect(stats[:total_participants_web]).to eq(2)

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -76,7 +76,7 @@ describe Poll::Voter do
 
     it "is not valid if the user has voted via web" do
       answer = create(:poll_answer)
-      answer.record_voter_participation("token")
+      create(:poll_voter, :from_web, user: answer.author, poll: answer.poll)
 
       voter = build(:poll_voter, poll: answer.question.poll, user: answer.author)
       expect(voter).not_to be_valid
@@ -113,9 +113,9 @@ describe Poll::Voter do
 
     describe "#web" do
       it "returns voters with a web origin" do
-        voter1 = create(:poll_voter, origin: "web")
-        voter2 = create(:poll_voter, origin: "web")
-        voter3 = create(:poll_voter, origin: "booth")
+        voter1 = create(:poll_voter, :from_web)
+        voter2 = create(:poll_voter, :from_web)
+        voter3 = create(:poll_voter, :from_booth)
 
         web_voters = described_class.web
 
@@ -128,9 +128,9 @@ describe Poll::Voter do
 
     describe "#booth" do
       it "returns voters with a booth origin" do
-        voter1 = create(:poll_voter, origin: "booth")
-        voter2 = create(:poll_voter, origin: "booth")
-        voter3 = create(:poll_voter, origin: "web")
+        voter1 = create(:poll_voter, :from_booth)
+        voter2 = create(:poll_voter, :from_booth)
+        voter3 = create(:poll_voter, :from_web)
 
         booth_voters = described_class.booth
 


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1931

## Objectives

* Make it easier to write tests using poll voters in booths
* Generate less records in the database during tests