### PR TITLE
Check the comment is present after commenting

### DIFF
--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -412,6 +412,10 @@ describe "Commenting Budget::Investments" do
         check "comment-as-administrator-budget_investment_#{investment.id}"
         click_button "Publish comment"
 
+        within "#comments" do
+          expect(page).to have_content "I am your Admin!"
+        end
+
         visit admin_budget_budget_investment_path(investment.budget, investment)
 
         within "#comments" do


### PR DESCRIPTION
## Background

We've got a bug which causes the admin description not to appear immediately after commenting, due to the `admin_layout` variable being false when we add a comment using an AJAX request.

So the test reloaded the page to check the admin description was there. However, sometimes reloading the page is faster than the AJAX request, and so the comment is not there yet.

## Objectives

* Don't make two requests at the same time while testing
* Simplify the test which was doing two request simultaneously

## Notes

A proper solution would be to display the admin description or name right after the comment is added.