### PR TITLE
Fix legislation process feed order

### DIFF
--- a/app/models/widget/feed.rb
+++ b/app/models/widget/feed.rb
@@ -31,7 +31,7 @@ class Widget::Feed < ActiveRecord::Base
   end
 
   def processes
-    Legislation::Process.open.published.limit(limit)
+    Legislation::Process.open.published.order("created_at DESC").limit(limit)
   end
 
 end


### PR DESCRIPTION
## References

* Closes #3312 

## Objectives

Make the legislation process shown on a feed consistent.

## Notes

As mentioned in the commit message, we need to add an ORDER BY clause; not doing so was causing different processes to show up sometimes. Quoting the PostgreSQL manual:

> Because the order of the rows in the database table is unpredictable, when you use the LIMIT clause, you should always use the ORDER BY clause to control the order of rows. If you don’t do so, you will get an unpredictable result set.