### PR TITLE
Update restart script for capistrano

### DIFF
--- a/lib/capistrano/tasks/restart.cap
+++ b/lib/capistrano/tasks/restart.cap
@@ -1,10 +1,10 @@
 namespace :deploy do
-  desc 'Commands for unicorn application'
-  %w(start stop force-stop restart upgrade reopen-logs).each do |command|
-    task command.to_sym do
-      on roles(:app), in: :sequence, wait: 5 do
-        execute "/etc/init.d/unicorn_#{fetch(:full_app_name)} #{command}"
-      end
+  desc "Restart Unicorn"
+  task :restart do
+    on roles(:app) do
+      execute "kill -QUIT `cat /home/deploy/consul/pids/unicorn.pid`; true"
+      execute "kill -QUIT `cat /home/deploy/consul/shared/pids/unicorn.pid`; true"
+      execute "cd /home/deploy/consul/current && /home/deploy/.rvm/gems/ruby-2.3.2/wrappers/unicorn -c config/unicorn.rb -E production -D"
     end
   end
 end


### PR DESCRIPTION
## Context
The `restart.cap` file is used to restart the unicorn application server when doing a [deploy with Capistrano](https://github.com/consul/installer#deploys-with-capistrano).

## Objectives
Bring back `restart.cap` configuration that works with the Installer.

## Notes
It was accidentally modified in [this PR](https://github.com/consul/consul/pull/3412/files#diff-ac7de15c1e5ac3c181930f22d9e50e50L2)