### PR TITLE
Evaluate mailer from address at runtime

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
   helper :settings
   helper :application
-  default from: "#{Setting["mailer_from_name"]} <#{Setting["mailer_from_address"]}>"
+  default from: Proc.new { "#{Setting["mailer_from_name"]} <#{Setting["mailer_from_address"]}>" }
   layout "mailer"
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,11 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  if Rails.env.test? || !ActiveRecord::Base.connection.data_source_exists?("settings")
-    config.mailer_sender = "noreply@consul.dev"
-  else
-    config.mailer_sender = "'#{Setting["mailer_from_name"]}' <#{Setting["mailer_from_address"]}>"
-  end
+  config.mailer_sender = Proc.new { "'#{Setting["mailer_from_name"]}' <#{Setting["mailer_from_address"]}>" }
 
   # Configure the class responsible to send e-mails.
   config.mailer = "DeviseMailer"

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -12,5 +12,14 @@ describe DeviseMailer do
 
       expect(email.subject).to include("confirmación")
     end
+
+    it "reads the from address at runtime" do
+      Setting["mailer_from_name"] = "New organization"
+      Setting["mailer_from_address"] = "new@consul.dev"
+
+      email = DeviseMailer.confirmation_instructions(create(:user), "ABC")
+
+      expect(email).to deliver_from "'New organization' <new@consul.dev>"
+    end
   end
 end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -13,5 +13,14 @@ describe Mailer do
 
       expect(email.subject).to include("comentado")
     end
+
+    it "reads the from address at runtime" do
+      Setting["mailer_from_name"] = "New organization"
+      Setting["mailer_from_address"] = "new@consul.dev"
+
+      email = Mailer.comment(create(:comment))
+
+      expect(email).to deliver_from "New organization <new@consul.dev>"
+    end
   end
 end


### PR DESCRIPTION
## References

* Failures on [Travis build 31267, job 2](https://travis-ci.org/consul/consul/jobs/569001778)

## Background

We're reading the value from the database, but the `ApplicationMailer.default` method is evaluated when the application is started. So if we don't use a Proc, we'll need to restart the server every time we change the value in the database, or else the old value will still be used.

## Objectives

Make sure emails are sent using the from address currently defined in the database.

## Notes

Before these changes, the following tests failed locally if executed right after running `rake db:test:prepare`, because the `default from:` was being evaluated before seeding the test database.

```
  1) Dashboards Rake #send_notifications Send notifications to proposal author when there are news actions actived for draft proposals
     Failure/Error: expect(email).to deliver_from("CONSUL <noreply@consul.dev>")

     NoMethodError:
       undefined method `addrs' for #<Mail::UnstructuredField:0x00562f174330e0>
     # ./spec/lib/tasks/dashboards_spec.rb:80:in `block (4 levels) in <top (required)>'

  2) Dashboards Rake #send_notifications Send notifications to proposal author  when there are news actions actived for published proposals
     Failure/Error: expect(email).to deliver_from("CONSUL <noreply@consul.dev>")

     NoMethodError:
       undefined method `addrs' for #<Mail::UnstructuredField:0x00562f0f85c250>
     # ./spec/lib/tasks/dashboards_spec.rb:67:in `block (4 levels) in <top (required)>'

  3) Dashboard::Mailer#new_actions_notification rake task #new_actions_notification_rake_published sends emails when detect new actions for proposal
     Failure/Error: expect(email).to deliver_from("CONSUL <noreply@consul.dev>")

     NoMethodError:
       undefined method `addrs' for #<Mail::UnstructuredField:0x007fd676f2c250>
     # ./spec/mailers/dashboard/mailer_spec.rb:125:in `block (4 levels) in <top (required)>'

  4) Dashboard::Mailer#new_actions_notification rake task #new_actions_notification_rake_created sends emails when detect new actions for draft proposal
     Failure/Error: expect(email).to deliver_from("CONSUL <noreply@consul.dev>")

     NoMethodError:
       undefined method `addrs' for #<Mail::UnstructuredField:0x00562f1bdc1068>
     # ./spec/mailers/dashboard/mailer_spec.rb:83:in `block (4 levels) in <top (required)>'

  5) Dashboard::Mailer#new_actions_notification_on_create sends emails if new actions detected when creating a proposal
     Failure/Error: expect(email).to deliver_from("CONSUL <noreply@consul.dev>")

     NoMethodError:
       undefined method `addrs' for #<Mail::UnstructuredField:0x007fd677494800>
     # ./spec/mailers/dashboard/mailer_spec.rb:181:in `block (3 levels) in <top (required)>'

  6) Dashboard::Mailer#new_actions_notification_on_published sends emails when detect new actions when publish a proposal
     Failure/Error: expect(email).to deliver_from("CONSUL <noreply@consul.dev>")

     NoMethodError:
       undefined method `addrs' for #<Mail::UnstructuredField:0x00562f1bef7040>
     # ./spec/mailers/dashboard/mailer_spec.rb:247:in `block (3 levels) in <top (required)>'

  7) Dashboard::Mailer#forward sends forward email
     Failure/Error: expect(email).to deliver_from("CONSUL <noreply@consul.dev>")

     NoMethodError:
       undefined method `addrs' for #<Mail::UnstructuredField:0x007fd6756b02d0>
     # ./spec/mailers/dashboard/mailer_spec.rb:40:in `block (3 levels) in <top (required)>'
```