### PR TITLE
Use RemoteCensusAPI in Officing residence verification

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -23,7 +23,7 @@ class Admin::SettingsController < Admin::BaseController
   def update
     @setting = Setting.find(params[:id])
     @setting.update(settings_params)
-    redirect_to request.referer, notice: t("admin.settings.flash.updated")
+    redirect_to request_referer, notice: t("admin.settings.flash.updated")
   end
 
   def update_map
@@ -53,4 +53,8 @@ class Admin::SettingsController < Admin::BaseController
       params.permit(:jpg, :png, :gif, :pdf, :doc, :docx, :xls, :xlsx, :csv, :zip)
     end
 
+    def request_referer
+      return request.referer + params[:setting][:tab] if params[:setting][:tab]
+      request.referer
+    end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -14,6 +14,9 @@ class Admin::SettingsController < Admin::BaseController
     @participation_processes_settings = all_settings["process"]
     @map_configuration_settings = all_settings["map"]
     @proposals_settings = all_settings["proposals"]
+    @remote_census_general_settings = all_settings["remote_census.general"]
+    @remote_census_request_settings = all_settings["remote_census.request"]
+    @remote_census_response_settings = all_settings["remote_census.response"]
     @uploads_settings = all_settings["uploads"]
   end
 

--- a/app/controllers/officing/residence_controller.rb
+++ b/app/controllers/officing/residence_controller.rb
@@ -20,7 +20,8 @@ class Officing::ResidenceController < Officing::BaseController
   private
 
     def residence_params
-      params.require(:residence).permit(:document_number, :document_type, :year_of_birth)
+      params.require(:residence).permit(:document_number, :document_type, :year_of_birth,
+                                        :date_of_birth, :postal_code)
     end
 
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -8,4 +8,12 @@ module SettingsHelper
     @all_settings ||= Hash[ Setting.all.map{|s| [s.key, s.value.presence]} ]
   end
 
+  def display_setting_name(setting_name)
+    if setting_name == "setting"
+      t("admin.settings.setting_name")
+    else
+      t("admin.settings.#{setting_name}")
+    end
+  end
+
 end

--- a/app/models/officing/residence.rb
+++ b/app/models/officing/residence.rb
@@ -102,7 +102,7 @@ class Officing::Residence
   private
 
     def retrieve_census_data
-      @census_api_response = CensusCaller.new.call(document_type, document_number)
+      @census_api_response = CensusCaller.new.call(document_type, document_number, nil, nil)
     end
 
     def residency_valid?

--- a/app/models/officing/residence.rb
+++ b/app/models/officing/residence.rb
@@ -10,7 +10,9 @@ class Officing::Residence
 
   validates :document_number, presence: true
   validates :document_type, presence: true
-  validates :year_of_birth, presence: true
+  validates :date_of_birth, presence: true, if: -> { Setting.force_presence_date_of_birth? }
+  validates :postal_code, presence: true, if: -> { Setting.force_presence_postal_code? }
+  validates :year_of_birth, presence: true, unless: -> { Setting.force_presence_date_of_birth? }
 
   validate :allowed_age
   validate :residence_in_madrid

--- a/app/models/officing/residence.rb
+++ b/app/models/officing/residence.rb
@@ -1,5 +1,6 @@
 class Officing::Residence
   include ActiveModel::Model
+  include ActiveModel::Dates
   include ActiveModel::Validations::Callbacks
 
   attr_accessor :user, :officer, :document_number, :document_type, :year_of_birth,
@@ -15,6 +16,8 @@ class Officing::Residence
   validate :residence_in_madrid
 
   def initialize(attrs = {})
+    self.date_of_birth = parse_date("date_of_birth", attrs)
+    attrs = remove_date("date_of_birth", attrs)
     super
     clean_document_number
   end

--- a/app/models/officing/residence.rb
+++ b/app/models/officing/residence.rb
@@ -35,7 +35,7 @@ class Officing::Residence
         document_number:       document_number,
         document_type:         document_type,
         geozone:               geozone,
-        date_of_birth:         date_of_birth.in_time_zone.to_datetime,
+        date_of_birth:         response_date_of_birth.in_time_zone.to_datetime,
         gender:                gender,
         residence_verified_at: Time.current,
         verified_at:           Time.current,
@@ -86,7 +86,7 @@ class Officing::Residence
   end
 
   def allowed_age?
-    Age.in_years(date_of_birth) >= User.minimum_required_age
+    Age.in_years(response_date_of_birth) >= User.minimum_required_age
   end
 
   def geozone
@@ -101,7 +101,7 @@ class Officing::Residence
     @census_api_response.gender
   end
 
-  def date_of_birth
+  def response_date_of_birth
     @census_api_response.date_of_birth
   end
 

--- a/app/models/officing/residence.rb
+++ b/app/models/officing/residence.rb
@@ -117,12 +117,12 @@ class Officing::Residence
     end
 
     def residency_valid?
-      @census_api_response.valid? &&
-        @census_api_response.date_of_birth.year.to_s == year_of_birth.to_s
+      @census_api_response.valid? && valid_year_of_birth?
     end
 
-    def census_year_of_birth
-      @census_api_response.date_of_birth.year
+    def valid_year_of_birth?
+      return true if Setting.force_presence_date_of_birth?
+      @census_api_response.date_of_birth.year.to_s == year_of_birth.to_s
     end
 
     def clean_document_number

--- a/app/models/officing/residence.rb
+++ b/app/models/officing/residence.rb
@@ -53,6 +53,8 @@ class Officing::Residence
       user: user,
       document_number: document_number,
       document_type: document_type,
+      date_of_birth: date_of_birth,
+      postal_code: postal_code,
       year_of_birth: year_of_birth,
       poll_officer: officer
     )

--- a/app/models/officing/residence.rb
+++ b/app/models/officing/residence.rb
@@ -2,7 +2,8 @@ class Officing::Residence
   include ActiveModel::Model
   include ActiveModel::Validations::Callbacks
 
-  attr_accessor :user, :officer, :document_number, :document_type, :year_of_birth
+  attr_accessor :user, :officer, :document_number, :document_type, :year_of_birth,
+                :date_of_birth, :postal_code
 
   before_validation :retrieve_census_data
 
@@ -102,7 +103,10 @@ class Officing::Residence
   private
 
     def retrieve_census_data
-      @census_api_response = CensusCaller.new.call(document_type, document_number, nil, nil)
+      @census_api_response = CensusCaller.new.call(document_type,
+                                                   document_number,
+                                                   date_of_birth,
+                                                   postal_code)
     end
 
     def residency_valid?

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -10,6 +10,8 @@ class Setting < ApplicationRecord
   def type
     if %w[feature process proposals map html homepage uploads].include? prefix
       prefix
+    elsif %w[remote_census].include? prefix
+      key.rpartition(".").first
     else
       "configuration"
     end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -166,7 +166,21 @@ class Setting < ApplicationRecord
         "hot_score_period_in_days": 31,
         "related_content_score_threshold": -0.3,
         "featured_proposals_number": 3,
-        "dashboard.emails": nil
+        "dashboard.emails": nil,
+        "remote_census.general.endpoint": "",
+        "remote_census.request.method_name": "",
+        "remote_census.request.structure": "",
+        "remote_census.request.document_type": "",
+        "remote_census.request.document_number": "",
+        "remote_census.request.date_of_birth": "",
+        "remote_census.request.postal_code": "",
+        "remote_census.response.date_of_birth": "",
+        "remote_census.response.postal_code": "",
+        "remote_census.response.district": "",
+        "remote_census.response.gender": "",
+        "remote_census.response.name": "",
+        "remote_census.response.surname": "",
+        "remote_census.response.valid": ""
       }
     end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -195,5 +195,15 @@ class Setting < ApplicationRecord
         self[name] = value unless find_by(key: name)
       end
     end
+
+    def force_presence_date_of_birth?
+      Setting["feature.remote_census"].present? &&
+        Setting["remote_census.request.date_of_birth"].present?
+    end
+
+    def force_presence_postal_code?
+      Setting["feature.remote_census"].present? &&
+        Setting["remote_census.request.postal_code"].present?
+    end
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -93,6 +93,7 @@ class Setting < ApplicationRecord
         "feature.allow_attached_documents": true,
         "feature.allow_images": true,
         "feature.help_page": true,
+        "feature.remote_census": nil,
         "feature.valuation_comment_notification": true,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -69,7 +69,7 @@ class Signature < ApplicationRecord
 
   def in_census?
     document_types.detect do |document_type|
-      response = CensusCaller.new.call(document_type, document_number)
+      response = CensusCaller.new.call(document_type, document_number, nil, nil)
       if response.valid?
         @census_api_response = response
         true

--- a/app/models/verification/management/document.rb
+++ b/app/models/verification/management/document.rb
@@ -18,7 +18,7 @@ class Verification::Management::Document
   end
 
   def in_census?
-    response = CensusCaller.new.call(document_type, document_number)
+    response = CensusCaller.new.call(document_type, document_number, nil, nil)
     response.valid? && valid_age?(response)
   end
 

--- a/app/models/verification/residence.rb
+++ b/app/models/verification/residence.rb
@@ -71,7 +71,7 @@ class Verification::Residence
   private
 
     def retrieve_census_data
-      @census_data = CensusCaller.new.call(document_type, document_number)
+      @census_data = CensusCaller.new.call(document_type, document_number, date_of_birth, postal_code)
     end
 
     def residency_valid?

--- a/app/views/admin/settings/_configuration_settings_tab.html.erb
+++ b/app/views/admin/settings/_configuration_settings_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.title") %></h2>
 
-<%= render "settings_table", settings: @configuration_settings, setting_name: "setting" %>
+<%= render "settings_table", settings: @configuration_settings, setting_name: "setting", tab: "#tab-configuration" %>

--- a/app/views/admin/settings/_configuration_settings_tab.html.erb
+++ b/app/views/admin/settings/_configuration_settings_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.title") %></h2>
 
-<%= render "settings_table", settings: @configuration_settings %>
+<%= render "settings_table", settings: @configuration_settings, setting_name: "setting" %>

--- a/app/views/admin/settings/_featured_settings_form.html.erb
+++ b/app/views/admin/settings/_featured_settings_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_for(feature, url: admin_setting_path(feature), html: { id: "edit_#{dom_id(feature)}"}) do |f| %>
+  <%= f.hidden_field :tab, value: tab if defined?(tab) %>
   <%= f.hidden_field :value, id: dom_id(feature), value: (feature.enabled? ? "" : "active") %>
   <%= f.submit(t("admin.settings.index.features.#{feature.enabled? ? "disable" : "enable"}"),
                class: "button expanded #{feature.enabled? ? "hollow alert" : "success"}",

--- a/app/views/admin/settings/_featured_settings_table.html.erb
+++ b/app/views/admin/settings/_featured_settings_table.html.erb
@@ -32,7 +32,7 @@
         </td>
 
         <td class="text-right">
-          <%= render "admin/settings/featured_settings_form", feature: feature %>
+          <%= render "admin/settings/featured_settings_form", feature: feature, tab: tab %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/settings/_features_tab.html.erb
+++ b/app/views/admin/settings/_features_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.feature_flags") %></h2>
 
-<%= render "featured_settings_table", features: @feature_settings %>
+<%= render "featured_settings_table", features: @feature_settings, tab: "#tab-feature-flags" %>

--- a/app/views/admin/settings/_filter_subnav.html.erb
+++ b/app/views/admin/settings/_filter_subnav.html.erb
@@ -40,4 +40,11 @@
       <%= t("admin.settings.index.dashboard.title") %>
     <% end %>
   </li>
+
+  <li class="tabs-title" id="remote-census-tab">
+   <%= link_to "#tab-remote-census-configuration" do %>
+      <%= t("admin.settings.index.remote_census.title") %>
+    <% end %>
+  </li>
+
 </ul>

--- a/app/views/admin/settings/_filter_subnav.html.erb
+++ b/app/views/admin/settings/_filter_subnav.html.erb
@@ -11,7 +11,7 @@
     <% end %>
   </li>
 
-  <li class="tabs-title">
+  <li class="tabs-title" id="participation-processes-tab">
     <%= link_to "#tab-participation-processes" do %>
       <%= t("admin.settings.index.participation_processes") %>
     <% end %>

--- a/app/views/admin/settings/_images_and_documents_tab.html.erb
+++ b/app/views/admin/settings/_images_and_documents_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.images_and_documents") %></h2>
 
-<%= render "settings_table", settings: @uploads_settings %>
+<%= render "settings_table", settings: @uploads_settings, setting_name: "setting" %>

--- a/app/views/admin/settings/_map_configuration_tab.html.erb
+++ b/app/views/admin/settings/_map_configuration_tab.html.erb
@@ -1,7 +1,7 @@
 <% if feature?(:map) %>
   <h2><%= t("admin.settings.index.map.title") %></h2>
 
-  <%= render "settings_table", settings: @map_configuration_settings %>
+  <%= render "settings_table", settings: @map_configuration_settings, setting_name: "setting" %>
 
   <p><%= t("admin.settings.index.map.help") %></p>
 

--- a/app/views/admin/settings/_map_configuration_tab.html.erb
+++ b/app/views/admin/settings/_map_configuration_tab.html.erb
@@ -1,7 +1,7 @@
 <% if feature?(:map) %>
   <h2><%= t("admin.settings.index.map.title") %></h2>
 
-  <%= render "settings_table", settings: @map_configuration_settings, setting_name: "setting" %>
+  <%= render "settings_table", settings: @map_configuration_settings, setting_name: "setting", tab: "#tab-map-configuration" %>
 
   <p><%= t("admin.settings.index.map.help") %></p>
 

--- a/app/views/admin/settings/_participation_processes_tab.html.erb
+++ b/app/views/admin/settings/_participation_processes_tab.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.participation_processes") %></h2>
 
-<%= render "featured_settings_table", features: @participation_processes_settings %>
+<%= render "featured_settings_table", features: @participation_processes_settings, tab: "#tab-participation-processes" %>

--- a/app/views/admin/settings/_proposals_dashboard.html.erb
+++ b/app/views/admin/settings/_proposals_dashboard.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.dashboard.title") %></h2>
 
-<%= render "settings_table", settings: @proposals_settings %>
+<%= render "settings_table", settings: @proposals_settings, setting_name: "setting" %> %>

--- a/app/views/admin/settings/_proposals_dashboard.html.erb
+++ b/app/views/admin/settings/_proposals_dashboard.html.erb
@@ -1,3 +1,3 @@
 <h2><%= t("admin.settings.index.dashboard.title") %></h2>
 
-<%= render "settings_table", settings: @proposals_settings, setting_name: "setting" %> %>
+<%= render "settings_table", settings: @proposals_settings, setting_name: "setting", tab: "#tab-proposals" %>

--- a/app/views/admin/settings/_remote_census_configuration_tab.html.erb
+++ b/app/views/admin/settings/_remote_census_configuration_tab.html.erb
@@ -1,9 +1,9 @@
 <% if feature?(:remote_census) %>
   <h2><%= t("admin.settings.index.remote_census.title") %></h2>
 
-  <%= render "settings_table", settings: @remote_census_general_settings, setting_name: "remote_census_general_name" %>
-  <%= render "settings_table", settings: @remote_census_request_settings, setting_name: "remote_census_request_name" %>
-  <%= render "settings_table", settings: @remote_census_response_settings, setting_name: "remote_census_response_name" %>
+  <%= render "settings_table", settings: @remote_census_general_settings, setting_name: "remote_census_general_name", tab: "#tab-remote-census-configuration" %>
+  <%= render "settings_table", settings: @remote_census_request_settings, setting_name: "remote_census_request_name", tab: "#tab-remote-census-configuration" %>
+  <%= render "settings_table", settings: @remote_census_response_settings, setting_name: "remote_census_response_name", tab: "#tab-remote-census-configuration" %>
 <% else %>
   <div class="callout primary">
     <%= t("admin.settings.index.remote_census.how_to_enable") %>

--- a/app/views/admin/settings/_remote_census_configuration_tab.html.erb
+++ b/app/views/admin/settings/_remote_census_configuration_tab.html.erb
@@ -1,9 +1,9 @@
 <% if feature?(:remote_census) %>
   <h2><%= t("admin.settings.index.remote_census.title") %></h2>
 
-  <%= render "settings_table", settings: @remote_census_general_settings %>
-  <%= render "settings_table", settings: @remote_census_request_settings %>
-  <%= render "settings_table", settings: @remote_census_response_settings %>
+  <%= render "settings_table", settings: @remote_census_general_settings, setting_name: "remote_census_general_name" %>
+  <%= render "settings_table", settings: @remote_census_request_settings, setting_name: "remote_census_request_name" %>
+  <%= render "settings_table", settings: @remote_census_response_settings, setting_name: "remote_census_response_name" %>
 <% else %>
   <div class="callout primary">
     <%= t("admin.settings.index.remote_census.how_to_enable") %>

--- a/app/views/admin/settings/_remote_census_configuration_tab.html.erb
+++ b/app/views/admin/settings/_remote_census_configuration_tab.html.erb
@@ -1,0 +1,5 @@
+  <h2><%= t("admin.settings.index.remote_census.title") %></h2>
+
+  <%= render "settings_table", settings: @remote_census_general_settings %>
+  <%= render "settings_table", settings: @remote_census_request_settings %>
+  <%= render "settings_table", settings: @remote_census_response_settings %>

--- a/app/views/admin/settings/_remote_census_configuration_tab.html.erb
+++ b/app/views/admin/settings/_remote_census_configuration_tab.html.erb
@@ -1,5 +1,11 @@
+<% if feature?(:remote_census) %>
   <h2><%= t("admin.settings.index.remote_census.title") %></h2>
 
   <%= render "settings_table", settings: @remote_census_general_settings %>
   <%= render "settings_table", settings: @remote_census_request_settings %>
   <%= render "settings_table", settings: @remote_census_response_settings %>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.settings.index.remote_census.how_to_enable") %>
+  </div>
+<% end %>

--- a/app/views/admin/settings/_settings_form.html.erb
+++ b/app/views/admin/settings/_settings_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
+  <%= f.hidden_field :tab, value: tab if defined?(tab) %>
   <div class="small-12 medium-6 large-8 column">
     <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
   </div>

--- a/app/views/admin/settings/_settings_table.html.erb
+++ b/app/views/admin/settings/_settings_table.html.erb
@@ -1,7 +1,7 @@
 <table>
   <thead>
     <tr>
-      <th><%= t("admin.settings.setting_name") %></th>
+      <th><%= display_setting_name(setting_name) %></th>
       <th><%= t("admin.settings.setting_value") %></th>
     </tr>
   </thead>

--- a/app/views/admin/settings/_settings_table.html.erb
+++ b/app/views/admin/settings/_settings_table.html.erb
@@ -19,7 +19,11 @@
           <% if setting.content_type? %>
             <%= render "admin/settings/content_types_settings_form", setting: setting %>
           <% else %>
-            <%= render "admin/settings/settings_form", setting: setting %>
+            <% if defined?(tab) %>
+              <%= render "admin/settings/settings_form", setting: setting, tab: tab %>
+            <% else %>
+              <%= render "admin/settings/settings_form", setting: setting %>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -25,4 +25,8 @@
   <div class="tabs-panel" id="tab-proposals">
     <%= render "proposals_dashboard" %>
   </div>
+
+  <div class="tabs-panel" id="tab-remote-census-configuration">
+    <%= render "remote_census_configuration_tab" %>
+  </div>
 </div>

--- a/app/views/admin/site_customization/content_blocks/index.html.erb
+++ b/app/views/admin/site_customization/content_blocks/index.html.erb
@@ -6,7 +6,7 @@
 
 <h2 class="inline-block"><%= t("admin.site_customization.content_blocks.index.title") %></h2>
 
-<%= render "admin/settings/settings_table", settings: @html_settings %>
+<%= render "admin/settings/settings_table", settings: @html_settings, setting_name: "setting" %>
 
 <h3><%= t("admin.site_customization.content_blocks.information") %></h3>
 

--- a/app/views/officing/residence/new.html.erb
+++ b/app/views/officing/residence/new.html.erb
@@ -12,21 +12,24 @@
                          placeholder: t("officing.residence.new.document_number"),
                          autocomplete: "off" %>
       </div>
+
       <% if Setting.force_presence_date_of_birth? %>
         <div class="date-of-birth small-12 medium-6 clear">
           <%= f.date_select :date_of_birth,
                             prompt: true,
                             start_year: 1900, end_year: minimum_required_age.years.ago.year %>
         </div>
+      <% else %>
+        <div class="date-of-birth small-12 medium-6">
+          <%= f.text_field :year_of_birth, type: "number", autocomplete: "off" %>
+        </div>
       <% end %>
+
       <% if Setting.force_presence_postal_code? %>
         <div class="small-12 medium-6">
           <%= f.text_field :postal_code, aria: {describedby: "postal-code-help-text"} %>
         </div>
       <% end %>
-      <div class="date-of-birth small-12 medium-6">
-        <%= f.text_field :year_of_birth, type: "number", autocomplete: "off" %>
-      </div>
 
       <div class="small-12 medium-6">
         <input type="submit" value="<%= t("officing.residence.new.submit") %>" class="button expanded">

--- a/app/views/officing/residence/new.html.erb
+++ b/app/views/officing/residence/new.html.erb
@@ -12,7 +12,18 @@
                          placeholder: t("officing.residence.new.document_number"),
                          autocomplete: "off" %>
       </div>
-
+      <% if Setting.force_presence_date_of_birth? %>
+        <div class="date-of-birth small-12 medium-6 clear">
+          <%= f.date_select :date_of_birth,
+                            prompt: true,
+                            start_year: 1900, end_year: minimum_required_age.years.ago.year %>
+        </div>
+      <% end %>
+      <% if Setting.force_presence_postal_code? %>
+        <div class="small-12 medium-6">
+          <%= f.text_field :postal_code, aria: {describedby: "postal-code-help-text"} %>
+        </div>
+      <% end %>
       <div class="date-of-birth small-12 medium-6">
         <%= f.text_field :year_of_birth, type: "number", autocomplete: "off" %>
       </div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1314,6 +1314,9 @@ en:
         remote_census:
           title: Remote Census configuration
           how_to_enable: 'To configure remote census (SOAP) you must enable "Configure connection to remote census (SOAP)" on "Features" tab.'
+      remote_census_general_name: General Information
+      remote_census_request_name: Request Data
+      remote_census_response_name: Response Data
       setting: Feature
       setting_actions: Actions
       setting_name: Setting

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1311,6 +1311,8 @@ en:
           how_to_enable: 'To show the map to users you must enable "Proposals and budget investments geolocation" on "Features" tab.'
         dashboard:
           title: Proposals dashboard
+        remote_census:
+          title: Remote Census configuration
       setting: Feature
       setting_actions: Actions
       setting_name: Setting

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1313,6 +1313,7 @@ en:
           title: Proposals dashboard
         remote_census:
           title: Remote Census configuration
+          how_to_enable: 'To configure remote census (SOAP) you must enable "Configure connection to remote census (SOAP)" on "Features" tab.'
       setting: Feature
       setting_actions: Actions
       setting_name: Setting

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -120,6 +120,38 @@ en:
       remote_census_description: "Allows to configure the connection to the remote census of each institution"
       valuation_comment_notification: "Valuation comment notification"
       valuation_comment_notification_description: "Send an email to all associated users except valuation commenter to budget investment when a new valuation comment is created"
+    remote_census:
+      general:
+        endpoint: "Endpoint"
+        endpoint_description: "Host name where the census service is available (wsdl)"
+      request:
+        method_name: "Request method name"
+        method_name_description: "Request method name accepted by the City Census WebService."
+        structure: "Request Structure"
+        structure_description: 'Request Structure that receives the Census WebService of the City council. The "static" values of this request should be filled. Values related to Document Type, Document Number, Date of Birth and Postal Code should be blank.'
+        document_type: "Path for Document Type"
+        document_type_description: "Path in the request structure that sends the Document Type. DO NOT FILL IN if the WebService does not require the Document Type to verify a user."
+        document_number: "Path for Document Number"
+        document_number_description: "Path in the request structure that sends the Document Number. DO NOT FILL IN if the WebService does not require the Document Number to verify a user."
+        date_of_birth: "Path for Date of Birth"
+        date_of_birth_description: "Path in the request structure that sends the Date of Birth. DO NOT FILL IN if the WebService does not require the Date of Birth to verify a user."
+        postal_code: "Path for Postal Code"
+        postal_code_description: "Path in the request structure that sends the Postal Code. DO NOT FILL IN if the WebService does not require the Postal Code to verify a user."
+      response:
+        date_of_birth: "Path for Date of Birth"
+        date_of_birth_description: "In what path of the response is the user's Date of Birth?"
+        postal_code: "Path for Postal Code"
+        postal_code_description: "In what path of the response is the user's Postal Code?"
+        district: "Path for District"
+        district_description: "In what path of the response is the user's District?"
+        gender: "Path for Gender"
+        gender_description: "In what path of response is the user's Gender?"
+        name: "Path for Name"
+        name_description: "In what path of the response is the user's Name?"
+        surname: "Path for the Last Name"
+        surname_description: "In what path of the response is the user's Last Name?"
+        valid: "Condition for detecting a valid response"
+        valid_description: "What response path has to come informed to be considered a valid response and user verified"
     map:
       latitude: "Latitude"
       latitude_description: "Latitude to show the map position"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -116,6 +116,8 @@ en:
       public_stats_description: "Display public stats in the Administration panel"
       help_page: "Help page"
       help_page_description: 'Displays a Help menu that contains a page with an info section about each enabled feature. Also custom pages and menus can be created in the "Custom pages" and  "Custom content blocks" sections'
+      remote_census: "Configure connection to remote census (SOAP)"
+      remote_census_description: "Allows to configure the connection to the remote census of each institution"
       valuation_comment_notification: "Valuation comment notification"
       valuation_comment_notification_description: "Send an email to all associated users except valuation commenter to budget investment when a new valuation comment is created"
     map:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1312,6 +1312,8 @@ es:
           how_to_enable: 'Para mostrar el mapa a los usuarios se debe de activar "Geolocalización de propuestas y proyectos de gasto" en la pestaña "Funcionalidades".'
         dashboard:
           title: Panel de progreso de propuestas
+        remote_census:
+          title: Configuración del Censo Remoto
       setting: Funcionalidad
       setting_actions: Acciones
       setting_name: Configuración

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1315,6 +1315,9 @@ es:
         remote_census:
           title: Configuración del Censo Remoto
           how_to_enable: 'Para configurar la conexión con el Censo Remoto (SOAP) se debe activar "Configurar la conexión al censo remoto (SOAP)" en la pestaña "Funcionalidades".'
+      remote_census_general_name: Datos Generales
+      remote_census_request_name: Datos Petición
+      remote_census_response_name: Datos Respuesta
       setting: Funcionalidad
       setting_actions: Acciones
       setting_name: Configuración

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1314,6 +1314,7 @@ es:
           title: Panel de progreso de propuestas
         remote_census:
           title: Configuración del Censo Remoto
+          how_to_enable: 'Para configurar la conexión con el Censo Remoto (SOAP) se debe activar "Configurar la conexión al censo remoto (SOAP)" en la pestaña "Funcionalidades".'
       setting: Funcionalidad
       setting_actions: Acciones
       setting_name: Configuración

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -116,6 +116,8 @@ es:
       public_stats_description: "Muestra las estadísticas públicas en el panel de Administración"
       help_page: "Página de ayuda"
       help_page_description: 'Muestra un menú Ayuda que contiene una página con una sección de información sobre cada funcionalidad habilitada. También se pueden crear páginas y menús personalizados en las secciones "Personalizar páginas" y "Personalizar bloques"'
+      remote_census: "Configurar conexión al censo remoto (SOAP)"
+      remote_census_description: "Permite configurar la conexión al censo remoto de cada institución"
       valuation_comment_notification: "Notificar comentarios de evaluación"
       valuation_comment_notification_description: "Envía un email a todos los usuarios menos al que haya comentado asociados a un presupuesto participativo cuando se cree un nuevo comentario de evaluación"
     map:

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -120,6 +120,38 @@ es:
       remote_census_description: "Permite configurar la conexión al censo remoto de cada institución"
       valuation_comment_notification: "Notificar comentarios de evaluación"
       valuation_comment_notification_description: "Envía un email a todos los usuarios menos al que haya comentado asociados a un presupuesto participativo cuando se cree un nuevo comentario de evaluación"
+    remote_census:
+      general:
+        endpoint: "Endpoint"
+        endpoint_description: "Nombre del host donde se encuentra el servicio del censo (wsdl)"
+      request:
+        method_name: "Nombre del método de la petición"
+        method_name_description: "Nombre del método qe acepta el WebService del Censo del Ayuntamiento."
+        structure: "Estructura de la petición"
+        structure_description: 'Estructura de la petición que recibe el WebService del Censo del Ayuntamiento. Los valores "fijos" de esta petición deberan informarse. Los valores relacionado con Tipo de Documento, Número de Documento, Fecha de Nacimiento y Código Postal deberán dejarse en blanco.'
+        document_type: "Ruta para Tipo de Documento"
+        document_type_description: "Ruta donde se encuentra el campo en la estructura de la petición que envia el Tipo de Documento. NO RELLENAR en caso de que el WebService no requiera el Tipo de Documento para verificar un usuario."
+        document_number: "Ruta para Número de Documento"
+        document_number_description: "Ruta donde se encuentra campo en la estructura de la petición que envia el Número de Documento. NO RELLENAR en caso de que el WebService no requiera el Número de Documento para verificar un usuario."
+        date_of_birth: "Ruta para Fecha de Nacimiento"
+        date_of_birth_description: "Ruta donde se encuentra campo en la estructura de la petición que envia la Fecha de Nacimiento. NO RELLENAR en caso de que el WebService no requiera la Fecha de Nacimiento para verificar un usuario."
+        postal_code: "Ruta para Código Postal."
+        postal_code_description: "Ruta donde se encuentra campo en la estructura de la petición que envia el Código Postal. NO RELLENAR en caso de que el WebService no requiera el Código Postal para verificar un usuario."
+      response:
+        date_of_birth: "Ruta para la Fecha de Nacimiento"
+        date_of_birth_description: "En que ruta de la respuesta se encuentra la Fecha de Nacimiento"
+        postal_code: "Ruta para el Código Postal"
+        postal_code_description: "En que ruta de la respuesta se encuentra el Código Postal"
+        district: "Ruta para el Distrito"
+        district_description: "En que ruta de la respuesta se encuentra el Distrito"
+        gender: "Ruta para el Género"
+        gender_description: "En que ruta de la respuesta se encuentra el Género"
+        name: "Ruta para el Nombre"
+        name_description: "En que ruta de la respuesta se encuentra Nombre"
+        surname: "Ruta para el Apellido"
+        surname_description: "En que ruta de la respuesta se encuentra el Apellido"
+        valid: "Condición para detectar una respuesta válida"
+        valid_description: "Que ruta de la respuesta tiene que venir informado para considerarse una respuesta válida"
     map:
       latitude: "Latitud"
       latitude_description: "Latitud para mostrar la posición del mapa"

--- a/lib/active_model/dates.rb
+++ b/lib/active_model/dates.rb
@@ -1,12 +1,12 @@
 module ActiveModel::Dates
 
   def parse_date(field, attrs)
-    day, month, year = attrs["#{field}(1i)"],
+    year, month, day = attrs["#{field}(1i)"],
                        attrs["#{field}(2i)"],
                        attrs["#{field}(3i)"]
 
     return nil unless day.present? && month.present? && year.present?
-    Date.new(day.to_i, month.to_i, year.to_i)
+    Date.new(year.to_i, month.to_i, day.to_i)
   end
 
   def remove_date(field, attrs)

--- a/lib/census_api.rb
+++ b/lib/census_api.rb
@@ -119,8 +119,4 @@ class CensusApi
       {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}, datos_vivienda: {}}}}
     end
 
-    def dni?(document_type)
-      document_type.to_s == "1"
-    end
-
 end

--- a/lib/census_caller.rb
+++ b/lib/census_caller.rb
@@ -1,7 +1,11 @@
 class CensusCaller
 
   def call(document_type, document_number)
-    response = CensusApi.new.call(document_type, document_number)
+    if Setting["feature.remote_census"].present?
+      response = RemoteCensusApi.new.call(document_type, document_number)
+    else
+      response = CensusApi.new.call(document_type, document_number)
+    end
     response = LocalCensus.new.call(document_type, document_number) unless response.valid?
 
     response

--- a/lib/census_caller.rb
+++ b/lib/census_caller.rb
@@ -1,8 +1,8 @@
 class CensusCaller
 
-  def call(document_type, document_number)
+  def call(document_type, document_number, date_of_birth, postal_code)
     if Setting["feature.remote_census"].present?
-      response = RemoteCensusApi.new.call(document_type, document_number)
+      response = RemoteCensusApi.new.call(document_type, document_number, date_of_birth, postal_code)
     else
       response = CensusApi.new.call(document_type, document_number)
     end

--- a/lib/document_parser.rb
+++ b/lib/document_parser.rb
@@ -57,4 +57,9 @@ module DocumentParser
     end
     variants
   end
+
+  def dni?(document_type)
+    document_type.to_s == "1"
+  end
+
 end

--- a/lib/local_census.rb
+++ b/lib/local_census.rb
@@ -63,8 +63,4 @@ class LocalCensus
       LocalCensusRecord.find_by(document_type: document_type, document_number: document_number)
     end
 
-    def dni?(document_type)
-      document_type.to_s == "1"
-    end
-
 end

--- a/lib/remote_census_api.rb
+++ b/lib/remote_census_api.rb
@@ -1,0 +1,152 @@
+include DocumentParser
+class RemoteCensusApi
+
+  def call(document_type, document_number)
+    response = nil
+    get_document_number_variants(document_type, document_number).each do |variant|
+      response = Response.new(get_response_body(document_type, variant))
+      return response if response.valid?
+    end
+    response
+  end
+
+  class Response
+    def initialize(body)
+      @body = body
+    end
+
+    def extract_value(path_value)
+      path = parse_path(path_value)
+      return nil unless path.present?
+      @body.dig(*path)
+    end
+
+    def valid?
+      path_value = Setting["remote_census.response.valid"]
+      extract_value(path_value).present?
+    end
+
+    def date_of_birth
+      path_value = Setting["remote_census.response.date_of_birth"]
+      str = extract_value(path_value)
+      return nil unless str.present?
+      day, month, year = str.match(/(\d\d?)\D(\d\d?)\D(\d\d\d?\d?)/)[1..3]
+      return nil unless day.present? && month.present? && year.present?
+      Time.zone.local(year.to_i, month.to_i, day.to_i).to_date
+    end
+
+    def postal_code
+      path_value = Setting["remote_census.response.postal_code"]
+      extract_value(path_value)
+    end
+
+    def district_code
+      path_value = Setting["remote_census.response.district"]
+      extract_value(path_value)
+    end
+
+    def gender
+      path_value = Setting["remote_census.response.gender"]
+
+      case extract_value(path_value)
+      when "Varón"
+        "male"
+      when "Mujer"
+        "female"
+      end
+    end
+
+    def name
+      path_value_name = Setting["remote_census.response.name"]
+      path_value_surname = Setting["remote_census.response.surname"]
+
+      "#{extract_value(path_value_name)} #{extract_value(path_value_surname)}"
+    end
+
+    def parse_path(path_value)
+      path_value.split(".").map{ |section| section.to_sym } if path_value.present?
+    end
+  end
+
+  private
+
+    def get_response_body(document_type, document_number)
+      if end_point_available?
+        client.call(Setting["remote_census.request.method_name"].to_sym, message: request(document_type, document_number)).body
+      else
+        stubbed_response(document_type, document_number)
+      end
+    end
+
+    def client
+      @client = Savon.client(wsdl: Setting["remote_census.general.endpoint"])
+    end
+
+    def request(document_type, document_number)
+      structure = eval(Setting["remote_census.request.structure"])
+
+      fill_in(structure, Setting["remote_census.request.document_type"], document_type)
+      fill_in(structure, Setting["remote_census.request.document_number"], document_number)
+
+      structure
+    end
+
+    def fill_in(structure, path_value, value)
+      path = parse_path(path_value)
+
+      update_value(structure, path, value) if path.present?
+    end
+
+    def parse_path(path_value)
+      path_value.split(".").map{ |section| section.to_sym } if path_value.present?
+    end
+
+    def update_value(structure, path, value)
+      *path, final_key = path
+      to_set = path.empty? ? structure : structure.dig(*path)
+
+      return unless to_set
+      to_set[final_key] = value
+    end
+
+    def end_point_available?
+      Rails.env.staging? || Rails.env.preproduction? || Rails.env.production?
+    end
+
+    def stubbed_response(document_type, document_number)
+      if (document_number == "12345678Z" || document_number == "12345678Y") && document_type == "1"
+        stubbed_valid_response
+      else
+        stubbed_invalid_response
+      end
+    end
+
+    def stubbed_valid_response
+      {
+        get_habita_datos_response: {
+          get_habita_datos_return: {
+            datos_habitante: {
+              item: {
+                fecha_nacimiento_string: "31-12-1980",
+                identificador_documento: "12345678Z",
+                descripcion_sexo: "Varón",
+                nombre: "José",
+                apellido1: "García"
+              }
+            },
+            datos_vivienda: {
+              item: {
+                codigo_postal: "28013",
+                codigo_distrito: "01"
+              }
+            }
+          }
+        }
+      }
+    end
+
+    def stubbed_invalid_response
+      {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}, datos_vivienda: {}}}}
+    end
+
+end

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -52,4 +52,5 @@ namespace :settings do
   task add_new_settings: :environment do
     Setting.add_new_settings
   end
+
 end

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -132,6 +132,35 @@ describe "Admin settings" do
 
   end
 
+  describe "Update Remote Census Configuration" do
+
+    scenario "Should not be able when remote census feature deactivated" do
+      Setting["feature.remote_census"] = nil
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#remote-census-tab").click
+
+      expect(page).to have_content 'To configure remote census (SOAP) you must enable ' \
+                                   '"Configure connection to remote census (SOAP)" ' \
+                                   'on "Features" tab.'
+    end
+
+    scenario "Should be able when remote census feature activated" do
+      Setting["feature.remote_census"] = true
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#remote-census-tab").click
+
+      expect(page).not_to have_content 'To configure remote census (SOAP) you must enable ' \
+                                       '"Configure connection to remote census (SOAP)" ' \
+                                       'on "Features" tab.'
+      Setting["feature.remote_census"] = nil
+    end
+
+  end
+
   describe "Skip verification" do
 
     scenario "deactivate skip verification", :js do

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -153,6 +153,9 @@ describe "Admin settings" do
       visit admin_settings_path
       find("#remote-census-tab").click
 
+      expect(page).to have_content("General Information")
+      expect(page).to have_content("Request Data")
+      expect(page).to have_content("Response Data")
       expect(page).not_to have_content 'To configure remote census (SOAP) you must enable ' \
                                        '"Configure connection to remote census (SOAP)" ' \
                                        'on "Features" tab.'

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -134,6 +134,14 @@ describe "Admin settings" do
 
   describe "Update Remote Census Configuration" do
 
+    before do
+      Setting["feature.remote_census"] = true
+    end
+
+    after do
+      Setting["feature.remote_census"] = nil
+    end
+
     scenario "Should not be able when remote census feature deactivated" do
       Setting["feature.remote_census"] = nil
       admin = create(:administrator).user
@@ -147,7 +155,6 @@ describe "Admin settings" do
     end
 
     scenario "Should be able when remote census feature activated" do
-      Setting["feature.remote_census"] = true
       admin = create(:administrator).user
       login_as(admin)
       visit admin_settings_path
@@ -159,28 +166,40 @@ describe "Admin settings" do
       expect(page).not_to have_content 'To configure remote census (SOAP) you must enable ' \
                                        '"Configure connection to remote census (SOAP)" ' \
                                        'on "Features" tab.'
-      Setting["feature.remote_census"] = nil
     end
 
-    scenario "Should redirect to #tab-remote-census-configuration after update any remote census setting", :js do
-      remote_census_setting = create(:setting, key: "remote_census.general.any_remote_census_general_setting")
-      Setting["feature.remote_census"] = true
-      admin = create(:administrator).user
-      login_as(admin)
-      visit admin_settings_path
-      find("#remote-census-tab").click
+  end
 
-      within("#edit_setting_#{remote_census_setting.id}") do
-        fill_in "setting_#{remote_census_setting.id}", with: "New value"
-        click_button "Update"
+  describe "Should redirect to same tab after update setting" do
+
+    context "remote census" do
+
+      before do
+        Setting["feature.remote_census"] = true
       end
 
-      expect(page).to have_current_path(admin_settings_path)
-      expect(page).to have_css("div#tab-remote-census-configuration.is-active")
-      Setting["feature.remote_census"] = nil
+      after do
+        Setting["feature.remote_census"] = nil
+      end
+
+      scenario "On #tab-remote-census-configuration", :js do
+        remote_census_setting = create(:setting, key: "remote_census.general.whatever")
+        admin = create(:administrator).user
+        login_as(admin)
+        visit admin_settings_path
+        find("#remote-census-tab").click
+
+        within("#edit_setting_#{remote_census_setting.id}") do
+          fill_in "setting_#{remote_census_setting.id}", with: "New value"
+          click_button "Update"
+        end
+
+        expect(page).to have_current_path(admin_settings_path)
+        expect(page).to have_css("div#tab-remote-census-configuration.is-active")
+      end
     end
 
-    scenario "Should redirect to #tab-configuration after update any configuration setting", :js do
+    scenario "On #tab-configuration", :js do
       configuration_setting = Setting.create(key: "whatever")
       admin = create(:administrator).user
       login_as(admin)
@@ -196,25 +215,34 @@ describe "Admin settings" do
       expect(page).to have_css("div#tab-configuration.is-active")
     end
 
-    scenario "Should redirect to #tab-map-configuration after update any map configuration setting", :js do
-      map_setting = Setting.create(key: "map.whatever")
-      Setting["feature.map"] = true
-      admin = create(:administrator).user
-      login_as(admin)
-      visit admin_settings_path
-      find("#map-tab").click
+    context "map configuration" do
 
-      within("#edit_setting_#{map_setting.id}") do
-        fill_in "setting_#{map_setting.id}", with: "New value"
-        click_button "Update"
+      before do
+        Setting["feature.map"] = true
       end
 
-      expect(page).to have_current_path(admin_settings_path)
-      expect(page).to have_css("div#tab-map-configuration.is-active")
-      Setting["feature.map"] = nil
+      after do
+        Setting["feature.map"] = nil
+      end
+
+      scenario "On #tab-map-configuration", :js do
+        map_setting = Setting.create(key: "map.whatever")
+        admin = create(:administrator).user
+        login_as(admin)
+        visit admin_settings_path
+        find("#map-tab").click
+
+        within("#edit_setting_#{map_setting.id}") do
+          fill_in "setting_#{map_setting.id}", with: "New value"
+          click_button "Update"
+        end
+
+        expect(page).to have_current_path(admin_settings_path)
+        expect(page).to have_css("div#tab-map-configuration.is-active")
+      end
     end
 
-    scenario "Should redirect to #tab-proposals after update any proposal dashboard setting", :js do
+    scenario "On #tab-proposals", :js do
       proposal_dashboard_setting = Setting.create(key: "proposals.whatever")
       admin = create(:administrator).user
       login_as(admin)
@@ -230,7 +258,7 @@ describe "Admin settings" do
       expect(page).to have_css("div#tab-proposals.is-active")
     end
 
-    scenario "Should redirect to #tab-participation-processes after update any participation_processes setting", :js do
+    scenario "On #tab-participation-processes", :js do
       process_setting = Setting.create(key: "process.whatever")
       admin = create(:administrator).user
       login_as(admin)
@@ -245,7 +273,7 @@ describe "Admin settings" do
       expect(page).to have_css("div#tab-participation-processes.is-active")
     end
 
-    scenario "Should redirect to #tab-feature-flags after update any feature flag setting", :js do
+    scenario "On #tab-feature-flags", :js do
       feature_setting = Setting.create(key: "feature.whatever")
       admin = create(:administrator).user
       login_as(admin)

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -163,15 +163,15 @@ describe "Admin settings" do
     end
 
     scenario "Should redirect to #tab-remote-census-configuration after update any remote census setting", :js do
-      setting_remote_census = create(:setting, key: "remote_census.general.any_remote_census_general_setting")
+      remote_census_setting = create(:setting, key: "remote_census.general.any_remote_census_general_setting")
       Setting["feature.remote_census"] = true
       admin = create(:administrator).user
       login_as(admin)
       visit admin_settings_path
       find("#remote-census-tab").click
 
-      within("#edit_setting_#{setting_remote_census.id}") do
-        fill_in "setting_#{setting_remote_census.id}", with: "New value"
+      within("#edit_setting_#{remote_census_setting.id}") do
+        fill_in "setting_#{remote_census_setting.id}", with: "New value"
         click_button "Update"
       end
 
@@ -180,21 +180,85 @@ describe "Admin settings" do
       Setting["feature.remote_census"] = nil
     end
 
-    scenario "Should not redirect to #tab-remote-census-configuration after do not update any remote census setting", :js do
+    scenario "Should redirect to #tab-configuration after update any configuration setting", :js do
+      configuration_setting = Setting.create(key: "whatever")
       admin = create(:administrator).user
       login_as(admin)
       visit admin_settings_path
+      find("#tab-configuration").click
 
-      within("#edit_setting_#{@setting1.id}") do
-        fill_in "setting_#{@setting1.id}", with: "New value"
+      within("#edit_setting_#{configuration_setting.id}") do
+        fill_in "setting_#{configuration_setting.id}", with: "New value"
         click_button "Update"
       end
 
       expect(page).to have_current_path(admin_settings_path)
       expect(page).to have_css("div#tab-configuration.is-active")
-      expect(page).not_to have_css("div#tab-remote-census-configuration.is-active")
     end
 
+    scenario "Should redirect to #tab-map-configuration after update any map configuration setting", :js do
+      map_setting = Setting.create(key: "map.whatever")
+      Setting["feature.map"] = true
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#map-tab").click
+
+      within("#edit_setting_#{map_setting.id}") do
+        fill_in "setting_#{map_setting.id}", with: "New value"
+        click_button "Update"
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-map-configuration.is-active")
+      Setting["feature.map"] = nil
+    end
+
+    scenario "Should redirect to #tab-proposals after update any proposal dashboard setting", :js do
+      proposal_dashboard_setting = Setting.create(key: "proposals.whatever")
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#proposals-tab").click
+
+      within("#edit_setting_#{proposal_dashboard_setting.id}") do
+        fill_in "setting_#{proposal_dashboard_setting.id}", with: "New value"
+        click_button "Update"
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-proposals.is-active")
+    end
+
+    scenario "Should redirect to #tab-participation-processes after update any participation_processes setting", :js do
+      process_setting = Setting.create(key: "process.whatever")
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#participation-processes-tab").click
+
+      accept_alert do
+        find("#edit_setting_#{process_setting.id} .button").click
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-participation-processes.is-active")
+    end
+
+    scenario "Should redirect to #tab-feature-flags after update any feature flag setting", :js do
+      feature_setting = Setting.create(key: "feature.whatever")
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#features-tab").click
+
+      accept_alert do
+        find("#edit_setting_#{feature_setting.id} .button").click
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-feature-flags.is-active")
+    end
   end
 
   describe "Skip verification" do

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -162,6 +162,39 @@ describe "Admin settings" do
       Setting["feature.remote_census"] = nil
     end
 
+    scenario "Should redirect to #tab-remote-census-configuration after update any remote census setting", :js do
+      setting_remote_census = create(:setting, key: "remote_census.general.any_remote_census_general_setting")
+      Setting["feature.remote_census"] = true
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#remote-census-tab").click
+
+      within("#edit_setting_#{setting_remote_census.id}") do
+        fill_in "setting_#{setting_remote_census.id}", with: "New value"
+        click_button "Update"
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-remote-census-configuration.is-active")
+      Setting["feature.remote_census"] = nil
+    end
+
+    scenario "Should not redirect to #tab-remote-census-configuration after do not update any remote census setting", :js do
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+
+      within("#edit_setting_#{@setting1.id}") do
+        fill_in "setting_#{@setting1.id}", with: "New value"
+        click_button "Update"
+      end
+
+      expect(page).to have_current_path(admin_settings_path)
+      expect(page).to have_css("div#tab-configuration.is-active")
+      expect(page).not_to have_css("div#tab-remote-census-configuration.is-active")
+    end
+
   end
 
   describe "Skip verification" do

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -116,4 +116,61 @@ describe "Residence", :with_frozen_time do
     expect(page).to have_content "Vote introduced!"
   end
 
+  context "With remote census configuration" do
+
+    before do
+      Setting["feature.remote_census"] = true
+      Setting["remote_census.request.date_of_birth"] = "some.value"
+      Setting["remote_census.request.postal_code"] = "some.value"
+      create(:poll_officer_assignment, officer: officer)
+      login_through_form_as_officer(officer.user)
+      visit officing_root_path
+    end
+
+    after do
+      Setting["feature.remote_census"] = nil
+      Setting["remote_census.request.date_of_birth"] = nil
+      Setting["remote_census.request.postal_code"] = nil
+    end
+
+    describe "Display form fields according to the remote census configuration" do
+
+      scenario "by default (without custom census) not display date_of_birth and postal_code" do
+        Setting["feature.remote_census"] = false
+
+        within("#side_menu") do
+          click_link "Validate document"
+        end
+
+        expect(page).to have_css("#residence_document_type")
+        expect(page).to have_css("#residence_document_number")
+        expect(page).to have_css("#residence_year_of_birth")
+        expect(page).not_to have_content("Date of birth")
+        expect(page).not_to have_css("#residence_postal_code")
+      end
+
+    end
+
+    scenario "can verify voter with date_of_birth and postal_code fields" do
+      access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
+      access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
+      Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
+      Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
+      Setting["remote_census.response.valid"] = access_user_data
+      within("#side_menu") do
+        click_link "Validate document"
+      end
+
+      select "DNI", from: "residence_document_type"
+      fill_in "residence_document_number", with: "12345678Z"
+      select_date "31-December-1980", from: "residence_date_of_birth"
+      fill_in "residence_postal_code", with: "28001"
+
+      click_button "Validate document"
+
+      expect(page).to have_content "Document verified with Census"
+    end
+
+  end
+
 end

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -149,6 +149,21 @@ describe "Residence", :with_frozen_time do
         expect(page).not_to have_css("#residence_postal_code")
       end
 
+      scenario "with all custom census not display year_of_birth" do
+        Setting["remote_census.request.date_of_birth"] = "some.value"
+        Setting["remote_census.request.postal_code"] = "some.value"
+
+        within("#side_menu") do
+          click_link "Validate document"
+        end
+
+        expect(page).to have_css("#residence_document_type")
+        expect(page).to have_css("#residence_document_number")
+        expect(page).to have_content("Date of birth")
+        expect(page).to have_css("#residence_postal_code")
+        expect(page).not_to have_css("#residence_year_of_birth")
+      end
+
     end
 
     scenario "can verify voter with date_of_birth and postal_code fields" do

--- a/spec/features/verification/residence_spec.rb
+++ b/spec/features/verification/residence_spec.rb
@@ -21,6 +21,31 @@ describe "Residence" do
     expect(page).to have_content "Residence verified"
   end
 
+  scenario "Verify resident throught RemoteCensusApi" do
+    Setting["feature.remote_census"] = true
+
+    access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
+    access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
+    Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
+    Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
+    Setting["remote_census.response.valid"] = access_user_data
+    user = create(:user)
+    login_as(user)
+
+    visit account_path
+    click_link "Verify my account"
+
+    fill_in "residence_document_number", with: "12345678Z"
+    select "DNI", from: "residence_document_type"
+    select_date "31-December-1980", from: "residence_date_of_birth"
+    fill_in "residence_postal_code", with: "28013"
+    check "residence_terms_of_service"
+    click_button "Verify residence"
+
+    expect(page).to have_content "Residence verified"
+    Setting["feature.remote_census"] = nil
+  end
+
   scenario "Residence form use min age to participate" do
     min_age = (Setting["min_age_to_participate"] = 16).to_i
     underage = min_age - 1

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -28,4 +28,13 @@ RSpec.describe SettingsHelper, type: :helper do
     end
   end
 
+  describe "#display_setting_name" do
+    it "returns correct setting_name" do
+      expect(display_setting_name("setting")).to eq("Setting")
+      expect(display_setting_name("remote_census_general_name")).to eq("General Information")
+      expect(display_setting_name("remote_census_request_name")).to eq("Request Data")
+      expect(display_setting_name("remote_census_response_name")).to eq("Response Data")
+    end
+  end
+
 end

--- a/spec/lib/census_api_spec.rb
+++ b/spec/lib/census_api_spec.rb
@@ -3,30 +3,6 @@ require "rails_helper"
 describe CensusApi do
   let(:api) { described_class.new }
 
-  describe "#get_document_number_variants" do
-    it "trims and cleans up entry" do
-      expect(api.get_document_number_variants(2, "  1 2@ 34")).to eq(["1234"])
-    end
-
-    it "returns only one try for passports & residence cards" do
-      expect(api.get_document_number_variants(2, "1234")).to eq(["1234"])
-      expect(api.get_document_number_variants(3, "1234")).to eq(["1234"])
-    end
-
-    it "takes only the last 8 digits for dnis and resicence cards" do
-      expect(api.get_document_number_variants(1, "543212345678")).to eq(["12345678"])
-    end
-
-    it "tries all the dni variants padding with zeroes" do
-      expect(api.get_document_number_variants(1, "0123456")).to eq(["123456", "0123456", "00123456"])
-      expect(api.get_document_number_variants(1, "00123456")).to eq(["123456", "0123456", "00123456"])
-    end
-
-    it "adds upper and lowercase letter when the letter is present" do
-      expect(api.get_document_number_variants(1, "1234567A")).to eq(%w(1234567 01234567 1234567a 1234567A 01234567a 01234567A))
-    end
-  end
-
   describe "#call" do
     let(:invalid_body) { {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}}}} }
     let(:valid_body) do

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -18,7 +18,7 @@ describe CensusCaller do
       allow(CensusApi).to   receive(:call).with(1, "12345678A")
       allow(LocalCensus).to receive(:call).with(1, "12345678A")
 
-      response = api.call(1, "12345678A")
+      response = api.call(1, "12345678A", nil, nil)
 
       expect(response).to eq(local_census_response)
     end
@@ -38,38 +38,68 @@ describe CensusCaller do
       allow(CensusApi).to receive(:call).with(1, "12345678A")
       allow(LocalCensus).to receive(:call).with(1, "12345678A")
 
-      response = api.call(1, "12345678A")
+      response = api.call(1, "12345678A", nil, nil)
 
       expect(response).to eq(census_api_response)
     end
 
-    it "returns data from Remote Census API if it's available and valid" do
-      Setting["feature.remote_census"] = true
-      access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-      access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-      Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-      Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-      Setting["remote_census.response.valid"] = access_user_data
+    describe "RemoteCensusApi" do
 
-      remote_census_api_response = RemoteCensusApi::Response.new(get_habita_datos_response: {
-        get_habita_datos_return: {
-          datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" } }
-        }
-      })
+      before do
+        access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
+        access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
+        Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
+        Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
+        Setting["remote_census.response.valid"] = access_user_data
+      end
 
-      local_census_response = LocalCensus::Response.new(create(:local_census_record))
+      it "returns data from Remote Census API if it's available and valid" do
+        Setting["feature.remote_census"] = true
 
-      expect_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)
-      allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
+        remote_census_api_response = RemoteCensusApi::Response.new(get_habita_datos_response: {
+          get_habita_datos_return: {
+            datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" } }
+          }
+        })
 
-      allow(RemoteCensusApi).to receive(:call).with(1, "12345678A")
-      allow(LocalCensus).to receive(:call).with(1, "12345678A")
+        local_census_response = LocalCensus::Response.new(create(:local_census_record))
 
-      response = api.call(1, "12345678A")
+        expect_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)
+        allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
 
-      expect(response).to eq(remote_census_api_response)
+        allow(RemoteCensusApi).to receive(:call).with(1, "12345678A", Date.parse("01/01/1983"), "28001")
+        allow(LocalCensus).to receive(:call).with(1, "12345678A")
 
-      Setting["feature.remote_census"] = nil
+        response = api.call(1, "12345678A", Date.parse("01/01/1983"), "28001")
+
+        expect(response).to eq(remote_census_api_response)
+
+        Setting["feature.remote_census"] = nil
+      end
+
+      it "returns data from Remote Census API if it's available and valid without send date_of_birth and postal_code" do
+        Setting["feature.remote_census"] = true
+
+        remote_census_api_response = RemoteCensusApi::Response.new(get_habita_datos_response: {
+          get_habita_datos_return: {
+            datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" } }
+          }
+        })
+
+        local_census_response = LocalCensus::Response.new(create(:local_census_record))
+
+        expect_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)
+        allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
+
+        allow(RemoteCensusApi).to receive(:call).with(1, "12345678A", nil, nil)
+        allow(LocalCensus).to receive(:call).with(1, "12345678A")
+
+        response = api.call(1, "12345678A", nil, nil)
+
+        expect(response).to eq(remote_census_api_response)
+
+        Setting["feature.remote_census"] = nil
+      end
     end
   end
 

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -42,6 +42,35 @@ describe CensusCaller do
 
       expect(response).to eq(census_api_response)
     end
+
+    it "returns data from Remote Census API if it's available and valid" do
+      Setting["feature.remote_census"] = true
+      access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
+      access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
+      Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
+      Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
+      Setting["remote_census.response.valid"] = access_user_data
+
+      remote_census_api_response = RemoteCensusApi::Response.new(get_habita_datos_response: {
+        get_habita_datos_return: {
+          datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" } }
+        }
+      })
+
+      local_census_response = LocalCensus::Response.new(create(:local_census_record))
+
+      expect_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)
+      allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
+
+      allow(RemoteCensusApi).to receive(:call).with(1, "12345678A")
+      allow(LocalCensus).to receive(:call).with(1, "12345678A")
+
+      response = api.call(1, "12345678A")
+
+      expect(response).to eq(remote_census_api_response)
+
+      Setting["feature.remote_census"] = nil
+    end
   end
 
 end

--- a/spec/lib/document_parser_spec.rb
+++ b/spec/lib/document_parser_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+include DocumentParser
+
+describe DocumentParser do
+
+  describe "#get_document_number_variants" do
+    it "trims and cleans up entry" do
+      expect(DocumentParser.get_document_number_variants(2, "  1 2@ 34")).to eq(["1234"])
+    end
+
+    it "returns only one try for passports & residence cards" do
+      expect(DocumentParser.get_document_number_variants(2, "1234")).to eq(["1234"])
+      expect(DocumentParser.get_document_number_variants(3, "1234")).to eq(["1234"])
+    end
+
+    it "takes only the last 8 digits for dnis and resicence cards" do
+      expect(DocumentParser.get_document_number_variants(1, "543212345678")).to eq(["12345678"])
+    end
+
+    it "tries all the dni variants padding with zeroes" do
+      expect(DocumentParser.get_document_number_variants(1, "0123456")).to eq(["123456", "0123456", "00123456"])
+      expect(DocumentParser.get_document_number_variants(1, "00123456")).to eq(["123456", "0123456", "00123456"])
+    end
+
+    it "adds upper and lowercase letter when the letter is present" do
+      expect(DocumentParser.get_document_number_variants(1, "1234567A")).to eq(%w(1234567 01234567 1234567a 1234567A 01234567a 01234567A))
+    end
+  end
+
+end

--- a/spec/lib/local_census_spec.rb
+++ b/spec/lib/local_census_spec.rb
@@ -3,30 +3,6 @@ require "rails_helper"
 describe LocalCensus do
   let(:api) { described_class.new }
 
-  describe "#get_document_number_variants" do
-    it "trims and cleans up entry" do
-      expect(api.get_document_number_variants(2, "  1 2@ 34")).to eq(["1234"])
-    end
-
-    it "returns only one try for passports & residence cards" do
-      expect(api.get_document_number_variants(2, "1234")).to eq(["1234"])
-      expect(api.get_document_number_variants(3, "1234")).to eq(["1234"])
-    end
-
-    it "takes only the last 8 digits for dnis and resicence cards" do
-      expect(api.get_document_number_variants(1, "543212345678")).to eq(["12345678"])
-    end
-
-    it "tries all the dni variants padding with zeroes" do
-      expect(api.get_document_number_variants(1, "0123456")).to eq(["123456", "0123456", "00123456"])
-      expect(api.get_document_number_variants(1, "00123456")).to eq(["123456", "0123456", "00123456"])
-    end
-
-    it "adds upper and lowercase letter when the letter is present" do
-      expect(api.get_document_number_variants(1, "1234567A")).to eq(["1234567", "01234567", "1234567a", "1234567A", "01234567a", "01234567A"])
-    end
-  end
-
   describe "#call" do
     let(:invalid_body) { nil }
     let(:valid_body) { create(:local_census_record) }

--- a/spec/lib/remote_census_api_spec.rb
+++ b/spec/lib/remote_census_api_spec.rb
@@ -28,24 +28,196 @@ describe RemoteCensusApi do
     end
 
     it "returns the response for the first valid variant" do
-      allow(api).to receive(:get_response_body).with(1, "00123456").and_return(invalid_body)
-      allow(api).to receive(:get_response_body).with(1, "123456").and_return(invalid_body)
-      allow(api).to receive(:get_response_body).with(1, "0123456").and_return(valid_body)
+      date = Date.parse("01/01/1983")
+      allow(api).to receive(:get_response_body).with(1, "00123456", date, "28001").and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "123456", date, "28001").and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "0123456", date, "28001").and_return(valid_body)
 
-      response = api.call(1, "123456")
+      response = api.call(1, "123456", date, "28001")
+
+      expect(response).to be_valid
+      expect(response.date_of_birth).to eq(Date.new(1980, 1, 1))
+    end
+
+    it "returns the response for the first valid variant without send date_of_birth and postal_code" do
+      allow(api).to receive(:get_response_body).with(1, "00123456", nil, nil).and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "123456", nil, nil).and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "0123456", nil, nil).and_return(valid_body)
+
+      response = api.call(1, "123456", nil, nil)
 
       expect(response).to be_valid
       expect(response.date_of_birth).to eq(Date.new(1980, 1, 1))
     end
 
     it "returns the last failed response" do
-      allow(api).to receive(:get_response_body).with(1, "00123456").and_return(invalid_body)
-      allow(api).to receive(:get_response_body).with(1, "123456").and_return(invalid_body)
-      allow(api).to receive(:get_response_body).with(1, "0123456").and_return(invalid_body)
-      response = api.call(1, "123456")
+      date = Date.parse("01/01/1983")
+      allow(api).to receive(:get_response_body).with(1, "00123456", date, "28001").and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "123456", date, "28001").and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "0123456", date, "28001").and_return(invalid_body)
+      response = api.call(1, "123456", date, "28001")
 
       expect(response).not_to be_valid
     end
+  end
+
+  describe "request structure correctly filled" do
+
+    before do
+      Setting["feature.remote_census"] = true
+      Setting["remote_census.request.structure"] = "{ request:
+                                                      { codigo_institucion: 1,
+                                                        codigo_portal: 1,
+                                                        codigo_usuario: 1,
+                                                        documento: 'xxx',
+                                                        tipo_documento: 'xxx',
+                                                        codigo_idioma: '102',
+                                                        nivel: '3' }
+                                                    }"
+      Setting["remote_census.request.document_type"] = "request.tipo_documento"
+      Setting["remote_census.request.document_number"] = "request.documento"
+      Setting["remote_census.request.date_of_birth"] = nil
+      Setting["remote_census.request.postal_code"] = nil
+    end
+
+    it "with default values" do
+      document_type = "1"
+      document_number = "0123456"
+
+      request = RemoteCensusApi.new.send(:request, document_type, document_number, nil, nil)
+
+      expect(request).to eq ({:request=>
+                              {:codigo_institucion=>1,
+                               :codigo_portal=>1,
+                               :codigo_usuario=>1,
+                               :documento=>"0123456",
+                               :tipo_documento=>"1",
+                               :codigo_idioma=>"102",
+                               :nivel=>"3"}
+                              })
+    end
+
+    it "when send date_of_birth and postal_code but are not configured" do
+      document_type = "1"
+      document_number = "0123456"
+      date_of_birth =  Date.new(1980, 1, 1)
+      postal_code = "28001"
+
+      request = RemoteCensusApi.new.send(:request, document_type, document_number, date_of_birth, postal_code)
+
+      expect(request).to eq ({:request=>
+                              {:codigo_institucion=>1,
+                               :codigo_portal=>1,
+                               :codigo_usuario=>1,
+                               :documento=>"0123456",
+                               :tipo_documento=>"1",
+                               :codigo_idioma=>"102",
+                               :nivel=>"3"}
+                              })
+    end
+
+    it "when send date_of_birth and postal_code but are configured" do
+      Setting["remote_census.request.structure"] = "{ request:
+                                                      { codigo_institucion: 1,
+                                                        codigo_portal: 1,
+                                                        codigo_usuario: 1,
+                                                        documento: nil,
+                                                        tipo_documento: nil,
+                                                        fecha_nacimiento: nil,
+                                                        codigo_postal: nil,
+                                                        codigo_idioma: '102',
+                                                        nivel: '3' }
+                                                    }"
+      Setting["remote_census.request.date_of_birth"] = "request.fecha_nacimiento"
+      Setting["remote_census.request.postal_code"] = "request.codigo_postal"
+      document_type = "1"
+      document_number = "0123456"
+      date_of_birth =  Date.new(1980, 1, 1)
+      postal_code = "28001"
+
+      request = RemoteCensusApi.new.send(:request, document_type, document_number, date_of_birth, postal_code)
+
+      expect(request).to eq ({:request=>
+                              {:codigo_institucion=>1,
+                               :codigo_portal=>1,
+                               :codigo_usuario=>1,
+                               :documento=>"0123456",
+                               :tipo_documento=>"1",
+                               :fecha_nacimiento=>"1980-01-01",
+                               :codigo_postal=>"28001",
+                               :codigo_idioma=>"102",
+                               :nivel=>"3"}
+                              })
+    end
+
+  end
+
+  describe "get_response_body" do
+
+    before do
+      Setting["feature.remote_census"] = true
+    end
+
+    it "return expected stubbed_response" do
+      document_type = "1"
+      document_number = "12345678Z"
+
+      response = RemoteCensusApi.new.send(:get_response_body, document_type, document_number, nil, nil)
+
+      expect(response).to eq ({ get_habita_datos_response: {
+                                  get_habita_datos_return: {
+                                    datos_habitante: {
+                                      item: {
+                                        fecha_nacimiento_string: "31-12-1980",
+                                        identificador_documento: "12345678Z",
+                                        descripcion_sexo: "Varón",
+                                        nombre: "José",
+                                        apellido1: "García"
+                                      }
+                                    },
+                                    datos_vivienda: {
+                                      item: {
+                                        codigo_postal: "28013",
+                                        codigo_distrito: "01"
+                                      }
+                                    }
+                                  }
+                                }
+                              })
+    end
+
+  end
+
+  describe "RemoteCensusApi::Response" do
+
+    before do
+      Setting["feature.remote_census"] = true
+      access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
+      access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
+      Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
+      Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
+      Setting["remote_census.response.district"] = "#{access_residence_data}.codigo_distrito"
+      Setting["remote_census.response.gender"] = "#{access_user_data}.descripcion_sexo"
+      Setting["remote_census.response.name"] = "#{access_user_data}.nombre"
+      Setting["remote_census.response.surname"] = "#{access_user_data}.apellido1"
+      Setting["remote_census.response.valid"] = access_user_data
+    end
+
+    it "return expected response methods with default values" do
+      document_type = "1"
+      document_number = "12345678Z"
+
+      get_response_body = RemoteCensusApi.new.send(:get_response_body, document_type, document_number, nil, nil)
+      response = RemoteCensusApi::Response.new(get_response_body)
+
+      expect(response.valid?).to eq true
+      expect(response.date_of_birth).to eq Time.zone.local(1980, 12, 31).to_date
+      expect(response.postal_code).to eq "28013"
+      expect(response.district_code).to eq "01"
+      expect(response.gender).to eq "male"
+      expect(response.name).to eq "José García"
+    end
+
   end
 
 end

--- a/spec/lib/remote_census_api_spec.rb
+++ b/spec/lib/remote_census_api_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe RemoteCensusApi do
+  let(:api) { described_class.new }
+
+  describe "#call" do
+    let(:invalid_body) { {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}}}} }
+    let(:valid_body) do
+      {
+        get_habita_datos_response: {
+          get_habita_datos_return: {
+            datos_habitante: {
+              item: {
+                fecha_nacimiento_string: "1-1-1980"
+              }
+            }
+          }
+        }
+      }
+    end
+
+    before do
+      access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
+      access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
+      Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
+      Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
+      Setting["remote_census.response.valid"] = access_user_data
+    end
+
+    it "returns the response for the first valid variant" do
+      allow(api).to receive(:get_response_body).with(1, "00123456").and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "123456").and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "0123456").and_return(valid_body)
+
+      response = api.call(1, "123456")
+
+      expect(response).to be_valid
+      expect(response.date_of_birth).to eq(Date.new(1980, 1, 1))
+    end
+
+    it "returns the last failed response" do
+      allow(api).to receive(:get_response_body).with(1, "00123456").and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "123456").and_return(invalid_body)
+      allow(api).to receive(:get_response_body).with(1, "0123456").and_return(invalid_body)
+      response = api.call(1, "123456")
+
+      expect(response).not_to be_valid
+    end
+  end
+
+end

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -113,13 +113,13 @@ describe Officing::Residence do
 
     describe "allowed age" do
       it "is not valid if user is under allowed age" do
-        allow_any_instance_of(described_class).to receive(:date_of_birth).and_return(15.years.ago)
+        allow_any_instance_of(described_class).to receive(:response_date_of_birth).and_return(15.years.ago)
         expect(residence).not_to be_valid
         expect(residence.errors[:year_of_birth]).to include("You don't have the required age to participate")
       end
 
       it "is valid if user is above allowed age" do
-        allow_any_instance_of(described_class).to receive(:date_of_birth).and_return(16.years.ago)
+        allow_any_instance_of(described_class).to receive(:response_date_of_birth).and_return(16.years.ago)
         expect(residence).to be_valid
         expect(residence.errors[:year_of_birth]).to be_empty
       end

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -36,6 +36,81 @@ describe Officing::Residence do
       expect(residence).to be_valid
     end
 
+    describe "custom validations" do
+
+      let(:custom_residence) { build(:officing_residence,
+                                     document_number: "12345678Z",
+                                     date_of_birth: "01/01/1980",
+                                     postal_code: "28001") }
+
+      before do
+        Setting["feature.remote_census"] = true
+        Setting["remote_census.request.date_of_birth"] = "some.value"
+        Setting["remote_census.request.postal_code"] = "some.value"
+        access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
+        access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
+        Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
+        Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
+        Setting["remote_census.response.valid"] = access_user_data
+      end
+
+      after do
+        Setting["feature.remote_census"] = nil
+        Setting["remote_census.request.date_of_birth"] = nil
+        Setting["remote_census.request.postal_code"] = nil
+      end
+
+      it "is valid" do
+        expect(custom_residence).to be_valid
+      end
+
+      it "is not valid without a document number" do
+        custom_residence.document_number = nil
+        expect(custom_residence).not_to be_valid
+      end
+
+      it "is not valid without a document type" do
+        custom_residence.document_type = nil
+        expect(custom_residence).not_to be_valid
+      end
+
+      it "is valid without a year of birth when date_of_birth is present" do
+        custom_residence.year_of_birth = nil
+
+        expect(custom_residence).to be_valid
+      end
+
+      it "is not valid without a date of birth" do
+        custom_residence.date_of_birth = nil
+
+        expect(custom_residence).not_to be_valid
+      end
+
+      it "is not valid without a postal_code" do
+        custom_residence.postal_code = nil
+
+        expect(custom_residence).not_to be_valid
+      end
+
+      describe "dates" do
+        it "is valid with a valid date of birth" do
+          custom_residence = described_class.new("date_of_birth(3i)" => "1",
+                                                 "date_of_birth(2i)" => "1",
+                                                 "date_of_birth(1i)" => "1980")
+          expect(custom_residence.errors[:date_of_birth].size).to eq(0)
+        end
+
+        it "is not valid without a date of birth" do
+          custom_residence = described_class.new("date_of_birth(3i)" => "",
+                                                 "date_of_birth(2i)" => "",
+                                                 "date_of_birth(1i)" => "")
+          expect(custom_residence).not_to be_valid
+          expect(custom_residence.errors[:date_of_birth]).to include("can't be blank")
+        end
+      end
+
+    end
+
     describe "allowed age" do
       it "is not valid if user is under allowed age" do
         allow_any_instance_of(described_class).to receive(:date_of_birth).and_return(15.years.ago)

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -109,6 +109,27 @@ describe Officing::Residence do
         end
       end
 
+      it "stores failed census calls and set postal_code attribute" do
+        Setting["remote_census.request.date_of_birth"] = ""
+
+        residence = build(:officing_residence,
+                          :invalid,
+                          document_number: "12345678Z",
+                          postal_code: "00001")
+        residence.save
+
+        expect(FailedCensusCall.count).to eq(1)
+        expect(FailedCensusCall.first).to have_attributes(
+          user_id:         residence.user.id,
+          poll_officer_id: residence.officer.id,
+          document_number: "12345678Z",
+          document_type:   "1",
+          date_of_birth: nil,
+          postal_code: "00001",
+          year_of_birth: Time.current.year
+        )
+      end
+
     end
 
     describe "allowed age" do
@@ -198,6 +219,8 @@ describe Officing::Residence do
         poll_officer_id: residence.officer.id,
         document_number: "12345678Z",
         document_type:   "1",
+        date_of_birth: nil,
+        postal_code: nil,
         year_of_birth:   Time.current.year
       )
     end

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -26,6 +26,16 @@ describe Officing::Residence do
       expect(residence).not_to be_valid
     end
 
+    it "is valid without a date of birth" do
+      residence.date_of_birth = nil
+      expect(residence).to be_valid
+    end
+
+    it "is valid without a postal code" do
+      residence.postal_code = nil
+      expect(residence).to be_valid
+    end
+
     describe "allowed age" do
       it "is not valid if user is under allowed age" do
         allow_any_instance_of(described_class).to receive(:date_of_birth).and_return(15.years.ago)

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -53,6 +53,21 @@ describe Setting do
       expect(homepage_setting.type).to eq "homepage"
     end
 
+    it "returns the key prefix for 'remote_census.general' settings" do
+      remote_census_general_setting = Setting.create(key: "remote_census.general.whatever")
+      expect(remote_census_general_setting.type).to eq "remote_census.general"
+    end
+
+    it "returns the key prefix for 'remote_census_request' settings" do
+      remote_census_request_setting = Setting.create(key: "remote_census.request.whatever")
+      expect(remote_census_request_setting.type).to eq "remote_census.request"
+    end
+
+    it "returns the key prefix for 'remote_census_response' settings" do
+      remote_census_response_setting = Setting.create(key: "remote_census.response.whatever")
+      expect(remote_census_response_setting.type).to eq "remote_census.response"
+    end
+
     it "returns 'configuration' for the rest of the settings" do
       configuration_setting = Setting.create(key: "whatever")
       expect(configuration_setting.type).to eq "configuration"

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -236,4 +236,50 @@ describe Setting do
       end
     end
   end
+
+  describe ".force_presence_date_of_birth?" do
+
+    it "return false when feature remote_census is not active" do
+      Setting["feature.remote_census"] = false
+
+      expect(Setting.force_presence_date_of_birth?).to eq false
+    end
+
+    it "return false when feature remote_census is active and date_of_birth is nil" do
+      Setting["feature.remote_census"] = true
+      Setting["remote_census.request.date_of_birth"] = nil
+
+      expect(Setting.force_presence_date_of_birth?).to eq false
+    end
+
+    it "return true when feature remote_census is active and date_of_birth is empty" do
+      Setting["feature.remote_census"] = true
+      Setting["remote_census.request.date_of_birth"] = "some.value"
+
+      expect(Setting.force_presence_date_of_birth?).to eq true
+    end
+  end
+
+  describe ".force_presence_postal_code?" do
+
+    it "return false when feature remote_census is not active" do
+      Setting["feature.remote_census"] = false
+
+      expect(Setting.force_presence_postal_code?).to eq false
+    end
+
+    it "return false when feature remote_census is active and postal_code is nil" do
+      Setting["feature.remote_census"] = true
+      Setting["remote_census.request.postal_code"] = nil
+
+      expect(Setting.force_presence_postal_code?).to eq false
+    end
+
+    it "return true when feature remote_census is active and postal_code is empty" do
+      Setting["feature.remote_census"] = true
+      Setting["remote_census.request.postal_code"] = "some.value"
+
+      expect(Setting.force_presence_postal_code?).to eq true
+    end
+  end
 end


### PR DESCRIPTION
## References
Related PR: #3498 
Related Issue: 
[Configure connection with WebServices (SOAP) #3525](https://github.com/consul/consul/issues/3525)

## Objectives
Allow "Validate Document" using new configurable fields (:date_of_birth, :postal_code) from Remote Census on Officing::Residence admin section.

## Visual Changes
![Captura de pantalla 2019-04-25 a las 18 43 30](https://user-images.githubusercontent.com/16189/56753080-0fd0ca00-678a-11e9-8f82-071250aa4bc3.png)

## Notes
This PR starts with code from: #3498  
