### PR TITLE
Hide polls created by users from proposals dashboard on admin poll index

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -8,7 +8,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   before_action :load_geozones, only: [:new, :create, :edit, :update]
 
   def index
-    @polls = Poll.not_budget.order(starts_at: :desc)
+    @polls = Poll.not_budget.created_by_admin.order(starts_at: :desc)
   end
 
   def show

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -47,6 +47,7 @@ class Poll < ApplicationRecord
   scope :by_geozone_id, ->(geozone_id) { where(geozones: {id: geozone_id}.joins(:geozones)) }
   scope :public_for_api, -> { all }
   scope :not_budget,    -> { where(budget_id: nil) }
+  scope :created_by_admin, -> { where(related_type: nil) }
 
   scope :sort_for_list, -> { joins(:translations).order(:geozone_restricted, :starts_at, "poll_translations.name") }
 

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -44,6 +44,17 @@ describe "Admin polls" do
     expect(page).not_to have_content "There are no polls"
   end
 
+  scenario "Index do not show polls created by users from proposals dashboard" do
+    create(:poll, name: "Poll created by admin")
+    create(:poll, name: "Poll from user's proposal", related_type: "Proposal")
+
+    visit admin_polls_path
+
+    expect(page).to have_css ".poll", count: 1
+    expect(page).to have_content "Poll created by admin"
+    expect(page).not_to have_content "Poll from user's proposal"
+  end
+
   scenario "Show" do
     poll = create(:poll)
 


### PR DESCRIPTION
## References

Backports https://github.com/AyuntamientoMadrid/consul/pull/1995.

## Objectives

Hide polls created by users from proposals dashboard on `/admin/polls`

## Visual Changes

Remove polls created by users from proposals dashboard from list:
![admin_polls](https://user-images.githubusercontent.com/631897/57310911-efd6ca00-70ea-11e9-9d4a-9dd8869fb3e8.png)