### PR TITLE
Use Date.current and Time.current

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,9 +93,6 @@ Rails/Blank:
 Rails/CreateTableWithTimestamps:
   Enabled: true
 
-Rails/Date:
-  Enabled: true
-
 Rails/Delegate:
   Enabled: true
 
@@ -175,9 +172,6 @@ Rails/ScopeArgs:
   Enabled: true
 
 Rails/SkipsModelValidations:
-  Enabled: true
-
-Rails/TimeZone:
   Enabled: true
 
 Rails/UniqBeforePluck:

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -56,10 +56,16 @@ Rails/ApplicationJob:
 Rails/ApplicationRecord:
   Enabled: true
 
+Rails/Date:
+  Enabled: true
+
 Rails/HttpPositionalArguments:
   Enabled: true
 
 Rails/RelativeDateConstant:
+  Enabled: true
+
+Rails/TimeZone:
   Enabled: true
 
 RSpec/NotToNot:

--- a/app/controllers/admin/dashboard/administrator_tasks_controller.rb
+++ b/app/controllers/admin/dashboard/administrator_tasks_controller.rb
@@ -15,7 +15,7 @@ class Admin::Dashboard::AdministratorTasksController < Admin::Dashboard::BaseCon
   def update
     authorize! :update, administrator_task
 
-    administrator_task.update(user: current_user, executed_at: Time.now)
+    administrator_task.update(user: current_user, executed_at: Time.current)
     redirect_to admin_dashboard_administrator_tasks_path,
                 { flash: { notice: t("admin.dashboard.administrator_tasks.update.success") } }
   end

--- a/app/controllers/concerns/dashboard/expects_date_range.rb
+++ b/app/controllers/concerns/dashboard/expects_date_range.rb
@@ -10,6 +10,6 @@ module Dashboard::ExpectsDateRange
 
   def end_date
     return Date.parse(params[:end_date]) unless params[:end_date].blank?
-    Date.today
+    Date.current
   end
 end

--- a/app/controllers/dashboard/actions_controller.rb
+++ b/app/controllers/dashboard/actions_controller.rb
@@ -12,7 +12,7 @@ class Dashboard::ActionsController < Dashboard::BaseController
     source_params = {
       proposal: proposal,
       action: dashboard_action,
-      executed_at: Time.now
+      executed_at: Time.current
     }
 
     @dashboard_executed_action = Dashboard::ExecutedAction.new(source_params)
@@ -31,7 +31,7 @@ class Dashboard::ActionsController < Dashboard::BaseController
     authorize! :dashboard, proposal
 
     Dashboard::ExecutedAction.create(proposal: proposal, action: dashboard_action,
-                                                         executed_at: Time.now)
+                                                         executed_at: Time.current)
     redirect_to request.referer
   end
 

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -112,7 +112,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     @phase = :resume
     respond_to do |format|
       format.html
-      format.xlsx {render xlsx: "resume_to_xlsx", filename: ("resume-" + Date.today.to_s + ".xlsx")}
+      format.xlsx {render xlsx: "resume_to_xlsx", filename: ("resume-" + Date.current.to_s + ".xlsx")}
     end
   end
 

--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -14,7 +14,7 @@ class Management::ProposalsController < Management::BaseController
 
   def create
     @resource = resource_model.new(strong_params.merge(author: current_user,
-                                                       published_at: Time.now))
+                                                       published_at: Time.current))
 
     if @resource.save
       track_event

--- a/app/models/dashboard/action.rb
+++ b/app/models/dashboard/action.rb
@@ -44,10 +44,10 @@ class Dashboard::Action < ApplicationRecord
   }
 
   def self.active_for(proposal)
-    published_at = proposal.published_at&.to_date || Date.today
+    published_at = proposal.published_at&.to_date || Date.current
 
     active.where("required_supports <= ?", proposal.cached_votes_up)
-          .where("day_offset <= ?", (Date.today - published_at).to_i)
+          .where("day_offset <= ?", (Date.current - published_at).to_i)
           .by_proposal(proposal)
   end
 
@@ -59,9 +59,9 @@ class Dashboard::Action < ApplicationRecord
   end
 
   def active_for?(proposal)
-    published_at = proposal.published_at&.to_date || Date.today
+    published_at = proposal.published_at&.to_date || Date.current
 
-    required_supports <= proposal.cached_votes_up && day_offset <= (Date.today - published_at).to_i
+    required_supports <= proposal.cached_votes_up && day_offset <= (Date.current - published_at).to_i
   end
 
   def requested_for?(proposal)
@@ -95,7 +95,7 @@ class Dashboard::Action < ApplicationRecord
   private
     def self.get_actions_for_today(proposal)
       proposal_votes = proposal.cached_votes_up
-      day_offset = calculate_day_offset(proposal, Date.today)
+      day_offset = calculate_day_offset(proposal, Date.current)
 
       calculate_actions(proposal_votes, day_offset, proposal)
     end

--- a/app/models/direct_message.rb
+++ b/app/models/direct_message.rb
@@ -8,7 +8,7 @@ class DirectMessage < ApplicationRecord
   validates :receiver, presence: true
   validate  :max_per_day
 
-  scope :today, lambda { where("DATE(created_at) = DATE(?)", Time.current) }
+  scope :today, lambda { where(created_at: Date.current.beginning_of_day..Date.current.end_of_day) }
 
   def max_per_day
     return if errors.any?

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -96,7 +96,7 @@ class Proposal < ApplicationRecord
   end
 
   def publish
-    update(published_at: Time.now)
+    update(published_at: Time.current)
     send_new_actions_notification_on_published
   end
 

--- a/app/views/dashboard/mailer/new_actions_notification_rake_published.html.erb
+++ b/app/views/dashboard/mailer/new_actions_notification_rake_published.html.erb
@@ -26,7 +26,7 @@
                                  Setting["months_to_archive_proposals"].to_i.months %>
   <p>
     <%= t("mailers.new_actions_notification_rake_published.text_3",
-          days_count: (limit_to_archive_proposal - Date.today).to_i,
+          days_count: (limit_to_archive_proposal - Date.current).to_i,
           max_votes_count: Setting["votes_for_proposal_success"]) %>
   </p>
 

--- a/app/views/legislation/processes/_key_dates.html.erb
+++ b/app/views/legislation/processes/_key_dates.html.erb
@@ -53,7 +53,7 @@
           </li>
         <% end %>
 
-        <% if process.result_publication.enabled? && process.end_date <= Date.today %>
+        <% if process.result_publication.enabled? && process.end_date <= Date.current %>
           <li <%= "class=is-active" if phase == :resume %>>
             <%= link_to resume_legislation_process_path(process) do %>
               <h4><%= t("legislation.summary.title") %></h4>

--- a/db/dev_seeds/newsletters.rb
+++ b/db/dev_seeds/newsletters.rb
@@ -17,7 +17,7 @@ section "Creating Newsletters" do
       segment_recipient: UserSegments::SEGMENTS.sample,
       from: "no-reply@consul.dev",
       body: newsletter_body.sample,
-      sent_at: [Time.now, nil].sample
+      sent_at: [Time.current, nil].sample
     )
   end
 end

--- a/db/dev_seeds/proposals.rb
+++ b/db/dev_seeds/proposals.rb
@@ -39,7 +39,7 @@ section "Creating Proposals" do
                                 geozone: Geozone.all.sample,
                                 skip_map: "1",
                                 terms_of_service: "1",
-                                published_at: Time.now)
+                                published_at: Time.current)
     random_locales.map do |locale|
       Globalize.with_locale(locale) do
         proposal.title = "Title for locale #{locale}"
@@ -97,7 +97,7 @@ section "Creating Successful Proposals" do
                                 skip_map: "1",
                                 terms_of_service: "1",
                                 cached_votes_up: Setting["votes_for_proposal_success"],
-                                published_at: Time.now)
+                                published_at: Time.current)
     random_locales.map do |locale|
       Globalize.with_locale(locale) do
         proposal.title = "Successful proposal title for locale #{locale}"
@@ -123,7 +123,7 @@ section "Creating Successful Proposals" do
                                 geozone: Geozone.all.sample,
                                 skip_map: "1",
                                 terms_of_service: "1",
-                                published_at: Time.now)
+                                published_at: Time.current)
     random_locales.map do |locale|
       Globalize.with_locale(locale) do
         proposal.title = "Tagged proposal title for locale #{locale}"

--- a/lib/tasks/proposal_actions.rake
+++ b/lib/tasks/proposal_actions.rake
@@ -418,12 +418,12 @@ namespace :proposal_actions do
                                 summary: Faker::Lorem.sentence(3),
                                 responsible_name: Faker::Name.name,
                                 description: description,
-                                created_at: Time.now - expected_supports.length.days,
+                                created_at: Time.current - expected_supports.length.days,
                                 tag_list: "Example",
                                 geozone: Geozone.all.sample,
                                 skip_map: "1",
                                 terms_of_service: "1",
-                                published_at: Time.now - expected_supports.length.days)
+                                published_at: Time.current - expected_supports.length.days)
 
     expected_supports.each_with_index do |supports, day_offset|
       supports = (supports * goal_votes / votes_count).ceil

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -51,7 +51,7 @@ describe "Admin collaborative legislation" do
 
     scenario "Processes are sorted by descending start date" do
       process_1 = create(:legislation_process, title: "Process 1", start_date: Date.yesterday)
-      process_2 = create(:legislation_process, title: "Process 2", start_date: Date.today)
+      process_2 = create(:legislation_process, title: "Process 2", start_date: Date.current)
       process_3 = create(:legislation_process, title: "Process 3", start_date: Date.tomorrow)
 
       visit admin_legislation_processes_path(filter: "all")

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -195,7 +195,7 @@ describe "Proposal's dashboard" do
   end
 
   scenario "Dashboard progress show available resources for published proposal" do
-    proposal.update(published_at: Date.today)
+    proposal.update(published_at: Date.current)
     available = create(:dashboard_action, :resource, :active)
 
     requested = create(:dashboard_action, :resource, :admin_request, :active)
@@ -481,7 +481,7 @@ describe "Proposal's dashboard" do
     scenario "Not display tag 'new' on resouce when there is not new resources since last login" do
       resource = create(:dashboard_action, :resource, :active, day_offset: 0,
                                                                published_proposal: false)
-      proposal.author.update(last_sign_in_at: Date.today)
+      proposal.author.update(last_sign_in_at: Date.current)
 
       visit progress_proposal_dashboard_path(proposal)
 
@@ -504,7 +504,7 @@ describe "Proposal's dashboard" do
     scenario "Not display tag 'new' on proposed_action when there is not new since last login" do
       proposed_action = create(:dashboard_action, :proposed_action, :active, day_offset: 0,
                                                                      published_proposal: false)
-      proposal.author.update(last_sign_in_at: Date.today)
+      proposal.author.update(last_sign_in_at: Date.current)
 
       visit progress_proposal_dashboard_path(proposal)
 
@@ -525,7 +525,7 @@ describe "Proposal's dashboard" do
 
     scenario "Not display tag 'new' on sidebar when there is not a new resouce since last login" do
       create(:dashboard_action, :resource, :active, day_offset: 0, published_proposal: false)
-      proposal.author.update(last_sign_in_at: Date.today)
+      proposal.author.update(last_sign_in_at: Date.current)
 
       visit progress_proposal_dashboard_path(proposal)
 

--- a/spec/features/tracking/budget_investments_spec.rb
+++ b/spec/features/tracking/budget_investments_spec.rb
@@ -200,7 +200,7 @@ describe "Valuation budget investments" do
 
       expect(page).to have_content("Create milestone")
       fill_in("Description", with: "Test Description")
-      page.find("#milestone_publication_date").set(Date.today)
+      page.find("#milestone_publication_date").set(Date.current)
 
       click_button "Create milestone"
 

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -136,7 +136,7 @@ describe Dashboard::Mailer do
 
         months_to_archive_proposals = Setting["months_to_archive_proposals"].to_i.months
         limit_to_archive_proposal = proposal.created_at.to_date + months_to_archive_proposals
-        days_count = (limit_to_archive_proposal - Date.today).to_i
+        days_count = (limit_to_archive_proposal - Date.current).to_i
 
         expect(email).to have_body_text("You are missing #{days_count} days before your proposal "\
                                         "gets the #{Setting["votes_for_proposal_success"]}  "\

--- a/spec/models/budget/phase_spec.rb
+++ b/spec/models/budget/phase_spec.rb
@@ -30,19 +30,19 @@ describe Budget::Phase do
 
     describe "#dates_range_valid?" do
       it "is valid when start & end dates are different & consecutive" do
-        first_phase.update_attributes(starts_at: Date.today, ends_at: Date.tomorrow)
+        first_phase.update_attributes(starts_at: Date.current, ends_at: Date.tomorrow)
 
         expect(first_phase).to be_valid
       end
 
       it "is not valid when dates are equal" do
-        first_phase.update_attributes(starts_at: Date.today, ends_at: Date.today)
+        first_phase.update_attributes(starts_at: Date.current, ends_at: Date.current)
 
         expect(first_phase).not_to be_valid
       end
 
       it "is not valid when start date is later than end date" do
-        first_phase.update_attributes(starts_at: Date.tomorrow, ends_at: Date.today)
+        first_phase.update_attributes(starts_at: Date.tomorrow, ends_at: Date.current)
 
         expect(first_phase).not_to be_valid
       end

--- a/spec/models/direct_message_spec.rb
+++ b/spec/models/direct_message_spec.rb
@@ -75,11 +75,11 @@ describe DirectMessage do
 
   describe "scopes" do
 
-    describe "today" do
+    describe "today", :with_non_utc_time_zone do
       it "returns direct messages created today" do
-        direct_message1 = create(:direct_message, created_at: Time.now.utc.beginning_of_day + 3.hours)
-        direct_message2 = create(:direct_message, created_at: Time.now.utc)
-        direct_message3 = create(:direct_message, created_at: Time.now.utc.end_of_day)
+        create(:direct_message, created_at: Date.current.beginning_of_day)
+        create(:direct_message, created_at: Time.current)
+        create(:direct_message, created_at: Date.current.end_of_day)
 
         expect(described_class.today.count).to eq 3
       end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -9,7 +9,7 @@ describe Tag do
 
     expect(tag.taggings_count).to eq(1)
 
-    debate.update(hidden_at: Time.now)
+    debate.update(hidden_at: Time.current)
 
     tag.reload
     expect(tag.taggings_count).to eq(0)
@@ -22,7 +22,7 @@ describe Tag do
 
     expect(tag.taggings_count).to eq(1)
 
-    proposal.update(hidden_at: Time.now)
+    proposal.update(hidden_at: Time.current)
 
     tag.reload
     expect(tag.taggings_count).to eq(0)

--- a/spec/requests/dashboard/achievements_spec.rb
+++ b/spec/requests/dashboard/achievements_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 describe Dashboard::AchievementsController do
-  let(:created_at) { DateTime.parse("2018-01-01 12:00:00") }
-  let(:proposal) { create(:proposal, created_at: created_at) }
+  let(:proposal) { create(:proposal, created_at: 7.days.ago.beginning_of_month) }
   let(:executed_actions) { create_list(:dashboard_action, 8, :active, :proposed_action) }
   let!(:non_executed_actions) { create_list(:dashboard_action, 8, :active, :proposed_action) }
 

--- a/spec/requests/dashboard/successful_supports_spec.rb
+++ b/spec/requests/dashboard/successful_supports_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Retrieves number of supports for the successful proposal" do
-  let(:created_at) { Time.now.beginning_of_day - 9.days }
+  let(:created_at) { Date.current.beginning_of_day - 9.days }
   let(:proposal) { create(:proposal, created_at: created_at, published_at: created_at) }
 
   before do

--- a/spec/requests/dashboard/supports_spec.rb
+++ b/spec/requests/dashboard/supports_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Dashboard::GroupSupports do
-  let(:created_at) { Time.now - 9.days }
+  let(:created_at) { Time.current - 9.days }
   let(:proposal) { create(:proposal, created_at: created_at, published_at: created_at) }
 
   before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,6 +104,12 @@ RSpec.configure do |config|
     allow(Date).to receive(:today).and_return(Time.now.to_date)
   end
 
+  config.before(:each, :with_non_utc_time_zone) do
+    application_zone = ActiveSupport::TimeZone.new("Madrid")
+
+    allow(Time).to receive(:zone).and_return(application_zone)
+  end
+
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options.
   config.example_status_persistence_file_path = "spec/examples.txt"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,13 +96,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :with_different_time_zone) do
-    system_zone = ActiveSupport::TimeZone.new("UTC")
-    local_zone = ActiveSupport::TimeZone.new("Madrid")
+    application_zone = ActiveSupport::TimeZone.new("UTC")
+    system_zone = ActiveSupport::TimeZone.new("Madrid")
 
-    # Make sure the date defined by `config.time_zone` and
-    # the local date are different.
-    allow(Time).to receive(:zone).and_return(system_zone)
-    allow(Time).to receive(:now).and_return(Date.current.at_end_of_day.in_time_zone(local_zone))
+    allow(Time).to receive(:zone).and_return(application_zone)
+    allow(Time).to receive(:now).and_return(Date.current.end_of_day.in_time_zone(system_zone))
     allow(Date).to receive(:today).and_return(Time.now.to_date)
   end
 


### PR DESCRIPTION
## Background

Using `Date.today` and `Time.now` might lead to inconsistencies if the time zone the application uses is not the same as the system time zone.

## Objectives

Fix all possible date errors we might have when the computer the application is running uses a different time zone than the one we define in `config.time_zone`.