### PR TITLE
Make WebSection seeds idempotent

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,11 +9,11 @@ end
 
 Setting.reset_defaults
 
-WebSection.create(name: "homepage")
-WebSection.create(name: "debates")
-WebSection.create(name: "proposals")
-WebSection.create(name: "budgets")
-WebSection.create(name: "help_page")
+WebSection.where(name: "homepage").first_or_create
+WebSection.where(name: "debates").first_or_create
+WebSection.where(name: "proposals").first_or_create
+WebSection.where(name: "budgets").first_or_create
+WebSection.where(name: "help_page").first_or_create
 
 # Default custom pages
 load Rails.root.join("db", "pages.rb")


### PR DESCRIPTION
## References

* Closes #3485

## Objectives

* Make the seeds task idempotent
* Reduce the number of records created when running the tests
* Fix some flaky specs which failed because they loaded too many records

## Notes

Creating more records before every test meant after running model tests the table had potentially thousands of records, and tests rendering all of them were slower and sometimes exceeded Capybara's wait time.

I've updated #3621 so after upgrading to Rails 5.1 at least the seeds will only be loaded once when running the tests. Maybe we shouldn't even load the seeds file, and just execute `Setting.reset_defaults` :thinking:, but then we would need to change the tests relying on default custom pages being created. 