### PR TITLE
Fix typo in budget executions spec

### DIFF
--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -53,7 +53,7 @@ feature "Executions" do
     click_link "See results"
     click_link "Milestones"
 
-    expect(page).not_to have_content("No winner investments in this state")
+    expect(page).to have_content("No winner investments in this state")
 
     select "Executed (0)", from: "status"
 


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#2002
* Failure in [Madrid's build 11517, job 4](https://travis-ci.org/AyuntamientoMadrid/consul/jobs/530443103)

## Objectives

Fix a typo which made a test check the opposite of what we intended.

## Notes

The test passed (most of the time) because before clicking the "Milestones" link the content was not present, and we checked the page content before the AJAX request generated by clicking the link had finished.