### PR TITLE
Add original heading id to investments

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -104,6 +104,7 @@ class Budget
 
     scope :for_render, -> { includes(:heading) }
 
+    before_create :set_original_heading_id
     before_save :calculate_confidence_score
     after_save :recalculate_heading_winners
     before_validation :set_responsible_name
@@ -402,6 +403,10 @@ class Budget
       def set_denormalized_ids
         self.group_id = heading&.group_id if heading_id_changed?
         self.budget_id ||= heading&.group&.budget_id
+      end
+
+      def set_original_heading_id
+        self.original_heading_id = heading_id
       end
 
       def change_log

--- a/db/migrate/20190531173316_add_original_heading_id_to_investments.rb
+++ b/db/migrate/20190531173316_add_original_heading_id_to_investments.rb
@@ -1,0 +1,5 @@
+class AddOriginalHeadingIdToInvestments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :budget_investments, :original_heading_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -294,6 +294,7 @@ ActiveRecord::Schema.define(version: 20190607160900) do
     t.datetime "ignored_flag_at"
     t.integer  "flags_count",                                 default: 0
     t.integer  "tracker_assignments_count"
+    t.integer  "original_heading_id"
     t.index ["administrator_id"], name: "index_budget_investments_on_administrator_id", using: :btree
     t.index ["author_id"], name: "index_budget_investments_on_author_id", using: :btree
     t.index ["community_id"], name: "index_budget_investments_on_community_id", using: :btree

--- a/lib/tasks/budgets.rake
+++ b/lib/tasks/budgets.rake
@@ -23,4 +23,14 @@ namespace :budgets do
 
   end
 
+  desc "Update investments original_heading_id with current heading_id"
+  task set_original_heading_id: :environment do
+    puts "Starting"
+    Budget::Investment.find_each do |investment|
+      investment.update_column(:original_heading_id, investment.heading_id)
+      print "."
+    end
+    puts "Finished"
+  end
+
 end

--- a/spec/lib/tasks/budgets_spec.rb
+++ b/spec/lib/tasks/budgets_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Budget do
+
+  let(:run_rake_task) do
+    Rake.application.invoke_task("budgets:set_original_heading_id")
+  end
+
+  it "sets attribute original_heading_id for existing investments" do
+    heading = create(:budget_heading)
+    investment = create(:budget_investment, heading: heading)
+    investment.update(original_heading_id: nil)
+
+    expect(investment.original_heading_id).to equal(nil)
+
+    run_rake_task
+    investment.reload
+
+    expect(investment.original_heading_id).to equal(heading.id)
+  end
+
+end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -56,6 +56,29 @@ describe Budget::Investment do
     expect(investment.group_id).to eq group_2.id
   end
 
+  it "logs previous heading value if it is changed" do
+    budget = create(:budget, phase: "balloting")
+
+    group = create(:budget_group, budget: budget)
+
+    heading_1 = create(:budget_heading, group: group)
+    heading_2 = create(:budget_heading, group: group)
+
+    investment = create(:budget_investment, heading: heading_1)
+
+    expect(investment.previous_heading_id).to eq nil
+
+    investment.update(heading: heading_2)
+
+    expect(investment.previous_heading_id).to eq heading_1.id
+  end
+
+  it "stores original heading id" do
+    investment = create(:budget_investment)
+
+    expect(investment.original_heading_id).to eq investment.heading_id
+  end
+
   describe "#unfeasibility_explanation blank" do
     it "is valid if valuation not finished" do
       investment.unfeasibility_explanation = ""


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/2033

## Context

Investments can be reclassified to a different heading during the participatory budget process.

Whilst we are recording this change of heading in the `previous_heading_id` attribute, we are only keeping the _last_ heading. If there are multiple reclassifications we lose this chain of reclassifications.

## Objectives

Keep a record of the heading id in which an investment was created, just in case it gets reclassified multiple times.

## Notes
To update attribute `original_heading_id` of existing investments run:
`bin/rake budgets:set_original_heading_id RAILS_ENV=production`