### PR TITLE
Stub the response to external request for available locales

### DIFF
--- a/spec/shared/features/remotely_translatable.rb
+++ b/spec/shared/features/remotely_translatable.rb
@@ -10,6 +10,9 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
   before do
     Setting["feature.remote_translations"] = true
+    available_locales_response = %w[de en es fr pt zh-Hans]
+    expect(RemoteTranslations::Microsoft::AvailableLocales).to receive(:available_locales).at_most(3).times.
+                                                            and_return(available_locales_response)
   end
 
   after do


### PR DESCRIPTION
## References
Related PRs: #3235, #3236, #3237 

## Objectives
In remote translation tests, an external request is made to request the available languages. These specs fail when travis has connection problems and when we have not an internet connection. For these reasons we believe that it is convenient to stub the response to this request.  

## Visual Changes
None

## Notes
The only problem with this change is when the Microsoft API is modified
It's true that the API doesn't change very often, but it may change someday... 🤔 