### PR TITLE
Add document uploads from admin section

### DIFF
--- a/app/controllers/admin/site_customization/documents_controller.rb
+++ b/app/controllers/admin/site_customization/documents_controller.rb
@@ -1,0 +1,40 @@
+class Admin::SiteCustomization::DocumentsController < Admin::SiteCustomization::BaseController
+
+  def index
+    @documents = Document.admin.page(params[:page])
+  end
+
+  def new
+    @document = Document.new
+  end
+
+  def create
+    @document = initialize_document
+    if @document.save
+      notice = t("admin.documents.create.success_notice")
+      redirect_to admin_site_customization_documents_path, notice: notice
+    else
+      notice = t("admin.documents.create.unable_notice")
+      redirect_to new_admin_site_customization_document_path, notice: notice
+    end
+  end
+
+  def destroy
+    @document = Document.find(params[:id])
+    @document.destroy
+
+    notice = t("admin.documents.destroy.success_notice")
+    redirect_to admin_site_customization_documents_path, notice: notice
+  end
+
+  private
+
+    def initialize_document
+      document = Document.new
+      document.attachment = params.dig(:document, :attachment)
+      document.title = document.attachment_file_name
+      document.user = current_user
+      document.admin = true
+      document
+    end
+end

--- a/app/controllers/admin/site_customization/documents_controller.rb
+++ b/app/controllers/admin/site_customization/documents_controller.rb
@@ -14,8 +14,8 @@ class Admin::SiteCustomization::DocumentsController < Admin::SiteCustomization::
       notice = t("admin.documents.create.success_notice")
       redirect_to admin_site_customization_documents_path, notice: notice
     else
-      notice = t("admin.documents.create.unable_notice")
-      redirect_to new_admin_site_customization_document_path, notice: notice
+      flash.now[:error] = t("admin.documents.create.unable_notice")
+      render :new
     end
   end
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -56,7 +56,7 @@ module AdminHelper
   end
 
   def menu_customization?
-    ["pages", "banners", "information_texts"].include?(controller_name) ||
+    ["pages", "banners", "information_texts", "documents"].include?(controller_name) ||
     menu_homepage? || menu_pages?
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -24,6 +24,8 @@ class Document < ApplicationRecord
   before_save :set_attachment_from_cached_attachment, if: -> { cached_attachment.present? }
   after_save :remove_cached_attachment,               if: -> { cached_attachment.present? }
 
+  scope :admin, -> { where(admin: true) }
+
   def set_cached_attachment_from_attachment
     self.cached_attachment = if Paperclip::Attachment.default_options[:storage] == :filesystem
                                attachment.path

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -134,6 +134,11 @@
         <li <%= "class=is-active" if controller_name == "information_texts" %>>
           <%= link_to t("admin.menu.site_customization.information_texts"), admin_site_customization_information_texts_path %>
         </li>
+
+        <li <%= "class=is-active" if controller_name == "documents" %>>
+          <%= link_to t("admin.menu.site_customization.documents"),
+                      admin_site_customization_documents_path %>
+        </li>
       </ul>
     </li>
 

--- a/app/views/admin/site_customization/documents/index.html.erb
+++ b/app/views/admin/site_customization/documents/index.html.erb
@@ -29,6 +29,7 @@
               <%= link_to t("admin.shared.delete"),
                           admin_site_customization_document_path(document),
                           method: :delete,
+                          class: "button hollow alert",
                           data: { confirm: t("admin.actions.confirm") } %>
             </div>
           </td>

--- a/app/views/admin/site_customization/documents/index.html.erb
+++ b/app/views/admin/site_customization/documents/index.html.erb
@@ -1,20 +1,20 @@
-<h2 class="inline-block">Documentos</h2>
+<h2 class="inline-block"><%= t("admin.documents.index.title") %></h2>
 
 <%= link_to t("admin.documents.index.new_link"),
             new_admin_site_customization_document_path,
             class: "button float-right" %>
 
-<h3><%= page_entries_info @documents %></h3>
-
 <% if @documents.any? %>
+  <h3><%= page_entries_info @documents %></h3>
+
   <table>
     <thead>
       <tr>
-        <th scope="col">Title</th>
-        <th scope="col">Format</th>
-        <th scope="col">Size</th>
-        <th scope="col">Url</th>
-        <th scope="col">Actions</th>
+        <th scope="col"><%= t("admin.shared.title") %></th>
+        <th scope="col"><%= t("admin.documents.index.format") %></th>
+        <th scope="col"><%= t("admin.documents.index.size") %></th>
+        <th scope="col"><%= t("admin.documents.index.url") %></th>
+        <th scope="col"><%= t("admin.shared.actions") %></th>
       </tr>
     </thead>
     <tbody id="documents">
@@ -26,10 +26,10 @@
           <td><%= link_to document.title, document.attachment.url, target: :blank %></td>
           <td>
             <div class="small-12 medium-6 column">
-              <%= link_to "Destroy", 
-                          admin_site_customization_document_path(document), 
+              <%= link_to t("admin.shared.delete"),
+                          admin_site_customization_document_path(document),
                           method: :delete,
-                          data: { confirm: t('admin.actions.confirm') } %>
+                          data: { confirm: t("admin.actions.confirm") } %>
             </div>
           </td>
         </tr>

--- a/app/views/admin/site_customization/documents/index.html.erb
+++ b/app/views/admin/site_customization/documents/index.html.erb
@@ -1,0 +1,45 @@
+<h2 class="inline-block">Documentos</h2>
+
+<%= link_to t("admin.documents.index.new_link"),
+            new_admin_site_customization_document_path,
+            class: "button float-right" %>
+
+<h3><%= page_entries_info @documents %></h3>
+
+<% if @documents.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Title</th>
+        <th scope="col">Format</th>
+        <th scope="col">Size</th>
+        <th scope="col">Url</th>
+        <th scope="col">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="documents">
+      <% @documents.each do |document| %>
+        <tr id="<%= dom_id(document) %>" class="document">
+          <td><%= document.title %></td>
+          <td><%= document.attachment.content_type %></td>
+          <td><%= number_to_human_size(document.attachment.size) %></td>
+          <td><%= link_to document.title, document.attachment.url, target: :blank %></td>
+          <td>
+            <div class="small-12 medium-6 column">
+              <%= link_to "Destroy", 
+                          admin_site_customization_document_path(document), 
+                          method: :delete,
+                          data: { confirm: t('admin.actions.confirm') } %>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  <table>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.documents.index.no_documents") %>
+  </div>
+<% end %>
+
+<%= paginate @documents %>

--- a/app/views/admin/site_customization/documents/new.html.erb
+++ b/app/views/admin/site_customization/documents/new.html.erb
@@ -1,0 +1,9 @@
+<h2><%= t("admin.documents.new.title") %></h2>
+
+<%= form_for @document, 
+             url: admin_site_customization_documents_path, 
+             multipart: true do |f| %>
+  
+  <%= f.file_field 'attachment', { label: false } %>
+  <%= f.submit t("admin.documents.new.submit_button") %>
+<% end %>

--- a/app/views/admin/site_customization/documents/new.html.erb
+++ b/app/views/admin/site_customization/documents/new.html.erb
@@ -1,9 +1,10 @@
 <h2><%= t("admin.documents.new.title") %></h2>
 
-<%= form_for @document, 
-             url: admin_site_customization_documents_path, 
-             multipart: true do |f| %>
-  
-  <%= f.file_field 'attachment', { label: false } %>
-  <%= f.submit t("admin.documents.new.submit_button") %>
+<%= form_for @document,
+             url: admin_site_customization_documents_path do |f| %>
+  <%= f.file_field 'attachment', label: t("admin.documents.new.label_attachment") %>
+
+  <div class="margin-top">
+    <%= f.submit t("admin.documents.new.submit_button"), class: "button success"  %>
+  </div>
 <% end %>

--- a/app/views/admin/site_customization/documents/new.html.erb
+++ b/app/views/admin/site_customization/documents/new.html.erb
@@ -5,6 +5,6 @@
   <%= f.file_field 'attachment', label: t("admin.documents.new.label_attachment") %>
 
   <div class="margin-top">
-    <%= f.submit t("admin.documents.new.submit_button"), class: "button success"  %>
+    <%= f.submit t("admin.documents.new.submit_button"), class: "button success" %>
   </div>
 <% end %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -79,6 +79,9 @@ en:
       site_customization/content_block:
         one: Custom content block
         other: Custom content blocks
+      document:
+        one: Document
+        other: Documents
       legislation/process:
         one: "Process"
         other: "Processes"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -441,11 +441,15 @@ en:
     documents:
       new:
         title: "Upload a document"
-        file_field_text: "Choose document"
+        label_attachment: "Choose document"
         submit_button: "Upload"
       index:
         new_link: "Add new document"
         no_documents: "There are no documents."
+        title: "Documents"
+        format: "Format"
+        size: "Size"
+        url: "URL"
       create:
         success_notice: "Document uploaded succesfully"
         unable_notice: "Invalid document"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -438,6 +438,19 @@ en:
           without_confirmed_hide: Pending
         title: Hidden debates
         no_hidden_debates: There is no hidden debates.
+    documents:
+      new:
+        title: "Upload a document"
+        file_field_text: "Choose document"
+        submit_button: "Upload"
+      index:
+        new_link: "Add new document"
+        no_documents: "There are no documents."
+      create:
+        success_notice: "Document uploaded succesfully"
+        unable_notice: "Invalid document"
+      destroy:
+        success_notice: "Document deleted succesfully"
     hidden_users:
       index:
         filter: Filter
@@ -678,6 +691,7 @@ en:
       stats: Statistics
       signature_sheets: Signature Sheets
       site_customization:
+        documents: Custom documents
         homepage: Homepage
         pages: Custom pages
         images: Custom images

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -79,6 +79,9 @@ es:
       site_customization/content_block:
         one: Bloque
         other: Bloques
+      document:
+        one: Documento
+        other: Documentos
       legislation/process:
         one: "Proceso"
         other: "Procesos"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -438,6 +438,18 @@ es:
           without_confirmed_hide: Pendientes
         title: Debates ocultos
         no_hidden_debates: No hay debates ocultos.
+    documents:
+      new:
+        title: "Subir un documento"
+        submit_button: "Subir documento"
+      index:
+        new_link: "Subir un documento"
+        no_documents: "No hay documentos."
+      create:
+        success_notice: "Documento creado correctamente"
+        unable_notice: "Document inválido"
+      destroy:
+        success_notice: "Documento borrado correctamente"
     hidden_users:
       index:
         filter: Filtro
@@ -677,6 +689,7 @@ es:
       stats: Estadísticas
       signature_sheets: Hojas de firmas
       site_customization:
+        documents: Documentos
         homepage: Homepage
         pages: Personalizar páginas
         images: Personalizar imágenes

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -441,13 +441,18 @@ es:
     documents:
       new:
         title: "Subir un documento"
+        label_attachment: "Selecciona un documento"
         submit_button: "Subir documento"
       index:
+        title: "Documentos"
         new_link: "Subir un documento"
         no_documents: "No hay documentos."
+        format: "Formato"
+        size: "Tamaño"
+        url: "URL"
       create:
         success_notice: "Documento creado correctamente"
-        unable_notice: "Document inválido"
+        unable_notice: "Documento inválido"
       destroy:
         success_notice: "Documento borrado correctamente"
     hidden_users:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -230,6 +230,7 @@ namespace :admin do
     resources :information_texts, only: [:index] do
       post :update, on: :collection
     end
+    resources :documents, only: [:index, :new, :create, :destroy]
   end
 
   resource :homepage, controller: :homepage, only: [:show]

--- a/db/migrate/20181128175808_add_admin_to_documents.rb
+++ b/db/migrate/20181128175808_add_admin_to_documents.rb
@@ -1,0 +1,5 @@
+class AddAdminToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -504,6 +504,7 @@ ActiveRecord::Schema.define(version: 20190411090023) do
     t.string   "documentable_type"
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
+    t.boolean  "admin",                   default: false
     t.index ["documentable_type", "documentable_id"], name: "index_documents_on_documentable_type_and_documentable_id", using: :btree
     t.index ["user_id", "documentable_type", "documentable_id"], name: "access_documents", using: :btree
     t.index ["user_id"], name: "index_documents_on_user_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -502,8 +502,8 @@ ActiveRecord::Schema.define(version: 20190411090023) do
     t.integer  "user_id"
     t.integer  "documentable_id"
     t.string   "documentable_type"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
     t.boolean  "admin",                   default: false
     t.index ["documentable_type", "documentable_id"], name: "index_documents_on_documentable_type_and_documentable_id", using: :btree
     t.index ["user_id", "documentable_type", "documentable_id"], name: "access_documents", using: :btree

--- a/spec/factories/files.rb
+++ b/spec/factories/files.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
     trait :poll_question_document do
       association :documentable, factory: :poll_question
     end
+
+    trait :admin do
+      admin true
+    end
   end
 
   factory :direct_upload do

--- a/spec/features/admin/site_customization/documents_spec.rb
+++ b/spec/features/admin/site_customization/documents_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Documents' do
+feature "Documents" do
 
   before do
     admin = create(:administrator)
@@ -37,22 +37,22 @@ feature 'Documents' do
     expect(page).to have_content "There are no documents."
   end
 
-  scenario 'Index (pagination)' do
+  scenario "Index (pagination)" do
     per_page = Kaminari.config.default_per_page
     (per_page + 5).times { create(:document, :admin) }
 
     visit admin_site_customization_documents_path
 
-    expect(page).to have_selector('#documents .document', count: per_page)
+    expect(page).to have_selector("#documents .document", count: per_page)
 
     within("ul.pagination") do
       expect(page).to have_content("1")
-      expect(page).to have_link('2', href: admin_site_customization_documents_url(page: 2))
+      expect(page).to have_link("2", href: admin_site_customization_documents_url(page: 2))
       expect(page).not_to have_content("3")
       click_link "Next", exact: false
     end
 
-    expect(page).to have_selector('#documents .document', count: 5)
+    expect(page).to have_selector("#documents .document", count: 5)
   end
 
   scenario "Create" do

--- a/spec/features/admin/site_customization/documents_spec.rb
+++ b/spec/features/admin/site_customization/documents_spec.rb
@@ -79,7 +79,7 @@ feature 'Documents' do
     visit admin_site_customization_documents_path
 
     within("#document_#{document.id}") do
-      accept_confirm { click_link "Destroy" }
+      accept_confirm { click_link "Delete" }
     end
 
     expect(page).to have_content "Document deleted succesfully"

--- a/spec/features/admin/site_customization/documents_spec.rb
+++ b/spec/features/admin/site_customization/documents_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+feature 'Documents' do
+
+  before do
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
+
+  scenario "Navigation", :js do
+    visit admin_root_path
+
+    within("#side_menu") do
+      click_link "Site content"
+      click_link "Custom documents"
+    end
+
+    expect(page).to have_link "Add new document",
+                              href: new_admin_site_customization_document_path
+  end
+
+  scenario "Index" do
+    3.times { create(:document, :admin) }
+    1.times { create(:document) }
+
+    visit admin_site_customization_documents_path
+
+    expect(page).to have_content "There are 3 documents"
+
+    document = Document.first
+    expect(page).to have_link document.title, href: document.attachment.url
+  end
+
+  scenario "Index (empty)" do
+    visit admin_site_customization_documents_path
+
+    expect(page).to have_content "There are no documents."
+  end
+
+  scenario 'Index (pagination)' do
+    per_page = Kaminari.config.default_per_page
+    (per_page + 5).times { create(:document, :admin) }
+
+    visit admin_site_customization_documents_path
+
+    expect(page).to have_selector('#documents .document', count: per_page)
+
+    within("ul.pagination") do
+      expect(page).to have_content("1")
+      expect(page).to have_link('2', href: admin_site_customization_documents_url(page: 2))
+      expect(page).not_to have_content("3")
+      click_link "Next", exact: false
+    end
+
+    expect(page).to have_selector('#documents .document', count: 5)
+  end
+
+  scenario "Create" do
+    visit new_admin_site_customization_document_path
+
+    attach_file("document_attachment", Rails.root + "spec/fixtures/files/logo.pdf")
+    click_button "Upload"
+
+    expect(page).to have_content "Document uploaded succesfully"
+    expect(page).to have_link "logo.pdf", href: Document.last.attachment.url
+  end
+
+  scenario "Errors on create" do
+    visit new_admin_site_customization_document_path
+
+    click_button "Upload"
+
+    expect(page).to have_content "Invalid document"
+  end
+
+  scenario "Destroy", :js do
+    document = create(:document, :admin)
+
+    visit admin_site_customization_documents_path
+
+    within("#document_#{document.id}") do
+      accept_confirm { click_link "Destroy" }
+    end
+
+    expect(page).to have_content "Document deleted succesfully"
+    expect(page).to_not have_content document.title
+  end
+
+end

--- a/spec/features/admin/site_customization/documents_spec.rb
+++ b/spec/features/admin/site_customization/documents_spec.rb
@@ -83,7 +83,7 @@ feature 'Documents' do
     end
 
     expect(page).to have_content "Document deleted succesfully"
-    expect(page).to_not have_content document.title
+    expect(page).not_to have_content document.title
   end
 
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -19,7 +19,7 @@ describe Document do
         expect(Document.admin).to include admin_document1
         expect(Document.admin).to include admin_document2
         expect(Document.admin).to include admin_document3
-        expect(Document.admin).to_not include user_document
+        expect(Document.admin).not_to include user_document
       end
 
     end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -5,4 +5,23 @@ describe Document do
   it_behaves_like "document validations", "budget_investment_document"
   it_behaves_like "document validations", "proposal_document"
 
+  context "scopes" do
+
+    describe "#admin" do
+
+      it "returns admin documents" do
+        user_document = create(:document)
+        admin_document1 = create(:document, :admin)
+        admin_document2 = create(:document, :admin)
+        admin_document3 = create(:document, :admin)
+
+        expect(Document.admin.count).to eq(3)
+        expect(Document.admin).to include admin_document1
+        expect(Document.admin).to include admin_document2
+        expect(Document.admin).to include admin_document3
+        expect(Document.admin).to_not include user_document
+      end
+
+    end
+  end
 end


### PR DESCRIPTION
## References
This closes consul#3009
This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1733/

## Objectives

Allow admins to upload documents and later link them from anywhere in the site.

## Visual Changes

<img width="1679" alt="custom_documents_index" src="https://user-images.githubusercontent.com/631897/48077790-6cdec080-e1e8-11e8-84b5-6fc41969ed77.png">

<img width="1676" alt="custom_documents_form" src="https://user-images.githubusercontent.com/631897/48077789-6cdec080-e1e8-11e8-9ecd-d0e409b17d84.png">
