### PR TITLE
Remove system recounts in the admin section

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -81,6 +81,10 @@ class Poll < ApplicationRecord
     ends_at < timestamp
   end
 
+  def recounts_confirmed?
+    ends_at < 1.month.ago
+  end
+
   def self.current_or_recounting
     current + recounting
   end

--- a/app/views/admin/poll/booth_assignments/show.html.erb
+++ b/app/views/admin/poll/booth_assignments/show.html.erb
@@ -81,13 +81,13 @@
         </tr>
       </thead>
       <tbody>
-      <% (@poll.starts_at.to_date..@poll.ends_at.to_date).each do |voting_date| %>
-        <% system_count = @voters_by_date[voting_date].present? ? @voters_by_date[voting_date].size : 0 %>
-        <tr id="recounting_<%= voting_date.strftime("%Y%m%d") %>">
-          <td><%= l voting_date %></td>
-          <td class="text-center"><%= system_count %></td>
-        </tr>
-      <% end %>
+        <% (@poll.starts_at.to_date..@poll.ends_at.to_date).each do |voting_date| %>
+          <% system_count = @voters_by_date[voting_date].present? ? @voters_by_date[voting_date].size : 0 %>
+          <tr id="recounting_<%= voting_date.strftime("%Y%m%d") %>">
+            <td><%= l voting_date %></td>
+            <td class="text-center"><%= system_count %></td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/app/views/admin/poll/booth_assignments/show.html.erb
+++ b/app/views/admin/poll/booth_assignments/show.html.erb
@@ -58,7 +58,10 @@
       <thead>
         <tr>
           <th class="text-center"><%= t("admin.poll_booth_assignments.show.count_final") %></th>
-          <th class="text-center"><%= t("admin.poll_booth_assignments.show.total_system") %></th>
+
+          <% unless @poll.recounts_confirmed? %>
+            <th class="text-center"><%= t("admin.poll_booth_assignments.show.total_system") %></th>
+          <% end %>
         </tr>
       </thead>
       <tbody>
@@ -66,30 +69,35 @@
           <td class="text-center" id="total_final">
             <%= total_recounts_by_booth(@booth_assignment) || "-"  %>
           </td>
-          <td class="text-center" id="total_system">
-            <%= @booth_assignment.voters.count %>
-          </td>
+
+          <% unless @poll.recounts_confirmed? %>
+            <td class="text-center" id="total_system">
+              <%= @booth_assignment.voters.count %>
+            </td>
+          <% end %>
         </tr>
       </tbody>
     </table>
 
-    <table id="recounts_list">
-      <thead>
-        <tr>
-          <th><%= t("admin.poll_booth_assignments.show.date") %></th>
-          <th class="text-center"><%= t("admin.poll_booth_assignments.show.count_by_system") %></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% (@poll.starts_at.to_date..@poll.ends_at.to_date).each do |voting_date| %>
-          <% system_count = @voters_by_date[voting_date].present? ? @voters_by_date[voting_date].size : 0 %>
-          <tr id="recounting_<%= voting_date.strftime("%Y%m%d") %>">
-            <td><%= l voting_date %></td>
-            <td class="text-center"><%= system_count %></td>
+    <% unless @poll.recounts_confirmed? %>
+      <table id="recounts_list">
+        <thead>
+          <tr>
+            <th><%= t("admin.poll_booth_assignments.show.date") %></th>
+            <th class="text-center"><%= t("admin.poll_booth_assignments.show.count_by_system") %></th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% (@poll.starts_at.to_date..@poll.ends_at.to_date).each do |voting_date| %>
+            <% system_count = @voters_by_date[voting_date].present? ? @voters_by_date[voting_date].size : 0 %>
+            <tr id="recounting_<%= voting_date.strftime("%Y%m%d") %>">
+              <td><%= l voting_date %></td>
+              <td class="text-center"><%= system_count %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
   </div>
   <div class="tabs-panel is-active" id="tab-results">
     <%= render "results" %>

--- a/app/views/admin/poll/recounts/index.html.erb
+++ b/app/views/admin/poll/recounts/index.html.erb
@@ -50,8 +50,6 @@
       </thead>
       <tbody>
         <% @booth_assignments.each do |booth_assignment| %>
-          <% total_recounts = total_recounts_by_booth(booth_assignment) %>
-          <% system_count = booth_assignment.voters.size %>
           <tr id="<%= dom_id(booth_assignment) %>_recounts" class="booth_recounts">
             <td>
               <strong>
@@ -60,21 +58,13 @@
             </td>
             <% unless @poll.budget_poll? %>
               <td class="text-center" id="<%= dom_id(booth_assignment) %>_recount">
-                <% if total_recounts.present? %>
-                  <strong><%= total_recounts %></strong>
-                <% else %>
-                  <span>-</span>
-                <% end %>
+                <%= total_recounts_by_booth(booth_assignment) || "-" %>
               </td>
             <% end %>
 
             <% unless @poll.recounts_confirmed? %>
               <td class="text-center" id="<%= dom_id(booth_assignment) %>_system">
-                <% if system_count.present? %>
-                  <strong><%= system_count %></strong>
-                <% else %>
-                  <span>0</span>
-                <% end %>
+                <%= booth_assignment.voters.size || 0 %>
               </td>
             <% end %>
           </tr>

--- a/app/views/admin/poll/recounts/index.html.erb
+++ b/app/views/admin/poll/recounts/index.html.erb
@@ -17,7 +17,10 @@
           <% unless @poll.budget_poll? %>
             <th class="text-center"><%= t("admin.recounts.index.total_final") %></th>
           <% end %>
-          <th class="text-center"><%= t("admin.recounts.index.total_system") %></th>
+
+          <% unless @poll.recounts_confirmed? %>
+            <th class="text-center"><%= t("admin.recounts.index.total_system") %></th>
+          <% end %>
         </tr>
       </thead>
       <tbody>
@@ -26,7 +29,10 @@
           <% unless @poll.budget_poll? %>
             <td class="text-center" id="total_final"><%= @stats.total_participants_booth %></td>
           <% end %>
-          <td class="text-center" id="total_system"><%= @stats.total_registered_booth %></td>
+
+          <% unless @poll.recounts_confirmed? %>
+            <td class="text-center" id="total_system"><%= @stats.total_registered_booth %></td>
+          <% end %>
         </tr>
       </tbody>
     </table>
@@ -37,7 +43,10 @@
         <% unless @poll.budget_poll? %>
           <th class="text-center"><%= t("admin.recounts.index.table_total_recount") %></th>
         <% end %>
-        <th class="text-center"><%= t("admin.recounts.index.table_system_count") %></th>
+
+        <% unless @poll.recounts_confirmed? %>
+          <th class="text-center"><%= t("admin.recounts.index.table_system_count") %></th>
+        <% end %>
       </thead>
       <tbody>
         <% @booth_assignments.each do |booth_assignment| %>
@@ -50,7 +59,7 @@
               </strong>
             </td>
             <% unless @poll.budget_poll? %>
-              <td class="text-center <%= "count-error" if total_recounts.to_i != system_count %>" id="<%= dom_id(booth_assignment) %>_recount">
+              <td class="text-center" id="<%= dom_id(booth_assignment) %>_recount">
                 <% if total_recounts.present? %>
                   <strong><%= total_recounts %></strong>
                 <% else %>
@@ -58,13 +67,16 @@
                 <% end %>
               </td>
             <% end %>
-            <td class="text-center" id="<%= dom_id(booth_assignment) %>_system">
-              <% if system_count.present? %>
-                <strong><%= system_count %></strong>
-              <% else %>
-                <span>0</span>
-              <% end %>
-            </td>
+
+            <% unless @poll.recounts_confirmed? %>
+              <td class="text-center" id="<%= dom_id(booth_assignment) %>_system">
+                <% if system_count.present? %>
+                  <strong><%= system_count %></strong>
+                <% else %>
+                  <span>0</span>
+                <% end %>
+              </td>
+            <% end %>
           </tr>
         <% end %>
       </tbody>

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -17,6 +17,11 @@ FactoryBot.define do
       ends_at { 15.days.ago }
     end
 
+    trait :old do
+      starts_at { 3.months.ago }
+      ends_at { 2.months.ago }
+    end
+
     trait :recounting do
       starts_at { 1.month.ago }
       ends_at { Date.current }

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -204,6 +204,26 @@ describe "Admin booths assignments" do
       end
     end
 
+    scenario "Doesn't show system recounts for old polls" do
+      poll = create(:poll, :old)
+      booth_assignment = create(:poll_booth_assignment, poll: poll)
+
+      create(:poll_voter, poll: poll, booth_assignment: booth_assignment)
+      create(:poll_recount, booth_assignment: booth_assignment, total_amount: 10)
+
+      visit admin_poll_booth_assignment_path(poll, booth_assignment)
+
+      within("#totals") do
+        within("#total_final") do
+          expect(page).to have_content "10"
+        end
+
+        expect(page).not_to have_selector "#total_system"
+      end
+
+      expect(page).not_to have_selector "#recounts_list"
+    end
+
     scenario "Results for a booth assignment" do
       poll = create(:poll)
       booth_assignment = create(:poll_booth_assignment, poll: poll)

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -328,6 +328,27 @@ describe "Admin polls" do
           expect(page).to have_content("2")
         end
       end
+
+      scenario "Recounts list with old polls" do
+        poll = create(:poll, :old)
+        booth_assignment = create(:poll_booth_assignment, poll: poll)
+
+        create(:poll_recount, booth_assignment: booth_assignment, total_amount: 10)
+        create(:poll_voter, :from_booth, poll: poll, booth_assignment: booth_assignment)
+
+        visit admin_poll_recounts_path(poll)
+
+        within("#totals") do
+          within("#total_final") do
+            expect(page).to have_content("10")
+          end
+
+          expect(page).not_to have_selector "#total_system"
+        end
+
+        expect(page).to have_selector "#poll_booth_assignment_#{booth_assignment.id}_recounts"
+        expect(page).not_to have_selector "#poll_booth_assignment_#{booth_assignment.id}_system"
+      end
     end
   end
 

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -414,4 +414,30 @@ describe Poll do
       end
     end
   end
+
+  describe "#recounts_confirmed" do
+    it "is false for current polls" do
+      poll = create(:poll, :current)
+
+      expect(poll.recounts_confirmed?).to be false
+    end
+
+    it "is false for recounting polls" do
+      poll = create(:poll, :recounting)
+
+      expect(poll.recounts_confirmed?).to be false
+    end
+
+    it "is false for polls which finished less than a month ago" do
+      poll = create(:poll, starts_at: 3.months.ago, ends_at: 27.days.ago )
+
+      expect(poll.recounts_confirmed?).to be false
+    end
+
+    it "is true for polls which finished more than a month ago" do
+      poll = create(:poll, starts_at: 3.months.ago, ends_at: 1.month.ago - 1.day)
+
+      expect(poll.recounts_confirmed?).to be true
+    end
+  end
 end


### PR DESCRIPTION
## References

* Backports AyuntamientoMadrid#2036

## Background

In the past, we had two numbers to track the total numbers of votes in a booth; what we called "final" recounts and "system" recounts. However, sytem recounts are not relevant anymore.

## Objectives

* Remove system recounts in the admin section, so administrators are not confused when they see two numbers for the same result.

## Visual Changes

Before these changes:

![Poll recounts show final and system recounts](https://user-images.githubusercontent.com/35156/58821049-79b77b80-8634-11e9-8b03-1da94c517595.png)
![Booth recounts show final and system recounts](https://user-images.githubusercontent.com/35156/58821118-b1262800-8634-11e9-982f-d15087d8eb8b.png)

After these changes:

![Poll recounts show only final recounts](https://user-images.githubusercontent.com/35156/58821148-bbe0bd00-8634-11e9-81bf-0b0565ec9a22.png)
![Booth recounts show only final recounts](https://user-images.githubusercontent.com/35156/58821192-d5820480-8634-11e9-9b7a-4182231b0bae.png)