### PR TITLE
Fix flaky spec: Proposals Search Reorder results maintaing search

### DIFF
--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1478,7 +1478,11 @@ describe "Proposals" do
       visit proposals_path
       fill_in "search", with: "Show what you got"
       click_button "Search"
+
+      expect(page).to have_content "Search results"
+
       click_link "newest"
+
       expect(page).to have_selector("a.is-active", text: "newest")
 
       within("#proposals") do


### PR DESCRIPTION
## References

* Failure in [Travis build 30862, job 3](https://travis-ci.org/consul/consul/jobs/540608403)

## Objectives

* Fix a flaky spec in `spec/features/proposals_spec.rb:1449`:  Proposals Search Reorder results maintaing search

## Why was the spec failing?

When clicking the button "Search", the link "newest" is already present, so capybara might click the "newest" link before the "Search" request is finished, leading to unexpected results.

Checking the page to make sure the "Search" request has finished before clicking the "newest" link solves the problem.