### PR TITLE
Add tags to milestones

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -83,7 +83,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
       params.require(:budget_investment)
             .permit(:title, :description, :external_url, :heading_id, :administrator_id, :tag_list,
                     :valuation_tag_list, :incompatible, :visible_to_valuators, :selected,
-                    valuator_ids: [], valuator_group_ids: [])
+                    :milestone_tag_list, valuator_ids: [], valuator_group_ids: [])
     end
 
     def load_budget

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -12,15 +12,15 @@ module Budgets
 
     private
       def investments_by_heading
+        base = @budget.investments.winners
+        base = base.joins(milestones: :translations).includes(:milestones)
+        base = base.tagged_with(params[:milestone_tag]) if params[:milestone_tag].present?
+
         if params[:status].present?
-          @budget.investments.winners
-                  .with_milestone_status_id(params[:status])
-                  .uniq
-                  .group_by(&:heading)
+          base = base.with_milestone_status_id(params[:status])
+          base.uniq.group_by(&:heading)
         else
-          @budget.investments.winners
-                  .joins(milestones: :translations)
-                  .distinct.group_by(&:heading)
+          base.distinct.group_by(&:heading)
         end
       end
 

--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -4,6 +4,12 @@ module BudgetExecutionsHelper
     @budget.investments.winners.with_milestone_status_id(status).count
   end
 
+  def options_for_milestone_tags
+    @budget.milestone_tags.map do |tag|
+      ["#{tag} (#{@budget.investments.winners.tagged_with(tag).count})", tag]
+    end
+  end
+
   def first_milestone_with_image(investment)
     investment.milestones.order_by_publication_date
                          .select{ |milestone| milestone.image.present? }.last

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -195,6 +195,10 @@ class Budget < ApplicationRecord
     investments.winners.any?
   end
 
+  def milestone_tags
+    investments.winners.map(&:milestone_tag_list).flatten.uniq.sort
+  end
+
   private
 
   def sanitize_descriptions

--- a/app/models/concerns/milestoneable.rb
+++ b/app/models/concerns/milestoneable.rb
@@ -8,6 +8,8 @@ module Milestoneable
 
     has_many :progress_bars, as: :progressable
 
+    acts_as_taggable_on :milestone_tags
+
     def primary_progress_bar
       progress_bars.primary.first
     end

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -105,6 +105,14 @@
     </div>
   </div>
 
+  <div class="small-12 column">
+    <%= f.label :milestone_tag_list, t("admin.budget_investments.edit.milestone_tags") %>
+    <%= f.text_field :milestone_tag_list,
+                   value: @investment.milestone_tag_list.sort.join(", "),
+                   label: false %>
+  </div>
+
+
   <div class="small-12 column margin-top">
     <%= f.submit(class: "button", value: t("admin.budget_investments.edit.submit_button")) %>
   </div>

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -106,10 +106,9 @@
   </div>
 
   <div class="small-12 column">
-    <%= f.label :milestone_tag_list, t("admin.budget_investments.edit.milestone_tags") %>
     <%= f.text_field :milestone_tag_list,
                    value: @investment.milestone_tag_list.sort.join(", "),
-                   label: false %>
+                   label: t("admin.budget_investments.edit.milestone_tags") %>
   </div>
 
 

--- a/app/views/admin/milestones/_milestones.html.erb
+++ b/app/views/admin/milestones/_milestones.html.erb
@@ -4,6 +4,12 @@
             polymorphic_path([:admin, *resource_hierarchy_for(milestoneable.progress_bars.new)]),
             class: "button hollow float-right" %>
 
+<% if milestoneable.milestone_tag_list.any? %>
+  <div>
+    <b><%= t("admin.milestones.index.milestone_tags") %>:</b> <%= milestoneable.milestone_tag_list.sort.join(", ") %>
+  </div>
+<% end %>
+
 <% if milestoneable.milestones.any? %>
   <table>
     <thead>

--- a/app/views/admin/milestones/_milestones.html.erb
+++ b/app/views/admin/milestones/_milestones.html.erb
@@ -6,7 +6,9 @@
 
 <% if milestoneable.milestone_tag_list.any? %>
   <div>
-    <b><%= t("admin.milestones.index.milestone_tags") %>:</b> <%= milestoneable.milestone_tag_list.sort.join(", ") %>
+    <strong>
+      <%= t("admin.milestones.index.milestone_tags") %>:
+    </strong> <%= milestoneable.milestone_tag_list.sort.join(", ") %>
   </div>
 <% end %>
 

--- a/app/views/budgets/executions/show.html.erb
+++ b/app/views/budgets/executions/show.html.erb
@@ -44,13 +44,24 @@
   <div class="small-12 medium-9 large-10 column">
     <%= form_tag(budget_executions_path(@budget), method: :get) do %>
       <div class="small-12 medium-3 column">
-        <%= label_tag :status, t("budgets.executions.filters.label") %>
+        <%= label_tag :milestone_tag, t("budgets.executions.filters.milestone_tag.label") %>
+        <%= select_tag :milestone_tag,
+                      options_for_select(
+                        options_for_milestone_tags,
+                        params[:milestone_tag]
+                      ),
+                      class: "js-submit-on-change",
+                      prompt: t("budgets.executions.filters.milestone_tag.all",
+                      count: @budget.investments.winners.with_milestones.count) %>
+      </div>
+      <div class="small-12 medium-3 column">
+        <%= label_tag :status, t("budgets.executions.filters.status.label") %>
         <%= select_tag :status,
                       options_from_collection_for_select(@statuses,
                       :id, lambda { |s| "#{s.name} (#{filters_select_counts(s.id)})" },
                       params[:status]),
                       class: "js-submit-on-change",
-                      prompt: t("budgets.executions.filters.all",
+                      prompt: t("budgets.executions.filters.status.all",
                       count: @budget.investments.winners.with_milestones.count) %>
       </div>
     <% end %>

--- a/config/locales/ar/budgets.yml
+++ b/config/locales/ar/budgets.yml
@@ -168,8 +168,9 @@ ar:
       heading_selection_title: "جسب المنطقة"
       no_winner_investments: "لا يوجد استثمارات فائزة"
       filters:
-        label: "حالة المشروع الحالية"
-        all: "الكل (%{count})"
+        status:
+          label: "حالة المشروع الحالية"
+          all: "الكل (%{count})"
     phases:
       errors:
         dates_range_invalid: "تاريخ البدأ لا يمكن ان يكون مساو او يتجاوز تاريخ الانتهاء"

--- a/config/locales/de-DE/budgets.yml
+++ b/config/locales/de-DE/budgets.yml
@@ -182,8 +182,9 @@ de:
       heading_selection_title: "Nach Bezirk"
       no_winner_investments: "Keine erfolgreichen Ausgabenvorschläge in diesem Status"
       filters:
-        label: "Aktueller Stand des Projekts"
-        all: "Alle (%{count})"
+        status:
+          label: "Aktueller Stand des Projekts"
+          all: "Alle (%{count})"
     phases:
       errors:
         dates_range_invalid: "Das Anfangsdatum kann nicht gleich oder später als das Enddatum sein"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -298,6 +298,7 @@ en:
         documents: "Documents"
         milestone: Milestone
         new_milestone: Create new milestone
+        milestone_tags: Milestone Tags
       form:
         admin_statuses: Manage statuses
         no_statuses_defined: There are no defined statuses yet

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -281,6 +281,7 @@ en:
         tags_placeholder: "Write the tags you want separated by commas (,)"
         undefined: Undefined
         user_groups: "Groups"
+        milestone_tags: Milestone tags
       search_unfeasible: Search unfeasible
     milestones:
       index:

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -184,8 +184,12 @@ en:
       heading_selection_title: "By district"
       no_winner_investments: "No winner investments in this state"
       filters:
-        label: "Project's current state"
-        all: "All (%{count})"
+        status:
+          label: "Project's current state"
+          all: "All (%{count})"
+        milestone_tag:
+          label: "Milestone tag"
+          all: "All (%{count})"
     phases:
       errors:
         dates_range_invalid: "Start date can't be equal or later than End date"

--- a/config/locales/en/milestones.yml
+++ b/config/locales/en/milestones.yml
@@ -3,6 +3,7 @@ en:
     index:
       no_milestones: Don't have defined milestones
       progress: Progress
+      milestone_tags: Milestone Tags
     show:
       publication_date: "Published %{publication_date}"
       status_changed: Status changed to

--- a/config/locales/en/milestones.yml
+++ b/config/locales/en/milestones.yml
@@ -3,7 +3,6 @@ en:
     index:
       no_milestones: Don't have defined milestones
       progress: Progress
-      milestone_tags: Milestone Tags
     show:
       publication_date: "Published %{publication_date}"
       status_changed: Status changed to

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -298,6 +298,7 @@ es:
         documents: "Documentos"
         milestone: Seguimiento
         new_milestone: Crear nuevo hito
+        milestone_tags: Etiquetas de Seguimiento
       form:
         admin_statuses: Gestionar estados
         no_statuses_defined: No hay estados definidos

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -281,6 +281,7 @@ es:
         tags_placeholder: "Escribe las etiquetas que desees separadas por comas (,)"
         undefined: Sin definir
         user_groups: "Grupos"
+        milestone_tags: Etiquetas de Seguimiento
       search_unfeasible: Buscar inviables
     milestones:
       index:

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -184,8 +184,12 @@ es:
       heading_selection_title: "Ámbito de actuación"
       no_winner_investments: "No hay proyectos de gasto ganadores en este estado"
       filters:
-        label: "Estado actual del proyecto"
-        all: "Todos (%{count})"
+        status:
+          label: "Estado actual del proyecto"
+          all: "Todos (%{count})"
+        milestone_tag:
+          label: "Etiquetas de Seguimiento"
+          all: "Todos (%{count})"
     phases:
       errors:
         dates_range_invalid: "La fecha de comienzo no puede ser igual o superior a la de finalización"

--- a/config/locales/es/milestones.yml
+++ b/config/locales/es/milestones.yml
@@ -3,7 +3,6 @@ es:
     index:
       no_milestones: No hay hitos definidos
       progress: Progreso
-      milestone_tags: Etiquetas de Seguimiento
     show:
       publication_date: "Publicado el %{publication_date}"
       status_changed: El proyecto ha cambiado al estado

--- a/config/locales/es/milestones.yml
+++ b/config/locales/es/milestones.yml
@@ -3,6 +3,7 @@ es:
     index:
       no_milestones: No hay hitos definidos
       progress: Progreso
+      milestone_tags: Etiquetas de Seguimiento
     show:
       publication_date: "Publicado el %{publication_date}"
       status_changed: El proyecto ha cambiado al estado

--- a/config/locales/fi-FI/budgets.yml
+++ b/config/locales/fi-FI/budgets.yml
@@ -50,4 +50,5 @@ fi:
       link: "Tavoitteet"
       page_title: "%{budget} - Tavoitteet"
       filters:
-        all: "Kaikki (%{count})"
+        status:
+          all: "Kaikki (%{count})"

--- a/config/locales/gl/budgets.yml
+++ b/config/locales/gl/budgets.yml
@@ -182,8 +182,9 @@ gl:
       heading_selection_title: "Por ámbito de actuación"
       no_winner_investments: "Non hai investimentos gañadores neste estado"
       filters:
-        label: "Estado actual do proxecto"
-        all: "Todo (%{count})"
+        status:
+          label: "Estado actual do proxecto"
+          all: "Todo (%{count})"
     phases:
       errors:
         dates_range_invalid: "A data de comezo non pode ser igual ou superior á de remate"

--- a/config/locales/it/budgets.yml
+++ b/config/locales/it/budgets.yml
@@ -176,7 +176,8 @@ it:
       link: "Traguardi"
       heading_selection_title: "Per circoscrizione"
       filters:
-        all: "Tutto (%{count})"
+        status:
+          all: "Tutto (%{count})"
     phases:
       errors:
         dates_range_invalid: "La Data di inizio non può essere uguale o successiva alla Data finale"

--- a/config/locales/nl/budgets.yml
+++ b/config/locales/nl/budgets.yml
@@ -184,8 +184,9 @@ nl:
       heading_selection_title: "Per wijk"
       no_winner_investments: "Geen geaccepteerde investeringen in deze status"
       filters:
-        label: "Status van het project"
-        all: "Alle (%{count})"
+        status:
+          label: "Status van het project"
+          all: "Alle (%{count})"
     phases:
       errors:
         dates_range_invalid: "De begindatum dient kleiner te zijn dan de einddatum"

--- a/config/locales/so-SO/budgets.yml
+++ b/config/locales/so-SO/budgets.yml
@@ -181,8 +181,9 @@ so:
       heading_selection_title: "Degmo ahaan"
       no_winner_investments: "Mana jiraan maalgalin ku guuleysta gobolkan"
       filters:
-        label: "Mashruca hada gobolka kasocda"
-        all: "Dhaman%{count}"
+        status:
+          label: "Mashruca hada gobolka kasocda"
+          all: "Dhaman%{count}"
     phases:
       errors:
         dates_range_invalid: "Taariikhda bilowga ma noqon karto mid siman ama ka dambeysa taariikhda dhammaadka"

--- a/config/locales/sq-AL/budgets.yml
+++ b/config/locales/sq-AL/budgets.yml
@@ -49,7 +49,7 @@ sq:
         all_phases: Shihni të gjitha fazat
       all_phases: Fazat e investimeve buxhetore
       map: Propozimet e investimeve buxhetore të vendosura gjeografikisht
-      investment_proyects: Lista e të gjitha projekteve të investimeve 
+      investment_proyects: Lista e të gjitha projekteve të investimeve
       unfeasible_investment_proyects: Lista e të gjitha projekteve të investimeve të papranueshme
       not_selected_investment_proyects: Lista e të gjitha projekteve të investimeve të pa zgjedhur për votim
       finished_budgets: Përfunduan buxhetet pjesëmarrëse.
@@ -171,7 +171,7 @@ sq:
       accepted: "Propozimi i pranuar i shpenzimeve:"
       discarded: "Propozimi i hedhur poshtë i shpenzimeve:"
       incompatibles: I papajtueshëm
-      investment_proyects: Lista e të gjitha projekteve të investimeve 
+      investment_proyects: Lista e të gjitha projekteve të investimeve
       unfeasible_investment_proyects: Lista e të gjitha projekteve të investimeve të papranueshme
       not_selected_investment_proyects: Lista e të gjitha projekteve të investimeve të pa zgjedhur për votim
     executions:
@@ -181,8 +181,9 @@ sq:
       heading_selection_title: "Nga rrethi"
       no_winner_investments: "Asnjë investim fitues në këtë gjendje"
       filters:
-        label: "Gjendja aktuale e projektit"
-        all: "Të gjitha (%{count})"
+        status:
+          label: "Gjendja aktuale e projektit"
+          all: "Të gjitha (%{count})"
     phases:
       errors:
         dates_range_invalid: "Data e fillimit nuk mund të jetë e barabartë ose më vonë se data e përfundimit"

--- a/config/locales/val/budgets.yml
+++ b/config/locales/val/budgets.yml
@@ -182,8 +182,9 @@ val:
       heading_selection_title: "Àmbit d'actuació"
       no_winner_investments: "No hi ha propostes en aquest estat"
       filters:
-        label: "Estat actual del projecte"
-        all: "Tots (%{count})"
+        status:
+          label: "Estat actual del projecte"
+          all: "Tots (%{count})"
     phases:
       errors:
         dates_range_invalid: "La data d'inici no ha de ser igual o posterior a la data de fi"

--- a/config/locales/zh-CN/budgets.yml
+++ b/config/locales/zh-CN/budgets.yml
@@ -176,8 +176,9 @@ zh-CN:
       heading_selection_title: "按区域"
       no_winner_investments: "这个州里没有胜出的投资"
       filters:
-        label: "项目的当前状态"
-        all: "所有(%{count})"
+        status:
+          label: "项目的当前状态"
+          all: "所有(%{count})"
     phases:
       errors:
         dates_range_invalid: "开始日期不能等于或晚于结束日期"

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -166,6 +166,10 @@ FactoryBot.define do
      trait :with_confirmed_hide do
        confirmed_hide_at { Time.current }
      end
+
+    trait :with_milestone_tags do
+      after(:create) { |investment| investment.milestone_tags << create(:tag, :milestone) }
+    end
   end
 
   factory :budget_phase, class: "Budget::Phase" do

--- a/spec/factories/classifications.rb
+++ b/spec/factories/classifications.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     trait :category do
       kind "category"
     end
+
+    trait :milestone do
+      kind "milestone"
+    end
   end
 
   factory :tagging, class: "ActsAsTaggableOn::Tagging" do

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -112,6 +112,10 @@ FactoryBot.define do
       result_publication_enabled false
       published true
     end
+
+    trait :with_milestone_tags do
+      after(:create) { |legislation| legislation.milestone_tags << create(:tag, :milestone) }
+    end
   end
 
   factory :legislation_draft_version, class: "Legislation::DraftVersion" do

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -66,6 +66,7 @@ FactoryBot.define do
 
     trait :published do
       published_at { Time.current }
+    end
 
     trait :with_milestone_tags do
       after(:create) { |proposal| proposal.milestone_tags << create(:tag, :milestone) }

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -66,6 +66,9 @@ FactoryBot.define do
 
     trait :published do
       published_at { Time.current }
+
+    trait :with_milestone_tags do
+      after(:create) { |proposal| proposal.milestone_tags << create(:tag, :milestone) }
     end
   end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1335,6 +1335,7 @@ describe "Admin budget investments" do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
+
       expect(page).not_to have_content("Milestone Tags:")
 
       click_link "Edit classification"

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1331,6 +1331,22 @@ describe "Admin budget investments" do
       expect(page).to have_content "can't be blank"
     end
 
+    scenario "Add milestone tags" do
+      budget_investment = create(:budget_investment)
+
+      visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
+      expect(page).not_to have_content("Milestone Tags:")
+
+      click_link "Edit classification"
+
+      fill_in "budget_investment_milestone_tag_list", with: "tag1, tag2"
+
+      click_button "Update"
+
+      expect(page).to have_content "Investment project updated succesfully."
+      expect(page).to have_content("Milestone Tags: tag1, tag2")
+    end
+
   end
 
   context "Selecting" do

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -235,6 +235,52 @@ describe "Executions" do
       select "Bidding (0)", from: "status"
       expect(page).not_to have_content(investment1.title)
     end
+
+    scenario "by milestone tag, only display tags for winner investments", :js do
+      create(:milestone, milestoneable: investment1, status: status1)
+      create(:milestone, milestoneable: investment2, status: status2)
+      create(:milestone, milestoneable: investment3, status: status2)
+      investment1.milestone_tag_list.add("tag1", "tag2")
+      investment1.save
+      investment2.milestone_tag_list.add("tag2")
+      investment2.save
+      investment3.milestone_tag_list.add("tag2")
+      investment3.save
+
+      visit budget_path(budget)
+
+      click_link "See results"
+      click_link "Milestones"
+
+      expect(page).to have_content(investment1.title)
+      expect(page).to have_content(investment2.title)
+
+      select "tag2 (2)", from: "milestone_tag"
+
+      expect(page).to have_content(investment1.title)
+      expect(page).to have_content(investment2.title)
+
+      select "Studying the project (1)", from: "status"
+
+      expect(page).to have_content(investment1.title)
+      expect(page).not_to have_content(investment2.title)
+
+      select "Bidding (1)", from: "status"
+
+      expect(page).not_to have_content(investment1.title)
+      expect(page).to have_content(investment2.title)
+
+      select "tag1 (1)", from: "milestone_tag"
+
+      expect(page).not_to have_content(investment1.title)
+      expect(page).not_to have_content(investment2.title)
+
+      select "All (2)", from: "milestone_tag"
+
+      expect(page).not_to have_content(investment1.title)
+      expect(page).to have_content(investment2.title)
+    end
+
   end
 
   context "Heading Order" do

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -1274,17 +1274,22 @@ describe Budget::Investment do
   describe "milestone_tags" do
     context "without milestone_tags" do
       let(:investment) {create(:budget_investment)}
+
       it "do not have milestone_tags" do
         expect(investment.milestone_tag_list).to eq([])
         expect(investment.milestone_tags).to eq([])
       end
+
       it "add a new milestone_tag" do
         investment.milestone_tag_list = "tag1,tag2"
+
         expect(investment.milestone_tag_list).to eq(["tag1", "tag2"])
       end
     end
+
     context "with milestone_tags" do
       let(:investment) {create(:budget_investment, :with_milestone_tags)}
+
       it "has milestone_tags" do
         expect(investment.milestone_tag_list.count).to eq(1)
       end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -1267,6 +1267,27 @@ describe Budget::Investment do
       investment.valuators << valuator
       investment.administrator = administrator
       expect(investment.admin_and_valuator_users_associated).to eq([valuator, administrator])
+
+    end
+  end
+
+  describe "milestone_tags" do
+    context "without milestone_tags" do
+      let(:investment) {create(:budget_investment)}
+      it "do not have milestone_tags" do
+        expect(investment.milestone_tag_list).to eq([])
+        expect(investment.milestone_tags).to eq([])
+      end
+      it "add a new milestone_tag" do
+        investment.milestone_tag_list = "tag1,tag2"
+        expect(investment.milestone_tag_list).to eq(["tag1", "tag2"])
+      end
+    end
+    context "with milestone_tags" do
+      let(:investment) {create(:budget_investment, :with_milestone_tags)}
+      it "has milestone_tags" do
+        expect(investment.milestone_tag_list.count).to eq(1)
+      end
     end
   end
 end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -306,4 +306,46 @@ describe Budget do
       expect(budget.formatted_amount(1000.00)).to eq ("€1,000")
     end
   end
+
+  describe "#milestone_tags" do
+    let(:investment1) { build(:budget_investment, :winner) }
+    let(:investment2) { build(:budget_investment, :winner) }
+    let(:investment3) { build(:budget_investment) }
+
+    it "returns an empty array if not investments milestone_tags" do
+      budget.investments << investment1
+
+      expect(budget.milestone_tags).to eq([])
+    end
+
+    it "returns array of investments milestone_tags" do
+      investment1.milestone_tag_list = "tag1"
+      investment1.save
+      budget.investments << investment1
+
+      expect(budget.milestone_tags).to eq(["tag1"])
+    end
+
+    it "returns uniq list of investments milestone_tags" do
+      investment1.milestone_tag_list = "tag1"
+      investment1.save
+      investment2.milestone_tag_list = "tag1"
+      investment2.save
+      budget.investments << investment1
+      budget.investments << investment2
+
+      expect(budget.milestone_tags).to eq(["tag1"])
+    end
+
+    it "returns tags only for winner investments" do
+      investment1.milestone_tag_list = "tag1"
+      investment1.save
+      investment3.milestone_tag_list = "tag2"
+      investment3.save
+      budget.investments << investment1
+      budget.investments << investment3
+
+      expect(budget.milestone_tags).to eq(["tag1"])
+    end
+  end
 end

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -194,4 +194,24 @@ describe Legislation::Process do
     end
   end
 
+  describe "milestone_tags" do
+    context "without milestone_tags" do
+      let(:process) {create(:legislation_process)}
+      it "do not have milestone_tags" do
+        expect(process.milestone_tag_list).to eq([])
+        expect(process.milestone_tags).to eq([])
+      end
+      it "add a new milestone_tag" do
+        process.milestone_tag_list = "tag1,tag2"
+        expect(process.milestone_tag_list).to eq(["tag1", "tag2"])
+      end
+    end
+    context "with milestone_tags" do
+      let(:process) {create(:legislation_process, :with_milestone_tags)}
+      it "has milestone_tags" do
+        expect(process.milestone_tag_list.count).to eq(1)
+      end
+    end
+  end
+
 end

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -197,21 +197,28 @@ describe Legislation::Process do
   describe "milestone_tags" do
     context "without milestone_tags" do
       let(:process) {create(:legislation_process)}
+
       it "do not have milestone_tags" do
         expect(process.milestone_tag_list).to eq([])
         expect(process.milestone_tags).to eq([])
       end
+
       it "add a new milestone_tag" do
         process.milestone_tag_list = "tag1,tag2"
+
         expect(process.milestone_tag_list).to eq(["tag1", "tag2"])
       end
     end
+
     context "with milestone_tags" do
+
       let(:process) {create(:legislation_process, :with_milestone_tags)}
+
       it "has milestone_tags" do
         expect(process.milestone_tag_list.count).to eq(1)
       end
     end
+
   end
 
 end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -1084,4 +1084,32 @@ describe Proposal do
 
   end
 
+  describe "milestone_tags" do
+
+    context "without milestone_tags" do
+
+      let(:proposal) {create(:proposal)}
+
+      it "do not have milestone_tags" do
+        expect(proposal.milestone_tag_list).to eq([])
+        expect(proposal.milestone_tags).to eq([])
+      end
+
+      it "add a new milestone_tag" do
+        proposal.milestone_tag_list = "tag1,tag2"
+
+        expect(proposal.milestone_tag_list).to eq(["tag1", "tag2"])
+      end
+    end
+
+    context "with milestone_tags" do
+
+      let(:proposal) {create(:proposal, :with_milestone_tags)}
+
+      it "has milestone_tags" do
+        expect(proposal.milestone_tag_list.count).to eq(1)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
## References

#3411 

## Objectives

Add new tags for milestones. That tags will be a milestoneable object property.
For investment budgets, add a public executions filter based on that milestone_tags 

## Visual Changes

### Admin
#### Edit investment
![image](https://user-images.githubusercontent.com/1029265/55462703-a3820100-55f7-11e9-997f-6736558491b4.png)
#### Show investment
![image](https://user-images.githubusercontent.com/1029265/55462773-cd3b2800-55f7-11e9-9395-3e5a795541b9.png)


### Public
#### Large Viewport
![image](https://user-images.githubusercontent.com/1029265/55462545-5140e000-55f7-11e9-83c4-11fc071eeeec.png)
#### Small Viewport
![image](https://user-images.githubusercontent.com/1029265/55462581-6158bf80-55f7-11e9-82f4-703868dcf681.png)


## Notes

I change a translation from budgets.executions.filters.* to budgets.executions.filters.status.* to wrap different visual components translations
