### PR TITLE
Remove deprecated translations code

### DIFF
--- a/app/models/concerns/notifiable.rb
+++ b/app/models/concerns/notifiable.rb
@@ -12,6 +12,10 @@ module Notifiable
     end
   end
 
+  def notifiable_body
+    body if attribute_names.include?("body")
+  end
+
   def notifiable_available?
     case self.class.name
     when "ProposalNotification"

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -11,8 +11,9 @@ class Notification < ApplicationRecord
   scope :recent,      -> { order(id: :desc) }
   scope :for_render,  -> { includes(:notifiable) }
 
-  delegate :notifiable_title, :notifiable_available?, :check_availability,
-           :linkable_resource, to: :notifiable, allow_nil: true
+  delegate :notifiable_title, :notifiable_body, :notifiable_available?,
+           :check_availability, :linkable_resource,
+           to: :notifiable, allow_nil: true
 
   def mark_as_read
     update(read_at: Time.current)

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -3,7 +3,7 @@
     <% locals = { notification: notification,
                   timestamp: notification.timestamp,
                   title: notification.notifiable_title,
-                  body: notification.notifiable.try(:body) } %>
+                  body: notification.notifiable_body } %>
     <% link_text = render partial: "/notifications/notification_body", locals: locals %>
     <%= link_to_if notification.link.present?, link_text, notification.link %>
   <% else %>

--- a/db/migrate/20190221154819_remove_deprecated_translatable_fields_from_banners.rb
+++ b/db/migrate/20190221154819_remove_deprecated_translatable_fields_from_banners.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromBanners < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :banners, :title, :string
+    remove_column :banners, :description, :string
+  end
+end

--- a/db/migrate/20190221162450_remove_deprecated_translatable_fields_from_polls.rb
+++ b/db/migrate/20190221162450_remove_deprecated_translatable_fields_from_polls.rb
@@ -1,0 +1,7 @@
+class RemoveDeprecatedTranslatableFieldsFromPolls < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :polls, :name, :string
+    remove_column :polls, :summary, :text
+    remove_column :polls, :description, :text
+  end
+end

--- a/db/migrate/20190221162858_remove_deprecated_translatable_fields_from_poll_questions.rb
+++ b/db/migrate/20190221162858_remove_deprecated_translatable_fields_from_poll_questions.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromPollQuestions < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :poll_questions, :title, :string
+  end
+end

--- a/db/migrate/20190221163117_remove_deprecated_translatable_fields_from_poll_question_answers.rb
+++ b/db/migrate/20190221163117_remove_deprecated_translatable_fields_from_poll_question_answers.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromPollQuestionAnswers < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :poll_question_answers, :title, :string
+    remove_column :poll_question_answers, :description, :text
+  end
+end

--- a/db/migrate/20190221163818_remove_deprecated_translatable_fields_from_admin_notifications.rb
+++ b/db/migrate/20190221163818_remove_deprecated_translatable_fields_from_admin_notifications.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromAdminNotifications < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :admin_notifications, :title, :string
+    remove_column :admin_notifications, :body, :text
+  end
+end

--- a/db/migrate/20190221164056_remove_deprecated_translatable_fields_from_milestones.rb
+++ b/db/migrate/20190221164056_remove_deprecated_translatable_fields_from_milestones.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromMilestones < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :milestones, :title, :string
+    remove_column :milestones, :description, :text
+  end
+end

--- a/db/migrate/20190221164559_remove_deprecated_translatable_fields_from_legislation_draft_versions.rb
+++ b/db/migrate/20190221164559_remove_deprecated_translatable_fields_from_legislation_draft_versions.rb
@@ -1,0 +1,9 @@
+class RemoveDeprecatedTranslatableFieldsFromLegislationDraftVersions < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :legislation_draft_versions, :title, :string
+    remove_column :legislation_draft_versions, :changelog, :text
+    remove_column :legislation_draft_versions, :body, :text
+    remove_column :legislation_draft_versions, :body_html, :text
+    remove_column :legislation_draft_versions, :toc_html, :text
+  end
+end

--- a/db/migrate/20190221164928_remove_deprecated_translatable_fields_from_legislation_processes.rb
+++ b/db/migrate/20190221164928_remove_deprecated_translatable_fields_from_legislation_processes.rb
@@ -1,0 +1,8 @@
+class RemoveDeprecatedTranslatableFieldsFromLegislationProcesses < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :legislation_processes, :title, :string
+    remove_column :legislation_processes, :summary, :text
+    remove_column :legislation_processes, :description, :text
+    remove_column :legislation_processes, :additional_info, :text
+  end
+end

--- a/db/migrate/20190221165347_remove_deprecated_translatable_fields_from_legislation_questions.rb
+++ b/db/migrate/20190221165347_remove_deprecated_translatable_fields_from_legislation_questions.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromLegislationQuestions < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :legislation_questions, :title, :text
+  end
+end

--- a/db/migrate/20190221171155_remove_deprecated_translatable_fields_from_legislation_question_options.rb
+++ b/db/migrate/20190221171155_remove_deprecated_translatable_fields_from_legislation_question_options.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromLegislationQuestionOptions < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :legislation_question_options, :value, :string
+  end
+end

--- a/db/migrate/20190221171859_remove_deprecated_translatable_fields_from_site_customization_pages.rb
+++ b/db/migrate/20190221171859_remove_deprecated_translatable_fields_from_site_customization_pages.rb
@@ -1,0 +1,7 @@
+class RemoveDeprecatedTranslatableFieldsFromSiteCustomizationPages < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :site_customization_pages, :title, :string
+    remove_column :site_customization_pages, :subtitle, :string
+    remove_column :site_customization_pages, :content, :text
+  end
+end

--- a/db/migrate/20190221172209_remove_deprecated_translatable_fields_from_widget_cards.rb
+++ b/db/migrate/20190221172209_remove_deprecated_translatable_fields_from_widget_cards.rb
@@ -1,0 +1,8 @@
+class RemoveDeprecatedTranslatableFieldsFromWidgetCards < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :widget_cards, :label, :string
+    remove_column :widget_cards, :title, :string
+    remove_column :widget_cards, :description, :text
+    remove_column :widget_cards, :link_text, :string
+  end
+end

--- a/db/migrate/20190325184500_remove_deprecated_translatable_fields_from_budgets.rb
+++ b/db/migrate/20190325184500_remove_deprecated_translatable_fields_from_budgets.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromBudgets < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :budgets, :name, :string
+  end
+end

--- a/db/migrate/20190325185046_remove_deprecated_translatable_fields_from_budget_groups.rb
+++ b/db/migrate/20190325185046_remove_deprecated_translatable_fields_from_budget_groups.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromBudgetGroups < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :budget_groups, :name, :string
+  end
+end

--- a/db/migrate/20190325185405_remove_deprecated_translatable_fields_from_budget_headings.rb
+++ b/db/migrate/20190325185405_remove_deprecated_translatable_fields_from_budget_headings.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromBudgetHeadings < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :budget_headings, :name, :string
+  end
+end

--- a/db/migrate/20190325185550_remove_deprecated_translatable_fields_from_budget_phases.rb
+++ b/db/migrate/20190325185550_remove_deprecated_translatable_fields_from_budget_phases.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromBudgetPhases < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :budget_phases, :summary, :text
+    remove_column :budget_phases, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -756,7 +756,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
 
   create_table "legislation_question_options", force: :cascade do |t|
     t.integer  "legislation_question_id"
-    t.string   "value"
     t.integer  "answers_count",           default: 0
     t.datetime "hidden_at"
     t.datetime "created_at",                          null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,9 +154,8 @@ ActiveRecord::Schema.define(version: 20190411090023) do
 
   create_table "budget_groups", force: :cascade do |t|
     t.integer "budget_id"
-    t.string  "name",                 limit: 50
     t.string  "slug"
-    t.integer "max_votable_headings",            default: 1
+    t.integer "max_votable_headings", default: 1
     t.index ["budget_id"], name: "index_budget_groups_on_budget_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1031,7 +1031,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
     t.integer  "poll_id"
     t.integer  "author_id"
     t.string   "author_visible_name"
-    t.string   "title"
     t.integer  "comments_count"
     t.datetime "hidden_at"
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -671,9 +671,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
   end
 
   create_table "legislation_processes", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.text     "additional_info"
     t.date     "start_date"
     t.date     "end_date"
     t.date     "debate_start_date"
@@ -685,7 +682,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
     t.datetime "hidden_at"
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
-    t.text     "summary"
     t.boolean  "debate_phase_enabled",       default: false
     t.boolean  "allegations_phase_enabled",  default: false
     t.boolean  "draft_publication_enabled",  default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,8 +55,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
   end
 
   create_table "admin_notifications", force: :cascade do |t|
-    t.string   "title"
-    t.text     "body"
     t.string   "link"
     t.string   "segment_recipient"
     t.integer  "recipients_count"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -863,12 +863,10 @@ ActiveRecord::Schema.define(version: 20190411090023) do
   create_table "milestones", force: :cascade do |t|
     t.integer  "milestoneable_id"
     t.string   "milestoneable_type"
-    t.string   "title",              limit: 80
-    t.text     "description"
     t.datetime "publication_date"
     t.integer  "status_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
     t.index ["status_id"], name: "index_milestones_on_status_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -273,8 +273,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
     t.integer  "budget_id"
     t.integer  "next_phase_id"
     t.string   "kind",                         null: false
-    t.text     "summary"
-    t.text     "description"
     t.datetime "starts_at"
     t.datetime "ends_at"
     t.boolean  "enabled",       default: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -171,11 +171,10 @@ ActiveRecord::Schema.define(version: 20190411090023) do
 
   create_table "budget_headings", force: :cascade do |t|
     t.integer "group_id"
-    t.string  "name",                 limit: 50
     t.bigint  "price"
     t.integer "population"
     t.string  "slug"
-    t.boolean "allow_custom_content",            default: false
+    t.boolean "allow_custom_content", default: false
     t.text    "latitude"
     t.text    "longitude"
     t.index ["group_id"], name: "index_budget_headings_on_group_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1113,13 +1113,10 @@ ActiveRecord::Schema.define(version: 20190411090023) do
   end
 
   create_table "polls", force: :cascade do |t|
-    t.string   "name"
     t.datetime "starts_at"
     t.datetime "ends_at"
     t.boolean  "published",          default: false
     t.boolean  "geozone_restricted", default: false
-    t.text     "summary"
-    t.text     "description"
     t.integer  "comments_count",     default: 0
     t.integer  "author_id"
     t.datetime "hidden_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -645,16 +645,11 @@ ActiveRecord::Schema.define(version: 20190411090023) do
 
   create_table "legislation_draft_versions", force: :cascade do |t|
     t.integer  "legislation_process_id"
-    t.string   "title"
-    t.text     "changelog"
     t.string   "status",                 default: "draft"
     t.boolean  "final_version",          default: false
-    t.text     "body"
     t.datetime "hidden_at"
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
-    t.text     "body_html"
-    t.text     "toc_html"
     t.index ["hidden_at"], name: "index_legislation_draft_versions_on_hidden_at", using: :btree
     t.index ["legislation_process_id"], name: "index_legislation_draft_versions_on_legislation_process_id", using: :btree
     t.index ["status"], name: "index_legislation_draft_versions_on_status", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -102,14 +102,12 @@ ActiveRecord::Schema.define(version: 20190411090023) do
   end
 
   create_table "banners", force: :cascade do |t|
-    t.string   "title",            limit: 80
-    t.string   "description"
     t.string   "target_url"
     t.date     "post_started_at"
     t.date     "post_ended_at"
     t.datetime "hidden_at"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
     t.text     "background_color"
     t.text     "font_color"
     t.index ["hidden_at"], name: "index_banners_on_hidden_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -988,8 +988,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
   end
 
   create_table "poll_question_answers", force: :cascade do |t|
-    t.string  "title"
-    t.text    "description"
     t.integer "question_id"
     t.integer "given_order", default: 1
     t.boolean "most_voted",  default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1274,9 +1274,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
 
   create_table "site_customization_pages", force: :cascade do |t|
     t.string   "slug",                                 null: false
-    t.string   "title"
-    t.string   "subtitle"
-    t.text     "content"
     t.boolean  "more_info_flag"
     t.boolean  "print_content_flag"
     t.string   "status",             default: "draft"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -777,7 +777,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
 
   create_table "legislation_questions", force: :cascade do |t|
     t.integer  "legislation_process_id"
-    t.text     "title"
     t.integer  "answers_count",          default: 0
     t.datetime "hidden_at"
     t.datetime "created_at",                         null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -318,7 +318,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
   end
 
   create_table "budgets", force: :cascade do |t|
-    t.string   "name",                          limit: 80
     t.string   "currency_symbol",               limit: 10
     t.string   "phase",                         limit: 40, default: "accepting"
     t.datetime "created_at",                                                     null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1524,11 +1524,7 @@ ActiveRecord::Schema.define(version: 20190411090023) do
   end
 
   create_table "widget_cards", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.string   "link_text"
     t.string   "link_url"
-    t.string   "label"
     t.boolean  "header",                     default: false
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false


### PR DESCRIPTION
## References

* Adapts pull request #3327 to the current master branch
* Backports AyuntamientoMadrid#1985 and AyuntamientoMadrid#1996

## Objectives

* Remove obsolete columns which might still accidentally be used by active record scopes
* Fix incompatibilities between Globalize and Rails 5