### PR TITLE
Add description field to administrator users like evaluators description

### DIFF
--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -28,4 +28,22 @@ class Admin::AdministratorsController < Admin::BaseController
 
     redirect_to admin_administrators_path
   end
+
+  def edit
+  end
+
+  def update
+    if @administrator.update(update_administrator_params)
+      notice = t("admin.administrators.form.updated")
+      redirect_to admin_administrators_path, notice: notice
+    else
+      render :edit
+    end
+  end
+
+  private
+
+    def update_administrator_params
+      params.require(:administrator).permit(:description)
+    end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -77,7 +77,9 @@ module AdminHelper
   end
 
   def admin_select_options
-    Administrator.all.order("users.username asc").includes(:user).collect { |v| [ v.name, v.id ] }
+    Administrator.with_user
+                 .collect { |v| [ v.description_or_name, v.id ] }
+                 .sort_by { |a| a[0] }
   end
 
   def admin_submit_action(resource)

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -51,7 +51,7 @@ module Abilities
       can :comment_as_administrator, [Debate, Comment, Proposal, Poll::Question, Budget::Investment,
                                       Legislation::Question, Legislation::Proposal, Legislation::Annotation, Topic]
 
-      can [:search, :create, :index, :destroy], ::Administrator
+      can [:search, :create, :index, :destroy, :edit, :update], ::Administrator
       can [:search, :create, :index, :destroy], ::Moderator
       can [:search, :show, :edit, :update, :create, :index, :destroy, :summary], ::Valuator
       can [:search, :create, :index, :destroy], ::Manager

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -3,4 +3,14 @@ class Administrator < ApplicationRecord
   delegate :name, :email, :name_and_email, to: :user
 
   validates :user_id, presence: true, uniqueness: true
+
+  scope :with_user, -> { includes(:user) }
+
+  def description_or_name
+    description.presence || name
+  end
+
+  def description_or_name_and_email
+    "#{description_or_name} (#{email})"
+  end
 end

--- a/app/views/admin/administrators/edit.html.erb
+++ b/app/views/admin/administrators/edit.html.erb
@@ -1,0 +1,15 @@
+<%= back_link_to admin_administrators_path %>
+
+<h2><%= t("admin.administrators.form.edit_title") %></h2>
+
+<div class="callout highlight">
+  <strong><%= @administrator.name %></strong><br>
+  <%= @administrator.email %>
+</div>
+
+<div class="margin-top">
+  <%= form_for [:admin, @administrator] do |f| %>
+    <%= f.text_field :description %>
+    <%= f.submit class: "button success" %>
+  <% end %>
+</div>

--- a/app/views/admin/administrators/index.html.erb
+++ b/app/views/admin/administrators/index.html.erb
@@ -11,6 +11,7 @@
         <th scope="col" class="text-center"><%= t("admin.administrators.index.id") %></th>
         <th scope="col"><%= t("admin.administrators.index.name") %></th>
         <th scope="col"><%= t("admin.administrators.index.email") %></th>
+        <th scope="col"><%= t("admin.administrators.index.description") %></th>
         <th scope="col" class="small-3"><%= t("admin.shared.actions") %></th>
       </thead>
       <% @administrators.each do |administrator| %>
@@ -25,12 +26,17 @@
             <%= administrator.email %>
           </td>
           <td>
+            <%= administrator.description %>
+          </td>
+          <td>
             <% if administrator.persisted? %>
+              <%= link_to t("admin.actions.edit"),
+                          edit_admin_administrator_path(administrator),
+                          class: "button hollow" %>
               <%= link_to t("admin.administrators.administrator.delete"),
                           admin_administrator_path(administrator),
                           method: :delete,
-                          class: "button hollow alert expanded"
-              %>
+                          class: "button hollow alert" %>
             <% else %>
               <%= link_to t("admin.administrators.administrator.add"),
                           { controller: "admin/administrators", action: :create,

--- a/app/views/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/admin/budget_investments/_select_investment.html.erb
@@ -13,9 +13,9 @@
 </td>
 <td class="small">
   <% if investment.administrator.present? %>
-              <span title="<%= t("admin.budget_investments.index.assigned_admin") %>">
-                <%= investment.administrator.name %>
-              </span>
+    <span title="<%= t("admin.budget_investments.index.assigned_admin") %>">
+      <%= investment.administrator.description_or_name %>
+    </span>
   <% else %>
       <%= t("admin.budget_investments.index.no_admin_assigned") %>
   <% end %>

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -46,7 +46,7 @@
 
       <div class="small-12 medium-6">
         <%= f.select(:administrator_id,
-                       @admins.collect{ |a| [a.name_and_email, a.id ] },
+                       @admins.collect{ |a| [a.description_or_name_and_email, a.id ] },
                        { include_blank: t("admin.budget_investments.edit.undefined") }) %>
       </div>
     </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -3,7 +3,8 @@
 <% allow_votes = local_assigns.fetch(:allow_votes, true) %>
 <% allow_actions = local_assigns.fetch(:allow_actions, true) %>
 <% allow_comments = local_assigns.fetch(:allow_comments, true) %>
-<% cache [locale_and_user_status(comment), comment, commentable_cache_key(comment.commentable), comment.author, (comment_flags[comment.id] if comment_flags)] do %>
+<% admin_layout = local_assigns.fetch(:admin_layout, false) %>
+<% cache [locale_and_user_status(comment), comment, commentable_cache_key(comment.commentable), comment.author, (comment_flags[comment.id] if comment_flags), (admin_layout if admin_layout)] do %>
   <ul id="<%= dom_id(comment) %>" class="comment no-bullet small-12">
     <li class="comment-body">
       <% if comment.hidden? || comment.user.hidden? %>
@@ -30,7 +31,14 @@
         <div class="comment-info">
 
           <% if comment.as_administrator? %>
-            <span class="user-name"><%= t("comments.comment.admin") %> #<%= comment.administrator_id %></span>
+            <span class="user-name">
+              <%= t("comments.comment.admin") %>
+              <% if admin_layout %>
+                <%= Administrator.find(comment.administrator_id).description_or_name %>
+              <% else %>
+                #<%= comment.administrator_id %>
+              <% end %>
+            </span>
           <% elsif comment.as_moderator? %>
             <span class="user-name"><%= t("comments.comment.moderator") %> #<%= comment.moderator_id %></span>
           <% else %>

--- a/app/views/comments/_comment_tree.html.erb
+++ b/app/views/comments/_comment_tree.html.erb
@@ -1,7 +1,8 @@
 <% commentable = comment_tree.commentable %>
 <% valuation = local_assigns.fetch(:valuation, false) %>
 <% allow_comments = local_assigns.fetch(:allow_comments, true) %>
-<% cache [locale_and_user_status, comment_tree.order, commentable_cache_key(commentable), comment_tree.comments, comment_tree.comment_authors, commentable.comments_count, comment_flags] do %>
+<% admin_layout = local_assigns.fetch(:admin_layout, false) %>
+<% cache [locale_and_user_status, comment_tree.order, commentable_cache_key(commentable), comment_tree.comments, comment_tree.comment_authors, commentable.comments_count, comment_flags, admin_layout] do %>
   <section class="expanded comments">
     <div class="row">
       <div id="comments" class="small-12 column">
@@ -46,7 +47,8 @@
                                            valuation: valuation,
                                            allow_votes: !valuation,
                                            allow_actions: !valuation,
-                                           allow_comments: allow_comments } %>
+                                           allow_comments: allow_comments,
+                                           admin_layout: admin_layout } %>
         <% end %>
         <%= paginate comment_tree.root_comments %>
       </div>

--- a/app/views/valuation/budget_investments/_valuation_comments.html.erb
+++ b/app/views/valuation/budget_investments/_valuation_comments.html.erb
@@ -1,8 +1,10 @@
 <h2><%= t("valuation.budget_investments.valuation_comments") %></h2>
 <% unless @comment_tree.nil? %>
-  <%= render partial: "/comments/comment_tree", locals: { comment_tree: @comment_tree,
-                                                          comment_flags: @comment_flags,
-                                                          display_comments_count: false,
-                                                          valuation: true,
-                                                          allow_comments: !@budget.finished? } %>
+  <%= render partial: "/comments/comment_tree", locals: {
+    comment_tree: @comment_tree,
+    comment_flags: @comment_flags,
+    display_comments_count: false,
+    valuation: true,
+    allow_comments: !@budget.finished?,
+    admin_layout: true } %>
 <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -728,6 +728,7 @@ en:
         title: Administrators
         name: Name
         email: Email
+        description: Description
         id: Administrator ID
         no_administrators: There are no administrators.
       administrator:
@@ -736,6 +737,9 @@ en:
         restricted_removal: "Sorry, you can't remove yourself from the administrators"
       search:
         title: "Administrators: User search"
+      form:
+        edit_title: "Edit administrator"
+        updated: "Administrator updated successfully"
     moderators:
       index:
         title: Moderators

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -126,6 +126,8 @@ es:
         one: Enlace
         other: Enlaces
     attributes:
+      administrator:
+        description: Descripción
       budget:
         name: "Nombre"
         description_accepting: "Descripción durante la fase de presentación de proyectos"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -727,6 +727,7 @@ es:
         title: Administradores
         name: Nombre
         email: Email
+        description: Descripción
         id: ID de Administrador
         no_administrators: No hay administradores.
       administrator:
@@ -735,6 +736,9 @@ es:
         restricted_removal: "Lo sentimos, no puedes eliminarte a ti mismo de la lista"
       search:
         title: "Administradores: Búsqueda de usuarios"
+      form:
+        edit_title: "Editar administrador"
+        updated: "Administrador actualizado correctamente"
     moderators:
       index:
         title: Moderadores

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -106,7 +106,7 @@ namespace :admin do
     get :search, on: :collection
   end
 
-  resources :administrators, only: [:index, :create, :destroy] do
+  resources :administrators, only: [:index, :create, :destroy, :edit, :update] do
     get :search, on: :collection
   end
 

--- a/db/migrate/20190314150724_add_description_to_administrator.rb
+++ b/db/migrate/20190314150724_add_description_to_administrator.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToAdministrator < ActiveRecord::Migration
+  def change
+    add_column :administrators, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20190429125842) do
 
   create_table "administrators", force: :cascade do |t|
     t.integer "user_id"
+    t.string  "description"
     t.index ["user_id"], name: "index_administrators_on_user_id", using: :btree
   end
 

--- a/spec/features/admin/administrators_spec.rb
+++ b/spec/features/admin/administrators_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Admin administrators" do
   let!(:admin) { create(:administrator) }
   let!(:user) { create(:user, username: "Jose Luis Balbin") }
-  let!(:user_administrator) { create(:administrator) }
+  let!(:user_administrator) { create(:administrator, description: "admin_alias") }
 
   before do
     login_as(admin.user)
@@ -14,6 +14,7 @@ describe "Admin administrators" do
     expect(page).to have_content user_administrator.id
     expect(page).to have_content user_administrator.name
     expect(page).to have_content user_administrator.email
+    expect(page).to have_content user_administrator.description
     expect(page).not_to have_content user.name
   end
 
@@ -97,6 +98,21 @@ describe "Admin administrators" do
       expect(page).to have_content("Administrators: User search")
       expect(page).to have_content(administrator2.email)
       expect(page).not_to have_content(administrator1.email)
+    end
+  end
+
+  context "Edit" do
+    let!(:administrator1) { create(:administrator, user: create(:user,
+                                                                 username: "Bernard Sumner",
+                                                                 email: "bernard@sumner.com")) }
+
+    scenario "admin can edit administrator1" do
+      visit(edit_admin_administrator_path(administrator1))
+      fill_in "administrator_description", with: "Admin Alias"
+      click_button "Update Administrator"
+
+      expect(page).to have_content("Administrator updated successfully")
+      expect(page).to have_content("Admin Alias")
     end
   end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -149,8 +149,9 @@ describe "Admin budget investments" do
 
     scenario "Filtering by admin", :js do
       user = create(:user, username: "Admin 1")
+      user2 = create(:user, username: "Admin 2")
       administrator = create(:administrator, user: user)
-
+      create(:administrator, user: user2, description: "Alias")
       create(:budget_investment, title: "Realocate visitors", budget: budget,
                                                               administrator: administrator)
       create(:budget_investment, title: "Destroy the city", budget: budget)
@@ -165,6 +166,13 @@ describe "Admin budget investments" do
       expect(page).to have_content("There is 1 investment")
       expect(page).not_to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
+
+      select "Alias", from: "administrator_id"
+      click_button "Filter"
+
+      expect(page).to have_content("There are no investment projects")
+      expect(page).not_to have_link("Destroy the city")
+      expect(page).not_to have_link("Realocate visitors")
 
       select "All administrators", from: "administrator_id"
       click_button "Filter"
@@ -1066,12 +1074,12 @@ describe "Admin budget investments" do
     scenario "Add administrator" do
       budget_investment = create(:budget_investment)
       user = create(:user, username: "Marta", email: "marta@admins.org")
-      create(:administrator, user: user)
+      create(:administrator, user: user, description: "Marta desc")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
       click_link "Edit classification"
 
-      select "Marta (marta@admins.org)", from: "budget_investment[administrator_id]"
+      select "Marta desc (marta@admins.org)", from: "budget_investment[administrator_id]"
       click_button "Update"
 
       expect(page).to have_content "Investment project updated succesfully."

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe Administrator do
+
+  describe "#description_or_name" do
+    let!(:user) { create(:user, username: "Billy Wilder" )}
+
+    it "returns description if present" do
+      administrator = create(:administrator, user: user, description: "John Doe")
+
+      expect(administrator.description_or_name).to eq("John Doe")
+    end
+
+    it "returns name if description is nil" do
+      administrator = create(:administrator, user: user)
+
+      expect(administrator.description_or_name).to eq("Billy Wilder")
+    end
+
+    it "returns name if description is blank" do
+      administrator = create(:administrator, description: "")
+
+      expect(administrator.description_or_name).to eq(administrator.name)
+    end
+  end
+
+  describe "#description_or_name_and_email" do
+    let!(:user) { create(:user, username: "Billy Wilder", email: "test@test.com")}
+
+    it "returns description and email if decription present" do
+      administrator = create(:administrator,
+                              description: "John Doe",
+                              user: user)
+
+      expect(administrator.description_or_name_and_email).to eq("John Doe (test@test.com)")
+    end
+
+    it "returns name and email if description is not present" do
+      administrator = create(:administrator, user: user)
+
+      expect(administrator.description_or_name_and_email).to eq("Billy Wilder (test@test.com)")
+    end
+  end
+
+end


### PR DESCRIPTION
## References

https://github.com/consul/consul/issues/3375

## Objectives

Add model, controller and views changes to let admin users manage administrator description
Display this new description as administrator name if exists

## Visual Changes

**Edit administrator view**
![image](https://user-images.githubusercontent.com/1029265/54671642-9690e800-4af6-11e9-9958-d6378ecf0ded.png)

**Administrators index**
![image](https://user-images.githubusercontent.com/1029265/54671680-b32d2000-4af6-11e9-988f-7b1c37906f72.png)

**Budget investments filter_by administrator options and table information**
![image](https://user-images.githubusercontent.com/1029265/54671858-14ed8a00-4af7-11e9-972a-3d6c331d9569.png)

## Notes

- Needs a migration to add new administrator field
- Administrator name will be used as fallback in case of alias was not set