### PR TITLE
Fix Infinity exceptions in hot score calculator

### DIFF
--- a/lib/score_calculator.rb
+++ b/lib/score_calculator.rb
@@ -3,10 +3,7 @@ module ScoreCalculator
   def self.hot_score(resource)
     return 0 unless resource.created_at
 
-    period = [
-      Setting["hot_score_period_in_days"].to_i,
-      ((Time.current - resource.created_at) / 1.day).ceil
-    ].min
+    period = [max_period, resource_age(resource)].min
 
     votes_total = resource.votes_for.where("created_at >= ?", period.days.ago).count
     votes_up  = resource.get_upvotes.where("created_at >= ?", period.days.ago).count
@@ -25,6 +22,14 @@ module ScoreCalculator
     score       = votes_up - votes_down
 
     score * (votes_up / votes_total) * 100
+  end
+
+  def self.max_period
+    Setting["hot_score_period_in_days"].to_i
+  end
+
+  def self.resource_age(resource)
+    ((Time.current - resource.created_at) / 1.day).ceil
   end
 
 end

--- a/lib/score_calculator.rb
+++ b/lib/score_calculator.rb
@@ -3,7 +3,7 @@ module ScoreCalculator
   def self.hot_score(resource)
     return 0 unless resource.created_at
 
-    period = [max_period, resource_age(resource)].min
+    period = [1, [max_period, resource_age(resource)].min].max
 
     votes_total = resource.votes_for.where("created_at >= ?", period.days.ago).count
     votes_up  = resource.get_upvotes.where("created_at >= ?", period.days.ago).count

--- a/spec/lib/score_calculator_spec.rb
+++ b/spec/lib/score_calculator_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe ScoreCalculator do
+  describe ".hot_score" do
+    let(:resource) { create(:debate) }
+
+    before do
+      resource.vote_by(voter: create(:user), vote: "yes")
+    end
+
+    it "ignores small time leaps", :with_frozen_time do
+      resource.created_at = Time.current + 0.01
+
+      expect(ScoreCalculator.hot_score(resource)).to eq 1
+    end
+
+    it "ignores setting with negative value " do
+      Setting["hot_score_period_in_days"] = -1
+
+      expect(ScoreCalculator.hot_score(resource)).to eq 1
+    end
+
+    it "ignores setting with zero value" do
+      Setting["hot_score_period_in_days"] = 0
+
+      expect(ScoreCalculator.hot_score(resource)).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
## References

* Closes #3325

## Objectives

Fix a rare case we've found on some Travis builds where the system time suddenly moved back to the past a couple of tenths of a second, meaning `Time.current - resource.created_at` returned a negative number, which lead to a division by zero.