### PR TITLE
Add title to differentiate signature sheets

### DIFF
--- a/app/controllers/admin/signature_sheets_controller.rb
+++ b/app/controllers/admin/signature_sheets_controller.rb
@@ -27,7 +27,7 @@ class Admin::SignatureSheetsController < Admin::BaseController
   private
 
     def signature_sheet_params
-      params.require(:signature_sheet).permit(:signable_type, :signable_id, :document_numbers)
+      params.require(:signature_sheet).permit(:signable_type, :signable_id, :document_numbers, :title)
     end
 
 end

--- a/app/models/signature_sheet.rb
+++ b/app/models/signature_sheet.rb
@@ -13,7 +13,7 @@ class SignatureSheet < ApplicationRecord
   validate  :signable_found
 
   def name
-    "#{signable_name} #{signable_id}"
+    title ? "#{signable_name} #{signable_id}: #{title}" : "#{signable_name} #{signable_id}"
   end
 
   def signable_name

--- a/app/views/admin/signature_sheets/new.html.erb
+++ b/app/views/admin/signature_sheets/new.html.erb
@@ -7,6 +7,10 @@
               resource: @signature_sheet %>
 
   <div class="small-12 medium-6 large-4">
+    <%= f.text_field :title %>
+  </div>
+
+  <div class="small-12 medium-6 large-4">
     <%= f.select :signable_type, signable_options %>
   </div>
 

--- a/db/migrate/20190621181440_add_name_field_to_signature_sheets.rb
+++ b/db/migrate/20190621181440_add_name_field_to_signature_sheets.rb
@@ -1,0 +1,5 @@
+class AddNameFieldToSignatureSheets < ActiveRecord::Migration[5.0]
+  def change
+    add_column :signature_sheets, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190607160900) do
+ActiveRecord::Schema.define(version: 20190621181440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1389,6 +1389,7 @@ ActiveRecord::Schema.define(version: 20190607160900) do
     t.integer  "author_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "title"
   end
 
   create_table "signatures", force: :cascade do |t|

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -100,6 +100,11 @@ FactoryBot.define do
     association :signable, factory: :proposal
     association :author, factory: :user
     document_numbers "123A, 456B, 789C"
+
+    trait :with_title do
+      title { Faker::Lorem.sentence }
+    end
+
   end
 
   factory :signature do

--- a/spec/features/admin/signature_sheets_spec.rb
+++ b/spec/features/admin/signature_sheets_spec.rb
@@ -37,6 +37,7 @@ describe "Signature sheets" do
       proposal = create(:proposal)
       visit new_admin_signature_sheet_path
 
+      fill_in "signature_sheet_title", with: "definitive signature sheet"
       select "Citizen proposal", from: "signature_sheet_signable_type"
       fill_in "signature_sheet_signable_id", with: proposal.id
       fill_in "signature_sheet_document_numbers", with: "12345678Z, 1234567L, 99999999Z"
@@ -59,6 +60,7 @@ describe "Signature sheets" do
 
       visit new_admin_signature_sheet_path
 
+      fill_in "signature_sheet_title", with: "definitive signature sheet"
       select "Investment", from: "signature_sheet_signable_type"
       fill_in "signature_sheet_signable_id", with: investment.id
       fill_in "signature_sheet_document_numbers", with: "12345678Z, 1234567L, 99999999Z"
@@ -88,6 +90,7 @@ describe "Signature sheets" do
     proposal = create(:proposal)
     user = Administrator.first.user
     signature_sheet = create(:signature_sheet,
+                             :with_title,
                              signable: proposal,
                              document_numbers: "12345678Z, 123A, 123B",
                              author: user)
@@ -95,7 +98,7 @@ describe "Signature sheets" do
 
     visit admin_signature_sheet_path(signature_sheet)
 
-    expect(page).to have_content "Citizen proposal #{proposal.id}"
+    expect(page).to have_content "Citizen proposal #{proposal.id}: #{signature_sheet.title}"
     expect(page).to have_content "12345678Z, 123A, 123B"
     expect(page).to have_content signature_sheet.created_at.strftime("%B %d, %Y %H:%M")
     expect(page).to have_content user.name

--- a/spec/models/signature_sheet_spec.rb
+++ b/spec/models/signature_sheet_spec.rb
@@ -40,18 +40,38 @@ describe SignatureSheet do
   end
 
   describe "#name" do
-    it "returns name for proposal signature sheets" do
-      proposal = create(:proposal)
-      signature_sheet.signable = proposal
+    context "when name is nil" do
+      it "returns name for proposal signature sheets" do
+        proposal = create(:proposal)
+        signature_sheet.signable = proposal
 
-      expect(signature_sheet.name).to eq("Citizen proposal #{proposal.id}")
+        expect(signature_sheet.name).to eq("Citizen proposal #{proposal.id}")
+      end
+
+      it "returns name for budget investment signature sheets" do
+        budget_investment = create(:budget_investment)
+        signature_sheet.signable = budget_investment
+
+        expect(signature_sheet.name).to eq("Investment #{budget_investment.id}")
+      end
     end
 
-    it "returns name for budget investment signature sheets" do
-      budget_investment = create(:budget_investment)
-      signature_sheet.signable = budget_investment
+    context "when name is not nil" do
+      let(:signature_sheet) { build(:signature_sheet, :with_title) }
 
-      expect(signature_sheet.name).to eq("Investment #{budget_investment.id}")
+      it "returns name for proposal signature sheets" do
+        proposal = create(:proposal)
+        signature_sheet.signable = proposal
+
+        expect(signature_sheet.name).to eq("Citizen proposal #{proposal.id}: #{signature_sheet.title}")
+      end
+
+      it "returns name for budget investment signature sheets" do
+        budget_investment = create(:budget_investment)
+        signature_sheet.signable = budget_investment
+
+        expect(signature_sheet.name).to eq("Investment #{budget_investment.id}: #{signature_sheet.title}")
+      end
     end
   end
 


### PR DESCRIPTION
## References

Related to #3557 

## Objectives

Add a title to differentiate between signature sheets on `admin/signature_sheets`

## Visual Changes
![image](https://user-images.githubusercontent.com/9721558/60014569-abca6500-9657-11e9-97d2-4b2083eb89c0.png)

