### PR TITLE
Use Rails 5 conventions in ballot migrations

### DIFF
--- a/app/models/poll/ballot.rb
+++ b/app/models/poll/ballot.rb
@@ -1,4 +1,4 @@
-class Poll::Ballot < ActiveRecord::Base
+class Poll::Ballot < ApplicationRecord
   belongs_to :ballot_sheet, class_name: Poll::BallotSheet
 
   validates :ballot_sheet_id, presence: true

--- a/app/models/poll/ballot_sheet.rb
+++ b/app/models/poll/ballot_sheet.rb
@@ -1,4 +1,4 @@
-class Poll::BallotSheet < ActiveRecord::Base
+class Poll::BallotSheet < ApplicationRecord
   belongs_to :poll
   belongs_to :officer_assignment
   has_many :ballots, class_name: Poll::Ballot

--- a/db/migrate/20170514192303_add_balloted_heading_id_to_users.rb
+++ b/db/migrate/20170514192303_add_balloted_heading_id_to_users.rb
@@ -1,4 +1,4 @@
-class AddBallotedHeadingIdToUsers < ActiveRecord::Migration
+class AddBallotedHeadingIdToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :balloted_heading_id, :integer, default: nil
   end

--- a/db/migrate/20180604173248_add_budget_to_polls.rb
+++ b/db/migrate/20180604173248_add_budget_to_polls.rb
@@ -1,4 +1,4 @@
-class AddBudgetToPolls < ActiveRecord::Migration
+class AddBudgetToPolls < ActiveRecord::Migration[4.2]
   def change
     add_reference :polls, :budget, index: { unique: true }, foreign_key: true
   end

--- a/db/migrate/20180621182723_create_poll_ballot_sheets.rb
+++ b/db/migrate/20180621182723_create_poll_ballot_sheets.rb
@@ -1,4 +1,4 @@
-class CreatePollBallotSheets < ActiveRecord::Migration
+class CreatePollBallotSheets < ActiveRecord::Migration[4.2]
   def change
     create_table :poll_ballot_sheets do |t|
       t.text :data

--- a/db/migrate/20180704093831_create_poll_ballot.rb
+++ b/db/migrate/20180704093831_create_poll_ballot.rb
@@ -1,4 +1,4 @@
-class CreatePollBallot < ActiveRecord::Migration
+class CreatePollBallot < ActiveRecord::Migration[4.2]
   def change
     create_table :poll_ballots do |t|
       t.integer :ballot_sheet_id

--- a/db/migrate/20180704095538_add_physical_to_budget_ballot.rb
+++ b/db/migrate/20180704095538_add_physical_to_budget_ballot.rb
@@ -1,4 +1,4 @@
-class AddPhysicalToBudgetBallot < ActiveRecord::Migration
+class AddPhysicalToBudgetBallot < ActiveRecord::Migration[4.2]
   def change
     add_column :budget_ballots, :physical, :boolean, default: false
     add_column :budget_ballots, :poll_ballot_id, :integer


### PR DESCRIPTION


## References

* Pull request #3414
* Pull request #2857
* Pull request #2858

## Objectives

Upgrade migration and model files in order to follow Rails 5 inheritance conventions. These migrations and models were created shortly before updating to Rails 5, and so the migrations didn't have the version number and the models inherited from `ActiveRecord::Base` instead of `ApplicationRecord`.
