### PR TITLE
Fix text confirming investment heading support

### DIFF
--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -20,7 +20,7 @@
           method: "post",
           remote: (display_support_alert?(investment) ? false : true),
           data:   (display_support_alert?(investment) ? {
-                  confirm: t("budgets.investments.investment.confirm_group") } : nil),
+                  confirm: t("budgets.investments.investment.confirm_group", count: investment.group.max_votable_headings) } : nil),
           "aria-hidden" => css_for_aria_hidden(reason) do %>
         <%= t("budgets.investments.investment.give_support") %>
       <% end %>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -137,7 +137,7 @@ en:
         support_title: Support this project
         confirm_group:
           one: "You can only support investments in %{count} district. If you continue you cannot change the election of your district. Are you sure?"
-          other: "You can only support investments in %{count} district. If you continue you cannot change the election of your district. Are you sure?"
+          other: "You can only support investments in %{count} districts. If you continue you cannot change the election of your district. Are you sure?"
         supports:
           one: 1 support
           other: "%{count} supports"

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -191,6 +191,13 @@ describe "Votes" do
                                          "Share it!"
       end
 
+      scenario "Confirm message shows the right text", :js do
+        visit budget_investments_path(budget, heading_id: new_york.id)
+        find(".in-favor a").click
+
+        expect(page.driver.send(:find_modal).text).to match "You can only support investments in 2 districts."
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Background

We accidentally removed the `count` option in the confirm group text in commit 55fb14ac, which made the translation return a hash.

## Visual Changes

Before this change:

![Confirmation text shows Object object](https://user-images.githubusercontent.com/35156/60815104-3aca9780-a197-11e9-9ebf-e15ac6ba1506.png)

After this change:

![Confirmation text shows a useful message](https://user-images.githubusercontent.com/35156/60815150-4b7b0d80-a197-11e9-8f94-83eabc4fe503.png)