### PR TITLE
Use min age to participate setting on verification residence form

### DIFF
--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -6,6 +6,10 @@ module VerificationHelper
      [t("verification.residence.new.document_type.residence_card"), 3]]
   end
 
+  def minimum_required_age
+    (Setting["min_age_to_participate"] || 16).to_i
+  end
+
   def mask_phone(number)
     match = number.match(/\d{3}$/)
     "******#{match}"

--- a/app/views/verification/residence/new.html.erb
+++ b/app/views/verification/residence/new.html.erb
@@ -67,7 +67,7 @@
       <%= f.label t("verification.residence.new.date_of_birth") %>
       <%= f.date_select :date_of_birth,
                         prompt: true,
-                        start_year: 1900, end_year: 16.years.ago.year,
+                        start_year: 1900, end_year: minimum_required_age.years.ago.year,
                         label: false %>
       </div>
 

--- a/spec/features/verification/residence_spec.rb
+++ b/spec/features/verification/residence_spec.rb
@@ -16,10 +16,24 @@ feature "Residence" do
     select_date "31-December-1980", from: "residence_date_of_birth"
     fill_in "residence_postal_code", with: "28013"
     check "residence_terms_of_service"
-
     click_button "Verify residence"
 
     expect(page).to have_content "Residence verified"
+  end
+
+  scenario "Residence form use min age to participate" do
+    min_age = (Setting["min_age_to_participate"] = 16).to_i
+    underage = min_age - 1
+    user = create(:user)
+    login_as(user)
+
+    visit account_path
+    click_link "Verify my account"
+
+    expect(page).to have_select("residence_date_of_birth_1i",
+                                 with_options: [min_age.years.ago.year])
+    expect(page).not_to have_select("residence_date_of_birth_1i",
+                                     with_options: [underage.years.ago.year])
   end
 
   scenario "When trying to verify a deregistered account old votes are reassigned" do


### PR DESCRIPTION
## References

This a backport of part of https://github.com/AyuntamientoMadrid/consul/pull/1917

## Objectives

Use `Setting["min_age_to_participate"]` on **verification residence form**. Before, the form was using hardcoded `16` value for birthdate field on verification residence form:

```
start_year: 1900, end_year: 16.years.ago.year
```
Now uses the setting:

```
start_year: 1900, end_year: minimum_required_age.years.ago.year
```

```
def minimum_required_age
  (Setting["min_age_to_participate"] || 16).to_i
end
```