### PR TITLE
Add options to show advanced stats

### DIFF
--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -1,5 +1,6 @@
 class Admin::BudgetsController < Admin::BaseController
   include Translatable
+  include ReportAttributes
   include FeatureFlags
   feature_flag :budgets
 
@@ -62,7 +63,7 @@ class Admin::BudgetsController < Admin::BaseController
     def budget_params
       descriptions = Budget::Phase::PHASE_KINDS.map{|p| "description_#{p}"}.map(&:to_sym)
       valid_attributes = [:phase, :currency_symbol] + descriptions
-      params.require(:budget).permit(*valid_attributes, translation_params(Budget))
+      params.require(:budget).permit(*valid_attributes, *report_attributes, translation_params(Budget))
     end
 
 end

--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -1,6 +1,7 @@
 class Admin::Poll::PollsController < Admin::Poll::BaseController
   include Translatable
   include ImageAttributes
+  include ReportAttributes
   load_and_authorize_resource
 
   before_action :load_search, only: [:search_booths, :search_officers]
@@ -75,11 +76,10 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
     end
 
     def poll_params
-      image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
-      attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :results_enabled,
-                    :stats_enabled, :budget_id, geozone_ids: [],
-                    image_attributes: image_attributes]
-      params.require(:poll).permit(*attributes, translation_params(Poll))
+      attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :budget_id,
+                    geozone_ids: [], image_attributes: image_attributes]
+
+      params.require(:poll).permit(*attributes, *report_attributes, translation_params(Poll))
     end
 
     def search_params

--- a/app/controllers/concerns/report_attributes.rb
+++ b/app/controllers/concerns/report_attributes.rb
@@ -1,0 +1,9 @@
+module ReportAttributes
+  extend ActiveSupport::Concern
+
+  private
+
+    def report_attributes
+      Report::KINDS.map { |kind| :"#{kind}_enabled" }
+    end
+end

--- a/app/controllers/dashboard/polls_controller.rb
+++ b/app/controllers/dashboard/polls_controller.rb
@@ -15,8 +15,7 @@ class Dashboard::PollsController < Dashboard::BaseController
   def create
     authorize! :manage_polls, proposal
 
-    @poll = Poll.new(poll_params.merge(author: current_user, related: proposal,
-                                       stats_enabled: false))
+    @poll = Poll.new(poll_params.merge(author: current_user, related: proposal))
     if @poll.save
       redirect_to proposal_dashboard_polls_path(proposal), notice: t("flash.actions.create.poll")
     else
@@ -54,7 +53,7 @@ class Dashboard::PollsController < Dashboard::BaseController
     end
 
     def poll_attributes
-      [:name, :starts_at, :ends_at, :description, :results_enabled, :stats_enabled,
+      [:name, :starts_at, :ends_at, :description, :results_enabled,
        questions_attributes: question_attributes]
     end
 

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -20,8 +20,9 @@ module Abilities
       can [:read], Budget
       can [:read], Budget::Group
       can [:read, :print, :json_data], Budget::Investment
-      can [:read_results, :read_executions], Budget, phase: "finished"
-      can(:read_stats, Budget) { |budget| budget.valuating_or_later? }
+      can(:read_results, Budget) { |budget| budget.results_enabled? && budget.finished? }
+      can(:read_stats, Budget) { |budget| budget.stats_enabled? && budget.valuating_or_later? }
+      can :read_executions, Budget, phase: "finished"
       can :new, DirectMessage
       can [:read, :debate, :draft_publication, :allegations, :result_publication,
            :proposals, :milestones], Legislation::Process, published: true

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -3,6 +3,7 @@ class Budget < ApplicationRecord
   include Measurable
   include Sluggable
   include StatsVersionable
+  include Reportable
 
   translates :name, touch: true
   include Globalizable

--- a/app/models/concerns/reportable.rb
+++ b/app/models/concerns/reportable.rb
@@ -1,0 +1,30 @@
+module Reportable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :report, as: :process, dependent: :destroy
+    accepts_nested_attributes_for :report
+  end
+
+  def report
+    super || build_report
+  end
+
+  def results_enabled?
+    report&.results?
+  end
+  alias_method :results_enabled, :results_enabled?
+
+  def stats_enabled?
+    report&.stats?
+  end
+  alias_method :stats_enabled, :stats_enabled?
+
+  def results_enabled=(enabled)
+    report.results = enabled
+  end
+
+  def stats_enabled=(enabled)
+    report.stats = enabled
+  end
+end

--- a/app/models/concerns/reportable.rb
+++ b/app/models/concerns/reportable.rb
@@ -10,21 +10,14 @@ module Reportable
     super || build_report
   end
 
-  def results_enabled?
-    report&.results?
-  end
-  alias_method :results_enabled, :results_enabled?
+  Report::KINDS.each do |kind|
+    define_method "#{kind}_enabled?" do
+      report.send(kind)
+    end
+    alias_method "#{kind}_enabled", "#{kind}_enabled?"
 
-  def stats_enabled?
-    report&.stats?
-  end
-  alias_method :stats_enabled, :stats_enabled?
-
-  def results_enabled=(enabled)
-    report.results = enabled
-  end
-
-  def stats_enabled=(enabled)
-    report.stats = enabled
+    define_method "#{kind}_enabled=" do |enabled|
+      report.send("#{kind}=", enabled)
+    end
   end
 end

--- a/app/models/concerns/statisticable.rb
+++ b/app/models/concerns/statisticable.rb
@@ -93,6 +93,10 @@ module Statisticable
     "v#{resource.find_or_create_stats_version.updated_at.to_i}"
   end
 
+  def advanced?
+    resource.advanced_stats_enabled?
+  end
+
   private
 
     def base_stats_methods

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -7,6 +7,7 @@ class Poll < ApplicationRecord
   include Notifiable
   include Sluggable
   include StatsVersionable
+  include Reportable
 
   translates :name,        touch: true
   translates :summary,     touch: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,3 @@
+class Report < ApplicationRecord
+  belongs_to :process, polymorphic: true
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,5 +1,5 @@
 class Report < ApplicationRecord
-  KINDS = %i[results stats]
+  KINDS = %i[results stats advanced_stats]
 
   belongs_to :process, polymorphic: true
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,3 +1,5 @@
 class Report < ApplicationRecord
+  KINDS = %i[results stats]
+
   belongs_to :process, polymorphic: true
 end

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -66,6 +66,10 @@
   <% end %>
 
   <div class="small-12 column">
+    <%= render "admin/shared/show_results_fields", form: f %>
+  </div>
+
+  <div class="small-12 column">
     <div class="clear small-12 medium-4 large-3 inline-block">
       <%= f.submit nil, class: "button success" %>
     </div>

--- a/app/views/admin/poll/results/_show_results.html.erb
+++ b/app/views/admin/poll/results/_show_results.html.erb
@@ -1,11 +1,10 @@
 <%= form_for [:admin, @poll], action: "update" do |f| %>
   <fieldset class="fieldset">
     <legend><%= t("admin.polls.new.show_results_and_stats") %></legend>
-    <%= f.check_box :results_enabled, checked: @poll.results_enabled?, label: t("admin.polls.new.show_results") %>
-    <%= f.check_box :stats_enabled, checked: @poll.stats_enabled?, label: t("admin.polls.new.show_stats") %>
+    <%= f.check_box :results_enabled %>
+    <%= f.check_box :stats_enabled %>
     <p class="small"><%= t("admin.polls.new.results_and_stats_reminder") %></p>
   </fieldset>
-
 
   <div class="small-12 medium-4 large-2">
     <%= f.submit t("admin.polls.#{admin_submit_action(@poll)}.submit_button"),

--- a/app/views/admin/poll/results/_show_results.html.erb
+++ b/app/views/admin/poll/results/_show_results.html.erb
@@ -1,10 +1,5 @@
 <%= form_for [:admin, @poll], action: "update" do |f| %>
-  <fieldset class="fieldset">
-    <legend><%= t("admin.polls.new.show_results_and_stats") %></legend>
-    <%= f.check_box :results_enabled %>
-    <%= f.check_box :stats_enabled %>
-    <p class="small"><%= t("admin.polls.new.results_and_stats_reminder") %></p>
-  </fieldset>
+  <%= render "admin/shared/show_results_fields", form: f %>
 
   <div class="small-12 medium-4 large-2">
     <%= f.submit t("admin.polls.#{admin_submit_action(@poll)}.submit_button"),

--- a/app/views/admin/shared/_show_results_fields.html.erb
+++ b/app/views/admin/shared/_show_results_fields.html.erb
@@ -2,5 +2,6 @@
   <legend><%= t("admin.shared.show_results_and_stats") %></legend>
   <%= form.check_box :results_enabled %>
   <%= form.check_box :stats_enabled %>
+  <%= form.check_box :advanced_stats_enabled %>
   <p class="small"><%= t("admin.shared.results_and_stats_reminder") %></p>
 </fieldset>

--- a/app/views/admin/shared/_show_results_fields.html.erb
+++ b/app/views/admin/shared/_show_results_fields.html.erb
@@ -1,6 +1,6 @@
 <fieldset class="fieldset">
-  <legend><%= t("admin.polls.new.show_results_and_stats") %></legend>
+  <legend><%= t("admin.shared.show_results_and_stats") %></legend>
   <%= form.check_box :results_enabled %>
   <%= form.check_box :stats_enabled %>
-  <p class="small"><%= t("admin.polls.new.results_and_stats_reminder") %></p>
+  <p class="small"><%= t("admin.shared.results_and_stats_reminder") %></p>
 </fieldset>

--- a/app/views/admin/shared/_show_results_fields.html.erb
+++ b/app/views/admin/shared/_show_results_fields.html.erb
@@ -1,0 +1,6 @@
+<fieldset class="fieldset">
+  <legend><%= t("admin.polls.new.show_results_and_stats") %></legend>
+  <%= form.check_box :results_enabled %>
+  <%= form.check_box :stats_enabled %>
+  <p class="small"><%= t("admin.polls.new.results_and_stats_reminder") %></p>
+</fieldset>

--- a/app/views/budgets/stats/_advanced_stats.html.erb
+++ b/app/views/budgets/stats/_advanced_stats.html.erb
@@ -1,0 +1,83 @@
+<div id="advanced_statistics">
+  <h3 class="section-title"><%= t("stats.advanced") %></h3>
+
+  <div id="total_investments" class="stats-group">
+    <h4><%= t("stats.budgets.total_investments") %></h4>
+
+    <%= number_with_info_tags(
+      stats.total_budget_investments,
+      t("stats.budgets.total_investments"),
+      html_class: "total-investments"
+    ) %>
+
+    <%= number_with_info_tags(stats.total_unfeasible_investments,
+                              t("stats.budgets.total_unfeasible_investments")) %>
+    <%= number_with_info_tags(stats.total_selected_investments,
+                              t("stats.budgets.total_selected_investments")) %>
+  </div>
+
+  <div id="stats_by_phase" class="stats-group">
+    <h4><%= t("stats.budgets.by_phase") %></h4>
+
+    <% stats.phases.each do |phase| %>
+      <%= number_with_info_tags(
+        stats.send("total_participants_#{phase}_phase"),
+        t("stats.budgets.participants_#{phase}_phase")
+      ) %>
+    <% end %>
+  </div>
+
+  <div id="stats_by_heading" class="stats-group">
+    <h4 class="margin-bottom"><%= t("stats.budgets.by_heading") %></h4>
+
+    <table class="stats-districts survey-districts">
+      <thead>
+        <tr>
+          <th scope="col" rowspan="2"><%= t("stats.budgets.heading") %></th>
+          <th scope="col" rowspan="2"><%= t("stats.budgets.investments_sent_html") %></th>
+
+          <% stats.all_phases.each do |phase| %>
+            <th scope="col" colspan="3">
+              <%= t("stats.budgets.participants_#{phase}_phase") %>
+            </th>
+          <% end %>
+        </tr>
+        <tr>
+          <% stats.all_phases.each do %>
+            <th scope="col" class="phase-subheader"><%= t("stats.budgets.total") %></th>
+            <th scope="col" class="phase-subheader"><%= t("stats.budgets.percent_total_participants") %></th>
+            <th scope="col" class="phase-subheader"><%= t("stats.budgets.percent_heading_census") %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody id="headings">
+        <% @headings.each do |heading| %>
+          <tr id="<%= heading.name.parameterize %>">
+            <td class="border-left">
+              <strong><%= heading.name %></strong>
+            </td>
+            <td id="total_spending_proposals_heading_<%= heading.id %>"
+                class="text-center border-left border-right">
+              <%= stats.headings[heading.id][:total_investments_count] %>
+            </td>
+
+            <% stats.all_phases.each do |phase| %>
+              <td id="total_participants_<%= phase %>_phase_heading_<%= heading.id %>"
+                  class="border-left text-center">
+                <%= stats.headings[heading.id]["total_participants_#{phase}_phase".to_sym] %>
+              </td>
+              <td id="percentage_participants_<%= phase %>_phase_heading_<%= heading.id %>"
+                  class="border-left border-right text-center">
+                <%= number_to_stats_percentage(stats.headings[heading.id]["percentage_participants_#{phase}_phase".to_sym]) %>
+              </td>
+              <td id="percentage_district_population_<%= phase %>_phase_heading_<%= heading.id %>"
+                  class="text-center border-right">
+                <%= number_to_stats_percentage(stats.headings[heading.id]["percentage_district_population_#{phase}_phase".to_sym]) %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/budgets/stats/_advanced_stats_links.html.erb
+++ b/app/views/budgets/stats/_advanced_stats_links.html.erb
@@ -1,0 +1,12 @@
+<p><strong><%= link_to t("stats.advanced"), "#advanced_statistics" %></strong></p>
+<ul class="menu vertical">
+  <li>
+    <%= link_to t("stats.budgets.total_investments"), "#total_investments" %>
+  </li>
+  <li>
+    <%= link_to t("stats.budgets.by_phase"), "#stats_by_phase" %>
+  </li>
+  <li>
+    <%= link_to t("stats.budgets.by_heading"), "#stats_by_heading" %>
+  </li>
+</ul>

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -41,12 +41,12 @@
   <div class="row margin">
     <div class="small-12 medium-3 column sidebar">
       <%= render "shared/stats/links", stats: @stats %>
-      <%= render "advanced_stats_links" %>
+      <%= render "advanced_stats_links" if @stats.advanced? %>
     </div>
 
     <div class="small-12 medium-9 column stats-content">
       <%= render "shared/stats/participation", stats: @stats %>
-      <%= render "advanced_stats", stats: @stats %>
+      <%= render "advanced_stats", stats: @stats if @stats.advanced? %>
 
       <div class="row margin">
         <div class="small-12 column">

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -41,107 +41,12 @@
   <div class="row margin">
     <div class="small-12 medium-3 column sidebar">
       <%= render "shared/stats/links", stats: @stats %>
-
-      <p><strong><%= link_to t("stats.advanced"), "#advanced_statistics" %></strong></p>
-      <ul class="menu vertical">
-        <li>
-          <%= link_to t("stats.budgets.total_investments"), "#total_investments" %>
-        </li>
-        <li>
-          <%= link_to t("stats.budgets.by_phase"), "#stats_by_phase" %>
-        </li>
-        <li>
-          <%= link_to t("stats.budgets.by_heading"), "#stats_by_heading" %>
-        </li>
-      </ul>
+      <%= render "advanced_stats_links" %>
     </div>
 
     <div class="small-12 medium-9 column stats-content">
       <%= render "shared/stats/participation", stats: @stats %>
-
-      <div id="advanced_statistics">
-        <h3 class="section-title"><%= t("stats.advanced") %></h3>
-
-        <div id="total_investments" class="stats-group">
-          <h4><%= t("stats.budgets.total_investments") %></h4>
-
-          <%= number_with_info_tags(
-            @stats.total_budget_investments,
-            t("stats.budgets.total_investments"),
-            html_class: "total-investments"
-          ) %>
-
-          <%= number_with_info_tags(@stats.total_unfeasible_investments,
-                                    t("stats.budgets.total_unfeasible_investments")) %>
-          <%= number_with_info_tags(@stats.total_selected_investments,
-                                    t("stats.budgets.total_selected_investments")) %>
-        </div>
-
-        <div id="stats_by_phase" class="stats-group">
-          <h4><%= t("stats.budgets.by_phase") %></h4>
-
-          <% @stats.phases.each do |phase| %>
-            <%= number_with_info_tags(
-              @stats.send("total_participants_#{phase}_phase"),
-              t("stats.budgets.participants_#{phase}_phase")
-            ) %>
-          <% end %>
-        </div>
-
-        <div id="stats_by_heading" class="stats-group">
-          <h4 class="margin-bottom"><%= t("stats.budgets.by_heading") %></h4>
-
-          <table class="stats-districts survey-districts">
-            <thead>
-              <tr>
-                <th scope="col" rowspan="2"><%= t("stats.budgets.heading") %></th>
-                <th scope="col" rowspan="2"><%= t("stats.budgets.investments_sent_html") %></th>
-
-                <% @stats.all_phases.each do |phase| %>
-                  <th scope="col" colspan="3">
-                    <%= t("stats.budgets.participants_#{phase}_phase") %>
-                  </th>
-                <% end %>
-              </tr>
-              <tr>
-                <% @stats.all_phases.each do %>
-                  <th scope="col" class="phase-subheader"><%= t("stats.budgets.total") %></th>
-                  <th scope="col" class="phase-subheader"><%= t("stats.budgets.percent_total_participants") %></th>
-                  <th scope="col" class="phase-subheader"><%= t("stats.budgets.percent_heading_census") %></th>
-                <% end %>
-              </tr>
-            </thead>
-            <tbody id="headings">
-              <% @headings.each do |heading| %>
-                <tr id="<%= heading.name.parameterize %>">
-                  <td class="border-left">
-                    <strong><%= heading.name %></strong>
-                  </td>
-                  <td id="total_spending_proposals_heading_<%= heading.id %>"
-                      class="text-center border-left border-right">
-                    <%= @stats.headings[heading.id][:total_investments_count] %>
-                  </td>
-
-                  <% @stats.all_phases.each do |phase| %>
-                    <td id="total_participants_<%= phase %>_phase_heading_<%= heading.id %>"
-                        class="border-left text-center">
-                      <%= @stats.headings[heading.id]["total_participants_#{phase}_phase".to_sym] %>
-                    </td>
-                    <td id="percentage_participants_<%= phase %>_phase_heading_<%= heading.id %>"
-                        class="border-left border-right text-center">
-                      <%= number_to_stats_percentage(@stats.headings[heading.id]["percentage_participants_#{phase}_phase".to_sym]) %>
-                    </td>
-                    <td id="percentage_district_population_<%= phase %>_phase_heading_<%= heading.id %>"
-                        class="text-center border-right">
-                      <%= number_to_stats_percentage(@stats.headings[heading.id]["percentage_district_population_#{phase}_phase".to_sym]) %>
-                    </td>
-                  <% end %>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <%= render "advanced_stats", stats: @stats %>
 
       <div class="row margin">
         <div class="small-12 column">

--- a/app/views/polls/_advanced_stats.html.erb
+++ b/app/views/polls/_advanced_stats.html.erb
@@ -1,0 +1,92 @@
+<div id="advanced_statistics">
+  <h3 class="section-title"><%= t("stats.advanced") %></h3>
+
+  <div id="stats_by_channel" class="stats-group">
+    <h4><%= t("stats.polls.by_channel") %></h4>
+
+    <% stats.channels.each do |channel| %>
+      <%= number_with_info_tags(
+        stats.send("total_participants_#{channel}"),
+        t("stats.polls.#{channel}_percentage",
+          percentage: number_to_stats_percentage(stats.send(:"total_participants_#{channel}_percentage"))
+        ),
+        html_class: channel
+      ) %>
+    <% end %>
+  </div>
+
+  <div id="vote_stats_by_channel" class="stats-group">
+    <h4><%= t("stats.polls.vote_by_channel") %></h4>
+
+    <table class="stack">
+      <thead>
+        <tr>
+          <th scope="col"><%= t("polls.show.stats.votes") %></th>
+          <% stats.channels.each do |channel| %>
+            <th scope="col"><%= t("polls.show.stats.#{channel}") %></th>
+          <% end %>
+          <th scope="col"><%= t("polls.show.stats.total") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><%= t("polls.show.stats.valid") %></th>
+
+          <% stats.channels.each do |channel| %>
+            <td>
+              <%= stats.send(:"total_#{channel}_valid") %>
+              <small><em>(<%= stats.send(:"valid_percentage_#{channel}").round(2) %>%)</em></small>
+            </td>
+          <% end %>
+
+          <td>
+            <%= stats.total_valid_votes %>
+            <small><em>(<%= stats.total_valid_percentage.round(2) %>%)</em></small>
+          </td>
+
+        </tr>
+        <tr>
+          <th scope="row"><%= t("polls.show.stats.white") %></th>
+
+          <% stats.channels.each do |channel| %>
+            <td>
+              <%= stats.send(:"total_#{channel}_white") %>
+              <small><em>(<%= stats.send(:"white_percentage_#{channel}").round(2) %>%)</em></small>
+            </td>
+          <% end %>
+
+          <td><%= stats.total_white_votes %>
+            <small><em>(<%= stats.total_white_percentage.round(2) %>%)</em></small>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row"><%= t("polls.show.stats.null_votes") %></th>
+
+          <% stats.channels.each do |channel| %>
+            <td>
+              <%= stats.send(:"total_#{channel}_null") %>
+              <small><em>(<%= stats.send(:"null_percentage_#{channel}").round(2) %>%)</em></small>
+            </td>
+          <% end %>
+
+          <td>
+            <%= stats.total_null_votes %>
+            <small><em>(<%= stats.total_null_percentage.round(2) %>%)</em></small>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row"><%= t("polls.show.stats.total") %></th>
+
+          <% stats.channels.each do |channel| %>
+            <td>
+              <%= stats.send(:"total_participants_#{channel}") %>
+              <small><em>(<%= stats.send(:"total_participants_#{channel}_percentage").round(2) %>%)</em></small>
+            </td>
+          <% end %>
+
+          <td><%= stats.total_participants %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/polls/_advanced_stats_links.html.erb
+++ b/app/views/polls/_advanced_stats_links.html.erb
@@ -1,0 +1,9 @@
+<p><strong><%= link_to t("stats.advanced"), "#advanced_statistics" %></strong></p>
+<ul class="menu vertical">
+  <li>
+    <%= link_to t("stats.polls.by_channel"), "#stats_by_channel" %>
+  </li>
+  <li>
+    <%= link_to t("stats.polls.vote_by_channel"), "#vote_stats_by_channel" %>
+  </li>
+</ul>

--- a/app/views/polls/stats.html.erb
+++ b/app/views/polls/stats.html.erb
@@ -8,12 +8,12 @@
   <div class="row margin">
     <div class="small-12 medium-3 column sidebar">
       <%= render "shared/stats/links", stats: @stats %>
-      <%= render "advanced_stats_links" %>
+      <%= render "advanced_stats_links" if @stats.advanced? %>
     </div>
 
     <div class="small-12 medium-9 column stats-content">
       <%= render "shared/stats/participation", stats: @stats %>
-      <%= render "advanced_stats", stats: @stats %>
+      <%= render "advanced_stats", stats: @stats if @stats.advanced? %>
 
       <div id="total_no_demographic_data">
         <p class="help-text">

--- a/app/views/polls/stats.html.erb
+++ b/app/views/polls/stats.html.erb
@@ -8,118 +8,17 @@
   <div class="row margin">
     <div class="small-12 medium-3 column sidebar">
       <%= render "shared/stats/links", stats: @stats %>
-
-      <p><strong><%= link_to t("stats.advanced"), "#advanced_statistics" %></strong></p>
-      <ul class="menu vertical">
-        <li>
-          <%= link_to t("stats.polls.by_channel"), "#stats_by_channel" %>
-        </li>
-        <li>
-          <%= link_to t("stats.polls.vote_by_channel"), "#vote_stats_by_channel" %>
-        </li>
-      </ul>
+      <%= render "advanced_stats_links" %>
     </div>
 
     <div class="small-12 medium-9 column stats-content">
       <%= render "shared/stats/participation", stats: @stats %>
+      <%= render "advanced_stats", stats: @stats %>
 
-      <div id="advanced_statistics">
-        <h3 class="section-title"><%= t("stats.advanced") %></h3>
-
-        <div id="stats_by_channel" class="stats-group">
-          <h4><%= t("stats.polls.by_channel") %></h4>
-
-          <% @stats.channels.each do |channel| %>
-            <%= number_with_info_tags(
-              @stats.send("total_participants_#{channel}"),
-              t("stats.polls.#{channel}_percentage",
-                percentage: number_to_stats_percentage(@stats.send(:"total_participants_#{channel}_percentage"))
-              ),
-              html_class: channel
-            ) %>
-          <% end %>
-        </div>
-
-        <div id="vote_stats_by_channel" class="stats-group">
-          <h4><%= t("stats.polls.vote_by_channel") %></h4>
-
-          <table class="stack">
-            <thead>
-              <tr>
-                <th scope="col"><%= t("polls.show.stats.votes") %></th>
-                <% @stats.channels.each do |channel| %>
-                  <th scope="col"><%= t("polls.show.stats.#{channel}") %></th>
-                <% end %>
-                <th scope="col"><%= t("polls.show.stats.total") %></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row"><%= t("polls.show.stats.valid") %></th>
-
-                <% @stats.channels.each do |channel| %>
-                  <td>
-                    <%= @stats.send(:"total_#{channel}_valid") %>
-                    <small><em>(<%= @stats.send(:"valid_percentage_#{channel}").round(2) %>%)</em></small>
-                  </td>
-                <% end %>
-
-                <td>
-                  <%= @stats.total_valid_votes %>
-                  <small><em>(<%= @stats.total_valid_percentage.round(2) %>%)</em></small>
-                </td>
-
-              </tr>
-              <tr>
-                <th scope="row"><%= t("polls.show.stats.white") %></th>
-
-                <% @stats.channels.each do |channel| %>
-                  <td>
-                    <%= @stats.send(:"total_#{channel}_white") %>
-                    <small><em>(<%= @stats.send(:"white_percentage_#{channel}").round(2) %>%)</em></small>
-                  </td>
-                <% end %>
-
-                <td><%= @stats.total_white_votes %>
-                  <small><em>(<%= @stats.total_white_percentage.round(2) %>%)</em></small>
-                </td>
-              </tr>
-              <tr>
-                <th scope="row"><%= t("polls.show.stats.null_votes") %></th>
-
-                <% @stats.channels.each do |channel| %>
-                  <td>
-                    <%= @stats.send(:"total_#{channel}_null") %>
-                    <small><em>(<%= @stats.send(:"null_percentage_#{channel}").round(2) %>%)</em></small>
-                  </td>
-                <% end %>
-
-                <td>
-                  <%= @stats.total_null_votes %>
-                  <small><em>(<%= @stats.total_null_percentage.round(2) %>%)</em></small>
-                </td>
-              </tr>
-              <tr>
-                <th scope="row"><%= t("polls.show.stats.total") %></th>
-
-                <% @stats.channels.each do |channel| %>
-                  <td>
-                    <%= @stats.send(:"total_participants_#{channel}") %>
-                    <small><em>(<%= @stats.send(:"total_participants_#{channel}_percentage").round(2) %>%)</em></small>
-                  </td>
-                <% end %>
-
-                <td><%= @stats.total_participants %></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div id="total_no_demographic_data">
-          <p class="help-text">
-            <%= t("stats.no_demographic_data", count: @stats.total_no_demographic_data) %>
-          </p>
-        </div>
+      <div id="total_no_demographic_data">
+        <p class="help-text">
+          <%= t("stats.no_demographic_data", count: @stats.total_no_demographic_data) %>
+        </p>
       </div>
     </div>
   </div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -127,6 +127,7 @@ ignore_unused:
   - "budgets.index.section_header.*"
   - "activerecord.*"
   - "activemodel.*"
+  - "attributes.*"
   - "date.order"
   - "unauthorized.*"
   - "admin.officials.level_*"

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -212,6 +212,8 @@ en:
         geozone_restricted: "Restricted by geozone"
         summary: "Summary"
         description: "Description"
+        results_enabled: "Show results"
+        stats_enabled: "Show stats"
       poll/translation:
         name: "Name"
         summary: "Summary"

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -2,6 +2,7 @@ en:
   attributes:
     results_enabled: "Show results"
     stats_enabled: "Show stats"
+    advanced_stats_enabled: "Show advanced stats"
   activerecord:
     models:
       activity:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -1,4 +1,7 @@
 en:
+  attributes:
+    results_enabled: "Show results"
+    stats_enabled: "Show stats"
   activerecord:
     models:
       activity:
@@ -212,8 +215,6 @@ en:
         geozone_restricted: "Restricted by geozone"
         summary: "Summary"
         description: "Description"
-        results_enabled: "Show results"
-        stats_enabled: "Show stats"
       poll/translation:
         name: "Name"
         summary: "Summary"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1049,8 +1049,6 @@ en:
       new:
         title: "New poll"
         show_results_and_stats: "Show results and stats"
-        show_results: "Show results"
-        show_stats: "Show stats"
         results_and_stats_reminder: "Marking these checkboxes the results and/or stats of this poll will be publicly available and every user will see them."
         submit_button: "Create poll"
       edit:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1048,8 +1048,6 @@ en:
         geozone_restricted: "Restricted to districts"
       new:
         title: "New poll"
-        show_results_and_stats: "Show results and stats"
-        results_and_stats_reminder: "Marking these checkboxes the results and/or stats of this poll will be publicly available and every user will see them."
         submit_button: "Create poll"
       edit:
         title: "Edit poll"
@@ -1327,6 +1325,8 @@ en:
       created_at: Created at
       delete: Delete
       color_help: Hexadecimal format
+      show_results_and_stats: "Show results and stats"
+      results_and_stats_reminder: "Marking these checkboxes the results and/or stats will be publicly available and every user will see them."
     spending_proposals:
       index:
         geozone_filter_all: All zones

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -212,6 +212,8 @@ es:
         geozone_restricted: "Restringida por zonas"
         summary: "Resumen"
         description: "Descripción"
+        results_enabled: "Mostrar resultados"
+        stats_enabled: "Mostrar estadísticas"
       poll/translation:
         name: "Nombre"
         summary: "Resumen"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -2,6 +2,7 @@ es:
   attributes:
     results_enabled: "Mostrar resultados"
     stats_enabled: "Mostrar estadísticas"
+    advanced_stats_enabled: "Mostrar estadísticas avanzadas"
   activerecord:
     models:
       activity:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -1,4 +1,7 @@
 es:
+  attributes:
+    results_enabled: "Mostrar resultados"
+    stats_enabled: "Mostrar estadísticas"
   activerecord:
     models:
       activity:
@@ -212,8 +215,6 @@ es:
         geozone_restricted: "Restringida por zonas"
         summary: "Resumen"
         description: "Descripción"
-        results_enabled: "Mostrar resultados"
-        stats_enabled: "Mostrar estadísticas"
       poll/translation:
         name: "Nombre"
         summary: "Resumen"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1048,8 +1048,6 @@ es:
       new:
         title: "Nueva votación"
         show_results_and_stats: "Mostrar resultados y estadísticas"
-        show_results: "Mostrar resultados"
-        show_stats: "Mostrar estadísticas"
         results_and_stats_reminder: "Si marcas estas casillas los resultados y/o estadísticas de esta votación serán públicos y podrán verlos todos los usuarios."
         submit_button: "Crear votación"
       edit:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1047,8 +1047,6 @@ es:
         geozone_restricted: "Restringida a los distritos"
       new:
         title: "Nueva votación"
-        show_results_and_stats: "Mostrar resultados y estadísticas"
-        results_and_stats_reminder: "Si marcas estas casillas los resultados y/o estadísticas de esta votación serán públicos y podrán verlos todos los usuarios."
         submit_button: "Crear votación"
       edit:
         title: "Editar votación"
@@ -1326,6 +1324,8 @@ es:
       created_at: Fecha de creación
       delete: Eliminar
       color_help: Formato hexadecimal
+      show_results_and_stats: "Mostrar resultados y estadísticas"
+      results_and_stats_reminder: "Si marcas estas casillas los resultados y/o estadísticas serán públicos y podrán verlos todos los usuarios."
     spending_proposals:
       index:
         geozone_filter_all: Todos los ámbitos de actuación

--- a/db/migrate/20190424114803_create_reports.rb
+++ b/db/migrate/20190424114803_create_reports.rb
@@ -1,0 +1,11 @@
+class CreateReports < ActiveRecord::Migration[5.0]
+  def change
+    create_table :reports do |t|
+      t.boolean :stats
+      t.boolean :results
+      t.references :process, polymorphic: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20190429125842_add_advanced_stats_to_reports.rb
+++ b/db/migrate/20190429125842_add_advanced_stats_to_reports.rb
@@ -1,0 +1,5 @@
+class AddAdvancedStatsToReports < ActiveRecord::Migration[5.0]
+  def change
+    add_column :reports, :advanced_stats, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190424114803) do
+ActiveRecord::Schema.define(version: 20190429125842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1239,8 +1239,9 @@ ActiveRecord::Schema.define(version: 20190424114803) do
     t.boolean  "results"
     t.string   "process_type"
     t.integer  "process_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.boolean  "advanced_stats"
     t.index ["process_type", "process_id"], name: "index_reports_on_process_type_and_process_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190411090023) do
+ActiveRecord::Schema.define(version: 20190424114803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1232,6 +1232,16 @@ ActiveRecord::Schema.define(version: 20190411090023) do
     t.index ["parent_relationable_id", "parent_relationable_type", "child_relationable_id", "child_relationable_type"], name: "unique_parent_child_related_content", unique: true, using: :btree
     t.index ["parent_relationable_type", "parent_relationable_id"], name: "index_related_contents_on_parent_relationable", using: :btree
     t.index ["related_content_id"], name: "opposite_related_content", using: :btree
+  end
+
+  create_table "reports", force: :cascade do |t|
+    t.boolean  "stats"
+    t.boolean  "results"
+    t.string   "process_type"
+    t.integer  "process_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["process_type", "process_id"], name: "index_reports_on_process_type_and_process_id", using: :btree
   end
 
   create_table "settings", force: :cascade do |t|

--- a/lib/migrations/reports.rb
+++ b/lib/migrations/reports.rb
@@ -1,0 +1,29 @@
+class Migrations::Reports
+  def migrate
+    migrate_polls
+    migrate_budgets
+  end
+
+  private
+
+    def migrate_polls
+      Poll.find_each do |poll|
+        next unless poll.report.new_record?
+
+        poll.report.update!(
+          results:        poll.read_attribute(:results_enabled),
+          stats:          poll.read_attribute(:stats_enabled),
+          advanced_stats: poll.read_attribute(:stats_enabled),
+        )
+    end
+
+    end
+
+    def migrate_budgets
+      Budget.find_each do |budget|
+        next unless budget.report.new_record?
+
+        budget.report.update!(results: true, stats: true, advanced_stats: true)
+      end
+    end
+end

--- a/lib/tasks/stats_and_results.rake
+++ b/lib/tasks/stats_and_results.rake
@@ -1,0 +1,6 @@
+namespace :stats_and_results do
+  desc "Migrates stats_enabled and results_enabled data to enabled reports"
+  task migrate_to_reports: :environment do
+    Migrations::Reports.new.migrate
+  end
+end

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -61,6 +61,8 @@ FactoryBot.define do
 
     trait :finished do
       phase "finished"
+      results_enabled true
+      stats_enabled true
     end
   end
 

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -269,7 +269,7 @@ feature "Admin budgets" do
     end
 
     scenario "For a finished Budget" do
-      budget = create(:budget, phase: "finished")
+      budget = create(:budget, :finished)
       allow_any_instance_of(Budget).to receive(:has_winning_investments?).and_return(true)
 
       visit edit_admin_budget_path(budget)
@@ -279,7 +279,7 @@ feature "Admin budgets" do
     end
 
     scenario "Recalculate for a finished Budget" do
-      budget = create(:budget, phase: "finished")
+      budget = create(:budget, :finished)
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group)
       create(:budget_investment, :winner, heading: heading)

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "Executions" do
 
-  let(:budget)  { create(:budget, phase: "finished") }
+  let(:budget)  { create(:budget, :finished) }
   let(:group)   { create(:budget_group, budget: budget) }
   let(:heading) { create(:budget_heading, group: group) }
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -522,7 +522,7 @@ feature "Budget Investments" do
 
     context "Results Phase" do
 
-      before { budget.update(phase: "finished") }
+      before { budget.update(phase: "finished", results_enabled: true) }
 
       scenario "show winners by default" do
         investment1 = create(:budget_investment, :winner, heading: heading)

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "Results" do
 
-  let(:budget)  { create(:budget, phase: "finished") }
+  let(:budget)  { create(:budget, :finished) }
   let(:group)   { create(:budget_group, budget: budget) }
   let(:heading) { create(:budget_heading, group: group, price: 1000) }
 

--- a/spec/features/budgets/stats_spec.rb
+++ b/spec/features/budgets/stats_spec.rb
@@ -7,6 +7,22 @@ feature "Stats" do
   let(:heading) { create(:budget_heading, group: group, price: 1000) }
 
   describe "Show" do
-  end
+    describe "advanced stats" do
+      let(:budget) { create(:budget, :finished) }
 
+      scenario "advanced stats enabled" do
+        budget.update(advanced_stats_enabled: true)
+
+        visit budget_stats_path(budget)
+
+        expect(page).to have_content "Advanced statistics"
+      end
+
+      scenario "advanced stats disabled" do
+        visit budget_stats_path(budget)
+
+        expect(page).not_to have_content "Advanced statistics"
+      end
+    end
+  end
 end

--- a/spec/features/budgets/stats_spec.rb
+++ b/spec/features/budgets/stats_spec.rb
@@ -7,22 +7,6 @@ feature "Stats" do
   let(:heading) { create(:budget_heading, group: group, price: 1000) }
 
   describe "Show" do
-
-    it "is not accessible if supports phase is not finished" do
-      budget.update(phase: "selecting")
-
-      visit budget_stats_path(budget.id)
-      expect(page).to have_content "You do not have permission to carry out the action "\
-                                   "'read_stats' on budget."
-    end
-
-    it "is accessible if supports phase is finished" do
-      budget.update(phase: "valuating")
-
-      visit budget_stats_path(budget.id)
-      expect(page).to have_content "Stats"
-    end
-
   end
 
 end

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -432,7 +432,18 @@ feature "Polls" do
       expect(page).to have_content("Questions")
 
       visit stats_poll_path(poll)
+
       expect(page).to have_content("Participation data")
+      expect(page).not_to have_content "Advanced statistics"
+    end
+
+    scenario "Advanced stats enabled" do
+      poll = create(:poll, :expired, stats_enabled: true, advanced_stats_enabled: true)
+
+      visit stats_poll_path(poll)
+
+      expect(page).to have_content "Participation data"
+      expect(page).to have_content "Advanced statistics"
     end
 
     scenario "Don't show poll results and stats if not enabled" do

--- a/spec/lib/migrations/reports_spec.rb
+++ b/spec/lib/migrations/reports_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe Migrations::Reports do
+  describe "#migrate" do
+    it "ignores polls with existing reports" do
+      create(:poll, results_enabled: true, stats_enabled: true) do |poll|
+        poll.write_attribute(:results_enabled, false)
+        poll.write_attribute(:stats_enabled, false)
+        poll.save
+      end
+
+      Migrations::Reports.new.migrate
+
+      expect(Poll.last.results_enabled).to be true
+      expect(Poll.last.stats_enabled).to be true
+      expect(Poll.last.advanced_stats_enabled).to be nil
+    end
+
+    it "migrates polls with no reports" do
+      create(:poll) do |poll|
+        poll.write_attribute(:results_enabled, true)
+        poll.write_attribute(:stats_enabled, true)
+        poll.save
+      end
+
+      Migrations::Reports.new.migrate
+
+      expect(Poll.last.results_enabled).to be true
+      expect(Poll.last.stats_enabled).to be true
+      expect(Poll.last.advanced_stats_enabled).to be true
+    end
+
+    it "ignores budgets with existing reports" do
+      create(:budget, results_enabled: false, stats_enabled: false, advanced_stats_enabled: false)
+
+      Migrations::Reports.new.migrate
+
+      expect(Budget.last.results_enabled).to be false
+      expect(Budget.last.stats_enabled).to be false
+      expect(Budget.last.advanced_stats_enabled).to be false
+    end
+
+    it "enables results and stats for every budget" do
+      create(:budget)
+
+      Migrations::Reports.new.migrate
+
+      expect(Budget.last.results_enabled).to be true
+      expect(Budget.last.stats_enabled).to be true
+      expect(Budget.last.advanced_stats_enabled).to be true
+    end
+  end
+end

--- a/spec/models/abilities/everyone_spec.rb
+++ b/spec/models/abilities/everyone_spec.rb
@@ -8,9 +8,6 @@ describe Abilities::Everyone do
   let(:debate) { create(:debate) }
   let(:proposal) { create(:proposal) }
 
-  let(:reviewing_ballot_budget) { create(:budget, phase: "reviewing_ballots") }
-  let(:finished_budget) { create(:budget, phase: "finished") }
-
   it { should be_able_to(:index, Debate) }
   it { should be_able_to(:show, debate) }
   it { should_not be_able_to(:edit, Debate) }
@@ -32,8 +29,6 @@ describe Abilities::Everyone do
 
   it { should be_able_to(:index, Budget) }
 
-  it { should be_able_to(:read_results, finished_budget) }
-  it { should_not be_able_to(:read_results, reviewing_ballot_budget) }
   it { should_not be_able_to(:manage, Dashboard::Action) }
 
   context "when accessing poll results" do
@@ -74,17 +69,43 @@ describe Abilities::Everyone do
     end
   end
 
+  context "when accessing budget results" do
+    context "budget is not finished" do
+      let(:budget) { create(:budget, phase: "reviewing_ballots", results_enabled: true) }
+
+      it { should_not be_able_to(:read_results, budget) }
+    end
+
+    context "budget is finished" do
+      let(:budget) { create(:budget, :finished) }
+
+      it { should be_able_to(:read_results, budget) }
+    end
+
+    context "results disabled" do
+      let(:budget) { create(:budget, :finished, results_enabled: false) }
+
+      it { should_not be_able_to(:read_results, budget) }
+    end
+  end
+
   context "when accessing budget stats" do
     context "supports phase is not finished" do
-      let(:budget) { create(:budget, phase: "selecting") }
+      let(:budget) { create(:budget, phase: "selecting", stats_enabled: true) }
 
       it { should_not be_able_to(:read_stats, budget) }
     end
 
     context "supports phase is finished" do
-      let(:budget) { create(:budget, phase: "valuating") }
+      let(:budget) { create(:budget, phase: "valuating", stats_enabled: true) }
 
       it { should be_able_to(:read_stats, budget) }
+    end
+
+    context "stats disabled" do
+      let(:budget) { create(:budget, phase: "valuating", stats_enabled: false) }
+
+      it { should_not be_able_to(:read_stats, budget) }
     end
   end
 end

--- a/spec/models/abilities/everyone_spec.rb
+++ b/spec/models/abilities/everyone_spec.rb
@@ -73,4 +73,18 @@ describe Abilities::Everyone do
       it { should_not be_able_to(:stats, poll) }
     end
   end
+
+  context "when accessing budget stats" do
+    context "supports phase is not finished" do
+      let(:budget) { create(:budget, phase: "selecting") }
+
+      it { should_not be_able_to(:read_stats, budget) }
+    end
+
+    context "supports phase is finished" do
+      let(:budget) { create(:budget, phase: "valuating") }
+
+      it { should be_able_to(:read_stats, budget) }
+    end
+  end
 end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -5,6 +5,7 @@ describe Budget do
   let(:budget) { create(:budget) }
 
   it_behaves_like "sluggable", updatable_slug_trait: :drafting
+  it_behaves_like "reportable"
 
   describe "name" do
     before do

--- a/spec/models/concerns/reportable.rb
+++ b/spec/models/concerns/reportable.rb
@@ -1,0 +1,71 @@
+shared_examples "reportable" do
+  let(:reportable) { create(model_name(described_class)) }
+
+  describe "#results_enabled" do
+    it "can write and read the attribute" do
+      reportable.results_enabled = true
+
+      expect(reportable.results_enabled?).to be true
+      expect(reportable.results_enabled).to be true
+
+      reportable.results_enabled = false
+
+      expect(reportable.results_enabled?).to be false
+      expect(reportable.results_enabled).to be false
+    end
+
+    it "can save the value to the database" do
+      reportable.update(results_enabled: true)
+      saved_reportable = described_class.last
+
+      expect(saved_reportable.results_enabled?).to be true
+      expect(saved_reportable.results_enabled).to be true
+
+      reportable.update(results_enabled: false)
+      saved_reportable = described_class.last
+
+      expect(saved_reportable.results_enabled?).to be false
+      expect(saved_reportable.results_enabled).to be false
+    end
+
+    it "uses the `has_one` relation instead of the original column" do
+      reportable.update(results_enabled: true)
+
+      expect(reportable.read_attribute(:results_enabled)).to be false
+    end
+  end
+
+  describe "#stats_enabled" do
+    it "can write and read the attribute" do
+      reportable.stats_enabled = true
+
+      expect(reportable.stats_enabled?).to be true
+      expect(reportable.stats_enabled).to be true
+
+      reportable.stats_enabled = false
+
+      expect(reportable.stats_enabled?).to be false
+      expect(reportable.stats_enabled).to be false
+    end
+
+    it "can save the attribute to the database" do
+      reportable.update(stats_enabled: true)
+      saved_reportable = described_class.last
+
+      expect(saved_reportable.stats_enabled?).to be true
+      expect(saved_reportable.stats_enabled).to be true
+
+      reportable.update(stats_enabled: false)
+      saved_reportable = described_class.last
+
+      expect(saved_reportable.stats_enabled?).to be false
+      expect(saved_reportable.stats_enabled).to be false
+    end
+
+    it "uses the `has_one` relation instead of the original column" do
+      reportable.update(stats_enabled: true)
+
+      expect(reportable.read_attribute(:stats_enabled)).to be false
+    end
+  end
+end

--- a/spec/models/concerns/reportable.rb
+++ b/spec/models/concerns/reportable.rb
@@ -29,6 +29,8 @@ shared_examples "reportable" do
     end
 
     it "uses the `has_one` relation instead of the original column" do
+      skip "there's no original column" unless reportable.has_attribute?(:results_enabled)
+
       reportable.update(results_enabled: true)
 
       expect(reportable.read_attribute(:results_enabled)).to be false
@@ -63,6 +65,8 @@ shared_examples "reportable" do
     end
 
     it "uses the `has_one` relation instead of the original column" do
+      skip "there's no original column" unless reportable.has_attribute?(:stats_enabled)
+
       reportable.update(stats_enabled: true)
 
       expect(reportable.read_attribute(:stats_enabled)).to be false

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -6,6 +6,7 @@ describe Poll do
 
   describe "Concerns" do
     it_behaves_like "notifiable"
+    it_behaves_like "reportable"
   end
 
   describe "validations" do


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#1989

## Objectives

* Add option to show the advanced stats in polls
* Add option to show stats, results and advanced stats in budgets

## Visual Changes

![Fieldset with fields to enable stats and results for budgets](https://user-images.githubusercontent.com/35156/56954255-a7456c80-6b3e-11e9-833d-7f96abb5d3c1.png)

## Release notes

:warning: To update existing stats and result permissions, run:

```
bin/rake stats_and_results:migrate_to_reports RAILS_ENV=production
```