### PR TITLE
Add Bosnian, Croatian, Czech, Danish, Greek, and Turkish locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,13 +21,18 @@ module Consul
     config.i18n.default_locale = :en
     available_locales = [
       "ar",
+      "bs",
+      "cs",
+      "da",
       "de",
+      "el",
       "en",
       "es",
       "fa",
       "fr",
       "gl",
       "he",
+      "hr",
       "id",
       "it",
       "nl",
@@ -38,6 +43,7 @@ module Consul
       "sq",
       "so",
       "sv",
+      "tr",
       "val",
       "zh-CN",
       "zh-TW"]

--- a/config/locales/bs-BA/i18n.yml
+++ b/config/locales/bs-BA/i18n.yml
@@ -1,4 +1,4 @@
 bs:
   i18n:
     language:
-      name: "Engleski"
+      name: "Bosanski"

--- a/config/locales/da-DK/i18n.yml
+++ b/config/locales/da-DK/i18n.yml
@@ -1,4 +1,4 @@
 da:
   i18n:
     language:
-      name: "Engelsk"
+      name: "Dansk"

--- a/config/locales/hr-HR/i18n.yml
+++ b/config/locales/hr-HR/i18n.yml
@@ -1,4 +1,4 @@
 hr:
   i18n:
     language:
-      name: "Engleski"
+      name: "Hrvatski"

--- a/config/locales/it/i18n.yml
+++ b/config/locales/it/i18n.yml
@@ -1,4 +1,4 @@
 it:
   i18n:
     language:
-      name: "Inglese"
+      name: "Italiano"

--- a/config/locales/pl-PL/i18n.yml
+++ b/config/locales/pl-PL/i18n.yml
@@ -1,4 +1,4 @@
 pl:
   i18n:
     language:
-      name: "angielski"
+      name: "Polski"

--- a/config/locales/sq-AL/i18n.yml
+++ b/config/locales/sq-AL/i18n.yml
@@ -1,4 +1,4 @@
 sq:
   i18n:
     language:
-      name: "Anglisht"
+      name: "Shqiptar"


### PR DESCRIPTION
## References

**PR**: https://github.com/consul/consul/pull/3378

## Objectives

- Add Bosnian, Croatian, Czech, Danish, Greek, and Turkish as available locales.
- Update locale names for Italian, Polish and Albanian.

## Visual Changes

Before:
![with old locales](https://user-images.githubusercontent.com/4169/58690860-d0019180-838a-11e9-9e0c-724c4dc67ed3.png)

After:
![with new locales](https://user-images.githubusercontent.com/4169/58690868-d4c64580-838a-11e9-8d11-dff170ee526e.png)

## Notes
Prerequisite PR https://github.com/consul/consul/pull/3378

## Update
Rebased with master after Prerequisite PR being merged.