### PR TITLE
ID searching for Proposals, Investments

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -193,6 +193,7 @@ class Budget
 
     def searchable_values
       { title              => "A",
+        id.to_s            => "A",
         author.username    => "B",
         heading.try(:name) => "B",
         tag_list.join(" ") => "B",

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -122,8 +122,10 @@ class Proposal < ApplicationRecord
 
   def searchable_values
     { title              => "A",
+      id.to_s            => "A",
       author.username    => "B",
       tag_list.join(" ") => "B",
+      to_param()         => "B",
       geozone.try(:name) => "B",
       summary            => "C",
       description        => "D"
@@ -131,6 +133,7 @@ class Proposal < ApplicationRecord
   end
 
   def self.search(terms)
+    terms = terms.to_s if terms.is_a? Numeric
     by_code = search_by_code(terms.strip)
     by_code.present? ? by_code : pg_search(terms)
   end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -647,6 +647,12 @@ describe Budget::Investment do
         expect(results).to eq([budget_investment])
       end
 
+      it "searches by id" do
+        budget_investment = create(:budget_investment, title: "free willy")
+        results = described_class.search(budget_investment.id)
+        expect(results).to eq([budget_investment])
+      end
+
       it "searches by author name" do
         author = create(:user, username: "Danny Trejo")
         budget_investment = create(:budget_investment, author: author)

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -462,6 +462,12 @@ describe Proposal do
         expect(results).to eq([proposal])
       end
 
+      it "searches by id" do
+        proposal = create(:proposal, title: "free willy")
+        results = described_class.search(proposal.id)
+        expect(results).to eq([proposal])
+      end
+
       it "searches by summary" do
         proposal = create(:proposal, summary: "basically...")
         results = described_class.search("basically")
@@ -478,6 +484,12 @@ describe Proposal do
         author = create(:user, username: "Danny Trejo")
         proposal = create(:proposal, author: author)
         results = described_class.search("Danny")
+        expect(results).to eq([proposal])
+      end
+
+      it "searches by parameterized id-title" do
+        proposal = create(:proposal, title: "river cleanup")
+        results = described_class.search(proposal.to_param)
         expect(results).to eq([proposal])
       end
 


### PR DESCRIPTION
Investment searching is now responsive to investment.id. Proposals are now responsive to proposal.id and to the string returned by proposal.to_param().

## References

> Related Issues/Pull Requests/Travis Builds/Rollbar errors/etc...

Closes: #3560

## Objectives

> What are the objectives of these changes?

To allow users and admins to input ID's or the parameterized ID+title (for proposals) in the search bar for Participatory Budget Investments and Proposals.

## Visual Changes

> Any visual changes? please attach screenshots (or gifs) showing them.
> If modified views are public (not the admin panel), try them in mobile display (with your browser's developer console) and add screenshots.

No visual changes. Functional only.

## Notes

> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
> Explain any caveats, or important things to notice like deprecations (if any).

For this functionality to work, contributors with existing local copies of the project will need to reset the database in order to add these additional columns to the tsvector column.

```
bin/rake db.reset
bin/rake db.migrate
bin/rake db.dev_seed
```