### PR TITLE
Upgrade Ruby version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use Ruby 2.3.6 as base image
-FROM ruby:2.3.6
+# Use Ruby 2.3.8 as base image
+FROM ruby:2.3.8
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
`docker-compose up` is broken on my mac.

```
➜  docker-compose up
Creating network "consul_default" with the default driver
Creating volume "consul_docker-example-postgres" with default driver
Creating volume "consul_bundle" with default driver
Pulling database (postgres:9.4.5)...
9.4.5: Pulling from library/postgres
03e1855d4f31: Pull complete
a3ed95caeb02: Pull complete
9fa1fd7786d8: Pull complete
b0119b52de2a: Pull complete
5bea54cbf09c: Pull complete
5de01a15fe86: Pull complete
27b06e1f36cf: Pull complete
5ad9907af87a: Pull complete
6d4c10585b85: Pull complete
2d4f8ba8bf6e: Pull complete
f8899d5c9afb: Pull complete
9b433e892030: Pull complete
Building app
Step 1/25 : FROM ruby:2.3.6
2.3.6: Pulling from library/ruby
f2b6b4884fc8: Pull complete
4fb899b4df21: Pull complete
74eaa8be7221: Pull complete
2d6e98fe4040: Pull complete
638a4a258268: Pull complete
3aae84250a19: Pull complete
16dbfde3ef5f: Pull complete
Digest: sha256:139ecd159fb74b1de1b1645b17cb7297bcdacee92aed8cdd0c1ada03eb9af994
Status: Downloaded newer image for ruby:2.3.6
 ---> 7ab6e81790b8
Step 2/25 : ENV DEBIAN_FRONTEND noninteractive
 ---> Running in c1e900d7ed43
Removing intermediate container c1e900d7ed43
 ---> cf958833d9a7
Step 3/25 : RUN apt-get update -qq
 ---> Running in 4523f96cf248
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

E: Some index files failed to download. They have been ignored, or old ones used instead.
ERROR: Service 'app' failed to build: The command '/bin/sh -c apt-get update -qq' returned a non-zero code: 100
```

## References

## Objectives

Fix the build by bumping ruby:2.3.6 to  ruby:2.3.8 on the Dockerfile.

## Visual Changes

None

## Notes

