### PR TITLE
New setting tab remote census

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -23,7 +23,7 @@ class Admin::SettingsController < Admin::BaseController
   def update
     @setting = Setting.find(params[:id])
     @setting.update(settings_params)
-    redirect_to request.referer, notice: t("admin.settings.flash.updated")
+    redirect_to request_referer, notice: t("admin.settings.flash.updated")
   end
 
   def update_map
@@ -53,4 +53,8 @@ class Admin::SettingsController < Admin::BaseController
       params.permit(:jpg, :png, :gif, :pdf, :doc, :docx, :xls, :xlsx, :csv, :zip)
     end
 
+    def request_referer
+      return request.referer + params[:setting][:tab] if params[:setting][:tab]
+      request.referer
+    end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -14,6 +14,9 @@ class Admin::SettingsController < Admin::BaseController
     @participation_processes_settings = all_settings["process"]
     @map_configuration_settings = all_settings["map"]
     @proposals_settings = all_settings["proposals"]
+    @remote_census_general_settings = all_settings["remote_census.general"]
+    @remote_census_request_settings = all_settings["remote_census.request"]
+    @remote_census_response_settings = all_settings["remote_census.response"]
     @uploads_settings = all_settings["uploads"]
   end
 

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -8,4 +8,12 @@ module SettingsHelper
     @all_settings ||= Hash[ Setting.all.map{|s| [s.key, s.value.presence]} ]
   end
 
+  def display_setting_name(setting_name)
+    if setting_name == "setting"
+      t("admin.settings.setting_name")
+    else
+      t("admin.settings.#{setting_name}")
+    end
+  end
+
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -10,6 +10,8 @@ class Setting < ApplicationRecord
   def type
     if %w[feature process proposals map html homepage uploads].include? prefix
       prefix
+    elsif %w[remote_census].include? prefix
+      key.rpartition(".").first
     else
       "configuration"
     end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -166,7 +166,21 @@ class Setting < ApplicationRecord
         "hot_score_period_in_days": 31,
         "related_content_score_threshold": -0.3,
         "featured_proposals_number": 3,
-        "dashboard.emails": nil
+        "dashboard.emails": nil,
+        "remote_census.general.endpoint": "",
+        "remote_census.request.method_name": "",
+        "remote_census.request.structure": "",
+        "remote_census.request.document_type": "",
+        "remote_census.request.document_number": "",
+        "remote_census.request.date_of_birth": "",
+        "remote_census.request.postal_code": "",
+        "remote_census.response.date_of_birth": "",
+        "remote_census.response.postal_code": "",
+        "remote_census.response.district": "",
+        "remote_census.response.gender": "",
+        "remote_census.response.name": "",
+        "remote_census.response.surname": "",
+        "remote_census.response.valid": ""
       }
     end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -93,6 +93,7 @@ class Setting < ApplicationRecord
         "feature.allow_attached_documents": true,
         "feature.allow_images": true,
         "feature.help_page": true,
+        "feature.remote_census": nil,
         "feature.valuation_comment_notification": true,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,

--- a/app/views/admin/settings/_configuration_settings_tab.html.erb
+++ b/app/views/admin/settings/_configuration_settings_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.title") %></h2>
 
-<%= render "settings_table", settings: @configuration_settings, setting_name: "setting" %>
+<%= render "settings_table", settings: @configuration_settings, setting_name: "setting", tab: "#tab-configuration" %>

--- a/app/views/admin/settings/_configuration_settings_tab.html.erb
+++ b/app/views/admin/settings/_configuration_settings_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.title") %></h2>
 
-<%= render "settings_table", settings: @configuration_settings %>
+<%= render "settings_table", settings: @configuration_settings, setting_name: "setting" %>

--- a/app/views/admin/settings/_featured_settings_form.html.erb
+++ b/app/views/admin/settings/_featured_settings_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_for(feature, url: admin_setting_path(feature), html: { id: "edit_#{dom_id(feature)}"}) do |f| %>
+  <%= f.hidden_field :tab, value: tab if defined?(tab) %>
   <%= f.hidden_field :value, id: dom_id(feature), value: (feature.enabled? ? "" : "active") %>
   <%= f.submit(t("admin.settings.index.features.#{feature.enabled? ? "disable" : "enable"}"),
                class: "button expanded #{feature.enabled? ? "hollow alert" : "success"}",

--- a/app/views/admin/settings/_featured_settings_table.html.erb
+++ b/app/views/admin/settings/_featured_settings_table.html.erb
@@ -32,7 +32,7 @@
         </td>
 
         <td class="text-right">
-          <%= render "admin/settings/featured_settings_form", feature: feature %>
+          <%= render "admin/settings/featured_settings_form", feature: feature, tab: tab %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/settings/_features_tab.html.erb
+++ b/app/views/admin/settings/_features_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.feature_flags") %></h2>
 
-<%= render "featured_settings_table", features: @feature_settings %>
+<%= render "featured_settings_table", features: @feature_settings, tab: "#tab-feature-flags" %>

--- a/app/views/admin/settings/_filter_subnav.html.erb
+++ b/app/views/admin/settings/_filter_subnav.html.erb
@@ -40,4 +40,11 @@
       <%= t("admin.settings.index.dashboard.title") %>
     <% end %>
   </li>
+
+  <li class="tabs-title" id="remote-census-tab">
+   <%= link_to "#tab-remote-census-configuration" do %>
+      <%= t("admin.settings.index.remote_census.title") %>
+    <% end %>
+  </li>
+
 </ul>

--- a/app/views/admin/settings/_filter_subnav.html.erb
+++ b/app/views/admin/settings/_filter_subnav.html.erb
@@ -11,7 +11,7 @@
     <% end %>
   </li>
 
-  <li class="tabs-title">
+  <li class="tabs-title" id="participation-processes-tab">
     <%= link_to "#tab-participation-processes" do %>
       <%= t("admin.settings.index.participation_processes") %>
     <% end %>

--- a/app/views/admin/settings/_images_and_documents_tab.html.erb
+++ b/app/views/admin/settings/_images_and_documents_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.images_and_documents") %></h2>
 
-<%= render "settings_table", settings: @uploads_settings %>
+<%= render "settings_table", settings: @uploads_settings, setting_name: "setting" %>

--- a/app/views/admin/settings/_map_configuration_tab.html.erb
+++ b/app/views/admin/settings/_map_configuration_tab.html.erb
@@ -1,7 +1,7 @@
 <% if feature?(:map) %>
   <h2><%= t("admin.settings.index.map.title") %></h2>
 
-  <%= render "settings_table", settings: @map_configuration_settings %>
+  <%= render "settings_table", settings: @map_configuration_settings, setting_name: "setting" %>
 
   <p><%= t("admin.settings.index.map.help") %></p>
 

--- a/app/views/admin/settings/_map_configuration_tab.html.erb
+++ b/app/views/admin/settings/_map_configuration_tab.html.erb
@@ -1,7 +1,7 @@
 <% if feature?(:map) %>
   <h2><%= t("admin.settings.index.map.title") %></h2>
 
-  <%= render "settings_table", settings: @map_configuration_settings, setting_name: "setting" %>
+  <%= render "settings_table", settings: @map_configuration_settings, setting_name: "setting", tab: "#tab-map-configuration" %>
 
   <p><%= t("admin.settings.index.map.help") %></p>
 

--- a/app/views/admin/settings/_participation_processes_tab.html.erb
+++ b/app/views/admin/settings/_participation_processes_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.participation_processes") %></h2>
 
-<%= render "featured_settings_table", features: @participation_processes_settings %>
+<%= render "featured_settings_table", features: @participation_processes_settings, tab: "#tab-participation-processes" %>

--- a/app/views/admin/settings/_proposals_dashboard.html.erb
+++ b/app/views/admin/settings/_proposals_dashboard.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.dashboard.title") %></h2>
 
-<%= render "settings_table", settings: @proposals_settings %>
+<%= render "settings_table", settings: @proposals_settings, setting_name: "setting" %> %>

--- a/app/views/admin/settings/_proposals_dashboard.html.erb
+++ b/app/views/admin/settings/_proposals_dashboard.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.dashboard.title") %></h2>
 
-<%= render "settings_table", settings: @proposals_settings, setting_name: "setting" %> %>
+<%= render "settings_table", settings: @proposals_settings, setting_name: "setting", tab: "#tab-proposals" %>

--- a/app/views/admin/settings/_remote_census_configuration_tab.html.erb
+++ b/app/views/admin/settings/_remote_census_configuration_tab.html.erb
@@ -1,9 +1,9 @@
 <% if feature?(:remote_census) %>
   <h2><%= t("admin.settings.index.remote_census.title") %></h2>
 
-  <%= render "settings_table", settings: @remote_census_general_settings, setting_name: "remote_census_general_name" %>
-  <%= render "settings_table", settings: @remote_census_request_settings, setting_name: "remote_census_request_name" %>
-  <%= render "settings_table", settings: @remote_census_response_settings, setting_name: "remote_census_response_name" %>
+  <%= render "settings_table", settings: @remote_census_general_settings, setting_name: "remote_census_general_name", tab: "#tab-remote-census-configuration" %>
+  <%= render "settings_table", settings: @remote_census_request_settings, setting_name: "remote_census_request_name", tab: "#tab-remote-census-configuration" %>
+  <%= render "settings_table", settings: @remote_census_response_settings, setting_name: "remote_census_response_name", tab: "#tab-remote-census-configuration" %>
 <% else %>
   <div class="callout primary">
     <%= t("admin.settings.index.remote_census.how_to_enable") %>

--- a/app/views/admin/settings/_remote_census_configuration_tab.html.erb
+++ b/app/views/admin/settings/_remote_census_configuration_tab.html.erb
@@ -1,9 +1,9 @@
 <% if feature?(:remote_census) %>
   <h2><%= t("admin.settings.index.remote_census.title") %></h2>
 
-  <%= render "settings_table", settings: @remote_census_general_settings %>
-  <%= render "settings_table", settings: @remote_census_request_settings %>
-  <%= render "settings_table", settings: @remote_census_response_settings %>
+  <%= render "settings_table", settings: @remote_census_general_settings, setting_name: "remote_census_general_name" %>
+  <%= render "settings_table", settings: @remote_census_request_settings, setting_name: "remote_census_request_name" %>
+  <%= render "settings_table", settings: @remote_census_response_settings, setting_name: "remote_census_response_name" %>
 <% else %>
   <div class="callout primary">
     <%= t("admin.settings.index.remote_census.how_to_enable") %>

--- a/app/views/admin/settings/_remote_census_configuration_tab.html.erb
+++ b/app/views/admin/settings/_remote_census_configuration_tab.html.erb
@@ -1,0 +1,5 @@
+  <h2><%= t("admin.settings.index.remote_census.title") %></h2>
+
+  <%= render "settings_table", settings: @remote_census_general_settings %>
+  <%= render "settings_table", settings: @remote_census_request_settings %>
+  <%= render "settings_table", settings: @remote_census_response_settings %>

--- a/app/views/admin/settings/_remote_census_configuration_tab.html.erb
+++ b/app/views/admin/settings/_remote_census_configuration_tab.html.erb
@@ -1,5 +1,11 @@
+<% if feature?(:remote_census) %>
   <h2><%= t("admin.settings.index.remote_census.title") %></h2>
 
   <%= render "settings_table", settings: @remote_census_general_settings %>
   <%= render "settings_table", settings: @remote_census_request_settings %>
   <%= render "settings_table", settings: @remote_census_response_settings %>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.settings.index.remote_census.how_to_enable") %>
+  </div>
+<% end %>

--- a/app/views/admin/settings/_settings_form.html.erb
+++ b/app/views/admin/settings/_settings_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
+  <%= f.hidden_field :tab, value: tab if defined?(tab) %>
   <div class="small-12 medium-6 large-8 column">
     <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
   </div>

--- a/app/views/admin/settings/_settings_table.html.erb
+++ b/app/views/admin/settings/_settings_table.html.erb
@@ -1,7 +1,7 @@
 <table>
   <thead>
     <tr>
-      <th><%= t("admin.settings.setting_name") %></th>
+      <th><%= display_setting_name(setting_name) %></th>
       <th><%= t("admin.settings.setting_value") %></th>
     </tr>
   </thead>

--- a/app/views/admin/settings/_settings_table.html.erb
+++ b/app/views/admin/settings/_settings_table.html.erb
@@ -19,7 +19,11 @@
           <% if setting.content_type? %>
             <%= render "admin/settings/content_types_settings_form", setting: setting %>
           <% else %>
-            <%= render "admin/settings/settings_form", setting: setting %>
+            <% if defined?(tab) %>
+              <%= render "admin/settings/settings_form", setting: setting, tab: tab %>
+            <% else %>
+              <%= render "admin/settings/settings_form", setting: setting %>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -25,4 +25,8 @@
   <div class="tabs-panel" id="tab-proposals">
     <%= render "proposals_dashboard" %>
   </div>
+
+  <div class="tabs-panel" id="tab-remote-census-configuration">
+    <%= render "remote_census_configuration_tab" %>
+  </div>
 </div>

--- a/app/views/admin/site_customization/content_blocks/index.html.erb
+++ b/app/views/admin/site_customization/content_blocks/index.html.erb
@@ -6,7 +6,7 @@
 
 <h2 class="inline-block"><%= t("admin.site_customization.content_blocks.index.title") %></h2>
 
-<%= render "admin/settings/settings_table", settings: @html_settings %>
+<%= render "admin/settings/settings_table", settings: @html_settings, setting_name: "setting" %>
 
 <h3><%= t("admin.site_customization.content_blocks.information") %></h3>
 

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1314,6 +1314,9 @@ en:
         remote_census:
           title: Remote Census configuration
           how_to_enable: 'To configure remote census (SOAP) you must enable "Configure connection to remote census (SOAP)" on "Features" tab.'
+      remote_census_general_name: General Information
+      remote_census_request_name: Request Data
+      remote_census_response_name: Response Data
       setting: Feature
       setting_actions: Actions
       setting_name: Setting

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1311,6 +1311,8 @@ en:
           how_to_enable: 'To show the map to users you must enable "Proposals and budget investments geolocation" on "Features" tab.'
         dashboard:
           title: Proposals dashboard
+        remote_census:
+          title: Remote Census configuration
       setting: Feature
       setting_actions: Actions
       setting_name: Setting

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1313,6 +1313,7 @@ en:
           title: Proposals dashboard
         remote_census:
           title: Remote Census configuration
+          how_to_enable: 'To configure remote census (SOAP) you must enable "Configure connection to remote census (SOAP)" on "Features" tab.'
       setting: Feature
       setting_actions: Actions
       setting_name: Setting

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -120,6 +120,38 @@ en:
       remote_census_description: "Allows to configure the connection to the remote census of each institution"
       valuation_comment_notification: "Valuation comment notification"
       valuation_comment_notification_description: "Send an email to all associated users except valuation commenter to budget investment when a new valuation comment is created"
+    remote_census:
+      general:
+        endpoint: "Endpoint"
+        endpoint_description: "Host name where the census service is available (wsdl)"
+      request:
+        method_name: "Request method name"
+        method_name_description: "Request method name accepted by the City Census WebService."
+        structure: "Request Structure"
+        structure_description: 'Request Structure that receives the Census WebService of the City council. The "static" values of this request should be filled. Values related to Document Type, Document Number, Date of Birth and Postal Code should be blank.'
+        document_type: "Path for Document Type"
+        document_type_description: "Path in the request structure that sends the Document Type. DO NOT FILL IN if the WebService does not require the Document Type to verify a user."
+        document_number: "Path for Document Number"
+        document_number_description: "Path in the request structure that sends the Document Number. DO NOT FILL IN if the WebService does not require the Document Number to verify a user."
+        date_of_birth: "Path for Date of Birth"
+        date_of_birth_description: "Path in the request structure that sends the Date of Birth. DO NOT FILL IN if the WebService does not require the Date of Birth to verify a user."
+        postal_code: "Path for Postal Code"
+        postal_code_description: "Path in the request structure that sends the Postal Code. DO NOT FILL IN if the WebService does not require the Postal Code to verify a user."
+      response:
+        date_of_birth: "Path for Date of Birth"
+        date_of_birth_description: "In what path of the response is the user's Date of Birth?"
+        postal_code: "Path for Postal Code"
+        postal_code_description: "In what path of the response is the user's Postal Code?"
+        district: "Path for District"
+        district_description: "In what path of the response is the user's District?"
+        gender: "Path for Gender"
+        gender_description: "In what path of response is the user's Gender?"
+        name: "Path for Name"
+        name_description: "In what path of the response is the user's Name?"
+        surname: "Path for the Last Name"
+        surname_description: "In what path of the response is the user's Last Name?"
+        valid: "Condition for detecting a valid response"
+        valid_description: "What response path has to come informed to be considered a valid response and user verified"
     map:
       latitude: "Latitude"
       latitude_description: "Latitude to show the map position"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -116,6 +116,8 @@ en:
       public_stats_description: "Display public stats in the Administration panel"
       help_page: "Help page"
       help_page_description: 'Displays a Help menu that contains a page with an info section about each enabled feature. Also custom pages and menus can be created in the "Custom pages" and  "Custom content blocks" sections'
+      remote_census: "Configure connection to remote census (SOAP)"
+      remote_census_description: "Allows to configure the connection to the remote census of each institution"
       valuation_comment_notification: "Valuation comment notification"
       valuation_comment_notification_description: "Send an email to all associated users except valuation commenter to budget investment when a new valuation comment is created"
     map:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1312,6 +1312,8 @@ es:
           how_to_enable: 'Para mostrar el mapa a los usuarios se debe de activar "Geolocalización de propuestas y proyectos de gasto" en la pestaña "Funcionalidades".'
         dashboard:
           title: Panel de progreso de propuestas
+        remote_census:
+          title: Configuración del Censo Remoto
       setting: Funcionalidad
       setting_actions: Acciones
       setting_name: Configuración

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1315,6 +1315,9 @@ es:
         remote_census:
           title: Configuración del Censo Remoto
           how_to_enable: 'Para configurar la conexión con el Censo Remoto (SOAP) se debe activar "Configurar la conexión al censo remoto (SOAP)" en la pestaña "Funcionalidades".'
+      remote_census_general_name: Datos Generales
+      remote_census_request_name: Datos Petición
+      remote_census_response_name: Datos Respuesta
       setting: Funcionalidad
       setting_actions: Acciones
       setting_name: Configuración

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1314,6 +1314,7 @@ es:
           title: Panel de progreso de propuestas
         remote_census:
           title: Configuración del Censo Remoto
+          how_to_enable: 'Para configurar la conexión con el Censo Remoto (SOAP) se debe activar "Configurar la conexión al censo remoto (SOAP)" en la pestaña "Funcionalidades".'
       setting: Funcionalidad
       setting_actions: Acciones
       setting_name: Configuración

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -116,6 +116,8 @@ es:
       public_stats_description: "Muestra las estadísticas públicas en el panel de Administración"
       help_page: "Página de ayuda"
       help_page_description: 'Muestra un menú Ayuda que contiene una página con una sección de información sobre cada funcionalidad habilitada. También se pueden crear páginas y menús personalizados en las secciones "Personalizar páginas" y "Personalizar bloques"'
+      remote_census: "Configurar conexión al censo remoto (SOAP)"
+      remote_census_description: "Permite configurar la conexión al censo remoto de cada institución"
       valuation_comment_notification: "Notificar comentarios de evaluación"
       valuation_comment_notification_description: "Envía un email a todos los usuarios menos al que haya comentado asociados a un presupuesto participativo cuando se cree un nuevo comentario de evaluación"
     map:

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -120,6 +120,38 @@ es:
       remote_census_description: "Permite configurar la conexión al censo remoto de cada institución"
       valuation_comment_notification: "Notificar comentarios de evaluación"
       valuation_comment_notification_description: "Envía un email a todos los usuarios menos al que haya comentado asociados a un presupuesto participativo cuando se cree un nuevo comentario de evaluación"
+    remote_census:
+      general:
+        endpoint: "Endpoint"
+        endpoint_description: "Nombre del host donde se encuentra el servicio del censo (wsdl)"
+      request:
+        method_name: "Nombre del método de la petición"
+        method_name_description: "Nombre del método qe acepta el WebService del Censo del Ayuntamiento."
+        structure: "Estructura de la petición"
+        structure_description: 'Estructura de la petición que recibe el WebService del Censo del Ayuntamiento. Los valores "fijos" de esta petición deberan informarse. Los valores relacionado con Tipo de Documento, Número de Documento, Fecha de Nacimiento y Código Postal deberán dejarse en blanco.'
+        document_type: "Ruta para Tipo de Documento"
+        document_type_description: "Ruta donde se encuentra el campo en la estructura de la petición que envia el Tipo de Documento. NO RELLENAR en caso de que el WebService no requiera el Tipo de Documento para verificar un usuario."
+        document_number: "Ruta para Número de Documento"
+        document_number_description: "Ruta donde se encuentra campo en la estructura de la petición que envia el Número de Documento. NO RELLENAR en caso de que el WebService no requiera el Número de Documento para verificar un usuario."
+        date_of_birth: "Ruta para Fecha de Nacimiento"
+        date_of_birth_description: "Ruta donde se encuentra campo en la estructura de la petición que envia la Fecha de Nacimiento. NO RELLENAR en caso de que el WebService no requiera la Fecha de Nacimiento para verificar un usuario."
+        postal_code: "Ruta para Código Postal."
+        postal_code_description: "Ruta donde se encuentra campo en la estructura de la petición que envia el Código Postal. NO RELLENAR en caso de que el WebService no requiera el Código Postal para verificar un usuario."
+      response:
+        date_of_birth: "Ruta para la Fecha de Nacimiento"
+        date_of_birth_description: "En que ruta de la respuesta se encuentra la Fecha de Nacimiento"
+        postal_code: "Ruta para el Código Postal"
+        postal_code_description: "En que ruta de la respuesta se encuentra el Código Postal"
+        district: "Ruta para el Distrito"
+        district_description: "En que ruta de la respuesta se encuentra el Distrito"
+        gender: "Ruta para el Género"
+        gender_description: "En que ruta de la respuesta se encuentra el Género"
+        name: "Ruta para el Nombre"
+        name_description: "En que ruta de la respuesta se encuentra Nombre"
+        surname: "Ruta para el Apellido"
+        surname_description: "En que ruta de la respuesta se encuentra el Apellido"
+        valid: "Condición para detectar una respuesta válida"
+        valid_description: "Que ruta de la respuesta tiene que venir informado para considerarse una respuesta válida"
     map:
       latitude: "Latitud"
       latitude_description: "Latitud para mostrar la posición del mapa"

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -52,4 +52,5 @@ namespace :settings do
   task add_new_settings: :environment do
     Setting.add_new_settings
   end
+
 end

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -132,6 +132,35 @@ describe "Admin settings" do
 
   end
 
+  describe "Update Remote Census Configuration" do
+
+    scenario "Should not be able when remote census feature deactivated" do
+      Setting["feature.remote_census"] = nil
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#remote-census-tab").click
+
+      expect(page).to have_content 'To configure remote census (SOAP) you must enable ' \
+                                   '"Configure connection to remote census (SOAP)" ' \
+                                   'on "Features" tab.'
+    end
+
+    scenario "Should be able when remote census feature activated" do
+      Setting["feature.remote_census"] = true
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#remote-census-tab").click
+
+      expect(page).not_to have_content 'To configure remote census (SOAP) you must enable ' \
+                                       '"Configure connection to remote census (SOAP)" ' \
+                                       'on "Features" tab.'
+      Setting["feature.remote_census"] = nil
+    end
+
+  end
+
   describe "Skip verification" do
 
     scenario "deactivate skip verification", :js do

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -153,6 +153,9 @@ describe "Admin settings" do
       visit admin_settings_path
       find("#remote-census-tab").click
 
+      expect(page).to have_content("General Information")
+      expect(page).to have_content("Request Data")
+      expect(page).to have_content("Response Data")
       expect(page).not_to have_content 'To configure remote census (SOAP) you must enable ' \
                                        '"Configure connection to remote census (SOAP)" ' \
                                        'on "Features" tab.'

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -134,6 +134,14 @@ describe "Admin settings" do
 
   describe "Update Remote Census Configuration" do
 
+    before do
+      Setting["feature.remote_census"] = true
+    end
+
+    after do
+      Setting["feature.remote_census"] = nil
+    end
+
     scenario "Should not be able when remote census feature deactivated" do
       Setting["feature.remote_census"] = nil
       admin = create(:administrator).user
@@ -147,7 +155,6 @@ describe "Admin settings" do
     end
 
     scenario "Should be able when remote census feature activated" do
-      Setting["feature.remote_census"] = true
       admin = create(:administrator).user
       login_as(admin)
       visit admin_settings_path
@@ -159,28 +166,40 @@ describe "Admin settings" do
       expect(page).not_to have_content 'To configure remote census (SOAP) you must enable ' \
                                        '"Configure connection to remote census (SOAP)" ' \
                                        'on "Features" tab.'
-      Setting["feature.remote_census"] = nil
     end
 
-    scenario "Should redirect to #tab-remote-census-configuration after update any remote census setting", :js do
-      remote_census_setting = create(:setting, key: "remote_census.general.any_remote_census_general_setting")
-      Setting["feature.remote_census"] = true
-      admin = create(:administrator).user
-      login_as(admin)
-      visit admin_settings_path
-      find("#remote-census-tab").click
+  end
 
-      within("#edit_setting_#{remote_census_setting.id}") do
-        fill_in "setting_#{remote_census_setting.id}", with: "New value"
-        click_button "Update"
+  describe "Should redirect to same tab after update setting" do
+
+    context "remote census" do
+
+      before do
+        Setting["feature.remote_census"] = true
       end
 
-      expect(page).to have_current_path(admin_settings_path)
-      expect(page).to have_css("div#tab-remote-census-configuration.is-active")
-      Setting["feature.remote_census"] = nil
+      after do
+        Setting["feature.remote_census"] = nil
+      end
+
+      scenario "On #tab-remote-census-configuration", :js do
+        remote_census_setting = create(:setting, key: "remote_census.general.whatever")
+        admin = create(:administrator).user
+        login_as(admin)
+        visit admin_settings_path
+        find("#remote-census-tab").click
+
+        within("#edit_setting_#{remote_census_setting.id}") do
+          fill_in "setting_#{remote_census_setting.id}", with: "New value"
+          click_button "Update"
+        end
+
+        expect(page).to have_current_path(admin_settings_path)
+        expect(page).to have_css("div#tab-remote-census-configuration.is-active")
+      end
     end
 
-    scenario "Should redirect to #tab-configuration after update any configuration setting", :js do
+    scenario "On #tab-configuration", :js do
       configuration_setting = Setting.create(key: "whatever")
       admin = create(:administrator).user
       login_as(admin)
@@ -196,25 +215,34 @@ describe "Admin settings" do
       expect(page).to have_css("div#tab-configuration.is-active")
     end
 
-    scenario "Should redirect to #tab-map-configuration after update any map configuration setting", :js do
-      map_setting = Setting.create(key: "map.whatever")
-      Setting["feature.map"] = true
-      admin = create(:administrator).user
-      login_as(admin)
-      visit admin_settings_path
-      find("#map-tab").click
+    context "map configuration" do
 
-      within("#edit_setting_#{map_setting.id}") do
-        fill_in "setting_#{map_setting.id}", with: "New value"
-        click_button "Update"
+      before do
+        Setting["feature.map"] = true
       end
 
-      expect(page).to have_current_path(admin_settings_path)
-      expect(page).to have_css("div#tab-map-configuration.is-active")
-      Setting["feature.map"] = nil
+      after do
+        Setting["feature.map"] = nil
+      end
+
+      scenario "On #tab-map-configuration", :js do
+        map_setting = Setting.create(key: "map.whatever")
+        admin = create(:administrator).user
+        login_as(admin)
+        visit admin_settings_path
+        find("#map-tab").click
+
+        within("#edit_setting_#{map_setting.id}") do
+          fill_in "setting_#{map_setting.id}", with: "New value"
+          click_button "Update"
+        end
+
+        expect(page).to have_current_path(admin_settings_path)
+        expect(page).to have_css("div#tab-map-configuration.is-active")
+      end
     end
 
-    scenario "Should redirect to #tab-proposals after update any proposal dashboard setting", :js do
+    scenario "On #tab-proposals", :js do
       proposal_dashboard_setting = Setting.create(key: "proposals.whatever")
       admin = create(:administrator).user
       login_as(admin)
@@ -230,7 +258,7 @@ describe "Admin settings" do
       expect(page).to have_css("div#tab-proposals.is-active")
     end
 
-    scenario "Should redirect to #tab-participation-processes after update any participation_processes setting", :js do
+    scenario "On #tab-participation-processes", :js do
       process_setting = Setting.create(key: "process.whatever")
       admin = create(:administrator).user
       login_as(admin)
@@ -245,7 +273,7 @@ describe "Admin settings" do
       expect(page).to have_css("div#tab-participation-processes.is-active")
     end
 
-    scenario "Should redirect to #tab-feature-flags after update any feature flag setting", :js do
+    scenario "On #tab-feature-flags", :js do
       feature_setting = Setting.create(key: "feature.whatever")
       admin = create(:administrator).user
       login_as(admin)

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -163,15 +163,15 @@ describe "Admin settings" do
     end
 
     scenario "Should redirect to #tab-remote-census-configuration after update any remote census setting", :js do
-      setting_remote_census = create(:setting, key: "remote_census.general.any_remote_census_general_setting")
+      remote_census_setting = create(:setting, key: "remote_census.general.any_remote_census_general_setting")
       Setting["feature.remote_census"] = true
       admin = create(:administrator).user
       login_as(admin)
       visit admin_settings_path
       find("#remote-census-tab").click
 
-      within("#edit_setting_#{setting_remote_census.id}") do
-        fill_in "setting_#{setting_remote_census.id}", with: "New value"
+      within("#edit_setting_#{remote_census_setting.id}") do
+        fill_in "setting_#{remote_census_setting.id}", with: "New value"
         click_button "Update"
       end
 
@@ -180,21 +180,85 @@ describe "Admin settings" do
       Setting["feature.remote_census"] = nil
     end
 
-    scenario "Should not redirect to #tab-remote-census-configuration after do not update any remote census setting", :js do
+    scenario "Should redirect to #tab-configuration after update any configuration setting", :js do
+      configuration_setting = Setting.create(key: "whatever")
       admin = create(:administrator).user
       login_as(admin)
       visit admin_settings_path
+      find("#tab-configuration").click
 
-      within("#edit_setting_#{@setting1.id}") do
-        fill_in "setting_#{@setting1.id}", with: "New value"
+      within("#edit_setting_#{configuration_setting.id}") do
+        fill_in "setting_#{configuration_setting.id}", with: "New value"
         click_button "Update"
       end
 
       expect(page).to have_current_path(admin_settings_path)
       expect(page).to have_css("div#tab-configuration.is-active")
-      expect(page).not_to have_css("div#tab-remote-census-configuration.is-active")
     end
 
+    scenario "Should redirect to #tab-map-configuration after update any map configuration setting", :js do
+      map_setting = Setting.create(key: "map.whatever")
+      Setting["feature.map"] = true
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#map-tab").click
+
+      within("#edit_setting_#{map_setting.id}") do
+        fill_in "setting_#{map_setting.id}", with: "New value"
+        click_button "Update"
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-map-configuration.is-active")
+      Setting["feature.map"] = nil
+    end
+
+    scenario "Should redirect to #tab-proposals after update any proposal dashboard setting", :js do
+      proposal_dashboard_setting = Setting.create(key: "proposals.whatever")
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#proposals-tab").click
+
+      within("#edit_setting_#{proposal_dashboard_setting.id}") do
+        fill_in "setting_#{proposal_dashboard_setting.id}", with: "New value"
+        click_button "Update"
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-proposals.is-active")
+    end
+
+    scenario "Should redirect to #tab-participation-processes after update any participation_processes setting", :js do
+      process_setting = Setting.create(key: "process.whatever")
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#participation-processes-tab").click
+
+      accept_alert do
+        find("#edit_setting_#{process_setting.id} .button").click
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-participation-processes.is-active")
+    end
+
+    scenario "Should redirect to #tab-feature-flags after update any feature flag setting", :js do
+      feature_setting = Setting.create(key: "feature.whatever")
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#features-tab").click
+
+      accept_alert do
+        find("#edit_setting_#{feature_setting.id} .button").click
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-feature-flags.is-active")
+    end
   end
 
   describe "Skip verification" do

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -162,6 +162,39 @@ describe "Admin settings" do
       Setting["feature.remote_census"] = nil
     end
 
+    scenario "Should redirect to #tab-remote-census-configuration after update any remote census setting", :js do
+      setting_remote_census = create(:setting, key: "remote_census.general.any_remote_census_general_setting")
+      Setting["feature.remote_census"] = true
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#remote-census-tab").click
+
+      within("#edit_setting_#{setting_remote_census.id}") do
+        fill_in "setting_#{setting_remote_census.id}", with: "New value"
+        click_button "Update"
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-remote-census-configuration.is-active")
+      Setting["feature.remote_census"] = nil
+    end
+
+    scenario "Should not redirect to #tab-remote-census-configuration after do not update any remote census setting", :js do
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+
+      within("#edit_setting_#{@setting1.id}") do
+        fill_in "setting_#{@setting1.id}", with: "New value"
+        click_button "Update"
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-configuration.is-active")
+      expect(page).not_to have_css("div#tab-remote-census-configuration.is-active")
+    end
+
   end
 
   describe "Skip verification" do

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -28,4 +28,13 @@ RSpec.describe SettingsHelper, type: :helper do
     end
   end
 
+  describe "#display_setting_name" do
+    it "returns correct setting_name" do
+      expect(display_setting_name("setting")).to eq("Setting")
+      expect(display_setting_name("remote_census_general_name")).to eq("General Information")
+      expect(display_setting_name("remote_census_request_name")).to eq("Request Data")
+      expect(display_setting_name("remote_census_response_name")).to eq("Response Data")
+    end
+  end
+
 end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -53,6 +53,21 @@ describe Setting do
       expect(homepage_setting.type).to eq "homepage"
     end
 
+    it "returns the key prefix for 'remote_census.general' settings" do
+      remote_census_general_setting = Setting.create(key: "remote_census.general.whatever")
+      expect(remote_census_general_setting.type).to eq "remote_census.general"
+    end
+
+    it "returns the key prefix for 'remote_census_request' settings" do
+      remote_census_request_setting = Setting.create(key: "remote_census.request.whatever")
+      expect(remote_census_request_setting.type).to eq "remote_census.request"
+    end
+
+    it "returns the key prefix for 'remote_census_response' settings" do
+      remote_census_response_setting = Setting.create(key: "remote_census.response.whatever")
+      expect(remote_census_response_setting.type).to eq "remote_census.response"
+    end
+
     it "returns 'configuration' for the rest of the settings" do
       configuration_setting = Setting.create(key: "whatever")
       expect(configuration_setting.type).to eq "configuration"


### PR DESCRIPTION
## References
[Configure connection with WebServices (SOAP) #3525](https://github.com/consul/consul/issues/3525)

## Objectives
Create new section on Settings "Remote Census Configuration" to store all necessary values to configure the connection with a WebService.

Also done:
- Settings Tabs: Allow redirect to current tab (See notes)
- Partial `_setting_table.html.erb`: Allow customize setting_name key by default to clarify the information to render (See notes)
## Visual Changes
![Captura de pantalla 2019-04-10 a las 16 28 56](https://user-images.githubusercontent.com/16189/55887479-e0c53080-5bad-11e9-844b-7586c2ed9f1e.png)
![Captura de pantalla 2019-04-10 a las 16 29 26](https://user-images.githubusercontent.com/16189/55887494-e91d6b80-5bad-11e9-8935-1302e3e88658.png)

## Notes
- All the new calls to `_setting_table.html.erb` partial will need add a new param called `setting_name`. (Related commits e0990eb, 8c7bbda)
- Allow redirect to current tab:
  Currently after each update of any Settings is redirected to the first
  tab by default.
  As this new tab remote_census_configuation has a lot of fields to fill
  in it is a bit uncomfortable to have to go back to the tab after each
  update. (Related commits 8b24ea739964e7d0b5416635342da7be3ebd10c3, c4060631873bf501e9c1d368fa7985e7e7e069e0)

- ⚠️ ~~Create Remote Census Configuration Settings: Setting["feature.remote_census"]. Execute this command to create: `bin/rake settings:create_remote_census_setting RAILS_ENV=production`~~ Remove rake task because now we manage new Settings with `add_new_settings` method.
