### PR TITLE
Fix table layout after selecting an investment

### DIFF
--- a/app/assets/javascripts/columns_selector.js
+++ b/app/assets/javascripts/columns_selector.js
@@ -1,7 +1,7 @@
 (function() {
   "use strict";
   App.ColumnsSelector = {
-    initColums: function() {
+    initColumns: function() {
       var c_value, columns;
       App.ColumnsSelector.hideAll();
       c_value = App.ColumnsSelector.currentValue();
@@ -71,7 +71,7 @@
     },
     initialize: function() {
       App.ColumnsSelector.initChecks();
-      App.ColumnsSelector.initColums();
+      App.ColumnsSelector.initColumns();
       $("#js-columns-selector").on({
         click: function(event) {
           App.ColumnsSelector.toggleOptions(event);

--- a/app/assets/javascripts/columns_selector.js
+++ b/app/assets/javascripts/columns_selector.js
@@ -82,6 +82,9 @@
           App.ColumnsSelector.toggleColumn(event);
         }
       });
+      $(".column-selecteable").on("inserted", function() {
+        App.ColumnsSelector.initColumns();
+      });
     }
   };
 }).call(this);

--- a/app/views/admin/budget_investments/toggle_selection.js.erb
+++ b/app/views/admin/budget_investments/toggle_selection.js.erb
@@ -1,1 +1,1 @@
-$("#<%= dom_id(@investment) %>").html("<%= j render("select_investment", investment: @investment) %>");
+$("#<%= dom_id(@investment) %>").html("<%= j render("select_investment", investment: @investment) %>").trigger("inserted");

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1892,6 +1892,21 @@ describe "Admin budget investments" do
         "visible_to_valuators,selected,incompatible,author")
 
     end
+
+    scenario "Select an investment when some columns are not displayed", :js do
+      investment.update_attribute(:title, "Don't display me, please!")
+
+      visit admin_budget_budget_investments_path(budget)
+      within("#js-columns-selector") { find("strong", text: "Columns").click }
+      within("#js-columns-selector-wrapper") { uncheck "Title" }
+
+      within("#budget_investment_#{investment.id}") do
+        click_link "Selected"
+
+        expect(page).to have_link "Select"
+        expect(page).not_to have_content "Don't display me, please!"
+      end
+    end
   end
 
 end

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1585,6 +1585,8 @@ describe "Admin budget investments" do
 
         within("#budget_investment_#{selected_bi.id}") do
           click_link("Selected")
+
+          expect(page).to have_link "Select"
         end
 
         click_link("Next")


### PR DESCRIPTION
## References

* Pull request #3439

## Objectives

Fix a bug which broke the table layout after selecting an investment, which added even the columns which were not supposed to be shown:

![The inserted row has more columns than the other rows](https://user-images.githubusercontent.com/35156/61090523-47711900-a43f-11e9-9dc0-5f81b8f8a8b4.png)