### PR TITLE
show only not-retired proposal in Related content section

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -25,6 +25,7 @@ class ProposalsController < ApplicationController
 
   def show
     super
+    @proposal = @proposal.not_retired  #showing only proposal which is not Retired
     @notifications = @proposal.notifications
     @notifications = @proposal.notifications.not_moderated
     @related_contents = Kaminari.paginate_array(@proposal.relationed_contents)


### PR DESCRIPTION
## References

Issue #3559

## Objectives

The debates and proposals have a "related content" section where users can add related proposals and other content. Proposals can be retired by the proposal author through the "Edit my proposal" menu in the author's proposal dashboard.

## Visual Changes

If a proposal is retired by his/her author, it should disappear from all "related content" sections where it appears.
