### PR TITLE
Fix style for remote-translation-button

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -471,7 +471,7 @@ header {
 
   .remote-translations-button {
 
-    .callout {
+    &.callout {
       margin: 0;
       padding: rem-calc(6);
 


### PR DESCRIPTION
## References
Related PR: #3237 

## Objectives
Fix styles for remote-translations-button

## Visual Changes
With the last change on layout.scss, the remote translations button it is displaying wrong:
![Captura de pantalla 2019-06-04 a las 10 09 26](https://user-images.githubusercontent.com/16189/58863816-d5751980-86b3-11e9-83e7-e189fdb662c8.png)

The correct way to visualize the button would be:
![Captura de pantalla 2019-06-04 a las 10 10 04](https://user-images.githubusercontent.com/16189/58863789-ca21ee00-86b3-11e9-98e4-e5b7e04b3e17.png)

