### PR TITLE
Allow delete polls with associated questions and answers

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -58,6 +58,16 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
     @polls = Poll.current
   end
 
+  def destroy
+    if ::Poll::Voter.where(poll: @poll).any?
+      redirect_to admin_poll_path(@poll), alert: t("admin.polls.destroy.unable_notice")
+    else
+      @poll.destroy
+
+      redirect_to admin_polls_path, notice: t("admin.polls.destroy.success_notice")
+    end
+  end
+
   private
 
     def load_geozones

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -20,7 +20,7 @@ class Poll < ApplicationRecord
   has_many :voters
   has_many :officer_assignments, through: :booth_assignments
   has_many :officers, through: :officer_assignments
-  has_many :questions, inverse_of: :poll
+  has_many :questions, inverse_of: :poll, dependent: :destroy
   has_many :comments, as: :commentable
   has_many :ballot_sheets
 

--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -13,7 +13,7 @@ class Poll::Question < ApplicationRecord
 
   has_many :comments, as: :commentable
   has_many :answers, class_name: "Poll::Answer"
-  has_many :question_answers, -> { order "given_order asc" }, class_name: "Poll::Question::Answer"
+  has_many :question_answers, -> { order "given_order asc" }, class_name: "Poll::Question::Answer", dependent: :destroy
   has_many :partial_results
   belongs_to :proposal
 

--- a/app/views/admin/poll/polls/_poll.html.erb
+++ b/app/views/admin/poll/polls/_poll.html.erb
@@ -15,6 +15,12 @@
                 edit_admin_poll_path(poll),
                 class: "button hollow" %>
 
+    <%= link_to t("admin.actions.delete"),
+            admin_poll_path(poll),
+            method: :delete,
+            "data-confirm": t("admin.polls.destroy.alert"),
+            class: "button hollow alert" %>
+
     <%= link_to t("admin.actions.configure"),
                 admin_poll_path(poll),
                 class: "button hollow " %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1016,7 +1016,7 @@ en:
     polls:
       index:
         title: "List of polls"
-        no_polls: "There are no polls coming up."
+        no_polls: "There are no polls."
         create: "Create poll"
         name: "Name"
         dates: "Dates"
@@ -1047,6 +1047,10 @@ en:
       flash:
         question_added: "Question added to this poll"
         error_on_question_added: "Question could not be assigned to this poll"
+      destroy:
+        alert: "This action will remove the poll and all its associated questions."
+        success_notice: "Poll deleted successfully"
+        unable_notice: "You cannot delete a poll that has votes"
     questions:
       index:
         title: "Questions"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1015,7 +1015,7 @@ es:
     polls:
       index:
         title: "Listado de votaciones"
-        no_polls: "No hay ninguna votación próximamente."
+        no_polls: "No hay votaciones."
         create: "Crear votación"
         name: "Nombre"
         dates: "Fechas"
@@ -1046,6 +1046,10 @@ es:
       flash:
         question_added: "Pregunta añadida a esta votación"
         error_on_question_added: "No se pudo asignar la pregunta"
+      destroy:
+        alert: "Esta acción eliminará la votación y todas sus preguntas asociadas."
+        success_notice: "Votación eliminada correctamente"
+        unable_notice: "No se pueden eliminar votaciones con votos"
     questions:
       index:
         title: "Preguntas de votaciones"

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -109,6 +109,55 @@ feature "Admin polls" do
     expect(page).to have_current_path(edit_admin_poll_path(poll))
   end
 
+  context "Destroy" do
+
+    scenario "Can destroy poll without questions", :js do
+      poll = create(:poll)
+
+      visit admin_polls_path
+
+      within("#poll_#{poll.id}") do
+        accept_confirm { click_link "Delete" }
+      end
+
+      expect(page).to have_content("Poll deleted successfully")
+      expect(page).to have_content("There are no polls.")
+    end
+
+    scenario "Can destroy poll with questions and answers", :js do
+      poll = create(:poll)
+      question = create(:poll_question, poll: poll)
+      create(:poll_question_answer, question: question, title: "Yes")
+      create(:poll_question_answer, question: question, title: "No")
+
+      visit admin_polls_path
+
+      within("#poll_#{poll.id}") do
+        accept_confirm { click_link "Delete" }
+      end
+
+      expect(page).to     have_content("Poll deleted successfully")
+      expect(page).not_to have_content(poll.name)
+      expect(Poll::Question.count).to eq(0)
+      expect(Poll::Question::Answer.count). to eq(0)
+    end
+
+    scenario "Can't destroy poll with votes", :js  do
+      poll = create(:poll)
+      create(:poll_question, poll: poll)
+      create(:poll_voter, :from_booth, :valid_document, poll: poll)
+
+      visit admin_polls_path
+
+      within("#poll_#{poll.id}") do
+        accept_confirm { click_link "Delete" }
+      end
+
+      expect(page).to have_content("You cannot delete a poll that has votes")
+      expect(page).to have_content(poll.name)
+    end
+  end
+
   context "Booths" do
 
     context "Poll show" do


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1915

## Objectives

Add a "Delete" button on `/admin/polls` to allow admins delete polls and associated questions (the poll only delete if has not votes).

## Visual Changes
![admin_polls](https://user-images.githubusercontent.com/631897/54043575-3c765580-41cd-11e9-8c45-0aa026f70b01.png)

![alert](https://user-images.githubusercontent.com/631897/54681484-c8ad4480-4b0c-11e9-9f9c-b085f3dd8b66.png)

![delete](https://user-images.githubusercontent.com/631897/54838825-cfcd8180-4cc9-11e9-8d7f-a2c8bf063ce8.png)