### PR TITLE
Fix CKEditor height in dashboard actions form

### DIFF
--- a/app/views/admin/dashboard/actions/_form.html.erb
+++ b/app/views/admin/dashboard/actions/_form.html.erb
@@ -34,7 +34,9 @@
       <%= f.text_field :short_description, label: false %>
     </div>
 
-    <%= f.cktext_area :description, ckeditor: { language: I18n.locale } %>
+    <div class="ckeditor">
+      <%= f.cktext_area :description, ckeditor: { language: I18n.locale } %>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## References

The following Travis builds failed due to this problem:

* [Travis build ](https://travis-ci.org/consul/consul/jobs/539634075) (failure not available anymore; the build was restarted).
* [Travis build 31038, job 2](https://travis-ci.org/consul/consul/jobs/548852348)
* [Travis build 31057, job 4](https://travis-ci.org/consul/consul/jobs/549717221)
* [Travis build 31067, job 2](https://travis-ci.org/consul/consul/jobs/549805247)

## Objectives

* Improve the dashboard actions form usability
* Fix flaky specs caused by this issue

## Notes

Not wrapping the editor in a `.ckeditor` div made it change height when the editor was loaded. That caused a weird effect for users, and also made some tests fail sometimes since the position of the "Add new document" link might change right when capybara is clicking it.

These specs have failed because of this issue:

```
  1) Admin dashboard actions behaves like nested documentable at new_admin_dashboard_action_path Should update document cached_attachment field after valid file upload
     Failure/Error: document_input = document.find("input[type=file]", visible: false)
     NoMethodError:
       undefined method `find' for nil:NilClass
     Shared Example Group: "nested documentable" called from ./spec/features/admin/dashboard/actions_spec.rb:10
     # ./spec/shared/features/nested_documentable.rb:330:in `documentable_attach_new_file'
     # ./spec/shared/features/nested_documentable.rb:151:in `block (3 levels) in <top (required)>'
```

```
  1) Admin dashboard actions behaves like nested documentable at new_admin_dashboard_action_path Should show document errors after documentable submit with
              empty document fields
     Failure/Error:
       within "#nested-documents .document" do
         expect(page).to have_content("can't be blank", count: 2)
       end
     Capybara::ElementNotFound:
       Unable to find visible css "#nested-documents .document"
     Shared Example Group: "nested documentable" called from ./spec/features/admin/dashboard/actions_spec.rb:10
     # ./spec/shared/features/nested_documentable.rb:176:in `block (3 levels) in <top (required)>'
```

```
  1) Admin dashboard actions behaves like nested documentable at new_admin_dashboard_action_path Should not update document cached_attachment field after invalid file upload
     Failure/Error: document_input = document.find("input[type=file]", visible: false)
     NoMethodError:
       undefined method `find' for nil:NilClass
     Shared Example Group: "nested documentable" called from ./spec/features/admin/dashboard/actions_spec.rb:10
     # ./spec/shared/features/nested_documentable.rb:330:in `documentable_attach_new_file'
     # ./spec/shared/features/nested_documentable.rb:160:in `block (3 levels) in <top (required)>'