### PR TITLE
Adding missing subtasks to upgrade task and adding info log

### DIFF
--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -8,6 +8,8 @@ namespace :consul do
     "stats_and_results:migrate_to_reports",
     "budgets:calculate_ballot_lines",
     "settings:remove_deprecated_settings",
+    "settings:rename_setting_keys",
+    "settings:add_new_settings",
     "stats:generate"
   ]
 end

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -30,6 +30,7 @@ namespace :settings do
 
   desc "Rename existing settings"
   task rename_setting_keys: :environment do
+    ApplicationLogger.new.info "Renaming existing settings"
     Setting.rename_key from: "map_latitude",  to: "map.latitude"
     Setting.rename_key from: "map_longitude", to: "map.longitude"
     Setting.rename_key from: "map_zoom",      to: "map.zoom"
@@ -50,6 +51,7 @@ namespace :settings do
 
   desc "Add new settings"
   task add_new_settings: :environment do
+    ApplicationLogger.new.info "Adding new settings"
     Setting.add_new_settings
   end
 end


### PR DESCRIPTION
## References

- #3610

## Objectives

Fixes a bug when upgrading to v1.0.0 because the taks `add_new_settings` is not run and upload settings are missing, crashing the whole `admin/settings` page

## Visual Changes

- None

## Notes

- Please patch quickly to avoid any problem for other people who will try to update to v1.0.0 in the coming days
- The settings management needs to be made more robust, see more explanation in #3610.