### PR TITLE
Create less headings in budget investment tests

### DIFF
--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -83,7 +83,8 @@ FactoryBot.define do
 
   factory :budget_investment, class: "Budget::Investment" do
     sequence(:title) { |n| "Budget Investment #{n} title" }
-    heading { association :budget_heading, budget: budget }
+    heading { budget&.headings&.reload&.sample || association(:budget_heading, budget: budget) }
+
     association :author, factory: :user
     description          { "Spend money on this" }
     price                { 10 }

--- a/spec/models/budget/stats_spec.rb
+++ b/spec/models/budget/stats_spec.rb
@@ -87,7 +87,7 @@ describe Budget::Stats do
 
     it "doesn't count nil user ids" do
       create(:budget_ballot_line, investment: investment,
-        ballot: create(:budget_ballot, budget: budget, user: nil, physical: true)
+        ballot: create(:budget_ballot, budget: budget.reload, user: nil, physical: true)
       )
 
       expect(stats.total_participants_vote_phase).to be 0


### PR DESCRIPTION
## References

* Failures on [Travis build 31324, job 2](https://travis-ci.org/consul/consul/jobs/580719547) and [Travis build 31326, job 3](https://travis-ci.org/consul/consul/jobs/580735684)

## Objectives

Make tests creating many budget investments faster.

## Notes

The following test started to fail recently because it created many headings and ordering them by name took about half a second on Travis:

```
  1) Admin budget investments Selecting Pagination After unselecting an investment
     Failure/Error: expect(page).to have_link("Previous")
       expected to find visible link "Previous" but there were no matches
     # ./spec/features/admin/budget_investments_spec.rb:1596:in `block (4 levels) in <top (required)>'
```