### PR TITLE
 Fix sort by random inconsistencies

### DIFF
--- a/app/models/concerns/randomizable.rb
+++ b/app/models/concerns/randomizable.rb
@@ -3,7 +3,7 @@ module Randomizable
 
   class_methods do
     def sort_by_random(seed = rand(10_000_000))
-      ids = pluck(:id).shuffle(random: Random.new(seed))
+      ids = order(:id).pluck(:id).shuffle(random: Random.new(seed))
 
       return all if ids.empty?
 


### PR DESCRIPTION
## References

* Backports pull request AyuntamientoMadrid#1946
* Pull request #3321
* Closes #3075
* Closes #3368

## Objectives

* Consistently maintain the random legislation proposals and budget investments order for the same user session
* Fix the flaky specs that appeared in `spec/features/legislation/proposals_spec.rb:34` ("Legislation Proposals Each user as a different and consistent random proposals order"), `spec/features/legislation/proposals_spec.rb:60` ("Legislation Proposals Random order maintained with pagination"), and `spec/features/budgets/investments_spec.rb:611` ("Budget Investments Orders Each user has a different and consistent random budget investment order when random_seed is disctint")

## Notes

* The order of the array before being shuffled needs to be the same if we want to have the same array after being shuffled with a certain seed. We were using `pluck(:id)`, which doesn't guarantee the order of the elements returned. Replacing it with `order(:id).pluck(:id)` adds an `ORDER BY` clause and
so guarantees the order of the elements.
* Debugging showed sometimes we were getting different IDs using the same seed to shuffle the array, so the problem seemed not to be related to the user's session nor the random seed generation.