### PR TITLE
Avoid error for polls results

### DIFF
--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -67,7 +67,7 @@ class Poll::Question < ApplicationRecord
   end
 
   def most_voted_answer_id
-    question_answers.max_by(&:total_votes).id
+    question_answers.max_by(&:total_votes)&.id
   end
 
   def possible_answers

--- a/spec/features/polls/results_spec.rb
+++ b/spec/features/polls/results_spec.rb
@@ -52,4 +52,13 @@ describe "Poll Results" do
       expect(find("#answer_#{answer5.id}_result")).to have_content("1 (33.33%)")
     end
   end
+
+  scenario "Results for polls with questions but without answers" do
+    poll = create(:poll, :expired, results_enabled: true)
+    question = create(:poll_question, poll: poll)
+
+    visit results_poll_path(poll)
+
+    expect(page).to have_content question.title
+  end
 end


### PR DESCRIPTION
## References

This is a backport of PR https://github.com/AyuntamientoMadrid/consul/pull/2043

## Objectives

When a poll is created, and any of the questions for that poll doesn't have any answer created, the following exception was raised when trying to see the results:

```
Failure/Error: question_answers.max_by {|answer| answer.total_votes }.id

  ActionView::Template::Error:
    undefined method `id' for nil:NilClass
      ./app/models/poll/question.rb:66:in `most_voted_answer_id'
```
