### PR TITLE
Use an inline CKEditor

### DIFF
--- a/app/assets/javascripts/ckeditor/reinit.js
+++ b/app/assets/javascripts/ckeditor/reinit.js
@@ -1,7 +1,0 @@
-$(document).on("page:change", function() {
-  if (typeof(CKEDITOR) != "undefined"){
-    for(name in CKEDITOR.instances){
-      try{CKEDITOR.replace(name);}catch(err){};
-    }
-  }
-});

--- a/app/assets/javascripts/html_editor.js
+++ b/app/assets/javascripts/html_editor.js
@@ -4,9 +4,9 @@
     initialize: function() {
       $("textarea.html-area").each(function() {
         if ($(this).hasClass("admin")) {
-          CKEDITOR.replace(this.name, { language: $("html").attr("lang"), toolbar: "admin", height: 500 });
+          CKEDITOR.inline(this.name, { language: $("html").attr("lang"), toolbar: "admin" });
         } else {
-          CKEDITOR.replace(this.name, { language: $("html").attr("lang") });
+          CKEDITOR.inline(this.name, { language: $("html").attr("lang") });
         }
       });
     }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1085,16 +1085,20 @@ form {
     margin: $line-height / 2 0 $line-height / 2 $line-height / 4;
   }
 
-  .cke {
-    margin-bottom: $line-height;
+  .cke_textarea_inline {
+    @include form-element;
+    overflow-y: auto;
   }
 
   .html-area:not(.form-error) {
-    height: 272px;
-    margin-bottom: $line-height;
+    &,
+    & + .cke_textarea_inline {
+      min-height: $line-height * 10;
+    }
 
-    &.admin {
-      height: 572px;
+    &.admin,
+    &.admin + .cke_textarea_inline {
+      min-height: $line-height * 20;
     }
   }
 

--- a/spec/features/admin/site_customization/pages_spec.rb
+++ b/spec/features/admin/site_customization/pages_spec.rb
@@ -86,9 +86,12 @@ describe "Admin custom pages" do
 
     scenario "Allows images in CKEditor", :js do
       visit edit_admin_site_customization_page_path(custom_page)
+
+      expect(page).not_to have_link "Image"
+
       fill_in_ckeditor "Content", with: "Will add an image"
 
-      expect(page).to have_css(".cke_toolbar .cke_button__image_icon")
+      expect(page).to have_link "Image"
     end
   end
 

--- a/spec/features/ckeditor_spec.rb
+++ b/spec/features/ckeditor_spec.rb
@@ -7,22 +7,27 @@ describe "CKEditor" do
 
     visit new_debate_path
 
-    expect(page).to have_css ".translatable-fields[data-locale='en'] .cke_wysiwyg_frame"
+    within(".translatable-fields[data-locale='en']") do
+      expect(page).to have_css ".cke_textarea_inline[aria-label*='debate'][aria-label*='description']"
+    end
 
     click_link "Debates"
     click_link "Start a debate"
 
-    expect(page).to have_css ".translatable-fields[data-locale='en'] .cke_wysiwyg_frame"
+    within(".translatable-fields[data-locale='en']") do
+      expect(page).to have_css ".cke_textarea_inline[aria-label*='debate'][aria-label*='description']"
+    end
   end
 
   scenario "uploading an image through the upload tab", :js do
     login_as(create(:administrator).user)
 
     visit new_admin_site_customization_page_path
-    find(".cke_button__image").click
+    fill_in_ckeditor "Content", with: "Focus to make toolbar appear"
+    click_link "Image"
     click_link "Upload"
 
-    within_frame(1) do
+    within_frame(0) do
       attach_file "Send it to the Server", Rails.root.join("spec/fixtures/files/clippy.jpg")
     end
 

--- a/spec/support/matchers/have_ckeditor.rb
+++ b/spec/support/matchers/have_ckeditor.rb
@@ -3,25 +3,21 @@ RSpec::Matchers.define :have_ckeditor do |label, with:|
     find("label", text: label)[:for]
   end
 
-  define_method :ckeditor_id do
-    "#cke_#{textarea_id}"
+  define_method :ckeditor_selector do
+    "[aria-label~='#{textarea_id}']"
   end
 
   define_method :has_ckeditor? do
-    has_css?("label", text: label) && has_css?(ckeditor_id)
+    has_css?("label", text: label) && has_css?(ckeditor_selector)
   end
 
   match do
-    return false unless has_ckeditor?
-
-    page.within(ckeditor_id) do
-      within_frame(0) { has_content?(with) }
-    end
+    has_ckeditor? && has_css?(ckeditor_selector, exact_text: with)
   end
 
   failure_message do
     if has_ckeditor?
-      text = page.within(ckeditor_id) { within_frame(0) { page.text } }
+      text = page.find(ckeditor_selector).text
 
       "expected to find visible CKEditor '#{label}' with '#{with}', but had '#{text}'"
     else


### PR DESCRIPTION
## References

* Check the notes of this pull request to see the reasons why it wasn't merged

## Objectives

* Improve the user interface to edit textareas
* Make CKEditor load faster

## Visual Changes

Before these changes:

![A textarea with a toolbar on top](https://user-images.githubusercontent.com/35156/68417308-75206180-0196-11ea-827e-231edb35c80f.png)

Loading in the development environment with Rails 5.1 takes a while:

![Loading takes several seconds](https://user-images.githubusercontent.com/35156/79003425-e2c02780-7b52-11ea-8993-20828845fcf4.gif)

After these changes:

![A textarea with an editable preview](https://user-images.githubusercontent.com/35156/78896705-2cd0dc80-7a71-11ea-9eea-92c553d07882.png)

Loading in the development environment takes an instant:

![Loading time is almost imperceptible](https://user-images.githubusercontent.com/35156/79002514-ef438080-7b50-11ea-8e73-5ab4a610f6a6.gif)

## Notes

While developing this pull request, we've reached the following conclusions, which we'll take into account if we ever decide to replace CKEditor with another editor (like Trix).

Editors which use HTML's `contenteditable` property, like CKEditor's inline mode, are usually designed to edit the content of the page we're currently seeing. That's why they are not resizable and use the same CSS styles which are currently loaded on the page.

However, we allow users to edit the content using traditional forms, where there are many fields to be filled and CSS styles might be different than in the page displaying the content (for example, if the content is edited in the admin section, which uses different styles than the public area).

So when we try to combine both ideas and use an inline editor in traditional forms, we get some issues:

* The editable area is not resizable. If we let it grow to fit the content of the page, forms are harder to navigate. If we force it to have a fixed size, the editable area is harder to navigate.
* Styles are confusing. When administrators are adding, let's say, a table, the table will be displayed with the styles used in the admin section, which have nothing to do with the styles used in the public area.
* Toolbars might get in the way. At least using an inline CKEditor, toolbars suddenly appear on top of the editable area, right where that field's label is. This means the label is not seen while we're editing a field, which might make users unsure about which field they're editing, particularly when creating new records. The way CKEditor loads this toolbar makes it hard to change this behaviour.

On the plus side, the editor loads much faster in both development and production environments. However, we aren't sure this benefit is enough to compensate the aforementioned issues.

So we've decided not to merge this pull request.
