### PR TITLE
Reduce the number of proposals in pagination spec

### DIFF
--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -4,7 +4,6 @@ require "sessions_helper"
 describe "Legislation Proposals" do
 
   let(:user)     { create(:user) }
-  let(:user2)    { create(:user) }
   let(:process)  { create(:legislation_process) }
   let(:proposal) { create(:legislation_proposal) }
 
@@ -21,8 +20,10 @@ describe "Legislation Proposals" do
   end
 
   describe "Random pagination" do
+    let(:per_page) { 4 }
+
     before do
-      allow(Legislation::Proposal).to receive(:default_per_page).and_return(12)
+      allow(Legislation::Proposal).to receive(:default_per_page).and_return(per_page)
 
       create_list(
         :legislation_proposal,
@@ -31,29 +32,34 @@ describe "Legislation Proposals" do
       )
     end
 
-    scenario "Each user has a different and consistent random proposals order", :js do
-      in_browser(:one) do
-        login_as user
-        visit legislation_process_proposals_path(process)
-        @first_user_proposals_order = legislation_proposals_order
-      end
+    context "for several users" do
+      let(:user2)    { create(:user) }
+      let(:per_page) { 12 }
 
-      in_browser(:two) do
-        login_as user2
-        visit legislation_process_proposals_path(process)
-        @second_user_proposals_order = legislation_proposals_order
-      end
+      scenario "Each user has a different and consistent random proposals order", :js do
+        in_browser(:one) do
+          login_as user
+          visit legislation_process_proposals_path(process)
+          @first_user_proposals_order = legislation_proposals_order
+        end
 
-      expect(@first_user_proposals_order).not_to eq(@second_user_proposals_order)
+        in_browser(:two) do
+          login_as user2
+          visit legislation_process_proposals_path(process)
+          @second_user_proposals_order = legislation_proposals_order
+        end
 
-      in_browser(:one) do
-        visit legislation_process_proposals_path(process)
-        expect(legislation_proposals_order).to eq(@first_user_proposals_order)
-      end
+        expect(@first_user_proposals_order).not_to eq(@second_user_proposals_order)
 
-      in_browser(:two) do
-        visit legislation_process_proposals_path(process)
-        expect(legislation_proposals_order).to eq(@second_user_proposals_order)
+        in_browser(:one) do
+          visit legislation_process_proposals_path(process)
+          expect(legislation_proposals_order).to eq(@first_user_proposals_order)
+        end
+
+        in_browser(:two) do
+          visit legislation_process_proposals_path(process)
+          expect(legislation_proposals_order).to eq(@second_user_proposals_order)
+        end
       end
     end
 


### PR DESCRIPTION
## References

* Failures in [Travis build 31238, job 1](https://travis-ci.org/consul/consul/jobs/562538892), [Travis build 31253, job 4](https://travis-ci.org/consul/consul/jobs/568820389), [Travis build 31337, job 4](https://travis-ci.org/consul/consul/jobs/581841638), [Travis build 31350, job 4](https://travis-ci.org/consul/consul/jobs/582026851) and [Travis build 31353, job 5](https://travis-ci.org/consul/consul/jobs/582380999)

## Background

We're getting a failure on Travis in one of these tests. Debugging shows the AJAX request rendering the first page (after clicking the "Previous" link) takes too long and sometimes it exceeds Capybara's timeout.

## Objectives

Make the test faster so we don't reach Capybara's timeout.

## Notes

After running the test thousands of times, the only way I've found to clearly reduce the number of times the test fails (reducing the time of the request by 0.4 seconds on average) is to reduce the number of records shown on the first page. Other experiments, like adding an `includes(:author)` to the query getting the proposals in the controller, or adding `author: user` to the `create_list` part of the test (so only one author needs to be fetched when rendering the proposals) show inconsistent results regarding performance.

Of course improving the performance of the partial rendering legislation proposals would be a better solution. However, after some debugging I wasn't able to find a clear bottleneck, so speeding up this part would be a complex task.

The test failed with the following message:

```
  1) Legislation Proposals Random pagination Random order maintained with pagination
     Failure/Error: expect(page).to have_content "You're on page 1"
       expected to find text "You're on page 1" in "CONSUL Language: عربى Bosanski Čeština Dansk Deutsch Ελληνικά English Español فارسى Français Galego עברית Hrvatski Bahasa Inggris Italiano Nederlands Polski Português brasileiro Pусский Slovenščina Shqiptar Af Soomaali Svenska Türkçe Valencià 中文 英文 Notifications My content My account Sign out Debates Proposals Voting You are in Collaborative legislation Participatory budgeting Help Go back A collaborative legislation process DESCRIPTION Description of the process SHARE twitter facebook google_plus DRAFT PUBLICATION 06 Aug 2019 FINAL RESULT PUBLICATION 12 Aug 2019 Participation phases Debate 02 Aug 2019 - 09 Aug 2019 Proposals 07 Aug 2019 - 09 Aug 2019 Comments 07 Aug 2019 - 10 Aug 2019 : Random Selected Proposal 32 for a legislation No comments • 2019-08-07 • Manuela1550 This law should include... I agree 0% I disagree 0% No votes Proposal 19 for a legislation No comments • 2019-08-07 • Manuela1537 This law should include... I agree 0% I disagree 0% No votes First Previous 1 You're on page 2 Create a proposal CATEGORIES Open government This portal uses the CONSUL application which is open-source software. For technical assistance visit Participation Decide how to shape the city you want to live in. CONSUL, 2019 | Privacy Policy | Terms and conditions of use | Accessibility"
```