### PR TITLE
Don't show links to disabled budget results

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -105,4 +105,18 @@ module BudgetsHelper
                               ends_at:   balloting_phase.ends_at }),
             method: :post
   end
+
+  def budget_subnav_items_for(budget)
+    {
+      results:    t("budgets.results.link"),
+      stats:      t("stats.budgets.link"),
+      executions: t("budgets.executions.link")
+    }.map do |section, text|
+      {
+        text: text,
+        url:  send("budget_#{section}_path", budget),
+        active: controller_name == section.to_s
+      }
+    end
+  end
 end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -111,7 +111,7 @@ module BudgetsHelper
       results:    t("budgets.results.link"),
       stats:      t("stats.budgets.link"),
       executions: t("budgets.executions.link")
-    }.map do |section, text|
+    }.select { |section, _| can?(:"read_#{section}", budget) }.map do |section, text|
       {
         text: text,
         url:  send("budget_#{section}_path", budget),

--- a/app/views/budgets/_finished.html.erb
+++ b/app/views/budgets/_finished.html.erb
@@ -15,9 +15,12 @@
 
               <div class="small-12 medium-6 column table" data-equalizer-watch>
                 <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
-                  <%= link_to t("budgets.index.see_results"),
-                              budget_results_path(budget),
-                              class: "button" %>
+                  <% if can?(:read_results, budget) %>
+                    <%= link_to t("budgets.index.see_results"),
+                                budget_results_path(budget),
+                                class: "button" %>
+                  <% end %>
+
                   <%= link_to t("budgets.index.milestones"),
                               budget_executions_path(budget),
                               class: "button" %>

--- a/app/views/budgets/_finished.html.erb
+++ b/app/views/budgets/_finished.html.erb
@@ -16,10 +16,10 @@
               <div class="small-12 medium-6 column table" data-equalizer-watch>
                 <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
                   <%= link_to t("budgets.index.see_results"),
-                              budget_results_path(budget.id),
+                              budget_results_path(budget),
                               class: "button" %>
                   <%= link_to t("budgets.index.milestones"),
-                              budget_executions_path(budget.id),
+                              budget_executions_path(budget),
                               class: "button" %>
                 </div>
               </div>

--- a/app/views/budgets/_finished.html.erb
+++ b/app/views/budgets/_finished.html.erb
@@ -1,0 +1,32 @@
+<div class="row margin-top">
+  <div class="small-12 medium-9 column">
+    <h2><%= t("budgets.index.finished_budgets") %></h2>
+
+    <div id="finished_budgets" class="budget-investments-list">
+      <% budgets.each do |budget| %>
+        <div class="budget-investment clear">
+          <div class="panel past-budgets">
+            <div class="row" data-equalizer data-equalizer-on="medium">
+              <div class="small-12 medium-6 column table" data-equalizer-watch>
+                <div class="table-cell align-middle">
+                  <h3><%= budget.name %></h3>
+                </div>
+              </div>
+
+              <div class="small-12 medium-6 column table" data-equalizer-watch>
+                <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
+                  <%= link_to t("budgets.index.see_results"),
+                              budget_results_path(budget.id),
+                              class: "button" %>
+                  <%= link_to t("budgets.index.milestones"),
+                              budget_executions_path(budget.id),
+                              class: "button" %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/budgets/_subnav.html.erb
+++ b/app/views/budgets/_subnav.html.erb
@@ -1,0 +1,17 @@
+<div class="row margin-top">
+  <div class="small-12 column">
+    <ul class="tabs">
+      <% budget_subnav_items_for(budget).each do |item| %>
+        <% if item[:active] %>
+          <li class="tabs-title is-active">
+            <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
+
+            <%= link_to item[:text], item[:url], class: "is-active" %>
+          </li>
+        <% else %>
+          <li class="tabs-title"><%= link_to item[:text], item[:url] %></li>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/budgets/executions/show.html.erb
+++ b/app/views/budgets/executions/show.html.erb
@@ -25,21 +25,7 @@
   </div>
 </div>
 
-<div class="row margin-top">
-  <div class="small-12 column">
-    <ul class="tabs">
-      <li class="tabs-title">
-        <%= link_to t("budgets.results.link"), budget_results_path(@budget) %>
-      </li>
-      <li class="tabs-title">
-        <%= link_to t("stats.budgets.link"), budget_stats_path(@budget) %>
-      </li>
-      <li class="tabs-title is-active">
-        <%= link_to t("budgets.executions.link"), budget_executions_path(@budget), class: "is-active" %>
-      </li>
-    </ul>
-  </div>
-</div>
+<%= render "budgets/subnav", budget: @budget %>
 
 <div class="row">
   <div class="small-12 medium-3 large-2 column">

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -53,7 +53,7 @@
             <% end %>
           <% end %>
 
-        <% if current_budget.finished? %>
+        <% if can?(:read_results, current_budget) %>
           <%= link_to t("budgets.show.see_results"),
                       budget_results_path(current_budget, heading_id: current_budget.headings.first),
                       class: "button margin-top expanded" %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -126,38 +126,7 @@
     </div>
 
     <% if @finished_budgets.present? %>
-      <div class="row margin-top">
-        <div class="small-12 medium-9 column">
-          <h2><%= t("budgets.index.finished_budgets") %></h2>
-
-          <div id="finished_budgets" class="budget-investments-list">
-            <% @finished_budgets.each do |budget| %>
-              <div class="budget-investment clear">
-                <div class="panel past-budgets">
-                  <div class="row" data-equalizer data-equalizer-on="medium">
-                    <div class="small-12 medium-6 column table" data-equalizer-watch>
-                      <div class="table-cell align-middle">
-                        <h3><%= budget.name %></h3>
-                      </div>
-                    </div>
-
-                    <div class="small-12 medium-6 column table" data-equalizer-watch>
-                      <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
-                        <%= link_to t("budgets.index.see_results"),
-                                    budget_results_path(budget.id),
-                                    class: "button" %>
-                        <%= link_to t("budgets.index.milestones"),
-                                    budget_executions_path(budget.id),
-                                    class: "button" %>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      </div>
+      <%= render "finished", budgets: @finished_budgets %>
     <% end %>
   </div>
 <% else %>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -24,22 +24,7 @@
   </div>
 </div>
 
-<div class="row margin-top">
-  <div class="small-12 column">
-    <ul class="tabs">
-      <li class="tabs-title is-active">
-        <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-        <%= link_to t("budgets.results.link"), budget_results_path(@budget), class: "is-active" %>
-      </li>
-      <li class="tabs-title">
-        <%= link_to t("stats.budgets.link"), budget_stats_path(@budget) %>
-      </li>
-      <li class="tabs-title">
-        <%= link_to t("budgets.executions.link"), budget_executions_path(@budget) %>
-      </li>
-    </ul>
-  </div>
-</div>
+<%= render "budgets/subnav", budget: @budget %>
 
 <div class="row">
   <div class="small-12 medium-3 large-2 column">

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -36,7 +36,7 @@
         <% end %>
       <% end %>
 
-      <% if @budget.finished? %>
+      <% if can?(:read_results, @budget) %>
         <%= link_to t("budgets.show.see_results"),
                     budget_results_path(@budget),
                     class: "button margin-top expanded" %>

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -21,22 +21,7 @@
     </div>
   </div>
 
-  <div class="row margin-top">
-    <div class="small-12 column">
-      <ul class="tabs">
-        <li class="tabs-title">
-          <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-          <%= link_to t("budgets.results.link"), budget_results_path(@budget) %>
-        </li>
-        <li class="tabs-title is-active">
-          <%= link_to t("stats.budgets.link"), budget_stats_path(@budget), class: "is-active" %>
-        </li>
-        <li class="tabs-title">
-          <%= link_to t("budgets.executions.link"), budget_executions_path(@budget) %>
-        </li>
-      </ul>
-    </div>
-  </div>
+  <%= render "budgets/subnav", budget: @budget %>
 
   <div class="row margin">
     <div class="small-12 medium-3 column sidebar">

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -15,6 +15,22 @@ describe "Results" do
     Budget::Result.new(budget, heading).calculate_winners
   end
 
+  scenario "No links to budget results with results disabled" do
+    budget.update(results_enabled: false)
+
+    visit budgets_path
+
+    expect(page).not_to have_link "See results"
+
+    visit budget_path(budget)
+
+    expect(page).not_to have_link "See results"
+
+    visit budget_executions_path(budget)
+
+    expect(page).not_to have_link "See results"
+  end
+
   scenario "Diplays winner investments" do
     create(:budget_heading, group: group)
 


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#2037

## Objectives

## Background

We were blocking the access to the budget results path when results were not enabled. However, links to the page were still available even if clicking them resulted in a "you are not authorized to access this page" message.

## Objectives

* Don't show links to disabled budget results