### PR TITLE
Fix houncibot parse error

### DIFF
--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -18,7 +18,7 @@
 
       <div class="small-12 column">
         <%= translations_form.label :question %>
-        <p class="help-text" id=<%= question_help_text_id(translations_form) %>>
+        <p class="help-text" id="<%= question_help_text_id(translations_form) %>">
           <%= t("proposals.form.proposal_question_example_html") %>
         </p>
         <%= translations_form.text_field :question,
@@ -30,7 +30,7 @@
 
       <div class="small-12 column">
         <%= translations_form.label :summary %>
-        <p class="help-text" id=<%= summary_help_text_id(translations_form) %>>
+        <p class="help-text" id="<%= summary_help_text_id(translations_form) %>">
           <%= t("proposals.form.proposal_summary_note") %>
         </p>
         <%= translations_form.text_area :summary,


### PR DESCRIPTION
## References
#3243 

## Objectives
Fix houncibot parse error: Add missing quotes.

https://github.com/consul/consul/pull/3243/files#diff-6b0eb8973ffd055fa4a97d58c7d46df9R21
https://github.com/consul/consul/pull/3243/files#diff-6b0eb8973ffd055fa4a97d58c7d46df9R33

## Notes
```
@houndci-bot commented on this pull request.

Some files could not be reviewed due to errors:

warning: parser/current is loading parser/ruby26, which recognizes
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.0-dev-compliant syntax, but you are running 2.6.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
2 error(s) were found in ERB files
Linting 1 files with 12 linters...
expected attribute value after '=' (at >)

In file: app/views/proposals/_form.html.erb:21
In file: app/views/proposals/_form.html.erb:33
```