### PR TITLE
Change devise configuration

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -76,7 +76,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -340,9 +340,11 @@ feature "Users" do
     fill_in "user_email", with: "manuela@consul.dev"
     click_button "Send instructions"
 
-    expect(page).to have_content "In a few minutes, you will receive an email containing instructions on resetting your password."
+    expect(page).to have_content "If your email address is in our database, in a few minutes "\
+                                 "you will receive a link to use to reset your password."
 
-    sent_token = /.*reset_password_token=(.*)".*/.match(ActionMailer::Base.deliveries.last.body.to_s)[1]
+    action_mailer = ActionMailer::Base.deliveries.last.body.to_s
+    sent_token = /.*reset_password_token=(.*)".*/.match(action_mailer)[1]
     visit edit_user_password_path(reset_password_token: sent_token)
 
     fill_in "user_password", with: "new password"
@@ -350,6 +352,47 @@ feature "Users" do
     click_button "Change my password"
 
     expect(page).to have_content "Your password has been changed successfully."
+  end
+
+  scenario "Reset password with unexisting email" do
+    visit "/"
+    click_link "Sign in"
+    click_link "Forgotten your password?"
+
+    fill_in "user_email", with: "fake@mail.dev"
+    click_button "Send instructions"
+
+    expect(page).to have_content "If your email address is in our database, in a few minutes "\
+                                 "you will receive a link to use to reset your password."
+
+  end
+
+  scenario "Re-send confirmation instructions" do
+    create(:user, email: "manuela@consul.dev")
+
+    visit "/"
+    click_link "Sign in"
+    click_link "Haven't received instructions to activate your account?"
+
+    fill_in "user_email", with: "manuela@consul.dev"
+    click_button "Re-send instructions"
+
+    expect(page).to have_content "If your email address is in our database, in a few minutes you "\
+                                 "will receive an email containing instructions on how to reset "\
+                                 "your password."
+  end
+
+  scenario "Re-send confirmation instructions with unexisting email" do
+    visit "/"
+    click_link "Sign in"
+    click_link "Haven't received instructions to activate your account?"
+
+    fill_in "user_email", with: "fake@mail.dev"
+    click_button "Re-send instructions"
+
+    expect(page).to have_content "If your email address is in our database, in a few minutes you "\
+                                 "will receive an email containing instructions on how to reset "\
+                                 "your password."
   end
 
   scenario "Sign in, admin with password expired" do


### PR DESCRIPTION
## References

This is a backport of https://github.com/AyuntamientoMadrid/consul/pull/1992.

## Objectives

This change don't let the user know if the email address exists when asking to **resend confirmation** or **password reset** instructions.

## Visual Changes

![password_1](https://user-images.githubusercontent.com/631897/57228924-35c15e80-7015-11e9-9cd4-d44c5fb106b1.png)

![password_2](https://user-images.githubusercontent.com/631897/57228925-3659f500-7015-11e9-8d3a-452dfb2940b8.png)