### PR TITLE
Reset globalize fallbacks before every test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,9 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     I18n.locale = :en
     Globalize.locale = I18n.locale
+    unless %i[controller feature request].include? example.metadata[:type]
+      Globalize.set_fallbacks_to_all_available_locales
+    end
     load Rails.root.join("db", "seeds.rb").to_s
     Setting["feature.user.skip_verification"] = nil
   end


### PR DESCRIPTION
## Background

When any helper, lib, mailer, model or view spec is executed after a feature, controller or request spec Globalize.fallbacks returns nil and this can cause some flaky specs. With this patch we are ensuring to initialize Globalize fallbacks between specs.

## Objectives

* Reset globalize fallbacks before every test, so previous tests don't affect the result of the current test