### PR TITLE
Add deploy-secrets.yml.example file

### DIFF
--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -1,0 +1,28 @@
+staging:
+  deploy_to: "/var/www/consul"
+  ssh_port: "21"
+  server: "staging.consul.es"
+  db_server: "postgre.consul.es"
+  user: "xxxxx"
+  server_name: "staging.consul.es"
+  full_app_name: "consul"
+
+preproduction:
+  deploy_to: "/var/www/consul"
+  ssh_port: "2222"
+  server1: xxx.xxx.xxx.xxx
+  server2: xxx.xxx.xxx.xxx
+  db_server: xxx.xxx.xxx.xxx
+  user: xxxxx
+  server_name: pre.consul.es
+  full_app_name: "consul"
+
+production:
+  deploy_to: "/var/www/consul"
+  ssh_port: "22"
+  server1: xxx.xxx.xxx.xxx
+  server2: xxx.xxx.xxx.xxx
+  db_server: xxx.xxx.xxx.xxx
+  user: "deploy"
+  server_name: "consul.es"
+  full_app_name: "consul"


### PR DESCRIPTION
## Context
The `deploy-secrets.yml.example` file is used to help in the [Capistrano configuration](https://github.com/consul/installer#deploys-with-capistrano).

## Objectives
Bring back deploy-secrets.yml.example.

## Notes
It was accidentally removed in [this PR](https://github.com/consul/consul/pull/3412/files#diff-e2e7e59de6b2b5c76f396a862c48ccc5L1)