### PR TITLE
Hide information on selected proposals

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -450,6 +450,7 @@
   }
 
   blockquote {
+    clear: both;
     color: #4c4c4c;
     margin-top: rem-calc(12);
     padding-top: 0;

--- a/app/views/proposals/_info.html.erb
+++ b/app/views/proposals/_info.html.erb
@@ -19,10 +19,12 @@
 <%= render_image(@proposal.image, :large, true) if @proposal.image.present? %>
 
 <br>
-<p>
-  <%= t("proposals.show.code") %>
-  <strong><%= @proposal.code %></strong>
-</p>
+<% unless @proposal.selected? %>
+  <p>
+    <%= t("proposals.show.code") %>
+    <strong><%= @proposal.code %></strong>
+  </p>
+<% end %>
 
 <blockquote><%= @proposal.summary %></blockquote>
 

--- a/app/views/proposals/_info.html.erb
+++ b/app/views/proposals/_info.html.erb
@@ -3,9 +3,12 @@
 
   <span class="bullet">&nbsp;&bull;&nbsp;</span>
   <%= l @proposal.created_at.to_date %>
-  <span class="bullet">&nbsp;&bull;&nbsp;</span>
-  <span class="icon-comments"></span>&nbsp;
-  <%= link_to t("proposals.show.comments", count: @proposal.comments_count), "#comments" %>
+
+  <% unless @proposal.selected? %>
+    <span class="bullet">&nbsp;&bull;&nbsp;</span>
+    <span class="icon-comments"></span>&nbsp;
+    <%= link_to t("proposals.show.comments", count: @proposal.comments_count), "#comments" %>
+  <% end %>
 
   <% if current_user %>
     <span class="bullet">&nbsp;&bull;&nbsp;</span>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -71,11 +71,13 @@
         </div>
       <% end %>
 
-      <div class="row">
-        <div class="small-12 column">
-          <%= render "view_mode" %>
+      <% unless params[:selected].present? %>
+        <div class="row">
+          <div class="small-12 column">
+            <%= render "view_mode" %>
+          </div>
         </div>
-      </div>
+      <% end %>
 
       <% unless params[:retired].present? || params[:selected].present? %>
         <%= render "shared/advanced_search",

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -40,7 +40,10 @@
 
         <%= render "proposals/info", proposal: @proposal %>
         <%= render "shared/geozone", geozonable: @proposal %>
-        <%= render "relationable/related_content", relationable: @proposal %>
+
+        <% unless @proposal.selected? %>
+          <%= render "relationable/related_content", relationable: @proposal %>
+        <% end %>
 
         <div class="js-moderator-proposal-actions margin">
           <%= render "proposals/actions", proposal: @proposal %>

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -186,26 +186,15 @@ describe "Proposals" do
       expect(page).not_to have_content "Access the community"
     end
 
-    scenario "Selected proposals does not show proposal code" do
+    scenario "Selected proposals does not show all information" do
       proposal = create(:proposal, :selected)
 
       visit proposal_path(proposal)
       expect(page).not_to have_content proposal.code
       expect(page).not_to have_content("Proposal code:")
-    end
 
-    scenario "Selected proposals does not show related content section" do
-      proposal = create(:proposal, :selected)
-
-      visit proposal_path(proposal)
       expect(page).not_to have_content("Related content")
       expect(page).not_to have_button("Add related content")
-    end
-
-    scenario "Selected proposals does not show comments count" do
-      proposal = create(:proposal, :selected)
-
-      visit proposal_path(proposal)
 
       within(".proposal-info") do
         expect(page).not_to have_link("No comments", href: "#comments")

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -193,6 +193,14 @@ describe "Proposals" do
       expect(page).not_to have_content proposal.code
       expect(page).not_to have_content("Proposal code:")
     end
+
+    scenario "Selected proposals does not show related content section" do
+      proposal = create(:proposal, :selected)
+
+      visit proposal_path(proposal)
+      expect(page).not_to have_content("Related content")
+      expect(page).not_to have_button("Add related content")
+    end
   end
 
   context "Show on mobile screens" do

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -185,6 +185,14 @@ describe "Proposals" do
       visit proposal_path(proposal)
       expect(page).not_to have_content "Access the community"
     end
+
+    scenario "Selected proposals does not show proposal code" do
+      proposal = create(:proposal, :selected)
+
+      visit proposal_path(proposal)
+      expect(page).not_to have_content proposal.code
+      expect(page).not_to have_content("Proposal code:")
+    end
   end
 
   context "Show on mobile screens" do

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -201,6 +201,16 @@ describe "Proposals" do
       expect(page).not_to have_content("Related content")
       expect(page).not_to have_button("Add related content")
     end
+
+    scenario "Selected proposals does not show comments count" do
+      proposal = create(:proposal, :selected)
+
+      visit proposal_path(proposal)
+
+      within(".proposal-info") do
+        expect(page).not_to have_link("No comments", href: "#comments")
+      end
+    end
   end
 
   context "Show on mobile screens" do

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -82,6 +82,15 @@ describe "Proposals" do
       end
     end
 
+    scenario "Index view mode is not shown with selected filter" do
+      visit proposals_path
+
+      click_link "View selected proposals"
+
+      expect(page).not_to have_selector(".view-mode")
+      expect(page).not_to have_button("View mode")
+    end
+
     scenario "Pagination" do
       per_page = Kaminari.config.default_per_page
       (per_page + 5).times { create(:proposal) }


### PR DESCRIPTION
## References

Backport of https://github.com/AyuntamientoMadrid/consul/pull/2038.

## Objectives
To simplify UI on selected proposals:

- Hide view mode on selected proposals index list.
- Hide on proposal show view:
    - Proposal code.
    - Related content section.
    - Comments count.

## Visual Changes
**Index**
<img width="1216" alt="selected_proposals_list" src="https://user-images.githubusercontent.com/631897/59135823-b8c13600-8980-11e9-92cd-1d95ef6d7f8c.png">

**Show**
<img width="1019" alt="selected_proposal" src="https://user-images.githubusercontent.com/631897/59135826-bc54bd00-8980-11e9-87df-d622c1f65bf5.png">