### PR TITLE
Simplify link to poll

### DIFF
--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -49,6 +49,16 @@ module PollsHelper
     question.answers.where(author: current_user).any? { |vote| current_user.current_sign_in_at > vote.updated_at }
   end
 
+  def link_to_poll(text, poll)
+    if poll.results_enabled?
+      link_to text, results_poll_path(id: poll.slug || poll.id)
+    elsif poll.stats_enabled?
+      link_to text, stats_poll_path(id: poll.slug || poll.id)
+    else
+      link_to text, poll_path(id: poll.slug || poll.id)
+    end
+  end
+
   def show_stats_or_results?
     @poll.expired? && (@poll.results_enabled? || @poll.stats_enabled?)
   end

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -29,14 +29,13 @@
       </div>
       <div class="small-12 medium-6 column" data-equalizer-watch>
         <div class="dates"></div>
-        <% if poll.questions.count == 1 %>
-          <% poll.questions.each do |question| %>
-            <h4><%= link_to_poll question.title, poll %></h4>
-            <%= poll_dates(poll) %>
-          <% end %>
+        <% if poll.questions.one? %>
+          <h4><%= link_to_poll poll.questions.first.title, poll %></h4>
+          <%= poll_dates(poll) %>
         <% else %>
           <h4><%= link_to_poll poll.name, poll %></h4>
           <%= poll_dates(poll) %>
+
           <ul class="margin-top">
             <% poll.questions.each do |question| %>
               <li><%= question.title %></li>

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -31,27 +31,11 @@
         <div class="dates"></div>
         <% if poll.questions.count == 1 %>
           <% poll.questions.each do |question| %>
-            <h4>
-              <% if poll.results_enabled? %>
-                <%= link_to question.title, results_poll_path(poll) %>
-              <% elsif poll.stats_enabled? %>
-                <%= link_to question.title, stats_poll_path(poll) %>
-              <% else %>
-                <%= link_to question.title, poll %>
-              <% end %>
-            </h4>
+            <h4><%= link_to_poll question.title, poll %></h4>
             <%= poll_dates(poll) %>
           <% end %>
         <% else %>
-          <h4>
-            <% if poll.results_enabled? %>
-              <%= link_to poll.name, results_poll_path(poll) %>
-            <% elsif poll.stats_enabled? %>
-                <%= link_to poll.name, stats_poll_path(poll) %>
-            <% else %>
-              <%= link_to poll.name, poll_path(id: poll.slug || poll.id) %>
-            <% end %>
-          </h4>
+          <h4><%= link_to_poll poll.name, poll %></h4>
           <%= poll_dates(poll) %>
           <ul class="margin-top">
             <% poll.questions.each do |question| %>

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -114,7 +114,7 @@ feature "Polls" do
 
       visit polls_path
 
-      expect(page).to have_link("Poll with stats", href: stats_poll_path(poll))
+      expect(page).to have_link("Poll with stats", href: stats_poll_path(poll.slug))
     end
 
     scenario "Poll title link to results if enabled" do
@@ -122,7 +122,7 @@ feature "Polls" do
 
       visit polls_path
 
-      expect(page).to have_link("Poll with results", href: results_poll_path(poll))
+      expect(page).to have_link("Poll with results", href: results_poll_path(poll.slug))
     end
   end
 


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1973

## Objectives

Remove duplication in the logic used to link to either a poll, its results, or its stats