### PR TITLE
 Don't destroy budgets with an associated poll

### DIFF
--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -49,6 +49,8 @@ class Admin::BudgetsController < Admin::BaseController
   def destroy
     if @budget.investments.any?
       redirect_to admin_budgets_path, alert: t("admin.budgets.destroy.unable_notice")
+    elsif @budget.poll.present?
+      redirect_to admin_budgets_path, alert: t("admin.budgets.destroy.unable_notice_polls")
     else
       @budget.destroy
       redirect_to admin_budgets_path, notice: t("admin.budgets.destroy.success_notice")

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -107,6 +107,7 @@ en:
       destroy:
         success_notice: Budget deleted successfully
         unable_notice: You cannot destroy a budget that has associated investments
+        unable_notice_polls: You cannot destroy a budget that has an associated poll
       new:
         title: New participatory budget
       winners:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -106,7 +106,7 @@ en:
         blank_dates: Dates are blank
       destroy:
         success_notice: Budget deleted successfully
-        unable_notice: You cannot destroy a Budget that has associated investments
+        unable_notice: You cannot destroy a budget that has associated investments
       new:
         title: New participatory budget
       winners:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -107,6 +107,7 @@ es:
       destroy:
         success_notice: Presupuesto eliminado correctamente
         unable_notice: No se puede eliminar un presupuesto con proyectos asociados
+        unable_notice_polls: No se puede eliminar un presupuesto con una votación asociada
       new:
         title: Nuevo presupuesto ciudadano
       winners:

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -148,7 +148,7 @@ feature "Admin budgets" do
       click_link "Edit budget"
       click_link "Delete budget"
 
-      expect(page).to have_content("You cannot destroy a Budget that has associated investments")
+      expect(page).to have_content("You cannot destroy a budget that has associated investments")
       expect(page).to have_content("There is 1 budget")
     end
   end

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -151,6 +151,16 @@ feature "Admin budgets" do
       expect(page).to have_content("You cannot destroy a budget that has associated investments")
       expect(page).to have_content("There is 1 budget")
     end
+
+    scenario "Try to destroy a budget with polls" do
+      create(:poll, budget: budget)
+
+      visit edit_admin_budget_path(budget)
+      click_link "Delete budget"
+
+      expect(page).to have_content("You cannot destroy a budget that has an associated poll")
+      expect(page).to have_content("There is 1 budget")
+    end
   end
 
   context "Edit" do


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#2001

## Objectives

Fix an exception happening when trying to delete a budget which has a poll associated.