### PR TITLE
Add missing link and button on management interface

### DIFF
--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -12,6 +12,10 @@
       <div class="top-links">
         <div class="expanded row">
           <%= render "shared/locale_switcher" %>
+
+          <%= link_to root_path, class: "float-right" do %>
+            <%= t("admin.dashboard.index.back", org: setting["org_name"]) %>
+          <% end %>
         </div>
       </div>
 
@@ -35,6 +39,7 @@
               <div class="top-bar-right">
                 <ul class="menu" data-responsive-menu="medium-dropdown">
                   <%= render "shared/admin_login_items", current_user: manager_logged_in %>
+                  <%= render "layouts/notification_item", current_user: manager_logged_in %>
                   <%= render "devise/menu/login_items", current_user: manager_logged_in %>
                 </ul>
               </div>


### PR DESCRIPTION
## Objectives

- Adds the notification bell and the link to go back to the homepage in the header of the management interface.

## Visual Changes

Before:

![Capture d’écran 2019-08-23 à 23 41 46](https://user-images.githubusercontent.com/7223028/63625468-02c0cc00-c600-11e9-9663-c66f0d6dd650.png)

After:

![Capture d’écran 2019-08-23 à 23 42 08](https://user-images.githubusercontent.com/7223028/63625474-0a807080-c600-11e9-942c-f290b8a0603b.png)