### PR TITLE
Fix flaky specs for uppercase tags

### DIFF
--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -511,28 +511,29 @@ describe "Consul Schema" do
       expect(received_tags).to match_array ["Parks", "Health"]
     end
 
-    it "uppercase and lowercase tags work ok together for proposals" do
-      create(:tag, name: "Health")
-      create(:tag, name: "health")
-      create(:proposal, tag_list: "health")
-      create(:proposal, tag_list: "Health")
+    context "uppercase and lowercase tags" do
+      let(:uppercase_tag) { create(:tag, name: "Health") }
+      let(:lowercase_tag) { create(:tag, name: "health") }
 
-      response = execute("{ tags { edges { node { name } } } }")
-      received_tags = extract_fields(response, "tags", "name")
+      it "works OK when both tags are present for proposals" do
+        create(:proposal).tags = [uppercase_tag]
+        create(:proposal).tags = [lowercase_tag]
 
-      expect(received_tags).to match_array ["Health", "health"]
-    end
+        response = execute("{ tags { edges { node { name } } } }")
+        received_tags = extract_fields(response, "tags", "name")
 
-    it "uppercase and lowercase tags work ok together for debates" do
-      create(:tag, name: "Health")
-      create(:tag, name: "health")
-      create(:debate, tag_list: "Health")
-      create(:debate, tag_list: "health")
+        expect(received_tags).to match_array ["Health", "health"]
+      end
 
-      response = execute("{ tags { edges { node { name } } } }")
-      received_tags = extract_fields(response, "tags", "name")
+      it "works OK when both tags are present for proposals" do
+        create(:debate).tags = [uppercase_tag]
+        create(:debate).tags = [lowercase_tag]
 
-      expect(received_tags).to match_array ["Health", "health"]
+        response = execute("{ tags { edges { node { name } } } }")
+        received_tags = extract_fields(response, "tags", "name")
+
+        expect(received_tags).to match_array ["Health", "health"]
+      end
     end
 
     it "does not display tags for hidden proposals" do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -34,4 +34,23 @@ describe Tag do
       expect(tag).to be_valid
     end
   end
+
+  context "Same tag uppercase and lowercase" do
+    before do
+      create(:tag, name: "Health")
+      create(:tag, name: "health")
+    end
+
+    it "assigns only one of the existing tags (we can't control which one)" do
+      debate = create(:debate, tag_list: "Health")
+
+      expect([["Health"], ["health"]]).to include debate.reload.tag_list
+    end
+
+    it "assigns existing tags instead of creating new similar ones" do
+      debate = create(:debate, tag_list: "hEaLth")
+
+      expect([["Health"], ["health"]]).to include debate.reload.tag_list
+    end
+  end
 end


### PR DESCRIPTION
## References

* Failures in [Travis build 31304, job 5](https://travis-ci.org/consul/consul/jobs/569805646) and [javierm's build 661](https://travis-ci.org/javierm/consul/builds/582032453)

## Background

Some tests in the `spec/lib/graphql_spec.rb` failed sometimes because creating a record with a tag list of `["health"]` when both "health" and "Health" tags exist might assign either one of them. These tests usually pass because we create two records and just by chance usually one of the records gets one tag and the other one gets the other tag. However, the tests were written as if we expected the first record to get the first tag and the second record to get the second tag, while very often the tests were passing because the first record got the second tag and the second record got the first tag. And when both records get the same tag, the tests fail.

## Objectives

Make the tests express the way the application behaves: a random tag is assigned when several tags with the same case-insensitive name exist.

We could also change the way the application works and make tags case sensitive or force lowercase tags. However, we might break existing data if we do so, as mentioned in AyuntamientoMadrid#747.

## Notes

Another option to assign the right tag to the record we're creatingwould be to add `ActsAsTaggableOn.strict_case_match = true` to an initializer. However, that would also create new tags on the database when we accidentally assign a tag like "hEaLth" (like in the test we add
in this commit). Ideally we would have a strict case match for existing tags and a non-strict case match for new tags, but I haven't found a way to do it.

The following tests failed sometimes due to this behaviour, with slightly different error messages, showing the assigned tag is random:

```
  1) Consul Schema Tags uppercase and lowercase tags work ok together for debates
     Failure/Error: expect(received_tags).to match_array ["Health", "health"]
       expected collection contained:  ["Health", "health"]
       actual collection contained:    ["Health"]
       the missing elements were:      ["health"]
     # ./spec/lib/graphql_spec.rb:535:in `block (3 levels) in <top (required)>'
  2) Consul Schema uppercase and lowercase tags work ok together for debates
     Failure/Error: expect(received_tags).to match_array ["Health", "health"]
       expected collection contained:  ["Health", "health"]
       actual collection contained:    ["health"]
       the missing elements were:      ["Health"]
  3) Consul Schema uppercase and lowercase tags work ok together for proposals
     Failure/Error: expect(received_tags).to match_array ["Health", "health"]
       expected collection contained:  ["Health", "health"]
       actual collection contained:    ["Health"]
       the missing elements were:      ["health"]
 4) Consul Schema uppercase and lowercase tags work ok together for proposals
     Failure/Error: expect(received_tags).to match_array ["Health", "health"]
       expected collection contained:  ["Health", "health"]
       actual collection contained:    ["health"]
       the missing elements were:      ["Health"]
     # ./spec/lib/graphql_spec.rb:5709:in `block (2 levels) in <top (required)>'
```