### PR TITLE
Avoid error when accessing final voting stats before the balloting phase

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -74,6 +74,9 @@ class Admin::StatsController < Admin::BaseController
 
   def budget_balloting
     @budget = Budget.find(params[:budget_id])
+
+    authorize! :read_admin_stats, @budget, message: t("admin.stats.budgets.no_data_before_balloting_phase")
+
     @user_count = @budget.ballots.select {|ballot| ballot.lines.any? }.count
 
     @vote_count = @budget.lines.count

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -66,6 +66,8 @@ module Abilities
       can [:valuate, :comment_valuation], Budget::Investment
       can :create, Budget::ValuatorAssignment
 
+      can(:read_admin_stats, Budget) { |budget| budget.balloting_or_later? }
+
       can [:search, :edit, :update, :create, :index, :destroy], Banner
 
       can [:index, :create, :edit, :update, :destroy], Geozone

--- a/app/views/admin/stats/budgets.html.erb
+++ b/app/views/admin/stats/budgets.html.erb
@@ -9,8 +9,15 @@
         <strong><%= budget.name %></strong>
       </td>
       <td>
-        <%= link_to t("admin.stats.budgets.supporting_phase"), budget_supporting_admin_stats_path(budget_id: budget.id), class: "button hollow" %>
-        <%= link_to t("admin.stats.budgets.balloting_phase"), budget_balloting_admin_stats_path(budget_id: budget.id), class: "button hollow" %>
+        <%= link_to t("admin.stats.budgets.supporting_phase"),
+                    budget_supporting_admin_stats_path(budget_id: budget.id),
+                    class: "button hollow" %>
+
+        <% if can? :read_admin_stats, budget %>
+          <%= link_to t("admin.stats.budgets.balloting_phase"),
+                      budget_balloting_admin_stats_path(budget_id: budget.id),
+                      class: "button hollow" %>
+        <% end %>
       </td>
     </tr>
   </table>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1417,6 +1417,7 @@ en:
         level_2_user: Level 2 users
         proposal_created: Citizen proposals
       budgets:
+        no_data_before_balloting_phase: "There isn't any data to show before the balloting phase."
         title: "Participatory Budgets - Participation stats"
         supporting_phase: Supporting phase
         balloting_phase: Final voting

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1416,6 +1416,7 @@ es:
         level_2_user: Usuarios nivel 2
         proposal_created: Propuestas Ciudadanas
       budgets:
+        no_data_before_balloting_phase: "No hay datos que mostrar hasta que la fase de votación no esté abierta."
         title: "Presupuestos participativos - Estadisticas de participación"
         supporting_phase: Fase de apoyos
         balloting_phase: Votación final

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -189,6 +189,21 @@ describe "Stats" do
           expect(page).to have_content 0
         end
       end
+
+      scenario "hide final voting link" do
+        visit admin_stats_path
+        click_link "Participatory Budgets"
+
+        within("#budget_#{@budget.id}") do
+          expect(page).not_to have_link "Final voting"
+        end
+      end
+
+      scenario "show message when accessing final voting stats" do
+        visit budget_balloting_admin_stats_path(budget_id: @budget.id)
+
+        expect(page).to have_content "There isn't any data to show before the balloting phase."
+      end
     end
 
     context "Balloting phase" do


### PR DESCRIPTION
## References

This is a backport of PR https://github.com/AyuntamientoMadrid/consul/pull/2040

## Objectives

When accessing the URL `/admin/stats/budget_balloting?budget_id=X` for a budget in a phase prior to the balloting phase, the following error was raised due to the stats were not calculated yet. Instead, we'll now show a flash message.

```
NoMethodError:
  undefined method `[]' for nil:NilClass
    ./app/controllers/admin/stats_controller.rb:82
```

## Visual Changes
![Captura de pantalla 2019-06-06 a las 18 15 02](https://user-images.githubusercontent.com/942995/59049247-e1b1d000-8887-11e9-8547-00f59830b94a.png)

![Captura de pantalla 2019-06-06 a las 18 54 16](https://user-images.githubusercontent.com/942995/59051188-88986b00-888c-11e9-9333-50fc3ccf83af.png)