### PR TITLE
Admin basic customization texts

### DIFF
--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -2,9 +2,8 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
   before_action :delete_translations, only: [:update]
 
   def index
-    fetch_existing_keys
-    append_or_create_keys
-    @content = @content[@tab.to_s]
+    @tab = params[:tab] || :debates
+    @content = I18nContent.content_for(@tab)
   end
 
   def update
@@ -47,29 +46,6 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
 
       languages_to_delete.each do |locale|
         I18nContentTranslation.where(locale: locale).destroy_all
-      end
-    end
-
-    def fetch_existing_keys
-      @existing_keys = {}
-      @tab = params[:tab] || :debates
-
-      I18nContent.begins_with_key(@tab).map { |content|
-        @existing_keys[content.key] = content
-      }
-    end
-
-    def append_or_create_keys
-      @content = {}
-      I18n.backend.send(:init_translations) unless I18n.backend.initialized?
-
-      locale = params[:locale] || I18n.locale
-      translations = I18n.backend.send(:translations)[locale.to_sym]
-
-      translations.each do |key, value|
-        @content[key.to_s] = I18nContent.flat_hash(value).keys.map { |string|
-          @existing_keys["#{key.to_s}.#{string}"] || I18nContent.new(key: "#{key.to_s}.#{string}")
-        }
       end
     end
 

--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -2,7 +2,7 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
   before_action :delete_translations, only: [:update]
 
   def index
-    @tab = params[:tab] || :debates
+    @tab = params[:tab] || :basic
     @content = I18nContent.content_for(@tab)
   end
 

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -17,4 +17,8 @@ module SiteCustomizationHelper
       false
     end
   end
+
+  def information_texts_tabs
+    [:basic, :debates, :community, :proposals, :polls, :layouts, :mailers, :management, :welcome]
+  end
 end

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -8,11 +8,9 @@ module SiteCustomizationHelper
   end
 
   def translation_for_locale(content, locale)
-    i18n_content = I18nContent.where(key: content.key).first
-
-    if i18n_content.present?
+    if content.present?
       I18nContentTranslation.where(
-        i18n_content_id: i18n_content.id,
+        i18n_content_id: content.id,
         locale: locale
       ).first.try(:value)
     else

--- a/app/models/i18n_content.rb
+++ b/app/models/i18n_content.rb
@@ -1,7 +1,6 @@
 class I18nContent < ApplicationRecord
 
   scope :by_key,          ->(key) { where(key: key) }
-  scope :begins_with_key, ->(key) { where("key ILIKE ?", "#{key}%") }
 
   validates :key, uniqueness: true
 
@@ -46,4 +45,17 @@ class I18nContent < ApplicationRecord
     return output
   end
 
+  def self.content_for(tab)
+    flat_hash(translations_for(tab)).keys.map do |string|
+      I18nContent.find_or_initialize_by(key: string)
+    end
+  end
+
+  def self.translations_for(tab)
+    I18n.backend.send(:init_translations) unless I18n.backend.initialized?
+
+    I18n.backend.send(:translations)[I18n.locale].select do |key, _translations|
+      key.to_s == tab.to_s
+    end
+  end
 end

--- a/app/models/i18n_content.rb
+++ b/app/models/i18n_content.rb
@@ -46,16 +46,54 @@ class I18nContent < ApplicationRecord
   end
 
   def self.content_for(tab)
-    flat_hash(translations_for(tab)).keys.map do |string|
+    translations_for(tab).map do |string|
       I18nContent.find_or_initialize_by(key: string)
     end
   end
 
   def self.translations_for(tab)
+    if tab.to_s == "basic"
+      basic_translations
+    else
+      flat_hash(translations_hash_for(tab)).keys
+    end
+  end
+
+  def self.translations_hash_for(tab)
     I18n.backend.send(:init_translations) unless I18n.backend.initialized?
 
     I18n.backend.send(:translations)[I18n.locale].select do |key, _translations|
       key.to_s == tab.to_s
     end
+  end
+
+  def self.basic_translations
+    %w[
+      debates.index.section_footer.title
+      debates.index.section_footer.description
+      debates.index.section_footer.help_text_1
+      debates.index.section_footer.help_text_2
+      debates.new.info
+      debates.new.info_link
+      debates.new.more_info
+      debates.new.recommendation_one
+      debates.new.recommendation_two
+      debates.new.recommendation_three
+      debates.new.recommendation_four
+      debates.new.recommendations_title
+      proposals.index.section_footer.title
+      proposals.index.section_footer.description
+      proposals.new.more_info
+      proposals.new.recommendation_one
+      proposals.new.recommendation_two
+      proposals.new.recommendation_three
+      proposals.new.recommendations_title
+      polls.index.section_footer.title
+      polls.index.section_footer.description
+      legislation.processes.index.section_footer.title
+      legislation.processes.index.section_footer.description
+      budgets.index.section_footer.title
+      budgets.index.section_footer.description
+    ]
   end
 end

--- a/app/views/admin/site_customization/information_texts/_tabs.html.erb
+++ b/app/views/admin/site_customization/information_texts/_tabs.html.erb
@@ -1,5 +1,5 @@
 <ul id="information-texts-tabs" class="tabs" >
-  <% [:debates, :community, :proposals, :polls, :layouts, :mailers, :management, :welcome].each do |tab| %>
+  <% information_texts_tabs.each do |tab| %>
     <li class="tabs-title">
       <% if tab.to_s == @tab %>
         <%= link_to t("admin.menu.site_customization.information_texts_menu.#{tab}"), admin_site_customization_information_texts_path(tab: tab), :class => "is-active" %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -703,6 +703,7 @@ en:
         content_blocks: Custom content blocks
         information_texts: Custom information texts
         information_texts_menu:
+          basic: "Basic customization"
           debates: "Debates"
           community: "Community"
           proposals: "Proposals"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -702,6 +702,7 @@ es:
         content_blocks: Personalizar bloques
         information_texts: Personalizar textos
         information_texts_menu:
+          basic: "Personalización básica"
           debates: "Debates"
           community: "Comunidad"
           proposals: "Propuestas"

--- a/spec/features/admin/site_customization/information_texts_spec.rb
+++ b/spec/features/admin/site_customization/information_texts_spec.rb
@@ -15,6 +15,13 @@ feature "Admin custom information texts" do
   scenario "page is correctly loaded" do
     visit admin_site_customization_information_texts_path
 
+    click_link "Basic customization"
+    expect(page).to have_content "Help about debates"
+    expect(page).to have_content "Help about proposals"
+    expect(page).to have_content "Help about voting"
+    expect(page).to have_content "Help about collaborative legislation"
+    expect(page).to have_content "Help with participatory budgets"
+
     click_link "Debates"
     expect(page).to have_content "Help about debates"
 
@@ -57,39 +64,40 @@ feature "Admin custom information texts" do
   context "Globalization" do
 
     scenario "Add a translation", :js do
-      key = "debates.form.debate_title"
+      key = "debates.index.section_footer.title"
 
       visit admin_site_customization_information_texts_path
 
       select "Français", from: "translation_locale"
-      fill_in "contents_content_#{key}values_value_fr", with: "Titre personalise du débat"
+      fill_in "contents[content_#{key}]values[value_fr]", with: "Aide personalise sur les débats"
 
       click_button "Save"
 
       expect(page).to have_content "Translation updated successfully"
 
-      select "Français", from: "translation_locale"
+      visit admin_site_customization_information_texts_path
 
-      expect(page).to have_content "Titre personalise du débat"
-      expect(page).not_to have_content "Titre du débat"
+      select "Français", from: "translation_locale"
+      expect(page).to have_content "Aide personalise sur les débats"
+      expect(page).not_to have_content "Aide sur les débats"
     end
 
     scenario "Update a translation", :js do
-      key = "debates.form.debate_title"
-      content = create(:i18n_content, key: key, value_fr: "Titre personalise du débat")
+      key = "proposals.form.proposal_title"
 
-      visit admin_site_customization_information_texts_path
+      visit admin_site_customization_information_texts_path(tab: "proposals")
 
       select "Français", from: "translation_locale"
-      fill_in "contents_content_#{key}values_value_fr", with: "Titre personalise again du débat"
+      fill_in "contents_content_#{key}values_value_fr", with: "Titre personalise de la proposition"
 
       click_button "Save"
       expect(page).to have_content "Translation updated successfully"
 
+      visit admin_site_customization_information_texts_path(tab: "proposals")
       click_link "Français"
 
-      expect(page).to have_content "Titre personalise again du débat"
-      expect(page).not_to have_content "Titre personalise du débat"
+      expect(page).to have_content "Titre personalise de la proposition"
+      expect(page).not_to have_content "Titre de la proposition"
     end
 
     scenario "Remove a translation", :js do
@@ -103,7 +111,7 @@ feature "Admin custom information texts" do
                                           value_en: "Custom debate text",
                                           value_es: "Texto personalizado de debate")
 
-      visit admin_site_customization_information_texts_path
+      visit admin_site_customization_information_texts_path(tab: "debates")
 
       click_link "Español"
       click_link "Remove language"
@@ -111,6 +119,7 @@ feature "Admin custom information texts" do
 
       expect(page).not_to have_link "Español"
 
+      visit admin_site_customization_information_texts_path(tab: "debates")
       click_link "English"
       expect(page).to have_content "Custom debate text"
       expect(page).to have_content "Custom debate title"

--- a/spec/features/site_customization/information_texts_spec.rb
+++ b/spec/features/site_customization/information_texts_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+feature "Custom information texts" do
+
+  scenario "Show custom texts instead of default ones" do
+    admin = create(:administrator)
+    login_as(admin.user)
+
+    debate_key = "debates.index.section_footer.title"
+    proposal_key = "proposals.index.section_footer.title"
+
+    visit admin_site_customization_information_texts_path(tab: "debates")
+    fill_in "contents[content_#{debate_key}]values[value_en]", with: "Custom help about debates"
+    click_button "Save"
+
+    visit admin_site_customization_information_texts_path(tab: "proposals")
+    fill_in "contents[content_#{proposal_key}]values[value_en]", with: "Custom help about proposals"
+    click_button "Save"
+
+    visit debates_path
+
+    within("#section_help") do
+      expect(page).to have_content "Custom help about debates"
+      expect(page).not_to have_content "Help about debates"
+    end
+
+    visit proposals_path
+
+    within("#section_help") do
+      expect(page).to have_content "Custom help about proposals"
+      expect(page).not_to have_content "Help about proposals"
+    end
+  end
+end

--- a/spec/models/i18n_content_spec.rb
+++ b/spec/models/i18n_content_spec.rb
@@ -27,20 +27,6 @@ RSpec.describe I18nContent, type: :model do
       expect(query.size).to eq(1)
       expect(query).to eq([debate_title])
     end
-
-    it "return all matching records when #begins_with_key is used" do
-      debate_text    = create(:i18n_content, key: "debates.form.debate_text")
-      debate_title   = create(:i18n_content, key: "debates.form.debate_title")
-      proposal_title = create(:i18n_content, key: "proposals.form.proposal_title")
-
-      expect(I18nContent.all.size).to eq(3)
-
-      query = I18nContent.begins_with_key("debates")
-
-      expect(query.size).to eq(2)
-      expect(query).to eq([debate_text, debate_title])
-      expect(query).not_to include(proposal_title)
-    end
   end
 
   context "Globalize" do


### PR DESCRIPTION
## Objectives

Create a new "Basic customization" tab on `/admin/site_customization/information_texts?tab=basic`. 

These texts are what most forks will change when they customize their CONSUL installation. 😌 

## Visual Changes

<img width="1669" alt="Screenshot 2019-05-10 at 17 27 12" src="https://user-images.githubusercontent.com/631897/57538557-f6627d00-7348-11e9-8adf-86ecaad74c98.png">