### PR TITLE
Fix flaky notifiable specs

### DIFF
--- a/spec/shared/features/notifiable_in_app.rb
+++ b/spec/shared/features/notifiable_in_app.rb
@@ -25,15 +25,15 @@ shared_examples "notifiable in-app" do |described_class|
   end
 
   scenario "Multiple users commented on my notifiable", :js do
-    3.times do
+    3.times do |n|
       login_as(create(:user, :verified))
 
       visit path_for(notifiable)
 
-      fill_in comment_body(notifiable), with: "I agree"
+      fill_in comment_body(notifiable), with: "Number #{n + 1} is the best!"
       click_button "publish_comment"
       within "#comments" do
-        expect(page).to have_content "I agree"
+        expect(page).to have_content "Number #{n + 1} is the best!"
       end
       logout
     end


### PR DESCRIPTION
## References

* Closes #3642

## Objectives

* Fix flaky specs regarding comment notifications

## Notes

The test failed sometimes because all comments created the same text, so the expectation checking for the text will always be true once the first comment is created. This caused a race condition: if the notifications page is accessed before the AJAX requests to create the second and third comment have finished, the test will fail.

By making the text of each comment different, we make sure all comments are created before accessing the notifications page.