### PR TITLE
Add rubocop spacing rules

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,5 +1,7 @@
 ---
 linters:
+  ExtraNewline:
+    enabled: true
   FinalNewline:
     enabled: true
   SelfClosingTag:
@@ -16,5 +18,27 @@ linters:
     enabled: true
     only:
       - Layout/EndOfLine
+      - Layout/SpaceAfterColon
+      - Layout/SpaceAfterComma
+      - Layout/SpaceAfterMethodName
+      - Layout/SpaceAfterNot
+      - Layout/SpaceAfterSemicolon
+      - Layout/SpaceAroundBlockParameters
+      - Layout/SpaceAroundOperators
+      - Layout/SpaceBeforeBlockBraces
+      - Layout/SpaceBeforeComma
+      - Layout/SpaceBeforeComment
+      - Layout/SpaceBeforeFirstArg
+      - Layout/SpaceBeforeSemicolon
+      - Layout/SpaceInsideArrayLiteralBrackets
+      - Layout/SpaceInsideArrayPercentLiteral
+      - Layout/SpaceInsideBlockBraces
+      - Layout/SpaceInsideHashLiteralBraces
+      - Layout/SpaceInsideParens
+      - Layout/SpaceInsidePercentLiteralDelimiters
+      - Layout/SpaceInsideRangeLiteral
+      - Layout/SpaceInsideReferenceBrackets
+      - Layout/SpaceInsideStringInterpolation
+      - Layout/Tab
       - Lint/LiteralAsCondition
       - Style/PercentLiteralDelimiters

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -32,6 +32,73 @@ Layout/EmptyLines:
 Layout/EndOfLine:
   EnforcedStyle: lf
 
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAfterMethodName:
+  Enabled: true
+
+Layout/SpaceAfterNot:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceAroundBlockParameters:
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Enabled: true
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: true
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+  EnforcedStyle: compact
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: true
+
+Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: true
+
+Layout/SpaceInsideStringInterpolation:
+  Enabled: true
+
+Layout/Tab:
+  Enabled: true
+
 Layout/TrailingBlankLines:
   Enabled: true
 

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -81,7 +81,7 @@ class Admin::BudgetsController < Admin::BaseController
   private
 
     def budget_params
-      descriptions = Budget::Phase::PHASE_KINDS.map{|p| "description_#{p}"}.map(&:to_sym)
+      descriptions = Budget::Phase::PHASE_KINDS.map { |p| "description_#{p}" }.map(&:to_sym)
       valid_attributes = [:phase,
                           :currency_symbol,
                           :help_link,

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -7,7 +7,7 @@ class Admin::CommentsController < Admin::BaseController
 
     respond_to do |format|
       format.html
-      format.csv {send_data to_csv(Comment.sort_by_newest, Comment),
+      format.csv { send_data to_csv(Comment.sort_by_newest, Comment),
                             type: "text/csv",
                             disposition: "attachment",
                             filename: "comments.csv" }

--- a/app/controllers/admin/dashboard/administrator_tasks_controller.rb
+++ b/app/controllers/admin/dashboard/administrator_tasks_controller.rb
@@ -17,7 +17,7 @@ class Admin::Dashboard::AdministratorTasksController < Admin::Dashboard::BaseCon
 
     administrator_task.update(user: current_user, executed_at: Time.current)
     redirect_to admin_dashboard_administrator_tasks_path,
-                { flash: { notice: t("admin.dashboard.administrator_tasks.update.success") } }
+                { flash: { notice: t("admin.dashboard.administrator_tasks.update.success") }}
   end
 
   private

--- a/app/controllers/admin/download_settings_controller.rb
+++ b/app/controllers/admin/download_settings_controller.rb
@@ -4,7 +4,7 @@ class Admin::DownloadSettingsController < Admin::BaseController
   load_and_authorize_resource
 
   def edit
-    permitted =  downloadable_params
+    permitted = downloadable_params
     @download_settings = []
     if permitted_models.include? permitted[:resource]
       set_edit(permitted[:resource])
@@ -12,7 +12,7 @@ class Admin::DownloadSettingsController < Admin::BaseController
   end
 
   def update
-    permitted =  downloadable_params
+    permitted = downloadable_params
     if permitted[:downloadable]
       DownloadSetting.where(name_model: get_model(permitted[:resource]).to_s,
                             config: permitted[:config].to_i).each do |download_setting|
@@ -27,7 +27,7 @@ class Admin::DownloadSettingsController < Admin::BaseController
   private
 
     def set_edit(resource)
-      @download_resource = {name: resource, config: get_config}
+      @download_resource = { name: resource, config: get_config }
       @download_settings = get_attrs(get_model(resource), get_config)
     end
 

--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -12,7 +12,7 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
                  .page(params[:page])
     respond_to do |format|
       format.html
-      format.csv {send_data to_csv(process_for_download, Legislation::Process),
+      format.csv { send_data to_csv(process_for_download, Legislation::Process),
                             type: "text/csv",
                             disposition: "attachment",
                             filename: "legislation_processes.csv" }

--- a/app/controllers/admin/local_census_records/imports_controller.rb
+++ b/app/controllers/admin/local_census_records/imports_controller.rb
@@ -4,7 +4,7 @@ class Admin::LocalCensusRecords::ImportsController < Admin::LocalCensusRecords::
   def create
     @import = LocalCensusRecords::Import.new(local_census_records_import_params)
     if @import.save
-      flash.now[:notice] =  t("admin.local_census_records.imports.create.notice")
+      flash.now[:notice] = t("admin.local_census_records.imports.create.notice")
       render :show
     else
       render :new

--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -18,7 +18,7 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
   def show
     included_relations = [:recounts, :voters, officer_assignments: [officer: [:user]]]
     @booth_assignment = @poll.booth_assignments.includes(*included_relations).find(params[:id])
-    @voters_by_date = @booth_assignment.voters.group_by {|v| v.created_at.to_date}
+    @voters_by_date = @booth_assignment.voters.group_by { |v| v.created_at.to_date }
     @partial_results = @booth_assignment.partial_results
     @recounts = @booth_assignment.recounts
   end

--- a/app/controllers/admin/site_customization/images_controller.rb
+++ b/app/controllers/admin/site_customization/images_controller.rb
@@ -18,7 +18,7 @@ class Admin::SiteCustomization::ImagesController < Admin::SiteCustomization::Bas
       flash.now[:error] = t("admin.site_customization.images.update.error")
 
       @images = SiteCustomization::Image.all_images
-      idx = @images.index {|e| e.name == @image.name }
+      idx = @images.index { |e| e.name == @image.name }
       @images[idx] = @image
 
       render :index

--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -77,13 +77,13 @@ class Admin::StatsController < Admin::BaseController
 
     authorize! :read_admin_stats, @budget, message: t("admin.stats.budgets.no_data_before_balloting_phase")
 
-    @user_count = @budget.ballots.select {|ballot| ballot.lines.any? }.count
+    @user_count = @budget.ballots.select { |ballot| ballot.lines.any? }.count
 
     @vote_count = @budget.lines.count
 
-    @vote_count_by_heading = @budget.lines.group(:heading_id).count.collect {|k,v| [Budget::Heading.find(k).name, v]}.sort
+    @vote_count_by_heading = @budget.lines.group(:heading_id).count.collect { |k, v| [Budget::Heading.find(k).name, v] }.sort
 
-    @user_count_by_district = User.where.not(balloted_heading_id: nil).group(:balloted_heading_id).count.collect {|k,v| [Budget::Heading.find(k).name, v]}.sort
+    @user_count_by_district = User.where.not(balloted_heading_id: nil).group(:balloted_heading_id).count.collect { |k, v| [Budget::Heading.find(k).name, v] }.sort
   end
 
   def polls

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -98,7 +98,7 @@ module Budgets
     end
 
     def json_data
-      investment =  Budget::Investment.find(params[:id])
+      investment = Budget::Investment.find(params[:id])
       data = {
         investment_id: investment.id,
         investment_title: investment.title,

--- a/app/controllers/concerns/commentable_actions.rb
+++ b/app/controllers/concerns/commentable_actions.rb
@@ -28,7 +28,7 @@ module CommentableActions
 
     respond_to do |format|
       format.html
-      format.csv {send_data to_csv(resources_csv, resource_model),
+      format.csv { send_data to_csv(resources_csv, resource_model),
                             type: "text/csv",
                             disposition: "attachment",
                             filename: "#{get_resource(resource_model)}.csv" }

--- a/app/controllers/concerns/dashboard/group_supports.rb
+++ b/app/controllers/concerns/dashboard/group_supports.rb
@@ -60,7 +60,7 @@ module Dashboard::GroupSupports
     end
 
     def calculate_year_of_week(date)
-      year =  date.year
+      year = date.year
       if first_week_of_year?(date) && date.end_of_week.year != date.year
         year = year + 1
       elsif last_week_of_year?(date) && date.beginning_of_week.year != date.year

--- a/app/controllers/concerns/moderate_actions.rb
+++ b/app/controllers/concerns/moderate_actions.rb
@@ -19,14 +19,14 @@ module ModerateActions
     @resources = @resources.where(id: params[:resource_ids])
 
     if params[:hide_resources].present?
-      @resources.accessible_by(current_ability, :hide).each {|resource| hide_resource resource}
+      @resources.accessible_by(current_ability, :hide).each { |resource| hide_resource resource }
 
     elsif params[:ignore_flags].present?
       @resources.accessible_by(current_ability, :ignore_flag).each(&:ignore_flag)
 
     elsif params[:block_authors].present?
       author_ids = @resources.pluck(author_id).uniq
-      User.where(id: author_ids).accessible_by(current_ability, :block).each {|user| block_user user}
+      User.where(id: author_ids).accessible_by(current_ability, :block).each { |user| block_user user }
     end
 
     redirect_to request.query_parameters.merge(action: :index)

--- a/app/controllers/dashboard/actions_controller.rb
+++ b/app/controllers/dashboard/actions_controller.rb
@@ -20,7 +20,7 @@ class Dashboard::ActionsController < Dashboard::BaseController
       Dashboard::AdministratorTask.create(source: @dashboard_executed_action)
 
       redirect_to progress_proposal_dashboard_path(proposal.to_param),
-                  { flash: { info: t("dashboard.create_request.success") } }
+                  { flash: { info: t("dashboard.create_request.success") }}
     else
       flash.now[:alert] = @dashboard_executed_action.errors.full_messages.join("<br>")
       render :new_request

--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -18,7 +18,7 @@ class DirectUploadsController < ApplicationController
       render json: { cached_attachment: @direct_upload.relation.cached_attachment,
                      filename: @direct_upload.relation.attachment.original_filename,
                      destroy_link: render_destroy_upload_link(@direct_upload).html_safe,
-                     attachment_url: @direct_upload.relation.attachment.url}
+                     attachment_url: @direct_upload.relation.attachment.url }
     else
       @direct_upload.destroy_attachment
       render json: { errors: @direct_upload.errors[:attachment].join(", ") },

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -111,7 +111,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     @phase = :resume
     respond_to do |format|
       format.html
-      format.xlsx {render xlsx: "resume_to_xlsx", filename: ("resume-" + Date.current.to_s + ".xlsx")}
+      format.xlsx { render xlsx: "resume_to_xlsx", filename: ("resume-" + Date.current.to_s + ".xlsx") }
     end
   end
 

--- a/app/controllers/management/sessions_controller.rb
+++ b/app/controllers/management/sessions_controller.rb
@@ -28,13 +28,13 @@ class Management::SessionsController < ActionController::Base
 
     def admin?
       if current_user.try(:administrator?)
-        session[:manager] = {login: "admin_user_#{current_user.id}"}
+        session[:manager] = { login: "admin_user_#{current_user.id}" }
       end
     end
 
     def manager?
       if current_user.try(:manager?)
-        session[:manager] = {login: "manager_user_#{current_user.id}"}
+        session[:manager] = { login: "manager_user_#{current_user.id}" }
       end
     end
 

--- a/app/controllers/officing/polls_controller.rb
+++ b/app/controllers/officing/polls_controller.rb
@@ -3,7 +3,7 @@ class Officing::PollsController < Officing::BaseController
 
   def index
     @polls = current_user.poll_officer? ? current_user.poll_officer.voting_days_assigned_polls : []
-    @polls = @polls.select {|poll| poll.current?(Time.current) || poll.current?(1.day.ago)}
+    @polls = @polls.select { |poll| poll.current?(Time.current) || poll.current?(1.day.ago) }
   end
 
   def final

--- a/app/controllers/polls/answers_controller.rb
+++ b/app/controllers/polls/answers_controller.rb
@@ -19,7 +19,7 @@ class Polls::AnswersController < ApplicationController
     load_for_answers
     if @question.enum_type&.include?("answer_couples")
       last_pair ||= generate_and_store_new_pair(@question)
-      @last_pair_question_answers = {@question.id => last_pair}
+      @last_pair_question_answers = { @question.id => last_pair }
     end
     render "polls/questions/answer", format: :js
   end
@@ -34,7 +34,7 @@ class Polls::AnswersController < ApplicationController
     load_for_answers
     if @question.enum_type&.include?("answer_couples")
       last_pair ||= generate_and_store_new_pair(@question)
-      @last_pair_question_answers = {@question.id => last_pair}
+      @last_pair_question_answers = { @question.id => last_pair }
     end
     render "polls/questions/answer", format: :js
   end
@@ -53,10 +53,10 @@ class Polls::AnswersController < ApplicationController
     def load_for_answers
       @page = params[:page].present? ? params[:page] : 1
       question_answers
-      @answers_by_question_id = {@question.id => @question.answers
+      @answers_by_question_id = { @question.id => @question.answers
                                                    .by_author(current_user)
                                                    .order(:order)
-                                                   .pluck(:answer)}
+                                                   .pluck(:answer) }
     end
 
     def question_answers

--- a/app/controllers/polls/questions_controller.rb
+++ b/app/controllers/polls/questions_controller.rb
@@ -11,7 +11,7 @@ class Polls::QuestionsController < ApplicationController
     load_for_answers
     if @question.enum_type&.include?("answer_couples")
       last_pair ||= generate_and_store_new_pair(@question)
-      @last_pair_question_answers = {@question.id => last_pair}
+      @last_pair_question_answers = { @question.id => last_pair }
     end
   end
 
@@ -39,10 +39,10 @@ class Polls::QuestionsController < ApplicationController
     def load_for_answers
       @page = params[:page].present? ? params[:page] : 1
       question_answers
-      @answers_by_question_id = {@question.id => @question.answers
+      @answers_by_question_id = { @question.id => @question.answers
                                                    .by_author(current_user)
                                                    .order(:order)
-                                                   .pluck(:answer)}
+                                                   .pluck(:answer) }
     end
 
     def vote_stored(answer, new_answer, token)

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -98,7 +98,7 @@ class ProposalsController < ApplicationController
   private
 
     def proposal_params
-      attributes = [:video_url,:responsible_name, :tag_list,
+      attributes = [:video_url, :responsible_name, :tag_list,
                     :terms_of_service, :geozone_id, :skip_map,
                     image_attributes: image_attributes,
                     documents_attributes: [:id, :title, :attachment, :cached_attachment,

--- a/app/controllers/remote_translations_controller.rb
+++ b/app/controllers/remote_translations_controller.rb
@@ -20,7 +20,7 @@ class RemoteTranslationsController < ApplicationController
     def set_remote_translations
       remote_translations = remote_translations_params["remote_translations"]
       decoded_remote_translations = ActiveSupport::JSON.decode(remote_translations)
-      @remote_translations = decoded_remote_translations.map{ |remote_translation|
+      @remote_translations = decoded_remote_translations.map { |remote_translation|
                               remote_translation.slice("remote_translatable_id",
                                                        "remote_translatable_type",
                                                        "locale")

--- a/app/controllers/tracking/budget_investments_controller.rb
+++ b/app/controllers/tracking/budget_investments_controller.rb
@@ -63,7 +63,7 @@ class Tracking::BudgetInvestmentsController < Tracking::BaseController
         filters << {
           name: heading.name,
           id: heading.id,
-          count: investments.select{|i| i.heading_id == heading.id}.size
+          count: investments.select { |i| i.heading_id == heading.id }.size
         }
       end
       filters.uniq

--- a/app/controllers/tracking/proposal_progress_bars_controller.rb
+++ b/app/controllers/tracking/proposal_progress_bars_controller.rb
@@ -1,4 +1,4 @@
-class Tracking::ProposalProgressBarsController <  Tracking::ProgressBarsController
+class Tracking::ProposalProgressBarsController < Tracking::ProgressBarsController
 
   private
     def progressable

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -19,7 +19,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
       end
     else
       resource.errors.add(:email, :password_already_set)
-      respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }
+      respond_with_navigational(resource.errors, status: :unprocessable_entity) { render :new }
     end
   end
 
@@ -33,14 +33,14 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
     # New condition added to if: when no password was given, display the "show" view (which uses "update" above)
     if resource.encrypted_password.blank?
-      respond_with_navigational(resource){ render :show }
+      respond_with_navigational(resource) { render :show }
     elsif resource.errors.empty?
       set_official_position if resource.has_official_email?
       resource.confirm # Last change: confirm happens here for people with passwords instead of af the top of the show action
       set_flash_message(:notice, :confirmed) if is_flashing_format?
-      respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
+      respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }
     else
-      respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }
+      respond_with_navigational(resource.errors, status: :unprocessable_entity) { render :new }
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -50,9 +50,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def check_username
     if User.find_by username: params[:username]
-      render json: {available: false, message: t("devise_views.users.registrations.new.username_is_not_available")}
+      render json: { available: false, message: t("devise_views.users.registrations.new.username_is_not_available") }
     else
-      render json: {available: true, message: t("devise_views.users.registrations.new.username_is_available")}
+      render json: { available: true, message: t("devise_views.users.registrations.new.username_is_available") }
     end
   end
 

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -89,7 +89,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
                   filters << {
                                name: heading.name,
                                id: heading.id,
-                               count: investments.select{|i| i.heading_id == heading.id}.size
+                               count: investments.select { |i| i.heading_id == heading.id }.size
                              }
                 end
     end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -85,7 +85,7 @@ module AdminHelper
 
   def admin_select_options
     Administrator.with_user
-                 .collect { |v| [ v.description_or_name, v.id ] }
+                 .collect { |v| [v.description_or_name, v.id] }
                  .sort_by { |a| a[0] }
   end
 

--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -12,7 +12,7 @@ module BudgetExecutionsHelper
 
   def first_milestone_with_image(investment)
     investment.milestones.order_by_publication_date
-                         .select{ |milestone| milestone.image.present? }.last
+                         .select { |milestone| milestone.image.present? }.last
   end
 
 end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -19,11 +19,11 @@ module BudgetsHelper
   end
 
   def budget_phases_select_options
-    Budget::Phase::PHASE_KINDS.map { |ph| [ t("budgets.phase.#{ph}"), ph ] }
+    Budget::Phase::PHASE_KINDS.map { |ph| [t("budgets.phase.#{ph}"), ph] }
   end
 
   def budget_currency_symbol_select_options
-    Budget::CURRENCY_SYMBOLS.map { |cs| [ cs, cs ] }
+    Budget::CURRENCY_SYMBOLS.map { |cs| [cs, cs] }
   end
 
   def namespaced_budget_investment_path(investment, options = {})

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -27,7 +27,7 @@ module DocumentsHelper
                   remote: true,
                   class: "delete remove-cached-attachment"
     else
-      link_to_remove_association document.new_record? ? t("documents.form.cancel_button") : t("documents.form.delete_button") , builder, class: "delete remove-document"
+      link_to_remove_association document.new_record? ? t("documents.form.cancel_button") : t("documents.form.delete_button"), builder, class: "delete remove-document"
     end
   end
 

--- a/app/helpers/followables_helper.rb
+++ b/app/helpers/followables_helper.rb
@@ -16,7 +16,7 @@ module FollowablesHelper
 
     followable = follow.followable
     partial = followable_class_name(followable) + "_follow"
-    locals = {followable_class_name(followable).to_sym => followable}
+    locals = { followable_class_name(followable).to_sym => followable }
 
     render partial, locals
   end

--- a/app/helpers/geozones_helper.rb
+++ b/app/helpers/geozones_helper.rb
@@ -5,7 +5,7 @@ module GeozonesHelper
   end
 
   def geozone_select_options
-    Geozone.all.order(name: :asc).collect { |g| [ g.name, g.id ] }
+    Geozone.all.order(name: :asc).collect { |g| [g.name, g.id] }
   end
 
 end

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -5,8 +5,8 @@ module GlobalizeHelper
   end
 
   def available_locales(resource)
-    I18n.available_locales.select{ |locale| enabled_locale?(resource, locale) }.map do |locale|
-      [name_for_locale(locale), locale , { data: { locale: locale } }]
+    I18n.available_locales.select { |locale| enabled_locale?(resource, locale) }.map do |locale|
+      [name_for_locale(locale), locale, { data: { locale: locale }}]
     end
   end
 

--- a/app/helpers/imageables_helper.rb
+++ b/app/helpers/imageables_helper.rb
@@ -17,7 +17,7 @@ module ImageablesHelper
   end
 
   def imageable_accepted_content_types
-    Setting["uploads.images.content_types"]&.split(" ") || [ "image/jpeg" ]
+    Setting["uploads.images.content_types"]&.split(" ") || ["image/jpeg"]
   end
 
   def imageable_accepted_content_types_extensions

--- a/app/helpers/officing_helper.rb
+++ b/app/helpers/officing_helper.rb
@@ -5,7 +5,7 @@ module OfficingHelper
     officer_assignments.each do |oa|
       options << [oa.booth_assignment.booth.name.to_s, oa.id]
     end
-    options.sort! {|x, y| x[0] <=> y[0]}
+    options.sort! { |x, y| x[0] <=> y[0] }
     options_for_select(options, params[:oa])
   end
 

--- a/app/helpers/proposals_dashboard_helper.rb
+++ b/app/helpers/proposals_dashboard_helper.rb
@@ -108,7 +108,7 @@ module ProposalsDashboardHelper
 
   def new_resources_since_last_login?(resources, new_actions_since_last_login)
     if resources.present?
-      resources.pluck(:id).any? {|id| new_actions_since_last_login.include?(id) }
+      resources.pluck(:id).any? { |id| new_actions_since_last_login.include?(id) }
     end
   end
 

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -29,7 +29,7 @@ module ProposalsHelper
   end
 
   def retire_proposals_options
-    Proposal::RETIRE_OPTIONS.collect { |option| [ t("proposals.retire_options.#{option}"), option ] }
+    Proposal::RETIRE_OPTIONS.collect { |option| [t("proposals.retire_options.#{option}"), option] }
   end
 
   def empty_recommended_proposals_message_text(user)

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,7 +1,7 @@
 module SearchHelper
 
   def official_level_search_options
-    options_for_select((1..5).map{ |i| [setting["official_level_#{i}_name"], i] },
+    options_for_select((1..5).map { |i| [setting["official_level_#{i}_name"], i] },
                        params[:advanced_search].try(:[], :official_level))
   end
 

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -5,7 +5,7 @@ module SettingsHelper
   end
 
   def setting
-    @all_settings ||= Hash[ Setting.all.map{|s| [s.key, s.value.presence]} ]
+    @all_settings ||= Hash[Setting.all.map { |s| [s.key, s.value.presence] }]
   end
 
   def display_setting_name(setting_name)

--- a/app/helpers/valuation_helper.rb
+++ b/app/helpers/valuation_helper.rb
@@ -6,11 +6,11 @@ module ValuationHelper
 
   def valuator_select_options
     Valuator.order("description ASC").order("users.email ASC").includes(:user).
-             collect { |v| [ v.description_or_email, "valuator_#{v.id}"] }
+             collect { |v| [v.description_or_email, "valuator_#{v.id}"] }
   end
 
   def valuator_group_select_options
-    ValuatorGroup.order("name ASC").collect { |g| [ g.name, "group_#{g.id}"] }
+    ValuatorGroup.order("name ASC").collect { |g| [g.name, "group_#{g.id}"] }
   end
 
   def assigned_valuators_info(valuators)

--- a/app/helpers/valuators_helper.rb
+++ b/app/helpers/valuators_helper.rb
@@ -5,7 +5,7 @@ module ValuatorsHelper
   end
 
   def valuator_abilities(valuator)
-    [ valuator.can_comment ? I18n.t("admin.valuators.index.can_comment") : nil ,
+    [valuator.can_comment ? I18n.t("admin.valuators.index.can_comment") : nil,
       valuator.can_edit_dossier ? I18n.t("admin.valuators.index.can_edit_dossier") : nil
     ].compact.join(", ")
   end

--- a/app/helpers/votes_helper.rb
+++ b/app/helpers/votes_helper.rb
@@ -16,11 +16,11 @@ module VotesHelper
   def css_classes_for_vote(votes, votable)
     case votes[votable.id]
     when true
-      {in_favor: "voted", against: "no-voted"}
+      { in_favor: "voted", against: "no-voted" }
     when false
-      {in_favor: "no-voted", against: "voted"}
+      { in_favor: "no-voted", against: "voted" }
     else
-      {in_favor: "", against: ""}
+      { in_favor: "", against: "" }
     end
   end
 

--- a/app/models/abilities/moderation.rb
+++ b/app/models/abilities/moderation.rb
@@ -6,8 +6,8 @@ module Abilities
       merge Abilities::Common.new(user)
 
       can :read, Organization
-      can(:verify, Organization){ |o| !o.verified? }
-      can(:reject, Organization){ |o| !o.rejected? }
+      can(:verify, Organization) { |o| !o.verified? }
+      can(:reject, Organization) { |o| !o.rejected? }
 
       can :read, Comment
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,7 +4,7 @@ class Activity < ApplicationRecord
 
   VALID_ACTIONS = %w[hide block restore valuate email]
 
-  validates :action, inclusion: {in: VALID_ACTIONS}
+  validates :action, inclusion: { in: VALID_ACTIONS }
 
   scope :on_proposals, -> { where(actionable_type: "Proposal") }
   scope :on_debates, -> { where(actionable_type: "Debate") }

--- a/app/models/ahoy/data_source.rb
+++ b/app/models/ahoy/data_source.rb
@@ -10,7 +10,7 @@ module Ahoy
     # chart
     def add(name, collection)
       collections.push data:  collection, name: name
-      collection.each_key{ |key| add_key key }
+      collection.each_key { |key| add_key key }
     end
 
     def build

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -44,8 +44,8 @@ class Budget
     has_many :valuator_group_assignments, dependent: :destroy
     has_many :valuator_groups, through: :valuator_group_assignments
 
-    has_many :comments, -> {where(valuation: false)}, as: :commentable, class_name: "Comment"
-    has_many :valuations, -> {where(valuation: true)}, as: :commentable, class_name: "Comment"
+    has_many :comments, -> { where(valuation: false) }, as: :commentable, class_name: "Comment"
+    has_many :valuations, -> { where(valuation: true) }, as: :commentable, class_name: "Comment"
 
     has_many :tracker_assignments, dependent: :destroy
     has_many :trackers, through: :tracker_assignments
@@ -74,7 +74,7 @@ class Budget
     scope :without_valuator,            -> { valuation_open.without_valuator_group.where(valuator_assignments_count: 0) }
     scope :under_valuation,             -> { valuation_open.valuating.where("administrator_id IS NOT ?", nil) }
     scope :managed,                     -> { valuation_open.where(valuator_assignments_count: 0).where("administrator_id IS NOT ?", nil) }
-    scope :valuating,                   -> { valuation_open.where("valuator_assignments_count > 0 OR valuator_group_assignments_count > 0" ) }
+    scope :valuating,                   -> { valuation_open.where("valuator_assignments_count > 0 OR valuator_group_assignments_count > 0") }
     scope :visible_to_valuators,        -> { where(visible_to_valuators: true) }
     scope :valuation_finished,          -> { where(valuation_finished: true) }
     scope :valuation_finished_feasible, -> { where(valuation_finished: true, feasibility: "feasible") }
@@ -88,7 +88,7 @@ class Budget
     scope :incompatible,                -> { where(incompatible: true) }
     scope :winners,                     -> { selected.compatible.where(winner: true) }
     scope :unselected,                  -> { not_unfeasible.where(selected: false) }
-    scope :last_week,                   -> { where("created_at >= ?", 7.days.ago)}
+    scope :last_week,                   -> { where("created_at >= ?", 7.days.ago) }
     scope :sort_by_flags,               -> { order(flags_count: :desc, updated_at: :desc) }
     scope :sort_by_created_at,          -> { reorder(created_at: :desc) }
 

--- a/app/models/budget/reclassified_vote.rb
+++ b/app/models/budget/reclassified_vote.rb
@@ -7,6 +7,6 @@ class Budget
 
     validates :user, presence: true
     validates :investment, presence: true
-    validates :reason, inclusion: {in: REASONS, allow_nil: false}
+    validates :reason, inclusion: { in: REASONS, allow_nil: false }
   end
 end

--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -72,18 +72,18 @@ class Budget::Stats
     end
 
     groups[:total] = Hash.new(0)
-    groups[:total][:total_investments_count] = groups.collect {|_k, v| v[:total_investments_count]}.sum
-    groups[:total][:total_participants_support_phase] = groups.collect {|_k, v| v[:total_participants_support_phase]}.sum
-    groups[:total][:total_participants_vote_phase] = groups.collect {|_k, v| v[:total_participants_vote_phase]}.sum
-    groups[:total][:total_participants_every_phase] = groups.collect {|_k, v| v[:total_participants_every_phase]}.sum
+    groups[:total][:total_investments_count] = groups.collect { |_k, v| v[:total_investments_count] }.sum
+    groups[:total][:total_participants_support_phase] = groups.collect { |_k, v| v[:total_participants_support_phase] }.sum
+    groups[:total][:total_participants_vote_phase] = groups.collect { |_k, v| v[:total_participants_vote_phase] }.sum
+    groups[:total][:total_participants_every_phase] = groups.collect { |_k, v| v[:total_participants_every_phase] }.sum
 
     budget.headings.each do |heading|
       groups[heading.id].merge!(calculate_heading_stats_with_totals(groups[heading.id], groups[:total], heading.population))
     end
 
-    groups[:total][:percentage_participants_support_phase] = groups.collect {|_k, v| v[:percentage_participants_support_phase]}.sum
-    groups[:total][:percentage_participants_vote_phase] = groups.collect {|_k, v| v[:percentage_participants_vote_phase]}.sum
-    groups[:total][:percentage_participants_every_phase] = groups.collect {|_k, v| v[:percentage_participants_every_phase]}.sum
+    groups[:total][:percentage_participants_support_phase] = groups.collect { |_k, v| v[:percentage_participants_support_phase] }.sum
+    groups[:total][:percentage_participants_vote_phase] = groups.collect { |_k, v| v[:percentage_participants_vote_phase] }.sum
+    groups[:total][:percentage_participants_every_phase] = groups.collect { |_k, v| v[:percentage_participants_every_phase] }.sum
 
     groups
   end
@@ -125,7 +125,7 @@ class Budget::Stats
     def balloters_by_heading(heading_id)
       stats_cache("balloters_by_heading_#{heading_id}") do
         budget.ballots.joins(:lines)
-                      .where(budget_ballot_lines: { heading_id: heading_id} )
+                      .where(budget_ballot_lines: { heading_id: heading_id })
                       .distinct.pluck(:user_id)
       end
     end

--- a/app/models/concerns/documentable.rb
+++ b/app/models/concerns/documentable.rb
@@ -16,7 +16,7 @@ module Documentable
     end
 
     def accepted_content_types
-      Setting["uploads.documents.content_types"]&.split(" ") || [ "application/pdf" ]
+      Setting["uploads.documents.content_types"]&.split(" ") || ["application/pdf"]
     end
   end
 

--- a/app/models/concerns/download_settings/budget_investment_csv.rb
+++ b/app/models/concerns/download_settings/budget_investment_csv.rb
@@ -19,7 +19,7 @@ module DownloadSettings
       CSV.generate(options) do |csv|
         csv << attributes
         budgets.each do |budget|
-          csv << attributes.map{ |attr| budget.send(attr)}
+          csv << attributes.map { |attr| budget.send(attr) }
         end
       end
     end

--- a/app/models/concerns/download_settings/comment_csv.rb
+++ b/app/models/concerns/download_settings/comment_csv.rb
@@ -19,7 +19,7 @@ module DownloadSettings
       CSV.generate(options) do |csv|
         csv << attributes
         comments.each do |comment|
-          csv << attributes.map {|attr| comment.send(attr)}
+          csv << attributes.map { |attr| comment.send(attr) }
         end
       end
     end

--- a/app/models/concerns/download_settings/debate_csv.rb
+++ b/app/models/concerns/download_settings/debate_csv.rb
@@ -19,7 +19,7 @@ module DownloadSettings
       CSV.generate(options) do |csv|
         csv << attributes
         debates.each do |debate|
-          csv << attributes.map{ |attr| debate.send(attr)}
+          csv << attributes.map { |attr| debate.send(attr) }
         end
       end
     end

--- a/app/models/concerns/download_settings/legislation_process_csv.rb
+++ b/app/models/concerns/download_settings/legislation_process_csv.rb
@@ -19,7 +19,7 @@ module DownloadSettings
       CSV.generate(options) do |csv|
         csv << attributes
         processes.each do |process|
-          csv << attributes.map{ |attr| process.send(attr)}
+          csv << attributes.map { |attr| process.send(attr) }
         end
       end
     end

--- a/app/models/concerns/download_settings/proposal_csv.rb
+++ b/app/models/concerns/download_settings/proposal_csv.rb
@@ -19,7 +19,7 @@ module DownloadSettings
       CSV.generate(options) do |csv|
         csv << attributes
         proposals.each do |proposal|
-          csv << attributes.map {|attr| proposal.send(attr)}
+          csv << attributes.map { |attr| proposal.send(attr) }
         end
       end
     end

--- a/app/models/concerns/followable.rb
+++ b/app/models/concerns/followable.rb
@@ -5,7 +5,7 @@ module Followable
     has_many :follows, as: :followable, dependent: :destroy
     has_many :followers, through: :follows, source: :user
 
-    scope :followed_by_user, ->(user){
+    scope :followed_by_user, ->(user) {
       joins(:follows).where("follows.user_id = ?", user.id)
     }
   end

--- a/app/models/concerns/globalizable.rb
+++ b/app/models/concerns/globalizable.rb
@@ -22,18 +22,18 @@ module Globalizable
     end
 
     def locales_persisted_and_marked_for_destruction
-      translations.select{|t| t.persisted? && t.marked_for_destruction? }.map(&:locale)
+      translations.select { |t| t.persisted? && t.marked_for_destruction? }.map(&:locale)
     end
 
     def translations_required?
-      translated_attribute_names.any?{|attr| required_attribute?(attr)}
+      translated_attribute_names.any? { |attr| required_attribute?(attr) }
     end
 
     if self.paranoid? && translation_class.attribute_names.include?("hidden_at")
       translation_class.send :acts_as_paranoid, column: :hidden_at
     end
 
-    scope :with_translation, -> { joins("LEFT OUTER JOIN #{translations_table_name} ON #{table_name}.id = #{translations_table_name}.#{reflections["translations"].foreign_key} AND #{translations_table_name}.locale='#{I18n.locale }'") }
+    scope :with_translation, -> { joins("LEFT OUTER JOIN #{translations_table_name} ON #{table_name}.id = #{translations_table_name}.#{reflections["translations"].foreign_key} AND #{translations_table_name}.locale='#{I18n.locale}'") }
 
     private
 
@@ -41,7 +41,7 @@ module Globalizable
         presence_validators = [ActiveModel::Validations::PresenceValidator,
           ActiveRecord::Validations::PresenceValidator]
 
-        attribute_validators(attribute).any?{|validator| presence_validators.include? validator }
+        attribute_validators(attribute).any? { |validator| presence_validators.include? validator }
       end
 
       def attribute_validators(attribute)

--- a/app/models/concerns/search_cache.rb
+++ b/app/models/concerns/search_cache.rb
@@ -14,8 +14,8 @@ module SearchCache
 
     def searchable_values_sql
       searchable_values
-        .select{ |k, _| k.present? }
-        .collect{ |value, weight| set_tsvector(value, weight) }
+        .select { |k, _| k.present? }
+        .collect { |value, weight| set_tsvector(value, weight) }
         .join(" || ")
     end
 

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -9,7 +9,7 @@ module Taggable
   def tag_list_with_limit(limit = nil)
     return tags if limit.blank?
 
-    tags.sort{|a, b| b.taggings_count <=> a.taggings_count}[0, limit]
+    tags.sort { |a, b| b.taggings_count <=> a.taggings_count }[0, limit]
   end
 
   def tags_count_out_of_limit(limit = nil)

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -47,8 +47,8 @@ class Debate < ApplicationRecord
   scope :sort_by_relevance,        -> { all }
   scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
   scope :sort_by_recommendations,  -> { order(cached_votes_total: :desc) }
-  scope :last_week,                -> { where("created_at >= ?", 7.days.ago)}
-  scope :featured,                 -> { where("featured_at is not null")}
+  scope :last_week,                -> { where("created_at >= ?", 7.days.ago) }
+  scope :featured,                 -> { where("featured_at is not null") }
   scope :public_for_api,           -> { all }
 
   # Ahoy setup
@@ -149,11 +149,11 @@ class Debate < ApplicationRecord
   end
 
   def after_hide
-    tags.each{ |t| t.decrement_custom_counter_for("Debate") }
+    tags.each { |t| t.decrement_custom_counter_for("Debate") }
   end
 
   def after_restore
-    tags.each{ |t| t.increment_custom_counter_for("Debate") }
+    tags.each { |t| t.increment_custom_counter_for("Debate") }
   end
 
   def featured?

--- a/app/models/legislation/annotation.rb
+++ b/app/models/legislation/annotation.rb
@@ -35,8 +35,8 @@ class Legislation::Annotation < ApplicationRecord
       selector_end = "/html/body/#{range_end}"
       el_end = doc.at_xpath(selector_end)
 
-      remainder_el_start = el_start.text[0 .. range_start_offset - 1] unless range_start_offset.zero?
-      remainder_el_end = el_end.text[range_end_offset .. -1]
+      remainder_el_start = el_start.text[0..range_start_offset - 1] unless range_start_offset.zero?
+      remainder_el_end = el_end.text[range_end_offset..-1]
 
       self.context = "#{remainder_el_start}<span class=annotator-hl>#{quote}</span>#{remainder_el_end}"
     rescue

--- a/app/models/legislation/answer.rb
+++ b/app/models/legislation/answer.rb
@@ -8,7 +8,7 @@ class Legislation::Answer < ApplicationRecord
                                inverse_of: :answers, counter_cache: true
   belongs_to :user, dependent: :destroy, inverse_of: :legislation_answers
 
-  validates :question, presence: true, uniqueness: { scope: :user_id}
+  validates :question, presence: true, uniqueness: { scope: :user_id }
   validates :question_option, presence: true
   validates :user, presence: true
 end

--- a/app/models/legislation/people_proposal.rb
+++ b/app/models/legislation/people_proposal.rb
@@ -46,7 +46,7 @@ class Legislation::PeopleProposal < ApplicationRecord
   scope :sort_by_id,               -> { reorder(id: :asc) }
   scope :sort_by_supports,         -> { reorder(cached_votes_score: :desc) }
   scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
-  scope :last_week,                -> { where("people_proposals.created_at >= ?", 7.days.ago)}
+  scope :last_week,                -> { where("people_proposals.created_at >= ?", 7.days.ago) }
   scope :validated,                -> { where(validated: true) }
   scope :selected,                 -> { where(selected: true) }
   scope :winners,                  -> { selected.sort_by_confidence_score }
@@ -60,7 +60,7 @@ class Legislation::PeopleProposal < ApplicationRecord
       author.username    => "B",
       tag_list.join(" ") => "B",
       summary            => "C",
-      description        => "D"}
+      description        => "D" }
   end
 
   def self.search(terms)
@@ -131,11 +131,11 @@ class Legislation::PeopleProposal < ApplicationRecord
   end
 
   def after_hide
-    tags.each{ |t| t.decrement_custom_counter_for("LegislationPeopleProposal") }
+    tags.each { |t| t.decrement_custom_counter_for("LegislationPeopleProposal") }
   end
 
   def after_restore
-    tags.each{ |t| t.increment_custom_counter_for("LegislationPeopleProposal") }
+    tags.each { |t| t.increment_custom_counter_for("LegislationPeopleProposal") }
   end
 
   def contact_info

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -47,7 +47,7 @@ class Legislation::Proposal < ApplicationRecord
   scope :sort_by_id,               -> { reorder(id: :asc) }
   scope :sort_by_supports,         -> { reorder(cached_votes_score: :desc) }
   scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
-  scope :last_week,                -> { where("proposals.created_at >= ?", 7.days.ago)}
+  scope :last_week,                -> { where("proposals.created_at >= ?", 7.days.ago) }
   scope :selected,                 -> { where(selected: true) }
   scope :winners,                  -> { selected.sort_by_confidence_score }
 
@@ -61,7 +61,7 @@ class Legislation::Proposal < ApplicationRecord
       tag_list.join(" ") => "B",
       geozone.try(:name) => "B",
       summary            => "C",
-      description        => "D"}
+      description        => "D" }
   end
 
   def self.search(terms)
@@ -132,11 +132,11 @@ class Legislation::Proposal < ApplicationRecord
   end
 
   def after_hide
-    tags.each{ |t| t.decrement_custom_counter_for("LegislationProposal") }
+    tags.each { |t| t.decrement_custom_counter_for("LegislationProposal") }
   end
 
   def after_restore
-    tags.each{ |t| t.increment_custom_counter_for("LegislationProposal") }
+    tags.each { |t| t.increment_custom_counter_for("LegislationProposal") }
   end
 
   protected

--- a/app/models/local_census_records/import.rb
+++ b/app/models/local_census_records/import.rb
@@ -68,8 +68,8 @@ class LocalCensusRecords::Import
 
     def file_headers_definition
       headers = fetch_file_headers
-      return if headers.all? {|header| ATTRIBUTES.include? header } &&
-        ATTRIBUTES.all? {|attr| headers.include? attr }
+      return if headers.all? { |header| ATTRIBUTES.include? header } &&
+        ATTRIBUTES.all? { |attr| headers.include? attr }
 
       errors.add :file, :headers, required_headers: ATTRIBUTES.join(", ")
     end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -44,7 +44,7 @@ class Poll < ApplicationRecord
   scope :expired,  -> { where("ends_at < ?", Date.current.beginning_of_day) }
   scope :recounting, -> { Poll.where(ends_at: (Date.current.beginning_of_day - RECOUNT_DURATION)..Date.current.beginning_of_day) }
   scope :published, -> { where("published = ?", true) }
-  scope :by_geozone_id, ->(geozone_id) { where(geozones: {id: geozone_id}.joins(:geozones)) }
+  scope :by_geozone_id, ->(geozone_id) { where(geozones: { id: geozone_id }.joins(:geozones)) }
   scope :public_for_api, -> { all }
   scope :not_budget,    -> { where(budget_id: nil) }
   scope :created_by_admin, -> { where(related_type: nil) }

--- a/app/models/poll/officer.rb
+++ b/app/models/poll/officer.rb
@@ -19,14 +19,14 @@ class Poll
       officer_assignments.voting_days.includes(booth_assignment: :poll).
                                map(&:booth_assignment).
                                map(&:poll).uniq.compact.
-                               sort {|x, y| y.ends_at <=> x.ends_at}
+                               sort { |x, y| y.ends_at <=> x.ends_at }
     end
 
     def final_days_assigned_polls
       officer_assignments.final.includes(booth_assignment: :poll).
                                map(&:booth_assignment).
                                map(&:poll).uniq.compact.
-                               sort {|x, y| y.ends_at <=> x.ends_at}
+                               sort { |x, y| y.ends_at <=> x.ends_at }
     end
 
     def todays_booths

--- a/app/models/poll/officer_assignment.rb
+++ b/app/models/poll/officer_assignment.rb
@@ -18,10 +18,10 @@ class Poll
     scope :by_officer_and_poll, ->(officer_id, poll_id) do
       where("officer_id = ? AND poll_booth_assignments.poll_id = ?", officer_id, poll_id)
     end
-    scope :by_officer, ->(officer){ where(officer_id: officer.id) }
-    scope :by_poll,  ->(poll){ joins(:booth_assignment).where("poll_booth_assignments.poll_id" => poll.id) }
-    scope :by_booth, ->(booth){ joins(:booth_assignment).where("poll_booth_assignments.booth_id" => booth.id) }
-    scope :by_date, ->(date){ where(date: date) }
+    scope :by_officer, ->(officer) { where(officer_id: officer.id) }
+    scope :by_poll,  ->(poll) { joins(:booth_assignment).where("poll_booth_assignments.poll_id" => poll.id) }
+    scope :by_booth, ->(booth) { joins(:booth_assignment).where("poll_booth_assignments.booth_id" => booth.id) }
+    scope :by_date, ->(date) { where(date: date) }
 
     before_create :log_user_data
 

--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -33,7 +33,7 @@ class Poll::Question < ApplicationRecord
 
   scope :by_poll_id,    ->(poll_id) { where(poll_id: poll_id) }
 
-  scope :sort_for_list, -> { order("poll_questions.proposal_id IS NULL", :created_at)}
+  scope :sort_for_list, -> { order("poll_questions.proposal_id IS NULL", :created_at) }
   scope :for_render,    -> { includes(:author, :proposal) }
 
   def self.search(params)

--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -76,12 +76,12 @@ class Poll::Question::Answer < ApplicationRecord
       when "positive_negative_open"
         answers = question.question_answers.visibles
                     .map { |a| count_positive_negative(a, true) - count_positive_negative(a, false) }
-        is_most_voted = answers.none? {|a| a > total_votes_positive_negative}
+        is_most_voted = answers.none? { |a| a > total_votes_positive_negative }
         update(most_voted: is_most_voted)
       when "prioritized"
         answers = question.question_answers.visibles
                     .map { |a| Poll::Answer.where(question_id: a.question, answer: a.title).sum(:value) }
-        is_most_voted = answers.none? {|a| a > total_votes_prioritized}
+        is_most_voted = answers.none? { |a| a > total_votes_prioritized }
         update(most_voted: is_most_voted)
       else
         for_only_votes
@@ -97,8 +97,8 @@ class Poll::Question::Answer < ApplicationRecord
 
     def for_only_votes
       answers = question.question_answers.visibles
-                  .map {|a| Poll::Answer.where(question_id: a.question, answer: a.title).count}
-      is_most_voted = answers.none? {|a| a > total_votes}
+                  .map { |a| Poll::Answer.where(question_id: a.question, answer: a.title).count }
+      is_most_voted = answers.none? { |a| a > total_votes }
       update(most_voted: is_most_voted)
     end
 

--- a/app/models/poll/recount.rb
+++ b/app/models/poll/recount.rb
@@ -7,7 +7,7 @@ class Poll::Recount < ApplicationRecord
   belongs_to :officer_assignment
 
   validates :author, presence: true
-  validates :origin, inclusion: {in: VALID_ORIGINS}
+  validates :origin, inclusion: { in: VALID_ORIGINS }
 
   scope :web,    -> { where(origin: "web") }
   scope :booth,  -> { where(origin: "booth") }

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -78,7 +78,7 @@ class Proposal < ApplicationRecord
   scope :sort_by_recommendations,  -> { order(cached_votes_up: :desc) }
   scope :archived,                 -> { where("proposals.created_at <= ?", Setting["months_to_archive_proposals"].to_i.months.ago) }
   scope :not_archived,             -> { where("proposals.created_at > ?", Setting["months_to_archive_proposals"].to_i.months.ago) }
-  scope :last_week,                -> { where("proposals.created_at >= ?", 7.days.ago)}
+  scope :last_week,                -> { where("proposals.created_at >= ?", 7.days.ago) }
   scope :retired,                  -> { where.not(retired_at: nil) }
   scope :not_retired,              -> { where(retired_at: nil) }
   scope :successful,               -> { where("cached_votes_up >= ?", Proposal.votes_needed_for_success) }
@@ -213,11 +213,11 @@ class Proposal < ApplicationRecord
   end
 
   def after_hide
-    tags.each{ |t| t.decrement_custom_counter_for("Proposal") }
+    tags.each { |t| t.decrement_custom_counter_for("Proposal") }
   end
 
   def after_restore
-    tags.each{ |t| t.increment_custom_counter_for("Proposal") }
+    tags.each { |t| t.increment_custom_counter_for("Proposal") }
   end
 
   def self.votes_needed_for_success

--- a/app/models/signature_sheet.rb
+++ b/app/models/signature_sheet.rb
@@ -7,7 +7,7 @@ class SignatureSheet < ApplicationRecord
   has_many :signatures
 
   validates :author, presence: true
-  validates :signable_type, inclusion: {in: VALID_SIGNABLES}
+  validates :signable_type, inclusion: { in: VALID_SIGNABLES }
   validates :required_fields_to_verify, presence: true
   validates :signable, presence: true
   validate  :signable_found
@@ -35,7 +35,7 @@ class SignatureSheet < ApplicationRecord
   end
 
   def parsed_required_fields_to_verify_groups
-    required_fields_to_verify.split(/[;]/).collect {|d| d.gsub(/\s+/, "") }.map { |group| group.split(/[,]/)}
+    required_fields_to_verify.split(/[;]/).collect { |d| d.gsub(/\s+/, "") }.map { |group| group.split(/[,]/) }
   end
 
   def signable_found

--- a/app/models/tag_cloud.rb
+++ b/app/models/tag_cloud.rb
@@ -20,7 +20,7 @@ class TagCloud
   end
 
   def geozone_names
-    Geozone.all.map {|geozone| geozone.name.downcase }
+    Geozone.all.map { |geozone| geozone.name.downcase }
   end
 
   def resource_model_scoped

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ApplicationRecord
 
   validate :validate_username_length
 
-  validates :official_level, inclusion: {in: 0..5}
+  validates :official_level, inclusion: { in: 0..5 }
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
 
   validates_associated :organization, message: false
@@ -128,7 +128,7 @@ class User < ApplicationRecord
 
   def comment_flags(comments)
     comment_flags = flags.for_comments(comments)
-    comment_flags.each_with_object({}){ |f, h| h[f.flaggable_id] = true }
+    comment_flags.each_with_object({}) { |f, h| h[f.flaggable_id] = true }
   end
 
   def voted_in_group?(group)

--- a/app/models/votation_type.rb
+++ b/app/models/votation_type.rb
@@ -24,12 +24,12 @@ class VotationType < ApplicationRecord
                          variables: [:max_votes, :max_groups_answers] },
   }.freeze
 
-  enum enum_type: ENUM_TYPES_PROPS.map{ |k,v| [k, v[:enum_type]] }.to_h.freeze
+  enum enum_type: ENUM_TYPES_PROPS.map { |k, v| [k, v[:enum_type]] }.to_h.freeze
 
-  enum prioritization_type: {borda: 1, dowdall: 2}.freeze
+  enum prioritization_type: { borda: 1, dowdall: 2 }.freeze
 
   validates :questionable, presence: true
-  validates :questionable_type, inclusion: {in: QUESTIONABLE_TYPES}
+  validates :questionable_type, inclusion: { in: QUESTIONABLE_TYPES }
   validates_presence_of :max_votes, allow_blank: false,
                         if: :max_votes_required?
   validates_presence_of :max_groups_answers, allow_blank: false,
@@ -49,7 +49,7 @@ class VotationType < ApplicationRecord
     prioritized
   end
 
-  def answer (user, answer, options = {})
+  def answer(user, answer, options = {})
     result = nil
     votes = questionable.answers
 
@@ -130,7 +130,7 @@ class VotationType < ApplicationRecord
   end
 
   def self.build_by_type(questionable, params)
-    attributes      = {questionable: questionable}
+    attributes      = { questionable: questionable }
     enum_type       = self.enum_types.key(params[:enum_type].to_i)
     enum_type_props = enum_properties(enum_type)
     attributes.merge!(enum_type_props.except(:variables))
@@ -155,7 +155,7 @@ class VotationType < ApplicationRecord
       end
     when "dowdall"
       questionable.answers.by_author(user).order(:order).each_with_index do |answer, i|
-        value = 60/(i + 1)
+        value = 60 / (i + 1)
         !answer.update(value: value)
       end
     end

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -32,14 +32,14 @@
       <div class="small-12 medium-6 column">
         <%= translations_form.text_field :title,
           placeholder: t("admin.banners.banner.title"),
-          data: {js_banner_title: "js_banner_title"},
+          data: { js_banner_title: "js_banner_title" },
           label: t("admin.banners.banner.title") %>
       </div>
 
       <div class="small-12 column">
         <%= translations_form.text_field :description,
           placeholder: t("admin.banners.banner.description"),
-          data: {js_banner_description: "js_banner_description"},
+          data: { js_banner_description: "js_banner_description" },
           label: t("admin.banners.banner.description") %>
       </div>
     <% end %>

--- a/app/views/admin/budget_headings/_form.html.erb
+++ b/app/views/admin/budget_headings/_form.html.erb
@@ -30,8 +30,8 @@
                         label: false,
                         maxlength: 8,
                         placeholder: t("admin.budget_headings.form.population"),
-                        data: {toggle_focus: "population-info"},
-                        aria: {describedby: "budgets-population-help-text"} %>
+                        data: { toggle_focus: "population-info" },
+                        aria: { describedby: "budgets-population-help-text" } %>
 
       <%= f.text_field :latitude,
                         label: t("admin.budget_headings.form.latitude"),

--- a/app/views/admin/budget_investments/_search_form.html.erb
+++ b/app/views/admin/budget_investments/_search_form.html.erb
@@ -2,7 +2,7 @@
 <%= form_tag(admin_budget_budget_investments_path(budget: @budget), method: :get, enforce_utf8: false) do %>
   <div class="small-12 column">
     <%= link_to "#advanced_filters_content",
-                data: {toggle: "advanced_filters"},
+                data: { toggle: "advanced_filters" },
                 class: "advanced-filters float-right clear" do %>
       <%= t("admin.budget_investments.index.advanced_filters") %>
     <% end %>
@@ -36,32 +36,32 @@
     <%= select_tag :administrator_id,
                    options_for_select(admin_select_options, params[:administrator_id]),
                    { prompt: t("admin.budget_investments.index.administrator_filter_all"),
-                     label: false} %>
+                     label: false } %>
   </div>
   <div class="small-12 medium-3 column">
     <%= select_tag :valuator_or_group_id,
                    options_for_select(valuator_or_group_select_options, params[:valuator_or_group_id]),
                    { prompt: t("admin.budget_investments.index.valuator_filter_all"),
-                     label: false} %>
+                     label: false } %>
   </div>
   <div class="small-12 medium-3 column">
     <%= select_tag :heading_id,
                    options_for_select(budget_heading_select_options(@budget), params[:heading_id]),
                    { prompt: t("admin.budget_investments.index.heading_filter_all"),
-                     label: false} %>
+                     label: false } %>
   </div>
   <div class="small-12 medium-3 column">
     <%= select_tag :tag_name,
                    options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
                    { prompt: t("admin.budget_investments.index.tags_filter_all"),
-                     label: false} %>
+                     label: false } %>
   </div>
 
   <div class="small-12 medium-3 column">
     <%= select_tag :milestone_tag_name,
                    options_for_select(investment_milestone_tags_select_options(@budget), params[:milestone_tag_name]),
                    { prompt: t("admin.budget_investments.index.milestone_tags_filter_all"),
-                     label: false} %>
+                     label: false } %>
   </div>
 
   <div class="small-12 medium-6 column">

--- a/app/views/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/admin/budget_investments/_select_investment.html.erb
@@ -47,7 +47,7 @@
 </td>
 
 <td class="small text-center" data-field="valuation_finished">
-  <%= investment.valuation_finished? ? t("shared.yes"): t("shared.no") %>
+  <%= investment.valuation_finished? ? t("shared.yes") : t("shared.no") %>
 </td>
 
 <td class="small text-center" data-field="visible_to_valuators">
@@ -94,6 +94,6 @@
 
 <% if params[:advanced_filters]&.include?("selected") %>
   <td class="small text-center" data-field="incompatible">
-    <%= investment.incompatible? ? t("shared.yes"): t("shared.no") %>
+    <%= investment.incompatible? ? t("shared.yes") : t("shared.no") %>
   </td>
 <% end %>

--- a/app/views/admin/budget_investments/edit.html.erb
+++ b/app/views/admin/budget_investments/edit.html.erb
@@ -53,7 +53,7 @@
 
         <div class="small-12 medium-6">
           <%= f.select(:administrator_id,
-                         @admins.collect{ |a| [a.description_or_name_and_email, a.id ] },
+                         @admins.collect { |a| [a.description_or_name_and_email, a.id] },
                          { include_blank: t("admin.budget_investments.edit.undefined") }) %>
         </div>
       </div>

--- a/app/views/admin/budget_investments/show.html.erb
+++ b/app/views/admin/budget_investments/show.html.erb
@@ -1,5 +1,5 @@
 <%= link_to admin_budget_budget_investments_path(Budget::Investment.filter_params(params).to_h),
-            class: "back", data: {no_turbolink: true} do %>
+            class: "back", data: { no_turbolink: true } do %>
   <span class="icon-angle-left"></span><%= t("shared.back") %>
 <% end %>
 
@@ -62,7 +62,7 @@
 <p>
   <%= link_to t("admin.budget_investments.show.edit_classification"),
                 edit_admin_budget_budget_investment_path(@budget, @investment,
-                                                  {anchor: "classification"}.merge(Budget::Investment.filter_params(params).to_h)) unless @budget.finished? %>
+                                                  { anchor: "classification" }.merge(Budget::Investment.filter_params(params).to_h)) unless @budget.finished? %>
 </p>
 
 <hr>

--- a/app/views/admin/dashboard/actions/_form.html.erb
+++ b/app/views/admin/dashboard/actions/_form.html.erb
@@ -6,7 +6,7 @@
     <% ::Dashboard::Action.action_types.keys.each do |action_type_value| %>
       <span class="margin-right">
         <%= f.radio_button :action_type, action_type_value, label: false,
-                            data: {toggle: "request_to_administrators short_description"} %>
+                            data: { toggle: "request_to_administrators short_description" } %>
         <%= f.label "action_type_#{action_type_value}", t("admin.dashboard.actions.action_type.#{action_type_value}") %>
       </span>
     <% end %>

--- a/app/views/admin/hidden_users/show.html.erb
+++ b/app/views/admin/hidden_users/show.html.erb
@@ -36,4 +36,4 @@
   <% end %>
 </table>
 
-<%= paginate [@debates, @comments].sort_by {|x| x.size}.last %>
+<%= paginate [@debates, @comments].sort_by { |x| x.size }.last %>

--- a/app/views/admin/homepage/_setting.html.erb
+++ b/app/views/admin/homepage/_setting.html.erb
@@ -6,6 +6,6 @@
 
     <%= f.submit(t("admin.settings.index.features.#{setting.enabled? ? "disable" : "enable"}"),
           class: "button #{setting.enabled? ? "hollow alert" : "success"}",
-          data: {confirm: t("admin.actions.confirm")}) %>
+          data: { confirm: t("admin.actions.confirm") }) %>
   <% end %>
 </div>

--- a/app/views/admin/legislation/draft_versions/_form.html.erb
+++ b/app/views/admin/legislation/draft_versions/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/globalize_locales", resource: @draft_version %>
 
-<%= translatable_form_for [:admin, @process, @draft_version], url: url, html: {data: {watch_changes: true}} do |f| %>
+<%= translatable_form_for [:admin, @process, @draft_version], url: url, html: { data: { watch_changes: true }} do |f| %>
 
   <% if @draft_version.errors.any? %>
     <div id="error_explanation" data-alert class="callout alert" data-closable>
@@ -38,7 +38,7 @@
           <div class="markdown-editor-header truncate">
             <%= t("admin.legislation.draft_versions.form.title_html",
                    draft_version_title: @draft_version.title,
-                   process_title: @process.title ) %>
+                   process_title: @process.title) %>
           </div>
 
           <div class="markdown-editor-buttons">

--- a/app/views/admin/legislation/homepages/_form.html.erb
+++ b/app/views/admin/legislation/homepages/_form.html.erb
@@ -3,7 +3,7 @@
            display_style: lambda { |locale| enable_translation_style(@process, locale) },
            manage_languages: false %>
 
-<%= translatable_form_for [:admin, @process], url: url, html: {data: {watch_changes: true}} do |f| %>
+<%= translatable_form_for [:admin, @process], url: url, html: { data: { watch_changes: true } } do |f| %>
 
   <%= render "shared/errors", resource: @process %>
   <div class="row">

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/globalize_locales", resource: @process %>
 
-<%= translatable_form_for [:admin, @process], html: {data: {watch_changes: true}} do |f| %>
+<%= translatable_form_for [:admin, @process], html: { data: { watch_changes: true } } do |f| %>
 
   <% if @process.errors.any? %>
 

--- a/app/views/admin/legislation/proposals/_form.html.erb
+++ b/app/views/admin/legislation/proposals/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, @process], html: {data: {watch_changes: true}} do |f| %>
+<%= form_for [:admin, @process], html: { data: { watch_changes: true } } do |f| %>
 
   <% if @process.errors.any? %>
 
@@ -22,7 +22,7 @@
                       label: false,
                       placeholder: t("admin.legislation.proposals.form.custom_categories_placeholder"),
                       class: "js-tag-list",
-                      aria: {describedby: "tag-list-help-text"} %>
+                      aria: { describedby: "tag-list-help-text" } %>
   </div>
 
   <div class="small-12 medium-3 column clear end">

--- a/app/views/admin/legislation/questions/_form.html.erb
+++ b/app/views/admin/legislation/questions/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/globalize_locales", resource: @question %>
 
-<%= translatable_form_for [:admin, @process, @question], url: url, html: {data: {watch_changes: true}} do |f| %>
+<%= translatable_form_for [:admin, @process, @question], url: url, html: { data: { watch_changes: true } } do |f| %>
 
   <% if @question.errors.any? %>
     <div class="small-12 medium-9 column">

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -17,7 +17,7 @@
                 remote: true,
                 title: t("admin.booth_assignments.manage.actions.unassign"),
                 class: "button hollow alert expanded",
-                data: (booth_assignment.shifts? ? {confirm: "#{t("admin.poll_booth_assignments.alert.shifts")}"} : nil) if !@poll.expired? %>
+                data: (booth_assignment.shifts? ? { confirm: "#{t("admin.poll_booth_assignments.alert.shifts")}" } : nil) if !@poll.expired? %>
   </td>
 <% else %>
   <td>

--- a/app/views/admin/poll/officers/_officer.html.erb
+++ b/app/views/admin/poll/officers/_officer.html.erb
@@ -21,7 +21,7 @@
                       method: :delete,
                       class: "button hollow alert expanded" %>
         <% else %>
-          <%= link_to t("admin.poll_officers.officer.add"),{ controller: "admin/poll/officers", action: :create, user_id: officer.user_id },
+          <%= link_to t("admin.poll_officers.officer.add"), { controller: "admin/poll/officers", action: :create, user_id: officer.user_id },
                       method: :post,
                       class: "button success expanded" %>
         <% end %>

--- a/app/views/admin/poll/questions/_form.html.erb
+++ b/app/views/admin/poll/questions/_form.html.erb
@@ -37,7 +37,7 @@
       <%= fields_for :votation_type do |votation_f| %>
         <div class="small-12 medium-6">
           <%= votation_f.select :enum_type,
-                                options_for_select(VotationType.enum_types.map {|k, v| [t(k, scope: :enum_type), v]},
+                                options_for_select(VotationType.enum_types.map { |k, v| [t(k, scope: :enum_type), v] },
                                 params.dig(:votation_type, :enum_type)), default: 0,
                                 disabled: @question.persisted?,  label: t("enum_type.title") %>
         </div>
@@ -53,8 +53,8 @@
           </div>
           <div class="small-12 medium-6 js-prioritization_type hidden">
             <%= votation_f.select :prioritization_type,
-                                  options_for_select(VotationType.prioritization_types.map {|k, v| [t(k, scope: :prioritization_type), v]},
-                                  params.dig(:votation_type, :prioritization_type) ), default: 0,
+                                  options_for_select(VotationType.prioritization_types.map { |k, v| [t(k, scope: :prioritization_type), v] },
+                                  params.dig(:votation_type, :prioritization_type)), default: 0,
                                   disabled: @question.persisted?, label: t("prioritization_type.title") %>
           </div>
           <div class="small-12 medium-6 js-max_group_votes hidden">

--- a/app/views/admin/poll/results/_results_by_booth.html.erb
+++ b/app/views/admin/poll/results/_results_by_booth.html.erb
@@ -7,7 +7,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @poll.booth_assignments.sort_by {|ba| ba.booth.name }.each do |booth_assignment| %>
+    <% @poll.booth_assignments.sort_by { |ba| ba.booth.name }.each do |booth_assignment| %>
       <tr id="booth_assignment_<%= booth_assignment.id %>_result">
         <td><%= booth_assignment.booth.name %></td>
         <td class="text-center">

--- a/app/views/admin/poll/shifts/_form.html.erb
+++ b/app/views/admin/poll/shifts/_form.html.erb
@@ -15,7 +15,7 @@
     <div class="small-12 medium-3 column">
       <label><%= t("admin.poll_shifts.new.task") %></label>
       <%= f.select :task,
-                    Poll::Shift.tasks.map {|k,v| [t("admin.poll_shifts.#{k}"), k]},
+                    Poll::Shift.tasks.map { |k, v| [t("admin.poll_shifts.#{k}"), k] },
                     { prompt: t("admin.poll_shifts.new.select_task"),
                     label: false },
                     class: "js-poll-shifts" %>

--- a/app/views/admin/settings/_featured_settings_form.html.erb
+++ b/app/views/admin/settings/_featured_settings_form.html.erb
@@ -1,7 +1,7 @@
-<%= form_for(feature, url: admin_setting_path(feature), html: { id: "edit_#{dom_id(feature)}"}) do |f| %>
+<%= form_for(feature, url: admin_setting_path(feature), html: { id: "edit_#{dom_id(feature)}" }) do |f| %>
   <%= f.hidden_field :tab, value: tab if defined?(tab) %>
   <%= f.hidden_field :value, id: dom_id(feature), value: (feature.enabled? ? "" : "active") %>
   <%= f.submit(t("admin.settings.index.features.#{feature.enabled? ? "disable" : "enable"}"),
                class: "button expanded #{feature.enabled? ? "hollow alert" : "success"}",
-               data: {confirm: t("admin.actions.confirm")}) %>
+               data: { confirm: t("admin.actions.confirm") }) %>
 <% end %>

--- a/app/views/admin/settings/_settings_form.html.erb
+++ b/app/views/admin/settings/_settings_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
+<%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}" }) do |f| %>
   <%= f.hidden_field :tab, value: tab if defined?(tab) %>
   <div class="small-12 medium-6 large-8 column">
     <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>

--- a/app/views/admin/signature_sheets/new.html.erb
+++ b/app/views/admin/signature_sheets/new.html.erb
@@ -17,7 +17,7 @@
   <%= f.label :required_fields_to_verify %>
   <p class="help-text" id="required-fields-to-verify-help-text"><%= required_fields_to_verify_text_help %></p>
   <p class="help-text"> <%= example_text_help %></p>
-  <%= f.text_area :required_fields_to_verify, rows: "6", label: false, aria: {describedby: "required-fields-to-verify-help-text"} %>
+  <%= f.text_area :required_fields_to_verify, rows: "6", label: false, aria: { describedby: "required-fields-to-verify-help-text" } %>
 
   <%= f.submit(class: "button", value: t("admin.signature_sheets.new.submit")) %>
 <% end %>

--- a/app/views/admin/signature_sheets/show.html.erb
+++ b/app/views/admin/signature_sheets/show.html.erb
@@ -21,7 +21,7 @@
 <div id="verified_signatures" class="callout success">
   <strong>
     <%= t("admin.signature_sheets.show.verified",
-        count: @signature_sheet.signatures.verified.count ) %>
+        count: @signature_sheet.signatures.verified.count) %>
   </strong>
   <br />
   <strong>
@@ -35,7 +35,7 @@
   <p>
     <strong>
       <%= t("admin.signature_sheets.show.unverified",
-          count: @signature_sheet.signatures.unverified.count ) %>
+          count: @signature_sheet.signatures.unverified.count) %>
       <%= t("admin.signature_sheets.show.unverified_error") %>
     </strong>
   </p>

--- a/app/views/admin/site_customization/content_blocks/_form_content_block.html.erb
+++ b/app/views/admin/site_customization/content_blocks/_form_content_block.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, @content_block], html: {class: "edit_page", data: {watch_changes: true}} do |f| %>
+<%= form_for [:admin, @content_block], html: { class: "edit_page", data: { watch_changes: true } } do |f| %>
 
   <% if @content_block.errors.any? %>
 

--- a/app/views/admin/site_customization/content_blocks/_form_heading_content_block.html.erb
+++ b/app/views/admin/site_customization/content_blocks/_form_heading_content_block.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class="small-12 column">
     <%= label_tag :body %>
-    <%= text_area_tag  :body, @content_block.body, rows: 10 %>
+    <%= text_area_tag :body, @content_block.body, rows: 10 %>
     <div class="small-12 medium-6 large-3">
       <%= button_tag t("admin.menu.site_customization.buttons.content_block.update"), class: "button success expanded" %>
     </div>

--- a/app/views/admin/site_customization/images/index.html.erb
+++ b/app/views/admin/site_customization/images/index.html.erb
@@ -14,7 +14,7 @@
           <strong><%= image.name %></strong> (<%= image.required_width %>x<%= image.required_height %>)
         </td>
         <td class="small-12 medium-8">
-          <%= form_for([:admin, image], html: { id: "edit_#{dom_id(image)}"}) do |f| %>
+          <%= form_for([:admin, image], html: { id: "edit_#{dom_id(image)}" }) do |f| %>
             <div class="small-12 medium-6 large-6 column">
               <%= image_tag image.image.url if image.image.exists? %>
               <%= f.file_field :image, label: false %>

--- a/app/views/admin/site_customization/pages/_form.html.erb
+++ b/app/views/admin/site_customization/pages/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/globalize_locales", resource: @page %>
 
-<%= translatable_form_for [:admin, @page], html: {class: "edit_page", data: {watch_changes: true}} do |f| %>
+<%= translatable_form_for [:admin, @page], html: { class: "edit_page", data: { watch_changes: true } } do |f| %>
   <% if @page.errors.any? %>
     <div id="error_explanation" data-alert class="callout alert" data-closable>
       <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -25,7 +25,7 @@
         <%= form_for(tag,
             url: admin_tag_path(tag),
             as: :tag,
-            html: { id: "edit_tag_#{tag.id}"}) do |f| %>
+            html: { id: "edit_tag_#{tag.id}" }) do |f| %>
 
             <strong><%= tag.name %></strong>
         <% end %>

--- a/app/views/admin/valuators/edit.html.erb
+++ b/app/views/admin/valuators/edit.html.erb
@@ -12,7 +12,7 @@
     <%= f.text_field :description %>
     <div class="small-12 medium-6">
       <%= f.select :valuator_group_id,
-                   @valuator_groups.map {|group| [group.name, group.id] },
+                   @valuator_groups.map { |group| [group.name, group.id] },
                    { include_blank: true } %>
     </div>
     <div>

--- a/app/views/budgets/investments/_flag_actions.html.erb
+++ b/app/views/budgets/investments/_flag_actions.html.erb
@@ -7,7 +7,7 @@
       <%= link_to t("shared.flag"), flag_budget_investment_path(investment.budget, investment.id),
                                     method: :put,
                                     remote: true,
-                                    id: "flag-investment-#{ investment.id }" %>
+                                    id: "flag-investment-#{investment.id}" %>
     </span>
   <% end %>
 
@@ -19,7 +19,7 @@
       <%= link_to t("shared.unflag"), unflag_budget_investment_path(investment.budget, investment.id),
                                       method: :put,
                                       remote: true,
-                                      id: "unflag-investment-#{ investment.id }" %>
+                                      id: "unflag-investment-#{investment.id}" %>
     </span>
   <% end %>
 </span>

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -4,7 +4,7 @@
 
   <div class="row column">
     <div class="small-12 medium-8 column">
-      <%= f.select :heading_id, budget_heading_select_options(@budget), {include_blank: true, } %>
+      <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true, } %>
     </div>
     <div class="row">
       <div class="small-12 column">
@@ -82,9 +82,9 @@
       <%= f.text_field :tag_list, value: @investment.tag_list.to_s,
                         label: false,
                         placeholder: t("budgets.investments.form.tags_placeholder"),
-                        aria: {describedby: "tags-list-help-text"},
+                        aria: { describedby: "tags-list-help-text" },
                         class: "js-tag-list tag-autocomplete",
-                        data: {js_url: suggest_tags_path} %>
+                        data: { js_url: suggest_tags_path } %>
     </div>
 
     <% unless current_user.manager? %>

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -18,9 +18,9 @@
           class: "button button-support small expanded",
           title: t("budgets.investments.investment.support_title"),
           method: "post",
-          remote: (display_support_alert?(investment) ? false: true ),
+          remote: (display_support_alert?(investment) ? false : true),
           data:   (display_support_alert?(investment) ? {
-                  confirm: t("budgets.investments.investment.confirm_group")} : nil),
+                  confirm: t("budgets.investments.investment.confirm_group") } : nil),
           "aria-hidden" => css_for_aria_hidden(reason) do %>
         <%= t("budgets.investments.investment.give_support") %>
       <% end %>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -45,8 +45,8 @@
   <div class="small-12 medium-9 large-10 column">
     <%= link_to t("budgets.results.show_all_link"), "#",
                 class: "js-toggle-link button hollow margin-bottom float-right-medium",
-                data: {"toggle-selector" => ".js-discarded",
-                       "toggle-text" => t("budgets.results.hide_discarded_link")} %>
+                data: { "toggle-selector" => ".js-discarded",
+                        "toggle-text" => t("budgets.results.hide_discarded_link") } %>
 
     <%= link_to t("shared.download.link.investments"), current_path_with_query_params(format: :csv),
                 class: "button hollow margin-bottom margin-right float-right-medium" %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -91,7 +91,7 @@
           <% end %>
 
           <% if comment.children.size > 0 %>
-            <%= link_to "", class: "js-toggle-children relative", data: {"id": "#{dom_id(comment)}"} do %>
+            <%= link_to "", class: "js-toggle-children relative", data: { "id": "#{dom_id(comment)}" } do %>
               <span class="show-for-sr js-child-toggle" style="display: none;"><%= t("shared.show") %></span>
               <span class="show-for-sr js-child-toggle"><%= t("shared.hide") %></span>
               <span id="<%= dom_id(comment) %>_children_arrow" class="icon-arrow-down"></span>
@@ -105,14 +105,14 @@
           <% if user_signed_in? && !comments_closed_for_commentable?(comment.commentable) && !require_verified_resident_for_commentable?(comment.commentable, current_user) %>
             <span class="divider">&nbsp;|&nbsp;</span>
             <%= link_to(comment_link_text(comment), "",
-                        class: "js-add-comment-link", data: {"id": dom_id(comment)}) %>
+                        class: "js-add-comment-link", data: { "id": dom_id(comment) }) %>
 
             <% if allow_actions %>
               <%= render "comments/actions", { comment: comment } %>
             <% end %>
 
             <% if allow_comments %>
-              <%= render "comments/form", {commentable: comment.commentable,
+              <%= render "comments/form", { commentable: comment.commentable,
                                            parent_id: comment.id,
                                            toggeable: true,
                                            valuation: valuation } %>

--- a/app/views/comments/_comment_tree.html.erb
+++ b/app/views/comments/_comment_tree.html.erb
@@ -24,7 +24,7 @@
           <% elsif require_verified_resident_for_commentable?(commentable, current_user) %>
             <br>
             <div data-alert class="callout primary">
-              <%= t("comments.verified_only", verify_account: link_to(t("comments.verify_account"), verification_path )).html_safe %>
+              <%= t("comments.verified_only", verify_account: link_to(t("comments.verify_account"), verification_path)).html_safe %>
             </div>
           <% elsif allow_comments %>
             <%= render "comments/form", { commentable: commentable,

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -20,7 +20,7 @@
       <% end %>
       <% if can? :comment_as_administrator, commentable %>
         <div class="float-right">
-          <%= f.check_box :as_administrator, title: t("comments.form.comment_as_admin"), id: "comment-as-administrator-#{css_id}",label: false %>
+          <%= f.check_box :as_administrator, title: t("comments.form.comment_as_admin"), id: "comment-as-administrator-#{css_id}", label: false %>
           <%= label_tag "comment-as-administrator-#{css_id}", t("comments.form.comment_as_admin"), class: "checkbox" %>
         </div>
       <% end %>

--- a/app/views/communities/_participant.html.erb
+++ b/app/views/communities/_participant.html.erb
@@ -1,7 +1,7 @@
 <div class="comment-body">
   <div class="comment-info">
 
-    <%= avatar_image( participant, seed: participant.id, size: 32, class: "author-photo") %>
+    <%= avatar_image(participant, seed: participant.id, size: 32, class: "author-photo") %>
 
     <div class="comment-info">
 

--- a/app/views/communities/_poll.html.erb
+++ b/app/views/communities/_poll.html.erb
@@ -5,6 +5,6 @@
 
   <p class="topic-info">
     <%= t("communities.poll.take_part",
-           from: l(poll.starts_at.to_date), to:(poll.ends_at.to_date)) %>
+           from: l(poll.starts_at.to_date), to: (poll.ends_at.to_date)) %>
   </p>
 </div>

--- a/app/views/dashboard/_menu.html.erb
+++ b/app/views/dashboard/_menu.html.erb
@@ -20,7 +20,7 @@
         <strong><%= t("dashboard.menu.recommended_actions") %></strong>
       <% end %>
       <% if new_resources_since_last_login?(proposed_actions, @new_actions_since_last_login) %>
-        <span class="label"><%= t("dashboard.progress.new_action" ) %></span>
+        <span class="label"><%= t("dashboard.progress.new_action") %></span>
       <% end %>
     </li>
   <% end %>
@@ -30,7 +30,7 @@
       <span class="icon-zip"></span>
       <strong><%= t("dashboard.menu.resources") %></strong>
       <% if new_resources_since_last_login?(resources, @new_actions_since_last_login) %>
-        <span class="label"><%= t("dashboard.progress.new_action" ) %></span>
+        <span class="label"><%= t("dashboard.progress.new_action") %></span>
       <% end %>
       <ul class="no-bullet resources">
         <% if can?(:manage_polls, proposal) %>

--- a/app/views/debates/_comments.html.erb
+++ b/app/views/debates/_comments.html.erb
@@ -9,7 +9,7 @@
       <%= render "shared/wide_order_selector", i18n_namespace: "comments" %>
 
       <% if user_signed_in? %>
-        <%= render "comments/form", {commentable: @debate, parent_id: nil, toggeable: false} %>
+        <%= render "comments/form", { commentable: @debate, parent_id: nil, toggeable: false } %>
       <% else %>
       <br>
 

--- a/app/views/debates/_flag_actions.html.erb
+++ b/app/views/debates/_flag_actions.html.erb
@@ -4,7 +4,7 @@
       <span class="icon-flag flag-disable"></span>
     </a>
     <span class="dropdown-pane" id="flag-drop-debate-<%= debate.id %>" data-dropdown data-auto-focus="true">
-      <%= link_to t("shared.flag"), flag_debate_path(debate), method: :put, remote: true, id: "flag-debate-#{ debate.id }" %>
+      <%= link_to t("shared.flag"), flag_debate_path(debate), method: :put, remote: true, id: "flag-debate-#{debate.id}" %>
     </span>
   <% end %>
 
@@ -13,7 +13,7 @@
       <span class="icon-flag flag-active"></span>
     </a>
     <span class="dropdown-pane" id="unflag-drop-debate-<%= debate.id %>" data-dropdown data-auto-focus="true">
-      <%= link_to t("shared.unflag"), unflag_debate_path(debate), method: :put, remote: true, id: "unflag-debate-#{ debate.id }" %>
+      <%= link_to t("shared.unflag"), unflag_debate_path(debate), method: :put, remote: true, id: "unflag-debate-#{debate.id}" %>
     </span>
   <% end %>
 </span>

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -32,8 +32,8 @@
       <%= f.text_field :tag_list, value: @debate.tag_list.to_s,
                         label: false,
                         placeholder: t("debates.form.tags_placeholder"),
-                        aria: {describedby: "tag-list-help-text"},
-                        data: {js_url: suggest_tags_path},
+                        aria: { describedby: "tag-list-help-text" },
+                        data: { js_url: suggest_tags_path },
                         class: "tag-autocomplete" %>
     </div>
     <div class="small-12 column">

--- a/app/views/debates/_votes.html.erb
+++ b/app/views/debates/_votes.html.erb
@@ -53,7 +53,7 @@
     <div class="participation-not-allowed" style="display:none" aria-hidden="false">
       <p>
         <%= t("votes.anonymous",
-            verify_account: link_to(t("votes.verify_account"), verification_path )).html_safe %>
+            verify_account: link_to(t("votes.verify_account"), verification_path)).html_safe %>
       </p>
     </div>
   <% elsif !user_signed_in? %>

--- a/app/views/debates/new.html.erb
+++ b/app/views/debates/new.html.erb
@@ -6,7 +6,7 @@
     <h1><%= t("debates.new.start_new") %></h1>
     <div data-alert class="callout primary">
       <%= t("debates.new.info",
-      info_link: link_to(t("debates.new.info_link"), new_proposal_path )).html_safe %>
+      info_link: link_to(t("debates.new.info_link"), new_proposal_path)).html_safe %>
 
       <% if feature?(:help_page) %>
         <%= link_to help_path, title: t("shared.target_blank_html"), target: "_blank" do %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -13,7 +13,7 @@
           <p><%= f.password_field :password_confirmation %></p>
       <% end %>
 
-      <%= hidden_field_tag :confirmation_token,@confirmation_token %>
+      <%= hidden_field_tag :confirmation_token, @confirmation_token %>
 
       <div class="small-12 medium-6 small-centered">
         <%= f.submit(t("devise_views.confirmations.new.submit"), class: "button expanded") %>

--- a/app/views/direct_messages/new.html.erb
+++ b/app/views/direct_messages/new.html.erb
@@ -38,8 +38,8 @@
       <div class="callout warning">
         <p>
           <%= t("users.direct_messages.new.verified_only",
-          verify_account: link_to( t("users.direct_messages.new.verify_account"),
-                                    verification_path )).html_safe %>
+          verify_account: link_to(t("users.direct_messages.new.verify_account"),
+                                    verification_path)).html_safe %>
         </p>
       </div>
     <% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -5,6 +5,6 @@
   </li>
 <% else %>
   <li>
-    <%= link_to page, kaminari_path(url), {:remote => remote, :rel => page.next? ? "next" : page.prev? ? "prev" : nil} %>
+    <%= link_to page, kaminari_path(url), { :remote => remote, :rel => page.next? ? "next" : page.prev? ? "prev" : nil } %>
   </li>
 <% end %>

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -8,7 +8,7 @@
     <%= render "layouts/meta_tags" %>
     <title><%= content_for?(:title) ? yield(:title) : setting["org_name"] %></title>
     <%= content_for :canonical %>
-    <%= stylesheet_link_tag    "application" %>
+    <%= stylesheet_link_tag "application" %>
     <!--[if lt IE 9]>
       <%= stylesheet_link_tag "ie" %>
     <![endif]-->

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -3,7 +3,7 @@
 
   <head>
     <%= render "layouts/common_head", default_title: "Management" %>
-    <%= stylesheet_link_tag  "print", media: "print" %>
+    <%= stylesheet_link_tag "print", media: "print" %>
     <%= content_for :head %>
   </head>
 

--- a/app/views/layouts/proposals_dashboard.html.erb
+++ b/app/views/layouts/proposals_dashboard.html.erb
@@ -8,7 +8,7 @@
     <%= render "layouts/meta_tags" %>
     <title><%= content_for?(:title) ? yield(:title) : setting["org_name"] %></title>
     <%= content_for :canonical %>
-    <%= stylesheet_link_tag    "application" %>
+    <%= stylesheet_link_tag "application" %>
     <!--[if lt IE 9]>
       <%= stylesheet_link_tag "ie" %>
     <![endif]-->

--- a/app/views/legislation/processes/resume.html.erb
+++ b/app/views/legislation/processes/resume.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title) {@process.title} %>
+<% provide(:title) { @process.title } %>
 
 <%= render "legislation/processes/header", process: @process, header: :full %>
 

--- a/app/views/legislation/processes/resume_to_xlsx.xlsx.axlsx
+++ b/app/views/legislation/processes/resume_to_xlsx.xlsx.axlsx
@@ -7,10 +7,10 @@ wb.add_worksheet(name: "Resume") do |sheet|
       sheet.add_row [question.title, t("legislation.summary.comments", count: question.comments.count)]
       sheet.add_hyperlink :location => legislation_process_question_url(question.process, question), :ref => sheet.rows.last.cells.first
       question.best_comments(3).each do |comment|
-        sheet.add_row [comment.body, (comment.cached_votes_up - comment.cached_votes_down).to_s + space +t("legislation.summary.votes")]
+        sheet.add_row [comment.body, (comment.cached_votes_up - comment.cached_votes_down).to_s + space + t("legislation.summary.votes")]
         sheet.add_hyperlink :location => comment_url(comment), :ref => sheet.rows.last.cells.first
       end
-      sheet.add_row ["",""]
+      sheet.add_row ["", ""]
     end
   end
 
@@ -21,14 +21,14 @@ wb.add_worksheet(name: "Resume") do |sheet|
                      (proposal.cached_votes_total - proposal.cached_votes_down).to_s + space + t("legislation.summary.votes")]
       sheet.add_hyperlink :location => legislation_process_proposal_url(proposal.legislation_process_id, proposal), :ref => sheet.rows.last.cells.first
     end
-    sheet.add_row ["",""]
+    sheet.add_row ["", ""]
   end
 
   if @process.allegations_phase.enabled? && !@process.get_last_draft_version.nil? && !@process.get_last_draft_version.annotations.empty?
-    sheet.add_row [t("legislation.summary.comments_phase")+" ("+t("legislation.summary.version")+@process.get_last_draft_version.title+")",
+    sheet.add_row [t("legislation.summary.comments_phase") + " (" + t("legislation.summary.version") + @process.get_last_draft_version.title + ")",
                    t("legislation.annotations.index.comments_count", count: @process.get_best_annotation_comments.count)]
     @process.get_best_annotation_comments.take(10).each do |comment|
-      sheet.add_row [Legislation::Annotation.find_by(id: comment.commentable_id).quote,""]
+      sheet.add_row [Legislation::Annotation.find_by(id: comment.commentable_id).quote, ""]
       sheet.add_row [comment.body, (comment.cached_votes_up - comment.cached_votes_down).to_s + space + t("legislation.summary.votes")]
       sheet.add_hyperlink :location => comment_url(comment), :ref => sheet.rows.last.cells.first
     end

--- a/app/views/legislation/proposals/_comments.html.erb
+++ b/app/views/legislation/proposals/_comments.html.erb
@@ -4,7 +4,7 @@
       <%= render "shared/wide_order_selector", i18n_namespace: "comments" %>
 
       <% if user_signed_in? %>
-        <%= render "comments/form", {commentable: @proposal, parent_id: nil, toggeable: false} %>
+        <%= render "comments/form", { commentable: @proposal, parent_id: nil, toggeable: false } %>
       <% else %>
       <br>
 

--- a/app/views/legislation/proposals/_featured_votes.html.erb
+++ b/app/views/legislation/proposals/_featured_votes.html.erb
@@ -23,7 +23,7 @@
     <div class="participation-not-allowed" style="display:none" aria-hidden="false">
       <p>
         <%= t("votes.verified_only",
-            verify_account: link_to(t("votes.verify_account"), verification_path )).html_safe %>
+            verify_account: link_to(t("votes.verify_account"), verification_path)).html_safe %>
       </p>
     </div>
   <% elsif !user_signed_in? %>

--- a/app/views/legislation/proposals/_flag_actions.html.erb
+++ b/app/views/legislation/proposals/_flag_actions.html.erb
@@ -5,7 +5,7 @@
         <span class="icon-flag flag-disable"></span>
       </a>
       <span class="dropdown-pane" id="flag-drop-proposal-<%= proposal.id %>" data-dropdown data-auto-focus="true">
-        <%= link_to t("shared.flag"), flag_proposal_path(proposal), method: :put, remote: true, id: "flag-proposal-#{ proposal.id }" %>
+        <%= link_to t("shared.flag"), flag_proposal_path(proposal), method: :put, remote: true, id: "flag-proposal-#{proposal.id}" %>
       </span>
     <% end %>
 
@@ -14,7 +14,7 @@
         <span class="icon-flag flag-active"></span>
       </a>
       <span class="dropdown-pane" id="unflag-drop-proposal-<%= proposal.id %>" data-dropdown data-auto-focus="true">
-        <%= link_to t("shared.unflag"), unflag_proposal_path(proposal), method: :put, remote: true, id: "unflag-proposal-#{ proposal.id }" %>
+        <%= link_to t("shared.unflag"), unflag_proposal_path(proposal), method: :put, remote: true, id: "unflag-proposal-#{proposal.id}" %>
       </span>
     <% end %>
   </span>

--- a/app/views/legislation/proposals/_form.html.erb
+++ b/app/views/legislation/proposals/_form.html.erb
@@ -16,7 +16,7 @@
       <p class="help-text" id="summary-help-text"><%= t("proposals.form.proposal_summary_note") %></p>
       <%= f.text_area :summary, rows: 4, maxlength: 200, label: false,
                       placeholder: t("proposals.form.proposal_summary"),
-                      aria: {describedby: "summary-help-text"} %>
+                      aria: { describedby: "summary-help-text" } %>
     </div>
 
     <div class="ckeditor small-12 column">
@@ -28,7 +28,7 @@
       <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
       <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
       <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false,
-                                   aria: {describedby: "video-url-help-text"} %>
+                                   aria: { describedby: "video-url-help-text" } %>
     </div>
 
     <% if feature?(:allow_images) %>
@@ -43,7 +43,7 @@
 
     <div class="small-12 medium-6 column">
       <%= f.label :geozone_id,  t("proposals.form.geozone") %>
-      <%= f.select :geozone_id, geozone_select_options, {include_blank: t("geozones.none"), label: false} %>
+      <%= f.select :geozone_id, geozone_select_options, { include_blank: t("geozones.none"), label: false } %>
     </div>
 
     <div class="small-12 column">
@@ -61,7 +61,7 @@
                         label: false,
                         placeholder: t("proposals.form.tags_placeholder"),
                         class: "js-tag-list",
-                        aria: {describedby: "tag-list-help-text"} %>
+                        aria: { describedby: "tag-list-help-text" } %>
     </div>
 
     <div class="small-12 column">

--- a/app/views/legislation/proposals/_votes.html.erb
+++ b/app/views/legislation/proposals/_votes.html.erb
@@ -55,7 +55,7 @@
     <div class="participation-not-allowed" style="display:none" aria-hidden="false">
       <p>
         <%= t("legislation.proposals.not_verified",
-            verify_account: link_to(t("votes.verify_account"), verification_path )).html_safe %>
+            verify_account: link_to(t("votes.verify_account"), verification_path)).html_safe %>
       </p>
     </div>
   <% elsif !user_signed_in? %>

--- a/app/views/legislation/questions/_answer_form.html.erb
+++ b/app/views/legislation/questions/_answer_form.html.erb
@@ -1,7 +1,7 @@
 <% if question.question_options.any? %>
   <% if process.debate_phase.open? && !answer.persisted? %>
 
-    <%= form_for answer, url: legislation_process_question_answers_path(process, question, answer), remote: true , html: { class: "controls-stacked"} do |f| %>
+    <%= form_for answer, url: legislation_process_question_answers_path(process, question, answer), remote: true, html: { class: "controls-stacked" } do |f| %>
       <% question.question_options.each do |question_option| %>
         <label class="control radio <%= "is-active" if @answer.legislation_question_option_id == question_option.id %>">
           <%= f.radio_button :legislation_question_option_id, question_option.id, label: false %>

--- a/app/views/legislation/questions/_participation_not_allowed.html.erb
+++ b/app/views/legislation/questions/_participation_not_allowed.html.erb
@@ -8,7 +8,7 @@
   <div class="participation-not-allowed" style="display:none" aria-hidden="false">
     <p>
       <%= t("legislation.questions.participation.verified_only",
-          verify_account: link_to(t("legislation.questions.participation.verify_account"), verification_path )).html_safe %>
+          verify_account: link_to(t("legislation.questions.participation.verify_account"), verification_path)).html_safe %>
     </p>
   </div>
 <% elsif !user_signed_in? %>

--- a/app/views/mailer/direct_message_for_sender.html.erb
+++ b/app/views/mailer/direct_message_for_sender.html.erb
@@ -2,7 +2,7 @@
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif; font-size: 20px;">
     <%= t("mailers.direct_message_for_sender.title_html",
-        receiver: @direct_message.receiver.name ) %>
+        receiver: @direct_message.receiver.name) %>
   </p>
 
   <h2 style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif; font-size: 18px;">

--- a/app/views/management/document_verifications/index.html.erb
+++ b/app/views/management/document_verifications/index.html.erb
@@ -29,7 +29,7 @@
 
     <% if Setting.force_presence_postal_code? %>
       <div class="small-12 medium-5">
-        <%= f.text_field :postal_code, aria: {describedby: "postal-code-help-text"} %>
+        <%= f.text_field :postal_code, aria: { describedby: "postal-code-help-text" } %>
       </div>
     <% end %>
 

--- a/app/views/management/user_invites/new.html.erb
+++ b/app/views/management/user_invites/new.html.erb
@@ -5,7 +5,7 @@
   <p class="help-text" id="emails-help-text"><%= t("management.user_invites.new.info") %></p>
   <%= text_area_tag "emails", nil, rows: 5,
                     placeholder: t("management.user_invites.new.info"),
-                    aria: {describedby: "emails-help-text"} %>
+                    aria: { describedby: "emails-help-text" } %>
   <div class="small-12 medium-6 large-3">
     <input type="submit" name="" value="<%= t("management.user_invites.new.submit") %>" class="button expanded">
   </div>

--- a/app/views/officing/residence/new.html.erb
+++ b/app/views/officing/residence/new.html.erb
@@ -27,7 +27,7 @@
 
       <% if Setting.force_presence_postal_code? %>
         <div class="small-12 medium-6">
-          <%= f.text_field :postal_code, aria: {describedby: "postal-code-help-text"} %>
+          <%= f.text_field :postal_code, aria: { describedby: "postal-code-help-text" } %>
         </div>
       <% end %>
 

--- a/app/views/officing/results/new.html.erb
+++ b/app/views/officing/results/new.html.erb
@@ -1,7 +1,7 @@
 <% if @officer_assignments.any? %>
   <h2><%= t("officing.results.new.title", poll: @poll.name) %></h2>
 
-  <%= form_tag(officing_poll_results_path(@poll), {id: "officer_assignment_form"}) do %>
+  <%= form_tag(officing_poll_results_path(@poll), { id: "officer_assignment_form" }) do %>
     <div class="row">
       <div class="small-12 medium-6 column">
         <label><%= t("officing.results.new.booth") %></label>

--- a/app/views/organizations/registrations/new.html.erb
+++ b/app/views/organizations/registrations/new.html.erb
@@ -12,12 +12,12 @@
         <p class="help-text" id="responsible-name-help-text"><%= t("devise_views.organizations.registrations.new.responsible_name_note") %></p>
         <%= fo.text_field :responsible_name, placeholder: t("devise_views.organizations.registrations.new.responsible_name_label"),
                                              maxlength: Organization.responsible_name_max_length, label: false,
-                                             aria: {describedby: "responsible-name-help-text"} %>
+                                             aria: { describedby: "responsible-name-help-text" } %>
       <% end %>
 
       <%= f.email_field :email, placeholder: t("devise_views.organizations.registrations.new.email_label") %>
 
-      <%= f.text_field  :phone_number,  placeholder: t("devise_views.organizations.registrations.new.phone_number_label") %>
+      <%= f.text_field :phone_number,  placeholder: t("devise_views.organizations.registrations.new.phone_number_label") %>
 
       <%= f.invisible_captcha :address %>
 

--- a/app/views/polls/_comments.html.erb
+++ b/app/views/polls/_comments.html.erb
@@ -4,7 +4,7 @@
       <%= render "shared/wide_order_selector", i18n_namespace: "comments" %>
 
       <% if user_signed_in? %>
-        <%= render "comments/form", {commentable: @poll, parent_id: nil, toggeable: false} %>
+        <%= render "comments/form", { commentable: @poll, parent_id: nil, toggeable: false } %>
       <% else %>
       <br>
 

--- a/app/views/polls/questions/_answers_positive_negative.html.erb
+++ b/app/views/polls/questions/_answers_positive_negative.html.erb
@@ -35,7 +35,7 @@
         </tr>
       <% end %>
     </table>
-    <%= paginate answers, params: {controller: "polls/questions", action: :load_answers, id: question}, remote: true %>
+    <%= paginate answers, params: { controller: "polls/questions", action: :load_answers, id: question }, remote: true %>
 
     <%= render "/polls/questions/new_answer", question: question, token: token %>
 

--- a/app/views/proposals/_comments.html.erb
+++ b/app/views/proposals/_comments.html.erb
@@ -4,7 +4,7 @@
       <%= render "shared/wide_order_selector", i18n_namespace: "comments" %>
 
       <% if user_signed_in? %>
-        <%= render "comments/form", {commentable: @proposal, parent_id: nil, toggeable: false} %>
+        <%= render "comments/form", { commentable: @proposal, parent_id: nil, toggeable: false } %>
       <% else %>
       <br>
 

--- a/app/views/proposals/_featured_votes.html.erb
+++ b/app/views/proposals/_featured_votes.html.erb
@@ -23,7 +23,7 @@
     <div class="participation-not-allowed" style="display:none" aria-hidden="false">
       <p>
         <%= t("votes.verified_only",
-            verify_account: link_to(t("votes.verify_account"), verification_path )).html_safe %>
+            verify_account: link_to(t("votes.verify_account"), verification_path)).html_safe %>
       </p>
     </div>
   <% elsif !user_signed_in? %>

--- a/app/views/proposals/_flag_actions.html.erb
+++ b/app/views/proposals/_flag_actions.html.erb
@@ -4,7 +4,7 @@
       <span class="icon-flag flag-disable"></span>
     </a>
     <span class="dropdown-pane" id="flag-drop-proposal-<%= proposal.id %>" data-dropdown data-auto-focus="true">
-      <%= link_to t("shared.flag"), flag_proposal_path(proposal), method: :put, remote: true, id: "flag-proposal-#{ proposal.id }" %>
+      <%= link_to t("shared.flag"), flag_proposal_path(proposal), method: :put, remote: true, id: "flag-proposal-#{proposal.id}" %>
     </span>
   <% end %>
 
@@ -13,7 +13,7 @@
       <span class="icon-flag flag-active"></span>
     </a>
     <span class="dropdown-pane" id="unflag-drop-proposal-<%= proposal.id %>" data-dropdown data-auto-focus="true">
-      <%= link_to t("shared.unflag"), unflag_proposal_path(proposal), method: :put, remote: true, id: "unflag-proposal-#{ proposal.id }" %>
+      <%= link_to t("shared.unflag"), unflag_proposal_path(proposal), method: :put, remote: true, id: "unflag-proposal-#{proposal.id}" %>
     </span>
   <% end %>
 </span>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -25,7 +25,7 @@
                                         rows: 4, maxlength: 200,
                                         label: false,
                                         placeholder: t("proposals.form.proposal_summary"),
-                                        aria: {describedby: summary_help_text_id(translations_form)} %>
+                                        aria: { describedby: summary_help_text_id(translations_form) } %>
       </div>
 
       <div class="ckeditor small-12 column">
@@ -42,7 +42,7 @@
       <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
       <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"),
                                    label: false,
-                                   aria: {describedby: "video-url-help-text"} %>
+                                   aria: { describedby: "video-url-help-text" } %>
     </div>
 
     <% if feature?(:allow_images) %>
@@ -59,7 +59,7 @@
 
     <div class="small-12 medium-6 column">
       <%= f.label :geozone_id,  t("proposals.form.geozone") %>
-      <%= f.select :geozone_id, geozone_select_options, {include_blank: t("geozones.none"), label: false} %>
+      <%= f.select :geozone_id, geozone_select_options, { include_blank: t("geozones.none"), label: false } %>
     </div>
 
     <% if feature?(:map) %>
@@ -93,8 +93,8 @@
                         label: false,
                         placeholder: t("proposals.form.tags_placeholder"),
                         class: "js-tag-list tag-autocomplete",
-                        aria: {describedby: "tag-list-help-text"},
-                        data: {js_url: suggest_tags_path} %>
+                        aria: { describedby: "tag-list-help-text" },
+                        data: { js_url: suggest_tags_path } %>
     </div>
 
     <% if current_user.unverified? %>
@@ -102,7 +102,7 @@
         <%= f.label :responsible_name, t("proposals.form.proposal_responsible_name") %>
         <p class="help-text" id="responsible-name-help-text"><%= t("proposals.form.proposal_responsible_name_note") %></p>
         <%= f.text_field :responsible_name, placeholder: t("proposals.form.proposal_responsible_name"), label: false,
-                                            aria: {describedby: "responsible-name-help-text"} %>
+                                            aria: { describedby: "responsible-name-help-text" } %>
       </div>
     <% end %>
 

--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -30,7 +30,7 @@
       <div class="participation-not-allowed" style="display:none" aria-hidden="false">
         <p>
           <%= t("votes.verified_only",
-              verify_account: link_to(t("votes.verify_account"), verification_path )).html_safe %>
+              verify_account: link_to(t("votes.verify_account"), verification_path)).html_safe %>
         </p>
       </div>
     </div>

--- a/app/views/proposals/retire_form.html.erb
+++ b/app/views/proposals/retire_form.html.erb
@@ -17,7 +17,7 @@
       <div class="row">
         <div class="small-12 medium-6 large-4 column">
           <%= f.label :retired_reason,  t("proposals.retire_form.retired_reason_label") %>
-          <%= f.select :retired_reason, retire_proposals_options, {include_blank: t("proposals.retire_form.retired_reason_blank"), label: false} %>
+          <%= f.select :retired_reason, retire_proposals_options, { include_blank: t("proposals.retire_form.retired_reason_blank"), label: false } %>
         </div>
       </div>
 

--- a/app/views/relationable/_score.html.erb
+++ b/app/views/relationable/_score.html.erb
@@ -5,13 +5,13 @@
               score_positive_related_content_path(related),
               method: :put,
               remote: true,
-              id: "score-positive-related-#{ related.id }",
+              id: "score-positive-related-#{related.id}",
               class: "score-positive" %>
 
   <%= link_to t("related_content.score_negative"),
               score_negative_related_content_path(related),
               method: :put,
               remote: true,
-              id: "score-negative-related-#{ related.id }",
+              id: "score-negative-related-#{related.id}",
               class: "score-negative" %>
 </span>

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -29,11 +29,11 @@
 
     <h2><%= t("map.proposal_for_district") %></h2>
 
-    <%= form_for(@resource, url: new_url_path, method: :get ) do |f| %>
+    <%= form_for(@resource, url: new_url_path, method: :get) do |f| %>
       <div class="small-12 medium-4">
         <%= f.label :geozone_id,  t("map.select_district") %>
         <%= f.select :geozone_id, geozone_select_options,
-                     {include_blank: t("geozones.none"), label: false} %>
+                     { include_blank: t("geozones.none"), label: false } %>
       </div>
 
       <div class="actions small-12">

--- a/app/views/topics/_comments.html.erb
+++ b/app/views/topics/_comments.html.erb
@@ -11,7 +11,7 @@
       <%= paginate @comment_tree.root_comments %>
 
       <% if user_signed_in? %>
-        <%= render "comments/form", {commentable: @topic, parent_id: nil, toggeable: false} %>
+        <%= render "comments/form", { commentable: @topic, parent_id: nil, toggeable: false } %>
       <% else %>
 
       <div data-alert class="callout primary">

--- a/app/views/users/_budget_investment.html.erb
+++ b/app/views/users/_budget_investment.html.erb
@@ -6,7 +6,7 @@
     <% if can? :destroy, budget_investment %>
       <%= link_to t("shared.delete"), budget_investment_path(budget_investment.budget, budget_investment),
                   method: :delete, class: "button hollow alert expanded",
-                  data: {confirm: "#{t("users.show.delete_alert")}"} %>
+                  data: { confirm: "#{t("users.show.delete_alert")}" } %>
     <% end %>
   </td>
 </tr>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -21,7 +21,7 @@
       <p class="help-text" id="password-help-text"><%= t("devise_views.users.registrations.edit.leave_blank") %></p>
       <%= f.password_field :password, autocomplete: "off", label: false,
                                       placeholder: t("devise_views.users.registrations.edit.password_label"),
-                                      aria: {describedby: "password-help-text"} %>
+                                      aria: { describedby: "password-help-text" } %>
     </div>
 
     <div class="small-12 column">
@@ -34,7 +34,7 @@
       <p class="help-text" id="current-password-help-text"><%= t("devise_views.users.registrations.edit.need_current") %></p>
       <%= f.password_field :current_password, label: false, autocomplete: "off",
                                               placeholder: t("devise_views.users.registrations.edit.current_password_label"),
-                                              aria: {describedby: "current-password-help-text"} %>
+                                              aria: { describedby: "current-password-help-text" } %>
     </div>
 
     <div class="small-12 column">

--- a/app/views/users/registrations/finish_signup.html.erb
+++ b/app/views/users/registrations/finish_signup.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t("omniauth.finish_signup.title") %></h2>
 
-<%= form_for current_user, as: :user, url: do_finish_signup_path, html: { role: "form"} do |f| %>
+<%= form_for current_user, as: :user, url: do_finish_signup_path, html: { role: "form" } do |f| %>
   <%= render "shared/errors", resource: current_user %>
 
   <div class="callout primary">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -22,7 +22,7 @@
       <%= f.text_field :username,  autofocus: true, maxlength: User.username_max_length,
                                    placeholder: t("devise_views.users.registrations.new.username_label"),
                                    label: false,
-                                   aria: {describedby: "username-help-text"} %>
+                                   aria: { describedby: "username-help-text" } %>
 
       <%= f.invisible_captcha :address %>
 

--- a/app/views/valuation/budget_investments/_dossier_form.html.erb
+++ b/app/views/valuation/budget_investments/_dossier_form.html.erb
@@ -1,5 +1,5 @@
 <% budget = investment.budget %>
-<%= form_for(investment, url: valuate_valuation_budget_budget_investment_path(budget, investment), html: {id: "valuation_budget_investment_edit_form"}) do |f| %>
+<%= form_for(investment, url: valuate_valuation_budget_budget_investment_path(budget, investment), html: { id: "valuation_budget_investment_edit_form" }) do |f| %>
   <%= render "shared/errors", resource: investment %>
   <div class="row">
     <div class="small-12 column">

--- a/app/views/verification/letter/edit.html.erb
+++ b/app/views/verification/letter/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="row verify">
-  <% track_event(category: "verification", action: "edit_letter" ) %>
+  <% track_event(category: "verification", action: "edit_letter") %>
   <div class="small-12 medium-9 large-6 small-centered column">
     <div class="text-center">
       <h1>

--- a/app/views/verification/letter/new.html.erb
+++ b/app/views/verification/letter/new.html.erb
@@ -1,5 +1,5 @@
 <div class="verification account row">
-  <% track_event(category: "verification", action: "success_sms" ) %>
+  <% track_event(category: "verification", action: "success_sms") %>
   <div class="small-12 column">
 
     <div class="text-center">

--- a/app/views/verification/letter/show.html.erb
+++ b/app/views/verification/letter/show.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <% track_event(category: "verification", action: "start_letter" ) %>
+  <% track_event(category: "verification", action: "start_letter") %>
   <div class="small-12 column">
 
     <%= back_link_to account_path, t("verification.back") %>

--- a/app/views/verification/residence/new.html.erb
+++ b/app/views/verification/residence/new.html.erb
@@ -1,5 +1,5 @@
 <div class="verification account row">
-  <% track_event(category: "verification", action: "start_census" ) %>
+  <% track_event(category: "verification", action: "start_census") %>
   <div class="small-12 column">
 
     <div class="text-center">
@@ -75,7 +75,7 @@
         <%= f.label t("verification.residence.new.postal_code") %>
         <p class="help-text" id="postal-code-help-text"><%= t("verification.residence.new.postal_code_note") %></p>
         <div class="medium-6">
-          <%= f.text_field :postal_code, label: false, aria: {describedby: "postal-code-help-text"} %>
+          <%= f.text_field :postal_code, label: false, aria: { describedby: "postal-code-help-text" } %>
         </div>
       </div>
 

--- a/app/views/verification/sms/edit.html.erb
+++ b/app/views/verification/sms/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="verification account row">
-  <% track_event(category: "verification", action: "start_sms" ) %>
+  <% track_event(category: "verification", action: "start_sms") %>
   <div class="small-12 column">
     <div class="text-center">
 

--- a/app/views/verification/sms/new.html.erb
+++ b/app/views/verification/sms/new.html.erb
@@ -1,5 +1,5 @@
 <div class="verification account row">
-  <% track_event(category: "verification", action: "success_census" ) %>
+  <% track_event(category: "verification", action: "success_census") %>
   <div class="small-12 column">
     <div class="text-center">
 
@@ -31,7 +31,7 @@
         <p class="help-text" id="phone-text-help"><%= t("verification.sms.new.phone_note") %></p>
         <%= f.text_field :phone, label: false,
                                  placeholder: t("verification.sms.new.phone_placeholder"),
-                                 aria: {describedby: "phone-help-text"} %>
+                                 aria: { describedby: "phone-help-text" } %>
       </div>
 
       <%= f.submit t("verification.sms.new.submit_button"), class: "button success" %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_level = :warn
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   config.cache_store = :dalli_store, { value_max_bytes: 2000000 }

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -47,7 +47,7 @@ module ActsAsTaggableOn
 
     pg_search_scope :pg_search, against: :name,
                                 using: {
-                                  tsearch: {prefix: true}
+                                  tsearch: { prefix: true }
                                 },
                                 ignoring: :accents
 

--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -7,6 +7,6 @@ Ckeditor.setup do |config|
 
   config.authorize_with :cancan
 
-  config.assets_languages = Rails.application.config.i18n.available_locales.map{|l| l.to_s.downcase}
+  config.assets_languages = Rails.application.config.i18n.available_locales.map { |l| l.to_s.downcase }
   config.assets_plugins = %w[copyformatting image link magicline scayt table tableselection wsc]
 end

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -159,8 +159,8 @@ end
 section "Geolocating Investments" do
   Budget.find_each do |budget|
     budget.investments.each do |investment|
-      MapLocation.create(latitude: Setting["map.latitude"].to_f + rand(-10..10)/100.to_f,
-                         longitude: Setting["map.longitude"].to_f + rand(-10..10)/100.to_f,
+      MapLocation.create(latitude: Setting["map.latitude"].to_f + rand(-10..10) / 100.to_f,
+                         longitude: Setting["map.longitude"].to_f + rand(-10..10) / 100.to_f,
                          zoom: Setting["map.zoom"],
                          investment_id: investment.id)
     end

--- a/lib/census_api.rb
+++ b/lib/census_api.rb
@@ -116,7 +116,7 @@ class CensusApi
     end
 
     def stubbed_invalid_response
-      {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}, datos_vivienda: {}}}}
+      { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}, datos_vivienda: {}}}}
     end
 
 end

--- a/lib/graph_ql/query_type_creator.rb
+++ b/lib/graph_ql/query_type_creator.rb
@@ -14,7 +14,7 @@ module GraphQL
               type created_type
               description model.graphql_field_description
               argument :id, !types.ID
-              resolve ->(object, arguments, context) { model.public_for_api.find_by(id: arguments["id"])}
+              resolve ->(object, arguments, context) { model.public_for_api.find_by(id: arguments["id"]) }
             end
           end
 

--- a/lib/manager_authenticator.rb
+++ b/lib/manager_authenticator.rb
@@ -1,11 +1,11 @@
 class ManagerAuthenticator
 
   def initialize(data = {})
-    @manager = {login: data[:login], user_key: data[:clave_usuario], date: data[:fecha_conexion]}.with_indifferent_access
+    @manager = { login: data[:login], user_key: data[:clave_usuario], date: data[:fecha_conexion] }.with_indifferent_access
   end
 
   def auth
-    return false unless [@manager[:login], @manager[:user_key], @manager[:date]].all? {|manager| manager.present?}
+    return false unless [@manager[:login], @manager[:user_key], @manager[:date]].all? { |manager| manager.present? }
     return @manager if manager_exists? && application_authorized?
     false
   end
@@ -13,7 +13,7 @@ class ManagerAuthenticator
   private
 
     def manager_exists?
-      response = client.call(:get_status_user_data, message: { ub: {user_key: @manager[:user_key], date: @manager[:date]} }).body
+      response = client.call(:get_status_user_data, message: { ub: { user_key: @manager[:user_key], date: @manager[:date] }}).body
       parsed_response = parser.parse((response[:get_status_user_data_response][:get_status_user_data_return]))
       @manager[:login] == parsed_response["USUARIO"]["LOGIN"]
     rescue
@@ -21,7 +21,7 @@ class ManagerAuthenticator
     end
 
     def application_authorized?
-      response = client.call(:get_applications_user_list, message: { ub: {user_key: @manager[:user_key]} }).body
+      response = client.call(:get_applications_user_list, message: { ub: { user_key: @manager[:user_key] }}).body
       parsed_response = parser.parse((response[:get_applications_user_list_response][:get_applications_user_list_return]))
       aplication_value = parsed_response["APLICACIONES"]["APLICACION"]
       # aplication_value from UWEB can be an array of hashes or a hash

--- a/lib/remote_census_api.rb
+++ b/lib/remote_census_api.rb
@@ -64,7 +64,7 @@ class RemoteCensusApi
     end
 
     def parse_path(path_value)
-      path_value.split(".").map{ |section| section.to_sym } if path_value.present?
+      path_value.split(".").map { |section| section.to_sym } if path_value.present?
     end
   end
 
@@ -105,7 +105,7 @@ class RemoteCensusApi
     end
 
     def parse_path(path_value)
-      path_value.split(".").map{ |section| section.to_sym } if path_value.present?
+      path_value.split(".").map { |section| section.to_sym } if path_value.present?
     end
 
     def update_value(structure, path, value)
@@ -153,7 +153,7 @@ class RemoteCensusApi
     end
 
     def stubbed_invalid_response
-      {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}, datos_vivienda: {}}}}
+      { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}, datos_vivienda: {}}}}
     end
 
 end

--- a/lib/remote_translations/microsoft/client.rb
+++ b/lib/remote_translations/microsoft/client.rb
@@ -21,7 +21,7 @@ class RemoteTranslations::Microsoft::Client
 
     split_position = detect_split_position(text)
     start_text = text[0..split_position]
-    end_text = text[split_position + 1 .. text.size]
+    end_text = text[split_position + 1..text.size]
 
     fragments_for(start_text) + [end_text]
   end

--- a/lib/score_calculator.rb
+++ b/lib/score_calculator.rb
@@ -6,7 +6,7 @@ module ScoreCalculator
     period = [1, [max_period, resource_age(resource)].min].max
 
     votes_total = resource.votes_for.where("created_at >= ?", period.days.ago).count
-    votes_up  = resource.get_upvotes.where("created_at >= ?", period.days.ago).count
+    votes_up = resource.get_upvotes.where("created_at >= ?", period.days.ago).count
     votes_down  = votes_total - votes_up
     votes_score = votes_up - votes_down
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -10,7 +10,7 @@ describe ApplicationController do
       current_budget  = create(:budget, phase: "accepting", created_at: 1.month.ago)
       next_budget     = create(:budget, phase: "drafting",  created_at: 1.week.ago)
 
-      budget = subject.instance_eval{ current_budget }
+      budget = subject.instance_eval { current_budget }
       expect(budget).to eq(current_budget)
     end
 

--- a/spec/controllers/legislation/annotations_controller_spec.rb
+++ b/spec/controllers/legislation/annotations_controller_spec.rb
@@ -91,13 +91,13 @@ describe Legislation::AnnotationsController do
                         draft_version_id: draft_version.id,
                         legislation_annotation: {
                           "quote" => "ipsum",
-                          "ranges"=> [{
+                          "ranges" => [{
                                         "start"       => "/p[1]",
                                         "startOffset" => 6,
                                         "end"         => "/p[1]",
                                         "endOffset"   => 11
                                       }],
-                          "text"  => "una anotacion"
+                          "text" => "una anotacion"
                         }
                       }
       end.not_to change { draft_version.annotations.count }

--- a/spec/controllers/management/sessions_controller_spec.rb
+++ b/spec/controllers/management/sessions_controller_spec.rb
@@ -14,11 +14,11 @@ describe Management::SessionsController do
     end
 
     it "redirects to management root path if authorized manager with right credentials" do
-      manager = {login: "JJB033", user_key: "31415926", date: "20151031135905"}
+      manager = { login: "JJB033", user_key: "31415926", date: "20151031135905" }
       allow_any_instance_of(ManagerAuthenticator).to receive(:auth).and_return(manager)
 
       get :create, params: {
-                     login: "JJB033" ,
+                     login: "JJB033",
                      clave_usuario: "31415926",
                      fecha_conexion: "20151031135905"
                    }
@@ -54,7 +54,7 @@ describe Management::SessionsController do
 
   describe "Sign out" do
     it "destroys the session data and redirect" do
-      session[:manager] = {user_key: "31415926", date: "20151031135905", login: "JJB033"}
+      session[:manager] = { user_key: "31415926", date: "20151031135905", login: "JJB033" }
       session[:document_type] = "1"
       session[:document_number] = "12345678Z"
 

--- a/spec/controllers/management/users_controller_spec.rb
+++ b/spec/controllers/management/users_controller_spec.rb
@@ -4,7 +4,7 @@ describe Management::UsersController do
 
   describe "logout" do
     it "removes user data from the session" do
-      session[:manager] = {user_key: "31415926", date: "20151031135905", login: "JJB033"}
+      session[:manager] = { user_key: "31415926", date: "20151031135905", login: "JJB033" }
       session[:document_type] = "1"
       session[:document_number] = "12345678Z"
 

--- a/spec/factories/administration.rb
+++ b/spec/factories/administration.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
   factory :banner do
     sequence(:title) { |n| "Banner title #{n}" }
     sequence(:description) { |n| "This is the text of Banner #{n}" }
-    target_url {["/proposals", "/debates" ].sample}
+    target_url { ["/proposals", "/debates"].sample }
     post_started_at { Time.current - 7.days }
     post_ended_at { Time.current + 7.days }
     background_color { "#FF0000" }

--- a/spec/factories/analytics.rb
+++ b/spec/factories/analytics.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :ahoy_event, class: Ahoy::Event do
     id { SecureRandom.uuid }
     time { DateTime.current }
-    sequence(:name) {|n| "Event #{n} type"}
+    sequence(:name) { |n| "Event #{n} type" }
   end
 
   factory :visit  do

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -152,7 +152,7 @@ LOREM_IPSUM
     author factory: :user
     quote { "ipsum" }
     text { "a comment" }
-    ranges { [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}] }
+    ranges { [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11 }] }
     range_start { "/p[1]" }
     range_start_offset { 6 }
     range_end { "/p[1]" }

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -33,7 +33,7 @@ describe "Admin budget investments" do
     end
 
     scenario "Disabled with a feature flag" do
-      expect{ visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+      expect { visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 
   end
@@ -503,7 +503,7 @@ describe "Admin budget investments" do
       valuating.valuators.push(create(:valuator))
       valuated.valuators.push(create(:valuator))
 
-      query_params = {budget_id: budget.id, advanced_filters: ["under_valuation"]}
+      query_params = { budget_id: budget.id, advanced_filters: ["under_valuation"] }
 
       visit admin_budget_budget_investments_path(query_params)
 
@@ -1822,7 +1822,7 @@ describe "Admin budget investments" do
       visit admin_budget_budget_investments_path(budget)
 
       cookies = page.driver.browser.manage.all_cookies
-      cookie = cookies.find{|cookie| cookie[:name] == "investments-columns"}
+      cookie = cookies.find { |cookie| cookie[:name] == "investments-columns" }
       cookie_value = cookie[:value]
 
       expect(cookie_value).to eq("id,title,supports,admin,valuator,geozone," +
@@ -1876,7 +1876,7 @@ describe "Admin budget investments" do
       end
 
       cookies = page.driver.browser.manage.all_cookies
-      cookie = cookies.find{|cookie| cookie[:name] == "investments-columns"}
+      cookie = cookies.find { |cookie| cookie[:name] == "investments-columns" }
       cookie_value = cookie[:value]
 
       expect(cookie_value).to eq("id,supports,admin,geozone," +
@@ -1885,7 +1885,7 @@ describe "Admin budget investments" do
       visit admin_budget_budget_investments_path(budget)
 
       cookies = page.driver.browser.manage.all_cookies
-      cookie = cookies.find{|cookie| cookie[:name] == "investments-columns"}
+      cookie = cookies.find { |cookie| cookie[:name] == "investments-columns" }
       cookie_value = cookie[:value]
 
       expect(cookie_value).to eq("id,supports,admin,geozone,feasibility,valuation_finished," +

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -19,7 +19,7 @@ describe "Admin budgets" do
     end
 
     scenario "Disabled with a feature flag" do
-      expect{ visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+      expect { visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 
   end
@@ -93,7 +93,7 @@ describe "Admin budgets" do
     end
 
     scenario "Open filter is properly highlighted" do
-      filters_links = {"current" => "Open", "finished" => "Finished"}
+      filters_links = { "current" => "Open", "finished" => "Finished" }
 
       visit admin_budgets_path
 

--- a/spec/features/admin/change_log_spec.rb
+++ b/spec/features/admin/change_log_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Admin change log" do
-  let(:budget) {create(:budget)}
+  let(:budget) { create(:budget) }
   let(:administrator) do
     create(:administrator, user: create(:user, username: "Ana", email: "ana@admins.org"))
   end

--- a/spec/features/admin/dashboard/actions_spec.rb
+++ b/spec/features/admin/dashboard/actions_spec.rb
@@ -11,7 +11,7 @@ describe "Admin dashboard actions" do
                   "administrator",
                   "dashboard_action",
                   "new_admin_dashboard_action_path",
-                  { },
+                  {},
                   "documentable_fill_new_valid_dashboard_action",
                   "Save",
                   "Action created successfully"

--- a/spec/features/admin/debates_spec.rb
+++ b/spec/features/admin/debates_spec.rb
@@ -7,7 +7,7 @@ describe "Admin debates" do
     admin = create(:administrator)
     login_as(admin.user)
 
-    expect{ visit admin_hidden_debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit admin_hidden_debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
 
     Setting["process.debates"] = true
   end

--- a/spec/features/admin/download_settings_spec.rb
+++ b/spec/features/admin/download_settings_spec.rb
@@ -284,7 +284,7 @@ describe "Admin download settings" do
                                heading: heading,
                                price: 600,
                                ballot_lines_count: 600) }
-    let(:budget) {create :budget}
+    let(:budget) { create :budget }
 
     before do
       Budget::Result.new(budget_finished, heading).calculate_winners

--- a/spec/features/admin/emails/newsletters_spec.rb
+++ b/spec/features/admin/emails/newsletters_spec.rb
@@ -66,7 +66,7 @@ describe "Admin newsletter emails" do
 
     fill_in_newsletter_form(subject: "This is a subject",
                             segment_recipient: "Proposal authors",
-                            body: "This is a body" )
+                            body: "This is a body")
     click_button "Create Newsletter"
 
     expect(page).to have_content "Newsletter created successfully"
@@ -86,7 +86,7 @@ describe "Admin newsletter emails" do
 
     fill_in_newsletter_form(subject: "This is a subject",
                             segment_recipient: "Investment authors in the current budget",
-                            body: "This is a body" )
+                            body: "This is a body")
     click_button "Update Newsletter"
 
     expect(page).to have_content "Newsletter updated successfully"

--- a/spec/features/admin/feature_flags_spec.rb
+++ b/spec/features/admin/feature_flags_spec.rb
@@ -35,8 +35,8 @@ describe "Admin feature flags" do
       expect(page).not_to have_link "Participatory budgets"
     end
 
-    expect{ visit budget_path(budget) }.to raise_exception(FeatureFlags::FeatureDisabled)
-    expect{ visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit budget_path(budget) }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   scenario "Enable a disabled participatory process" do

--- a/spec/features/admin/hidden_budget_investments_spec.rb
+++ b/spec/features/admin/hidden_budget_investments_spec.rb
@@ -14,7 +14,7 @@ describe "Admin hidden budget investments" do
   scenario "Disabled with a feature flag" do
     Setting["process.budgets"] = nil
 
-    expect{ visit admin_hidden_budget_investments_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit admin_hidden_budget_investments_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   scenario "List shows all relevant info" do

--- a/spec/features/admin/hidden_proposals_spec.rb
+++ b/spec/features/admin/hidden_proposals_spec.rb
@@ -12,7 +12,7 @@ describe "Admin hidden proposals" do
     admin = create(:administrator)
     login_as(admin.user)
 
-    expect{ visit admin_hidden_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit admin_hidden_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   scenario "List shows all relevant info" do

--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -18,7 +18,7 @@ describe "Admin legislation draft versions" do
     scenario "Disabled with a feature flag" do
       Setting["process.legislation"] = nil
       process = create(:legislation_process)
-      expect{ visit admin_legislation_process_draft_versions_path(process) }.to raise_exception(FeatureFlags::FeatureDisabled)
+      expect { visit admin_legislation_process_draft_versions_path(process) }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 
   end

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -20,7 +20,7 @@ describe "Admin collaborative legislation" do
 
     scenario "Disabled with a feature flag" do
       Setting["process.legislation"] = nil
-      expect{ visit admin_legislation_processes_path }
+      expect { visit admin_legislation_processes_path }
       .to raise_exception(FeatureFlags::FeatureDisabled)
     end
 

--- a/spec/features/admin/legislation/questions_spec.rb
+++ b/spec/features/admin/legislation/questions_spec.rb
@@ -21,7 +21,7 @@ describe "Admin legislation questions" do
     end
 
     scenario "Disabled with a feature flag" do
-      expect{ visit admin_legislation_process_questions_path(process) }.to raise_exception(FeatureFlags::FeatureDisabled)
+      expect { visit admin_legislation_process_questions_path(process) }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 
   end

--- a/spec/features/admin/local_census_records_spec.rb
+++ b/spec/features/admin/local_census_records_spec.rb
@@ -51,7 +51,7 @@ describe "Admin local census records" do
 
     context "Search" do
       before do
-        create(:local_census_record, document_number: "X66777888" )
+        create(:local_census_record, document_number: "X66777888")
       end
 
       scenario "Should show matching records by document number at first visit" do
@@ -88,9 +88,9 @@ describe "Admin local census records" do
 
       fill_in :local_census_record_document_type, with: "DNI"
       fill_in :local_census_record_document_number, with: "#DOCUMENT"
-      select "1982" , from: :local_census_record_date_of_birth_1i
-      select "July" , from: :local_census_record_date_of_birth_2i
-      select "7" , from: :local_census_record_date_of_birth_3i
+      select "1982", from: :local_census_record_date_of_birth_1i
+      select "July", from: :local_census_record_date_of_birth_2i
+      select "7", from: :local_census_record_date_of_birth_3i
       fill_in :local_census_record_postal_code, with: "07003"
       click_on "Save"
 
@@ -120,9 +120,9 @@ describe "Admin local census records" do
 
       fill_in :local_census_record_document_type, with: "NIE"
       fill_in :local_census_record_document_number, with: "#NIE_NUMBER"
-      select "1982" , from: :local_census_record_date_of_birth_1i
-      select "August" , from: :local_census_record_date_of_birth_2i
-      select "8" , from: :local_census_record_date_of_birth_3i
+      select "1982", from: :local_census_record_date_of_birth_1i
+      select "August", from: :local_census_record_date_of_birth_2i
+      select "8", from: :local_census_record_date_of_birth_3i
       fill_in :local_census_record_postal_code, with: "07007"
       click_on "Save"
 

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -220,7 +220,7 @@ describe "Admin polls" do
         booth = create(:poll_booth, polls: [poll])
 
         booth.booth_assignments.each do |booth_assignment|
-          3.times {create(:poll_officer_assignment, booth_assignment: booth_assignment) }
+          3.times { create(:poll_officer_assignment, booth_assignment: booth_assignment) }
         end
 
         visit admin_poll_path(poll)

--- a/spec/features/admin/system_emails_spec.rb
+++ b/spec/features/admin/system_emails_spec.rb
@@ -268,7 +268,7 @@ describe "System Emails" do
       expect(page).to have_content comment.body
 
       expect(page).to have_link "Cleaner city",
-        href: admin_budget_budget_investment_url( investment.budget, investment, anchor: "comments")
+        href: admin_budget_budget_investment_url(investment.budget, investment, anchor: "comments")
     end
 
   end

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -380,7 +380,7 @@ describe "Budgets" do
 
       visit budget_path(budget)
 
-      budget.groups.each {|group| expect(page).to have_link(group.name)}
+      budget.groups.each { |group| expect(page).to have_link(group.name) }
     end
 
     scenario "Links to unfeasible and selected if balloting or later" do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -195,9 +195,9 @@ describe "Budget Investments" do
     context "Advanced search" do
 
       scenario "Search by text", :js do
-        bdgt_invest1 = create(:budget_investment, heading: heading,title: "Get Schwifty")
-        bdgt_invest2 = create(:budget_investment, heading: heading,title: "Schwifty Hello")
-        bdgt_invest3 = create(:budget_investment, heading: heading,title: "Do not show me")
+        bdgt_invest1 = create(:budget_investment, heading: heading, title: "Get Schwifty")
+        bdgt_invest2 = create(:budget_investment, heading: heading, title: "Schwifty Hello")
+        bdgt_invest3 = create(:budget_investment, heading: heading, title: "Do not show me")
 
         visit budget_investments_path(budget)
 
@@ -339,9 +339,9 @@ describe "Budget Investments" do
         context "Predefined date ranges" do
 
           scenario "Last day", :js do
-            bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 1.minute.ago)
-            bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 1.hour.ago)
-            bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 2.days.ago)
+            bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 1.minute.ago)
+            bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 1.hour.ago)
+            bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 2.days.ago)
 
             visit budget_investments_path(budget)
 
@@ -359,9 +359,9 @@ describe "Budget Investments" do
           end
 
           scenario "Last week", :js do
-            bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 1.day.ago)
-            bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 5.days.ago)
-            bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 8.days.ago)
+            bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 1.day.ago)
+            bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 5.days.ago)
+            bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 8.days.ago)
 
             visit budget_investments_path(budget)
 
@@ -379,9 +379,9 @@ describe "Budget Investments" do
           end
 
           scenario "Last month", :js do
-            bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 10.days.ago)
-            bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 20.days.ago)
-            bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 33.days.ago)
+            bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 10.days.ago)
+            bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 20.days.ago)
+            bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 33.days.ago)
 
             visit budget_investments_path(budget)
 
@@ -399,9 +399,9 @@ describe "Budget Investments" do
           end
 
           scenario "Last year", :js do
-            bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 300.days.ago)
-            bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 350.days.ago)
-            bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 370.days.ago)
+            bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 300.days.ago)
+            bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 350.days.ago)
+            bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 370.days.ago)
 
             visit budget_investments_path(budget)
 
@@ -421,9 +421,9 @@ describe "Budget Investments" do
         end
 
         scenario "Search by custom date range", :js do
-          bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 2.days.ago)
-          bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 3.days.ago)
-          bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 9.days.ago)
+          bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 2.days.ago)
+          bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 3.days.ago)
+          bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 9.days.ago)
 
           visit budget_investments_path(budget)
 
@@ -443,9 +443,9 @@ describe "Budget Investments" do
         end
 
         scenario "Search by custom invalid date range", :js do
-          bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 2.days.ago)
-          bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 3.days.ago)
-          bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 9.days.ago)
+          bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 2.days.ago)
+          bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 3.days.ago)
+          bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 9.days.ago)
 
           visit budget_investments_path(budget)
 
@@ -468,9 +468,9 @@ describe "Budget Investments" do
           ana  = create :user, official_level: 1
           john = create :user, official_level: 1
 
-          bdgt_invest1 = create(:budget_investment, heading: heading,title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
-          bdgt_invest2 = create(:budget_investment, heading: heading,title: "Hello Schwifty", author: john, created_at: 2.days.ago)
-          bdgt_invest3 = create(:budget_investment, heading: heading,title: "Save the forest")
+          bdgt_invest1 = create(:budget_investment, heading: heading, title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
+          bdgt_invest2 = create(:budget_investment, heading: heading, title: "Hello Schwifty", author: john, created_at: 2.days.ago)
+          bdgt_invest3 = create(:budget_investment, heading: heading, title: "Save the forest")
 
           visit budget_investments_path(budget)
 
@@ -861,7 +861,7 @@ describe "Budget Investments" do
     end
 
     def investments_order
-      all(".budget-investment h3").collect {|i| i.text }
+      all(".budget-investment h3").collect { |i| i.text }
     end
 
   end
@@ -1419,7 +1419,7 @@ describe "Budget Investments" do
         another_heading1 = create(:budget_heading, group: group2)
         another_heading2 = create(:budget_heading, group: group2)
 
-        heading_investment   = create(:budget_investment, heading: heading)
+        heading_investment = create(:budget_investment, heading: heading)
         another_group_investment = create(:budget_investment, heading: another_heading1)
 
         create(:vote, votable: heading_investment, voter: author)

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -54,7 +54,7 @@ describe "Votes" do
     end
 
     describe "Single investment" do
-      let(:investment) { create(:budget_investment, budget: budget, heading: heading)}
+      let(:investment) { create(:budget_investment, budget: budget, heading: heading) }
 
       scenario "Show no votes" do
         visit budget_investment_path(budget, investment)

--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -164,7 +164,7 @@ describe "Commenting Budget::Investments" do
 
   scenario "Paginated comments" do
     per_page = 10
-    (per_page + 2).times { create(:comment, commentable: investment)}
+    (per_page + 2).times { create(:comment, commentable: investment) }
 
     visit budget_investment_path(investment.budget, investment)
 

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -159,7 +159,7 @@ describe "Commenting debates" do
 
   scenario "Paginated comments" do
     per_page = 10
-    (per_page + 2).times { create(:comment, commentable: debate)}
+    (per_page + 2).times { create(:comment, commentable: debate) }
 
     visit debate_path(debate)
 

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -190,7 +190,7 @@ describe "Commenting legislation questions" do
 
   scenario "Paginated comments" do
     per_page = 10
-    (per_page + 2).times { create(:comment, commentable: legislation_annotation)}
+    (per_page + 2).times { create(:comment, commentable: legislation_annotation) }
 
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
                                                             legislation_annotation.draft_version,
@@ -623,11 +623,11 @@ describe "Commenting legislation questions" do
     let!(:draft_version) { create(:legislation_draft_version, :published) }
     let!(:annotation1) do
       create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
-                                      ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5}])
+                                      ranges: [{ "start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5 }])
     end
     let!(:annotation2) do
       create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
-                                      ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10}])
+                                      ranges: [{ "start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10 }])
     end
 
     before do

--- a/spec/features/comments/legislation_questions_spec.rb
+++ b/spec/features/comments/legislation_questions_spec.rb
@@ -166,7 +166,7 @@ describe "Commenting legislation questions" do
 
   scenario "Paginated comments" do
     per_page = 10
-    (per_page + 2).times { create(:comment, commentable: legislation_question)}
+    (per_page + 2).times { create(:comment, commentable: legislation_question) }
 
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -160,7 +160,7 @@ describe "Commenting polls" do
 
   scenario "Paginated comments" do
     per_page = 10
-    (per_page + 2).times { create(:comment, commentable: poll)}
+    (per_page + 2).times { create(:comment, commentable: poll) }
 
     visit poll_path(poll)
 

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -158,7 +158,7 @@ describe "Commenting proposals" do
 
   scenario "Paginated comments" do
     per_page = 10
-    (per_page + 2).times { create(:comment, commentable: proposal)}
+    (per_page + 2).times { create(:comment, commentable: proposal) }
 
     visit proposal_path(proposal)
 

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -173,7 +173,7 @@ describe "Commenting topics from proposals" do
     community = proposal.community
     topic = create(:topic, community: community)
     per_page = 10
-    (per_page + 2).times { create(:comment, commentable: topic)}
+    (per_page + 2).times { create(:comment, commentable: topic) }
 
     visit community_topic_path(community, topic)
 
@@ -726,7 +726,7 @@ describe "Commenting topics from budget investments" do
     community = investment.community
     topic = create(:topic, community: community)
     per_page = 10
-    (per_page + 2).times { create(:comment, commentable: topic)}
+    (per_page + 2).times { create(:comment, commentable: topic) }
 
     visit community_topic_path(community, topic)
 

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -5,7 +5,7 @@ describe "Debates" do
 
   scenario "Disabled with a feature flag" do
     Setting["process.debates"] = nil
-    expect{ visit debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   context "Concerns" do

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -184,9 +184,9 @@ describe "Legislation Draft Versions" do
     scenario "View annotations and comments" do
       draft_version = create(:legislation_draft_version, :published)
       annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
-                                                    ranges: [{"start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10}])
+                                                    ranges: [{ "start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10 }])
       create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
-                                      ranges: [{"start" => "/p[1]", "startOffset" => 12, "end" => "/p[1]", "endOffset" => 19}])
+                                      ranges: [{ "start" => "/p[1]", "startOffset" => 12, "end" => "/p[1]", "endOffset" => 19 }])
       comment = create(:comment, commentable: annotation1)
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
@@ -203,7 +203,7 @@ describe "Legislation Draft Versions" do
     scenario "Publish new comment for an annotation from comments box" do
       draft_version = create(:legislation_draft_version, :published)
       annotation = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
-                                                   ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
+                                                   ranges: [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11 }])
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
@@ -227,9 +227,9 @@ describe "Legislation Draft Versions" do
     scenario "View annotations and comments in an included range" do
       draft_version = create(:legislation_draft_version, :published)
       annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
-                                                    ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5}])
+                                                    ranges: [{ "start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5 }])
       annotation2 = create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
-                                                    ranges: [{"start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10}])
+                                                    ranges: [{ "start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10 }])
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
@@ -249,9 +249,9 @@ describe "Legislation Draft Versions" do
     before do
       @draft_version = create(:legislation_draft_version, :published)
       create(:legislation_annotation, draft_version: @draft_version, text: "my annotation",       quote: "ipsum",
-                                      ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
+                                      ranges: [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11 }])
       create(:legislation_annotation, draft_version: @draft_version, text: "my other annotation", quote: "audiam",
-                                      ranges: [{"start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}])
+                                      ranges: [{ "start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11 }])
     end
 
     scenario "See all annotations for a draft version" do
@@ -267,11 +267,11 @@ describe "Legislation Draft Versions" do
         @draft_version_1 = create(:legislation_draft_version, :published, process: @process,
                                                                           title: "Version 1", body: "Text with quote for version 1")
         create(:legislation_annotation, draft_version: @draft_version_1, text: "annotation for version 1", quote: "quote for version 1",
-                                        ranges: [{"start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30}])
+                                        ranges: [{ "start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30 }])
         @draft_version_2 = create(:legislation_draft_version, :published, process: @process,
                                                                           title: "Version 2", body: "Text with quote for version 2")
         create(:legislation_annotation, draft_version: @draft_version_2, text: "annotation for version 2", quote: "quote for version 2",
-                                        ranges: [{"start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30}])
+                                        ranges: [{ "start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30 }])
       end
 
       scenario "without js" do
@@ -301,9 +301,9 @@ describe "Legislation Draft Versions" do
     before do
       @draft_version = create(:legislation_draft_version, :published)
       create(:legislation_annotation, draft_version: @draft_version, text: "my annotation", quote: "ipsum",
-                                      ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11}])
+                                      ranges: [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11 }])
       @annotation = create(:legislation_annotation, draft_version: @draft_version, text: "my other annotation", quote: "audiam",
-                                                    ranges: [{"start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}])
+                                                    ranges: [{ "start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11 }])
     end
 
     scenario "See one annotation with replies for a draft version" do

--- a/spec/features/legislation/resume_spec.rb
+++ b/spec/features/legislation/resume_spec.rb
@@ -180,13 +180,13 @@ describe "Legislation" do
                                status: "published")
       annotation0 = create(:legislation_annotation,
                            draft_version: draft_version_1, text: "my annotation123",
-                           ranges: [{"start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10}])
+                           ranges: [{ "start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10 }])
       annotation1 = create(:legislation_annotation,
                            draft_version: draft_version_2, text: "hola",
-                           ranges: [{"start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10}])
+                           ranges: [{ "start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10 }])
       annotation2 = create(:legislation_annotation,
                            draft_version: draft_version_2,
-                           ranges: [{"start" => "/p[1]", "startOffset" => 12, "end" => "/p[1]", "endOffset" => 19}])
+                           ranges: [{ "start" => "/p[1]", "startOffset" => 12, "end" => "/p[1]", "endOffset" => 19 }])
       create(:text_comment, user: user, commentable_id: annotation0.id, body: "Comment 0")
       create(:text_comment, user: user, commentable_id: annotation1.id, body: "Comment 1")
       create(:text_comment, user: user, commentable_id: annotation2.id, body: "Comment 2")
@@ -238,7 +238,7 @@ describe "Legislation" do
     end
 
     it "download execl file test" do
-      get :resume, params: {id: @process, format: :xlsx}
+      get :resume, params: { id: @process, format: :xlsx }
       expect(response).to be_success
     end
   end

--- a/spec/features/moderation/budget_investments_spec.rb
+++ b/spec/features/moderation/budget_investments_spec.rb
@@ -15,7 +15,7 @@ describe "Moderate budget investments" do
     Setting["process.budgets"] = nil
     login_as(@mod.user)
 
-    expect{ visit moderation_budget_investments_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit moderation_budget_investments_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   scenario "Hiding an investment", :js do

--- a/spec/features/moderation/debates_spec.rb
+++ b/spec/features/moderation/debates_spec.rb
@@ -7,7 +7,7 @@ describe "Moderate debates" do
     moderator = create(:moderator)
     login_as(moderator.user)
 
-    expect{ visit moderation_debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit moderation_debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   scenario "Hide", :js do

--- a/spec/features/moderation/proposals_spec.rb
+++ b/spec/features/moderation/proposals_spec.rb
@@ -7,7 +7,7 @@ describe "Moderate proposals" do
     moderator = create(:moderator)
     login_as(moderator.user)
 
-    expect{ visit moderation_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit moderation_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   scenario "Hide", :js do

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -178,8 +178,8 @@ describe "Voters" do
 
     second_booth = create(:poll_booth)
 
-    ba1 = create(:poll_booth_assignment, poll: poll1, booth: second_booth )
-    ba2 = create(:poll_booth_assignment, poll: poll2, booth: second_booth )
+    ba1 = create(:poll_booth_assignment, poll: poll1, booth: second_booth)
+    ba2 = create(:poll_booth_assignment, poll: poll2, booth: second_booth)
     create(:poll_shift, officer: officer, booth: second_booth, date: Date.current, task: :vote_collection)
 
     validate_officer

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -9,7 +9,7 @@ describe "Proposals" do
 
   scenario "Disabled with a feature flag" do
     Setting["process.proposals"] = nil
-    expect{ visit proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   context "Concerns" do
@@ -1621,7 +1621,7 @@ describe "Proposals" do
   it_behaves_like "nested imageable",
                   "proposal",
                   "new_proposal_path",
-                  { },
+                  {},
                   "imageable_fill_new_valid_proposal",
                   "Create proposal",
                   "Proposal created successfully"
@@ -1640,7 +1640,7 @@ describe "Proposals" do
                   "user",
                   "proposal",
                   "new_proposal_path",
-                  { },
+                  {},
                   "documentable_fill_new_valid_proposal",
                   "Create proposal",
                   "Proposal created successfully"
@@ -1660,7 +1660,7 @@ describe "Proposals" do
                   "new_proposal_path",
                   "edit_proposal_path",
                   "proposal_path",
-                  { }
+                  {}
 
   scenario "Erased author" do
     user = create(:user)

--- a/spec/features/social_media_meta_tags_spec.rb
+++ b/spec/features/social_media_meta_tags_spec.rb
@@ -41,7 +41,7 @@ describe "Social media meta tags" do
       expect(page).to have_meta "twitter:title", with: meta_title
       expect(page).to have_meta "twitter:description", with: meta_description
       expect(page).to have_meta "twitter:image",
-                                 with:"http://www.example.com/social_media_icon_twitter.png"
+                                 with: "http://www.example.com/social_media_icon_twitter.png"
 
       expect(page).to have_property "og:title", with: meta_title
       expect(page).to have_property "article:publisher", with: url

--- a/spec/features/tracking/budget_investments_spec.rb
+++ b/spec/features/tracking/budget_investments_spec.rb
@@ -13,7 +13,7 @@ describe "Valuation budget investments" do
 
   scenario "Disabled with a feature flag" do
     Setting["process.budgets"] = nil
-    expect{
+    expect {
       visit tracking_budget_budget_investments_path(create(:budget))
     }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
@@ -161,7 +161,7 @@ describe "Valuation budget investments" do
       logout
       login_as create(:tracker).user
 
-      expect{
+      expect {
         visit tracking_budget_budget_investment_path(budget, investment)
       }.to raise_error "Not Found"
     end
@@ -273,7 +273,7 @@ describe "Valuation budget investments" do
       logout
       login_as create(:tracker, user: create(:user)).user
 
-      expect{
+      expect {
         visit tracking_budget_budget_investment_progress_bars_path(budget, investment)
       }.to raise_error "Not Found"
     end

--- a/spec/features/tracking/budgets_spec.rb
+++ b/spec/features/tracking/budgets_spec.rb
@@ -10,7 +10,7 @@ describe "Tracking budgets" do
 
   scenario "Disabled with a feature flag" do
     Setting["process.budgets"] = nil
-    expect{ visit tracking_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit tracking_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   context "Index" do

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -106,8 +106,8 @@ describe "Users" do
   context "OAuth authentication" do
     context "Twitter" do
 
-      let(:twitter_hash){ {provider: "twitter", uid: "12345", info: {name: "manuela"}} }
-      let(:twitter_hash_with_email){ {provider: "twitter", uid: "12345", info: {name: "manuela", email: "manuelacarmena@example.com"}} }
+      let(:twitter_hash) { { provider: "twitter", uid: "12345", info: { name: "manuela" }} }
+      let(:twitter_hash_with_email) { { provider: "twitter", uid: "12345", info: { name: "manuela", email: "manuelacarmena@example.com" }} }
       let(:twitter_hash_with_verified_email) do
         {
           provider: "twitter",

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -6,10 +6,10 @@ describe "Users" do
 
     before do
       @user = create(:user)
-      1.times {create(:debate, author: @user)}
-      2.times {create(:proposal, author: @user)}
-      3.times {create(:budget_investment, author: @user)}
-      4.times {create(:comment, user: @user)}
+      1.times { create(:debate, author: @user) }
+      2.times { create(:proposal, author: @user) }
+      3.times { create(:budget_investment, author: @user) }
+      4.times { create(:comment, user: @user) }
 
       visit user_path(@user)
     end
@@ -401,9 +401,9 @@ describe "Users" do
 
     scenario "shows only comments from active features" do
       user = create(:user)
-      1.times {create(:comment, user: user, commentable: create(:debate))}
-      2.times {create(:comment, user: user, commentable: create(:budget_investment))}
-      4.times {create(:comment, user: user, commentable: create(:proposal))}
+      1.times { create(:comment, user: user, commentable: create(:debate)) }
+      2.times { create(:comment, user: user, commentable: create(:budget_investment)) }
+      4.times { create(:comment, user: user, commentable: create(:proposal)) }
 
       visit user_path(user)
       expect(page).to have_content("7 Comments")

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -37,7 +37,7 @@ describe "Valuation budget investments" do
 
   scenario "Disabled with a feature flag" do
     Setting["process.budgets"] = nil
-    expect{
+    expect {
       visit valuation_budget_budget_investments_path(create(:budget))
     }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
@@ -188,8 +188,8 @@ describe "Valuation budget investments" do
     end
 
     scenario "Current filter is properly highlighted" do
-      filters_links = {"valuating" => "Under valuation",
-                       "valuation_finished" => "Valuation finished"}
+      filters_links = { "valuating" => "Under valuation",
+                        "valuation_finished" => "Valuation finished" }
 
       visit valuation_budget_budget_investments_path(budget)
 
@@ -298,7 +298,7 @@ describe "Valuation budget investments" do
       logout
       login_as create(:valuator).user
 
-      expect{
+      expect {
         visit valuation_budget_budget_investment_path(budget, investment)
       }.to raise_error "Not Found"
     end

--- a/spec/features/valuation/budgets_spec.rb
+++ b/spec/features/valuation/budgets_spec.rb
@@ -9,7 +9,7 @@ describe "Valuation budgets" do
 
   scenario "Disabled with a feature flag" do
     Setting["process.budgets"] = nil
-    expect{ visit valuation_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect { visit valuation_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
   end
 
   context "Index" do

--- a/spec/helpers/votes_helper_spec.rb
+++ b/spec/helpers/votes_helper_spec.rb
@@ -5,14 +5,14 @@ describe VotesHelper do
   describe "#voted_for?" do
     it "returns true if voted for a proposal" do
       proposal = create(:proposal)
-      votes = {proposal.id => true}
+      votes = { proposal.id => true }
 
       expect(voted_for?(votes, proposal)).to eq(true)
     end
 
     it "returns false if not voted for a proposals" do
       proposal = create(:proposal)
-      votes = {proposal.id => nil}
+      votes = { proposal.id => nil }
 
       expect(voted_for?(votes, proposal)).to eq(nil)
     end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -40,7 +40,7 @@ describe "I18n" do
                other: "%{count} comments" }
 
       I18n.backend.store_translations(I18n.default_locale, { test_plural: keys })
-      I18n.backend.store_translations(:zz, {} )
+      I18n.backend.store_translations(:zz, {})
 
       I18n.enforce_available_locales = false
       I18n.locale = :zz

--- a/spec/lib/cache_spec.rb
+++ b/spec/lib/cache_spec.rb
@@ -7,7 +7,7 @@ describe "Cache flow" do
       debate = create(:debate, tag_list: "Good, Bad")
       tag = ActsAsTaggableOn::Tag.find_by(name: "Bad")
 
-      expect{tag.destroy}.to change {debate.reload.cache_key}
+      expect { tag.destroy }.to change { debate.reload.cache_key }
     end
   end
 

--- a/spec/lib/census_api_spec.rb
+++ b/spec/lib/census_api_spec.rb
@@ -4,7 +4,7 @@ describe CensusApi do
   let(:api) { described_class.new }
 
   describe "#call" do
-    let(:invalid_body) { {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}}}} }
+    let(:invalid_body) { { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}}}} }
     let(:valid_body) do
       {
         get_habita_datos_response: {

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -6,7 +6,7 @@ describe CensusCaller do
   describe "#call" do
     it "returns data from local_census_records if census API is not available" do
       census_api_response = CensusApi::Response.new(get_habita_datos_response: {
-          get_habita_datos_return: { datos_habitante: {}, datos_vivienda: {} }
+          get_habita_datos_return: { datos_habitante: {}, datos_vivienda: {}}
         }
       )
 
@@ -26,7 +26,7 @@ describe CensusCaller do
     it "returns data from census API if it's available and valid" do
       census_api_response = CensusApi::Response.new(get_habita_datos_response: {
         get_habita_datos_return: {
-          datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" } }
+          datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" }}
         }
       })
 
@@ -58,7 +58,7 @@ describe CensusCaller do
 
         remote_census_api_response = RemoteCensusApi::Response.new(get_habita_datos_response: {
           get_habita_datos_return: {
-            datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" } }
+            datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" }}
           }
         })
 
@@ -82,7 +82,7 @@ describe CensusCaller do
 
         remote_census_api_response = RemoteCensusApi::Response.new(get_habita_datos_response: {
           get_habita_datos_return: {
-            datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" } }
+            datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" }}
           }
         })
 

--- a/spec/lib/evaluation_comment_email_spec.rb
+++ b/spec/lib/evaluation_comment_email_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe EvaluationCommentEmail do
 
   let(:author)        { create(:user) }
-  let(:administrator) { create(:administrator)}
+  let(:administrator) { create(:administrator) }
   let(:investment)    { create(:budget_investment, author: author, administrator: administrator) }
   let(:commenter)     { create(:user, email: "email@commenter.org") }
   let(:comment)       { create(:comment, commentable: investment, user: commenter) }

--- a/spec/lib/graph_ql/query_type_creator_spec.rb
+++ b/spec/lib/graph_ql/query_type_creator_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe GraphQL::QueryTypeCreator do
   let(:api_type_definitions) do
     {
-      ProposalNotification => { fields: { title: :string } },
-      Proposal => { fields: { id: :integer, title: :string } }
+      ProposalNotification => { fields: { title: :string }},
+      Proposal => { fields: { id: :integer, title: :string }}
     }
   end
   let(:api_types) { GraphQL::ApiTypesCreator.create(api_type_definitions) }

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -435,7 +435,7 @@ describe "Consul Schema" do
 
   describe "Geozones" do
     it "returns geozones" do
-      geozone_names = [ create(:geozone), create(:geozone) ].map { |geozone| geozone.name }
+      geozone_names = [create(:geozone), create(:geozone)].map { |geozone| geozone.name }
 
       response = execute("{ geozones { edges { node { name } } } }")
       received_names = extract_fields(response, "geozones", "name")

--- a/spec/lib/manager_authenticator_spec.rb
+++ b/spec/lib/manager_authenticator_spec.rb
@@ -45,7 +45,7 @@ describe ManagerAuthenticator do
 
   describe "SOAP" do
     it "calls the verification user method" do
-      message = { ub: {user_key: "31415926", date: "20151031135905"} }
+      message = { ub: { user_key: "31415926", date: "20151031135905" }}
       allow(authenticator).to receive(:application_authorized?).and_return(true)
       allow(authenticator.send(:client)).to receive(:call).with(:get_status_user_data, message: message)
       authenticator.auth
@@ -53,7 +53,7 @@ describe ManagerAuthenticator do
 
     it "calls the permissions check method" do
       allow(authenticator).to receive(:manager_exists?).and_return(true)
-      allow(authenticator.send(:client)).to receive(:call).with(:get_applications_user_list, message: { ub: {user_key: "31415926"} })
+      allow(authenticator.send(:client)).to receive(:call).with(:get_applications_user_list, message: { ub: { user_key: "31415926" }})
       authenticator.auth
     end
   end

--- a/spec/lib/remote_census_api_spec.rb
+++ b/spec/lib/remote_census_api_spec.rb
@@ -4,7 +4,7 @@ describe RemoteCensusApi do
   let(:api) { described_class.new }
 
   describe "#call" do
-    let(:invalid_body) { {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}}}} }
+    let(:invalid_body) { { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}}}} }
     let(:valid_body) do
       {
         get_habita_datos_response: {
@@ -86,33 +86,33 @@ describe RemoteCensusApi do
 
       request = RemoteCensusApi.new.send(:request, document_type, document_number, nil, nil)
 
-      expect(request).to eq ({:request=>
-                              {:codigo_institucion=>1,
-                               :codigo_portal=>1,
-                               :codigo_usuario=>1,
-                               :documento=>"0123456",
-                               :tipo_documento=>"1",
-                               :codigo_idioma=>"102",
-                               :nivel=>"3"}
+      expect(request).to eq ({ :request =>
+                              { :codigo_institucion => 1,
+                               :codigo_portal => 1,
+                               :codigo_usuario => 1,
+                               :documento => "0123456",
+                               :tipo_documento => "1",
+                               :codigo_idioma => "102",
+                               :nivel => "3" }
                               })
     end
 
     it "when send date_of_birth and postal_code but are not configured" do
       document_type = "1"
       document_number = "0123456"
-      date_of_birth =  Date.new(1980, 1, 1)
+      date_of_birth = Date.new(1980, 1, 1)
       postal_code = "28001"
 
       request = RemoteCensusApi.new.send(:request, document_type, document_number, date_of_birth, postal_code)
 
-      expect(request).to eq ({:request=>
-                              {:codigo_institucion=>1,
-                               :codigo_portal=>1,
-                               :codigo_usuario=>1,
-                               :documento=>"0123456",
-                               :tipo_documento=>"1",
-                               :codigo_idioma=>"102",
-                               :nivel=>"3"}
+      expect(request).to eq ({ :request =>
+                              { :codigo_institucion => 1,
+                               :codigo_portal => 1,
+                               :codigo_usuario => 1,
+                               :documento => "0123456",
+                               :tipo_documento => "1",
+                               :codigo_idioma => "102",
+                               :nivel => "3" }
                               })
     end
 
@@ -132,21 +132,21 @@ describe RemoteCensusApi do
       Setting["remote_census.request.postal_code"] = "request.codigo_postal"
       document_type = "1"
       document_number = "0123456"
-      date_of_birth =  Date.new(1980, 1, 1)
+      date_of_birth = Date.new(1980, 1, 1)
       postal_code = "28001"
 
       request = RemoteCensusApi.new.send(:request, document_type, document_number, date_of_birth, postal_code)
 
-      expect(request).to eq ({:request=>
-                              {:codigo_institucion=>1,
-                               :codigo_portal=>1,
-                               :codigo_usuario=>1,
-                               :documento=>"0123456",
-                               :tipo_documento=>"1",
-                               :fecha_nacimiento=>"1980-01-01",
-                               :codigo_postal=>"28001",
-                               :codigo_idioma=>"102",
-                               :nivel=>"3"}
+      expect(request).to eq ({ :request =>
+                              { :codigo_institucion => 1,
+                               :codigo_portal => 1,
+                               :codigo_usuario => 1,
+                               :documento => "0123456",
+                               :tipo_documento => "1",
+                               :fecha_nacimiento => "1980-01-01",
+                               :codigo_postal => "28001",
+                               :codigo_idioma => "102",
+                               :nivel => "3" }
                               })
     end
 

--- a/spec/lib/remote_translations/microsoft/client_spec.rb
+++ b/spec/lib/remote_translations/microsoft/client_spec.rb
@@ -12,7 +12,7 @@ describe RemoteTranslations::Microsoft::Client do
 
         expect_any_instance_of(TranslatorText::Client).to receive(:translate).and_return(response)
 
-        result = client.call([ "New title", "New description"], :es)
+        result = client.call(["New title", "New description"], :es)
 
         expect(result).to eq(["Nuevo título", "Nueva descripción"])
       end

--- a/spec/lib/tasks/dashboards_spec.rb
+++ b/spec/lib/tasks/dashboards_spec.rb
@@ -31,7 +31,7 @@ describe "Dashboards Rake" do
         action.update(published_proposal: true)
         resource.update(published_proposal: true)
 
-        expect {run_rake_task}.to change { ActionMailer::Base.deliveries.count }.by(0)
+        expect { run_rake_task }.to change { ActionMailer::Base.deliveries.count }.by(0)
       end
 
       it "when there are not news actions actived for draft proposals" do
@@ -39,7 +39,7 @@ describe "Dashboards Rake" do
         action.update(published_proposal: false)
         resource.update(published_proposal: false)
 
-        expect {run_rake_task}.to change { ActionMailer::Base.deliveries.count }.by(0)
+        expect { run_rake_task }.to change { ActionMailer::Base.deliveries.count }.by(0)
       end
 
       it "when there are news actions actived for archived proposals" do
@@ -47,7 +47,7 @@ describe "Dashboards Rake" do
         action.update(day_offset: 0, published_proposal: true)
         resource.update(day_offset: 0, published_proposal: true)
 
-        expect {run_rake_task}.to change { ActionMailer::Base.deliveries.count }.by(0)
+        expect { run_rake_task }.to change { ActionMailer::Base.deliveries.count }.by(0)
       end
 
     end

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -8,7 +8,7 @@ describe UserSegments do
   describe "#all_users" do
     it "returns all active users enabled" do
       active_user = create(:user)
-      erased_user  = create(:user, erased_at: Time.current)
+      erased_user = create(:user, erased_at: Time.current)
 
       expect(described_class.all_users).to include active_user
       expect(described_class.all_users).not_to include erased_user

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -88,10 +88,10 @@ describe Abilities::Administrator do
   it { should be_able_to(:stats, poll) }
   it { should be_able_to(:results, poll) }
 
-  it { should be_able_to(:read, Poll::Question)}
-  it { should be_able_to(:create, Poll::Question)}
-  it { should be_able_to(:update, Poll::Question)}
-  it { should be_able_to(:get_options_traductions, Poll::Question)}
+  it { should be_able_to(:read, Poll::Question) }
+  it { should be_able_to(:create, Poll::Question) }
+  it { should be_able_to(:update, Poll::Question) }
+  it { should be_able_to(:get_options_traductions, Poll::Question) }
 
   it { is_expected.to be_able_to :manage, Dashboard::AdministratorTask }
   it { is_expected.to be_able_to :manage, dashboard_administrator_task }

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -189,7 +189,7 @@ describe Abilities::Common do
   describe "when level 2 verified" do
     let(:own_direct_message) { create(:direct_message, sender: user) }
 
-    before{ user.update(residence_verified_at: Time.current, confirmed_phone: "1") }
+    before { user.update(residence_verified_at: Time.current, confirmed_phone: "1") }
 
     describe "Proposal" do
       it { should be_able_to(:vote, Proposal) }
@@ -274,7 +274,7 @@ describe Abilities::Common do
   describe "when level 3 verified" do
     let(:own_direct_message) { create(:direct_message, sender: user) }
 
-    before{ user.update(verified_at: Time.current) }
+    before { user.update(verified_at: Time.current) }
 
     it { should be_able_to(:vote, Proposal)          }
     it { should be_able_to(:vote_featured, Proposal) }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -23,7 +23,7 @@ describe Activity do
       user = create(:user)
       proposal = create(:proposal)
 
-      expect{ described_class.log(user, :hide, proposal) }.to change { described_class.count }.by(1)
+      expect { described_class.log(user, :hide, proposal) }.to change { described_class.count }.by(1)
 
       activity = described_class.last
       expect(activity.user_id).to eq(user.id)

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Administrator do
 
   describe "#description_or_name" do
-    let!(:user) { create(:user, username: "Billy Wilder" )}
+    let!(:user) { create(:user, username: "Billy Wilder") }
 
     it "returns description if present" do
       administrator = create(:administrator, user: user, description: "John Doe")
@@ -25,7 +25,7 @@ describe Administrator do
   end
 
   describe "#description_or_name_and_email" do
-    let!(:user) { create(:user, username: "Billy Wilder", email: "test@test.com")}
+    let!(:user) { create(:user, username: "Billy Wilder", email: "test@test.com") }
 
     it "returns description and email if decription present" do
       administrator = create(:administrator,

--- a/spec/models/budget/ballot/line_spec.rb
+++ b/spec/models/budget/ballot/line_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 describe Budget::Ballot::Line do
 
-  let(:budget){ create(:budget) }
-  let(:group){ create(:budget_group, budget: budget) }
-  let(:heading){ create(:budget_heading, group: group, price: 10000000) }
-  let(:investment){ create(:budget_investment, :selected, price: 5000000, heading: heading) }
+  let(:budget) { create(:budget) }
+  let(:group) { create(:budget_group, budget: budget) }
+  let(:heading) { create(:budget_heading, group: group, price: 10000000) }
+  let(:investment) { create(:budget_investment, :selected, price: 5000000, heading: heading) }
   let(:ballot) { create(:budget_ballot, budget: budget) }
   let(:ballot_line) { build(:budget_ballot_line, ballot: ballot, investment: investment) }
 

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -124,7 +124,7 @@ describe Budget::Investment do
     end
 
     it "send an email" do
-      expect {investment.send_unfeasible_email}.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect { investment.send_unfeasible_email }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
   end
 
@@ -137,7 +137,7 @@ describe Budget::Investment do
     end
 
     it "returns false in any other phase" do
-      Budget::Phase::PHASE_KINDS.reject {|phase| phase == "selecting"}.each do |phase|
+      Budget::Phase::PHASE_KINDS.reject { |phase| phase == "selecting" }.each do |phase|
         budget = create(:budget, phase: phase)
         investment = create(:budget_investment, budget: budget)
 
@@ -155,7 +155,7 @@ describe Budget::Investment do
     end
 
     it "returns false in any other phase" do
-      Budget::Phase::PHASE_KINDS.reject {|phase| phase == "valuating"}.each do |phase|
+      Budget::Phase::PHASE_KINDS.reject { |phase| phase == "valuating" }.each do |phase|
         budget = create(:budget, phase: phase)
         investment = create(:budget_investment, budget: budget)
 
@@ -180,7 +180,7 @@ describe Budget::Investment do
     end
 
     it "returns false in any other phase" do
-      Budget::Phase::PHASE_KINDS.reject {|phase| phase == "balloting"}.each do |phase|
+      Budget::Phase::PHASE_KINDS.reject { |phase| phase == "balloting" }.each do |phase|
         budget = create(:budget, phase: phase)
         investment = create(:budget_investment, :selected, budget: budget)
 
@@ -386,17 +386,17 @@ describe Budget::Investment do
     let!(:investment) { create(:budget_investment, :feasible, heading: heading) }
 
     it "finds budget by id or slug" do
-      result = described_class.scoped_filter({budget_id: budget.id}, nil)
+      result = described_class.scoped_filter({ budget_id: budget.id }, nil)
       expect(result.count).to be 1
       expect(result.first.id).to be investment.id
 
-      result = described_class.scoped_filter({budget_id: "budget_slug"}, nil)
+      result = described_class.scoped_filter({ budget_id: "budget_slug" }, nil)
       expect(result.count).to be 1
       expect(result.first.id).to be investment.id
     end
 
     it "does not raise error if budget is not found" do
-      result = described_class.scoped_filter({budget_id: "wrong_budget"}, nil)
+      result = described_class.scoped_filter({ budget_id: "wrong_budget" }, nil)
       expect(result).to be_empty
     end
 
@@ -1094,7 +1094,7 @@ describe Budget::Investment do
       end
 
       it "returns false if budget is not balloting phase" do
-        Budget::Phase::PHASE_KINDS.reject {|phase| phase == "balloting"}.each do |phase|
+        Budget::Phase::PHASE_KINDS.reject { |phase| phase == "balloting" }.each do |phase|
           budget.update(phase: phase)
           investment = create(:budget_investment, budget: budget)
 
@@ -1215,7 +1215,7 @@ describe Budget::Investment do
     let(:investment) { create(:budget_investment, budget: budget) }
 
     describe "with without_admin filter" do
-      let(:params) { {advanced_filters: ["without_admin"], budget_id: budget.id} }
+      let(:params) { { advanced_filters: ["without_admin"], budget_id: budget.id } }
       it "returns only investment without admin" do
         create(:budget_investment,
           :finished,
@@ -1230,7 +1230,7 @@ describe Budget::Investment do
     end
 
     describe "with without_valuator filter" do
-      let(:params) { {advanced_filters: ["without_valuator"], budget_id: budget.id} }
+      let(:params) { { advanced_filters: ["without_valuator"], budget_id: budget.id } }
       it "returns only investment without valuator" do
         create(:budget_investment,
           :finished,
@@ -1248,7 +1248,7 @@ describe Budget::Investment do
     end
 
     describe "with under_valuation filter" do
-      let(:params) { {advanced_filters: ["under_valuation"], budget_id: budget.id} }
+      let(:params) { { advanced_filters: ["under_valuation"], budget_id: budget.id } }
       it "returns only investment under valuation" do
         valuator1 = create(:valuator)
         investment1 = create(:budget_investment,
@@ -1265,7 +1265,7 @@ describe Budget::Investment do
     end
 
     describe "with valuation_finished filter" do
-      let(:params) { {advanced_filters: ["valuation_finished"], budget_id: budget.id} }
+      let(:params) { { advanced_filters: ["valuation_finished"], budget_id: budget.id } }
       it "returns only investment with valuation finished" do
         investment1 = create(:budget_investment,
           :selected,
@@ -1281,7 +1281,7 @@ describe Budget::Investment do
     end
 
     describe "with winners filter" do
-      let(:params) { {advanced_filters: ["winners"], budget_id: budget.id} }
+      let(:params) { { advanced_filters: ["winners"], budget_id: budget.id } }
       it "returns only investment winners" do
         investment1 = create(:budget_investment,
           :winner,
@@ -1327,7 +1327,7 @@ describe Budget::Investment do
 
   describe "milestone_tags" do
     context "without milestone_tags" do
-      let(:investment) {create(:budget_investment)}
+      let(:investment) { create(:budget_investment) }
 
       it "do not have milestone_tags" do
         expect(investment.milestone_tag_list).to eq([])
@@ -1342,7 +1342,7 @@ describe Budget::Investment do
     end
 
     context "with milestone_tags" do
-      let(:investment) {create(:budget_investment, :with_milestone_tags)}
+      let(:investment) { create(:budget_investment, :with_milestone_tags) }
 
       it "has milestone_tags" do
         expect(investment.milestone_tag_list.count).to eq(1)

--- a/spec/models/budget/phase_spec.rb
+++ b/spec/models/budget/phase_spec.rb
@@ -7,7 +7,7 @@ describe Budget::Phase do
   let(:second_phase)  { budget.phases.informing }
   let(:third_phase) { budget.phases.accepting }
   let(:fourth_phase)  { budget.phases.reviewing }
-  let(:final_phase) { budget.phases.finished}
+  let(:final_phase) { budget.phases.finished }
 
   describe "validates" do
     it "is not valid without a budget" do
@@ -136,17 +136,17 @@ describe Budget::Phase do
       end
 
       it "adjusts previous enabled phase end date to its own start date" do
-        expect{
+        expect {
           second_phase.update_attributes(enabled: true)
-        }.to change{
+        }.to change {
           prev_enabled_phase.ends_at.to_date
         }.to(Date.current)
       end
 
       it "adjusts next enabled phase start date to its own end date" do
-        expect{
+        expect {
           second_phase.update_attributes(enabled: true)
-        }.to change{
+        }.to change {
           next_enabled_phase.starts_at.to_date
         }.to(Date.current + 2.days)
       end
@@ -161,14 +161,14 @@ describe Budget::Phase do
         expect {
           second_phase.update_attributes(starts_at: Date.current,
                                          ends_at:  Date.current + 2.days)
-        }.not_to (change{ prev_enabled_phase.ends_at })
+        }.not_to (change { prev_enabled_phase.ends_at })
       end
 
       it "doesn't change next enabled phase start date" do
-        expect{
+        expect {
           second_phase.update_attributes(starts_at: Date.current,
                                          ends_at:  Date.current + 2.days)
-        }.not_to (change{ next_enabled_phase.starts_at })
+        }.not_to (change { next_enabled_phase.starts_at })
       end
     end
 
@@ -178,7 +178,7 @@ describe Budget::Phase do
           second_phase.update_attributes(enabled: false,
                                          starts_at: Date.current,
                                          ends_at:  Date.current + 2.days)
-        }.not_to (change{ prev_enabled_phase.ends_at })
+        }.not_to (change { prev_enabled_phase.ends_at })
       end
 
       it "adjusts next enabled phase start date to its own start date" do
@@ -186,7 +186,7 @@ describe Budget::Phase do
           second_phase.update_attributes(enabled: false,
                                          starts_at: Date.current,
                                          ends_at:  Date.current + 2.days)
-        }.to change{ next_enabled_phase.starts_at.to_date }.to(Date.current)
+        }.to change { next_enabled_phase.starts_at.to_date }.to(Date.current)
       end
     end
   end
@@ -215,9 +215,9 @@ describe Budget::Phase do
 
   describe "#sanitize_description" do
     it "removes not allowed html entities from the description" do
-      expect{
+      expect {
         first_phase.update_attributes(description: '<p><a href="/"><b>a</b></a></p> <script>javascript</script>')
-      }.to change{ first_phase.description }.to('<p><a href="/">a</a></p> javascript')
+      }.to change { first_phase.description }.to('<p><a href="/">a</a></p> javascript')
     end
   end
 end

--- a/spec/models/concerns/sluggable.rb
+++ b/spec/models/concerns/sluggable.rb
@@ -15,15 +15,15 @@ shared_examples_for "sluggable" do |updatable_slug_trait:|
     context "slug updating condition is true" do
       it "slug is updated" do
         updatable = create(factory_name, updatable_slug_trait, name: "Old Name")
-        expect{updatable.update_attributes(name: "New Name")}
-          .to change{ updatable.slug }.from("old-name").to("new-name")
+        expect { updatable.update_attributes(name: "New Name") }
+          .to change { updatable.slug }.from("old-name").to("new-name")
       end
     end
 
     context "slug updating condition is false" do
       it "slug isn't updated" do
-        expect{sluggable.update_attributes(name: "New Name")}
-          .not_to (change{ sluggable.slug })
+        expect { sluggable.update_attributes(name: "New Name") }
+          .not_to (change { sluggable.slug })
       end
     end
   end

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -163,52 +163,52 @@ describe Debate do
     describe "from level two verified users" do
       it "registers vote" do
         user = create(:user, residence_verified_at: Time.current, confirmed_phone: "666333111")
-        expect {debate.register_vote(user, "yes")}.to change{debate.reload.votes_for.size}.by(1)
+        expect { debate.register_vote(user, "yes") }.to change { debate.reload.votes_for.size }.by(1)
       end
 
       it "does not increase anonymous votes counter " do
         user = create(:user, residence_verified_at: Time.current, confirmed_phone: "666333111")
-        expect {debate.register_vote(user, "yes")}.not_to change{debate.reload.cached_anonymous_votes_total}
+        expect { debate.register_vote(user, "yes") }.not_to change { debate.reload.cached_anonymous_votes_total }
       end
     end
 
     describe "from level three verified users" do
       it "registers vote" do
         user = create(:user, verified_at: Time.current)
-        expect {debate.register_vote(user, "yes")}.to change{debate.reload.votes_for.size}.by(1)
+        expect { debate.register_vote(user, "yes") }.to change { debate.reload.votes_for.size }.by(1)
       end
 
       it "does not increase anonymous votes counter " do
         user = create(:user, verified_at: Time.current)
-        expect {debate.register_vote(user, "yes")}.not_to change{debate.reload.cached_anonymous_votes_total}
+        expect { debate.register_vote(user, "yes") }.not_to change { debate.reload.cached_anonymous_votes_total }
       end
     end
 
     describe "from anonymous users when anonymous votes are allowed" do
-      before {debate.update(cached_anonymous_votes_total: 42, cached_votes_total: 100)}
+      before { debate.update(cached_anonymous_votes_total: 42, cached_votes_total: 100) }
 
       it "registers vote" do
         user = create(:user)
-        expect {debate.register_vote(user, "yes")}.to change {debate.reload.votes_for.size}.by(1)
+        expect { debate.register_vote(user, "yes") }.to change { debate.reload.votes_for.size }.by(1)
       end
 
       it "increases anonymous votes counter" do
         user = create(:user)
-        expect {debate.register_vote(user, "yes")}.to change {debate.reload.cached_anonymous_votes_total}.by(1)
+        expect { debate.register_vote(user, "yes") }.to change { debate.reload.cached_anonymous_votes_total }.by(1)
       end
     end
 
     describe "from anonymous users when there are too many anonymous votes" do
-      before {debate.update(cached_anonymous_votes_total: 520, cached_votes_total: 1000)}
+      before { debate.update(cached_anonymous_votes_total: 520, cached_votes_total: 1000) }
 
       it "does not register vote " do
         user = create(:user)
-        expect {debate.register_vote(user, "yes")}.not_to change {debate.reload.votes_for.size}
+        expect { debate.register_vote(user, "yes") }.not_to change { debate.reload.votes_for.size }
       end
 
       it "does not increase anonymous votes counter " do
         user = create(:user)
-        expect {debate.register_vote(user, "yes")}.not_to change {debate.reload.cached_anonymous_votes_total}
+        expect { debate.register_vote(user, "yes") }.not_to change { debate.reload.cached_anonymous_votes_total }
       end
     end
   end

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -8,7 +8,7 @@ describe Flag do
   describe ".flag" do
 
     it "creates a flag when there is none" do
-      expect { described_class.flag(user, comment) }.to change{ described_class.count }.by(1)
+      expect { described_class.flag(user, comment) }.to change { described_class.count }.by(1)
       expect(described_class.last.user).to eq(user)
       expect(described_class.last.flaggable).to eq(comment)
     end
@@ -20,7 +20,7 @@ describe Flag do
     end
 
     it "increases the flag count" do
-      expect { described_class.flag(user, comment) }.to change{ comment.reload.flags_count }.by(1)
+      expect { described_class.flag(user, comment) }.to change { comment.reload.flags_count }.by(1)
     end
   end
 
@@ -33,11 +33,11 @@ describe Flag do
       before { described_class.flag(user, comment) }
 
       it "removes an existing flag" do
-        expect { described_class.unflag(user, comment) }.to change{ described_class.count }.by(-1)
+        expect { described_class.unflag(user, comment) }.to change { described_class.count }.by(-1)
       end
 
       it "decreases the flag count" do
-        expect { described_class.unflag(user, comment) }.to change{ comment.reload.flags_count }.by(-1)
+        expect { described_class.unflag(user, comment) }.to change { comment.reload.flags_count }.by(-1)
       end
     end
   end

--- a/spec/models/i18n_content_spec.rb
+++ b/spec/models/i18n_content_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe I18nContent, type: :model do
         "w" => "string"
       })
 
-      expect(I18nContent.flat_hash({ w: { p: "string" } })).to eq({
+      expect(I18nContent.flat_hash({ w: { p: "string" }})).to eq({
         "w.p" => "string"
       })
     end
@@ -92,7 +92,7 @@ RSpec.describe I18nContent, type: :model do
         "f.w" => "string"
       })
 
-      expect(I18nContent.flat_hash({ w: { p: "string" } }, "f")).to eq({
+      expect(I18nContent.flat_hash({ w: { p: "string" }}, "f")).to eq({
         "f.w.p" => "string"
       })
     end
@@ -112,7 +112,7 @@ RSpec.describe I18nContent, type: :model do
         "w" => "string"
       })
 
-      expect(I18nContent.flat_hash({w: { p: "string" } }, nil, { q: "other string" })).to eq({
+      expect(I18nContent.flat_hash({ w: { p: "string" }}, nil, { q: "other string" })).to eq({
         q: "other string",
         "w.p" => "string"
       })
@@ -133,7 +133,7 @@ RSpec.describe I18nContent, type: :model do
         "f.w" => "string"
       })
 
-      expect(I18nContent.flat_hash({ w: { p: "string" } }, "f", { q: "other string" })).to eq({
+      expect(I18nContent.flat_hash({ w: { p: "string" }}, "f", { q: "other string" })).to eq({
         q: "other string",
         "f.w.p" => "string"
       })

--- a/spec/models/legislation/annotation_spec.rb
+++ b/spec/models/legislation/annotation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Legislation::Annotation, type: :model do
     annotation = create(:legislation_annotation,
       draft_version: draft_version,
       quote: quote,
-      ranges: [{"start" => "/p[1]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11}]
+      ranges: [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11 }]
     )
 
     context = "Lorem <span class=annotator-hl>ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt"\
@@ -49,7 +49,7 @@ RSpec.describe Legislation::Annotation, type: :model do
     annotation = create(:legislation_annotation,
       draft_version: draft_version,
       quote: quote,
-      ranges: [{"start" => "/p[1]", "startOffset" => 273, "end" => "/p[2]", "endOffset" => 190}]
+      ranges: [{ "start" => "/p[1]", "startOffset" => 273, "end" => "/p[2]", "endOffset" => 190 }]
     )
 
     context = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna"\
@@ -95,7 +95,7 @@ RSpec.describe Legislation::Annotation, type: :model do
     annotation = create(:legislation_annotation,
       draft_version: draft_version,
       quote: quote,
-      ranges: [{"start" => "/p[2]", "startOffset" => 127, "end" => "/p[3]", "endOffset" => 223}]
+      ranges: [{ "start" => "/p[2]", "startOffset" => 127, "end" => "/p[3]", "endOffset" => 223 }]
     )
 
     context = "The licenses for most software and other practical works are designed to take away your freedom to share and change the"\

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -198,7 +198,7 @@ describe Legislation::Process do
 
   describe "milestone_tags" do
     context "without milestone_tags" do
-      let(:process) {create(:legislation_process)}
+      let(:process) { create(:legislation_process) }
 
       it "do not have milestone_tags" do
         expect(process.milestone_tag_list).to eq([])
@@ -214,7 +214,7 @@ describe Legislation::Process do
 
     context "with milestone_tags" do
 
-      let(:process) {create(:legislation_process, :with_milestone_tags)}
+      let(:process) { create(:legislation_process, :with_milestone_tags) }
 
       it "has milestone_tags" do
         expect(process.milestone_tag_list.count).to eq(1)

--- a/spec/models/poll/ballot_spec.rb
+++ b/spec/models/poll/ballot_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 describe Poll::Ballot do
 
-  let(:budget){ create(:budget) }
-  let(:group){ create(:budget_group, budget: budget) }
-  let(:heading){ create(:budget_heading, group: group, price: 10000000) }
-  let(:investment){ create(:budget_investment, :selected, price: 5000000, heading: heading) }
+  let(:budget) { create(:budget) }
+  let(:group) { create(:budget_group, budget: budget) }
+  let(:heading) { create(:budget_heading, group: group, price: 10000000) }
+  let(:investment) { create(:budget_investment, :selected, price: 5000000, heading: heading) }
   let(:poll) { create(:poll, budget: budget) }
   let(:poll_ballot_sheet) { create(:poll_ballot_sheet, poll: poll) }
   let(:poll_ballot) { create(:poll_ballot, ballot_sheet: poll_ballot_sheet, external_id: 1, data: investment.id) }

--- a/spec/models/poll/booth_assignment_spec.rb
+++ b/spec/models/poll/booth_assignment_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Poll::BoothAssignment do
-  let(:poll){create(:poll)}
-  let(:booth){create(:poll_booth)}
-  let(:booth1){create(:poll_booth)}
+  let(:poll) { create(:poll) }
+  let(:booth) { create(:poll_booth) }
+  let(:booth1) { create(:poll_booth) }
 
   it "checks if there are shifts" do
     assignment_with_shifts = create(:poll_booth_assignment, poll: poll, booth: booth)

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -139,7 +139,7 @@ describe Poll do
   end
 
   describe "answerable_by" do
-    let(:geozone) {create(:geozone) }
+    let(:geozone) { create(:geozone) }
 
     let!(:current_poll) { create(:poll) }
     let!(:expired_poll) { create(:poll, :expired) }
@@ -429,7 +429,7 @@ describe Poll do
     end
 
     it "is false for polls which finished less than a month ago" do
-      poll = create(:poll, starts_at: 3.months.ago, ends_at: 27.days.ago )
+      poll = create(:poll, starts_at: 3.months.ago, ends_at: 27.days.ago)
 
       expect(poll.recounts_confirmed?).to be false
     end

--- a/spec/models/poll/shift_spec.rb
+++ b/spec/models/poll/shift_spec.rb
@@ -63,7 +63,7 @@ describe Poll::Shift do
       booth_assignment1 = create(:poll_booth_assignment, poll: poll, booth: booth)
       booth_assignment2 = create(:poll_booth_assignment, poll: poll2, booth: booth)
 
-      expect { create(:poll_shift, booth: booth, officer: officer, date: Date.current) }.to change {Poll::OfficerAssignment.all.count}.by(2)
+      expect { create(:poll_shift, booth: booth, officer: officer, date: Date.current) }.to change { Poll::OfficerAssignment.all.count }.by(2)
 
       officer_assignments = Poll::OfficerAssignment.all
       oa1 = officer_assignments.first
@@ -81,7 +81,7 @@ describe Poll::Shift do
 
       create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment1, date: Date.tomorrow)
 
-      expect { described_class.last.destroy }.to change {Poll::OfficerAssignment.all.count}.by(-2)
+      expect { described_class.last.destroy }.to change { Poll::OfficerAssignment.all.count }.by(-2)
     end
 
     it "creates final officer_assignments" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -177,8 +177,8 @@ describe Proposal do
   describe "#editable?" do
     let(:proposal) { create(:proposal) }
 
-    before {Setting["max_votes_for_proposal_edit"] = 5}
-    after {Setting["max_votes_for_proposal_edit"] = 1000}
+    before { Setting["max_votes_for_proposal_edit"] = 5 }
+    after { Setting["max_votes_for_proposal_edit"] = 1000 }
 
     it "is true if proposal has no votes yet" do
       expect(proposal.total_votes).to eq(0)
@@ -223,21 +223,21 @@ describe Proposal do
     describe "from level two verified users" do
       it "registers vote" do
         user = create(:user, residence_verified_at: Time.current, confirmed_phone: "666333111")
-        expect {proposal.register_vote(user, "yes")}.to change{proposal.reload.votes_for.size}.by(1)
+        expect { proposal.register_vote(user, "yes") }.to change { proposal.reload.votes_for.size }.by(1)
       end
     end
 
     describe "from level three verified users" do
       it "registers vote" do
         user = create(:user, verified_at: Time.current)
-        expect {proposal.register_vote(user, "yes")}.to change{proposal.reload.votes_for.size}.by(1)
+        expect { proposal.register_vote(user, "yes") }.to change { proposal.reload.votes_for.size }.by(1)
       end
     end
 
     describe "from anonymous users" do
       it "does not register vote" do
         user = create(:user)
-        expect {proposal.register_vote(user, "yes")}.to change{proposal.reload.votes_for.size}.by(0)
+        expect { proposal.register_vote(user, "yes") }.to change { proposal.reload.votes_for.size }.by(0)
       end
     end
 
@@ -245,7 +245,7 @@ describe Proposal do
       user = create(:user, verified_at: Time.current)
       archived_proposal = create(:proposal, :archived)
 
-      expect {archived_proposal.register_vote(user, "yes")}.to change{proposal.reload.votes_for.size}.by(0)
+      expect { archived_proposal.register_vote(user, "yes") }.to change { proposal.reload.votes_for.size }.by(0)
     end
   end
 
@@ -1031,7 +1031,7 @@ describe Proposal do
     end
 
     it "does not return proposals when user is follower" do
-      proposal1 =  create(:proposal, tag_list: "Sport")
+      proposal1 = create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal1, user: user)
 
       result = described_class.recommendations(user)
@@ -1144,7 +1144,7 @@ describe Proposal do
 
     context "without milestone_tags" do
 
-      let(:proposal) {create(:proposal)}
+      let(:proposal) { create(:proposal) }
 
       it "do not have milestone_tags" do
         expect(proposal.milestone_tag_list).to eq([])
@@ -1160,7 +1160,7 @@ describe Proposal do
 
     context "with milestone_tags" do
 
-      let(:proposal) {create(:proposal, :with_milestone_tags)}
+      let(:proposal) { create(:proposal, :with_milestone_tags) }
 
       it "has milestone_tags" do
         expect(proposal.milestone_tag_list.count).to eq(1)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -252,7 +252,7 @@ describe User do
   end
 
   describe "organization_attributes" do
-    before { subject.organization_attributes = {name: "org", responsible_name: "julia"} }
+    before { subject.organization_attributes = { name: "org", responsible_name: "julia" } }
 
     it "triggers the creation of an associated organization" do
       expect(subject.organization).to be
@@ -461,18 +461,18 @@ describe User do
 
     it "expires cache with becoming a moderator" do
       expect { create(:moderator, user: user) }
-      .to change { user.updated_at}
+      .to change { user.updated_at }
     end
 
     it "expires cache with becoming an admin" do
       expect { create(:administrator, user: user) }
-      .to change { user.updated_at}
+      .to change { user.updated_at }
     end
 
     it "expires cache with becoming a veridied organization" do
       create(:organization, user: user)
       expect { user.organization.verify }
-      .to change { user.reload.updated_at}
+      .to change { user.reload.updated_at }
     end
   end
 

--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -1,6 +1,4 @@
-shared_examples "documentable" do |documentable_factory_name,
-                                   documentable_path,
-                                   documentable_path_arguments|
+shared_examples "documentable" do |documentable_factory_name, documentable_path, documentable_path_arguments|
   include ActionView::Helpers
 
   let(:administrator) { create(:user) }

--- a/spec/shared/features/imageable_destroy.rb
+++ b/spec/shared/features/imageable_destroy.rb
@@ -1,6 +1,4 @@
-shared_examples "imageable destroy" do |imageable_factory_name,
-                                        imageable_path,
-                                        imageable_path_arguments|
+shared_examples "imageable destroy" do |imageable_factory_name, imageable_path, imageable_path_arguments|
   include ActionView::Helpers
   include ImagesHelper
   include ImageablesHelper

--- a/spec/shared/features/mappable.rb
+++ b/spec/shared/features/mappable.rb
@@ -1,10 +1,4 @@
-shared_examples "mappable" do |mappable_factory_name,
-                               mappable_association_name,
-                               mappable_new_path,
-                               mappable_edit_path,
-                               mappable_show_path,
-                               mappable_path_arguments,
-                               management = false|
+shared_examples "mappable" do |mappable_factory_name, mappable_association_name, mappable_new_path, mappable_edit_path, mappable_show_path, mappable_path_arguments, management = false|
 
   include ActionView::Helpers
 

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -1,7 +1,4 @@
-shared_examples "nested documentable" do |login_as_name, documentable_factory_name,
-                                          path, documentable_path_arguments,
-                                          fill_resource_method_name, submit_button,
-                                          documentable_success_notice|
+shared_examples "nested documentable" do |login_as_name, documentable_factory_name, path, documentable_path_arguments, fill_resource_method_name, submit_button, documentable_success_notice|
   include ActionView::Helpers
   include DocumentsHelper
   include DocumentablesHelper
@@ -14,7 +11,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
   else
     let!(:documentable)           { create(documentable_factory_name, author: user) }
   end
-  let!(:user_to_login)          { send(login_as_name)}
+  let!(:user_to_login)          { send(login_as_name) }
 
   before do
     create(:administrator, user: administrator)

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -1,7 +1,4 @@
-shared_examples "nested imageable" do |imageable_factory_name, path,
-                                       imageable_path_arguments, fill_resource_method_name,
-                                       submit_button, imageable_success_notice,
-                                       has_many_images = false|
+shared_examples "nested imageable" do |imageable_factory_name, path, imageable_path_arguments, fill_resource_method_name, submit_button, imageable_success_notice, has_many_images = false|
   include ActionView::Helpers
   include ImagesHelper
   include ImageablesHelper

--- a/spec/shared/models/acts_as_imageable.rb
+++ b/spec/shared/models/acts_as_imageable.rb
@@ -71,7 +71,7 @@ shared_examples "acts as imageable" do |imageable_factory|
     image_url = image.attachment.url
     new_url = "/attachments/original/missing.png"
 
-    expect{ image.attachment.destroy }.to change{ image.attachment.url }.from(image_url).to(new_url)
+    expect { image.attachment.destroy }.to change { image.attachment.url }.from(image_url).to(new_url)
   end
 
 end

--- a/spec/shared/models/acts_as_paranoid.rb
+++ b/spec/shared/models/acts_as_paranoid.rb
@@ -22,14 +22,14 @@ shared_examples "acts as paranoid" do |factory_name|
     end
 
     it "should be destroyed after parent resource really_destroy" do
-      expect{ resource.really_destroy! }.to change { resource.translations.with_deleted.count }.from(1).to(0)
+      expect { resource.really_destroy! }.to change { resource.translations.with_deleted.count }.from(1).to(0)
     end
 
     it "cannot be recovered through non recursive restore" do
       resource.destroy
       resource.reload
 
-      expect{ resource.restore }.not_to change { resource.translations.with_deleted.first.hidden_at }
+      expect { resource.restore }.not_to change { resource.translations.with_deleted.first.hidden_at }
     end
 
     it "can be recovered through recursive restore after non-recursive restore" do
@@ -38,7 +38,7 @@ shared_examples "acts as paranoid" do |factory_name|
       resource.destroy
       resource.reload
 
-      expect{ resource.restore(recursive: true) }.to change { resource.translations.with_deleted.first.hidden_at }
+      expect { resource.restore(recursive: true) }.to change { resource.translations.with_deleted.first.hidden_at }
     end
 
     it "can be recovered after soft deletion through recursive restore" do

--- a/spec/support/verifiable.rb
+++ b/spec/support/verifiable.rb
@@ -181,7 +181,7 @@ shared_examples_for "verifiable" do
 
   describe "methods modified by Setting user.skip_verification" do
 
-    let(:user) {create(:user)}
+    let(:user) { create(:user) }
 
     before do
       Setting["feature.user.skip_verification"] = "true"

--- a/spec/views/welcome/index.html.erb_spec.rb
+++ b/spec/views/welcome/index.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "welcome#index" do
                      image_default: "https://dummyimage.com/600x400/000/fff",
                      carousel_size: "medium-6 large-6 medium-centered large-centered",
                      btn_text_link: t("welcome.recommended.debates.btn_text_link"),
-                     btn_path_link: debates_path(order: "recommendations")}
+                     btn_path_link: debates_path(order: "recommendations") }
 
     within 'li[data-slide="0"] .card' do
       expect(page).to have_selector("img")
@@ -32,7 +32,7 @@ RSpec.describe "welcome#index" do
                      image_default: nil,
                      carousel_size: "medium-6 large-6 medium-centered large-centered",
                      btn_text_link: t("welcome.recommended.debates.btn_text_link"),
-                     btn_path_link: debates_path(order: "recommendations")}
+                     btn_path_link: debates_path(order: "recommendations") }
 
     within 'li[data-slide="0"] .card' do
       expect(page).not_to have_selector("img")


### PR DESCRIPTION
## References

* Depends on #3629

## Objectives

* Make it easier to detect code spacing issues in pull requests
* Apply guidelines developers have agreed upon to existing code

## Notes

In another pull request we'll make the code DRYer by removing the rules from the `.erb-lint.yml` file. We cannot do it yet because the option to do so in ERB Lint doesn't seem to work with Ruby 2.3.2.