### PR TITLE
Always use map image from admin site customization images

### DIFF
--- a/app/views/budgets/groups/show.html.erb
+++ b/app/views/budgets/groups/show.html.erb
@@ -45,7 +45,7 @@
   </div>
 
   <div class="medium-5 column show-for-medium text-center">
-    <%= image_tag "map.jpg" %>
+    <%= image_tag(image_path_for("map.jpg")) %>
   </div>
 </div>
 

--- a/app/views/legislation/proposals/_geozones.html.erb
+++ b/app/views/legislation/proposals/_geozones.html.erb
@@ -2,5 +2,5 @@
 <h2 class="sidebar-title"><%= t("shared.tags_cloud.districts") %></h2>
 <br>
 <%= link_to map_proposals_path, id: "map", title: t("shared.tags_cloud.districts_list") do %>
-  <%= image_tag("map.jpg", alt: t("shared.tags_cloud.districts_list")) %>
+  <%= image_tag(image_path_for("map.jpg", alt: t("shared.tags_cloud.districts_list")) %>
 <% end %>

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -13,7 +13,7 @@
       </div>
 
       <div class="show-for-medium medium-9 column text-center">
-        <%= image_tag("map.jpg", usemap: "#map") %>
+        <%= image_tag(image_path_for("map.jpg"), usemap: "#map") %>
       </div>
 
       <map name="map" id="html_map">

--- a/spec/features/admin/site_customization/images_spec.rb
+++ b/spec/features/admin/site_customization/images_spec.rb
@@ -39,7 +39,9 @@ feature "Admin custom images" do
     expect(page).to have_css("img[src*='custom_map.jpg']", count: 1)
   end
 
-  scenario "Image is replaced on front view" do
+  scenario "Image is replaced on front views" do
+    budget = create(:budget)
+    group = create(:budget_group, budget: budget)
     visit admin_root_path
 
     within("#side_menu") do
@@ -54,6 +56,18 @@ feature "Admin custom images" do
     visit proposals_path
 
     within("#map") do
+      expect(page).to have_css("img[src*='custom_map.jpg']")
+    end
+
+    visit map_proposals_path
+
+    within(".show-for-medium") do
+      expect(page).to have_css("img[src*='custom_map.jpg']")
+    end
+
+    visit budget_group_path(budget, group)
+
+    within(".show-for-medium") do
       expect(page).to have_css("img[src*='custom_map.jpg']")
     end
   end


### PR DESCRIPTION
## References

This closes https://github.com/consul/consul/issues/3374.

## Objectives

Admin users can change map image on `/admin/site_customization/images`.

This custom image is not rendering in all pages with the map. With this PR we always render custom map image from admin site customization images if it's present.
