### PR TITLE
Add Intellij IDE project settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@
 
 # Mac finder artifacts
 .DS_Store
+
+# Intellij IDE project settings
+/.idea
+
 .ruby-gemset
 
 public/sitemap.xml


### PR DESCRIPTION
### Context
Some developers use the [Intellij IDE](https://www.jetbrains.com/idea/) to work with Rails.

## Objectives

Adding the `/.idea` folder where project settings are stored, so that these files do not have to be skipped manually when sending a PR upstream.