### PR TITLE
notify by email new evaluation comments

### DIFF
--- a/app/controllers/admin/system_emails_controller.rb
+++ b/app/controllers/admin/system_emails_controller.rb
@@ -14,7 +14,8 @@ class Admin::SystemEmailsController < Admin::BaseController
       direct_message_for_receiver:  %w[view edit_info],
       direct_message_for_sender:    %w[view edit_info],
       email_verification:           %w[view edit_info],
-      user_invite:                  %w[view edit_info]
+      user_invite:                  %w[view edit_info],
+      evaluation_comment:           %w[view edit_info]
     }
   end
 
@@ -34,6 +35,8 @@ class Admin::SystemEmailsController < Admin::BaseController
       load_sample_user
     when "user_invite"
       @subject = t("mailers.user_invite.subject", org_name: Setting["org_name"])
+    when "evaluation_comment"
+      load_sample_valuation_comment
     end
   end
 
@@ -94,6 +97,17 @@ class Admin::SystemEmailsController < Admin::BaseController
         @email = ReplyEmail.new(reply)
       else
         redirect_to admin_system_emails_path, alert: t("admin.system_emails.alert.no_replies")
+      end
+    end
+
+    def load_sample_valuation_comment
+      comment = Comment.where(commentable_type: "Budget::Investment").last
+      if comment
+        @email = EvaluationCommentEmail.new(comment)
+        @email_to = @email.to.first
+      else
+        redirect_to admin_system_emails_path,
+                    alert: t("admin.system_emails.alert.no_evaluation_comments")
       end
     end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,6 +14,7 @@ class CommentsController < ApplicationController
     if @comment.save
       CommentNotifier.new(comment: @comment).process
       add_notification @comment
+      EvaluationCommentNotifier.new(comment: @comment).process if send_evaluation_notification?
     else
       render :new
     end
@@ -107,4 +108,7 @@ class CommentsController < ApplicationController
       end
     end
 
+    def send_evaluation_notification?
+      @comment.valuation && Setting["feature.valuation_comment_notification"]
+    end
 end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -9,7 +9,7 @@ module MailerHelper
   end
 
   def valuation_comments_url(commentable)
-    admin_budget_budget_investment_url( commentable.budget, commentable, anchor: "comments")
+    admin_budget_budget_investment_url(commentable.budget, commentable, anchor: "comments")
   end
 
   def valuation_comments_link(commentable)

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -8,4 +8,16 @@ module MailerHelper
     return budget_investment_url(commentable.budget_id, commentable) if commentable.is_a?(Budget::Investment)
   end
 
+  def valuation_comments_url(commentable)
+    admin_budget_budget_investment_url( commentable.budget, commentable, anchor: "comments")
+  end
+
+  def valuation_comments_link(commentable)
+    link_to(
+      commentable.title,
+      valuation_comments_url(@email.commentable),
+      target: :blank,
+      style: "color: #2895F1; text-decoration:none;"
+    )
+  end
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -120,6 +120,13 @@ class Mailer < ApplicationMailer
     mail(to: @email_to, from: @newsletter.from, subject: @newsletter.subject)
   end
 
+  def evaluation_comment(comment, to)
+    @email = EvaluationCommentEmail.new(comment)
+    @email_to = to
+
+    mail(to: @email_to.email, subject: @email.subject) if @email.can_be_sent?
+  end
+
   private
 
   def with_user(user, &block)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -377,6 +377,12 @@ class Budget
       milestones.published.with_status.order_by_publication_date.last&.status_id
     end
 
+    def admin_and_valuator_users_associated
+      valuator_users = (valuator_groups.map(&:valuators) + valuators).flatten
+      all_users = valuator_users << administrator
+      all_users.compact.uniq
+    end
+
     private
 
       def set_denormalized_ids

--- a/app/models/evaluation_comment_notifier.rb
+++ b/app/models/evaluation_comment_notifier.rb
@@ -1,0 +1,16 @@
+class EvaluationCommentNotifier
+  def initialize(args = {})
+    @comment = args.fetch(:comment)
+  end
+
+  def process
+    send_evaluation_comment_email
+  end
+
+  private
+    def send_evaluation_comment_email
+      EvaluationCommentEmail.new(@comment).to.each do |to|
+        Mailer.evaluation_comment(@comment, to).deliver_later
+      end
+    end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -58,6 +58,7 @@ class Setting < ApplicationRecord
         "feature.allow_attached_documents": true,
         "feature.allow_images": true,
         "feature.help_page": true,
+        "feature.valuation_comment_notification": true,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/app/views/mailer/evaluation_comment.html.erb
+++ b/app/views/mailer/evaluation_comment.html.erb
@@ -1,0 +1,19 @@
+<td style="padding-bottom: 20px; padding-left: 10px;">
+
+  <h1 style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;">
+    <%= t("mailers.evaluation_comment.title", investment: @email.commentable.title) %>
+  </h1>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.evaluation_comment.hi") %> <strong><%= @email_to.name %></strong>,
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= t("mailers.evaluation_comment.new_comment_by_html", commenter: @email.comment.author.name, investment: valuation_comments_link(@email.commentable)) %>
+  </p>
+
+  <%= t("mailers.evaluation_comment.commenter_info", commenter: @email.comment.author.name, time: l(@email.comment.created_at)) %>
+  <div style="border-left: 2px solid #DEE0E3;font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-style: italic;font-weight: normal;line-height: 24px;margin-left: 20px;padding: 10px;">
+    <%= simple_format text_with_links(@email.comment.body), {}, sanitize: false %>
+  </div>
+</td>

--- a/config/locales/ar/mailers.yml
+++ b/config/locales/ar/mailers.yml
@@ -3,7 +3,7 @@ ar:
     no_reply: "تم إرسال هذه الرسالة من عنوان بريد إلكتروني لا يقبل الردود."
     comment:
       hi: مرحبا
-      new_comment_by_html: هناك تعليق جديد من <b>%{commenter}</b>
+      new_comment_by_html: هناك تعليق جديد من <strong>%{commenter}</strong>
       subject: تم التعليق على %{commentable}
       title: تعليق جديد
     config:
@@ -16,7 +16,7 @@ ar:
       title: أكد حسابك باستخدام الرابط التالي
     reply:
       hi: مرحبا
-      new_reply_by_html: وهناك رد جديد من <b>%{commenter}</b> على التعليق الخاص بك
+      new_reply_by_html: وهناك رد جديد من <strong>%{commenter}</strong> على التعليق الخاص بك
       subject: يوجد رد على تعليقك
       title: اجابة جديدة على تعليقك
     unfeasible_spending_proposal:

--- a/config/locales/ast/mailers.yml
+++ b/config/locales/ast/mailers.yml
@@ -3,7 +3,7 @@ ast:
     no_reply: "Este mensaje se ha enviado desde una dirección de correo electrónico que no admite respuestas."
     comment:
       hi: Hola
-      new_comment_by_html: Hay un nuevo comentario de <b>%{commenter}</b> en
+      new_comment_by_html: Hay un nuevo comentario de <strong>%{commenter}</strong> en
       subject: Alguien ha comentado en tu %{commentable}
       title: Nuevo comentario
     config:
@@ -16,7 +16,7 @@ ast:
       title: Verifica tu cuenta con el siguiente enlace
     reply:
       hi: Hola
-      new_reply_by_html: Hay una nueva respuesta de <b>%{commenter}</b> a tu comentario en
+      new_reply_by_html: Hay una nueva respuesta de <strong>%{commenter}</strong> a tu comentario en
       subject: Alguien ha respondido a tu comentario
       title: Nueva respuesta a tu comentario
     unfeasible_spending_proposal:

--- a/config/locales/ca/mailers.yml
+++ b/config/locales/ca/mailers.yml
@@ -3,7 +3,7 @@ ca:
     no_reply: "Aquest missatge s'ha enviat des d'una adreça de correu electrònic que no admet respostes."
     comment:
       hi: Hola
-      new_comment_by_html: Hi ha un nou comentari de <b>%{commenter}</b> en
+      new_comment_by_html: Hi ha un nou comentari de <strong>%{commenter}</strong> en
       subject: Algú ha comentat en el teu %{commentable}
       title: Nou comentari
     config:
@@ -16,7 +16,7 @@ ca:
       title: Verifica el teu compte amb el següent enllaç
     reply:
       hi: Hola
-      new_reply_by_html: Hi ha una nova resposta de <b>%{commenter}</b> al teu comentari en
+      new_reply_by_html: Hi ha una nova resposta de <strong>%{commenter}</strong> al teu comentari en
       subject: Algú ha respost al teu comentari
       title: Nova resposta al teu comentari
     unfeasible_spending_proposal:

--- a/config/locales/de-DE/mailers.yml
+++ b/config/locales/de-DE/mailers.yml
@@ -3,7 +3,7 @@ de:
     no_reply: "Diese Nachricht wurde von einer E-Mail-Adresse gesendet, die keine Antworten akzeptiert."
     comment:
       hi: Hallo
-      new_comment_by_html: Es gibt einen neuen Kommentar von <b>%{commenter}</b>
+      new_comment_by_html: Es gibt einen neuen Kommentar von <strong>%{commenter}</strong>
       subject: Jemand hat Ihre %{commentable} kommentiert.
       title: Neuer Kommentar
     config:
@@ -16,7 +16,7 @@ de:
       title: Bestätigen Sie Ihr Konto über den folgenden Link
     reply:
       hi: Hallo
-      new_reply_by_html: Es gibt eine neue Antwort von <b>%{commenter}</b> auf Ihren Kommentar
+      new_reply_by_html: Es gibt eine neue Antwort von <strong>%{commenter}</strong> auf Ihren Kommentar
       subject: Jemand hat auf Ihren Kommentar geantwortet
       title: Neue Antwort auf Ihren Kommentar
     unfeasible_spending_proposal:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -875,6 +875,9 @@ en:
       user_invite:
         title: "User Invitation"
         description: "Sent to the person that has been invited to register an account."
+      evaluation_comment:
+        title: "New evaluation comment"
+        description: "Sent to administrators and evaluators related to commented investment"
       edit_info: "You can edit this email in"
       message_title: "Message's Title"
       message_body: "This is a sample of message's content."
@@ -882,6 +885,7 @@ en:
         no_investments: "There aren't any budget investment created. Some example data is needed in order to preview the email."
         no_comments: "There aren't any comments created. Some example data is needed in order to preview the email."
         no_replies: "There aren't any replies created. Some example data is needed in order to preview the email."
+        no_evaluation_comments: "There aren't any evaluation comments created. Some example data is needed in order to preview the email."
     emails_download:
       index:
         title: Emails download

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -3,7 +3,7 @@ en:
     no_reply: "This message was sent from an email address that does not accept replies."
     comment:
       hi: Hi
-      new_comment_by_html: There is a new comment from <b>%{commenter}</b>
+      new_comment_by_html: There is a new comment from <strong>%{commenter}</strong>
       subject: Someone has commented on your %{commentable}
       title: New comment
     config:
@@ -17,7 +17,7 @@ en:
       title: Confirm your account using the following link
     reply:
       hi: Hi
-      new_reply_by_html: There is a new response from <b>%{commenter}</b> to your comment on
+      new_reply_by_html: There is a new response from <strong>%{commenter}</strong> to your comment on
       subject: Someone has responded to your comment
       title: New response to your comment
     proposal_notification_digest:
@@ -74,7 +74,7 @@ en:
       subject: "New evaluation comment"
       title: New evaluation comment for %{investment}
       hi: Hi
-      new_comment_by_html: There is a new evaluation comment from <b>%{commenter}</b> to the budget investment %{investment}
+      new_comment_by_html: There is a new evaluation comment from <strong>%{commenter}</strong> to the budget investment %{investment}
       commenter_info: "%{commenter}, %{time}:"
     new_actions_notification_rake_created:
       subject: "More news about your citizen proposal"

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -70,6 +70,12 @@ en:
       hi: "Dear user,"
       thanks: "Thank you again for participating."
       sincerely: "Sincererly"
+    evaluation_comment:
+      subject: "New evaluation comment"
+      title: New evaluation comment for %{investment}
+      hi: Hi
+      new_comment_by_html: There is a new evaluation comment from <b>%{commenter}</b> to the budget investment %{investment}
+      commenter_info: "%{commenter}, %{time}:"
     new_actions_notification_rake_created:
       subject: "More news about your citizen proposal"
       hi: "Hello %{name},"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -116,6 +116,8 @@ en:
       public_stats_description: "Display public stats in the Administration panel"
       help_page: "Help page"
       help_page_description: 'Displays a Help menu that contains a page with an info section about each enabled feature. Also custom pages and menus can be created in the "Custom pages" and  "Custom content blocks" sections'
+      valuation_comment_notification: "Valuation comment notification"
+      valuation_comment_notification_description: "Send an email to all associated users except valuation commenter to budget investment when a new valuation comment is created"
     map:
       latitude: "Latitude"
       latitude_description: "Latitude to show the map position"

--- a/config/locales/es-PE/mailers.yml
+++ b/config/locales/es-PE/mailers.yml
@@ -3,7 +3,7 @@ es-PE:
     no_reply: "Este mensaje se ha enviado desde una dirección de correo electrónico que no admite respuestas."
     comment:
       hi: Hola
-      new_comment_by_html: Hay un nuevo comentario de <b>%{commenter}</b> en
+      new_comment_by_html: Hay un nuevo comentario de <strong>%{commenter}</strong> en
       subject: Alguien ha comentado en tu %{commentable}
       title: Nuevo comentario
     config:
@@ -16,7 +16,7 @@ es-PE:
       title: Verifica tu cuenta con el siguiente enlace
     reply:
       hi: Hola
-      new_reply_by_html: Hay una nueva respuesta de <b>%{commenter}</b> a tu comentario en
+      new_reply_by_html: Hay una nueva respuesta de <strong>%{commenter}</strong> a tu comentario en
       subject: Alguien ha respondido a tu comentario
       title: Nueva respuesta a tu comentario
     unfeasible_spending_proposal:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -874,6 +874,9 @@ es:
       user_invite:
         title: "Invitación de usuarios"
         description: "Enviado a la persona que ha sido invitada a registrar una cuenta."
+      evaluation_comment:
+        title: "Nuevo comentario de evaluación"
+        description: "Enviado a administradores y evaluadores del presupuesto."
       edit_info: "Puedes editar este email en"
       message_title: "Título del mensaje"
       message_body: "Este es un ejemplo de contenido de un mensaje."
@@ -881,6 +884,7 @@ es:
         no_investments: "No se ha creado ningún proyecto de gasto. Se necesita algún ejemplo para poder previsualizar el email."
         no_comments: "No se ha creado ningún comentario. Se necesita algún ejemplo para poder previsualizar el email."
         no_replies: "No se ha creado ninguna respuesta. Se necesita algún ejemplo para poder previsualizar el email."
+        no_evaluation_comments: "No se ha creado ningún comentario de evaluación. Se necesita algún ejemplo para poder previsualizar el email."
     emails_download:
       index:
         title: Descarga de emails

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -3,7 +3,7 @@ es:
     no_reply: "Este mensaje se ha enviado desde una dirección de correo electrónico que no admite respuestas."
     comment:
       hi: Hola
-      new_comment_by_html: Hay un nuevo comentario de <b>%{commenter}</b> en
+      new_comment_by_html: Hay un nuevo comentario de <strong>%{commenter}</strong> en
       subject: Alguien ha comentado en tu %{commentable}
       title: Nuevo comentario
     config:
@@ -17,7 +17,7 @@ es:
       title: Verifica tu cuenta con el siguiente enlace
     reply:
       hi: Hola
-      new_reply_by_html: Hay una nueva respuesta de <b>%{commenter}</b> a tu comentario en
+      new_reply_by_html: Hay una nueva respuesta de <strong>%{commenter}</strong> a tu comentario en
       subject: Alguien ha respondido a tu comentario
       title: Nueva respuesta a tu comentario
     proposal_notification_digest:
@@ -74,7 +74,7 @@ es:
       subject: "Nuevo comentario de evaluación"
       title: Nuevo comentario de evaluación para %{investment}
       hi: Hola
-      new_comment_by_html: Hay un nuevo comentario de evaluación de <b>%{commenter}</b> en el presupuesto participativo %{investment}
+      new_comment_by_html: Hay un nuevo comentario de evaluación de <strong>%{commenter}</strong> en el presupuesto participativo %{investment}
       commenter_info: "%{commenter}, %{time}"
     new_actions_notification_rake_created:
       subject: "Más novedades de tu propuesta ciudadana"

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -70,6 +70,12 @@ es:
       hi: "Estimado/a usuario/a"
       thanks: "Gracias de nuevo por tu participación."
       sincerely: "Atentamente"
+    evaluation_comment:
+      subject: "Nuevo comentario de evaluación"
+      title: Nuevo comentario de evaluación para %{investment}
+      hi: Hola
+      new_comment_by_html: Hay un nuevo comentario de evaluación de <b>%{commenter}</b> en el presupuesto participativo %{investment}
+      commenter_info: "%{commenter}, %{time}"
     new_actions_notification_rake_created:
       subject: "Más novedades de tu propuesta ciudadana"
       hi: "Hola %{name},"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -116,6 +116,8 @@ es:
       public_stats_description: "Muestra las estadísticas públicas en el panel de Administración"
       help_page: "Página de ayuda"
       help_page_description: 'Muestra un menú Ayuda que contiene una página con una sección de información sobre cada funcionalidad habilitada. También se pueden crear páginas y menús personalizados en las secciones "Personalizar páginas" y "Personalizar bloques"'
+      valuation_comment_notification: "Notificar comentarios de evaluación"
+      valuation_comment_notification_description: "Envía un email a todos los usuarios menos al que haya comentado asociados a un presupuesto participativo cuando se cree un nuevo comentario de evaluación"
     map:
       latitude: "Latitud"
       latitude_description: "Latitud para mostrar la posición del mapa"

--- a/config/locales/fr/mailers.yml
+++ b/config/locales/fr/mailers.yml
@@ -3,7 +3,7 @@ fr:
     no_reply: "Ce message a été envoyé d'une adresse qui n'accepte pas les réponses."
     comment:
       hi: Bonjour
-      new_comment_by_html: Il y a un nouveau commentaire de <b>%{commenter}</b>
+      new_comment_by_html: Il y a un nouveau commentaire de <strong>%{commenter}</strong>
       subject: Quelqu'un a commenté votre %{commentable}
       title: Nouveau commentaire
     config:
@@ -17,7 +17,7 @@ fr:
       title: Confirmer votre compte en utilisant le lien suivant
     reply:
       hi: Bonjour
-      new_reply_by_html: Il y a une nouvelle réponse de <b>%{commenter}</b> à votre commentaire sur
+      new_reply_by_html: Il y a une nouvelle réponse de <strong>%{commenter}</strong> à votre commentaire sur
       subject: Quelqu'un a répondu à votre commentaire
       title: Nouvelle réponse à votre commentaire
     unfeasible_spending_proposal:

--- a/config/locales/gl/mailers.yml
+++ b/config/locales/gl/mailers.yml
@@ -3,7 +3,7 @@ gl:
     no_reply: "Esta mensaxe enviouse desde un enderezo de correo electrónico que non admite respostas."
     comment:
       hi: Ola
-      new_comment_by_html: Hai un novo comentario de <b>%{commenter}</b> en
+      new_comment_by_html: Hai un novo comentario de <strong>%{commenter}</strong> en
       subject: Alguén comentou no teu %{commentable}
       title: Novo comentario
     config:
@@ -17,7 +17,7 @@ gl:
       title: Verifica a túa conta co seguinte enlace
     reply:
       hi: Ola
-      new_reply_by_html: Hai unha nova resposta de <b>%{commenter}</b> ao tu comentario en
+      new_reply_by_html: Hai unha nova resposta de <strong>%{commenter}</strong> ao tu comentario en
       subject: Alguén respondeu ao teu comentario
       title: Nova resposta ao teu comentario
     unfeasible_spending_proposal:

--- a/config/locales/he/mailers.yml
+++ b/config/locales/he/mailers.yml
@@ -3,7 +3,7 @@ he:
     no_reply: "נא לא לענות לכתובת דואר זו."
     comment:
       hi: שלום
-      new_comment_by_html: ישנה הערה חדשה מ  <b>%{commenter}</b>
+      new_comment_by_html: ישנה הערה חדשה מ  <strong>%{commenter}</strong>
       subject: ישנה הערה חדשה %{commentable}
       title: הערה חדשה
     config:
@@ -17,7 +17,7 @@ he:
       title: אשר את חשבונך באמצעות הקישור הבא
     reply:
       hi: שלום
-      new_reply_by_html: ישנה התייחסות חדשה מ <b>%{commenter}</b> לתגובתך בנושא
+      new_reply_by_html: ישנה התייחסות חדשה מ <strong>%{commenter}</strong> לתגובתך בנושא
       subject: מישהו הגיב להערה שלך
       title: התקבלה תגובה חדשה להערה שלך
     unfeasible_spending_proposal:

--- a/config/locales/id-ID/mailers.yml
+++ b/config/locales/id-ID/mailers.yml
@@ -3,7 +3,7 @@ id:
     no_reply: "Pesan ini dikirim dari alamat email yang tidak menerima balasan."
     comment:
       hi: Hai
-      new_comment_by_html: Ada komentar baru dari <b>%{commenter}</b>
+      new_comment_by_html: Ada komentar baru dari <strong>%{commenter}</strong>
       subject: Seseorang telah berkomentar tentang anda %{commentable}
       title: Komentar baru
     config:
@@ -16,7 +16,7 @@ id:
       title: Konfirmasikan akun anda menggunakan tautan berikut
     reply:
       hi: Hai
-      new_reply_by_html: Ada respon baru dari <b>%{commenter}</b> untuk komentar anda
+      new_reply_by_html: Ada respon baru dari <strong>%{commenter}</strong> untuk komentar anda
       subject: Seseorang telah menanggapi komentar anda
       title: Tanggapan baru atas komentar anda
     unfeasible_spending_proposal:

--- a/config/locales/it/mailers.yml
+++ b/config/locales/it/mailers.yml
@@ -3,7 +3,7 @@ it:
     no_reply: "Questo messaggio è stato inviato da un indirizzo di posta elettronica che non accetta risposte."
     comment:
       hi: Salve
-      new_comment_by_html: C'è un nuovo commento da <b>%{commenter}</b>
+      new_comment_by_html: C'è un nuovo commento da <strong>%{commenter}</strong>
       subject: Qualcuno ha commentato sul tuo %{commentable}
       title: Nuovo commento
     config:
@@ -17,7 +17,7 @@ it:
       title: Conferma il tuo account utilizzando il seguente link
     reply:
       hi: Ciao
-      new_reply_by_html: C'è una nuova risposta da <b>%{commenter}</b> per il tuo commento su
+      new_reply_by_html: C'è una nuova risposta da <strong>%{commenter}</strong> per il tuo commento su
       subject: Qualcuno ha risposto al tuo commento
       title: Nuova risposta al tuo commento
     unfeasible_spending_proposal:

--- a/config/locales/nl/mailers.yml
+++ b/config/locales/nl/mailers.yml
@@ -3,7 +3,7 @@ nl:
     no_reply: "This message was sent from an email address that does not accept replies."
     comment:
       hi: Hi
-      new_comment_by_html: There is a new comment from <b>%{commenter}</b>
+      new_comment_by_html: There is a new comment from <strong>%{commenter}</strong>
       subject: Someone has commented on your %{commentable}
       title: New comment
     config:
@@ -17,7 +17,7 @@ nl:
       title: Confirm your account using the following link
     reply:
       hi: Hoi
-      new_reply_by_html: There is a new response from <b>%{commenter}</b> to your comment on
+      new_reply_by_html: There is a new response from <strong>%{commenter}</strong> to your comment on
       subject: Someone has responded to your comment
       title: New response to your comment
     unfeasible_spending_proposal:

--- a/config/locales/pl-PL/mailers.yml
+++ b/config/locales/pl-PL/mailers.yml
@@ -3,7 +3,7 @@ pl:
     no_reply: "Ta wiadomość została wysłana z adresu e-mail, który nie akceptuje odpowiedzi."
     comment:
       hi: Cześć
-      new_comment_by_html: Nowy komentarz od <b>%{commenter}</b>
+      new_comment_by_html: Nowy komentarz od <strong>%{commenter}</strong>
       subject: Ktoś skomentował Twój %{commentable}
       title: Nowy komentarz
     config:
@@ -17,7 +17,7 @@ pl:
       title: Potwierdź swoje konto za pomocą następującego linku
     reply:
       hi: Cześć
-      new_reply_by_html: Nowa odpowiedź od <b>%{commenter}</b> na Twój komentarz odnośnie
+      new_reply_by_html: Nowa odpowiedź od <strong>%{commenter}</strong> na Twój komentarz odnośnie
       subject: Ktoś odpowiedział na Twój komentarz
       title: Nowa odpowiedź na Twój komentarz
     unfeasible_spending_proposal:

--- a/config/locales/pt-BR/mailers.yml
+++ b/config/locales/pt-BR/mailers.yml
@@ -3,7 +3,7 @@ pt-BR:
     no_reply: "Esta mensagem foi enviada de um endereço de e-mail que não aceita respostas."
     comment:
       hi: Oi
-      new_comment_by_html: Há um novo comentário de <b>%{commenter}</b>
+      new_comment_by_html: Há um novo comentário de <strong>%{commenter}</strong>
       subject: Alguém comentou sobre seu %{commentable}
       title: Novo comentário
     config:
@@ -17,7 +17,7 @@ pt-BR:
       title: Confirme sua conta usando o seguinte link
     reply:
       hi: Oi
-      new_reply_by_html: Há uma nova resposta de <b>%{commenter}</b> ao seu comentário sobre
+      new_reply_by_html: Há uma nova resposta de <strong>%{commenter}</strong> ao seu comentário sobre
       subject: Alguém respondeu ao seu comentário
       title: Nova resposta ao seu comentário
     unfeasible_spending_proposal:

--- a/config/locales/ru/mailers.yml
+++ b/config/locales/ru/mailers.yml
@@ -3,7 +3,7 @@ ru:
     no_reply: "Это сообщение было отправлено с email адреса, который не принимает ответы."
     comment:
       hi: Здравствуйте
-      new_comment_by_html: Появился новый комментарий от <b>%{commenter}</b>
+      new_comment_by_html: Появился новый комментарий от <strong>%{commenter}</strong>
       subject: Кто-то прокомментировал ваш %{commentable}
       title: Новый комментарий
     config:
@@ -17,7 +17,7 @@ ru:
       title: Подтвердить ваш аккаунт при помощи следующей ссылки
     reply:
       hi: Здравствуйте
-      new_reply_by_html: Появился новый ответ от <b>%{commenter}</b> на ваш комментарий на
+      new_reply_by_html: Появился новый ответ от <strong>%{commenter}</strong> на ваш комментарий на
       subject: Кто-то ответил на ваш комментарий
       title: Новый ответ на ваш комментарий
     unfeasible_spending_proposal:

--- a/config/locales/sl-SI/mailers.yml
+++ b/config/locales/sl-SI/mailers.yml
@@ -3,7 +3,7 @@ sl:
     no_reply: "To sporočilo je bilo poslano z e-naslova, ki ne sprejema odgovorov."
     comment:
       hi: Hej
-      new_comment_by_html: Imaš nov komentar uporabnika/-ce <b>%{commenter}</b>
+      new_comment_by_html: Imaš nov komentar uporabnika/-ce <strong>%{commenter}</strong>
       subject: Nekdo je komentiral na tvoj %{commentable}
       title: Nov komentar
     config:
@@ -17,7 +17,7 @@ sl:
       title: Potrdi svoj račun z uporabo naslednje povezave
     reply:
       hi: Hej
-      new_reply_by_html: Imaš nov odgovor uporabnika/-ce <b>%{commenter}</b> na tvoj komentar o
+      new_reply_by_html: Imaš nov odgovor uporabnika/-ce <strong>%{commenter}</strong> na tvoj komentar o
       subject: Nekdo se je odzval na tvoj komentar
       title: Nov odgovor na tvoj komentar
     unfeasible_spending_proposal:

--- a/config/locales/so-SO/mailers.yml
+++ b/config/locales/so-SO/mailers.yml
@@ -3,7 +3,7 @@ so:
     no_reply: "Farriintan waxaa loo direy cinwaanka emailka ah ee aan aqbalin jawaab-celinta."
     comment:
       hi: Haye
-      new_comment_by_html: Waxa jira faalo cusub<b>%{commenter}</b>
+      new_comment_by_html: Waxa jira faalo cusub<strong>%{commenter}</strong>
       subject: Qof ayaa ka falooday%{commentable}
       title: Faalo cusub
     config:
@@ -17,7 +17,7 @@ so:
       title: Xaqiiji xisaabtaada adigoo isticmaalaya xiriirka soo socda
     reply:
       hi: Haye
-      new_reply_by_html: Waxaa jira jawaab cusub oo ka socota <b>%{commenter}</b> si aad faallo uga bixiso
+      new_reply_by_html: Waxaa jira jawaab cusub oo ka socota <strong>%{commenter}</strong> si aad faallo uga bixiso
       subject: Qof ayaa kajawaabay faladadii
       title: Jawaabta cusub ee faalladaada
     unfeasible_spending_proposal:

--- a/config/locales/sq-AL/mailers.yml
+++ b/config/locales/sq-AL/mailers.yml
@@ -3,7 +3,7 @@ sq:
     no_reply: "Ky mesazh u dërgua nga një adresë e-mail që nuk pranon përgjigje."
     comment:
       hi: Përshëndetje!
-      new_comment_by_html: Ka një koment të ri nga<b>%{commenter}</b>
+      new_comment_by_html: Ka një koment të ri nga<strong>%{commenter}</strong>
       subject: Dikush ka komentuar mbi %{commentable} tuaj
       title: Komenti i ri
     config:
@@ -17,7 +17,7 @@ sq:
       title: Konfirmo llogarinë tënd duke përdorur lidhjen e mëposhtme
     reply:
       hi: Hi
-      new_reply_by_html: Ka një përgjigje të re nga <b>%{commenter}</b> në komentin tuaj
+      new_reply_by_html: Ka një përgjigje të re nga <strong>%{commenter}</strong> në komentin tuaj
       subject: Dikush i është përgjigjur komentit tuaj
       title: Përgjigje e re tek komentit tuaj
     unfeasible_spending_proposal:

--- a/config/locales/sv-SE/mailers.yml
+++ b/config/locales/sv-SE/mailers.yml
@@ -3,7 +3,7 @@ sv:
     no_reply: "Det går inte att svara till den här e-postadressen."
     comment:
       hi: Hej
-      new_comment_by_html: Det finns en ny kommentar från <b>%{commenter}</b>
+      new_comment_by_html: Det finns en ny kommentar från <strong>%{commenter}</strong>
       subject: Någon har kommenterat på ditt %{commentable}
       title: Ny kommentar
     config:
@@ -17,7 +17,7 @@ sv:
       title: Bekräfta kontot via länken nedan
     reply:
       hi: Hej
-      new_reply_by_html: Det finns ett nytt svar från <b>%{commenter}</b> till din kommentar på
+      new_reply_by_html: Det finns ett nytt svar från <strong>%{commenter}</strong> till din kommentar på
       subject: Någon har svarat på din kommentar
       title: Nytt svar på din kommentar
     unfeasible_spending_proposal:

--- a/config/locales/val/mailers.yml
+++ b/config/locales/val/mailers.yml
@@ -3,7 +3,7 @@ val:
     no_reply: "Aquest missatge s'ha enviat des d'una direcció de correu electrònic que no admet respostes."
     comment:
       hi: Hola
-      new_comment_by_html: Hi ha un nou comentari de <b>%{commenter}</b> en
+      new_comment_by_html: Hi ha un nou comentari de <strong>%{commenter}</strong> en
       subject: Algú ha comentat en el teu %{commentable}
       title: Nou comentari
     config:
@@ -17,7 +17,7 @@ val:
       title: Verifica el teu compte amb el següent enllaç
     reply:
       hi: Hola
-      new_reply_by_html: Hi ha noves respostes de <b>%{commenter}</b> al teu comentari en
+      new_reply_by_html: Hi ha noves respostes de <strong>%{commenter}</strong> al teu comentari en
       subject: Algú ha contestat el teu comentari
       title: Nova resposta al teu comentari
     unfeasible_spending_proposal:

--- a/config/locales/zh-CN/mailers.yml
+++ b/config/locales/zh-CN/mailers.yml
@@ -3,7 +3,7 @@ zh-CN:
     no_reply: "此消息是从一个不接受回复的电子邮件地址发送的。"
     comment:
       hi: 您好
-      new_comment_by_html: 来自<b>%{commenter}</b>的新评论
+      new_comment_by_html: 来自<strong>%{commenter}</strong>的新评论
       subject: 有人对您的%{commentable} 做了评论
       title: 新评论
     config:
@@ -17,7 +17,7 @@ zh-CN:
       title: 使用以下链接来确认您的账户
     reply:
       hi: 您好
-      new_reply_by_html: <b>%{commenter}</b> 对您评论有新回复
+      new_reply_by_html: <strong>%{commenter}</strong> 对您评论有新回复
       subject: 有人回复了您的评论
       title: 对您评论的新回复
     unfeasible_spending_proposal:

--- a/config/locales/zh-TW/mailers.yml
+++ b/config/locales/zh-TW/mailers.yml
@@ -3,7 +3,7 @@ zh-TW:
     no_reply: "此郵件是從一個不接受回覆的電郵地址發送的。"
     comment:
       hi: 您好
-      new_comment_by_html: <b>%{commenter}</b>發表了新評論
+      new_comment_by_html: <strong>%{commenter}</strong>發表了新評論
       subject: 有人評論了您的%{commentable}
       title: 新評論
     config:
@@ -17,7 +17,7 @@ zh-TW:
       title: 使用以下鏈接確認您的帳戶
     reply:
       hi: 您好
-      new_reply_by_html: <b>%{commenter}</b>對您的評論有新的回覆
+      new_reply_by_html: <strong>%{commenter}</strong>對您的評論有新的回覆
       subject: 有人回覆了您的評論
       title: 對您的評論的新回覆
     unfeasible_spending_proposal:

--- a/lib/evaluation_comment_email.rb
+++ b/lib/evaluation_comment_email.rb
@@ -1,0 +1,31 @@
+class EvaluationCommentEmail
+  attr_reader :comment
+
+  def initialize(comment)
+    @comment = comment
+  end
+
+  def commentable
+    comment.commentable
+  end
+
+  def to
+    @to ||= related_users
+  end
+
+  def subject
+    I18n.t("mailers.evaluation_comment.subject")
+  end
+
+  def can_be_sent?
+    commentable.present? && to.any?
+  end
+
+  private
+    def related_users
+      return [] if comment.commentable.nil?
+      comment.commentable
+             .admin_and_valuator_users_associated
+             .reject { |associated_user| associated_user.user == comment.author }
+    end
+end

--- a/spec/features/admin/system_emails_spec.rb
+++ b/spec/features/admin/system_emails_spec.rb
@@ -14,7 +14,8 @@ describe "System Emails" do
     let(:system_emails) do
       %w[proposal_notification_digest budget_investment_created budget_investment_selected
          budget_investment_unfeasible budget_investment_unselected comment reply
-         direct_message_for_receiver direct_message_for_sender email_verification user_invite]
+         direct_message_for_receiver direct_message_for_sender email_verification user_invite
+         evaluation_comment]
     end
 
     context "System emails" do
@@ -243,6 +244,31 @@ describe "System Emails" do
       visit admin_system_email_view_path("reply")
       expect(page).to have_content "There aren't any replies created."
       expect(page).to have_content "Some example data is needed in order to preview the email."
+
+      visit admin_system_email_view_path("evaluation_comment")
+      expect(page).to have_content "There aren't any evaluation comments created."
+      expect(page).to have_content "Some example data is needed in order to preview the email."
+    end
+
+    scenario "#evaluation_comment" do
+      admin = create(:administrator, user: create(:user, username: "Baby Doe"))
+      investment = create(:budget_investment,
+        title: "Cleaner city",
+        heading: heading,
+        author: user,
+        administrator: admin)
+      comment = create(:comment, :valuation, commentable: investment)
+
+      visit admin_system_email_view_path("evaluation_comment")
+
+      expect(page).to have_content "New evaluation comment for Cleaner city"
+      expect(page).to have_content "Hi #{admin.name}"
+      expect(page).to have_content "There is a new evaluation comment from #{comment.user.name} "\
+                                   "to the budget investment Cleaner city"
+      expect(page).to have_content comment.body
+
+      expect(page).to have_link "Cleaner city",
+        href: admin_budget_budget_investment_url( investment.budget, investment, anchor: "comments")
     end
 
   end

--- a/spec/features/comments/budget_investments_valuation_spec.rb
+++ b/spec/features/comments/budget_investments_valuation_spec.rb
@@ -171,7 +171,7 @@ describe "Internal valuation comments on Budget::Investments" do
     scenario "Create comment", :js do
       visit valuation_budget_budget_investment_path(budget, investment)
 
-      fill_in "comment-body-budget_investment_#{investment.id}", with: "Have you thought about...?"
+      fill_in "Leave your comment", with: "Have you thought about...?"
       click_button "Publish comment"
 
       within "#comments" do
@@ -199,7 +199,7 @@ describe "Internal valuation comments on Budget::Investments" do
       click_link "Reply"
 
       within "#js-comment-form-comment_#{comment.id}" do
-        fill_in "comment-body-comment_#{comment.id}", with: "It will be done next week."
+        fill_in "Leave your comment", with: "It will be done next week."
         click_button "Publish reply"
       end
 
@@ -261,8 +261,8 @@ describe "Internal valuation comments on Budget::Investments" do
       login_as(admin_user)
       visit valuation_budget_budget_investment_path(budget, investment)
 
-      fill_in "comment-body-budget_investment_#{investment.id}", with: "I am your Admin!"
-      check "comment-as-administrator-budget_investment_#{investment.id}"
+      fill_in "Leave your comment", with: "I am your Admin!"
+      check "Comment as admin"
       click_button "Publish comment"
 
       within "#comments" do
@@ -282,8 +282,8 @@ describe "Internal valuation comments on Budget::Investments" do
       click_link "Reply"
 
       within "#js-comment-form-comment_#{comment.id}" do
-        fill_in "comment-body-comment_#{comment.id}", with: "Top of the world!"
-        check "comment-as-administrator-comment_#{comment.id}"
+        fill_in "Leave your comment", with: "Top of the world!"
+        check "Comment as admin"
         click_button "Publish reply"
       end
 
@@ -296,6 +296,27 @@ describe "Internal valuation comments on Budget::Investments" do
 
       expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
     end
+  end
+
+  scenario "Send email notification", :js do
+    ActionMailer::Base.deliveries = []
+
+    login_as(admin_user)
+
+    expect(ActionMailer::Base.deliveries).to eq([])
+
+    visit valuation_budget_budget_investment_path(budget, investment)
+    fill_in "Leave your comment", with: "I am your Admin!"
+    check "Comment as admin"
+    click_button "Publish comment"
+
+    within "#comments" do
+      expect(page).to have_content("I am your Admin!")
+    end
+
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.first.to).to eq([valuator_user.email])
+    expect(ActionMailer::Base.deliveries.first.subject).to eq("New evaluation comment")
   end
 
 end

--- a/spec/lib/evaluation_comment_email_spec.rb
+++ b/spec/lib/evaluation_comment_email_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe EvaluationCommentEmail do
+
+  let(:author)        { create(:user) }
+  let(:administrator) { create(:administrator)}
+  let(:investment)    { create(:budget_investment, author: author, administrator: administrator) }
+  let(:commenter)     { create(:user, email: "email@commenter.org") }
+  let(:comment)       { create(:comment, commentable: investment, user: commenter) }
+  let(:comment_email) { EvaluationCommentEmail.new(comment) }
+
+  describe "#commentable" do
+    it "returns the commentable object that contains the replied comment" do
+      expect(comment_email.commentable).to eq investment
+    end
+  end
+
+  describe "#to" do
+    it "returns an array of users related to investment" do
+      expect(comment_email.to).to eq [administrator]
+    end
+
+    it "returns empty array if commentable not exists" do
+      allow(comment).to receive(:commentable).and_return(nil)
+      expect(comment_email.to).to eq []
+    end
+
+    it "returns empty array if not associated users" do
+      allow(investment).to receive(:admin_and_valuator_users_associated).and_return([])
+      expect(comment_email.to).to eq []
+    end
+  end
+
+  describe "#subject" do
+    it "returns the translation for a evaluation comment email subject" do
+      expect(comment_email.subject).to eq "New evaluation comment"
+    end
+  end
+
+  describe "#can_be_sent?" do
+    it "returns true if investment has any associated users" do
+      expect(comment_email.can_be_sent?).to be true
+    end
+
+    it "returns false if the comment doesn't exist" do
+      comment.update(commentable: nil)
+
+      expect(comment_email.can_be_sent?).to be false
+    end
+
+    it "returns false if recipients are empty" do
+      investment.administrator = nil
+      expect(comment_email.can_be_sent?).to be false
+    end
+  end
+
+end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -1218,4 +1218,31 @@ describe Budget::Investment do
       end
     end
   end
+
+  describe "admin_and_valuator_users_associated" do
+    let(:investment) { create(:budget_investment) }
+    let(:valuator_group) { create(:valuator_group) }
+    let(:valuator) { create(:valuator) }
+    let(:administrator) { create(:administrator) }
+
+    it "returns empty array if not valuators or administrator assigned" do
+      expect(investment.admin_and_valuator_users_associated).to eq([])
+    end
+
+    it "returns all valuator and administrator users" do
+      valuator_group.valuators << valuator
+      investment.valuator_groups << valuator_group
+      expect(investment.admin_and_valuator_users_associated).to eq([valuator])
+      investment.administrator = administrator
+      expect(investment.admin_and_valuator_users_associated).to eq([valuator, administrator])
+    end
+
+    it "returns uniq valuators or administrator users" do
+      valuator_group.valuators << valuator
+      investment.valuator_groups << valuator_group
+      investment.valuators << valuator
+      investment.administrator = administrator
+      expect(investment.admin_and_valuator_users_associated).to eq([valuator, administrator])
+    end
+  end
 end


### PR DESCRIPTION
## References

https://github.com/consul/consul/issues/3395

## Objectives

Notify valuators and admin users related with an investment when a new evaluation comment is created
This notification have a feature flag to enable and disable functionality

## Visual Changes

Add a new settings feature flag to enable/disable emails
![image](https://user-images.githubusercontent.com/1029265/55149209-10a21c00-514a-11e9-931b-753acfe7296b.png)

When an evaluation comment is created, an email will be sent to all valuators and admin user related to commented investment except to user which create the comment

Email
![image](https://user-images.githubusercontent.com/1029265/55149430-7098c280-514a-11e9-9184-6794f4dd72e4.png)

Add a new record inside system_emails to check email
![image](https://user-images.githubusercontent.com/1029265/55149646-dab16780-514a-11e9-9798-a246cf9d1336.png)
And the preview of system_email
![image](https://user-images.githubusercontent.com/1029265/55149716-f74d9f80-514a-11e9-8816-6096db23d539.png) 

## Notes

As this new functionality adds a feature flag, is required create this new system property to enable it.

The emails will be sent to different users, so process will send one email per user instead of use CC or BCC. I think it's better to protect user information and to make email more personal