### PR TITLE
Globalize initialization

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 require "application_responder"
 
 class ApplicationController < ActionController::Base
+  include GlobalizeFallbacks
   include HasFilters
   include HasOrders
 
@@ -10,7 +11,6 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
   before_action :track_email_campaign
   before_action :set_return_url
-  before_action :set_fallbacks_to_all_available_locales
 
   check_authorization unless: :devise_controller?
   self.responder = ApplicationResponder
@@ -128,9 +128,5 @@ class ApplicationController < ActionController::Base
 
     def current_budget
       Budget.current
-    end
-
-    def set_fallbacks_to_all_available_locales
-      Globalize.set_fallbacks_to_all_available_locales
     end
 end

--- a/app/controllers/concerns/globalize_fallbacks.rb
+++ b/app/controllers/concerns/globalize_fallbacks.rb
@@ -1,0 +1,13 @@
+module GlobalizeFallbacks
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :initialize_globalize_fallbacks
+  end
+
+  private
+
+    def initialize_globalize_fallbacks
+      Globalize.set_fallbacks_to_all_available_locales
+    end
+end

--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -1,4 +1,5 @@
 class Management::BaseController < ActionController::Base
+  include GlobalizeFallbacks
   layout "management"
 
   before_action :verify_manager

--- a/app/controllers/management/sessions_controller.rb
+++ b/app/controllers/management/sessions_controller.rb
@@ -1,6 +1,7 @@
 require "manager_authenticator"
 
 class Management::SessionsController < ActionController::Base
+  include GlobalizeFallbacks
 
   def create
     destroy_session

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,9 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     I18n.locale = :en
     Globalize.locale = I18n.locale
+    unless %i[controller feature request].include? example.metadata[:type]
+      Globalize.set_fallbacks_to_all_available_locales
+    end
     load Rails.root.join("db", "seeds.rb").to_s
     Setting["feature.user.skip_verification"] = nil
   end


### PR DESCRIPTION
## References

Related Issues: #3130 
Related PR's: #3194, #3239 

## Objectives
1. Ensure we are initializing Globalize.fallbacks always
2. Prevent flaky specs because of globalize fallbacks initialization

When any helper, lib, mailer, model or view spec is executed after a feature, controller or request spec Globalize.fallbacks returns nil and this can cause some flaky specs. With this patch we are ensuring to initialize Globalize fallbacks between specs. This behavior is normal at test environment with the latest version of globalize included at #3194 which uses the `request-store` gem who resets storage (whene fallbacks are stored) after every request, so when a model specs is executed after a feature specs Globalize.fallbacks will return nil and model spec will fail.
 
Controller, feature and request specs do not need this patch because of application_controller is currently initializing Globalize.fallback for each request.

## Visual Changes
None

## Notes
None
