### PR TITLE
Add lib folder path to eager_load_paths

### DIFF
--- a/config/environments/preproduction.rb
+++ b/config/environments/preproduction.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   # Because autoloading is disabled in production environments with Rails 5,
   # using autoload_paths will not load needed classes from specified paths.
   # The solution to this, is to ask Rails to eager load classes.
-  config.eager_load_paths << "#{config.root}/lib"
+  config.eager_load_paths += ["#{config.root}/lib"]
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   # Because autoloading is disabled in production environments with Rails 5,
   # using autoload_paths will not load needed classes from specified paths.
   # The solution to this, is to ask Rails to eager load classes.
-  config.eager_load_paths << "#{config.root}/lib"
+  config.eager_load_paths += ["#{config.root}/lib"]
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   # Because autoloading is disabled in production environments with Rails 5,
   # using autoload_paths will not load needed classes from specified paths.
   # The solution to this, is to ask Rails to eager load classes.
-  config.eager_load_paths << "#{config.root}/lib"
+  config.eager_load_paths += ["#{config.root}/lib"]
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false


### PR DESCRIPTION
## References

**Backport**: https://github.com/AyuntamientoMadrid/consul/commit/99ba7a6614b22941bcaa49aeff6e07cd531fd0bc

## Context

We are seeing an exception related to trying to modify a frozen array when deploy apps to heroku.

## Objectives
Use the correct Rails5 syntax to add `lib` to the path.
