### PR TITLE
Spending proposals migration to budget investments

### DIFF
--- a/app/models/ballot.rb
+++ b/app/models/ballot.rb
@@ -1,0 +1,5 @@
+class Ballot < ActiveRecord::Base
+  belongs_to :user
+  has_many :ballot_lines
+  has_many :spending_proposals, through: :ballot_lines
+end

--- a/app/models/ballot_line.rb
+++ b/app/models/ballot_line.rb
@@ -1,0 +1,4 @@
+class BallotLine < ActiveRecord::Base
+  belongs_to :ballot
+  belongs_to :spending_proposal
+end

--- a/app/models/ballot_line.rb
+++ b/app/models/ballot_line.rb
@@ -1,4 +1,4 @@
 class BallotLine < ActiveRecord::Base
-  belongs_to :ballot
+  belongs_to :ballot, counter_cache: true
   belongs_to :spending_proposal
 end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -20,6 +20,7 @@ class Budget < ActiveRecord::Base
   has_many :groups, dependent: :destroy
   has_many :headings, through: :groups
   has_many :phases, class_name: Budget::Phase
+  has_many :lines, through: :ballots, class_name: "Budget::Ballot::Line"
 
   has_one :poll
 

--- a/app/models/budget/ballot/line.rb
+++ b/app/models/budget/ballot/line.rb
@@ -1,7 +1,7 @@
 class Budget
   class Ballot
     class Line < ActiveRecord::Base
-      belongs_to :ballot
+      belongs_to :ballot, counter_cache: :ballot_lines_count
       belongs_to :investment, counter_cache: :ballot_lines_count
       belongs_to :heading
       belongs_to :group

--- a/app/models/budget/ballot/line.rb
+++ b/app/models/budget/ballot/line.rb
@@ -31,17 +31,15 @@ class Budget
         errors.add(:investment, "unselected investment") unless investment.selected?
       end
 
-      private
+      def set_denormalized_ids
+        self.heading_id ||= investment.try(:heading_id)
+        self.group_id   ||= investment.try(:group_id)
+        self.budget_id  ||= investment.try(:budget_id)
+      end
 
-        def set_denormalized_ids
-          self.heading_id ||= investment.try(:heading_id)
-          self.group_id   ||= investment.try(:group_id)
-          self.budget_id  ||= investment.try(:budget_id)
-        end
-
-        def store_user_heading
-          ballot.user.update(balloted_heading_id: heading.id) unless ballot.physical == true
-        end
+      def store_user_heading
+        ballot.user.update(balloted_heading_id: heading.id) unless ballot.physical == true
+      end
     end
   end
 end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -32,6 +32,7 @@ class Budget
     belongs_to :group
     belongs_to :budget
     belongs_to :administrator
+    belongs_to :spending_proposal, foreign_key: "original_spending_proposal_id"
 
     has_many :valuator_assignments, dependent: :destroy
     has_many :valuators, through: :valuator_assignments

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,7 +4,7 @@ class Comment < ActiveRecord::Base
   include Graphqlable
   include Notifiable
 
-  COMMENTABLE_TYPES = %w(Debate Proposal Budget::Investment Poll Topic Legislation::Question
+  COMMENTABLE_TYPES = %w(Debate Proposal SpendingProposal Budget::Investment Poll Topic Legislation::Question
                         Legislation::Annotation Legislation::Proposal).freeze
 
   acts_as_paranoid column: :hidden_at

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -19,7 +19,7 @@ class Comment < ActiveRecord::Base
 
   validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }
 
-  validate :validate_body_length
+  validate :validate_body_length, unless: -> { valuation }
   validate :comment_valuation, if: -> { valuation }
 
   belongs_to :commentable, -> { with_hidden }, polymorphic: true, counter_cache: true

--- a/app/models/spending_proposal.rb
+++ b/app/models/spending_proposal.rb
@@ -5,12 +5,15 @@ class SpendingProposal < ActiveRecord::Base
   include Searchable
 
   acts_as_votable
+  acts_as_paranoid column: :hidden_at
+  include ActsAsParanoidAliases
 
   belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
   belongs_to :geozone
   belongs_to :administrator
   has_many :valuation_assignments, dependent: :destroy
   has_many :valuators, through: :valuation_assignments
+  has_many :comments, as: :commentable
 
   validates :title, presence: true
   validates :author, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ActiveRecord::Base
   has_one :poll_officer, class_name: "Poll::Officer"
   has_one :organization
   has_one :lock
+  has_one :ballot
   has_many :flags
   has_many :identities, dependent: :destroy
   has_many :debates, -> { with_hidden }, foreign_key: :author_id

--- a/db/migrate/20160331151753_add_comments_count_to_spending_proposals.rb
+++ b/db/migrate/20160331151753_add_comments_count_to_spending_proposals.rb
@@ -1,0 +1,5 @@
+class AddCommentsCountToSpendingProposals < ActiveRecord::Migration
+  def change
+    add_column :spending_proposals, :comments_count, :integer
+  end
+end

--- a/db/migrate/20160331152642_add_hidden_at_to_spending_proposals.rb
+++ b/db/migrate/20160331152642_add_hidden_at_to_spending_proposals.rb
@@ -1,0 +1,5 @@
+class AddHiddenAtToSpendingProposals < ActiveRecord::Migration
+  def change
+    add_column :spending_proposals, :hidden_at, :datetime
+  end
+end

--- a/db/migrate/20160425190645_create_ballots.rb
+++ b/db/migrate/20160425190645_create_ballots.rb
@@ -1,0 +1,8 @@
+class CreateBallots < ActiveRecord::Migration
+  def change
+    create_table :ballots do |t|
+      t.integer :user_id
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160425190722_create_ballot_lines.rb
+++ b/db/migrate/20160425190722_create_ballot_lines.rb
@@ -1,0 +1,9 @@
+class CreateBallotLines < ActiveRecord::Migration
+  def change
+    create_table :ballot_lines do |t|
+      t.integer :ballot_id
+      t.integer :spending_proposal_id
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160516093006_add_ballot_line_counter_cached_to_ballots.rb
+++ b/db/migrate/20160516093006_add_ballot_line_counter_cached_to_ballots.rb
@@ -1,0 +1,5 @@
+class AddBallotLineCounterCachedToBallots < ActiveRecord::Migration
+  def change
+    add_column :ballots, :ballot_lines_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20170628211547_add_ballot_line_counter_cached_to_budget_ballots.rb
+++ b/db/migrate/20170628211547_add_ballot_line_counter_cached_to_budget_ballots.rb
@@ -1,0 +1,5 @@
+class AddBallotLineCounterCachedToBudgetBallots < ActiveRecord::Migration
+  def change
+    add_column :budget_ballots, :ballot_lines_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20171219110528_add_spending_id_to_budget_invesment.rb
+++ b/db/migrate/20171219110528_add_spending_id_to_budget_invesment.rb
@@ -1,0 +1,5 @@
+class AddSpendingIdToBudgetInvesment < ActiveRecord::Migration
+  def change
+    add_column :budget_investments, :original_spending_proposal_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -274,6 +274,7 @@ ActiveRecord::Schema.define(version: 20190205131722) do
     t.datetime "confirmed_hide_at"
     t.datetime "ignored_flag_at"
     t.integer  "flags_count",                                 default: 0
+    t.integer  "original_spending_proposal_id"
   end
 
   add_index "budget_investments", ["administrator_id"], name: "index_budget_investments_on_administrator_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190330055614) do
+ActiveRecord::Schema.define(version: 20190205131722) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,20 @@ ActiveRecord::Schema.define(version: 20190330055614) do
   add_index "ahoy_events", ["time"], name: "index_ahoy_events_on_time", using: :btree
   add_index "ahoy_events", ["user_id"], name: "index_ahoy_events_on_user_id", using: :btree
   add_index "ahoy_events", ["visit_id"], name: "index_ahoy_events_on_visit_id", using: :btree
+
+  create_table "ballot_lines", force: :cascade do |t|
+    t.integer  "ballot_id"
+    t.integer  "spending_proposal_id"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
+
+  create_table "ballots", force: :cascade do |t|
+    t.integer  "user_id"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.integer  "ballot_lines_count", default: 0
+  end
 
   create_table "banner_sections", force: :cascade do |t|
     t.integer  "banner_id"
@@ -270,12 +284,12 @@ ActiveRecord::Schema.define(version: 20190330055614) do
     t.boolean  "winner",                                      default: false
     t.boolean  "incompatible",                                default: false
     t.integer  "community_id"
+    t.integer  "original_spending_proposal_id"
     t.boolean  "visible_to_valuators",                        default: false
     t.integer  "valuator_group_assignments_count",            default: 0
     t.datetime "confirmed_hide_at"
     t.datetime "ignored_flag_at"
     t.integer  "flags_count",                                 default: 0
-    t.integer  "original_spending_proposal_id"
   end
 
   add_index "budget_investments", ["administrator_id"], name: "index_budget_investments_on_administrator_id", using: :btree
@@ -362,20 +376,6 @@ ActiveRecord::Schema.define(version: 20190330055614) do
     t.text     "description_drafting"
     t.text     "description_publishing_prices"
     t.text     "description_informing"
-  end
-
-  create_table "ballot_lines", force: :cascade do |t|
-    t.integer  "ballot_id"
-    t.integer  "spending_proposal_id"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
-  end
-
-  create_table "ballots", force: :cascade do |t|
-    t.integer  "user_id"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.integer  "ballot_lines_count", default: 0
   end
 
   create_table "campaigns", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190205131722) do
+ActiveRecord::Schema.define(version: 20190330055614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1373,6 +1373,8 @@ ActiveRecord::Schema.define(version: 20190205131722) do
     t.tsvector "tsv"
     t.string   "responsible_name",            limit: 60
     t.integer  "physical_votes",                         default: 0
+    t.integer  "comments_count"
+    t.datetime "hidden_at"
   end
 
   add_index "spending_proposals", ["author_id"], name: "index_spending_proposals_on_author_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(version: 20190205131722) do
     t.datetime "updated_at",                     null: false
     t.boolean  "physical",       default: false
     t.integer  "poll_ballot_id"
+    t.integer  "ballot_lines_count", default: 0
   end
 
   create_table "budget_content_blocks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -372,8 +372,9 @@ ActiveRecord::Schema.define(version: 20190205131722) do
 
   create_table "ballots", force: :cascade do |t|
     t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.integer  "ballot_lines_count", default: 0
   end
 
   create_table "campaigns", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -363,6 +363,19 @@ ActiveRecord::Schema.define(version: 20190205131722) do
     t.text     "description_informing"
   end
 
+  create_table "ballot_lines", force: :cascade do |t|
+    t.integer  "ballot_id"
+    t.integer  "spending_proposal_id"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
+
+  create_table "ballots", force: :cascade do |t|
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "campaigns", force: :cascade do |t|
     t.string   "name"
     t.string   "track_id"

--- a/lib/migrate_spending_proposals_to_investments.rb
+++ b/lib/migrate_spending_proposals_to_investments.rb
@@ -1,19 +1,19 @@
 class MigrateSpendingProposalsToInvestments
+  include Migrations::SpendingProposal::Common
 
   def import(sp)
-    budget = Budget.last || Budget.create!(name: Date.current.year.to_s, currency_symbol: "€")
+    budget = Budget.find_or_create_by(name: budget_name, slug: budget_name, phase: "finished", currency_symbol: "€")
 
     group = nil
     heading = nil
+    community = Community.create
 
     if sp.geozone_id.present?
-      group   = budget.groups.find_or_create_by!(name: "Barrios")
-      heading = group.headings.find_or_create_by!(name: sp.geozone.name, price: 10000000,
-                                                  latitude: "40.416775", longitude: "-3.703790")
+      group   = budget.groups.find_or_create_by!(name: districts_heading)
+      heading = group.headings.find_or_create_by!(name: sp.geozone.name, price: 10000000)
     else
-      group   = budget.groups.find_or_create_by!(name: "Toda la ciudad")
-      heading = group.headings.find_or_create_by!(name: "Toda la ciudad", price: 10000000,
-                                                  latitude: "40.416775", longitude: "-3.703790")
+      group   = budget.groups.find_or_create_by!(name: city_heading)
+      heading = group.headings.find_or_create_by!(name: city_heading, price: 10000000)
     end
 
     feasibility = case sp.feasible
@@ -26,45 +26,53 @@ class MigrateSpendingProposalsToInvestments
                   end
 
     investment = Budget::Investment.create!(
-      heading_id: heading.id,
       author_id: sp.author_id,
       administrator_id: sp.administrator_id,
       title: sp.title,
       description: sp.description,
       external_url: sp.external_url,
       price: sp.price,
-      price_explanation: sp.price_explanation,
-      duration: sp.time_scope,
       feasibility: feasibility,
-      unfeasibility_explanation: sp.feasible_explanation,
+      price_explanation: sp.price_explanation,
+      unfeasibility_explanation: "-",
       valuation_finished: sp.valuation_finished,
+      valuator_assignments_count: sp.valuation_assignments_count,
       price_first_year: sp.price_first_year,
+      duration: sp.time_scope,
+      hidden_at: sp.hidden_at,
       cached_votes_up: sp.cached_votes_up,
+      comments_count: sp.comments_count,
       physical_votes: sp.physical_votes,
+      tsv: sp.tsv,
       created_at: sp.created_at,
       updated_at: sp.updated_at,
+      heading_id: heading.id,
       responsible_name: sp.responsible_name,
-      terms_of_service: "1"
+      budget_id: budget.id,
+      group_id: group.id,
+      selected: false,
+      location: nil,
+      organization_name: sp.association_name,
+      unfeasible_email_sent_at: sp.unfeasible_email_sent_at,
+      previous_heading_id: nil,
+      visible_to_valuators: false,
+      winner: false,
+      community_id: community.id,
+      terms_of_service: "1",
+      original_spending_proposal_id: sp.id,
+      skip_map: "1"
     )
 
     investment.valuators = sp.valuation_assignments.map(&:valuator)
 
-    votes = ActsAsVotable::Vote.where(votable_type: "SpendingProposal", votable_id: sp.id)
+    Comment.where(commentable_type: "SpendingProposal", commentable_id: sp.id).update_all(
+      commentable_type: "Budget::Investment", commentable_id: investment.id
+    )
+    Budget::Investment.reset_counters(investment.id, :comments)
 
-    votes.each {|v| investment.vote_by(voter: v.voter, vote: "yes") }
-
-    # Spending proposals are not commentable in Consul so we can not test this
-    #
-    # Comment.where(commentable_type: "SpendingProposal", commentable_id: sp.id).update_all(
-    #   commentable_type: "Budget::Investment", commentable_id: investment.id
-    # )
-    # Budget::Investment.reset_counters(investment.id, :comments)
-
-    # Spending proposals have ballot_lines in Madrid, but not in consul, so we
-    # can not test this either
+    sp.update_column(:explanations_log, investment.id)
 
     investment
   end
 
 end
-

--- a/lib/migrations/log.rb
+++ b/lib/migrations/log.rb
@@ -1,0 +1,7 @@
+module Migrations::Log
+
+  def log(message)
+    print message unless Rails.env.test?
+  end
+
+end

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -1,0 +1,84 @@
+require_dependency "budget"
+require_dependency "budget/ballot"
+
+class Migrations::SpendingProposal::Ballot
+  include Migrations::SpendingProposal::Common
+
+  attr_accessor :spending_proposal_ballot, :budget_investment_ballot, :represented_user
+
+  def initialize(spending_proposal_ballot, represented_user=nil)
+    @represented_user = represented_user
+    @spending_proposal_ballot = spending_proposal_ballot
+    @budget_investment_ballot = find_or_initialize_budget_investment_ballot
+  end
+
+  def migrate_ballot
+    return if user_already_voted?
+
+    if budget_investment_ballot.save
+      log(".")
+      migrate_ballot_lines
+    else
+      log("\nError creating budget investment ballot from spending proposal ballot #{spending_proposal_ballot.id}\n")
+    end
+  end
+
+  def migrate_ballot_lines
+    spending_proposal_ballot.spending_proposals.each do |spending_proposal|
+      budget_investment = find_budget_investment(spending_proposal)
+
+      if budget_investment.blank?
+        log("Budget investment not found for spending proposal #{spending_proposal.id}")
+        next
+      end
+
+      ballot_line = find_or_initialize_ballot_line(budget_investment)
+      if ballot_line_saved?(ballot_line)
+        log(".")
+      else
+        log("Error adding spending proposal: #{spending_proposal.id} to ballot: #{budget_investment_ballot.id}\n")
+        log(ballot_line.errors.messages)
+      end
+    end
+  end
+
+  private
+
+    def find_or_initialize_budget_investment_ballot
+      Budget::Ballot.find_or_initialize_by(budget_investment_ballot_attributes)
+    end
+
+    def find_or_initialize_ballot_line(investment)
+      return nil if investment.blank?
+
+      attributes = { ballot: budget_investment_ballot, investment: investment }
+      budget_investment_ballot.lines.where(attributes).first_or_initialize
+    end
+
+    def user_already_voted?
+      budget_investment_ballot.ballot_lines_count > 0 && represented_user
+    end
+
+    def ballot_line_saved?(ballot_line)
+      return true if ballot_line_exists?(ballot_line)
+
+      ballot_line.set_denormalized_ids
+      ballot_line.save(validate: false)
+    end
+
+    def ballot_line_exists?(ballot_line)
+      budget_investment_ballot.investments.include?(ballot_line.investment)
+    end
+
+    def budget_investment_ballot_attributes
+      {
+        budget_id: budget.id,
+        user_id: user_id
+      }
+    end
+
+    def user_id
+      represented_user.try(:id) || spending_proposal_ballot.user_id
+    end
+
+end

--- a/lib/migrations/spending_proposal/ballots.rb
+++ b/lib/migrations/spending_proposal/ballots.rb
@@ -1,0 +1,23 @@
+class Migrations::SpendingProposal::Ballots
+  include Migrations::SpendingProposal::Common
+
+  attr_accessor :spending_proposal_ballots
+
+  def initialize
+    @spending_proposal_ballots = load_ballots
+  end
+
+  def migrate_all
+    spending_proposal_ballots.each do |spending_proposal_ballot|
+      budget_investment_ballot = Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot)
+      budget_investment_ballot.migrate_ballot
+    end
+  end
+
+  private
+
+    def load_ballots
+      ::Ballot.all
+    end
+
+end

--- a/lib/migrations/spending_proposal/budget.rb
+++ b/lib/migrations/spending_proposal/budget.rb
@@ -1,0 +1,108 @@
+require_dependency "spending_proposal"
+
+class Migrations::SpendingProposal::Budget
+  include Migrations::SpendingProposal::Common
+
+  def migrate
+    setup
+    migrate_data
+    expire_caches
+  end
+
+  def setup
+    initial_rake_task
+    update_heading_price
+    update_heading_population
+  end
+
+  def migrate_data
+    migrate_budget_investments
+    migrate_votes
+    migrate_ballots
+  end
+
+  def expire_caches
+    update_cached_votes
+    update_cached_ballots
+    calculate_winners
+  end
+
+  private
+
+    def initial_rake_task
+      log("Starting to migrate spending proposals to budget investments")
+      SpendingProposal.find_each { |sp| MigrateSpendingProposalsToInvestments.new.import(sp) }
+      log("Finished")
+    end
+
+    def migrate_budget_investments
+      update_selected_investments
+      Migrations::SpendingProposal::BudgetInvestments.new.update_all
+    end
+
+    def migrate_votes
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+    end
+
+    def migrate_ballots
+      Migrations::SpendingProposal::Ballots.new.migrate_all
+    end
+
+    def update_heading_price
+      update_city_heading_price
+      update_district_heading_price
+    end
+
+    def update_city_heading_price
+      budget.headings.where(name: city_heading).first&.update(price: city_price)
+    end
+
+    def update_district_heading_price
+      price_by_heading.each do |heading_name, price|
+        budget.headings.where(name: heading_name).first&.update(price: price)
+      end
+    end
+
+    def update_heading_population
+      update_city_heading_population
+      update_district_heading_population
+    end
+
+    def update_city_heading_population
+      budget.headings.where(name: "Toda la ciudad").first&.update(population: city_population)
+    end
+
+    def update_district_heading_population
+      population_by_heading.each do |heading_name, population|
+        budget.headings.where(name: heading_name).first&.update(population: population)
+      end
+    end
+
+    def city_population
+      population_by_heading.collect {|district, population| population}.sum
+    end
+
+    def update_selected_investments
+      ::SpendingProposal.feasible.valuation_finished.each do |spending_proposal|
+        find_budget_investment(spending_proposal)&.update(selected: true)
+      end
+    end
+
+    def update_cached_votes
+      budget.investments.map(&:update_cached_votes)
+    end
+
+    def update_cached_ballots
+      budget.investments.each do |investment|
+        ballot_lines_count = budget.lines.where(investment: investment).count
+        investment.update(ballot_lines_count: ballot_lines_count)
+      end
+    end
+
+    def calculate_winners
+      budget.headings.each do |heading|
+        Budget::Result.new(budget, heading).calculate_winners
+      end
+    end
+
+end

--- a/lib/migrations/spending_proposal/budget.rb
+++ b/lib/migrations/spending_proposal/budget.rb
@@ -7,6 +7,7 @@ class Migrations::SpendingProposal::Budget
     setup
     migrate_data
     expire_caches
+    destroy_associated
   end
 
   def setup
@@ -103,6 +104,10 @@ class Migrations::SpendingProposal::Budget
       budget.headings.each do |heading|
         Budget::Result.new(budget, heading).calculate_winners
       end
+    end
+
+    def destroy_associated
+      Migrations::SpendingProposal::Investments.new.destroy_associated
     end
 
 end

--- a/lib/migrations/spending_proposal/budget.rb
+++ b/lib/migrations/spending_proposal/budget.rb
@@ -109,7 +109,7 @@ class Migrations::SpendingProposal::Budget
     end
 
     def destroy_associated
-      Migrations::SpendingProposal::Investments.new.destroy_associated
+      Migrations::SpendingProposal::BudgetInvestments.new.destroy_associated
     end
 
 end

--- a/lib/migrations/spending_proposal/budget.rb
+++ b/lib/migrations/spending_proposal/budget.rb
@@ -4,6 +4,8 @@ class Migrations::SpendingProposal::Budget
   include Migrations::SpendingProposal::Common
 
   def migrate
+    return false unless budget
+
     setup
     migrate_data
     expire_caches

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -1,0 +1,77 @@
+class Migrations::SpendingProposal::BudgetInvestment
+  include Migrations::SpendingProposal::Common
+
+  attr_accessor :spending_proposal, :budget_investment
+
+  def initialize(spending_proposal)
+    @spending_proposal = spending_proposal
+    @budget_investment = find_budget_investment(spending_proposal)
+  end
+
+  def update
+    if updated?
+      log(".")
+    else
+      log("\nError updating budget investment from spending proposal: #{spending_proposal.id}\n")
+    end
+  end
+
+  private
+
+    def updated?
+      if budget_investment.blank?
+        log("No budget investment found for #{spending_proposal.id}")
+        return false
+      end
+
+      update_attributes && create_valuation_comments
+    end
+
+    def update_attributes
+      budget_investment.update(budget_investment_attributes)
+    end
+
+    def budget_investment_attributes
+      { unfeasibility_explanation: field_with_unfeasibility_explanation }
+    end
+
+    def field_with_unfeasibility_explanation
+      if spending_proposal.unfeasible?
+        spending_proposal.feasible_explanation.presence ||
+        spending_proposal.price_explanation.presence ||
+        spending_proposal.internal_comments
+      else
+        spending_proposal.feasible_explanation
+      end
+    end
+
+    def create_valuation_comments
+      return true if spending_proposal.internal_comments.blank?
+
+      comment = new_valuation_comment
+      if comment.save
+        log(".")
+        return true
+      else
+        log("Error creating comment for budget investment: #{budget_investment.id}\n")
+        log(comment.errors.messages)
+        return false
+      end
+    end
+
+    def new_valuation_comment
+      budget_investment.valuations.first_or_initialize(valuation_comment_attributes)
+    end
+
+    def valuation_comment_attributes
+      {
+        body: spending_proposal.internal_comments,
+        user: spending_proposal_administrator
+      }
+    end
+
+    def spending_proposal_administrator
+      spending_proposal.administrator.try(&:user) || Administrator.first.user
+    end
+
+end

--- a/lib/migrations/spending_proposal/budget_investments.rb
+++ b/lib/migrations/spending_proposal/budget_investments.rb
@@ -1,0 +1,23 @@
+class Migrations::SpendingProposal::BudgetInvestments
+  include Migrations::SpendingProposal::Common
+
+  attr_accessor :spending_proposals
+
+  def initialize
+    @spending_proposals = load_spending_proposals
+  end
+
+  def update_all
+    spending_proposals.each do |spending_proposal|
+      budget_investment = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      budget_investment.update
+    end
+  end
+
+  private
+
+    def load_spending_proposals
+      ::SpendingProposal.all
+    end
+
+end

--- a/lib/migrations/spending_proposal/budget_investments.rb
+++ b/lib/migrations/spending_proposal/budget_investments.rb
@@ -14,6 +14,13 @@ class Migrations::SpendingProposal::BudgetInvestments
     end
   end
 
+  def destroy_associated
+    if spending_proposals.any?
+      Vote.where(votable: spending_proposals).destroy_all
+      ActsAsTaggableOn::Tagging.where(taggable: spending_proposals).destroy_all
+    end
+  end
+
   private
 
     def load_spending_proposals

--- a/lib/migrations/spending_proposal/common.rb
+++ b/lib/migrations/spending_proposal/common.rb
@@ -1,0 +1,9 @@
+module Migrations::SpendingProposal::Common
+  include Migrations::SpendingProposal::Configuration
+  include Migrations::Log
+
+  def find_budget_investment(spending_proposal)
+    Budget::Investment.where(original_spending_proposal_id: spending_proposal.id).first
+  end
+
+end

--- a/lib/migrations/spending_proposal/configuration.rb
+++ b/lib/migrations/spending_proposal/configuration.rb
@@ -1,0 +1,86 @@
+### This is the configuration file to migrate spending proposals to budget investments
+### The values that you see are the ones used in Madrid's fork.
+### Please update them accordingly for your city.
+
+module Migrations::SpendingProposal::Configuration
+
+  # Name you want to give to the budget that you are migrating.
+  def budget_name
+    "2016"
+  end
+
+  # Budget to be created
+  def budget
+    ::Budget.where(slug: budget_name).first
+  end
+
+  # This is a special heading, that many forks use to represent their City Heading.
+  def city_heading
+    "Toda la ciudad"
+  end
+
+  # The name for the disticts group
+  def districts_heading
+    "Distritos"
+  end
+
+  # Total money avaiable for the City Heading.
+  def city_price
+    24000000
+  end
+
+  # Money available in every district heading
+  def price_by_heading
+    {
+      "Arganzuela"          => 1556169,
+      "Barajas"             => 433589,
+      "Carabanchel"         => 3247830,
+      "Centro"              => 1353966,
+      "Chamartín"           => 1313747,
+      "Chamberí"            => 1259587,
+      "Ciudad Lineal"       => 2287757,
+      "Fuencarral-El Pardo" => 2441608,
+      "Hortaleza"           => 1827228,
+      "Latina"              => 2927200,
+      "Moncloa-Aravaca"     => 1129851,
+      "Moratalaz"           => 1067341,
+      "Puente de Vallecas"  => 3349186,
+      "Retiro"              => 1075155,
+      "Salamanca"           => 1286657,
+      "San Blas-Canillejas" => 1712043,
+      "Tetuán"              => 1677256,
+      "Usera"               => 1923216,
+      "Vicálvaro"           => 879529,
+      "Villa de Vallecas"   => 1220810,
+      "Villaverde"          => 2030275
+    }
+  end
+
+  # Population in every district heading
+  def population_by_heading
+    {
+      "Arganzuela"          => 131429,
+      "Barajas"             =>  37725,
+      "Carabanchel"         => 205197,
+      "Centro"              => 120867,
+      "Chamartín"           => 123099,
+      "Chamberí"            => 122280,
+      "Ciudad Lineal"       => 184285,
+      "Fuencarral-El Pardo" => 194232,
+      "Hortaleza"           => 146471,
+      "Latina"              => 204427,
+      "Moncloa-Aravaca"     =>  99274,
+      "Moratalaz"           =>  82741,
+      "Puente de Vallecas"  => 194314,
+      "Retiro"              => 103666,
+      "Salamanca"           => 126699,
+      "San Blas-Canillejas" => 127800,
+      "Tetuán"              => 133972,
+      "Usera"               => 112158,
+      "Vicálvaro"           =>  55783,
+      "Villa de Vallecas"   =>  82504,
+      "Villaverde"          => 117478
+    }
+  end
+
+end

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -1,0 +1,41 @@
+class Migrations::SpendingProposal::Vote
+  include Migrations::SpendingProposal::Common
+
+  def create_budget_investment_votes
+    spending_proposal_votes.each do |vote|
+      create_budget_invesment_vote(vote)
+    end
+  end
+
+  private
+
+    def spending_proposal_votes
+      ::Vote.where(votable: SpendingProposal.all)
+    end
+
+    def create_budget_invesment_vote(vote)
+      budget_investment = find_budget_investment(vote.votable)
+      return false unless budget_investment
+
+      if vote.voter
+        budget_investment.vote_by(voter: vote.voter, vote: "yes")
+        log(".")
+      elsif vote_with_hidden_user(vote.voter_id, budget_investment)
+        log(".")
+      else
+        log("\nError creating budget investment vote from spending proposal vote: #{vote.id}\n")
+      end
+    end
+
+    def vote_with_hidden_user(voter_id, budget_investment)
+      vote_attributes = {
+        voter_id: voter_id,
+        votable: budget_investment,
+        vote_flag: true
+      }
+
+      vote = Vote.where(vote_attributes).first_or_create
+      vote.save(validate: false)
+    end
+
+end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -1,0 +1,9 @@
+namespace :spending_proposals do
+
+  desc "Migrates all necessary data from spending proposals to budget investments"
+  task migrate: :environment do
+    require "migrations/spending_proposal/budget"
+    Migrations::SpendingProposal::Budget.new.migrate
+  end
+
+end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -1,5 +1,18 @@
 namespace :spending_proposals do
 
+  desc "Check if there are any spending proposals in DB"
+  task check: :environment do
+    if Rails.env.production? && SpendingProposal.any?
+      puts "WARNING"
+      puts "You have spending proposals in your database."
+      puts "This model has been deprecated in favor of budget investments."
+      puts "In the next CONSUL release spending proposals will be deleted."
+      puts "If you do not need to keep this data, you don't have to do anything else."
+      print "If you would like to migrate the data from spending proposals to budget investments "
+      puts "please review this PR https://github.com/consul/consul/pull/3431."
+    end
+  end
+
   desc "Migrates all necessary data from spending proposals to budget investments"
   task migrate: :environment do
     require "migrations/spending_proposal/budget"

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -208,4 +208,13 @@ FactoryBot.define do
     locale "en"
     body "Some heading contents"
   end
+
+  factory :ballot do
+    user
+  end
+
+  factory :ballot_line do
+    ballot
+    spending_proposal { build(:spending_proposal, feasible: true) }
+  end
 end

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -6,6 +6,22 @@ FactoryBot.define do
     external_url         "http://external_documention.org"
     terms_of_service     "1"
     association :author, factory: :user
+
+    trait :feasible do
+      feasible true
+    end
+
+    trait :unfeasible do
+      feasible false
+    end
+
+    trait :finished do
+      valuation_finished true
+    end
+
+    trait :unfinished do
+      valuation_finished false
+    end
   end
 
   factory :budget do

--- a/spec/lib/migrations/spending_proposal/ballot_spec.rb
+++ b/spec/lib/migrations/spending_proposal/ballot_spec.rb
@@ -1,0 +1,146 @@
+require "rails_helper"
+require "migrations/spending_proposal/ballot"
+
+describe Migrations::SpendingProposal::Ballot do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+  let!(:spending_proposal_ballot) { create(:ballot) }
+
+  describe "#initialize" do
+
+    it "initializes the spending proposal ballot and corresponding budget investment ballot" do
+      migration = Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot)
+
+      expect(migration.spending_proposal_ballot.class).to eq(Ballot)
+      expect(migration.spending_proposal_ballot).to eq(spending_proposal_ballot)
+
+      expect(migration.budget_investment_ballot.class).to eq(Budget::Ballot)
+      expect(migration.budget_investment_ballot.budget).to eq(budget)
+      expect(migration.budget_investment_ballot.user).to eq(spending_proposal_ballot.user)
+    end
+
+  end
+
+  describe "#migrate_ballot" do
+
+    context "ballot" do
+
+      it "migrates a ballot" do
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.budget).to eq(budget)
+        expect(budget_investment_ballot.user).to eq(spending_proposal_ballot.user)
+      end
+
+      it "migrates a ballot for hidden users" do
+        spending_proposal_ballot.user.hide
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.budget).to eq(budget)
+        expect(budget_investment_ballot.user_id).to eq(spending_proposal_ballot.user_id)
+      end
+
+      it "verifies if ballot has already been created" do
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+      end
+
+    end
+
+    context "ballot lines" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates a single ballot line" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.investments).to eq([budget_investment])
+      end
+
+      it "migrates multiple ballot lines" do
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        spending_proposal_ballot.spending_proposals << spending_proposal1
+        spending_proposal_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+
+        expect(budget_investment_ballot.investments).to include(budget_investment1)
+        expect(budget_investment_ballot.investments).to include(budget_investment2)
+        expect(budget_investment_ballot.investments).not_to include(budget_investment3)
+      end
+
+      it "migrates ballot lines in all of a user's ballots" do
+        user = create(:user)
+        spending_proposal_ballot1 = create(:ballot, user: user)
+        spending_proposal_ballot2 = create(:ballot, user: user)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        spending_proposal_ballot1.spending_proposals << spending_proposal1
+        spending_proposal_ballot2.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot1).migrate_ballot
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot2).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+
+        expect(budget_investment_ballot.investments).to include(budget_investment1)
+        expect(budget_investment_ballot.investments).to include(budget_investment2)
+        expect(budget_investment_ballot.investments).not_to include(budget_investment3)
+      end
+
+      it "verifies that the ballot line does not exist" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.investments.count).to eq(1)
+      end
+
+      it "gracefully handles missing corresponding budget investment" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot.spending_proposals << spending_proposal
+
+        expect{ Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot }
+        .not_to raise_error
+      end
+
+    end
+  end
+end

--- a/spec/lib/migrations/spending_proposal/ballots_spec.rb
+++ b/spec/lib/migrations/spending_proposal/ballots_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+require "migrations/spending_proposal/ballots"
+
+describe Migrations::SpendingProposal::Ballots do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+  let!(:spending_proposal_ballot1) { create(:ballot) }
+  let!(:spending_proposal_ballot2) { create(:ballot) }
+
+  describe "#initialize" do
+
+    it "initializes all spending proposal ballots" do
+      migration = Migrations::SpendingProposal::Ballots.new
+
+      expect(migration.spending_proposal_ballots.count).to eq(2)
+      expect(migration.spending_proposal_ballots).to include(spending_proposal_ballot1)
+      expect(migration.spending_proposal_ballots).to include(spending_proposal_ballot2)
+    end
+
+  end
+
+  describe "#migrate_all" do
+
+    context "ballot" do
+
+      it "migrates all ballots" do
+        Migrations::SpendingProposal::Ballots.new.migrate_all
+
+        expect(Budget::Ballot.count).to eq(2)
+      end
+
+    end
+
+    context "ballot lines" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates ballot lines for all ballots" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot1.spending_proposals << spending_proposal
+        spending_proposal_ballot2.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::Ballots.new.migrate_all
+
+        expect(Budget::Ballot::Line.count).to eq(2)
+
+        budget_investment_ballot1 = Budget::Ballot.first
+        expect(budget_investment_ballot1.investments).to eq([budget_investment])
+
+        budget_investment_ballot2 = Budget::Ballot.second
+        expect(budget_investment_ballot2.investments).to eq([budget_investment])
+      end
+
+    end
+  end
+end

--- a/spec/lib/migrations/spending_proposal/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposal/budget_investment_spec.rb
@@ -1,0 +1,163 @@
+require "rails_helper"
+require "migrations/spending_proposal/budget_investment"
+
+describe Migrations::SpendingProposal::BudgetInvestment do
+
+  let!(:budget)            { create(:budget, slug: "2016") }
+
+  let!(:spending_proposal) { create(:spending_proposal) }
+
+  let!(:budget_investment) { create(:budget_investment,
+                                     budget: budget,
+                                     original_spending_proposal_id: spending_proposal.id) }
+
+  describe "#initialize" do
+
+    it "initializes the spending proposal and corresponding budget investment" do
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+
+      expect(migration.spending_proposal).to eq(spending_proposal)
+      expect(migration.budget_investment).to eq(budget_investment)
+    end
+
+  end
+
+  describe "#update" do
+
+    it "updates the attribute unfeasibility_explanation" do
+      explanation = "This project is not feasible because it is too expensive"
+      spending_proposal.update(feasible_explanation: explanation)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+
+      expect(budget_investment.unfeasibility_explanation).to eq(explanation)
+    end
+
+    it "uses the price explanation attribute if unfeasibility explanation is not present" do
+      spending_proposal.feasible_explanation = ""
+      spending_proposal.price_explanation = "price explanation saying it is too expensive"
+
+      spending_proposal.feasible = false
+      spending_proposal.valuation_finished = true
+
+      spending_proposal.save(validate: false)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+      expect(budget_investment.unfeasibility_explanation).to eq("price explanation saying it is too expensive")
+    end
+
+    it "uses the internal comments if unfeasibility explanation is not present" do
+      spending_proposal.feasible_explanation = ""
+      spending_proposal.internal_comments = "Internal comment with explanation"
+
+      spending_proposal.feasible = false
+      spending_proposal.valuation_finished = true
+      spending_proposal.update(administrator: create(:administrator))
+
+      spending_proposal.save(validate: false)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+      expect(budget_investment.unfeasibility_explanation).to eq("Internal comment with explanation")
+    end
+
+    it "does not use other attributes if investment is feasible" do
+      spending_proposal.feasible_explanation = ""
+      spending_proposal.price_explanation = "price explanation saying it is too expensive"
+
+      spending_proposal.feasible = true
+      spending_proposal.save(validate: false)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+      expect(budget_investment.unfeasibility_explanation).to eq("")
+    end
+
+    it "gracefully handles missing corresponding budget investment" do
+      budget_investment.destroy
+
+      expect{ migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal);
+              migration.update }
+      .not_to raise_error
+    end
+
+  end
+
+  context "internal comments" do
+
+    it "migrates internal_comments string to a comment object" do
+      internal_comment = "This project will last 2 years"
+
+      spending_proposal.update(internal_comments: internal_comment)
+      spending_proposal.update(administrator: create(:administrator))
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      comment = Comment.first
+      expect(Comment.count).to eq(1)
+      expect(comment.body).to eq(internal_comment)
+      expect(comment.author).to eq(spending_proposal.administrator.user)
+      expect(comment.commentable).to eq(budget_investment)
+      expect(comment.valuation).to eq(true)
+    end
+
+    it "migrates internal comments with a body larger than the standard comment limit" do
+      allow(Comment).to receive(:body_max_length).and_return(20)
+
+      internal_comment = "This project will last 2 years"
+      spending_proposal.update(internal_comments: internal_comment)
+      spending_proposal.update(administrator: create(:administrator))
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      comment = Comment.first
+      expect(Comment.count).to eq(1)
+      expect(comment.body).to eq(internal_comment)
+      expect(comment.commentable).to eq(budget_investment)
+      expect(comment.valuation).to eq(true)
+    end
+
+    it "does not create a comment if internal_comments is blank" do
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      expect(Comment.count).to eq(0)
+    end
+
+    it "verifies if the comment already exists" do
+      internal_comment = "This project will last 2 years"
+
+      spending_proposal.update(internal_comments: internal_comment)
+      spending_proposal.update(administrator: create(:administrator))
+
+      Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal).update
+      Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal).update
+
+      expect(Comment.count).to eq(1)
+    end
+
+    it "assigns the first administrator if a spending proposal does not have one" do
+      first_admin = create(:administrator).user
+      internal_comment = "This project will last 2 years"
+
+      spending_proposal.update(internal_comments: internal_comment)
+
+      Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal).update
+
+      expect(Comment.first.author).to eq(first_admin)
+    end
+
+  end
+end

--- a/spec/lib/migrations/spending_proposal/budget_investments_spec.rb
+++ b/spec/lib/migrations/spending_proposal/budget_investments_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+require "migrations/spending_proposal/budget_investments"
+
+describe Migrations::SpendingProposal::BudgetInvestments do
+
+  let!(:budget)            { create(:budget, slug: "2016") }
+
+  let!(:spending_proposal1) { create(:spending_proposal) }
+  let!(:spending_proposal2) { create(:spending_proposal) }
+
+  let!(:budget_investment1) { create(:budget_investment,
+                                     budget: budget,
+                                     original_spending_proposal_id: spending_proposal1.id) }
+
+  let!(:budget_investment2) { create(:budget_investment,
+                                     budget: budget,
+                                     original_spending_proposal_id: spending_proposal2.id) }
+
+  describe "#initialize" do
+
+    it "initializes all spending proposals" do
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+
+      expect(migration.spending_proposals.count).to eq(2)
+      expect(migration.spending_proposals).to include(spending_proposal1)
+      expect(migration.spending_proposals).to include(spending_proposal2)
+    end
+
+  end
+
+  describe "#update_all" do
+
+    it "updates all budget investments with their corresponding spending proposal attributes" do
+      explanation1 = "This project is not feasible because it is too expensive"
+      explanation2 = "This project is not feasible because it out of the governments jurisdiction"
+
+      spending_proposal1.update(feasible_explanation: explanation1)
+      spending_proposal2.update(feasible_explanation: explanation2)
+
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+      migration.update_all
+
+      budget_investment1.reload
+      budget_investment2.reload
+
+      expect(budget_investment1.unfeasibility_explanation).to eq(explanation1)
+      expect(budget_investment2.unfeasibility_explanation).to eq(explanation2)
+    end
+  end
+end

--- a/spec/lib/migrations/spending_proposal/budget_investments_spec.rb
+++ b/spec/lib/migrations/spending_proposal/budget_investments_spec.rb
@@ -47,4 +47,39 @@ describe Migrations::SpendingProposal::BudgetInvestments do
       expect(budget_investment2.unfeasibility_explanation).to eq(explanation2)
     end
   end
+
+  describe "#destroy_associated" do
+
+    it "destroys spending proposals votes" do
+      investment = create(:budget_investment)
+      spending_proposal = create(:spending_proposal)
+
+      investment_vote = create(:vote, votable: investment)
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+      migration.destroy_associated
+
+      expect(Vote.count).to eq(1)
+      expect(Vote.first).to eq(investment_vote)
+    end
+
+    it "destroys spending proposals taggings" do
+      investment = create(:budget_investment)
+      spending_proposal = create(:spending_proposal)
+
+      health_tag = create(:tag, name: "Health")
+      investment_tagging = create(:tagging, taggable: investment, tag: health_tag)
+      spending_proposal_tagging = create(:tagging, taggable: spending_proposal, tag: health_tag)
+
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+      migration.destroy_associated
+
+      expect(ActsAsTaggableOn::Tagging.count).to eq(1)
+      expect(ActsAsTaggableOn::Tagging.first).to eq(investment_tagging)
+
+      expect(Tag.count).to eq(1)
+      expect(Tag.first).to eq(health_tag)
+    end
+  end
 end

--- a/spec/lib/migrations/spending_proposal/budget_spec.rb
+++ b/spec/lib/migrations/spending_proposal/budget_spec.rb
@@ -134,7 +134,6 @@ describe Migrations::SpendingProposal::Budget do
       budget_investment_ballot2 = Budget::Ballot.second
       expect(budget_investment_ballot2.investments).to eq([investment])
     end
-
   end
 
   describe "#expire_caches" do
@@ -195,6 +194,23 @@ describe Migrations::SpendingProposal::Budget do
       migration.expire_caches
 
       expect(results.winners.count).to eq(3)
+    end
+  end
+
+  describe "#destroy_associated" do
+
+    it "destroys associated spending proposal records" do
+      investment = create(:budget_investment)
+      spending_proposal = create(:spending_proposal)
+
+      investment_vote = create(:vote, votable: investment)
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+      migration.destroy_associated
+
+      expect(Vote.count).to eq(1)
+      expect(Vote.first).to eq(investment_vote)
     end
 
   end

--- a/spec/lib/migrations/spending_proposal/budget_spec.rb
+++ b/spec/lib/migrations/spending_proposal/budget_spec.rb
@@ -1,0 +1,201 @@
+require "rails_helper"
+require "migrations/spending_proposal/budget"
+
+describe Migrations::SpendingProposal::Budget do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+  let(:migration) { Migrations::SpendingProposal::Budget.new }
+
+  describe "#initialize" do
+
+    it "initializes the budget to be migrated" do
+      expect(migration.budget).to eq(budget)
+    end
+
+  end
+
+  describe "#setup" do
+
+    let!(:city_group)   { create(:budget_group, budget: budget) }
+    let!(:city_heading) { create(:budget_heading, group: city_group, name: "Toda la ciudad") }
+
+    let!(:district_group)    { create(:budget_group, budget: budget) }
+    let!(:district_heading1) { create(:budget_heading, group: district_group, name: "Arganzuela") }
+    let!(:district_heading2) { create(:budget_heading, group: district_group, name: "Barajas") }
+
+    context "heading price" do
+
+      it "updates the city heading's price" do
+        migration.setup
+
+        city_heading.reload
+        expect(city_heading.price).to eq(24000000)
+      end
+
+      it "updates the district headings' price" do
+        migration.setup
+
+        district_heading1.reload
+        district_heading2.reload
+        expect(district_heading1.price).to eq(1556169)
+        expect(district_heading2.price).to eq(433589)
+      end
+    end
+
+    context "heading population" do
+
+      it "updates the city heading's population" do
+        migration.setup
+
+        city_heading.reload
+        expect(city_heading.population).to eq(2706401)
+      end
+
+      it "updates the district headings' population" do
+        migration.setup
+
+        district_heading1.reload
+        district_heading2.reload
+        expect(district_heading1.population).to eq(131429)
+        expect(district_heading2.population).to eq(37725)
+      end
+    end
+
+    it "migrates budget investments" do
+      spending_proposal1 = create(:spending_proposal)
+      spending_proposal2 = create(:spending_proposal)
+
+      migration.setup
+
+      expect(Budget::Investment.count).to eq(2)
+
+      budget_investment_references = Budget::Investment.pluck(:original_spending_proposal_id)
+      expect(budget_investment_references).to include(spending_proposal1.id)
+      expect(budget_investment_references).to include(spending_proposal2.id)
+    end
+  end
+
+  describe "migrate" do
+
+    context "Migrate budget investments" do
+
+      it "marks feasible and valuation finished investments as selected" do
+        spending_proposal1 = create(:spending_proposal, :feasible, :finished)
+        spending_proposal2 = create(:spending_proposal, :feasible, :finished)
+        spending_proposal3 = create(:spending_proposal, :feasible, :unfinished)
+        spending_proposal4 = create(:spending_proposal, :unfeasible, :finished)
+
+        budget_investment1 = create(:budget_investment, budget: budget, spending_proposal: spending_proposal1)
+        budget_investment2 = create(:budget_investment, budget: budget, spending_proposal: spending_proposal2)
+        budget_investment3 = create(:budget_investment, budget: budget, spending_proposal: spending_proposal3)
+        budget_investment4 = create(:budget_investment, budget: budget, spending_proposal: spending_proposal4)
+
+        migration.migrate_data
+
+        budget_investment1.reload
+        budget_investment2.reload
+        budget_investment3.reload
+        budget_investment4.reload
+
+        expect(budget_investment1.selected).to eq(true)
+        expect(budget_investment2.selected).to eq(true)
+        expect(budget_investment3.selected).to eq(false)
+        expect(budget_investment4.selected).to eq(false)
+      end
+
+    end
+
+    it "migrates votes" do
+      spending_proposal = create(:spending_proposal)
+      spending_proposal_vote1 = create(:vote, votable: spending_proposal)
+      spending_proposal_vote2 = create(:vote, votable: spending_proposal)
+
+      investment = budget_invesment_for(spending_proposal)
+
+      migration.migrate_data
+
+      expect(investment.votes_for.count).to eq(2)
+    end
+
+    it "migrates ballots" do
+      spending_proposal = create(:spending_proposal)
+      spending_proposal_ballot_line1 = create(:ballot_line, spending_proposal: spending_proposal)
+      spending_proposal_ballot_line2 = create(:ballot_line, spending_proposal: spending_proposal)
+
+      investment = budget_invesment_for(spending_proposal)
+
+      migration.migrate_data
+
+      expect(Budget::Ballot.count).to eq(2)
+
+      budget_investment_ballot1 = Budget::Ballot.first
+      expect(budget_investment_ballot1.investments).to eq([investment])
+
+      budget_investment_ballot2 = Budget::Ballot.second
+      expect(budget_investment_ballot2.investments).to eq([investment])
+    end
+
+  end
+
+  describe "#expire_caches" do
+
+    let!(:group)   { create(:budget_group, budget: budget) }
+    let!(:heading) { create(:budget_heading, group: group, price: 99999999) }
+
+    it "Updates cached votes" do
+      investment = create(:budget_investment, :selected, heading: heading)
+
+      create(:vote, votable: investment)
+      create(:vote, votable: investment)
+
+      investment.update(cached_votes_up: 3)
+
+      investment.reload
+      expect(investment.cached_votes_up).to eq(3)
+
+      migration.expire_caches
+
+      investment.reload
+      expect(investment.cached_votes_up).to eq(2)
+    end
+
+    it "Updates cached ballot lines" do
+      investment = create(:budget_investment, :selected, heading: heading)
+
+      ballot1 = create(:budget_ballot, budget: budget)
+      ballot2 = create(:budget_ballot, budget: budget)
+
+      create(:budget_ballot_line, ballot: ballot1, investment: investment)
+      create(:budget_ballot_line, ballot: ballot2, investment: investment)
+
+      investment.update(ballot_lines_count: 3)
+
+      investment.reload
+      expect(investment.ballot_lines_count).to eq(3)
+
+      migration.expire_caches
+
+      investment.reload
+      expect(investment.ballot_lines_count).to eq(2)
+    end
+
+    it "Calculates winners" do
+      ballot = create(:budget_ballot, budget: budget)
+
+      investment1 = create(:budget_investment, :selected, heading: heading)
+      investment2 = create(:budget_investment, :selected, heading: heading)
+      investment3 = create(:budget_investment, :selected, heading: heading)
+
+      create(:budget_ballot_line, ballot: ballot, investment: investment1)
+      create(:budget_ballot_line, ballot: ballot, investment: investment2)
+
+      results = Budget::Result.new(budget, heading)
+      expect(results.winners.count).to eq(0)
+
+      migration.expire_caches
+
+      expect(results.winners.count).to eq(3)
+    end
+
+  end
+end

--- a/spec/lib/migrations/spending_proposal/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposal/vote_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+require "migrations/spending_proposal/vote"
+
+describe Migrations::SpendingProposal::Vote do
+
+  describe "#create_budget_investment_votes" do
+
+    it "creates a budget investment's vote for a corresponding spending proposal's vote" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      budget_investment_vote = budget_investment.votes_for.first
+
+      expect(budget_investment.votes_for.count).to eq(1)
+      expect(budget_investment_vote.voter).to eq(spending_proposal_vote.voter)
+      expect(budget_investment_vote.votable).to eq(budget_investment)
+      expect(budget_investment_vote.vote_flag).to eq(true)
+    end
+
+    it "creates budget investment's votes for all correspoding spending proposal's votes" do
+      spending_proposal1 = create(:spending_proposal)
+      spending_proposal2 = create(:spending_proposal)
+      budget_investment1 = create(:budget_investment, original_spending_proposal_id: spending_proposal1.id)
+      budget_investment2 = create(:budget_investment, original_spending_proposal_id: spending_proposal2.id)
+
+      3.times { create(:vote, votable: spending_proposal1) }
+      5.times { create(:vote, votable: spending_proposal2) }
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      expect(budget_investment1.votes_for.count).to eq(3)
+      expect(budget_investment2.votes_for.count).to eq(5)
+    end
+
+    it "creates a budget investment's vote for a hidden user" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      spending_proposal_vote.voter.hide
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      budget_investment_vote = budget_investment.votes_for.first
+
+      expect(budget_investment.votes_for.count).to eq(1)
+      expect(budget_investment_vote.voter_id).to eq(spending_proposal_vote.voter_id)
+      expect(budget_investment_vote.votable).to eq(budget_investment)
+      expect(budget_investment_vote.vote_flag).to eq(true)
+    end
+
+    it "verifies if user has already voted" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      expect(budget_investment.votes_for.count).to eq(1)
+    end
+
+    it "verifies if hidden user has already voted" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+      spending_proposal_vote.voter.hide
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      expect(budget_investment.votes_for.count).to eq(1)
+    end
+
+    it "gracefully handles missing corresponding budget investment" do
+      spending_proposal = create(:spending_proposal)
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      expect{ Migrations::SpendingProposal::Vote.new.create_budget_investment_votes }
+      .not_to raise_error
+    end
+
+  end
+end

--- a/spec/support/common_actions/budgets.rb
+++ b/spec/support/common_actions/budgets.rb
@@ -10,4 +10,13 @@ module Budgets
       expect(page).to have_content "Remove"
     end
   end
+
+  def budget_invesment_for(spending_proposal, options={})
+    attributes = {
+      original_spending_proposal_id: spending_proposal.id,
+      selected: true
+    }.merge(options)
+
+    create(:budget_investment, attributes)
+  end
 end


### PR DESCRIPTION
## References

**PR**: Migrate spending proposals https://github.com/AyuntamientoMadrid/consul/pull/1776

**Partial backports**: 
https://github.com/AyuntamientoMadrid/consul/commit/92964ea4acb240cee3ffe16c0be100da621575ee
https://github.com/AyuntamientoMadrid/consul/commit/f1ba92ee60ab4a869ad435c8e3d589dcac4efa9a
https://github.com/AyuntamientoMadrid/consul/commit/6999bad326dc4e2dc2ada233f7ca75a58f20d52c
https://github.com/AyuntamientoMadrid/consul/commit/e482c3ce219471bebc8a293ce111635eca83ee03

## Context

Spending Proposals was used in the first Participatory Budgets to store proposals created by citizens. Since then Spending Proposals have become deprecated in favor of Budget Investments

Only the first forks will have Spending Proposals in their Production servers. The forks that started using CONSUL since version [0.7](https://github.com/consul/consul/releases/tag/v0.7) released on April 25th 2016 do not need to migrate. Please check out the rake tasks in this PR to make sure you do not having Spending Proposals in your Production environment.

## Objectives

Migrate Spending Proposals and all related data to Budget Investments.

These involves migrating data between the following tables:
- Spending Proposals -> Budget::Investments
- Ballots -> Budget::Ballots
- BallotLines -> Budget::Ballot::Lines

In addition, the following polymorphic models will also be migrated to reference the corresponding budget investments:
- Supports
- Comments

## Notes
⚠️
Please run the migration in a safe Staging environment, using the real data from the Production server,  before you actually run the migration in the Production environment.

Also check out the [configuration file](https://github.com/consul/consul/compare/spending_proposals_migration?expand=1#diff-c952204da9dc2ee0d6b5ba24a24e7a13) to setup the necesary variables:

To check if you have Spending Proposals in your Production environment run this rake task:
```
bin/rake spending_proposals:check RAILS_ENV=production

```

To migrate spending proposals and all it's associated data run this rake task:
```
bin/rake spending_proposals:migrate RAILS_ENV=production
```