### PR TITLE
Remove redirect for poll officers

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,9 +3,7 @@ class Users::SessionsController < Devise::SessionsController
   private
 
     def after_sign_in_path_for(resource)
-      if current_user.poll_officer?
-        new_officing_booth_path
-      elsif !verifying_via_email? && resource.show_welcome_screen?
+      if !verifying_via_email? && resource.show_welcome_screen?
         welcome_path
       else
         super


### PR DESCRIPTION
## Objectives

Remove redirect for poll officers. When a user have an "Officer" role the page was redirecting to `/officing` and it was a little confusing.
