### PR TITLE
Add slug to polls

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -42,7 +42,7 @@ class PollsController < ApplicationController
   private
 
     def load_poll
-      @poll = Poll.find_by(slug: params[:id]) || Poll.find_by(id: params[:id])
+      @poll = Poll.where(slug: params[:id]).first || Poll.where(id: params[:id]).first
     end
 
     def load_active_poll

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,6 +1,7 @@
 class PollsController < ApplicationController
   include PollsHelper
 
+  before_action :load_poll, except: [:index]
   before_action :load_active_poll, only: :index
 
   load_and_authorize_resource
@@ -39,6 +40,10 @@ class PollsController < ApplicationController
   end
 
   private
+
+    def load_poll
+      @poll = Poll.find_by(slug: params[:id]) || Poll.find_by(id: params[:id])
+    end
 
     def load_active_poll
       @active_poll = ActivePoll.first

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -5,6 +5,7 @@ class Poll < ApplicationRecord
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
   include Notifiable
+  include Sluggable
 
   translates :name,        touch: true
   translates :summary,     touch: true
@@ -127,6 +128,10 @@ class Poll < ApplicationRecord
     unless starts_at.present? && ends_at.present? && starts_at <= ends_at
       errors.add(:starts_at, I18n.t("errors.messages.invalid_date_range"))
     end
+  end
+
+  def generate_slug?
+    slug.nil?
   end
 
   def only_one_active

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -49,7 +49,7 @@
             <% elsif poll.stats_enabled? %>
                 <%= link_to poll.name, stats_poll_path(poll) %>
             <% else %>
-              <%= link_to poll.name, poll_path(id: poll.slug) %>
+              <%= link_to poll.name, poll_path(id: poll.slug || poll.id) %>
             <% end %>
           </h4>
           <%= poll_dates(poll) %>
@@ -72,7 +72,7 @@
       </div>
       <div class="small-12 medium-3 column table" data-equalizer-watch>
         <div class="table-cell align-middle">
-          <%= link_to poll_path(id: poll.slug), class: "button hollow expanded" do %>
+          <%= link_to poll_path(id: poll.slug || poll.id), class: "button hollow expanded" do %>
             <% if poll.expired? %>
               <%= t("polls.index.participate_button_expired") %>
             <% else %>

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -49,7 +49,7 @@
             <% elsif poll.stats_enabled? %>
                 <%= link_to poll.name, stats_poll_path(poll) %>
             <% else %>
-              <%= link_to poll.name, poll %>
+              <%= link_to poll.name, poll_path(poll.slug) %>
             <% end %>
           </h4>
           <%= poll_dates(poll) %>
@@ -72,7 +72,7 @@
       </div>
       <div class="small-12 medium-3 column table" data-equalizer-watch>
         <div class="table-cell align-middle">
-          <%= link_to poll, class: "button hollow expanded" do %>
+          <%= link_to poll_path(poll.slug), class: "button hollow expanded" do %>
             <% if poll.expired? %>
               <%= t("polls.index.participate_button_expired") %>
             <% else %>

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -49,7 +49,7 @@
             <% elsif poll.stats_enabled? %>
                 <%= link_to poll.name, stats_poll_path(poll) %>
             <% else %>
-              <%= link_to poll.name, poll_path(poll.slug) %>
+              <%= link_to poll.name, poll_path(id: poll.slug) %>
             <% end %>
           </h4>
           <%= poll_dates(poll) %>
@@ -72,7 +72,7 @@
       </div>
       <div class="small-12 medium-3 column table" data-equalizer-watch>
         <div class="table-cell align-middle">
-          <%= link_to poll_path(poll.slug), class: "button hollow expanded" do %>
+          <%= link_to poll_path(id: poll.slug), class: "button hollow expanded" do %>
             <% if poll.expired? %>
               <%= t("polls.index.participate_button_expired") %>
             <% else %>

--- a/app/views/polls/_poll_subnav.html.erb
+++ b/app/views/polls/_poll_subnav.html.erb
@@ -8,7 +8,7 @@
               <h2><%= t("polls.show.results_menu") %></h2>
             </li>
           <% else %>
-            <li><%= link_to t("polls.show.results_menu"), results_poll_path(id: @poll.slug) %></li>
+            <li><%= link_to t("polls.show.results_menu"), results_poll_path(id: @poll.slug || @poll.id) %></li>
           <% end %>
         <% end %>
 
@@ -18,7 +18,7 @@
               <h2><%= t("polls.show.stats_menu") %></h2>
             </li>
           <% else %>
-            <li><%= link_to t("polls.show.stats_menu"), stats_poll_path(id: @poll.slug) %></li>
+            <li><%= link_to t("polls.show.stats_menu"), stats_poll_path(id: @poll.slug || @poll.id) %></li>
           <% end %>
         <% end %>
 
@@ -27,7 +27,7 @@
             <h2><%= t("polls.show.info_menu") %></h2>
           </li>
         <% else %>
-          <li><%= link_to t("polls.show.info_menu"), poll_path(id: @poll.slug) %></li>
+          <li><%= link_to t("polls.show.info_menu"), poll_path(id: @poll.slug || @poll.id) %></li>
         <% end %>
       </ul>
     </div>

--- a/app/views/polls/_poll_subnav.html.erb
+++ b/app/views/polls/_poll_subnav.html.erb
@@ -8,7 +8,7 @@
               <h2><%= t("polls.show.results_menu") %></h2>
             </li>
           <% else %>
-            <li><%= link_to t("polls.show.results_menu"), results_poll_path(@poll) %></li>
+            <li><%= link_to t("polls.show.results_menu"), results_poll_path(id: @poll.slug) %></li>
           <% end %>
         <% end %>
 
@@ -18,7 +18,7 @@
               <h2><%= t("polls.show.stats_menu") %></h2>
             </li>
           <% else %>
-            <li><%= link_to t("polls.show.stats_menu"), stats_poll_path(@poll) %></li>
+            <li><%= link_to t("polls.show.stats_menu"), stats_poll_path(id: @poll.slug) %></li>
           <% end %>
         <% end %>
 
@@ -27,7 +27,7 @@
             <h2><%= t("polls.show.info_menu") %></h2>
           </li>
         <% else %>
-          <li><%= link_to t("polls.show.info_menu"), poll_path(@poll) %></li>
+          <li><%= link_to t("polls.show.info_menu"), poll_path(id: @poll.slug) %></li>
         <% end %>
       </ul>
     </div>

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -4,25 +4,31 @@ require_dependency "poll/question/answer"
 section "Creating polls" do
 
   Poll.create(name: I18n.t("seeds.polls.current_poll"),
+              slug: I18n.t("seeds.polls.current_poll").parameterize,
               starts_at: 7.days.ago,
               ends_at:   7.days.from_now,
               geozone_restricted: false)
 
   Poll.create(name: I18n.t("seeds.polls.current_poll_geozone_restricted"),
+              slug: I18n.t("seeds.polls.current_poll_geozone_restricted").parameterize,
               starts_at: 5.days.ago,
               ends_at:   5.days.from_now,
               geozone_restricted: true,
               geozones: Geozone.reorder("RANDOM()").limit(3))
 
   Poll.create(name: I18n.t("seeds.polls.recounting_poll"),
+              slug: I18n.t("seeds.polls.recounting_poll").parameterize,
               starts_at: 15.days.ago,
               ends_at:   2.days.ago)
 
   Poll.create(name: I18n.t("seeds.polls.expired_poll_without_stats"),
+              slug: I18n.t("seeds.polls.expired_poll_without_stats").parameterize,
+
               starts_at: 2.months.ago,
               ends_at:   1.month.ago)
 
   Poll.create(name: I18n.t("seeds.polls.expired_poll_with_stats"),
+              slug: I18n.t("seeds.polls.expired_poll_with_stats").parameterize,
               starts_at: 2.months.ago,
               ends_at:   1.month.ago,
               results_enabled: true,

--- a/db/migrate/20171008154106_add_slug_to_polls.rb
+++ b/db/migrate/20171008154106_add_slug_to_polls.rb
@@ -1,0 +1,5 @@
+class AddSlugToPolls < ActiveRecord::Migration
+  def change
+    add_column :polls, :slug, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1127,6 +1127,7 @@ ActiveRecord::Schema.define(version: 20190411090023) do
     t.integer  "comments_count",     default: 0
     t.integer  "author_id"
     t.datetime "hidden_at"
+    t.string   "slug"
     t.boolean  "results_enabled",    default: false
     t.boolean  "stats_enabled",      default: false
     t.datetime "created_at"

--- a/lib/tasks/polls.rake
+++ b/lib/tasks/polls.rake
@@ -1,0 +1,8 @@
+namespace :poll do
+  desc "Generate slugs polls"
+  task generate_slugs: :environment do
+    Poll.find_each do |poll|
+      poll.update_columns(slug: poll.generate_slug, updated_at: Time.current) if poll.generate_slug?
+    end
+  end
+end

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :poll do
     sequence(:name) { |n| "Poll #{SecureRandom.hex}" }
 
+    slug "this-is-a-slug"
+
     starts_at { 1.month.ago }
     ends_at { 1.month.from_now }
 

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -75,6 +75,7 @@ feature "Admin polls" do
     expect(page).to have_content "Upcoming poll"
     expect(page).to have_content I18n.l(start_date.to_date)
     expect(page).to have_content I18n.l(end_date.to_date)
+    expect(Poll.last.slug).to eq "#{Poll.last.name.to_s.parameterize}"
   end
 
   scenario "Edit" do

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -130,6 +130,16 @@ feature "Polls" do
     let(:geozone) { create(:geozone) }
     let(:poll) { create(:poll, summary: "Summary", description: "Description") }
 
+    scenario "Visit path with id" do
+      visit poll_path(poll.id)
+      expect(page).to have_current_path(poll_path(poll.id))
+    end
+
+    scenario "Visit path with slug" do
+      visit poll_path(poll.slug)
+      expect(page).to have_current_path(poll_path(poll.slug))
+    end
+
     scenario "Show answers with videos" do
       question = create(:poll_question, poll: poll)
       answer = create(:poll_question_answer, question: question, title: "Chewbacca")

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -492,5 +492,20 @@ feature "Polls" do
       expect(page).not_to have_content("Poll results")
       expect(page).not_to have_content("Participation statistics")
     end
+
+    scenario "Generates navigation links for polls without a slug" do
+      poll = create(:poll, :expired, results_enabled: true, stats_enabled: true)
+      poll.update_column(:slug, nil)
+
+      visit poll_path(poll)
+
+      expect(page).to have_link "Participation statistics"
+      expect(page).to have_link "Poll results"
+
+      click_link "Poll results"
+
+      expect(page).to have_link "Information"
+    end
+
   end
 end


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#919
* Backports commits AyuntamientoMadrid@ecf95c4ea and AyuntamientoMadrid@88264bd9 from AyuntamientoMadrid#942
* Backport commit AyuntamientoMadrid@4366fb2a from AyuntamientoMadrid#972
* Backport AyuntamientoMadrid#1560

## Objectives

* Add slug to poll to use as param in poll URLs

## Release notes

To generate slugs for existing polls, run:

```
bin/rake poll:generate_slugs RAILS_ENV=production
```