### PR TITLE
Rename deprecated translation columns

### DIFF
--- a/app/models/concerns/notifiable.rb
+++ b/app/models/concerns/notifiable.rb
@@ -12,6 +12,10 @@ module Notifiable
     end
   end
 
+  def notifiable_body
+    body if attribute_names.include?("body")
+  end
+
   def notifiable_available?
     case self.class.name
     when "ProposalNotification"

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -11,8 +11,9 @@ class Notification < ApplicationRecord
   scope :recent,      -> { order(id: :desc) }
   scope :for_render,  -> { includes(:notifiable) }
 
-  delegate :notifiable_title, :notifiable_available?, :check_availability,
-           :linkable_resource, to: :notifiable, allow_nil: true
+  delegate :notifiable_title, :notifiable_body, :notifiable_available?,
+           :check_availability, :linkable_resource,
+           to: :notifiable, allow_nil: true
 
   def mark_as_read
     update(read_at: Time.current)

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -3,7 +3,7 @@
     <% locals = { notification: notification,
                   timestamp: notification.timestamp,
                   title: notification.notifiable_title,
-                  body: notification.notifiable.try(:body) } %>
+                  body: notification.notifiable_body } %>
     <% link_text = render partial: "/notifications/notification_body", locals: locals %>
     <%= link_to_if notification.link.present?, link_text, notification.link %>
   <% else %>

--- a/db/migrate/20190221154820_rename_deprecated_translatable_banner_fields.rb
+++ b/db/migrate/20190221154820_rename_deprecated_translatable_banner_fields.rb
@@ -1,0 +1,6 @@
+class RenameDeprecatedTranslatableBannerFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :banners, :title, :deprecated_title
+    rename_column :banners, :description, :deprecated_description
+  end
+end

--- a/db/migrate/20190221162451_rename_deprecated_translatable_poll_fields.rb
+++ b/db/migrate/20190221162451_rename_deprecated_translatable_poll_fields.rb
@@ -1,0 +1,7 @@
+class RenameDeprecatedTranslatablePollFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :polls, :name, :deprecated_name
+    rename_column :polls, :summary, :deprecated_summary
+    rename_column :polls, :description, :deprecated_description
+  end
+end

--- a/db/migrate/20190221162859_rename_deprecated_translatable_poll_question_fields.rb
+++ b/db/migrate/20190221162859_rename_deprecated_translatable_poll_question_fields.rb
@@ -1,0 +1,5 @@
+class RenameDeprecatedTranslatablePollQuestionFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :poll_questions, :title, :deprecated_title
+  end
+end

--- a/db/migrate/20190221163118_rename_deprecated_translatable_poll_question_answer_fields.rb
+++ b/db/migrate/20190221163118_rename_deprecated_translatable_poll_question_answer_fields.rb
@@ -1,0 +1,6 @@
+class RenameDeprecatedTranslatablePollQuestionAnswerFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :poll_question_answers, :title, :deprecated_title
+    rename_column :poll_question_answers, :description, :deprecated_description
+  end
+end

--- a/db/migrate/20190221163819_rename_deprecated_translatable_admin_notification_fields.rb
+++ b/db/migrate/20190221163819_rename_deprecated_translatable_admin_notification_fields.rb
@@ -1,0 +1,6 @@
+class RenameDeprecatedTranslatableAdminNotificationFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :admin_notifications, :title, :deprecated_title
+    rename_column :admin_notifications, :body, :deprecated_body
+  end
+end

--- a/db/migrate/20190221164057_rename_deprecated_translatable_milestone_fields.rb
+++ b/db/migrate/20190221164057_rename_deprecated_translatable_milestone_fields.rb
@@ -1,0 +1,6 @@
+class RenameDeprecatedTranslatableMilestoneFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :milestones, :title, :deprecated_title
+    rename_column :milestones, :description, :deprecated_description
+  end
+end

--- a/db/migrate/20190221164560_rename_deprecated_translatable_legislation_draft_version_fields.rb
+++ b/db/migrate/20190221164560_rename_deprecated_translatable_legislation_draft_version_fields.rb
@@ -1,0 +1,9 @@
+class RenameDeprecatedTranslatableLegislationDraftVersionFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :legislation_draft_versions, :title, :deprecated_title
+    rename_column :legislation_draft_versions, :changelog, :deprecated_changelog
+    rename_column :legislation_draft_versions, :body, :deprecated_body
+    rename_column :legislation_draft_versions, :body_html, :deprecated_body_html
+    rename_column :legislation_draft_versions, :toc_html, :deprecated_toc_html
+  end
+end

--- a/db/migrate/20190221164929_rename_deprecated_translatable_legislation_process_fields.rb
+++ b/db/migrate/20190221164929_rename_deprecated_translatable_legislation_process_fields.rb
@@ -1,0 +1,8 @@
+class RenameDeprecatedTranslatableLegislationProcessFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :legislation_processes, :title, :deprecated_title
+    rename_column :legislation_processes, :summary, :deprecated_summary
+    rename_column :legislation_processes, :description, :deprecated_description
+    rename_column :legislation_processes, :additional_info, :deprecated_additional_info
+  end
+end

--- a/db/migrate/20190221165348_rename_deprecated_translatable_legislation_question_fields.rb
+++ b/db/migrate/20190221165348_rename_deprecated_translatable_legislation_question_fields.rb
@@ -1,0 +1,5 @@
+class RenameDeprecatedTranslatableLegislationQuestionFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :legislation_questions, :title, :deprecated_title
+  end
+end

--- a/db/migrate/20190221171156_rename_deprecated_translatable_legislation_question_option_fields.rb
+++ b/db/migrate/20190221171156_rename_deprecated_translatable_legislation_question_option_fields.rb
@@ -1,0 +1,5 @@
+class RenameDeprecatedTranslatableLegislationQuestionOptionFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :legislation_question_options, :value, :deprecated_value
+  end
+end

--- a/db/migrate/20190221171860_rename_deprecated_translatable_site_customization_page_fields.rb
+++ b/db/migrate/20190221171860_rename_deprecated_translatable_site_customization_page_fields.rb
@@ -1,0 +1,7 @@
+class RenameDeprecatedTranslatableSiteCustomizationPageFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :site_customization_pages, :title, :deprecated_title
+    rename_column :site_customization_pages, :subtitle, :deprecated_subtitle
+    rename_column :site_customization_pages, :content, :deprecated_content
+  end
+end

--- a/db/migrate/20190221172210_rename_deprecated_translatable_widget_card_fields.rb
+++ b/db/migrate/20190221172210_rename_deprecated_translatable_widget_card_fields.rb
@@ -1,0 +1,8 @@
+class RenameDeprecatedTranslatableWidgetCardFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :widget_cards, :label, :deprecated_label
+    rename_column :widget_cards, :title, :deprecated_title
+    rename_column :widget_cards, :description, :deprecated_description
+    rename_column :widget_cards, :link_text, :deprecated_link_text
+  end
+end

--- a/db/migrate/20190325184501_rename_deprecated_translatable_budget_fields.rb
+++ b/db/migrate/20190325184501_rename_deprecated_translatable_budget_fields.rb
@@ -1,0 +1,5 @@
+class RenameDeprecatedTranslatableBudgetFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :budgets, :name, :deprecated_name
+  end
+end

--- a/db/migrate/20190325185047_rename_deprecated_translatable_budget_group_fields.rb
+++ b/db/migrate/20190325185047_rename_deprecated_translatable_budget_group_fields.rb
@@ -1,0 +1,5 @@
+class RenameDeprecatedTranslatableBudgetGroupFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :budget_groups, :name, :deprecated_name
+  end
+end

--- a/db/migrate/20190325185406_rename_deprecated_translatable_budget_heading_fields.rb
+++ b/db/migrate/20190325185406_rename_deprecated_translatable_budget_heading_fields.rb
@@ -1,0 +1,5 @@
+class RenameDeprecatedTranslatableBudgetHeadingFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :budget_headings, :name, :deprecated_name
+  end
+end

--- a/db/migrate/20190325185551_rename_deprecated_translatable_budget_phase_fields.rb
+++ b/db/migrate/20190325185551_rename_deprecated_translatable_budget_phase_fields.rb
@@ -1,0 +1,6 @@
+class RenameDeprecatedTranslatableBudgetPhaseFields < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :budget_phases, :summary, :deprecated_summary
+    rename_column :budget_phases, :description, :deprecated_description
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1182,8 +1182,8 @@ ActiveRecord::Schema.define(version: 20190429125842) do
     t.datetime "confirmed_hide_at"
     t.bigint   "hot_score",                      default: 0
     t.integer  "confidence_score",               default: 0
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
     t.string   "responsible_name",    limit: 60
     t.text     "summary"
     t.string   "video_url"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -159,7 +159,7 @@ ActiveRecord::Schema.define(version: 20190429125842) do
 
   create_table "budget_groups", force: :cascade do |t|
     t.integer "budget_id"
-    t.string  "name",                 limit: 50
+    t.string  "deprecated_name",      limit: 50
     t.string  "slug"
     t.integer "max_votable_headings",            default: 1
     t.index ["budget_id"], name: "index_budget_groups_on_budget_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1010,11 +1010,11 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   end
 
   create_table "poll_question_answers", force: :cascade do |t|
-    t.string  "title"
-    t.text    "description"
+    t.string  "deprecated_title"
+    t.text    "deprecated_description"
     t.integer "question_id"
-    t.integer "given_order", default: 1
-    t.boolean "most_voted",  default: false
+    t.integer "given_order",            default: 1
+    t.boolean "most_voted",             default: false
     t.index ["question_id"], name: "index_poll_question_answers_on_question_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -790,7 +790,7 @@ ActiveRecord::Schema.define(version: 20190429125842) do
 
   create_table "legislation_questions", force: :cascade do |t|
     t.integer  "legislation_process_id"
-    t.text     "title"
+    t.text     "deprecated_title"
     t.integer  "answers_count",          default: 0
     t.datetime "hidden_at"
     t.datetime "created_at",                         null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -682,9 +682,9 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   end
 
   create_table "legislation_processes", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.text     "additional_info"
+    t.string   "deprecated_title"
+    t.text     "deprecated_description"
+    t.text     "deprecated_additional_info"
     t.date     "start_date"
     t.date     "end_date"
     t.date     "debate_start_date"
@@ -696,7 +696,7 @@ ActiveRecord::Schema.define(version: 20190429125842) do
     t.datetime "hidden_at"
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
-    t.text     "summary"
+    t.text     "deprecated_summary"
     t.boolean  "debate_phase_enabled",       default: false
     t.boolean  "allegations_phase_enabled",  default: false
     t.boolean  "draft_publication_enabled",  default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1115,19 +1115,19 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   end
 
   create_table "polls", force: :cascade do |t|
-    t.string   "name"
+    t.string   "deprecated_name"
     t.datetime "starts_at"
     t.datetime "ends_at"
-    t.boolean  "published",          default: false
-    t.boolean  "geozone_restricted", default: false
-    t.text     "summary"
-    t.text     "description"
-    t.integer  "comments_count",     default: 0
+    t.boolean  "published",              default: false
+    t.boolean  "geozone_restricted",     default: false
+    t.text     "deprecated_summary"
+    t.text     "deprecated_description"
+    t.integer  "comments_count",         default: 0
     t.integer  "author_id"
     t.datetime "hidden_at"
     t.string   "slug"
-    t.boolean  "results_enabled",    default: false
-    t.boolean  "stats_enabled",      default: false
+    t.boolean  "results_enabled",        default: false
+    t.boolean  "stats_enabled",          default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "budget_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1304,15 +1304,15 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   end
 
   create_table "site_customization_pages", force: :cascade do |t|
-    t.string   "slug",                                 null: false
-    t.string   "title"
-    t.string   "subtitle"
-    t.text     "content"
+    t.string   "slug",                                  null: false
+    t.string   "deprecated_title"
+    t.string   "deprecated_subtitle"
+    t.text     "deprecated_content"
     t.boolean  "more_info_flag"
     t.boolean  "print_content_flag"
-    t.string   "status",             default: "draft"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.string   "status",              default: "draft"
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.string   "locale"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -177,7 +177,7 @@ ActiveRecord::Schema.define(version: 20190429125842) do
 
   create_table "budget_headings", force: :cascade do |t|
     t.integer "group_id"
-    t.string  "name",                 limit: 50
+    t.string  "deprecated_name",      limit: 50
     t.bigint  "price"
     t.integer "population"
     t.string  "slug"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1526,11 +1526,11 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   end
 
   create_table "widget_cards", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.string   "link_text"
+    t.string   "deprecated_title"
+    t.text     "deprecated_description"
+    t.string   "deprecated_link_text"
     t.string   "link_url"
-    t.string   "label"
+    t.string   "deprecated_label"
     t.boolean  "header",                     default: false
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -279,12 +279,12 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   create_table "budget_phases", force: :cascade do |t|
     t.integer  "budget_id"
     t.integer  "next_phase_id"
-    t.string   "kind",                         null: false
-    t.text     "summary"
-    t.text     "description"
+    t.string   "kind",                                  null: false
+    t.text     "deprecated_summary"
+    t.text     "deprecated_description"
     t.datetime "starts_at"
     t.datetime "ends_at"
-    t.boolean  "enabled",       default: true
+    t.boolean  "enabled",                default: true
     t.index ["ends_at"], name: "index_budget_phases_on_ends_at", using: :btree
     t.index ["kind"], name: "index_budget_phases_on_kind", using: :btree
     t.index ["next_phase_id"], name: "index_budget_phases_on_next_phase_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,8 +55,8 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   end
 
   create_table "admin_notifications", force: :cascade do |t|
-    t.string   "title"
-    t.text     "body"
+    t.string   "deprecated_title"
+    t.text     "deprecated_body"
     t.string   "link"
     t.string   "segment_recipient"
     t.integer  "recipients_count"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -769,7 +769,7 @@ ActiveRecord::Schema.define(version: 20190429125842) do
 
   create_table "legislation_question_options", force: :cascade do |t|
     t.integer  "legislation_question_id"
-    t.string   "value"
+    t.string   "deprecated_value"
     t.integer  "answers_count",           default: 0
     t.datetime "hidden_at"
     t.datetime "created_at",                          null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -867,12 +867,12 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   create_table "milestones", force: :cascade do |t|
     t.string   "milestoneable_type"
     t.integer  "milestoneable_id"
-    t.string   "title",              limit: 80
-    t.text     "description"
+    t.string   "deprecated_title",       limit: 80
+    t.text     "deprecated_description"
     t.datetime "publication_date"
     t.integer  "status_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.index ["status_id"], name: "index_milestones_on_status_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -102,14 +102,14 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   end
 
   create_table "banners", force: :cascade do |t|
-    t.string   "title",            limit: 80
-    t.string   "description"
+    t.string   "deprecated_title",       limit: 80
+    t.string   "deprecated_description"
     t.string   "target_url"
     t.date     "post_started_at"
     t.date     "post_ended_at"
     t.datetime "hidden_at"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.text     "background_color"
     t.text     "font_color"
     t.index ["hidden_at"], name: "index_banners_on_hidden_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1033,7 +1033,7 @@ ActiveRecord::Schema.define(version: 20190429125842) do
     t.integer  "poll_id"
     t.integer  "author_id"
     t.string   "author_visible_name"
-    t.string   "title"
+    t.string   "deprecated_title"
     t.integer  "comments_count"
     t.datetime "hidden_at"
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -651,16 +651,16 @@ ActiveRecord::Schema.define(version: 20190429125842) do
 
   create_table "legislation_draft_versions", force: :cascade do |t|
     t.integer  "legislation_process_id"
-    t.string   "title"
-    t.text     "changelog"
+    t.string   "deprecated_title"
+    t.text     "deprecated_changelog"
     t.string   "status",                 default: "draft"
     t.boolean  "final_version",          default: false
-    t.text     "body"
+    t.text     "deprecated_body"
     t.datetime "hidden_at"
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
-    t.text     "body_html"
-    t.text     "toc_html"
+    t.text     "deprecated_body_html"
+    t.text     "deprecated_toc_html"
     t.index ["hidden_at"], name: "index_legislation_draft_versions_on_hidden_at", using: :btree
     t.index ["legislation_process_id"], name: "index_legislation_draft_versions_on_legislation_process_id", using: :btree
     t.index ["status"], name: "index_legislation_draft_versions_on_status", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -323,7 +323,7 @@ ActiveRecord::Schema.define(version: 20190429125842) do
   end
 
   create_table "budgets", force: :cascade do |t|
-    t.string   "name",                          limit: 80
+    t.string   "deprecated_name",               limit: 80
     t.string   "currency_symbol",               limit: 10
     t.string   "phase",                         limit: 40, default: "accepting"
     t.datetime "created_at",                                                     null: false


### PR DESCRIPTION
## References

* Adapts pull request #3327 to the current master branch
* Backports and adapts AyuntamientoMadrid#1985 and AyuntamientoMadrid#1996

## Objectives

* Rename obsolete columns which might still accidentally be used by active record scopes
* Fix incompatibilities between Globalize and Rails 5