### PR TITLE
Require logged in user if navigate to /welcome

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,6 +1,7 @@
 class WelcomeController < ApplicationController
   skip_authorization_check
   before_action :set_user_recommendations, only: :index, if: :current_user
+  before_action :authenticate_user!, only: :welcome
 
   layout "devise", only: [:welcome, :verification]
 

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -4,6 +4,11 @@ feature "Welcome screen" do
 
   let(:budget) { create(:budget) }
 
+  scenario "requires a logged in user" do
+    visit welcome_path
+    expect(page).to have_content "You must sign in or register to continue."
+  end
+
   scenario "for a not verified user" do
     user = create(:user)
     login_through_form_as(user)


### PR DESCRIPTION
## References

This is a backport of PR https://github.com/AyuntamientoMadrid/consul/pull/1928

## Objectives
- Do not raise an exception if a not logged in user navigates to `/welcome`
- Tell the user you need to be logged in with a flash message.