### PR TITLE
Add task to regenerate ballot_lines_count cache

### DIFF
--- a/lib/tasks/regenerate_ballot_lines_cache.rake
+++ b/lib/tasks/regenerate_ballot_lines_cache.rake
@@ -1,0 +1,8 @@
+namespace :budgets do
+  desc "Regenerate ballot_lines_count cache"
+  task calculate_ballot_lines: :environment do
+    Budget::Ballot.find_each do |ballot|
+      Budget::Ballot.reset_counters ballot.id, :lines
+    end
+  end
+end


### PR DESCRIPTION
## References

* Pull request #3438

## Objectives

Add a task we forgot to add when adding the column to cache the number of ballot lines.

## Release notes

In order to cache existing ballot lines, execute:

```
bin/rake budgets:calculate_ballot_lines RAILS_ENV=production
```

Not doing so might lead to inconsistencies in the stats.