### PR TITLE
Avoid Net::ReadTimeout errors in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ end
 
 group :test do
   gem "capybara", "~> 2.17.0"
+  gem "capybara-webmock", "~> 0.5.3"
   gem "coveralls", "~> 0.8.22", require: false
   gem "database_cleaner", "~> 1.7.0"
   gem "email_spec", "~> 2.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
+    capybara-webmock (0.5.3)
+      capybara (>= 2.4, < 4)
+      rack (>= 1.4)
+      rack-proxy (>= 0.6.0)
+      selenium-webdriver (~> 3.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
@@ -389,6 +394,8 @@ GEM
       rack (>= 0.4)
     rack-attack (5.0.1)
       rack
+    rack-proxy (0.6.5)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.7.2)
@@ -584,6 +591,7 @@ DEPENDENCIES
   capistrano-rails (~> 1.4.0)
   capistrano3-delayed-job (~> 1.7.3)
   capybara (~> 2.17.0)
+  capybara-webmock (~> 0.5.3)
   ckeditor (~> 4.2.3)
   cocoon (~> 1.2.9)
   coffee-rails (~> 4.2.2)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,9 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless no-sandbox window-size=1200,600) }
+    chromeOptions: {
+      args: %W[headless no-sandbox window-size=1200,600 proxy-server=127.0.0.1:#{Capybara::Webmock.port_number}]
+    }
   )
 
   Capybara::Selenium::Driver.new(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,14 @@ RSpec.configure do |config|
     end
   end
 
+  config.before(:each, type: :feature) do
+    Capybara::Webmock.start
+  end
+
+  config.after(:suite) do
+    Capybara::Webmock.stop
+  end
+
   config.after(:each, :page_driver) do
     page.driver.reset!
   end


### PR DESCRIPTION
## Background

Since August the 7th, 2019, we're experiencing `Net::ReadTimeout` errors on almost every Travis build.

Debugging shows most (maybe all) of these errors come from requesting images to OpenStreetMap. Sometimes, due to an unreliable internet connection, the images take too long to load. The issue can be reproduced locally by limiting the bandwidth of the development machine with tools like wondershaper.

## Objectives

Mock HTTP requests to fetch OpenStreetMap images, so we don't get any timeout errors, and tests work properly on machines with slow internet connections.

## Notes

Here are the builds which have failed with the `Net::ReadTimeout` exception. Most (if not all) of these failures take place on pages loading the map.

[Travis build 31262, job 1](https://travis-ci.org/consul/consul/jobs/568982855) and [Travis build 31303, job 5](https://travis-ci.org/consul/consul/jobs/569447733)
```
  1) Admin settings Should redirect to same tab after update setting map configuration On #tab-map-configuration
     Failure/Error: visit admin_settings_path
     Net::ReadTimeout:
       Net::ReadTimeout
     # ./spec/features/admin/settings_spec.rb:232:in `block (4 levels) in <top (required)>'
```

[Travis build 31293, job 3](https://travis-ci.org/consul/consul/jobs/569211837)
```
 1) Proposals behaves like mappable At edit_proposal_path Should edit default values from map on proposal edit page
     Failure/Error: visit send(mappable_edit_path, id: mappable.id)
     Net::ReadTimeout:
       Net::ReadTimeout
     Shared Example Group: "mappable" called from ./spec/features/proposals_spec.rb:1657
     # ./spec/shared/features/mappable.rb:130:in `block (3 levels) in <top (required)>'
```

```
  1) Budget Investments behaves like mappable At new_management_budget_investment_path Toggle map
     Failure/Error: visit send(mappable_new_path, arguments)
     Net::ReadTimeout:
       Net::ReadTimeout
     Shared Example Group: "mappable" called from ./spec/features/management/budget_investments_spec.rb:12
     # ./spec/shared/features/mappable.rb:105:in `block (3 levels) in <top (required)>'
```

[Travis build 31299, job 2](https://travis-ci.org/consul/consul/jobs/569384940)
```
  1) Proposals behaves like mappable At proposal_path Should display map on proposal show page
     Failure/Error: visit send(mappable_show_path, arguments)
     Net::ReadTimeout:
       Net::ReadTimeout
     Shared Example Group: "mappable" called from ./spec/features/proposals_spec.rb:1657
     # ./spec/shared/features/mappable.rb:214:in `block (3 levels) in <top (required)>'
```

[Travis build 31299, job 2](https://travis-ci.org/consul/consul/jobs/569384940) and [Travis build 31320, job 3](https://travis-ci.org/consul/consul/jobs/578001938)
```
  2) Budget Investments Balloting Phase Confirm
     Failure/Error: click_link "Global Group"
     Net::ReadTimeout:
       Net::ReadTimeout
     # ./spec/features/budgets/investments_spec.rb:1615:in `block (3 levels) in <top (required)>'
```

[Travis build 31300, job 4](https://travis-ci.org/consul/consul/jobs/569385223), [Travis build 31306, job 1](https://travis-ci.org/consul/consul/jobs/569806212), [Travis build 31309, job 1](https://travis-ci.org/consul/consul/jobs/569808479) and [Travis build 31320, job 3](https://travis-ci.org/consul/consul/jobs/578001938)
```
  1) Budget Investments Index should show a map if heading has coordinates defined
     Failure/Error: visit budget_investments_path(budget, heading_id: heading.id)
     Net::ReadTimeout:
       Net::ReadTimeout
     # ./spec/features/budgets/investments_spec.rb:158:in `block (2 levels) in <top (required)>'
```

[Travis build 31309, job 1](https://travis-ci.org/consul/consul/jobs/569808479) and [Travis build 31326, job 1](https://travis-ci.org/consul/consul/jobs/580735680)
```
  1) Proposals behaves like mappable At edit_proposal_path Can not display map on proposal edit when remove map marker
     Failure/Error: visit send(mappable_edit_path, id: mappable.id)
     Net::ReadTimeout:
       Net::ReadTimeout
     Shared Example Group: "mappable" called from ./spec/features/proposals_spec.rb:1657
     # ./spec/shared/features/mappable.rb:156:in `block (3 levels) in <top (required)>'
```

[Travis build 31306, job 1](https://travis-ci.org/consul/consul/jobs/569806212)
```
  2) Budget Investments Selecting Phase Popup alert to vote only in one heading per group When supporting in the first heading group
     Failure/Error: visit budget_investments_path(budget, heading_id: carabanchel.id)
     Net::ReadTimeout:
       Net::ReadTimeout
     # ./spec/features/budgets/investments_spec.rb:1391:in `block (4 levels) in <top (required)>'
```

[Travis build 31303, job 1](https://travis-ci.org/consul/consul/jobs/569447729) and [Travis build 31322, job 3](https://travis-ci.org/consul/consul/jobs/580717777)
```
  1) Budgets Index map Skip invalid map markers
     Failure/Error: visit budgets_path
     Net::ReadTimeout:
       Net::ReadTimeout
     # ./spec/features/budgets/budgets_spec.rb:367:in `block (3 levels) in <top (required)>'
```

[Travis build 31303, job 4](https://travis-ci.org/consul/consul/jobs/569447732)
```
  1) Budget Investments behaves like mappable At management_budget_investment_path Should display map on budget_investment show page
     Failure/Error: visit send(mappable_show_path, arguments)
     Net::ReadTimeout:
       Net::ReadTimeout
     Shared Example Group: "mappable" called from ./spec/features/management/budget_investments_spec.rb:12
     # ./spec/shared/features/mappable.rb:214:in `block (3 levels) in <top (required)>'
```

[Travis build 31311, job 2](https://travis-ci.org/consul/consul/jobs/569809308)
```
 1) Proposals behaves like mappable At edit_proposal_path Should edit map on proposal and contain default values
     Failure/Error: visit send(mappable_edit_path, id: mappable.id)
     Net::ReadTimeout:
       Net::ReadTimeout
     Shared Example Group: "mappable" called from ./spec/features/proposals_spec.rb:1657
     # ./spec/shared/features/mappable.rb:127:in `block (3 levels) in <top (required)>'
```

[Travis build 31264, job 5](https://travis-ci.org/consul/consul/jobs/569001232), [Travis build 31298, job 5](https://travis-ci.org/consul/consul/jobs/569384816), [Travis build 31308, job 3](https://travis-ci.org/consul/consul/jobs/569807956), [Travis build 31319, job 3](https://travis-ci.org/consul/consul/jobs/577405100), [Travis build 31321, job 5](https://travis-ci.org/consul/consul/jobs/580710918), [Travis build 31323, job 2](https://travis-ci.org/consul/consul/jobs/580719159), [Travis build 31324, job 3](https://travis-ci.org/consul/consul/jobs/580719548) and [Travis build 31325, job 1](https://travis-ci.org/consul/consul/jobs/580734238)
```
 1) Admin budget phases Edit behaves like edit_translatable Manage translations Should show first available fallback when current locale translation does not exist For Budget::Phase
     Failure/Error: visit budgets_path
     Net::ReadTimeout:
       Net::ReadTimeout
     Shared Example Group: "edit_translatable" called from ./spec/features/admin/budget_phases_spec.rb:13
     # ./spec/shared/features/edit_translatable.rb:99:in `block (4 levels) in <top (required)>'
```

[Travis build 31296, job 2](https://travis-ci.org/consul/consul/jobs/569377580), [Travis build 31313, job 5](https://travis-ci.org/consul/consul/jobs/569809518) and [Travis build 31319, job 2](https://travis-ci.org/consul/consul/jobs/577405099)
```
  1) Ballots Back link after removing an investment from Ballot
     Failure/Error: visit budget_investments_path(budget, heading_id: new_york.id)
     Net::ReadTimeout:
       Net::ReadTimeout
     # ./spec/features/budgets/ballots_spec.rb:508:in `block (2 levels) in <top (required)>'
```

[Travis build 31313, job 5](https://travis-ci.org/consul/consul/jobs/569809518)
```
1) Ballots Removing investments from ballot (sidebar)
     Got 0 failures and 2 other errors:
     1.1) Failure/Error: visit budget_investments_path(budget, heading_id: new_york.id)
          Net::ReadTimeout:
            Net::ReadTimeout
          # ./spec/features/budgets/ballots_spec.rb:475:in `block (2 levels) in <top (required)>'
     1.2) Failure/Error: @io.to_io.wait_readable(@read_timeout) or raise Net::ReadTimeout
          Net::ReadTimeout:
            Net::ReadTimeout
```

[Travis build 31296, job 4](https://travis-ci.org/consul/consul/jobs/569377582)
```
  1) Votes Investments Disable voting on investments
     Failure/Error: visit budget_investments_path(budget, heading_id: heading.id)
     Net::ReadTimeout:
       Net::ReadTimeout
     # ./spec/features/budgets/votes_spec.rb:96:in `block (3 levels) in <top (required)>'
```

[Travis build 31302, job 5](https://travis-ci.org/consul/consul/jobs/569447437) and [Travis build 31311, job 5](https://travis-ci.org/consul/consul/jobs/569809325)
```
  1) Moderate budget investments Hiding an investment's author
     Failure/Error: visit budget_investments_path(budget.id, heading_id: heading.id)
     Net::ReadTimeout:
       Net::ReadTimeout
     # ./spec/features/moderation/budget_investments_spec.rb:42:in `block (2 levels) in <top (required)>'
```

[Travis build 31306, job 5](https://travis-ci.org/consul/consul/jobs/569806216) and [Travis build 31310, job 5](https://travis-ci.org/consul/consul/jobs/569808607)
```
  1) Tags Turbolinks sanity check from budget heading's show
     Failure/Error: visit budget_investments_path(budget, heading_id: heading.id)
     Net::ReadTimeout:
       Net::ReadTimeout
     # ./spec/features/tags/budget_investments_spec.rb:135:in `block (2 levels) in <top (required)>'
```