### PR TITLE
Fix exception when confirming an invalid token

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -27,7 +27,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   def show
     # In the default implementation, this already confirms the resource:
     # self.resource = self.resource = resource_class.confirm_by_token(params[:confirmation_token])
-    self.resource = resource_class.find_by(confirmation_token: params[:confirmation_token])
+    self.resource = resource_class.find_by!(confirmation_token: params[:confirmation_token])
 
     yield resource if block_given?
 

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Users::ConfirmationsController do
+  before do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+
+  describe "GET show" do
+    it "returns a 404 code with a wrong token" do
+      expect { get :show, token: "non_existent" }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+end


### PR DESCRIPTION
## Objectives

Don't show a 500 Internal Server Error message when trying to confirm a user with a token which doesn't exist.