### PR TITLE
Define SMTP settings in secrets file

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,7 +21,7 @@ set :log_level, :info
 set :pty, true
 set :use_sudo, false
 
-set :linked_files, %w[config/database.yml config/secrets.yml config/environments/production.rb]
+set :linked_files, %w[config/database.yml config/secrets.yml]
 set :linked_dirs, %w[log tmp public/system public/assets public/ckeditor_assets]
 
 set :keep_releases, 5

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,7 +47,7 @@ namespace :deploy do
 
   after "deploy:migrate", "add_new_settings"
 
-  before :publishing, "smtp_and_ssl_secrets"
+  before :publishing, "smtp_ssl_and_delay_jobs_secrets"
 
   after :publishing, "deploy:restart"
   after :published, "delayed_job:restart"
@@ -131,7 +131,7 @@ task :setup_puma do
   end
 end
 
-task :smtp_and_ssl_secrets do
+task :smtp_ssl_and_delay_jobs_secrets do
   on roles(:app) do
     within current_path do
       with rails_env: fetch(:rails_env) do
@@ -141,7 +141,7 @@ task :smtp_and_ssl_secrets do
           begin
             execute "cp #{release_path}/#{tasks_file_path} #{current_path}/#{tasks_file_path}"
 
-            execute :rake, "secrets:smtp_and_ssl"
+            execute :rake, "secrets:smtp_ssl_and_delay_jobs"
           ensure
             execute "rm #{current_path}/#{tasks_file_path}"
           end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -136,9 +136,15 @@ task :smtp_ssl_and_delay_jobs_secrets do
     within current_path do
       with rails_env: fetch(:rails_env) do
         tasks_file_path = "lib/tasks/secrets.rake"
+        shared_secrets_path = "#{shared_path}/config/secrets.yml"
 
         unless test("[ -e #{current_path}/#{tasks_file_path} ]")
           begin
+            unless test("[ -w #{shared_secrets_path} ]")
+              execute "sudo chown `whoami` #{shared_secrets_path}"
+              execute "chmod u+w #{shared_secrets_path}"
+            end
+
             execute "cp #{release_path}/#{tasks_file_path} #{current_path}/#{tasks_file_path}"
 
             execute :rake, "secrets:smtp_ssl_and_delay_jobs"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -133,9 +133,19 @@ end
 
 task :smtp_and_ssl_secrets do
   on roles(:app) do
-    within release_path do
+    within current_path do
       with rails_env: fetch(:rails_env) do
-        execute :rake, "secrets:smtp_and_ssl"
+        tasks_file_path = "lib/tasks/secrets.rake"
+
+        unless test("[ -e #{current_path}/#{tasks_file_path} ]")
+          begin
+            execute "cp #{release_path}/#{tasks_file_path} #{current_path}/#{tasks_file_path}"
+
+            execute :rake, "secrets:smtp_and_ssl"
+          ensure
+            execute "rm #{current_path}/#{tasks_file_path}"
+          end
+        end
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,7 +47,7 @@ namespace :deploy do
 
   after "deploy:migrate", "add_new_settings"
 
-  before :publishing, "smtp_secrets"
+  before :publishing, "smtp_and_ssl_secrets"
 
   after :publishing, "deploy:restart"
   after :published, "delayed_job:restart"
@@ -131,11 +131,11 @@ task :setup_puma do
   end
 end
 
-task :smtp_secrets do
+task :smtp_and_ssl_secrets do
   on roles(:app) do
     within release_path do
       with rails_env: fetch(:rails_env) do
-        execute :rake, "secrets:smtp"
+        execute :rake, "secrets:smtp_and_ssl"
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -46,6 +46,9 @@ namespace :deploy do
   before "deploy:migrate", "remove_local_census_records_duplicates"
 
   after "deploy:migrate", "add_new_settings"
+
+  before :publishing, "smtp_secrets"
+
   after :publishing, "deploy:restart"
   after :published, "delayed_job:restart"
   after :published, "refresh_sitemap"
@@ -123,6 +126,16 @@ task :setup_puma do
 
       if test("[ -e #{shared_path}/sockets/unicorn.sock ]")
         execute "ln -sf #{shared_path}/tmp/sockets/puma.sock #{shared_path}/sockets/unicorn.sock; true"
+      end
+    end
+  end
+end
+
+task :smtp_secrets do
+  on roles(:app) do
+    within release_path do
+      with rails_env: fetch(:rails_env) do
+        execute :rake, "secrets:smtp"
       end
     end
   end

--- a/config/environments/preproduction.rb
+++ b/config/environments/preproduction.rb
@@ -47,7 +47,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # Configure force_ssl in secrets.yml
+  config.force_ssl = Rails.application.secrets.force_ssl
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/preproduction.rb
+++ b/config/environments/preproduction.rb
@@ -71,17 +71,11 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Rails.application.secrets.server_name }
   config.action_mailer.asset_host = "https://#{Rails.application.secrets.server_name}"
 
-  # SMTP configuration to deliver emails
-  # Uncomment the following block of code and add your SMTP service credentials
-  # config.action_mailer.delivery_method = :smtp
-  # config.action_mailer.smtp_settings = {
-  #   address:              "smtp.example.com",
-  #   port:                 587,
-  #   domain:               "example.com",
-  #   user_name:            "<username>",
-  #   password:             "<password>",
-  #   authentication:       "plain",
-  #   enable_starttls_auto: true }
+  # Configure your SMTP service credentials in secrets.yml
+  if Rails.application.secrets.smtp_settings
+    config.action_mailer.delivery_method = Rails.application.secrets.mailer_delivery_method || :smtp
+    config.action_mailer.smtp_settings = Rails.application.secrets.smtp_settings
+  end
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,8 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # Configure force_ssl in secrets.yml
+  config.force_ssl = Rails.application.secrets.force_ssl
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,17 +72,11 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Rails.application.secrets.server_name }
   config.action_mailer.asset_host = "https://#{Rails.application.secrets.server_name}"
 
-  # SMTP configuration to deliver emails
-  # Uncomment the following block of code and add your SMTP service credentials
-  # config.action_mailer.delivery_method = :smtp
-  # config.action_mailer.smtp_settings = {
-  #   address:              "smtp.example.com",
-  #   port:                 587,
-  #   domain:               "example.com",
-  #   user_name:            "<username>",
-  #   password:             "<password>",
-  #   authentication:       "plain",
-  #   enable_starttls_auto: true }
+  # Configure your SMTP service credentials in secrets.yml
+  if Rails.application.secrets.smtp_settings
+    config.action_mailer.delivery_method = Rails.application.secrets.mailer_delivery_method || :smtp
+    config.action_mailer.smtp_settings = Rails.application.secrets.smtp_settings
+  end
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -47,7 +47,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # Configure force_ssl in secrets.yml
+  config.force_ssl = Rails.application.secrets.force_ssl
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -71,17 +71,11 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Rails.application.secrets.server_name }
   config.action_mailer.asset_host = "https://#{Rails.application.secrets.server_name}"
 
-  # SMTP configuration to deliver emails
-  # Uncomment the following block of code and add your SMTP service credentials
-  # config.action_mailer.delivery_method = :smtp
-  # config.action_mailer.smtp_settings = {
-  #   address:              "smtp.example.com",
-  #   port:                 587,
-  #   domain:               "example.com",
-  #   user_name:            "<username>",
-  #   password:             "<password>",
-  #   authentication:       "plain",
-  #   enable_starttls_auto: true }
+  # Configure your SMTP service credentials in secrets.yml
+  if Rails.application.secrets.smtp_settings
+    config.action_mailer.delivery_method = Rails.application.secrets.mailer_delivery_method || :smtp
+    config.action_mailer.smtp_settings = Rails.application.secrets.smtp_settings
+  end
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,8 +1,11 @@
 if Rails.env.test? || Rails.env.development?
   Delayed::Worker.delay_jobs = false
-else
+elsif Rails.application.secrets.delay_jobs.nil?
   Delayed::Worker.delay_jobs = true
+else
+  Delayed::Worker.delay_jobs = Rails.application.secrets.delay_jobs
 end
+
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 2
 Delayed::Worker.max_attempts = 3

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -32,6 +32,7 @@ test:
 staging:
   secret_key_base: ""
   server_name: ""
+  force_ssl: true
   rollbar_server_token: ""
   http_basic_username: ""
   http_basic_password: ""
@@ -53,6 +54,7 @@ preproduction:
   #   password: "<password>"
   #   authentication: "plain"
   #   enable_starttls_auto: true
+  force_ssl: true
   rollbar_server_token: ""
   http_basic_username: ""
   http_basic_password: ""
@@ -79,6 +81,7 @@ production:
   #   password: "<password>"
   #   authentication: "plain"
   #   enable_starttls_auto: true
+  force_ssl: true
   rollbar_server_token: ""
   http_basic_username: ""
   http_basic_password: ""

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -44,6 +44,15 @@ staging:
 preproduction:
   secret_key_base: ""
   server_name: ""
+  # mailer_delivery_method: "smtp"
+  # smtp_settings:
+  #   address: "smtp.example.com"
+  #   port: 25
+  #   domain: "your_domain.com"
+  #   user_name: "<username>"
+  #   password: "<password>"
+  #   authentication: "plain"
+  #   enable_starttls_auto: true
   rollbar_server_token: ""
   http_basic_username: ""
   http_basic_password: ""
@@ -61,6 +70,15 @@ preproduction:
 production:
   secret_key_base: ""
   server_name: ""
+  # mailer_delivery_method: "smtp"
+  # smtp_settings:
+  #   address: "smtp.example.com"
+  #   port: 25
+  #   domain: "your_domain.com"
+  #   user_name: "<username>"
+  #   password: "<password>"
+  #   authentication: "plain"
+  #   enable_starttls_auto: true
   rollbar_server_token: ""
   http_basic_username: ""
   http_basic_password: ""

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -33,6 +33,7 @@ staging:
   secret_key_base: ""
   server_name: ""
   force_ssl: true
+  delay_jobs: true
   rollbar_server_token: ""
   http_basic_username: ""
   http_basic_password: ""
@@ -55,6 +56,7 @@ preproduction:
   #   authentication: "plain"
   #   enable_starttls_auto: true
   force_ssl: true
+  delay_jobs: true
   rollbar_server_token: ""
   http_basic_username: ""
   http_basic_password: ""
@@ -82,6 +84,7 @@ production:
   #   authentication: "plain"
   #   enable_starttls_auto: true
   force_ssl: true
+  delay_jobs: true
   rollbar_server_token: ""
   http_basic_username: ""
   http_basic_password: ""

--- a/lib/tasks/secrets.rake
+++ b/lib/tasks/secrets.rake
@@ -1,0 +1,23 @@
+namespace :secrets do
+  desc "Add SMTP settings to secrets.yml"
+  task smtp: :environment do
+    exit if Rails.application.secrets.smtp_settings
+
+    current_settings = {
+      "mailer_delivery_method" => ActionMailer::Base.delivery_method.to_s,
+      "smtp_settings"          => ActionMailer::Base.smtp_settings.stringify_keys
+    }
+
+    secrets = Rails.application.config.paths["config/secrets"].first
+    stream = Psych.parse_stream(File.read(secrets))
+    nodes = stream.children.first.children.first
+
+    environment_index = nodes.children.index do |child|
+      child.is_a?(Psych::Nodes::Scalar) && child.value == Rails.env
+    end
+
+    nodes.children[environment_index + 1].children.push(*Psych.parse(current_settings.to_yaml).children.first.children)
+
+    File.open(secrets, "w") { |file| file.write stream.to_yaml }
+  end
+end

--- a/lib/tasks/secrets.rake
+++ b/lib/tasks/secrets.rake
@@ -1,12 +1,17 @@
 namespace :secrets do
-  desc "Add SMTP settings to secrets.yml"
-  task smtp: :environment do
-    exit if Rails.application.secrets.smtp_settings
-
+  desc "Add SMTP and SSL settings to secrets.yml"
+  task smtp_and_ssl: :environment do
     current_settings = {
       "mailer_delivery_method" => ActionMailer::Base.delivery_method.to_s,
-      "smtp_settings"          => ActionMailer::Base.smtp_settings.stringify_keys
+      "smtp_settings"          => ActionMailer::Base.smtp_settings.stringify_keys,
+      "force_ssl"              => Rails.application.config.force_ssl
     }
+
+    settings_to_add = current_settings.select do |name, _|
+      Rails.application.secrets[name].nil?
+    end
+
+    exit if settings_to_add.empty?
 
     secrets = Rails.application.config.paths["config/secrets"].first
     stream = Psych.parse_stream(File.read(secrets))
@@ -16,7 +21,7 @@ namespace :secrets do
       child.is_a?(Psych::Nodes::Scalar) && child.value == Rails.env
     end
 
-    nodes.children[environment_index + 1].children.push(*Psych.parse(current_settings.to_yaml).children.first.children)
+    nodes.children[environment_index + 1].children.push(*Psych.parse(settings_to_add.to_yaml).children.first.children)
 
     File.open(secrets, "w") { |file| file.write stream.to_yaml }
   end

--- a/lib/tasks/secrets.rake
+++ b/lib/tasks/secrets.rake
@@ -1,10 +1,11 @@
 namespace :secrets do
-  desc "Add SMTP and SSL settings to secrets.yml"
-  task smtp_and_ssl: :environment do
+  desc "Add SMTP, SSL and delay jobs settings to secrets.yml"
+  task smtp_ssl_and_delay_jobs: :environment do
     current_settings = {
       "mailer_delivery_method" => ActionMailer::Base.delivery_method.to_s,
       "smtp_settings"          => ActionMailer::Base.smtp_settings.stringify_keys,
-      "force_ssl"              => Rails.application.config.force_ssl
+      "force_ssl"              => Rails.application.config.force_ssl,
+      "delay_jobs"             => Delayed::Worker.delay_jobs
     }
 
     settings_to_add = current_settings.select do |name, _|


### PR DESCRIPTION
## References

* Pull request rockandror#47 uses a different approach by storing settings in the database
* Continues pull request #2900
* Solves the first half of consul/installer#34
* Closes #3625

## Background

Currently, the CONSUL installer replaces the existing `production.rb` environment file with its own file. This way secrets like SMTP credentials are not included in the repository. However, it's hard to keep both files up to date, and so changes we did to the production environment file when we upgraded to Rails 5 haven't been included in the installer.

## Objectives

Avoid differences between the `production.rb` and `delayed_job_config.rb` files included in version control and the ones included in the CONSUL installer.

## Release notes

SMTP, SSL and delayed job activation settings are now configured in the `config/secrets.yml` file. If, as we strongly recommend, you use capistrano to deploy your code, your current settings will be copied to the `config/secrets.yml` file automatically so you won't have to worry about this change :wink:. If for some reason you don't use capistrano, either have a look at the task in `lib/tasks/secrets.rake` or edit your `config/secrets.yml` file manually.

If you've installed CONSUL using the CONSUL installer and you've activated delayed jobs and you've changed your delayed job (that is, `Delayed::Worker`) configuration, you might want to edit the `config/initializers/delayed_job_config.rb` file and adjust your settings.