### PR TITLE
Add rake task to check for spending proposals

### DIFF
--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -1,0 +1,16 @@
+namespace :spending_proposals do
+
+  desc "Check if there are any spending proposals in DB"
+  task check: :environment do
+    if Rails.env.production? && SpendingProposal.any?
+      puts "WARNING"
+      puts "You have spending proposals in your database."
+      puts "This model has been deprecated in favor of budget investments."
+      puts "In the next CONSUL release spending proposals will be deleted."
+      puts "If you do not need to keep this data, you don't have to do anything else."
+      print "If you would like to migrate the data from spending proposals to budget investments "
+      puts "please check this PR https://github.com/consul/consul/pull/3431."
+    end
+  end
+
+end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -2,14 +2,20 @@ namespace :spending_proposals do
 
   desc "Check if there are any spending proposals in DB"
   task check: :environment do
-    if Rails.env.production? && SpendingProposal.any?
-      puts "WARNING"
-      puts "You have spending proposals in your database."
-      puts "This model has been deprecated in favor of budget investments."
-      puts "In the next CONSUL release spending proposals will be deleted."
-      puts "If you do not need to keep this data, you don't have to do anything else."
-      print "If you would like to migrate the data from spending proposals to budget investments "
-      puts "please check this PR https://github.com/consul/consul/pull/3431."
+    if !Rails.env.production?
+      puts "Please run this rake task in your production environment."
+    else
+      if SpendingProposal.any?
+        puts "WARNING"
+        puts "You have spending proposals in your database."
+        puts "This model has been deprecated in favor of budget investments."
+        puts "In the next CONSUL release spending proposals will be deleted."
+        puts "If you do not need to keep this data, you don't have to do anything else."
+        print "If you would like to migrate the data from spending proposals to budget investments "
+        puts "please check this PR https://github.com/consul/consul/pull/3431."
+      else
+        puts "All good!"
+      end
     end
   end
 


### PR DESCRIPTION
## References

- [Migrate spending proposals to budget investments](https://github.com/consul/consul/pull/3431)
- [Delete spending proposals](https://github.com/AyuntamientoMadrid/consul/pull/1937)

## Context

Spending Proposals was used in the first Participatory Budgets to store proposals created by citizens. Since then Spending Proposals have become deprecated in favor of Budget Investments.

Only the first forks will have Spending Proposals in their Production servers. The forks that started using CONSUL since version [0.7](https://github.com/consul/consul/releases/tag/v0.7) released on April 25th 2016 do not need to migrate. Please check out the rake tasks in this PR to make sure you do not have Spending Proposals in your Production environment.

## Objectives

Add a rake task to be executed in the production environment to check for spending proposals. In case spending proposals are found, display a link to the PR with instructions on how to migrate to Budget Investments.

## Notes
To run the rake task to check for spending proposals run this command:

`bin/rake spending_proposals:check RAILS_ENV=production`