### PR TITLE
Update README link to PRs welcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Citizen Participation and Open Government Application
 [![A11y issues checked with Rocket Validator](https://rocketvalidator.com/badges/checked_with_rocket_validator.svg?url=https://rocketvalidator.com)](https://rocketvalidator.com/opensource)
 
 [![Join the chat at https://gitter.im/consul/consul](https://badges.gitter.im/consul/consul.svg)](https://gitter.im/consul/consul?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/consul/consul/issues?q=is%3Aissue+is%3Aopen+label%3APRs-welcome)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/consul/consul/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted")
 
 This is the opensource code repository of the eParticipation website CONSUL, originally developed for the Madrid City government eParticipation website
 


### PR DESCRIPTION
## Background

Until now, we were using the "PRs welcome" tag for issues we would like to implement but didn't have time do develop ourselves. However, GitHub treats "help-wanted" as a special label, showing issues labeled this way to other developers.

## Objectives

Make it easier for contributors to find pull requests where their help would be really appreciated.

## Notes 

I'm still keeping the "PRs welcome" text and icon because it sound less aggressive than "help wanted".