### PR TITLE
Load custom locales after everything is loaded

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,8 @@ module Consul
       "it"    => "es",
       "pt-BR" => "es"
     }
-    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
+
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**[^custom]*", "*.{rb,yml}")]
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "custom", "**", "*.{rb,yml}")]
 
     config.after_initialize do


### PR DESCRIPTION
## Background

The line:

```
config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
```

Was adding every locale under the `config/locales` folder, including the ones inside `config/locales/custom/`. The files were loaded in the same order as listed using `ls -f`.

So if the custom locales were loaded before the folder `config/locales/#{I18n.locale}`, the default locales would override the custom ones, and we want the custom locales to override the default
ones so CONSUL is easier to customize.

## Objectives

Make sure custom locales are loaded after every other locale is loaded.