### PR TITLE
Precompile CKEditor dialog plugins

### DIFF
--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -8,5 +8,5 @@ Ckeditor.setup do |config|
   config.authorize_with :cancan
 
   config.assets_languages = Rails.application.config.i18n.available_locales.map{|l| l.to_s.downcase}
-  config.assets_plugins = %w[copyformatting tableselection scayt wsc]
+  config.assets_plugins = %w[copyformatting image link magicline scayt table tableselection wsc]
 end


### PR DESCRIPTION
## References

* Based on commit 54c82a53 from pull request #2711
* Might be related to issue #3645, although it's unlikely since tests don't try to load any CKEditor dialogs

## Objectives

Make CKEditor dialogs for images, links and tables work on all production environments.

## Notes

This bug only affects production environments. These dialogs load (although they might take time to compile) correctly on the development and test environments, so this pull request doesn't add any tests.