### PR TITLE
Fix a bug where a category can't be created if it already exists as a tag

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -9,13 +9,8 @@ class Admin::TagsController < Admin::BaseController
   end
 
   def create
-    @existing_tag = Tag.where(name: tag_params.first).first
-    if @existing_tag
-      @existing_tag.kind = "category"
-      @existing_tag.save
-    else
-      Tag.category.create(tag_params)
-    end
+    Tag.find_or_create_by!(name: tag_params["name"]).update!(kind: "category")
+
     redirect_to admin_tags_path
   end
 

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -9,7 +9,13 @@ class Admin::TagsController < Admin::BaseController
   end
 
   def create
-    Tag.category.create!(tag_params)
+    @existing_tag = Tag.where(name: tag_params.first).first
+    if @existing_tag
+      @existing_tag.kind = "category"
+      @existing_tag.save
+    else
+      Tag.category.create(tag_params)
+    end
     redirect_to admin_tags_path
   end
 

--- a/spec/features/admin/tags_spec.rb
+++ b/spec/features/admin/tags_spec.rb
@@ -90,7 +90,7 @@ describe "Admin tags" do
   end
 
   scenario "Upgrade tag to category" do
-    not_category_tag = create(:tag, name: "Soon a category")
+    create(:tag, name: "Soon a category")
 
     visit admin_tags_path
 
@@ -101,5 +101,4 @@ describe "Admin tags" do
 
     expect(page).to have_content "Soon a category"
   end
-
 end

--- a/spec/features/admin/tags_spec.rb
+++ b/spec/features/admin/tags_spec.rb
@@ -88,4 +88,18 @@ describe "Admin tags" do
       expect(Tag.category.where(name: "wow_category")).to exist
     end
   end
+
+  scenario "Upgrade tag to category" do
+    not_category_tag = create(:tag, name: "Soon a category")
+
+    visit admin_tags_path
+
+    within("form.new_tag") do
+      fill_in "tag_name", with: "Soon a category"
+      click_button "Create topic"
+    end
+
+    expect(page).to have_content "Soon a category"
+  end
+
 end


### PR DESCRIPTION
## References

* Closes #2975

## Objectives

Fixes #2975 and adds a new spec to ensure that it works in this case