### PR TITLE
Fix flaky spec: Ballots Groups Change my heading

### DIFF
--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -307,6 +307,7 @@ feature "Ballots" do
 
       within("#budget_investment_#{investment1.id}") do
         find(".remove a").click
+        expect(page).to have_link "Vote"
       end
 
       visit budget_investments_path(budget, heading_id: new_york.id)


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1980
* Closes #3451
* [Recent change in the test environment](https://github.com/AyuntamientoMadrid/consul/pull/1947/files#diff-639e7393aa097999e816b53faa94bab4L18)

## Objectives

Check page after an AJAX call so the test doesn't fail sometimes due to two requests being processed simultaneosly.

## Notes

* This test started to fail after upgrading to Rails 5, since we removed the change done in commit eda47eff which set `config.allow_concurrency` to `false` in the test environment.
* This test failed with two possible errors: "undefined method `heading' for nil:NilClass" and "stale element reference: element is not attached to the page document". This change fixes the second error; it might fix the first error as well, but since I couldn't reproduce it locally, we'll only be sure when this test stops failing in travis builds.