### PR TITLE
Link DelayedJob's configuration file to Capistrano's shared folder

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,7 +21,7 @@ set :log_level, :info
 set :pty, true
 set :use_sudo, false
 
-set :linked_files, %w{config/database.yml config/secrets.yml config/unicorn.rb config/environments/production.rb}
+set :linked_files, %w{config/database.yml config/secrets.yml config/unicorn.rb config/environments/production.rb config/initializers/delayed_job_config.rb}
 set :linked_dirs, %w{log tmp public/system public/assets public/ckeditor_assets}
 
 set :keep_releases, 5


### PR DESCRIPTION
## Context
The `delayed_job_config.rb` file is used to configure the background queue to send emails asyncronously with [DelayedJobs](https://github.com/collectiveidea/delayed_job).

## Objectives
Add `delayed_job_config.rb` to the capistrano shared folder so that the [Installer's specific DelayedJob configuration](https://github.com/consul/installer/blob/master/roles/queue/templates/delayed_job_config.rb) does not get overwritten after a deploy by the [default DelayedJob configuration](https://github.com/consul/consul/blob/master/config/initializers/delayed_job_config.rb).