### PR TITLE
Add help texs, links and new message section to improve UX

### DIFF
--- a/app/assets/stylesheets/legislation.scss
+++ b/app/assets/stylesheets/legislation.scss
@@ -83,7 +83,7 @@
 }
 
 .legislation-calendar {
-  background: #e5ecf2;
+  background: $highlight;
   padding-top: 1rem;
 
   h4 {

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -212,7 +212,7 @@
     }
 
     .quiz-title {
-      background: #e5ecf2;
+      background: $highlight;
 
       .quiz-header-title {
         font-size: $small-font-size;
@@ -980,5 +980,29 @@
   .proposal h3 {
     font-size: rem-calc(20);
     margin-top: 0;
+  }
+}
+
+.process-proposal {
+  margin-bottom: $line-height;
+
+  .header {
+    background: $highlight;
+    padding: $line-height;
+
+    @include breakpoint(medium) {
+      height: $line-height * 4;
+    }
+  }
+
+  .process-title {
+    font-size: $small-font-size;
+    margin-bottom: 0;
+    text-transform: uppercase;
+  }
+
+  .process-link {
+    font-size: rem-calc(19);
+    font-weight: bold;
   }
 }

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,9 +1,9 @@
 class DashboardController < Dashboard::BaseController
   helper_method :dashboard_action, :active_resources, :course
   before_action :set_done_and_pending_actions, only: [:recommended_actions, :progress]
+  before_action :authorize_dashboard, only: [:show, :progress, :community, :recommended_actions, :messages]
 
   def show
-    authorize! :dashboard, proposal
   end
 
   def publish
@@ -14,15 +14,15 @@ class DashboardController < Dashboard::BaseController
   end
 
   def progress
-    authorize! :dashboard, proposal
   end
 
   def community
-    authorize! :dashboard, proposal
   end
 
   def recommended_actions
-    authorize! :dashboard, proposal
+  end
+
+  def messages
   end
 
   private
@@ -41,5 +41,9 @@ class DashboardController < Dashboard::BaseController
     def set_done_and_pending_actions
       @done_actions = proposed_actions.joins(:proposals).where("proposals.id = ?", proposal.id)
       @pending_actions = proposed_actions - @done_actions
+    end
+
+    def authorize_dashboard
+      authorize! :dashboard, proposal
     end
 end

--- a/app/helpers/proposals_dashboard_helper.rb
+++ b/app/helpers/proposals_dashboard_helper.rb
@@ -7,6 +7,10 @@ module ProposalsDashboardHelper
     controller_name == "dashboard" && action_name == "community"
   end
 
+  def messages_menu_active?
+    controller_name == "dashboard" && action_name == "messages"
+  end
+
   def progress_menu_active?
     is_proposed_action_request? || (controller_name == "dashboard" && action_name == "progress")
   end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -86,7 +86,9 @@
             <%= link_to "", class: "js-toggle-children relative", data: {"id": "#{dom_id(comment)}"} do %>
               <span class="show-for-sr js-child-toggle" style="display: none;"><%= t("shared.show") %></span>
               <span class="show-for-sr js-child-toggle"><%= t("shared.hide") %></span>
-              <span id="<%= dom_id(comment) %>_children_arrow" class="icon-arrow-down"></span> <%= t("comments.comment.responses", count: comment.children.size) %>
+              <span id="<%= dom_id(comment) %>_children_arrow" class="icon-arrow-down"></span>
+              <span class="js-child-toggle" style="display: none;"><%= t("comments.comment.responses_show", count: comment.children.size) %></span>
+              <span class="js-child-toggle"><%= t("comments.comment.responses_collapse", count: comment.children.size) %></span>
             <% end %>
           <% else %>
             <%= t("comments.comment.responses", count: 0) %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -61,7 +61,12 @@
 
           <% end %>
 
-          &nbsp;&bull;&nbsp;<span><%= l comment.created_at.to_datetime, format: :datetime %></span>
+          &nbsp;&bull;&nbsp;
+          <span>
+            <%= link_to comment_path(comment) do %>
+              <%= l comment.created_at.to_datetime, format: :datetime %>
+            <% end %>
+          </span>
         </div>
 
         <div class="comment-user

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -29,14 +29,6 @@
     </div>
 
     <aside class="small-12 medium-3 column hide-for-small-only">
-      <% if @community.proposal.present? %>
-        <div class="sidebar-divider"></div>
-        <h2><%= t("communities.show.author") %></h2>
-        <%= link_to t("communities.show.send_notification"),
-                    new_proposal_notification_path(proposal_id: @community.proposal.id),
-                    class: "button expanded hollow" %>
-      <% end %>
-
       <div class="sidebar-divider"></div>
       <h2><%= t("community.show.sidebar.participate") %></h2>
       <%= link_to t("community.show.sidebar.new_topic"),

--- a/app/views/dashboard/_menu.html.erb
+++ b/app/views/dashboard/_menu.html.erb
@@ -35,9 +35,9 @@
       <ul class="no-bullet resources">
         <% if can?(:manage_polls, proposal) %>
           <li>
-            <%= link_to proposal_dashboard_polls_path(proposal.to_param),
-                        class: "#{'submenu-active' if polls_menu_active?}" do %>
-              <span data-tooltip title="<%= Setting['proposals.poll_short_title'] ||
+            <%= link_to proposal_dashboard_polls_path(proposal),
+                        class: "#{"submenu-active" if polls_menu_active?}" do %>
+              <span data-tooltip title="<%= Setting["proposals.poll_short_title"] ||
                                             t("dashboard.menu.polls") %>">
                 <%= t("dashboard.menu.polls") %>
               </span>
@@ -47,9 +47,9 @@
 
         <% if can?(:manage_mailing, proposal) %>
           <li>
-            <%= link_to new_proposal_dashboard_mailing_path(proposal.to_param),
-                        class: "#{'submenu-active' if mailing_menu_active?}" do %>
-              <span data-tooltip title="<%= Setting['proposals.email_short_title'] ||
+            <%= link_to new_proposal_dashboard_mailing_path(proposal),
+                        class: "#{"submenu-active" if mailing_menu_active?}" do %>
+              <span data-tooltip title="<%= Setting["proposals.email_short_title"] ||
                                             t("dashboard.menu.mailing") %>">
                 <%= t("dashboard.menu.mailing") %>
               </span>
@@ -59,9 +59,9 @@
 
         <% if can?(:manage_poster, proposal) %>
           <li>
-            <%= link_to new_proposal_dashboard_poster_path(proposal.to_param),
-                        class: "#{'submenu-active' if poster_menu_active?}" do %>
-              <span data-tooltip title="<%= Setting['proposals.poster_short_title'] ||
+            <%= link_to new_proposal_dashboard_poster_path(proposal),
+                        class: "#{"submenu-active" if poster_menu_active?}" do %>
+              <span data-tooltip title="<%= Setting["proposals.poster_short_title"] ||
                                             t("dashboard.menu.poster") %>">
                 <%= t("dashboard.menu.poster") %>
               </span>
@@ -85,8 +85,15 @@
 
   <li class="section-title <%= 'is-active' if community_menu_active? %>">
     <span class="icon-organizations"></span>
-    <%= link_to community_proposal_dashboard_path(proposal.to_param) do %>
+    <%= link_to community_proposal_dashboard_path(proposal) do %>
       <strong><%= t("dashboard.menu.community") %></strong>
+    <% end %>
+  </li>
+
+  <li class="section-title <%= "is-active" if messages_menu_active? %>">
+    <span class="icon-letter"></span>
+    <%= link_to messages_proposal_dashboard_path(proposal) do %>
+      <strong><%= t("dashboard.menu.messages") %></strong>
     <% end %>
   </li>
 </ul>

--- a/app/views/dashboard/messages.html.erb
+++ b/app/views/dashboard/messages.html.erb
@@ -1,0 +1,7 @@
+<% content_for :action_title, t("dashboard.menu.messages") %>
+
+<%= link_to t("dashboard.messages.send_notification"),
+            new_proposal_notification_path(proposal_id: proposal.id), class: "button" %>
+
+<%= link_to t("dashboard.messages.previous_notifications"),
+            proposal_path(proposal, anchor: "tab-notifications"), class: "button hollow" %>

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -10,6 +10,17 @@
   <%= render "shared/canonical", href: legislation_process_proposal_url(process_id: @process) %>
 <% end %>
 
+<div class="row process-proposal">
+  <div class="small-12 column">
+    <div class="header">
+      <p class="process-title">
+        <strong><%= t("legislation.proposals.process_title") %></strong>
+      </p>
+      <%= link_to @process.title, @process, class: "process-link" %>
+    </div>
+  </div>
+</div>
+
 <% cache [locale_and_user_status(@proposal), @proposal, @proposal.author, Flag.flagged?(current_user, @proposal), @legislation_proposal_votes] do %>
   <div class="proposal-show legislation-proposal-show">
     <div id="<%= dom_id(@proposal) %>" class="row">

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -483,6 +483,7 @@ en:
       mailing: E-mail
       poster: Poster
       recommended_actions: Recommended actions
+      messages: Message to users
     form:
       request: Request
     create_request:
@@ -544,6 +545,9 @@ en:
       debates: Debates
       comments: Comments
       latest_comments: Latest messages
+    messages:
+      send_notification: Send message to proposal supporters
+      previous_notifications: See previous notifications
     polls:
       index:
         title: Polls

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -51,6 +51,14 @@ en:
         one: 1 response
         other: "%{count} responses"
         zero: No responses
+      responses_show:
+        one: "1 response (show)"
+        other: "%{count} responses (show)"
+        zero: No responses
+      responses_collapse:
+        one: "1 response (collapse)"
+        other: "%{count} responses (collapse)"
+        zero: No responses
       user_deleted: User deleted
       votes:
         one: 1 vote

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -1019,8 +1019,6 @@ en:
       url_placeholder: Link address
   communities:
     show:
-      send_notification: Send message to the community
-      author: Author
       surveys: Surveys
       complete_survey: Complete the survey
     subnav:

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -123,3 +123,4 @@ en:
       form:
         tags_label: "Categories"
       not_verified: "For vote proposals %{verify_account}."
+      process_title: Collaborative legislation process

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -137,7 +137,7 @@ en:
       polls_description:  "Citizens' polls are a participatory mechanism by which citizens with voting rights can make direct decisions"
       budgets: "Participatory budgeting"
       budgets_description: "With participatory budgets, citizens decide which projects presented by their neighbours will receive a part of the budget"
-      legislation: "Legislation"
+      legislation: "Collaborative Legislation"
       legislation_description: "In participatory processes, citizens are offered the opportunity to participate in the drafting and modification of regulations that affect the society and to give their opinion on certain actions that are planned to be carried out"
     html:
       per_page_code_head: "Code to be included on every page (<head>)"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -70,11 +70,11 @@ en:
       poll_link: Additional information link
       poll_link_description: Añade un enlace de información adicional a la funcionalidad de encuestas del panel de control
       email_short_title: Email
-      email_short_title_description: Short description of the email feature. Allows users to send an email to promote their proposal
+      email_short_title_description: 'Short description of the email feature. Allows users to send an email to promote their proposal. You can find all the content of this email in "/app/views/dashboard/mailer/forward.html.erb"'
       email_description: Email description
       email_description_description: Detailed description of the email feature
       poster_short_title: Poster
-      poster_short_title_description: Short description of the poster feature. Allows users to download a poster on PDF format to promote their proposal
+      poster_short_title_description: 'Short description of the poster feature. Allows users to download a poster on PDF format to promote their proposal. You can find all the content of this poster in "/app/views/dashboard/poster/index.pdf.erb"'
       poster_description: Poster description
       poster_description_description: Detailed description of the poster feature
     analytics_url: "Analytics URL"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -483,6 +483,7 @@ es:
       mailing: Correo electrónico
       poster: Póster
       recommended_actions: Acciones recomendadas
+      messages: Mensajes a usuarios
     form:
       request: Solicitar
     create_request:
@@ -544,6 +545,9 @@ es:
       debates: Debates
       comments: Comentarios
       latest_comments: Últimos mensajes
+    messages:
+      send_notification: Enviar mensaje a los que han apoyado la propuesta
+      previous_notifications: Ver notificaciones anteriores
     polls:
       index:
         title: Encuestas

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -49,8 +49,16 @@ es:
       moderator: Moderador
       responses:
         zero: Sin respuestas
-        one: 1 Respuesta
-        other: "%{count} Respuestas"
+        one: 1 respuesta
+        other: "%{count} respuestas"
+      responses_show:
+        one: "1 respuesta (mostrar)"
+        other: "%{count} respuestas (mostrar)"
+        zero: Sin respuestas
+      responses_collapse:
+        one: "1 respuesta (colapsar)"
+        other: "%{count} respuestas (colapsar)"
+        zero: Sin respuestas
       user_deleted: Usuario eliminado
       votes:
         zero: Sin votos

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -1019,8 +1019,6 @@ es:
       url_placeholder: Dirección del enlace
   communities:
     show:
-      send_notification: Enviar mensaje a la Comunidad
-      author: Autor
       surveys: Encuestas
       complete_survey: Completa la encuesta
     subnav:

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -123,3 +123,4 @@ es:
       form:
         tags_label: "Categorías"
       not_verified: "Para votar propuestas %{verify_account}."
+      process_title: Proceso de legislación colaborativa

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -75,11 +75,11 @@ es:
       poll_link: Enlace de información adicional
       poll_link_description: Añade un enlace de información adicional a la funcionalidad de encuestas del panel de control
       email_short_title: Correo electrónico
-      email_short_title_description: Breve descripción de la funcionalidad de correo electrónico. Permite a los usuarios enviar un email para difundir su propuesta
+      email_short_title_description: 'Breve descripción de la funcionalidad de correo electrónico. Permite a los usuarios enviar un email para difundir su propuesta. Puedes encontrar todo el contenido de este correo electrónico en "/app/views/dashboard/mailer/forward.html.erb"'
       email_description: Descripción correo electrónico
       email_description_description: Descripción detallada de la funcionalidad de correo electrónico
       poster_short_title: Póster
-      poster_short_title_description: Breve descripción de la funcionalidad de póster. Permite a los usuarios descargar un póster en formato PDF para difundir su propuesta
+      poster_short_title_description: 'Breve descripción de la funcionalidad de póster. Permite a los usuarios descargar un póster en formato PDF para difundir su propuesta. Puedes encontrar todo el contenido de este póster en "/app/views/dashboard/poster/index.pdf.erb"'
       poster_description: Descripción póster
       poster_description_description: Descripción detallada de la funcionalidad de póster
     feature:

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -137,7 +137,7 @@ es:
       polls_description: "Las votaciones ciudadanas son un mecanismo de participación por el que la ciudadanía con derecho a voto puede tomar decisiones de forma directa"
       budgets: "Presupuestos participativos"
       budgets_description: "Con los presupuestos participativos la ciudadanía decide a qué proyectos presentados por los vecinos y vecinas va destinada una parte del presupuesto"
-      legislation: "Legislación"
+      legislation: "Legislación colaborativa"
       legislation_description: "En los procesos participativos se ofrece a la ciudadanía la oportunidad de participar en la elaboración y modificación de normativa que afecta a la sociedad y de dar su opinión sobre ciertas actuaciones que se tiene previsto llevar a cabo"
     html:
       per_page_code_head: "Código a incluir en cada página (<head>)"

--- a/config/routes/proposal.rb
+++ b/config/routes/proposal.rb
@@ -5,6 +5,7 @@ resources :proposals do
       get :progress
       get :community
       get :recommended_actions
+      get :messages
     end
 
     resources :resources, only: [:index], controller: "dashboard/resources"

--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -44,6 +44,21 @@ describe "Commenting Budget::Investments" do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
+  scenario "Link to comment show" do
+    comment = create(:comment, commentable: investment, user: user)
+
+    visit budget_investment_path(investment.budget, investment)
+
+    within "#comment_#{comment.id}" do
+      expect(page).to have_link comment.created_at.strftime("%Y-%m-%d %T")
+    end
+
+    click_link comment.created_at.strftime("%Y-%m-%d %T")
+
+    expect(page).to have_link "Go back to #{investment.title}"
+    expect(page).to have_current_path(comment_path(comment))
+  end
+
   scenario "Collapsable comments", :js do
     parent_comment = create(:comment, body: "Main comment", commentable: investment)
     child_comment  = create(:comment, body: "First subcomment", commentable: investment, parent: parent_comment)

--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -67,20 +67,25 @@ describe "Commenting Budget::Investments" do
     visit budget_investment_path(investment.budget, investment)
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 2)
+    expect(page).to have_content("1 response (collapse)")
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content grandchild_comment.body
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
     expect(page).to have_content grandchild_comment.body
 
     find("#comment_#{parent_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 1)
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content child_comment.body
     expect(page).not_to have_content grandchild_comment.body
   end

--- a/spec/features/comments/budget_investments_valuation_spec.rb
+++ b/spec/features/comments/budget_investments_valuation_spec.rb
@@ -74,20 +74,25 @@ describe "Internal valuation comments on Budget::Investments" do
       visit valuation_budget_budget_investment_path(budget, investment)
 
       expect(page).to have_css(".comment", count: 3)
+      expect(page).to have_content("1 response (collapse)", count: 2)
 
       find("#comment_#{child_comment.id}_children_arrow").click
 
       expect(page).to have_css(".comment", count: 2)
+      expect(page).to have_content("1 response (collapse)")
+      expect(page).to have_content("1 response (show)")
       expect(page).not_to have_content grandchild_comment.body
 
       find("#comment_#{child_comment.id}_children_arrow").click
 
       expect(page).to have_css(".comment", count: 3)
+      expect(page).to have_content("1 response (collapse)", count: 2)
       expect(page).to have_content grandchild_comment.body
 
       find("#comment_#{parent_comment.id}_children_arrow").click
 
       expect(page).to have_css(".comment", count: 1)
+      expect(page).to have_content("1 response (show)")
       expect(page).not_to have_content child_comment.body
       expect(page).not_to have_content grandchild_comment.body
     end

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -62,20 +62,25 @@ describe "Commenting debates" do
     visit debate_path(debate)
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 2)
+    expect(page).to have_content("1 response (collapse)")
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content grandchild_comment.body
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
     expect(page).to have_content grandchild_comment.body
 
     find("#comment_#{parent_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 1)
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content child_comment.body
     expect(page).not_to have_content grandchild_comment.body
   end

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -39,6 +39,21 @@ describe "Commenting debates" do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
+  scenario "Link to comment show" do
+    comment = create(:comment, commentable: debate, user: user)
+
+    visit debate_path(debate)
+
+    within "#comment_#{comment.id}" do
+      expect(page).to have_link comment.created_at.strftime("%Y-%m-%d %T")
+    end
+
+    click_link comment.created_at.strftime("%Y-%m-%d %T")
+
+    expect(page).to have_link "Go back to #{debate.title}"
+    expect(page).to have_current_path(comment_path(comment))
+  end
+
   scenario "Collapsable comments", :js do
     parent_comment = create(:comment, body: "Main comment", commentable: debate)
     child_comment  = create(:comment, body: "First subcomment", commentable: debate, parent: parent_comment)

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -44,6 +44,22 @@ describe "Commenting legislation questions" do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
+  scenario "Link to comment show" do
+    comment = create(:comment, commentable: legislation_annotation, user: user)
+
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
+
+    within "#comment_#{comment.id}" do
+      expect(page).to have_link comment.created_at.strftime("%Y-%m-%d %T")
+      click_link comment.created_at.strftime("%Y-%m-%d %T")
+    end
+
+    expect(page).to have_link "Go back to #{legislation_annotation.title}"
+    expect(page).to have_current_path(comment_path(comment))
+  end
+
   scenario "Collapsable comments", :js do
     parent_comment = legislation_annotation.comments.first
     child_comment  = create(:comment, body: "First subcomment", commentable: legislation_annotation, parent: parent_comment)

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -70,20 +70,25 @@ describe "Commenting legislation questions" do
                                                             legislation_annotation)
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 2)
+    expect(page).to have_content("1 response (collapse)")
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content grandchild_comment.body
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
     expect(page).to have_content grandchild_comment.body
 
     find("#comment_#{parent_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 1)
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content child_comment.body
     expect(page).not_to have_content grandchild_comment.body
   end

--- a/spec/features/comments/legislation_questions_spec.rb
+++ b/spec/features/comments/legislation_questions_spec.rb
@@ -69,20 +69,25 @@ describe "Commenting legislation questions" do
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 2)
+    expect(page).to have_content("1 response (collapse)")
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content grandchild_comment.body
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
     expect(page).to have_content grandchild_comment.body
 
     find("#comment_#{parent_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 1)
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content child_comment.body
     expect(page).not_to have_content grandchild_comment.body
   end

--- a/spec/features/comments/legislation_questions_spec.rb
+++ b/spec/features/comments/legislation_questions_spec.rb
@@ -46,6 +46,21 @@ describe "Commenting legislation questions" do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
+  scenario "Link to comment show" do
+    comment = create(:comment, commentable: legislation_question, user: user)
+
+    visit legislation_process_question_path(legislation_question.process, legislation_question)
+
+    within "#comment_#{comment.id}" do
+      expect(page).to have_link comment.created_at.strftime("%Y-%m-%d %T")
+    end
+
+    click_link comment.created_at.strftime("%Y-%m-%d %T")
+
+    expect(page).to have_link "Go back to #{legislation_question.title}"
+    expect(page).to have_current_path(comment_path(comment))
+  end
+
   scenario "Collapsable comments", :js do
     parent_comment = create(:comment, body: "Main comment", commentable: legislation_question)
     child_comment  = create(:comment, body: "First subcomment", commentable: legislation_question, parent: parent_comment)

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -63,20 +63,25 @@ describe "Commenting polls" do
     visit poll_path(poll)
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 2)
+    expect(page).to have_content("1 response (collapse)")
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content grandchild_comment.body
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
     expect(page).to have_content grandchild_comment.body
 
     find("#comment_#{parent_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 1)
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content child_comment.body
     expect(page).not_to have_content grandchild_comment.body
   end

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -40,6 +40,21 @@ describe "Commenting polls" do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
+  scenario "Link to comment show" do
+    comment = create(:comment, commentable: poll, user: user)
+
+    visit poll_path(poll)
+
+    within "#comment_#{comment.id}" do
+      expect(page).to have_link comment.created_at.strftime("%Y-%m-%d %T")
+    end
+
+    click_link comment.created_at.strftime("%Y-%m-%d %T")
+
+    expect(page).to have_link "Go back to #{poll.title}"
+    expect(page).to have_current_path(comment_path(comment))
+  end
+
   scenario "Collapsable comments", :js do
     parent_comment = create(:comment, body: "Main comment", commentable: poll)
     child_comment  = create(:comment, body: "First subcomment", commentable: poll, parent: parent_comment)

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -38,6 +38,21 @@ describe "Commenting proposals" do
     expect(page).to have_selector("ul#comment_#{second_child.id}>li", count: 1)
   end
 
+  scenario "Link to comment show" do
+    comment = create(:comment, commentable: proposal, user: user)
+
+    visit proposal_path(proposal)
+
+    within "#comment_#{comment.id}" do
+      expect(page).to have_link comment.created_at.strftime("%Y-%m-%d %T")
+    end
+
+    click_link comment.created_at.strftime("%Y-%m-%d %T")
+
+    expect(page).to have_link "Go back to #{proposal.title}"
+    expect(page).to have_current_path(comment_path(comment))
+  end
+
   scenario "Collapsable comments", :js do
     parent_comment = create(:comment, body: "Main comment", commentable: proposal)
     child_comment  = create(:comment, body: "First subcomment", commentable: proposal, parent: parent_comment)

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -61,20 +61,25 @@ describe "Commenting proposals" do
     visit proposal_path(proposal)
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 2)
+    expect(page).to have_content("1 response (collapse)")
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content grandchild_comment.body
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
     expect(page).to have_content grandchild_comment.body
 
     find("#comment_#{parent_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 1)
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content child_comment.body
     expect(page).not_to have_content grandchild_comment.body
   end

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -66,20 +66,25 @@ describe "Commenting topics from proposals" do
     visit community_topic_path(community, topic)
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 2)
+    expect(page).to have_content("1 response (collapse)")
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content grandchild_comment.body
 
     find("#comment_#{child_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 3)
+    expect(page).to have_content("1 response (collapse)", count: 2)
     expect(page).to have_content grandchild_comment.body
 
     find("#comment_#{parent_comment.id}_children_arrow").click
 
     expect(page).to have_css(".comment", count: 1)
+    expect(page).to have_content("1 response (show)")
     expect(page).not_to have_content child_comment.body
     expect(page).not_to have_content grandchild_comment.body
   end

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -39,6 +39,23 @@ describe "Commenting topics from proposals" do
     expect(page).to have_link "Go back to #{topic.title}", href: community_topic_path(community, topic)
   end
 
+  scenario "Link to comment show" do
+    community = proposal.community
+    topic = create(:topic, community: community)
+    comment = create(:comment, commentable: topic, user: user)
+
+    visit community_topic_path(community, topic)
+
+    within "#comment_#{comment.id}" do
+      expect(page).to have_link comment.created_at.strftime("%Y-%m-%d %T")
+    end
+
+    click_link comment.created_at.strftime("%Y-%m-%d %T")
+
+    expect(page).to have_link "Go back to #{topic.title}"
+    expect(page).to have_current_path(comment_path(comment))
+  end
+
   scenario "Collapsable comments", :js do
     community = proposal.community
     topic = create(:topic, community: community)

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -358,6 +358,37 @@ describe "Proposal's dashboard" do
     expect(page).to have_content("Done")
   end
 
+  scenario "Dashboard has a link to messages" do
+    expect(page).to have_link("Message to users")
+
+    within("#side_menu") do
+      click_link "Message to users"
+    end
+
+    expect(page).to have_link("Send message to proposal supporters")
+    expect(page).to have_link("See previous notifications")
+  end
+
+  scenario "Dashboard has a link to send message to proposal supporters" do
+    visit messages_proposal_dashboard_path(proposal)
+    click_link("Send message to proposal supporters")
+
+    fill_in "Title", with: "Thank you for supporting my proposal"
+    fill_in "Message", with: "Please share it with others!"
+    click_button "Send message"
+
+    expect(page).to have_content "Your message has been sent correctly."
+    expect(page).to have_content "Thank you for supporting my proposal"
+    expect(page).to have_content "Please share it with others!"
+  end
+
+  scenario "Dashboard has a link to see previous notifications" do
+    visit messages_proposal_dashboard_path(proposal)
+
+    expect(page).to have_link("See previous notifications", href: proposal_path(proposal,
+                                                            anchor: "tab-notifications"))
+  end
+
   scenario "On recommended actions section display from the fourth proposed actions
             when click see_proposed_actions_link", js: true do
     create_list(:dashboard_action, 4, :proposed_action, :active)

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -190,4 +190,15 @@ describe "Legislation Proposals" do
     visit legislation_process_proposal_path(process, legislation_proposal_negative)
     expect(page).to have_content("-6 votes")
   end
+
+  scenario "Show link to process on show" do
+    create(:legislation_proposal, legislation_process_id: process.id)
+
+    visit legislation_process_proposal_path(proposal.process, proposal)
+
+    within(".process-proposal") do
+      expect(page).to have_content("Collaborative legislation process")
+      expect(page).to have_link(process.title)
+    end
+  end
 end

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -4,15 +4,19 @@ describe "Proposal Notifications" do
 
   scenario "Send a notification" do
     author = create(:user)
-    proposal = create(:proposal, author: author)
+    create(:proposal, author: author)
 
     login_as(author)
     visit root_path
 
     click_link "My content"
-    click_link proposal.title
-    click_link "Access the community"
-    click_link "Send message to the community"
+    click_link "Dashboard"
+
+    within("#side_menu") do
+      click_link "Message to users"
+    end
+
+    click_link "Send message to proposal supporters"
 
     fill_in "proposal_notification_title", with: "Thank you for supporting my proposal"
     fill_in "proposal_notification_body", with: "Please share it with "\
@@ -178,9 +182,19 @@ describe "Proposal Notifications" do
       proposal = create(:proposal, author: author)
 
       login_as(author)
-      visit community_path(proposal.community)
+      visit root_path
 
-      expect(page).to have_link "Send message to the community"
+      click_link "My content"
+
+      within("#proposal_#{proposal.id}") do
+        click_link "Dashboard"
+      end
+
+      within("#side_menu") do
+        click_link "Message to users"
+      end
+
+      expect(page).to have_link "Send message to proposal supporters"
     end
 
     scenario "Accessing form directly" do

--- a/spec/support/common_actions/notifications.rb
+++ b/spec/support/common_actions/notifications.rb
@@ -20,11 +20,14 @@ module Notifications
     click_link "My content"
 
     within("#proposal_#{proposal.id}") do
-      click_link proposal.title
+      click_link "Dashboard"
     end
 
-    click_link "Access the community"
-    click_link "Send message to the community"
+    within("#side_menu") do
+      click_link "Message to users"
+    end
+
+    click_link "Send message to proposal supporters"
 
     fill_in "proposal_notification_title", with: "Thanks for supporting proposal: #{proposal.title}"
     fill_in "proposal_notification_body", with: "Please share it with others! #{proposal.summary}"


### PR DESCRIPTION
## References

Backports https://github.com/AyuntamientoMadrid/consul/pull/2019.

## Objectives

- Add help text to email and poster proposals settings. *[Image_1]*
- Add link to process on legislation processes proposals. *[Image_2]*
- Add link to comment path on comment date. *[Image_3]*
- Add show and collapse text on comments tree. *[Image_4]*
- Remove send notification proposal from community
- Create new messages section for proposal's dashboard. *[Image_5]*

## Visual Changes

### Image 1
![1_admin_help](https://user-images.githubusercontent.com/631897/58329776-a3eb8b00-7e35-11e9-9e32-719e61cbb29e.png)

### Image 2
![2_link_to_process](https://user-images.githubusercontent.com/631897/58329783-a77f1200-7e35-11e9-8c4e-967664f12b21.png)

### Image 3
![3_comment_link](https://user-images.githubusercontent.com/631897/58329789-abab2f80-7e35-11e9-8963-de37e6f61c30.png)

![3_comment_show](https://user-images.githubusercontent.com/631897/58329791-ae0d8980-7e35-11e9-82e1-e288d44df4a1.png)
### Image 4
![4_comments_collapse](https://user-images.githubusercontent.com/631897/58329796-b1087a00-7e35-11e9-9726-1e08a078a15b.png)

### Image 5
![5_dashboard_messages](https://user-images.githubusercontent.com/631897/58329802-b4036a80-7e35-11e9-8832-7d33f707ffe1.png)