### PR TITLE
Add CRUD to manage local census records

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -24,6 +24,7 @@
 // 22. Images
 // 23. Maps
 // 24. Homepage
+// 25. LocalCensusRecords
 //
 
 // 01. Global styles
@@ -2875,6 +2876,21 @@ table {
       font-weight: bold;
       margin-bottom: $line-height / 4;
       padding: rem-calc(4) rem-calc(8);
+    }
+  }
+}
+
+// 25. Local Census Records
+// ------------------------
+
+.local-census-record-new,
+.local-census-record-edit {
+
+  .date-of-birth {
+    select {
+      float: left;
+      width: 30%;
+      margin-right: $line-height / 4;
     }
   }
 }

--- a/app/controllers/admin/local_census_records_controller.rb
+++ b/app/controllers/admin/local_census_records_controller.rb
@@ -1,0 +1,8 @@
+class Admin::LocalCensusRecordsController < Admin::BaseController
+  load_and_authorize_resource
+
+  def index
+    @local_census_records = @local_census_records.search(params[:search])
+    @local_census_records = @local_census_records.page(params[:page])
+  end
+end

--- a/app/controllers/admin/local_census_records_controller.rb
+++ b/app/controllers/admin/local_census_records_controller.rb
@@ -16,6 +16,15 @@ class Admin::LocalCensusRecordsController < Admin::BaseController
     end
   end
 
+  def update
+    if @local_census_record.update(local_census_record_params)
+      redirect_to admin_local_census_records_path,
+        notice: t("admin.local_census_records.update.notice")
+    else
+      render :edit
+    end
+  end
+
   private
 
     def local_census_record_params

--- a/app/controllers/admin/local_census_records_controller.rb
+++ b/app/controllers/admin/local_census_records_controller.rb
@@ -5,4 +5,21 @@ class Admin::LocalCensusRecordsController < Admin::BaseController
     @local_census_records = @local_census_records.search(params[:search])
     @local_census_records = @local_census_records.page(params[:page])
   end
+
+  def create
+    @local_census_record = LocalCensusRecord.new(local_census_record_params)
+    if @local_census_record.save
+      redirect_to admin_local_census_records_path,
+        notice: t("admin.local_census_records.create.notice")
+    else
+      render :new
+    end
+  end
+
+  private
+
+    def local_census_record_params
+      attributes = [:document_type, :document_number, :date_of_birth, :postal_code]
+      params.require(:local_census_record).permit(*attributes)
+    end
 end

--- a/app/controllers/admin/local_census_records_controller.rb
+++ b/app/controllers/admin/local_census_records_controller.rb
@@ -25,6 +25,12 @@ class Admin::LocalCensusRecordsController < Admin::BaseController
     end
   end
 
+  def destroy
+    @local_census_record.destroy
+    redirect_to admin_local_census_records_path,
+      notice: t("admin.local_census_records.destroy.notice")
+  end
+
   private
 
     def local_census_record_params

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -51,8 +51,10 @@ module AdminHelper
   end
 
   def menu_settings?
-    ["settings", "tags", "geozones", "images", "content_blocks"].include?(controller_name) &&
-    controller.class.parent != Admin::Poll::Questions::Answers
+    controllers_names = ["settings", "tags", "geozones", "images", "content_blocks",
+      "local_census_records"]
+    controllers_names.include?(controller_name) &&
+      controller.class.parent != Admin::Poll::Questions::Answers
   end
 
   def menu_customization?

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -98,6 +98,8 @@ module Abilities
 
       can [:deliver], Newsletter, hidden_at: nil
       can [:manage], Dashboard::AdministratorTask
+
+      can :manage, LocalCensusRecord
     end
   end
 end

--- a/app/models/local_census_record.rb
+++ b/app/models/local_census_record.rb
@@ -3,4 +3,6 @@ class LocalCensusRecord < ApplicationRecord
   validates :document_type, presence: true
   validates :date_of_birth, presence: true
   validates :postal_code, presence: true
+
+  scope :search,  -> (terms) { where("document_number ILIKE ?", "%#{terms}%") }
 end

--- a/app/models/local_census_record.rb
+++ b/app/models/local_census_record.rb
@@ -5,6 +5,7 @@ class LocalCensusRecord < ApplicationRecord
   validates :document_type, presence: true
   validates :date_of_birth, presence: true
   validates :postal_code, presence: true
+  validates :document_number, uniqueness: { scope: :document_type }
 
   scope :search,  -> (terms) { where("document_number ILIKE ?", "%#{terms}%") }
 

--- a/app/models/local_census_record.rb
+++ b/app/models/local_census_record.rb
@@ -1,8 +1,18 @@
 class LocalCensusRecord < ApplicationRecord
+  before_validation :sanitize
+
   validates :document_number, presence: true
   validates :document_type, presence: true
   validates :date_of_birth, presence: true
   validates :postal_code, presence: true
 
   scope :search,  -> (terms) { where("document_number ILIKE ?", "%#{terms}%") }
+
+  private
+
+    def sanitize
+      self.document_type   = self.document_type&.strip
+      self.document_number = self.document_number&.strip
+      self.postal_code     = self.postal_code&.strip
+    end
 end

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -247,6 +247,10 @@
         <li <%= "class=is-active" if controller_name == "content_blocks" %>>
           <%= link_to t("admin.menu.site_customization.content_blocks"), admin_site_customization_content_blocks_path%>
         </li>
+
+        <li <%= "class=is-active" if controller_name == "local_census_records" %>>
+          <%= link_to t("admin.menu.local_census_records"), admin_local_census_records_path %>
+        </li>
       </ul>
     </li>
     <li class="section-title">

--- a/app/views/admin/local_census_records/_form.html.erb
+++ b/app/views/admin/local_census_records/_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_for [:admin, @local_census_record] do |f| %>
+  <%= render "shared/errors", resource: @local_census_record %>
+
+  <div class="row">
+    <div class="small-12">
+      <%= f.text_field :document_type %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="small-12">
+      <%= f.text_field :document_number %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="date-of-birth small-12">
+      <%= f.label :date_of_birth, t("admin.local_census_records.form.date_of_birth") %>
+      <div class="clear">
+        <%= f.date_select :date_of_birth,
+                          prompt: true,
+                          start_year: 1900, end_year: minimum_required_age.years.ago.year,
+                          label: false %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="small-12">
+      <%= f.text_field :postal_code %>
+    </div>
+  </div>
+
+  <div class="small-12 medium-4 large-2 margin-top">
+    <%= f.submit(class: "button success expanded", value: t("shared.save")) %>
+  </div>
+<% end %>

--- a/app/views/admin/local_census_records/_local_census_record.html.erb
+++ b/app/views/admin/local_census_records/_local_census_record.html.erb
@@ -1,0 +1,25 @@
+<tr id="<%= dom_id(local_census_record) %>" class="local_census_record">
+  <td>
+    <%= local_census_record.document_type %>
+  </td>
+  <td>
+    <%= local_census_record.document_number %>
+  </td>
+  <td>
+    <%= l local_census_record.date_of_birth %>
+  </td>
+  <td>
+    <%= local_census_record.postal_code %>
+  </td>
+  <td>
+    <%= link_to t("admin.actions.edit"),
+                edit_admin_local_census_record_path(local_census_record),
+                class: "button hollow" %>
+
+    <%= link_to t("admin.actions.delete"),
+                admin_local_census_record_path(local_census_record),
+                method: :delete,
+                class: "button hollow alert",
+                data: { confirm: t("admin.actions.confirm") } %>
+  </td>
+</tr>

--- a/app/views/admin/local_census_records/_local_census_records.html.erb
+++ b/app/views/admin/local_census_records/_local_census_records.html.erb
@@ -1,0 +1,23 @@
+<% if @local_census_records.any? %>
+  <h3 class="margin"><%= page_entries_info @local_census_records %></h3>
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("admin.local_census_records.index.document_type") %></th>
+        <th><%= t("admin.local_census_records.index.document_number") %></th>
+        <th><%= t("admin.local_census_records.index.date_of_birth") %></th>
+        <th><%= t("admin.local_census_records.index.postal_code") %></th>
+        <th><%= t("admin.actions.actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render @local_census_records %>
+    </tbody>
+  </table>
+
+  <%= paginate @local_census_records %>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.local_census_records.index.no_local_census_records") %>
+  </div>
+<% end %>

--- a/app/views/admin/local_census_records/edit.html.erb
+++ b/app/views/admin/local_census_records/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="local-census-record-edit row">
+
+  <div class="small-12 column">
+    <%= back_link_to admin_local_census_records_path %>
+
+    <h1><%= t("admin.local_census_records.edit.editing") %></h1>
+
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/admin/local_census_records/index.html.erb
+++ b/app/views/admin/local_census_records/index.html.erb
@@ -1,0 +1,20 @@
+<h2 class="inline-block"><%= t("admin.local_census_records.index.title") %></h2>
+
+<%= link_to t("admin.local_census_records.index.create"),
+            new_admin_local_census_record_path,
+            class: "button float-right" %>
+
+<div class="small-12 medium-6">
+  <%= form_tag admin_local_census_records_path, method: :get, remote: true  do %>
+    <div class="input-group">
+      <%= text_field_tag :search, "", placeholder: t("admin.local_census_records.index.search.placeholder") %>
+      <div class="input-group-button">
+        <%= submit_tag t("admin.local_census_records.index.search.search"), class: "button" %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<div id="local_census_records">
+  <%= render "local_census_records" %>
+</div>

--- a/app/views/admin/local_census_records/index.js.erb
+++ b/app/views/admin/local_census_records/index.js.erb
@@ -1,0 +1,1 @@
+$("#local_census_records").html("<%= j render "local_census_records" %>");

--- a/app/views/admin/local_census_records/new.html.erb
+++ b/app/views/admin/local_census_records/new.html.erb
@@ -1,0 +1,10 @@
+<div class="local-census-record-new">
+
+  <div class="small-12 column">
+    <%= back_link_to admin_local_census_records_path %>
+
+    <h1><%= t("admin.local_census_records.new.creating") %></h1>
+
+    <%= render "form" %>
+  </div>
+</div>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -121,6 +121,9 @@ en:
       link:
         one: Link
         other: Links
+      local_census_record:
+        one: Local census record
+        other: Local census records
     attributes:
       budget:
         name: "Name"
@@ -354,6 +357,11 @@ en:
       link:
         label: Title
         url: Link
+      local_census_record:
+        document_type: Document type
+        document_number: Document number
+        date_of_birth: Date of birth
+        postal_code: Postal code
     errors:
       models:
         user:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1613,3 +1613,19 @@ en:
     translations:
         remove_language: Remove language
         add_language: Add language
+    local_census_records:
+      index:
+        title: Manage local census
+        create: Create new local census record
+        no_local_census_records: There are no local census records.
+        document_type: Document type
+        document_number: Document number
+        date_of_birth: Date of birth
+        postal_code: Postal code
+        search:
+          placeholder: Search by document number
+          search: Search
+      new:
+        creating: Creating new local census record
+      create:
+        notice: New local census record created successfully!

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1625,6 +1625,8 @@ en:
         search:
           placeholder: Search by document number
           search: Search
+      form:
+        date_of_birth: Date of birth
       new:
         creating: Creating new local census record
       create:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1631,3 +1631,7 @@ en:
         creating: Creating new local census record
       create:
         notice: New local census record created successfully!
+      edit:
+        editing: Editing local census record
+      update:
+        notice: Local census record updated successfully!

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -707,6 +707,7 @@ en:
       dashboard: Proposals dashboard
       administrator_tasks: Resources requested
       dashboard_actions: Resources and actions
+      local_census_records: Manage local census
     administrators:
       index:
         title: Administrators

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1635,3 +1635,5 @@ en:
         editing: Editing local census record
       update:
         notice: Local census record updated successfully!
+      destroy:
+        notice: Local census record removed successfully!

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -191,6 +191,7 @@ en:
     document: Document
     topic: Topic
     image: Image
+    local_census_record: Local Census Record
   geozones:
     none: All city
     all: All scopes

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -121,6 +121,9 @@ es:
       link:
         one: Enlace
         other: Enlaces
+      local_census_record:
+        one: Registro del censo local
+        other: Registros del censo local
     attributes:
       budget:
         name: "Nombre"
@@ -355,6 +358,11 @@ es:
       link:
         label: Título
         url: Enlace
+      local_census_record:
+        document_type: Tipo de documento
+        document_number: Número de documento
+        date_of_birth: Fecha de nacimiento
+        postal_code: Código postal
     errors:
       models:
         user:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1624,6 +1624,8 @@ es:
         search:
           placeholder: Búsqueda por número de documento
           search: Buscar
+      form:
+        date_of_birth: Fecha de nacimiento
       new:
         creating: Creando nuevo registro de censo local
       create:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1612,3 +1612,19 @@ es:
     translations:
       remove_language: Eliminar idioma
       add_language: Añadir idioma
+    local_census_records:
+      index:
+        title: Gestionar censo local
+        create: Crear nuevo registro en el censo local
+        no_local_census_records: No hay registros de censo local
+        document_type: Tipo de documento
+        document_number: Número de documento
+        date_of_birth: Fecha de nacimiento
+        postal_code: Código postal
+        search:
+          placeholder: Búsqueda por número de documento
+          search: Buscar
+      new:
+        creating: Creando nuevo registro de censo local
+      create:
+        notice: ¡Nuevo registro de censo local creado correctamente!

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1630,3 +1630,7 @@ es:
         creating: Creando nuevo registro de censo local
       create:
         notice: ¡Nuevo registro de censo local creado correctamente!
+      edit:
+        editing: Editando registro del censo local
+      update:
+        notice: ¡Registro del censo local actualizado correctamente!

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1634,3 +1634,5 @@ es:
         editing: Editando registro del censo local
       update:
         notice: ¡Registro del censo local actualizado correctamente!
+      destroy:
+        notice: ¡Registro del censo local eliminado correctamente!

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -706,6 +706,7 @@ es:
       dashboard: Panel de progreso de propuestas
       administrator_tasks: Recursos solicitados
       dashboard_actions: Recursos y acciones
+      local_census_records: Gestionar censo local
     administrators:
       index:
         title: Administradores

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -191,6 +191,7 @@ es:
     document: el documento
     topic: Tema
     image: Imagen
+    local_census_record: el registro del censo local
   geozones:
     none: Toda la ciudad
     all: Todos los ámbitos de actuación

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -243,4 +243,6 @@ namespace :admin do
     resources :actions, only: [:index, :new, :create, :edit, :update, :destroy]
     resources :administrator_tasks, only: [:index, :edit, :update]
   end
+
+  resources :local_census_records
 end

--- a/db/migrate/20190509085124_add_index_to_local_census_records_document_number.rb
+++ b/db/migrate/20190509085124_add_index_to_local_census_records_document_number.rb
@@ -1,0 +1,5 @@
+class AddIndexToLocalCensusRecordsDocumentNumber < ActiveRecord::Migration[5.0]
+  def change
+    add_index :local_census_records, :document_number
+  end
+end

--- a/db/migrate/20190530082138_add_unique_index_to_local_census_records.rb
+++ b/db/migrate/20190530082138_add_unique_index_to_local_census_records.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexToLocalCensusRecords < ActiveRecord::Migration[5.0]
+  def up
+    add_index :local_census_records, [:document_number, :document_type], unique: true
+  end
+
+  def down
+    remove_index :local_census_records, [:document_number, :document_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190411090023) do
+ActiveRecord::Schema.define(version: 20190509085124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -818,6 +818,7 @@ ActiveRecord::Schema.define(version: 20190411090023) do
     t.string   "postal_code",     null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.index ["document_number"], name: "index_local_census_records_on_document_number", using: :btree
   end
 
   create_table "locks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190509085124) do
+ActiveRecord::Schema.define(version: 20190530082138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -818,6 +818,7 @@ ActiveRecord::Schema.define(version: 20190509085124) do
     t.string   "postal_code",     null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.index ["document_number", "document_type"], name: "index_local_census_records_on_document_number_and_document_type", unique: true, using: :btree
     t.index ["document_number"], name: "index_local_census_records_on_document_number", using: :btree
   end
 

--- a/spec/factories/verifications.rb
+++ b/spec/factories/verifications.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :local_census_record, class: "LocalCensusRecord" do
-    document_number "12345678A"
+    sequence(:document_number) { |n| "DOC_NUMBER#{n}" }
     document_type 1
     date_of_birth Date.new(1970, 1, 31)
     postal_code "28002"

--- a/spec/features/admin/local_census_records_spec.rb
+++ b/spec/features/admin/local_census_records_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+feature "Admin local census records" do
+
+  background do
+    login_as(create(:administrator).user)
+  end
+
+  context "Index" do
+    let!(:local_census_record) { create(:local_census_record) }
+
+    scenario "Should show empty message when no local census records exists" do
+      LocalCensusRecord.delete_all
+      visit admin_local_census_records_path
+
+      expect(page).to have_content("There are no local census records.")
+    end
+
+    scenario "Should show existing local census records" do
+      visit admin_local_census_records_path
+
+      expect(page).to have_content(local_census_record.document_type)
+      expect(page).to have_content(local_census_record.document_number)
+      expect(page).to have_content(local_census_record.date_of_birth)
+      expect(page).to have_content(local_census_record.postal_code)
+    end
+
+    scenario "Should show edit and destroy actions for each record" do
+      visit admin_local_census_records_path
+
+      within "#local_census_record_#{local_census_record.id}" do
+        expect(page).to have_link "Edit"
+        expect(page).to have_link "Delete"
+      end
+    end
+
+    scenario "Should show page entries info" do
+      visit admin_local_census_records_path
+
+      expect(page).to have_content("There is 1 local census record")
+    end
+
+    scenario "Should show paginator" do
+      create_list(:local_census_record, 25)
+      visit admin_local_census_records_path
+
+      within ".pagination" do
+        expect(page).to have_link("2")
+      end
+    end
+
+    context "Search" do
+      background do
+        create(:local_census_record, document_number: "X66777888" )
+      end
+
+      scenario "Should show matching records by document number at first visit" do
+        visit admin_local_census_records_path(search: "X66777888")
+
+        expect(page).to have_content "X66777888"
+        expect(page).not_to have_content local_census_record.document_number
+      end
+
+      scenario "Should show matching records by document number", :js do
+        visit admin_local_census_records_path
+
+        fill_in :search, with: "X66777888"
+        click_on "Search"
+
+        expect(page).to have_content "X66777888"
+        expect(page).not_to have_content local_census_record.document_number
+      end
+    end
+  end
+end

--- a/spec/features/admin/local_census_records_spec.rb
+++ b/spec/features/admin/local_census_records_spec.rb
@@ -133,4 +133,19 @@ feature "Admin local census records" do
       expect(page).to have_content "07007"
     end
   end
+
+  context "Destroy" do
+    let!(:local_census_record) { create(:local_census_record) }
+    let!(:deleted_document_number) { local_census_record.document_number }
+
+    scenario "Should show successful destroy notice" do
+      visit admin_local_census_records_path
+
+      expect(page).to have_content deleted_document_number
+      click_on "Delete"
+
+      expect(page).to have_content "Local census record removed successfully!"
+      expect(page).not_to have_content deleted_document_number
+    end
+  end
 end

--- a/spec/features/admin/local_census_records_spec.rb
+++ b/spec/features/admin/local_census_records_spec.rb
@@ -72,4 +72,33 @@ feature "Admin local census records" do
       end
     end
   end
+
+  context "Create" do
+    scenario "Should show validation errors" do
+      visit new_admin_local_census_record_path
+
+      click_on "Save"
+
+      expect(page).to have_content "4 errors prevented this Local Census Record from being saved."
+      expect(page).to have_content "can't be blank", count: 4
+    end
+
+    scenario "Should show successful notice after create valid record" do
+      visit new_admin_local_census_record_path
+
+      fill_in :local_census_record_document_type, with: "DNI"
+      fill_in :local_census_record_document_number, with: "#DOCUMENT"
+      select "1982" , from: :local_census_record_date_of_birth_1i
+      select "July" , from: :local_census_record_date_of_birth_2i
+      select "7" , from: :local_census_record_date_of_birth_3i
+      fill_in :local_census_record_postal_code, with: "07003"
+      click_on "Save"
+
+      expect(page).to have_content "New local census record created successfully!"
+      expect(page).to have_content "DNI"
+      expect(page).to have_content "#DOCUMENT"
+      expect(page).to have_content "1982-07-07"
+      expect(page).to have_content "07003"
+    end
+  end
 end

--- a/spec/features/admin/local_census_records_spec.rb
+++ b/spec/features/admin/local_census_records_spec.rb
@@ -101,4 +101,36 @@ feature "Admin local census records" do
       expect(page).to have_content "07003"
     end
   end
+
+  context "Update" do
+    let!(:local_census_record) { create(:local_census_record) }
+
+    scenario "Should show validation errors" do
+      visit edit_admin_local_census_record_path(local_census_record)
+
+      fill_in :local_census_record_document_number, with: ""
+      click_on "Save"
+
+      expect(page).to have_content "1 error prevented this Local Census Record from being saved."
+      expect(page).to have_content "can't be blank", count: 1
+    end
+
+    scenario "Should show successful notice after valid update" do
+      visit edit_admin_local_census_record_path(local_census_record)
+
+      fill_in :local_census_record_document_type, with: "NIE"
+      fill_in :local_census_record_document_number, with: "#NIE_NUMBER"
+      select "1982" , from: :local_census_record_date_of_birth_1i
+      select "August" , from: :local_census_record_date_of_birth_2i
+      select "8" , from: :local_census_record_date_of_birth_3i
+      fill_in :local_census_record_postal_code, with: "07007"
+      click_on "Save"
+
+      expect(page).to have_content "Local census record updated successfully!"
+      expect(page).to have_content "NIE"
+      expect(page).to have_content "#NIE_NUMBER"
+      expect(page).to have_content "1982-08-08"
+      expect(page).to have_content "07007"
+    end
+  end
 end

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -95,4 +95,6 @@ describe Abilities::Administrator do
 
   it { is_expected.to be_able_to :manage, Dashboard::AdministratorTask }
   it { is_expected.to be_able_to :manage, dashboard_administrator_task }
+
+  it { should be_able_to(:manage, LocalCensusRecord) }
 end

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -99,6 +99,8 @@ describe Abilities::Common do
   it { should_not be_able_to(:destroy, budget_investment_image) }
   it { should_not be_able_to(:manage, Dashboard::Action) }
 
+  it { should_not be_able_to(:manage, LocalCensusRecord) }
+
   describe "flagging content" do
     it { should be_able_to(:flag, debate)   }
     it { should be_able_to(:unflag, debate) }

--- a/spec/models/abilities/everyone_spec.rb
+++ b/spec/models/abilities/everyone_spec.rb
@@ -35,6 +35,7 @@ describe Abilities::Everyone do
   it { should be_able_to(:read_results, finished_budget) }
   it { should_not be_able_to(:read_results, reviewing_ballot_budget) }
   it { should_not be_able_to(:manage, Dashboard::Action) }
+  it { should_not be_able_to(:manage, LocalCensusRecord) }
 
   context "when accessing poll results" do
     let(:results_enabled) { true }

--- a/spec/models/local_census_record_spec.rb
+++ b/spec/models/local_census_record_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe LocalCensusRecord do
+  let(:local_census_record) { build(:local_census_record) }
+
+  context "validations" do
+    it "is valid" do
+      expect(local_census_record).to be_valid
+    end
+
+    it "is not valid without document_number" do
+      local_census_record.document_number = nil
+
+      expect(local_census_record).not_to be_valid
+    end
+
+    it "is not valid without document_type" do
+      local_census_record.document_type = nil
+
+      expect(local_census_record).not_to be_valid
+    end
+
+    it "is not valid without date_of_birth" do
+      local_census_record.date_of_birth = nil
+
+      expect(local_census_record).not_to be_valid
+    end
+
+    it "is not valid without postal_code" do
+      local_census_record.postal_code = nil
+
+      expect(local_census_record).not_to be_valid
+    end
+  end
+
+  context "scopes" do
+    let!(:a_local_census_record) { create(:local_census_record, document_number: "AAAA") }
+    let!(:b_local_census_record) { create(:local_census_record, document_number: "BBBB") }
+
+    context "search" do
+      it "filter document_numbers by given terms" do
+        expect(LocalCensusRecord.search("A")).to include a_local_census_record
+        expect(LocalCensusRecord.search("A")).not_to include b_local_census_record
+      end
+
+      it "ignores terms case" do
+        expect(LocalCensusRecord.search("a")).to eq [a_local_census_record]
+      end
+    end
+  end
+end

--- a/spec/models/local_census_record_spec.rb
+++ b/spec/models/local_census_record_spec.rb
@@ -32,6 +32,14 @@ describe LocalCensusRecord do
       expect(local_census_record).not_to be_valid
     end
 
+    it "is not valid when a record already exists with same document_number and document_type" do
+      create(:local_census_record, document_number: "#DOC_NUMBER", document_type: "#DOC_TYPE")
+      local_census_record = build(:local_census_record, document_number: "#DOC_NUMBER",
+        document_type: "#DOC_TYPE")
+
+      expect(local_census_record).not_to be_valid
+    end
+
     it "sanitizes text attributes values before validation" do
       local_census_record.document_type = " DNI "
       local_census_record.document_number = " #DOCUMENT_NUMBER "

--- a/spec/models/local_census_record_spec.rb
+++ b/spec/models/local_census_record_spec.rb
@@ -31,6 +31,18 @@ describe LocalCensusRecord do
 
       expect(local_census_record).not_to be_valid
     end
+
+    it "sanitizes text attributes values before validation" do
+      local_census_record.document_type = " DNI "
+      local_census_record.document_number = " #DOCUMENT_NUMBER "
+      local_census_record.postal_code = " 07007 "
+
+      local_census_record.valid?
+
+      expect(local_census_record.document_type).to eq "DNI"
+      expect(local_census_record.document_number).to eq "#DOCUMENT_NUMBER"
+      expect(local_census_record.postal_code).to eq "07007"
+    end
   end
 
   context "scopes" do


### PR DESCRIPTION
## References
Related Issues: #3478 

## Objectives
Provide a way to manage local census records to administrator users through administration interface.

The following was also done:
* **Search by document_number**: As local_census_records could contain a lot of records we have added and index on `document_number` column and an AJAX search feature to allow administrators to find existing records by `document_number`.
* **Avoid the introduction of dirty records**: Now a sanitization is called before running validations to clear surrounding whitespaces on text attributes.
* **Avoid the introduction of duplicated records**: A uniqueness database constraint and a model validation has been added to the following attributes pair  `[:document_number, :document_type]`

## Visual Changes
![local-census-crud-index](https://user-images.githubusercontent.com/15726/57443965-71476d00-724f-11e9-81ab-26c0b6ccb7a3.png)
![local-census-crud-new](https://user-images.githubusercontent.com/15726/57443967-71e00380-724f-11e9-96aa-55b9d56ea3fd.png)
![local-census-crud-edit](https://user-images.githubusercontent.com/15726/57443968-71e00380-724f-11e9-9de6-53e0fa08ba53.png)
![local-census-menu-entry](https://user-images.githubusercontent.com/15726/57443969-71e00380-724f-11e9-8a0b-617180e82a56.png)

## Release notes ⚠️

Before uploading this code to the server first you need to ensure you have no duplicate records in the `local_census_records` table. If so, you will need to remove duplicates first to be able to run new uniqueness constraint migration successfully.

Here you have a code sample to delete your duplicated records:
```
      ids = LocalCensusRecord.select("MIN(id) as id")
        .group(:document_type, :document_number).collect(&:id)

      LocalCensusRecord.where("id NOT IN (?)", ids).destroy_all
```