### PR TITLE
Add historic fields to participatory budget

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -86,6 +86,7 @@
 //= require settings
 //= require cookies
 //= require columns_selector
+//= require budget_edit_associations.js.coffee
 
 var initialize_modules = function() {
   App.Answers.initialize();
@@ -138,6 +139,7 @@ var initialize_modules = function() {
   App.Cookies.initialize();
   if ( $('#js-columns-selector').length )
     App.ColumnsSelector.initialize();
+  App.BudgetEditAssociations.initialize();
 };
 
 $(function(){

--- a/app/assets/javascripts/budget_edit_associations.js.coffee
+++ b/app/assets/javascripts/budget_edit_associations.js.coffee
@@ -1,0 +1,25 @@
+App.BudgetEditAssociations =
+
+  set_text: (response)->
+    $(".js-budget-show-administrators-list").text(response["administrators"])
+    $(".js-budget-show-valuators-list").text(response["valuators"])
+    $(".js-budget-show-trackers-list").text(response["trackers"])
+
+  initialize: ->
+    $(".js-budget-list-checkbox-user").on
+      click: ->
+        admin_count = $(".js-budget-list-checkbox-administrators:checkbox:checked").length
+        valuator_count = $(".js-budget-list-checkbox-valuators:checkbox:checked").length
+        tracker_count = $(".js-budget-list-checkbox-trackers:checkbox:checked").length
+        budget = $(".js-budget-id").attr("id")
+        url = "/admin/budgets/" + budget + "/assigned_users_translation.json"
+        params = {administrators: admin_count, valuators: valuator_count, trackers: tracker_count}
+        $.get(url, params, (response) -> App.BudgetEditAssociations.set_text response, "json")
+
+    $(".js-budget-show-users-list").on
+      click: ->
+        div_id = $(this).data().toggle
+        for list in $(".js-budget-users-list")
+          do ->
+            if (list.id != div_id)
+              $(list).addClass("is-hidden") if !$(list).hasClass("is-hidden")

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -102,15 +102,17 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_admins
-      @admins = Administrator.includes(:user).all
+      @admins = @budget.administrators.includes(:user).all
     end
 
     def load_trackers
-      @trackers = Tracker.includes(:user).all.order(description: :asc).order("users.email ASC")
+      @trackers = @budget.trackers.includes(:user).all.order(description: :asc)
+                    .order("users.email ASC")
     end
 
     def load_valuators
-      @valuators = Valuator.includes(:user).all.order(description: :asc).order("users.email ASC")
+      @valuators = @budget.valuators.includes(:user).all.order(description: :asc)
+                     .order("users.email ASC")
     end
 
     def load_valuator_groups

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -54,7 +54,15 @@ module BudgetsHelper
   end
 
   def investment_tags_select_options(budget)
-    Budget::Investment.by_budget(budget).tags_on(:valuation).order(:name).select(:name).distinct
+    tags = Budget::Investment.by_budget(budget).tags_on(:valuation).order(:name).pluck(:name)
+    tags = tags.concat budget.budget_valuation_tags.split(",") if budget.budget_valuation_tags.present?
+    tags.uniq
+  end
+
+  def investment_milestone_tags_select_options(budget)
+    tags = Budget::Investment.by_budget(budget).tags_on(:milestone).order(:name).pluck(:name)
+    tags = tags.concat budget.budget_milestone_tags.split(",") if budget.budget_milestone_tags.present?
+    tags.uniq
   end
 
   def unfeasible_or_unselected_filter

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -1,6 +1,7 @@
 module TranslatableFormHelper
   def translatable_form_for(record, options = {})
-    form_for(record, options.merge(builder: TranslatableFormBuilder)) do |f|
+    options_full = options.merge(builder: TranslatableFormBuilder)
+    form_for(record, options_full) do |f|
       yield(f)
     end
   end

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -59,7 +59,7 @@ module Abilities
 
       can :manage, Dashboard::Action
 
-      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget
+      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners, :assigned_users_translation], Budget
       can [:read, :create, :update, :destroy], Budget::Group
       can [:read, :create, :update, :destroy], Budget::Heading
       can [:hide, :update, :toggle_selection], Budget::Investment

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -35,6 +35,12 @@ class Budget < ApplicationRecord
   has_many :headings, through: :groups
   has_many :lines, through: :ballots, class_name: "Budget::Ballot::Line"
   has_many :phases, class_name: "Budget::Phase"
+  has_many :budget_trackers
+  has_many :trackers, through: :budget_trackers
+  has_many :budget_administrators
+  has_many :administrators, through: :budget_administrators
+  has_many :budget_valuators
+  has_many :valuators, through: :budget_valuators
 
   has_one :poll
 
@@ -224,4 +230,5 @@ class Budget < ApplicationRecord
   def generate_slug?
     slug.nil? || drafting?
   end
+
 end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -97,7 +97,8 @@ class Budget
     scope :by_admin,          ->(admin_id)    { where(administrator_id: admin_id) }
     scope :by_tag,            ->(tag_name)    { tagged_with(tag_name) }
     scope :by_valuator,       ->(valuator_id) { where("budget_valuator_assignments.valuator_id = ?", valuator_id).joins(:valuator_assignments) }
-    scope :by_tracker,        ->(tracker_id) { where("budget_tracker_assignments.tracker_id = ?", tracker_id).joins(:tracker_assignments) }
+    scope :by_tracker,        ->(tracker_id) { where("budget_tracker_assignments.tracker_id = ?",
+                                                     tracker_id).joins(:tracker_assignments) }
     scope :by_valuator_group, ->(valuator_group_id) { where("budget_valuator_group_assignments.valuator_group_id = ?", valuator_group_id).joins(:valuator_group_assignments) }
 
     scope :for_render, -> { includes(:heading) }
@@ -130,6 +131,7 @@ class Budget
                               params[:max_total_supports])                 if params[:max_total_supports].present?
       results = results.where(group_id: params[:group_id])                 if params[:group_id].present?
       results = results.by_tag(params[:tag_name])                          if params[:tag_name].present?
+      results = results.by_tag(params[:milestone_tag_name])                if params[:milestone_tag_name].present?
       results = results.by_heading(params[:heading_id])                    if params[:heading_id].present?
       results = results.by_valuator(params[:valuator_id])                  if params[:valuator_id].present?
       results = results.by_valuator_group(params[:valuator_group_id])      if params[:valuator_group_id].present?

--- a/app/models/budget_administrator.rb
+++ b/app/models/budget_administrator.rb
@@ -1,0 +1,5 @@
+
+class BudgetAdministrator < ApplicationRecord
+  belongs_to :budget
+  belongs_to :administrator
+end

--- a/app/models/budget_rol_assignment.rb
+++ b/app/models/budget_rol_assignment.rb
@@ -1,0 +1,4 @@
+class BudgetRolAssignment < ApplicationRecord
+  belongs_to :budget
+  belongs_to :user
+end

--- a/app/models/budget_tracker.rb
+++ b/app/models/budget_tracker.rb
@@ -1,0 +1,4 @@
+class BudgetTracker < ApplicationRecord
+  belongs_to :budget
+  belongs_to :tracker
+end

--- a/app/models/budget_valuator.rb
+++ b/app/models/budget_valuator.rb
@@ -1,0 +1,4 @@
+class BudgetValuator < ApplicationRecord
+  belongs_to :budget
+  belongs_to :valuator
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,8 @@ class User < ApplicationRecord
   has_many :direct_messages_received, class_name: "DirectMessage", foreign_key: :receiver_id
   has_many :legislation_answers, class_name: "Legislation::Answer", dependent: :destroy, inverse_of: :user
   has_many :follows
+  has_many :budget_rol_assignments
+  has_many :budgets, through: :budget_rol_assignments
   belongs_to :geozone
 
   validates :username, presence: true, if: :username_required?

--- a/app/views/admin/budget_investments/_search_form.html.erb
+++ b/app/views/admin/budget_investments/_search_form.html.erb
@@ -57,6 +57,13 @@
                      label: false} %>
   </div>
 
+  <div class="small-12 medium-3 column">
+    <%= select_tag :milestone_tag_name,
+                   options_for_select(investment_milestone_tags_select_options(@budget), params[:milestone_tag_name]),
+                   { prompt: t("admin.budget_investments.index.milestone_tags_filter_all"),
+                     label: false} %>
+  </div>
+
   <div class="small-12 medium-6 column">
     <div class="input-group">
       <%= text_field_tag :title_or_id, params["title_or_id"], placeholder: t("admin.budget_investments.index.placeholder") %>

--- a/app/views/admin/budgets/_association.html.erb
+++ b/app/views/admin/budgets/_association.html.erb
@@ -1,0 +1,25 @@
+<div class="secondary callout is-hidden js-budget-users-list small-12" data-toggler="is-hidden" data-closable id="<%= assignable_type %>_list">
+  <% if assignables.nil? || assignables.empty? %>
+    <p><%= t("admin.budgets.edit.empty_#{assignable_type}") %></p>
+  <% else %>
+    <h3><%= t("admin.budgets.edit.#{assignable_type}", count: 0) %></h3>
+    <table class="table-for-mobile">
+      <thead>
+      <tr>
+        <th class="small-8"><%= t("admin.budgets.edit.name") %></th>
+        <th class="small-4"><%= t("admin.budgets.edit.selected") %></th>
+      </tr>
+      </thead>
+      <tbody>
+      <% assignables.each do |assignable| %>
+        <tr>
+          <td class="small-8"><%= assignable.name %></td>
+          <td class="small-4 text-center">
+            <input type="checkbox" id="<%= assignable_type.singularize %>_<%= assignable.user.id %>" name="budget[<%= assignable_type.singularize %>_ids][]" value="<%= assignable.id %>" <%= "checked" if @budget.send(assignable_type).include? assignable %> class="js-budget-list-checkbox-<%= assignable_type %> js-budget-list-checkbox-user">
+          </td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</div>

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -2,6 +2,8 @@
 
 <%= translatable_form_for [:admin, @budget] do |f| %>
 
+  <div class="js-budget-id" id="<%= @budget.id %>"></div>
+
   <%= render "shared/errors", resource: @budget %>
 
   <div class="small-12 medium-9 column">
@@ -19,6 +21,39 @@
     </div>
     <div class="small-12 medium-3 column end">
       <%= f.select :currency_symbol, budget_currency_symbol_select_options %>
+    </div>
+  </div>
+
+  <div class="margin-top">
+    <div class="small-12 medium-4 column end">
+      <a id="administrators_button" class="button expanded hollow js-budget-show-users-list js-budget-show-administrators-list" data-toggle="administrators_list"><%= t("admin.budgets.edit.administrators", count: @budget.administrators.count) %>
+      </a>
+    </div>
+    <div class="small-12 medium-4 column end">
+      <a id="valuators_button" class="button expanded hollow js-budget-show-users-list js-budget-show-valuators-list" data-toggle="valuators_list"><%= t("admin.budgets.edit.valuators", count: @budget.valuators.count) %>
+      </a>
+    </div>
+    <div class="small-12 medium-4 column end">
+      <a id="trackers_button" class="button expanded hollow js-budget-show-users-list js-budget-show-trackers-list" data-toggle="trackers_list"><%= t("admin.budgets.edit.trackers", count: @budget.trackers.count) %>
+      </a>
+    </div>
+  </div>
+
+  <div class="margin-top">
+      <%= render "/admin/budgets/association", assignable_type: "administrators", assignables: @admins, budget: @budget %>
+      <%= render "/admin/budgets/association", assignable_type: "valuators", assignables: @valuators, budget: @budget %>
+      <%= render "/admin/budgets/association", assignable_type: "trackers", assignables: @trackers, budget: @budget %>
+  </div>
+
+  <div class="margin-top">
+    <div class="small-12 medium-9 column end">
+      <%= f.text_field :budget_milestone_tags, placeholder: t("admin.budget_investments.edit.tags_placeholder") %>
+    </div>
+    <div class="small-12 medium-9 column end">
+      <%= f.text_field :budget_valuation_tags, placeholder: t("admin.budget_investments.edit.tags_placeholder") %>
+    </div>
+    <div class="small-12 medium-9 column end">
+      <%= f.text_field :help_link %>
     </div>
   </div>
 
@@ -95,5 +130,4 @@
       <% end %>
     </div>
   </div>
-
 <% end %>

--- a/app/views/admin/trackers/edit.html.erb
+++ b/app/views/admin/trackers/edit.html.erb
@@ -13,4 +13,3 @@
     <%= f.submit t("admin.trackers.form.update"), class: "button success" %>
   <% end %>
 </div>
-

--- a/app/views/tracking/budget_investments/edit.html.erb
+++ b/app/views/tracking/budget_investments/edit.html.erb
@@ -1,6 +1,6 @@
 <%= link_to tracking_budget_budget_investment_path(@budget, @investment), class: "back" do %>
   <span class="icon-angle-left"></span>
-  <%= "#{t("tracking.budget_investments.show.title")} #{@investment.id}"%>
+  <%= "#{t("tracking.budget_investments.show.title")} #{@investment.id}" %>
 <% end %>
 
 <br>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -137,6 +137,9 @@ en:
         description_finished: "Description when the budget is finished"
         phase: "Phase"
         currency_symbol: "Currency"
+        budget_milestone_tags: "Milestone tags"
+        budget_valuation_tags: "Valuation tags"
+        help_link: "Help link"
       budget/investment:
         heading_id: "Heading"
         title: "Title"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -104,6 +104,25 @@ en:
         edit_phase: Edit phase
         active: Active
         blank_dates: Dates are blank
+        administrators:
+          zero: "Select administrators"
+          one: "1 administrator selected"
+          other: "%{count} administrators selected"
+        valuators:
+          zero: "Select valuators"
+          one: "1 valuator selected"
+          other: "%{count} valuators selected"
+        trackers:
+          zero: "Select trackers"
+          one: "1 tracker selected"
+          other: "%{count} trackers selected"
+        empty_administrators: "There are no administrators"
+        empty_valuators: "There are no valuators"
+        empty_trackers: "There are no trackers"
+        name: "Name"
+        selected: "Selected"
+        cancel: "Cancel"
+        save: "Save"
       destroy:
         success_notice: Budget deleted successfully
         unable_notice: You cannot delete a budget that has associated investments
@@ -232,6 +251,7 @@ en:
           author: Author
         cannot_calculate_winners: The budget has to stay on phase "Balloting projects", "Reviewing Ballots" or "Finished budget" in order to calculate winners projects
         see_results: "See results"
+        milestone_tags_filter_all: "All milestone tags"
       show:
         assigned_admin: Assigned administrator
         assigned_valuators: Assigned valuators

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -139,6 +139,9 @@ es:
         description_finished: "Descripción cuando el presupuesto ha finalizado / Resultados"
         phase: "Fase"
         currency_symbol: "Divisa"
+        budget_milestone_tags: "Etiquetas de seguimiento"
+        budget_valuation_tags: "Etiquetas de evaluación"
+        help_link: "Enlace de ayuda"
       budget/investment:
         heading_id: "Partida presupuestaria"
         title: "Título"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -104,6 +104,25 @@ es:
         edit_phase: Editar fase
         active: Activa
         blank_dates: Sin fechas
+        administrators:
+          zero: "Seleccionar administradores"
+          one: "1 administrador seleccionado"
+          other: "%{count} administradores seleccionados"
+        valuators:
+          zero: "Seleccionar evaluadores"
+          one: "1 evaluador seleccionado"
+          other: "%{count} evaluadores seleccionados"
+        trackers:
+          zero: "Seleccionar gestores de seguimiento"
+          one: "1 gestor de seguimiento seleccionado"
+          other: "%{count} gestores de seguimiento seleccionados"
+        empty_administrators: "No hay administradores"
+        empty_valuators: "No hay evaluadores"
+        empty_trackers: "No hay gestores de seguimiento"
+        name: "Nombre"
+        selected: "Seleccionado"
+        cancel: "Cancelar"
+        save: "Guardar"
       destroy:
         success_notice: Presupuesto eliminado correctamente
         unable_notice: No se puede eliminar un presupuesto con proyectos asociados
@@ -232,6 +251,7 @@ es:
           author: Autor
         cannot_calculate_winners: El presupuesto debe estar en las fases "Votación final", "Votación finalizada" o "Resultados" para poder calcular las propuestas ganadoras
         see_results: "Ver resultados"
+        milestone_tags_filter_all: "Todas las etiquetas de seguimiento"
       show:
         assigned_admin: Administrador asignado
         assigned_valuators: Evaluadores asignados

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -54,6 +54,7 @@ namespace :admin do
   resources :budgets do
     member do
       put :calculate_winners
+      get :assigned_users_translation
     end
 
     resources :groups, except: [:show], controller: "budget_groups" do
@@ -65,6 +66,7 @@ namespace :admin do
     end
 
     resources :budget_phases, only: [:edit, :update]
+
   end
 
   resources :milestone_statuses, only: [:index, :new, :create, :update, :edit, :destroy]
@@ -252,5 +254,4 @@ namespace :admin do
   put 'download_settings/:resource', to: 'download_settings#update', as: 'update_download_settings'
 
   get "/change_log/:id", to: "budget_investments#show_investment_log", as: "change_log"
-
 end

--- a/db/migrate/20190509134133_create_budget_rol_assignments.rb
+++ b/db/migrate/20190509134133_create_budget_rol_assignments.rb
@@ -1,0 +1,11 @@
+class CreateBudgetRolAssignments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :budget_rol_assignments do |t|
+      t.references :budget, foreign_key: true
+      t.references :user, foreign_key: true
+      t.string :rol
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190513134902_create_budget_trackers.rb
+++ b/db/migrate/20190513134902_create_budget_trackers.rb
@@ -1,0 +1,10 @@
+class CreateBudgetTrackers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :budget_trackers do |t|
+      t.references :budget, foreign_key: true
+      t.references :tracker, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190513135051_create_budget_administrators.rb
+++ b/db/migrate/20190513135051_create_budget_administrators.rb
@@ -1,0 +1,10 @@
+class CreateBudgetAdministrators < ActiveRecord::Migration[5.0]
+  def change
+    create_table :budget_administrators do |t|
+      t.references :budget, foreign_key: true
+      t.references :administrator, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190513135149_create_budget_valuators.rb
+++ b/db/migrate/20190513135149_create_budget_valuators.rb
@@ -1,0 +1,10 @@
+class CreateBudgetValuators < ActiveRecord::Migration[5.0]
+  def change
+    create_table :budget_valuators do |t|
+      t.references :budget, foreign_key: true
+      t.references :valuator, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190516091051_add_help_link_to_budgets.rb
+++ b/db/migrate/20190516091051_add_help_link_to_budgets.rb
@@ -1,0 +1,7 @@
+class AddHelpLinkToBudgets < ActiveRecord::Migration[5.0]
+  def change
+    add_column :budgets, :help_link, :string
+    add_column :budgets, :budget_milestone_tags,:string
+    add_column :budgets, :budget_valuation_tags,:string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -116,6 +116,15 @@ ActiveRecord::Schema.define(version: 20190607160900) do
     t.index ["hidden_at"], name: "index_banners_on_hidden_at", using: :btree
   end
 
+  create_table "budget_administrators", force: :cascade do |t|
+    t.integer  "budget_id"
+    t.integer  "administrator_id"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.index ["administrator_id"], name: "index_budget_administrators_on_administrator_id", using: :btree
+    t.index ["budget_id"], name: "index_budget_administrators_on_budget_id", using: :btree
+  end
+
   create_table "budget_ballot_lines", force: :cascade do |t|
     t.integer  "ballot_id"
     t.integer  "investment_id"
@@ -134,9 +143,9 @@ ActiveRecord::Schema.define(version: 20190607160900) do
     t.integer  "budget_id"
     t.datetime "created_at",                         null: false
     t.datetime "updated_at",                         null: false
+    t.integer  "ballot_lines_count", default: 0
     t.boolean  "physical",           default: false
     t.integer  "poll_ballot_id"
-    t.integer  "ballot_lines_count", default: 0
   end
 
   create_table "budget_content_blocks", force: :cascade do |t|
@@ -311,6 +320,16 @@ ActiveRecord::Schema.define(version: 20190607160900) do
     t.datetime "updated_at",    null: false
   end
 
+  create_table "budget_rol_assignments", force: :cascade do |t|
+    t.integer  "budget_id"
+    t.integer  "user_id"
+    t.string   "rol"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["budget_id"], name: "index_budget_rol_assignments_on_budget_id", using: :btree
+    t.index ["user_id"], name: "index_budget_rol_assignments_on_user_id", using: :btree
+  end
+
   create_table "budget_tracker_assignments", force: :cascade do |t|
     t.integer  "tracker_id"
     t.integer  "investment_id"
@@ -318,6 +337,15 @@ ActiveRecord::Schema.define(version: 20190607160900) do
     t.datetime "updated_at",    null: false
     t.index ["investment_id"], name: "index_budget_tracker_assignments_on_investment_id", using: :btree
     t.index ["tracker_id"], name: "index_budget_tracker_assignments_on_tracker_id", using: :btree
+  end
+
+  create_table "budget_trackers", force: :cascade do |t|
+    t.integer  "budget_id"
+    t.integer  "tracker_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["budget_id"], name: "index_budget_trackers_on_budget_id", using: :btree
+    t.index ["tracker_id"], name: "index_budget_trackers_on_tracker_id", using: :btree
   end
 
   create_table "budget_translations", force: :cascade do |t|
@@ -343,6 +371,15 @@ ActiveRecord::Schema.define(version: 20190607160900) do
     t.integer "investment_id"
   end
 
+  create_table "budget_valuators", force: :cascade do |t|
+    t.integer  "budget_id"
+    t.integer  "valuator_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["budget_id"], name: "index_budget_valuators_on_budget_id", using: :btree
+    t.index ["valuator_id"], name: "index_budget_valuators_on_valuator_id", using: :btree
+  end
+
   create_table "budgets", force: :cascade do |t|
     t.string   "name",                          limit: 80
     t.string   "currency_symbol",               limit: 10
@@ -360,6 +397,9 @@ ActiveRecord::Schema.define(version: 20190607160900) do
     t.text     "description_drafting"
     t.text     "description_publishing_prices"
     t.text     "description_informing"
+    t.string   "help_link"
+    t.string   "budget_milestone_tags"
+    t.string   "budget_valuation_tags"
   end
 
   create_table "campaigns", force: :cascade do |t|
@@ -1197,12 +1237,12 @@ ActiveRecord::Schema.define(version: 20190607160900) do
     t.integer  "comments_count",     default: 0
     t.integer  "author_id"
     t.datetime "hidden_at"
+    t.string   "slug"
     t.boolean  "results_enabled",    default: false
     t.boolean  "stats_enabled",      default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "budget_id"
-    t.string   "slug"
     t.string   "related_type"
     t.integer  "related_id"
     t.index ["budget_id"], name: "index_polls_on_budget_id", unique: true, using: :btree
@@ -1630,8 +1670,16 @@ ActiveRecord::Schema.define(version: 20190607160900) do
   end
 
   add_foreign_key "administrators", "users"
+  add_foreign_key "budget_administrators", "administrators"
+  add_foreign_key "budget_administrators", "budgets"
   add_foreign_key "budget_investments", "communities"
+  add_foreign_key "budget_rol_assignments", "budgets"
+  add_foreign_key "budget_rol_assignments", "users"
   add_foreign_key "budget_tracker_assignments", "trackers"
+  add_foreign_key "budget_trackers", "budgets"
+  add_foreign_key "budget_trackers", "trackers"
+  add_foreign_key "budget_valuators", "budgets"
+  add_foreign_key "budget_valuators", "valuators"
   add_foreign_key "dashboard_administrator_tasks", "users"
   add_foreign_key "dashboard_executed_actions", "dashboard_actions", column: "action_id"
   add_foreign_key "dashboard_executed_actions", "proposals"

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1123,6 +1123,11 @@ describe "Admin budget investments" do
       user = create(:user, username: "Marta", email: "marta@admins.org")
       create(:administrator, user: user, description: "Marta desc")
 
+      visit edit_admin_budget_path(budget_investment.budget)
+
+      check "administrator_#{user.id}"
+      click_button "Update Budget"
+
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
       click_link "Edit classification"
 
@@ -1143,6 +1148,12 @@ describe "Admin budget investments" do
       valuator1 = create(:valuator, user: user1)
       valuator3 = create(:valuator, user: user3)
       create(:valuator, user: user2)
+
+      visit edit_admin_budget_path(budget_investment.budget)
+
+      check "valuator_#{user1.id}"
+      check "valuator_#{user3.id}"
+      click_button "Update Budget"
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
       click_link "Edit classification"

--- a/spec/features/tracking/budget_investments_spec.rb
+++ b/spec/features/tracking/budget_investments_spec.rb
@@ -78,7 +78,7 @@ feature "Valuation budget investments" do
       investment2 = create(:budget_investment,
                            budget: budget, title: "investment 2",
                            heading: create(:budget_heading, name: "last_heading"))
-      investment3 = create(:budget_investment,
+      create(:budget_investment,
                            budget: budget,
                            title: "investment 3",
                            heading: create(:budget_heading, name: "no_heading"))
@@ -320,7 +320,7 @@ feature "Valuation budget investments" do
     end
 
     scenario "delete" do
-      primary_progress_bar = create(:progress_bar, progressable: investment)
+      create(:progress_bar, progressable: investment)
       secondary_progress_bar = create(:progress_bar,
                                       :secondary,
                                       title: "to delete",
@@ -340,7 +340,7 @@ feature "Valuation budget investments" do
     end
 
     scenario "edit" do
-      primary_progress_bar = create(:progress_bar, progressable: investment)
+      create(:progress_bar, progressable: investment)
       secondary_progress_bar = create(:progress_bar,
                                       :secondary,
                                       title: "to edit",

--- a/spec/features/tracking/budgets_spec.rb
+++ b/spec/features/tracking/budgets_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 feature "Tracking budgets" do
 
   background do
-    @tracker = create(:tracker, user: create(:user, username: "Rachel", email: "rachel@trackers.org"))
+    @tracker = create(:tracker, user: create(:user, username: "Rachel",
+                                             email: "rachel@trackers.org"))
     login_as(@tracker.user)
   end
 


### PR DESCRIPTION
## References

#3481 

## Objectives

To be able to have diferent settings in diferent budgets. 

Administrators will be able to set which administrators, valuators and trackers will be able to be assigned to budget investments. 

Valuation and milestone default tags can also be added.

The help link could also be edited.

## Visual Changes

Edit budget:

![Screenshot from 2019-05-20 17-52-38](https://user-images.githubusercontent.com/14792089/58036038-6b446c80-7b2a-11e9-8fdb-dfffe116c42f.png)

![Screenshot from 2019-05-20 17-52-49](https://user-images.githubusercontent.com/14792089/58036042-6ed7f380-7b2a-11e9-807a-3e709522bb84.png)

Select administrators:

![Screenshot from 2019-05-20 17-53-20](https://user-images.githubusercontent.com/14792089/58036049-726b7a80-7b2a-11e9-85e7-9e3974e8b0d3.png)

Select trackers:

![Screenshot from 2019-05-20 17-55-18](https://user-images.githubusercontent.com/14792089/58036053-77302e80-7b2a-11e9-8028-764301972960.png)

There are no trackers in the system:

![Screenshot from 2019-05-20 18-11-10](https://user-images.githubusercontent.com/14792089/58036378-4270a700-7b2b-11e9-8814-78d4fb234b95.png)

Valuators tags:

![Screenshot from 2019-05-20 18-11-50](https://user-images.githubusercontent.com/14792089/58036382-44d30100-7b2b-11e9-8f29-9b688849e3be.png)



## Notes

Migrations are needed to add assignments tables, between users and budgets, and add new fields to budgets.
