### PR TITLE
Translations fix specs

### DIFF
--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -27,7 +27,7 @@ class Budget
     delegate :budget, :budget_id, to: :group, allow_nil: true
 
     scope :i18n,                  -> { includes(:translations) }
-    scope :allow_custom_content,  -> { i18n.where(allow_custom_content: true).order(:name) }
+    scope :allow_custom_content,  -> { i18n.where(allow_custom_content: true).order("budget_heading_translations.name") }
 
     def self.sort_by_name
       all.sort do |heading, other_heading|

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -175,7 +175,7 @@ class Budget
     def searchable_values
       { title              => "A",
         author.username    => "B",
-        heading.try(:name) => "B",
+        heading.name       => "B",
         tag_list.join(" ") => "B",
         description        => "C"
       }

--- a/spec/shared/features/translatable.rb
+++ b/spec/shared/features/translatable.rb
@@ -56,63 +56,67 @@ shared_examples "translatable" do |factory_name, path_name, input_fields, textar
       end
     end
 
-    scenario 'should show first available fallback when current locale translation does not exist', :js do
-      if translatable_class.name == "ActivePoll" || translatable_class.name == "Budget::Phase"
-        skip("Skip because after updating it doesn't render the description")
+    describe "Should show first available fallback when current locale translation does not exist" do
+
+      scenario "For all translatable except ActivePoll and Budget::Phase", :js do
+        if translatable_class.name == "ActivePoll" || translatable_class.name == "Budget::Phase"
+          skip("Skip because after updating it doesn't render the description")
+        end
+        attributes = fields.product(%i[fr]).map do |field, locale|
+          [:"#{field}_#{locale}", text_for(field, locale)]
+        end.to_h
+        translatable.update(attributes)
+        visit path
+
+        select "English", from: :translation_locale
+        click_link "Remove language"
+        select "Español", from: :translation_locale
+        click_link "Remove language"
+        click_button update_button_text
+
+        expect(page).to have_content "en Français"
       end
-      attributes = fields.product(%i[fr]).map do |field, locale|
-        [:"#{field}_#{locale}", text_for(field, locale)]
-      end.to_h
-      translatable.update(attributes)
-      visit path
 
-      select "English", from: :translation_locale
-      click_link 'Remove language'
-      select "Español", from: :translation_locale
-      click_link 'Remove language'
-      click_button update_button_text
+      scenario "For Budget::Phase", :js do
+        if translatable_class.name != "Budget::Phase"
+          skip("Skip because force visit budgets_path after update")
+        end
+        attributes = fields.product(%i[fr]).map do |field, locale|
+          [:"#{field}_#{locale}", text_for(field, locale)]
+        end.to_h
+        translatable.update(attributes)
+        visit path
 
-      expect(page).to have_content 'en Français'
-    end
+        select "English", from: :translation_locale
+        click_link "Remove language"
+        select "Español", from: :translation_locale
+        click_link "Remove language"
+        click_button update_button_text
+        visit budgets_path
 
-    scenario 'should show first available fallback when current locale translation does not exist', :js do
-      if translatable_class.name != "Budget::Phase"
-        skip("Skip because force visit budgets_path after update")
+        expect(page).to have_content "en Français"
       end
-      attributes = fields.product(%i[fr]).map do |field, locale|
-        [:"#{field}_#{locale}", text_for(field, locale)]
-      end.to_h
-      translatable.update(attributes)
-      visit path
 
-      select "English", from: :translation_locale
-      click_link 'Remove language'
-      select "Español", from: :translation_locale
-      click_link 'Remove language'
-      click_button update_button_text
-      visit budgets_path
+      scenario "For ActivePoll", :js do
+        if translatable_class.name != "ActivePoll"
+          skip("Skip because force visit polls_path after update")
+        end
+        attributes = fields.product(%i[fr]).map do |field, locale|
+          [:"#{field}_#{locale}", text_for(field, locale)]
+        end.to_h
+        translatable.update(attributes)
+        visit path
 
-      expect(page).to have_content 'en Français'
-    end
+        select "English", from: :translation_locale
+        click_link "Remove language"
+        select "Español", from: :translation_locale
+        click_link "Remove language"
+        click_button update_button_text
+        visit polls_path
 
-    scenario 'should show first available fallback when current locale translation does not exist for active polls', :js do
-      if translatable_class.name != "ActivePoll"
-        skip("Skip because force visit polls_path after update")
+        expect(page).to have_content "en Français"
       end
-      attributes = fields.product(%i[fr]).map do |field, locale|
-        [:"#{field}_#{locale}", text_for(field, locale)]
-      end.to_h
-      translatable.update(attributes)
-      visit path
 
-      select "English", from: :translation_locale
-      click_link 'Remove language'
-      select "Español", from: :translation_locale
-      click_link 'Remove language'
-      click_button update_button_text
-      visit polls_path
-
-      expect(page).to have_content 'en Français'
     end
 
     scenario "Add a translation", :js do

--- a/spec/shared/features/translatable.rb
+++ b/spec/shared/features/translatable.rb
@@ -57,6 +57,9 @@ shared_examples "translatable" do |factory_name, path_name, input_fields, textar
     end
 
     scenario 'should show first available fallback when current locale translation does not exist', :js do
+      if translatable_class.name == "ActivePoll"
+        skip("Skip because after updating it doesn't render the description")
+      end
       attributes = fields.product(%i[fr]).map do |field, locale|
         [:"#{field}_#{locale}", text_for(field, locale)]
       end.to_h
@@ -68,6 +71,26 @@ shared_examples "translatable" do |factory_name, path_name, input_fields, textar
       select "Español", from: :translation_locale
       click_link 'Remove language'
       click_button update_button_text
+
+      expect(page).to have_content 'en Français'
+    end
+
+    scenario 'should show first available fallback when current locale translation does not exist for active polls', :js do
+      if translatable_class.name != "ActivePoll"
+        skip("Skip because force visit polls_path after update")
+      end
+      attributes = fields.product(%i[fr]).map do |field, locale|
+        [:"#{field}_#{locale}", text_for(field, locale)]
+      end.to_h
+      translatable.update(attributes)
+      visit path
+
+      select "English", from: :translation_locale
+      click_link 'Remove language'
+      select "Español", from: :translation_locale
+      click_link 'Remove language'
+      click_button update_button_text
+      visit polls_path
 
       expect(page).to have_content 'en Français'
     end

--- a/spec/shared/features/translatable.rb
+++ b/spec/shared/features/translatable.rb
@@ -36,8 +36,8 @@ shared_examples "translatable" do |factory_name, path_name, input_fields, textar
   let(:translatable) do
     if factory_name == "budget_phase"
       budget = create(:budget)
-      budget.phases.first.update attributes
-      budget.phases.first
+      budget.phases.last.update attributes
+      budget.phases.last
     else
       create(factory_name, attributes)
     end
@@ -57,7 +57,7 @@ shared_examples "translatable" do |factory_name, path_name, input_fields, textar
     end
 
     scenario 'should show first available fallback when current locale translation does not exist', :js do
-      if translatable_class.name == "ActivePoll"
+      if translatable_class.name == "ActivePoll" || translatable_class.name == "Budget::Phase"
         skip("Skip because after updating it doesn't render the description")
       end
       attributes = fields.product(%i[fr]).map do |field, locale|
@@ -71,6 +71,26 @@ shared_examples "translatable" do |factory_name, path_name, input_fields, textar
       select "Español", from: :translation_locale
       click_link 'Remove language'
       click_button update_button_text
+
+      expect(page).to have_content 'en Français'
+    end
+
+    scenario 'should show first available fallback when current locale translation does not exist', :js do
+      if translatable_class.name != "Budget::Phase"
+        skip("Skip because force visit budgets_path after update")
+      end
+      attributes = fields.product(%i[fr]).map do |field, locale|
+        [:"#{field}_#{locale}", text_for(field, locale)]
+      end.to_h
+      translatable.update(attributes)
+      visit path
+
+      select "English", from: :translation_locale
+      click_link 'Remove language'
+      select "Español", from: :translation_locale
+      click_link 'Remove language'
+      click_button update_button_text
+      visit budgets_path
 
       expect(page).to have_content 'en Français'
     end


### PR DESCRIPTION
## References

- Update globalize gem #3194
- Initialize graphql after application initialization #3159
- Pananoid translations (Translations soft deletion) #3201
- Globalize and I18n fallbacks #3239
- Adapt translatable shared specs #3240
- Adapt suggest script for translations #3241
- Translations sanitization #3242
- Microsoft translate client #3235
- Avoid exception on paranoid translations migrations #3311

## Objectives
This PR fix failed specs that appear from PR creation from branch translations to master.

## Visual Changes
None
