### PR TITLE
Add search form on admin booths

### DIFF
--- a/app/controllers/admin/poll/booths_controller.rb
+++ b/app/controllers/admin/poll/booths_controller.rb
@@ -2,6 +2,7 @@ class Admin::Poll::BoothsController < Admin::Poll::BaseController
   load_and_authorize_resource class: "Poll::Booth"
 
   def index
+    @booths = @booths.search params[:search].strip if params[:search]
     @booths = @booths.order(name: :asc).page(params[:page])
   end
 

--- a/app/controllers/admin/poll/booths_controller.rb
+++ b/app/controllers/admin/poll/booths_controller.rb
@@ -2,7 +2,7 @@ class Admin::Poll::BoothsController < Admin::Poll::BaseController
   load_and_authorize_resource class: "Poll::Booth"
 
   def index
-    @booths = @booths.search params[:search].strip if params[:search]
+    @booths = @booths.search params[:search] if params[:search]
     @booths = @booths.order(name: :asc).page(params[:page])
   end
 

--- a/app/views/admin/poll/booths/index.html.erb
+++ b/app/views/admin/poll/booths/index.html.erb
@@ -10,9 +10,9 @@
   </div>
 <% end %>
 
-<% if @booths.any? %>
-  <%= render "/admin/shared/booth_search", url: admin_booths_path %>
+<%= render "/admin/shared/booth_search", url: admin_booths_path %>
 
+<% if @booths.any? %>
   <h3><%= page_entries_info @booths %></h3>
   <table>
     <thead>

--- a/app/views/admin/poll/booths/index.html.erb
+++ b/app/views/admin/poll/booths/index.html.erb
@@ -11,6 +11,8 @@
 <% end %>
 
 <% if @booths.any? %>
+  <%= render "/admin/shared/booth_search", url: admin_booths_path %>
+
   <h3><%= page_entries_info @booths %></h3>
   <table>
     <thead>

--- a/app/views/admin/shared/_booth_search.html.erb
+++ b/app/views/admin/shared/_booth_search.html.erb
@@ -1,9 +1,9 @@
 <%= form_for(Poll::Booth.new, url: url, as: :booth, method: :get) do |f| %>
   <div class="small-12 medium-6">
     <div class="input-group">
-      <%= text_field_tag :search, "", placeholder: t("admin.shared.booths_search.placeholder") %>
+      <%= text_field_tag :search, params[:search], placeholder: t("admin.shared.booths_search.placeholder") %>
       <div class="input-group-button">
-        <%= f.submit t("admin.shared.proposal_search.button"), class: "button" %>
+        <%= f.submit t("admin.shared.booths_search.button"), class: "button" %>
       </div>
     </div>
   </div>

--- a/app/views/admin/shared/_booth_search.html.erb
+++ b/app/views/admin/shared/_booth_search.html.erb
@@ -1,0 +1,10 @@
+<%= form_for(Poll::Booth.new, url: url, as: :booth, method: :get) do |f| %>
+  <div class="small-12 medium-6">
+    <div class="input-group">
+      <%= text_field_tag :search, "", placeholder: t("admin.shared.booths_search.placeholder") %>
+      <div class="input-group-button">
+        <%= f.submit t("admin.shared.proposal_search.button"), class: "button" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1330,7 +1330,7 @@ en:
       false_value: "No"
       booths_search:
         button: Search
-        placeholder: Search booth by name
+        placeholder: Search booth by name or location
       poll_officers_search:
         button: Search
         placeholder: Search poll officers

--- a/spec/features/admin/poll/booths_spec.rb
+++ b/spec/features/admin/poll/booths_spec.rb
@@ -123,4 +123,22 @@ describe "Admin booths" do
     click_link "Go back"
     expect(page).to have_current_path(available_admin_booths_path)
   end
+
+  scenario "Search" do
+    booth = create(:poll_booth)
+
+    visit admin_booths_path
+
+    fill_in "search", with: booth.name
+    click_button "Search"
+    expect(page).to have_css(".booth", count: 1)
+
+    fill_in "search", with: booth.location
+    click_button "Search"
+    expect(page).to have_css(".booth", count: 1)
+
+    fill_in "search", with: "Wrong search criteria"
+    click_button "Search"
+    expect(page).to have_content "There are no active booths for any upcoming poll."
+  end
 end

--- a/spec/features/admin/poll/shifts_spec.rb
+++ b/spec/features/admin/poll/shifts_spec.rb
@@ -48,7 +48,7 @@ describe "Admin shifts" do
       click_link "Manage shifts"
     end
 
-    expect(page).to have_content "git This booth has no shifts"
+    expect(page).to have_content "This booth has no shifts"
 
     fill_in "search", with: officer.email
     click_button "Search"

--- a/spec/features/admin/poll/shifts_spec.rb
+++ b/spec/features/admin/poll/shifts_spec.rb
@@ -48,6 +48,8 @@ describe "Admin shifts" do
       click_link "Manage shifts"
     end
 
+    expect(page).to have_content "git This booth has no shifts"
+
     fill_in "search", with: officer.email
     click_button "Search"
     click_link "Edit shifts"
@@ -71,6 +73,8 @@ describe "Admin shifts" do
     within("#booth_#{booth.id}") do
       click_link "Manage shifts"
     end
+
+    expect(page).to have_css(".shift", count: 1)
 
     fill_in "search", with: officer.email
     click_button "Search"
@@ -115,6 +119,8 @@ describe "Admin shifts" do
       click_link "Manage shifts"
     end
 
+    expect(page).to have_css(".shift", count: 2)
+
     fill_in "search", with: officer.email
     click_button "Search"
     click_link "Edit shifts"
@@ -153,6 +159,8 @@ describe "Admin shifts" do
     within("#booth_#{booth.id}") do
       click_link "Manage shifts"
     end
+
+    expect(page).to have_content "This booth has no shifts"
 
     fill_in "search", with: officer.email
     click_button "Search"


### PR DESCRIPTION
## References

* Closes #3607

## Objectives

Add ability to search booths by name and location

## Visual Changes
<img width="1059" alt="Снимок экрана 2019-09-11 в 21 48 24" src="https://user-images.githubusercontent.com/32555357/64725774-f5e81780-d4dd-11e9-9715-a09e4b74361d.png">