### PR TITLE
Fix Invalid Authenticity Token with Rails 5

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
   include HasFilters
   include HasOrders
 
+  protect_from_forgery with: :exception
+
   before_action :authenticate_http_basic, if: :http_basic_auth_site?
 
   before_action :ensure_signup_complete
@@ -14,8 +16,6 @@ class ApplicationController < ActionController::Base
 
   check_authorization unless: :devise_controller?
   self.responder = ApplicationResponder
-
-  protect_from_forgery with: :exception
 
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|


### PR DESCRIPTION
## References

* Backport commit AyuntamientoMadrid@01309528 from AyuntamientoMadrid#1947

## Objectives

Fix a bug which caused `ActionController::InvalidAuthenticityToken` after upgrading to Rails 5.

## Notes

* The exception was confirmed in development; I haven't checked it on production.
* It looks like we missed this commit when porting  AyuntamientoMadrid#1947 to CONSUL