### PR TITLE
Set locales in test environment to avoid failed specs

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,14 +4,7 @@ Rails.application.configure do
   # Some tests require the following languages (en, es, fr, nl, pt-BR)
   # so we override the available languages for the test environment.
   config.i18n.default_locale = :en
-  available_locales = [
-    "en",
-    "es",
-    "fr",
-    "nl",
-    "pt-BR"
-  ]
-  config.i18n.available_locales = available_locales
+  config.i18n.available_locales = %w[de en es fr nl pt-BR zh-CN]
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,18 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Some tests require the following languages (en, es, fr, nl, pt-BR)
+  # so we override the available languages for the test environment.
+  config.i18n.default_locale = :en
+  available_locales = [
+    "en",
+    "es",
+    "fr",
+    "nl",
+    "pt-BR"
+  ]
+  config.i18n.available_locales = available_locales
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped

--- a/spec/features/remote_translations_spec.rb
+++ b/spec/features/remote_translations_spec.rb
@@ -5,8 +5,7 @@ describe "Remote Translations" do
   before do
     Setting["feature.remote_translations"] = true
     create(:proposal)
-    available_locales_response = ["ar", "de", "en", "es", "fa", "fr", "he", "it", "nl", "pl",
-                                  "pt", "sv", "zh-Hans", "zh-Hant"]
+    available_locales_response = %w[de en es fr pt zh-Hans]
     expect(RemoteTranslations::Microsoft::AvailableLocales).to receive(:available_locales).
                                                             and_return(available_locales_response)
   end
@@ -27,18 +26,14 @@ describe "Remote Translations" do
       end
 
       scenario "should display text in English" do
-        available_locales_with_fallback_en = [:ar, :de, :fa, :he, :nl, :pl, :sv]
-
-        visit root_path(locale: available_locales_with_fallback_en.sample)
+        visit root_path(locale: :de)
 
         expect(page).to have_css ".remote-translations-button"
         expect(page).to have_content "The content of this page is not available in your language"
       end
 
       scenario "should display text in English after parse key" do
-        available_locales_with_fallback_en = [:"zh-CN", :"zh-TW"]
-
-        visit root_path(locale: available_locales_with_fallback_en.sample)
+        visit root_path(locale: :"zh-CN")
 
         expect(page).to have_css ".remote-translations-button"
         expect(page).to have_content "The content of this page is not available in your language"
@@ -53,9 +48,7 @@ describe "Remote Translations" do
       end
 
       scenario "with locale that has :es fallback" do
-        available_locales_with_fallback_es = [:es, :fr, :it]
-
-        visit root_path(locale: available_locales_with_fallback_es.sample)
+        visit root_path(locale: :fr)
 
         expect(page).to have_css ".remote-translations-button"
         expect(page).to have_content "El contenido de esta página no está disponible en tu idioma"
@@ -72,9 +65,7 @@ describe "Remote Translations" do
   end
 
   scenario "Not display remote translation button when locale is not included in microsoft translate client" do
-    not_available_locales = [:val, :gl, :sq]
-
-    visit root_path(locale: not_available_locales.sample)
+    visit root_path(locale: :nl)
 
     expect(page).not_to have_css ".remote-translations-button"
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,6 @@ require "capybara/rspec"
 require "selenium/webdriver"
 
 Rails.application.load_tasks if Rake::Task.tasks.empty?
-I18n.default_locale = :en
 
 include Warden::Test::Helpers
 Warden.test_mode!


### PR DESCRIPTION
## References

- Closes #3526

## Objectives

A few different specs fail when you inactivate certain languages.

This is a problem because you want people to keep a clean test suite for their forks but they might want to disable languages.

We solve this by overriding the available languages for the test environment.

## Notes

- Right now, I am setting only the necessary languages (en, es, fr, nl, pt-BR). This is open to discussion.