### PR TITLE
Fix obsolete `respond_with_bip` usage

### DIFF
--- a/app/controllers/dashboard/polls_controller.rb
+++ b/app/controllers/dashboard/polls_controller.rb
@@ -35,10 +35,10 @@ class Dashboard::PollsController < Dashboard::BaseController
       if poll.update(poll_params)
         format.html { redirect_to proposal_dashboard_polls_path(proposal),
                                   notice: t("flash.actions.update.poll") }
-        format.json { respond_with_bip(poll) }
+        format.json { head :no_content }
       else
         format.html { render :edit }
-        format.json { respond_with_bip(poll) }
+        format.json { render json: poll.errors.full_messages, status: :unprocessable_entity }
       end
     end
   end

--- a/spec/features/dashboard/polls_spec.rb
+++ b/spec/features/dashboard/polls_spec.rb
@@ -197,6 +197,19 @@ feature "Polls" do
     end
   end
 
+  scenario "Enable and disable results", :js do
+    create(:poll, related: proposal)
+
+    visit proposal_dashboard_polls_path(proposal)
+    check "Show results"
+
+    expect(find_field("Show results")).to be_checked
+
+    uncheck "Show results"
+
+    expect(find_field("Show results")).not_to be_checked
+  end
+
   scenario "Poll card" do
     poll = create(:poll, :expired, related: proposal)
 


### PR DESCRIPTION
## References

* Commit 80944178
* Backports AyuntamientoMadrid#1998


## Objectives

* Replace the method `respond_with_bip`, which belonged to a gem we removed
* Add tests checking the application behaves properly updating polls with AJAX requests