### PR TITLE
Simplify after blocks in specs

### DIFF
--- a/spec/controllers/concerns/remotely_translatable_spec.rb
+++ b/spec/controllers/concerns/remotely_translatable_spec.rb
@@ -7,10 +7,6 @@ describe RemotelyTranslatable do
     Setting["feature.remote_translations"] = true
   end
 
-  after do
-    Setting["feature.remote_translations"] = nil
-  end
-
   describe "#detect_remote_translations" do
 
     describe "Should detect remote_translations" do

--- a/spec/controllers/debates_controller_spec.rb
+++ b/spec/controllers/debates_controller_spec.rb
@@ -31,10 +31,6 @@ describe DebatesController do
   end
 
   describe "Vote with too many anonymous votes" do
-    after do
-      Setting["max_ratio_anon_votes_on_debates"] = 50
-    end
-
     it "allows vote if user is allowed" do
       Setting["max_ratio_anon_votes_on_debates"] = 100
       debate = create(:debate)

--- a/spec/controllers/installation_controller_spec.rb
+++ b/spec/controllers/installation_controller_spec.rb
@@ -13,19 +13,9 @@ describe InstallationController, type: :request do
     let(:seeds_feature_settings) { Setting.where("key LIKE 'feature.%'") }
 
     before do
-      @current_feature_settings = seeds_feature_settings.pluck(:key, :value).to_h
       seeds_feature_settings.destroy_all
       test_feature_settings.each do |feature_name, feature_value|
         Setting["feature.#{feature_name}"] = feature_value
-      end
-    end
-
-    after do
-      test_feature_settings.each_key do |feature_name|
-        Setting.find_by(key: "feature.#{feature_name}").destroy
-      end
-      @current_feature_settings.each do |feature_name, feature_value|
-        Setting[feature_name] = feature_value
       end
     end
 

--- a/spec/controllers/remote_translation_controller_spec.rb
+++ b/spec/controllers/remote_translation_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe RemoteTranslationsController do
 
-  describe "POST create" do
+  describe "POST create", :delay_jobs do
     let(:debate)             { create(:debate) }
 
     before do
@@ -10,11 +10,6 @@ describe RemoteTranslationsController do
                                        remote_translatable_type: debate.class.to_s,
                                        locale: :es }].to_json
       request.env["HTTP_REFERER"] = "any_path"
-      Delayed::Worker.delay_jobs = true
-    end
-
-    after do
-      Delayed::Worker.delay_jobs = false
     end
 
     it "create correctly remote translation" do

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -183,12 +183,6 @@ describe "Account" do
       Setting["feature.user.recommendations_on_proposals"] = true
     end
 
-    after do
-      Setting["feature.user.recommendations"] = nil
-      Setting["feature.user.recommendations_on_debates"] = nil
-      Setting["feature.user.recommendations_on_proposals"] = nil
-    end
-
     scenario "are enabled by default" do
       visit account_path
 

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -176,13 +176,6 @@ describe "Account" do
   end
 
   context "Recommendations" do
-
-    before do
-      Setting["feature.user.recommendations"] = true
-      Setting["feature.user.recommendations_on_debates"] = true
-      Setting["feature.user.recommendations_on_proposals"] = true
-    end
-
     scenario "are enabled by default" do
       visit account_path
 

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -20,10 +20,6 @@ describe "Admin budget groups" do
       Setting["process.budgets"] = nil
     end
 
-    after do
-      Setting["process.budgets"] = true
-    end
-
     scenario "Disabled with a feature flag" do
       expect do
         visit admin_budget_groups_path(budget)

--- a/spec/features/admin/budget_headings_spec.rb
+++ b/spec/features/admin/budget_headings_spec.rb
@@ -21,10 +21,6 @@ describe "Admin budget headings" do
       Setting["process.budgets"] = nil
     end
 
-    after do
-      Setting["process.budgets"] = true
-    end
-
     scenario "Disabled with a feature flag" do
       expect do
         visit admin_budget_group_headings_path(budget, group)

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -28,10 +28,6 @@ describe "Admin budget investments" do
       Setting["process.budgets"] = nil
     end
 
-    after do
-      Setting["process.budgets"] = true
-    end
-
     scenario "Disabled with a feature flag" do
       expect { visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end

--- a/spec/features/admin/debates_spec.rb
+++ b/spec/features/admin/debates_spec.rb
@@ -8,8 +8,6 @@ describe "Admin debates" do
     login_as(admin.user)
 
     expect { visit admin_hidden_debates_path }.to raise_exception(FeatureFlags::FeatureDisabled)
-
-    Setting["process.debates"] = true
   end
 
   before do

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -287,7 +287,6 @@ describe "Admin collaborative legislation" do
     let!(:process) { create(:legislation_process) }
 
     before { Setting["feature.translation_interface"] = true }
-    after { Setting["feature.translation_interface"] = nil }
 
     scenario "Cant manage translations on homepage form" do
       visit edit_admin_legislation_process_homepage_path(process)

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -138,10 +138,6 @@ describe "Admin settings" do
       Setting["feature.remote_census"] = true
     end
 
-    after do
-      Setting["feature.remote_census"] = nil
-    end
-
     scenario "Should not be able when remote census feature deactivated" do
       Setting["feature.remote_census"] = nil
       admin = create(:administrator).user
@@ -176,10 +172,6 @@ describe "Admin settings" do
 
       before do
         Setting["feature.remote_census"] = true
-      end
-
-      after do
-        Setting["feature.remote_census"] = nil
       end
 
       scenario "On #tab-remote-census-configuration", :js do
@@ -219,10 +211,6 @@ describe "Admin settings" do
 
       before do
         Setting["feature.map"] = true
-      end
-
-      after do
-        Setting["feature.map"] = nil
       end
 
       scenario "On #tab-map-configuration", :js do

--- a/spec/features/admin/signature_sheets_spec.rb
+++ b/spec/features/admin/signature_sheets_spec.rb
@@ -89,12 +89,6 @@ describe "Signature sheets" do
       Setting["remote_census.response.valid"] = access_user_data
     end
 
-    after do
-      Setting["feature.remote_census"] = nil
-      Setting["remote_census.request.date_of_birth"] = nil
-      Setting["remote_census.request.postal_code"] = nil
-    end
-
     scenario "Proposal" do
       proposal = create(:proposal)
       visit new_admin_signature_sheet_path

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -17,10 +17,6 @@ describe "Budget Investments" do
     Setting["feature.allow_images"] = true
   end
 
-  after do
-    Setting["feature.allow_images"] = nil
-  end
-
   context "Concerns" do
     it_behaves_like "notifiable in-app", Budget::Investment
     it_behaves_like "relationable", Budget::Investment
@@ -1107,8 +1103,6 @@ describe "Budget Investments" do
     investment = create(:budget_investment, heading: heading)
     visit budget_investment_path(budget, id: investment.id)
     expect(page).to have_content "Access the community"
-
-    Setting["feature.community"] = false
   end
 
   scenario "Can not access the community" do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -13,10 +13,6 @@ describe "Budget Investments" do
                   :budget_investment,
                   "budget_investment_path"
 
-  before do
-    Setting["feature.allow_images"] = true
-  end
-
   context "Concerns" do
     it_behaves_like "notifiable in-app", Budget::Investment
     it_behaves_like "relationable", Budget::Investment

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -340,8 +340,6 @@ describe "Commenting topics from proposals" do
       page.find("#flag-expand-comment-#{comment.id}").click
       expect(page).to have_selector("#flag-comment-#{comment.id}")
     end
-
-    Setting["feature.community"] = nil
   end
 
   scenario "Erasing a comment's author" do
@@ -893,8 +891,6 @@ describe "Commenting topics from budget investments" do
       page.find("#flag-expand-comment-#{comment.id}").click
       expect(page).to have_selector("#flag-comment-#{comment.id}")
     end
-
-    Setting["feature.community"] = nil
   end
 
   scenario "Erasing a comment's author" do

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -326,8 +326,6 @@ describe "Commenting topics from proposals" do
   end
 
   scenario "Flagging turbolinks sanity check", :js do
-    Setting["feature.community"] = true
-
     community = proposal.community
     topic = create(:topic, community: community, title: "Should we change the world?")
     comment = create(:comment, commentable: topic)
@@ -877,8 +875,6 @@ describe "Commenting topics from budget investments" do
   end
 
   scenario "Flagging turbolinks sanity check", :js do
-    Setting["feature.community"] = true
-
     community = investment.community
     topic = create(:topic, community: community, title: "Should we change the world?")
     comment = create(:comment, commentable: topic)

--- a/spec/features/communities_spec.rb
+++ b/spec/features/communities_spec.rb
@@ -6,10 +6,6 @@ describe "Communities" do
     Setting["feature.community"] = true
   end
 
-  after do
-    Setting["feature.community"] = nil
-  end
-
   context "Show" do
 
     scenario "Should display default content" do

--- a/spec/features/communities_spec.rb
+++ b/spec/features/communities_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 
 describe "Communities" do
 
-  before do
-    Setting["feature.community"] = true
-  end
-
   context "Show" do
 
     scenario "Should display default content" do

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -455,11 +455,6 @@ describe "Debates" do
       let!(:medium_debate) { create(:debate, title: "Medium", cached_votes_total: 5,  tag_list: "Sport") }
       let!(:worst_debate)  { create(:debate, title: "Worst",  cached_votes_total: 1,  tag_list: "Sport") }
 
-      before do
-        Setting["feature.user.recommendations"] = true
-        Setting["feature.user.recommendations_on_debates"] = true
-      end
-
       scenario "can't be sorted if there's no logged user" do
         visit debates_path
         expect(page).not_to have_selector("a", text: "recommendations")
@@ -975,9 +970,6 @@ describe "Debates" do
     end
 
     scenario "Reorder by recommendations results maintaing search" do
-      Setting["feature.user.recommendations"] = true
-      Setting["feature.user.recommendations_on_debates"] = true
-
       user = create(:user, recommended_debates: true)
       login_as(user)
 

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -460,11 +460,6 @@ describe "Debates" do
         Setting["feature.user.recommendations_on_debates"] = true
       end
 
-      after do
-        Setting["feature.user.recommendations"] = nil
-        Setting["feature.user.recommendations_on_debates"] = nil
-      end
-
       scenario "can't be sorted if there's no logged user" do
         visit debates_path
         expect(page).not_to have_selector("a", text: "recommendations")
@@ -1005,9 +1000,6 @@ describe "Debates" do
         expect(page).not_to have_content "Do not display with same tag"
         expect(page).not_to have_content "Do not display"
       end
-
-      Setting["feature.user.recommendations"] = nil
-      Setting["feature.user.recommendations_on_debates"] = nil
     end
 
     scenario "After a search do not show featured debates" do

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -350,11 +350,6 @@ describe "Emails" do
   end
 
   context "Budgets" do
-
-    before do
-      Setting["process.budgets"] = true
-    end
-
     let(:author)   { create(:user, :level_two) }
     let(:budget)   { create(:budget) }
     let(:group)    { create(:budget_group, name: "Health", budget: budget) }

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -25,7 +25,6 @@ describe "Home" do
     describe "Recommended" do
 
       before do
-        Setting["feature.user.recommendations"] = true
         user = create(:user)
         proposal = create(:proposal, tag_list: "Sport")
         create(:follow, followable: proposal, user: user)

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -32,10 +32,6 @@ describe "Home" do
         login_as(user)
       end
 
-      after do
-        Setting["feature.user.recommendations"] = nil
-      end
-
       scenario "Display recommended section when feature flag recommended is active" do
         debate = create(:debate, tag_list: "Sport")
         visit root_path

--- a/spec/features/management/document_verifications_spec.rb
+++ b/spec/features/management/document_verifications_spec.rb
@@ -73,12 +73,6 @@ describe "DocumentVerifications" do
         Setting["remote_census.response.valid"] = access_user_data
       end
 
-      after do
-        Setting["feature.remote_census"] = nil
-        Setting["remote_census.request.date_of_birth"] = nil
-        Setting["remote_census.request.postal_code"] = nil
-      end
-
       scenario "Verifying a user which does not exist and is not in the census shows an error" do
 
         expect_any_instance_of(Verification::Management::Document).to receive(:in_census?).

--- a/spec/features/moderation_spec.rb
+++ b/spec/features/moderation_spec.rb
@@ -98,10 +98,6 @@ describe "Moderation" do
       Setting["org_name"] = "OrgName"
     end
 
-    after do
-      Setting["org_name"] = "CONSUL"
-    end
-
     scenario "Contains correct elements" do
       create(:moderator, user: user)
       login_as(user)

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -181,7 +181,7 @@ describe "Notifications" do
     end
   end
 
-  describe "#send_pending" do
+  describe "#send_pending", :delay_jobs do
     let!(:user1) { create(:user) }
     let!(:user2) { create(:user) }
     let!(:user3) { create(:user) }
@@ -192,11 +192,6 @@ describe "Notifications" do
       create(:notification, notifiable: proposal_notification, user: user2)
       create(:notification, notifiable: proposal_notification, user: user3)
       reset_mailer
-      Delayed::Worker.delay_jobs = true
-    end
-
-    after do
-      Delayed::Worker.delay_jobs = false
     end
 
     it "sends pending proposal notifications" do

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -127,12 +127,6 @@ describe "Residence", :with_frozen_time do
       visit officing_root_path
     end
 
-    after do
-      Setting["feature.remote_census"] = nil
-      Setting["remote_census.request.date_of_birth"] = nil
-      Setting["remote_census.request.postal_code"] = nil
-    end
-
     describe "Display form fields according to the remote census configuration" do
 
       scenario "by default (without custom census) not display date_of_birth and postal_code" do

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -381,10 +381,6 @@ describe "Proposal Notifications" do
         Setting[:proposal_notification_minimum_interval_in_days] = 0
       end
 
-      after do
-        Setting[:proposal_notification_minimum_interval_in_days] = 3
-      end
-
       scenario "for the same proposal", :js do
         author = create(:user)
         user = create(:user)

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -38,7 +38,6 @@ describe "Proposals" do
   context "Index" do
 
     before do
-      Setting["feature.allow_images"] = true
       Setting["feature.featured_proposals"] = true
       Setting["featured_proposals_number"] = 3
     end
@@ -765,11 +764,6 @@ describe "Proposals" do
       let!(:best_proposal)   { create(:proposal, title: "Best",   cached_votes_up: 10, tag_list: "Sport") }
       let!(:medium_proposal) { create(:proposal, title: "Medium", cached_votes_up: 5,  tag_list: "Sport") }
       let!(:worst_proposal)  { create(:proposal, title: "Worst",  cached_votes_up: 1,  tag_list: "Sport") }
-
-      before do
-        Setting["feature.user.recommendations"] = true
-        Setting["feature.user.recommendations_on_proposals"] = true
-      end
 
       scenario "can't be sorted if there's no logged user" do
         visit proposals_path
@@ -1509,9 +1503,6 @@ describe "Proposals" do
     end
 
     scenario "Reorder by recommendations results maintaing search" do
-      Setting["feature.user.recommendations"] = true
-      Setting["feature.user.recommendations_for_proposals"] = true
-
       user = create(:user, recommended_proposals: true)
       login_as(user)
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -43,10 +43,6 @@ describe "Proposals" do
       Setting["featured_proposals_number"] = 3
     end
 
-    after do
-      Setting["feature.allow_images"] = nil
-    end
-
     scenario "Lists featured and regular proposals" do
       featured_proposals = create_featured_proposals
       proposals = [create(:proposal), create(:proposal), create(:proposal)]
@@ -632,7 +628,6 @@ describe "Proposals" do
 
     context "Special interface translation behaviour" do
       before { Setting["feature.translation_interface"] = true }
-      after { Setting["feature.translation_interface"] = nil }
 
       scenario "Cant manage translations" do
         proposal = create(:proposal)
@@ -774,11 +769,6 @@ describe "Proposals" do
       before do
         Setting["feature.user.recommendations"] = true
         Setting["feature.user.recommendations_on_proposals"] = true
-      end
-
-      after do
-        Setting["feature.user.recommendations"] = nil
-        Setting["feature.user.recommendations_on_proposals"] = nil
       end
 
       scenario "can't be sorted if there's no logged user" do
@@ -1544,9 +1534,6 @@ describe "Proposals" do
         expect(page).not_to have_content "Do not display with same tag"
         expect(page).not_to have_content "Do not display"
       end
-
-      Setting["feature.user.recommendations"] = nil
-      Setting["feature.user.recommendations_for_proposals"] = nil
     end
 
     scenario "After a search do not show featured proposals" do
@@ -1957,10 +1944,6 @@ describe "Successful proposals" do
 
     before do
       Setting["feature.user.skip_verification"] = "true"
-    end
-
-    after do
-      Setting["feature.user.skip_verification"] = nil
     end
 
     scenario "Create" do

--- a/spec/features/remote_translations_spec.rb
+++ b/spec/features/remote_translations_spec.rb
@@ -10,12 +10,6 @@ describe "Remote Translations" do
                                                             and_return(available_locales_response)
   end
 
-  after do
-    allow(I18n).to receive(:available_locales).and_call_original
-    allow(I18n.fallbacks).to receive(:[]).and_call_original
-    Globalize.set_fallbacks_to_all_available_locales
-  end
-
   describe "Display remote translation button when locale is included in microsoft translate client" do
 
     context "with locale that has :en fallback" do

--- a/spec/features/social_media_meta_tags_spec.rb
+++ b/spec/features/social_media_meta_tags_spec.rb
@@ -23,16 +23,6 @@ describe "Social media meta tags" do
       Setting["org_name"] = org_name
     end
 
-    after do
-      Setting["meta_keywords"] = nil
-      Setting["meta_title"] = nil
-      Setting["meta_description"] = nil
-      Setting["twitter_handle"] = nil
-      Setting["url"] = "http://example.com"
-      Setting["facebook_handle"] = nil
-      Setting["org_name"] = "CONSUL"
-    end
-
     scenario "Social media meta tags partial render settings content" do
 
       visit root_path

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -117,8 +117,6 @@ describe "Welcome screen" do
     4.times do |i|
       expect(page).to have_css "li:nth-child(#{i + 1})"
     end
-
-    Setting["feature.user.skip_verification"] = nil
   end
 
 end

--- a/spec/helpers/signature_sheets_helper_spec.rb
+++ b/spec/helpers/signature_sheets_helper_spec.rb
@@ -17,10 +17,6 @@ describe SignatureSheetsHelper do
       Setting["feature.remote_census"] = true
     end
 
-    after do
-      Setting["feature.remote_census"] = nil
-    end
-
     it "returns text help when date_of_birth and postal_code are not required" do
       text_help_1 = "To verify a user, your application needs: Document number"
       text_help_2 = "Required fields for each user must be separated by commas and each user must be separated by semicolons."

--- a/spec/lib/tasks/dashboards_spec.rb
+++ b/spec/lib/tasks/dashboards_spec.rb
@@ -12,10 +12,6 @@ describe "Dashboards Rake" do
       ActionMailer::Base.deliveries.clear
     end
 
-    after do
-      Setting["dashboard.emails"] = nil
-    end
-
     let :run_rake_task do
       Rake::Task["dashboards:send_notifications"].reenable
       Rake.application.invoke_task "dashboards:send_notifications"

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -13,10 +13,6 @@ describe Dashboard::Mailer do
     Setting["dashboard.emails"] = true
   end
 
-  after do
-    Setting["dashboard.emails"] = nil
-  end
-
   describe "#forward" do
     let!(:proposal) { create(:proposal) }
 

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -274,10 +274,6 @@ describe Budget do
   end
 
   describe "#formatted_amount" do
-    after do
-      I18n.locale = :en
-    end
-
     it "correctly formats Euros with Spanish" do
       budget.update(currency_symbol: "€")
       I18n.locale = :es

--- a/spec/models/concerns/globalizable.rb
+++ b/spec/models/concerns/globalizable.rb
@@ -21,12 +21,6 @@ shared_examples_for "globalizable" do |factory_name|
       end
     end
 
-    after do
-      allow(I18n).to receive(:available_locales).and_call_original
-      allow(I18n.fallbacks).to receive(:[]).and_call_original
-      Globalize.set_fallbacks_to_all_available_locales
-    end
-
     context "With a defined fallback" do
       before do
         allow(I18n.fallbacks).to receive(:[]).and_return([:fr, :es])

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -77,7 +77,6 @@ describe Debate do
     let(:debate) { create(:debate) }
 
     before { Setting["max_votes_for_debate_edit"] = 3 }
-    after { Setting["max_votes_for_debate_edit"] = 1000 }
 
     it "is true if debate has no votes yet" do
       expect(debate.total_votes).to eq(0)
@@ -101,7 +100,6 @@ describe Debate do
     let(:debate) { create(:debate) }
 
     before { Setting["max_votes_for_debate_edit"] = 1 }
-    after { Setting["max_votes_for_debate_edit"] = 1000 }
 
     it "is true if user is the author and debate is editable" do
       expect(debate.editable_by?(debate.author)).to be true

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -64,7 +64,7 @@ describe Newsletter do
     end
   end
 
-  describe "#deliver" do
+  describe "#deliver", :delay_jobs do
     let!(:proposals) { Array.new(3) { create(:proposal) } }
 
     let!(:recipients) { proposals.map(&:author).map(&:email) }
@@ -73,11 +73,6 @@ describe Newsletter do
     before do
       create(:debate)
       reset_mailer
-      Delayed::Worker.delay_jobs = true
-    end
-
-    after do
-      Delayed::Worker.delay_jobs = false
     end
 
     it "sends an email with the newsletter to every recipient" do

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -54,12 +54,6 @@ describe Officing::Residence do
         Setting["remote_census.response.valid"] = access_user_data
       end
 
-      after do
-        Setting["feature.remote_census"] = nil
-        Setting["remote_census.request.date_of_birth"] = nil
-        Setting["remote_census.request.postal_code"] = nil
-      end
-
       it "is valid" do
         expect(custom_residence).to be_valid
       end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -178,7 +178,6 @@ describe Proposal do
     let(:proposal) { create(:proposal) }
 
     before { Setting["max_votes_for_proposal_edit"] = 5 }
-    after { Setting["max_votes_for_proposal_edit"] = 1000 }
 
     it "is true if proposal has no votes yet" do
       expect(proposal.total_votes).to eq(0)
@@ -1083,10 +1082,6 @@ describe Proposal do
       ActionMailer::Base.deliveries.clear
     end
 
-    after do
-      Setting["dashboard.emails"] = nil
-    end
-
     it "send notification after create when there are new actived actions" do
       create(:dashboard_action, :proposed_action, :active, day_offset: 0, published_proposal: false)
       create(:dashboard_action, :resource, :active, day_offset: 0, published_proposal: false)
@@ -1112,10 +1107,6 @@ describe Proposal do
     before do
       Setting["dashboard.emails"] = true
       ActionMailer::Base.deliveries.clear
-    end
-
-    after do
-      Setting["dashboard.emails"] = nil
     end
 
     it "send notification after published when there are new actived actions" do

--- a/spec/models/remote_translation_spec.rb
+++ b/spec/models/remote_translation_spec.rb
@@ -28,16 +28,7 @@ describe RemoteTranslation do
     expect(remote_translation).not_to be_valid
   end
 
-  describe "#enqueue_remote_translation" do
-
-    before do
-      Delayed::Worker.delay_jobs = true
-    end
-
-    after do
-      Delayed::Worker.delay_jobs = false
-    end
-
+  describe "#enqueue_remote_translation", :delay_jobs do
     it "after create enqueue Delayed Job" do
       expect { remote_translation.save }.to change { Delayed::Job.count }.by(1)
     end

--- a/spec/models/signature_sheet_spec.rb
+++ b/spec/models/signature_sheet_spec.rb
@@ -82,10 +82,6 @@ describe SignatureSheet do
         Setting["feature.remote_census"] = true
       end
 
-      after do
-        Setting["feature.remote_census"] = nil
-      end
-
       it "creates signatures for each group with document_number" do
         required_fields_to_verify = "123A; 456B"
         signature_sheet = create(:signature_sheet, required_fields_to_verify: required_fields_to_verify)

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -41,12 +41,6 @@ describe Signature do
       Setting["remote_census.request.postal_code"] = "some.value"
     end
 
-    after do
-      Setting["feature.remote_census"] = nil
-      Setting["remote_census.request.date_of_birth"] = nil
-      Setting["remote_census.request.postal_code"] = nil
-    end
-
     it "is valid" do
       expect(signature).to be_valid
     end
@@ -253,12 +247,6 @@ describe Signature do
         Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
         Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
         Setting["remote_census.response.valid"] = access_user_data
-      end
-
-      after do
-        Setting["feature.remote_census"] = nil
-        Setting["remote_census.request.date_of_birth"] = nil
-        Setting["remote_census.request.postal_code"] = nil
       end
 
       it "calls assign_vote_to_user" do

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -43,12 +43,6 @@ describe Verification::Management::Document do
         Setting["remote_census.response.valid"] = access_user_data
       end
 
-      after do
-        Setting["feature.remote_census"] = nil
-        Setting["remote_census.request.date_of_birth"] = nil
-        Setting["remote_census.request.postal_code"] = nil
-      end
-
       it "is valid" do
         expect(verification_document).to be_valid
       end

--- a/spec/requests/dashboard/successful_supports_spec.rb
+++ b/spec/requests/dashboard/successful_supports_spec.rb
@@ -22,10 +22,6 @@ describe "Retrieves number of supports for the successful proposal" do
     sign_in(proposal.author)
   end
 
-  after do
-    Setting["proposals.successful_proposal_id"] = @successful_proposal_id
-  end
-
   it "returns the number of supports grouped by day" do
     get proposal_dashboard_successful_supports_path(proposal, format: :json)
 

--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -71,10 +71,6 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
         Setting["feature.allow_attached_documents"] = true
       end
 
-      after do
-        Setting["feature.allow_attached_documents"] = false
-      end
-
       scenario "Documents list should be available" do
         login_as(user)
         visit send(documentable_path, arguments)
@@ -96,10 +92,6 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
     describe "When allow attached documents setting is disabled" do
       before do
         Setting["feature.allow_attached_documents"] = false
-      end
-
-      after do
-        Setting["feature.allow_attached_documents"] = true
       end
 
       scenario "Documents list should not be available" do

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -297,10 +297,6 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
         Setting["feature.allow_attached_documents"] = false
       end
 
-      after do
-        Setting["feature.allow_attached_documents"] = true
-      end
-
       scenario "Add new document button should not be available" do
         login_as user_to_login
         visit send(path, arguments)

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -9,9 +9,6 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
   let!(:imageable)           { create(imageable_factory_name) }
 
   before do
-
-    Setting["feature.allow_images"] = true
-
     imageable_path_arguments&.each do |argument_name, path_to_value|
       arguments.merge!("#{argument_name}": imageable.send(path_to_value))
     end

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -19,10 +19,6 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
     imageable.update(author: user) if imageable.respond_to?(:author)
   end
 
-  after do
-    Setting["feature.allow_images"] = nil
-  end
-
   describe "at #{path}" do
 
     scenario "Should show new image link when imageable has not an associated image defined" do

--- a/spec/shared/features/remotely_translatable.rb
+++ b/spec/shared/features/remotely_translatable.rb
@@ -12,10 +12,6 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
     Setting["feature.remote_translations"] = true
   end
 
-  after do
-    Setting["feature.remote_translations"] = false
-  end
-
   context "Button to request remote translation" do
 
     scenario "should not be present when current locale translation exists", :js do

--- a/spec/shared/features/remotely_translatable.rb
+++ b/spec/shared/features/remotely_translatable.rb
@@ -48,10 +48,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
       expect(page).not_to have_button("Translate page")
     end
 
-    describe "with delayed job active" do
-      before { Delayed::Worker.delay_jobs = true }
-      after  { Delayed::Worker.delay_jobs = false }
-
+    describe "with delayed job active", :delay_jobs do
       scenario "should not be present when an equal RemoteTranslation is enqueued", :js do
         create(:remote_translation, remote_translatable: resource, locale: :de)
         visit path
@@ -154,16 +151,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
   context "After click remote translations button" do
 
-    describe "with delayed jobs" do
-
-      before do
-        Delayed::Worker.delay_jobs = true
-      end
-
-      after do
-        Delayed::Worker.delay_jobs = false
-      end
-
+    describe "with delayed jobs", :delay_jobs do
       scenario "the remote translation button should not be present", :js do
         visit path
         select("Deutsch", from: "locale-switcher")

--- a/spec/shared/models/map_validations.rb
+++ b/spec/shared/models/map_validations.rb
@@ -8,10 +8,6 @@ shared_examples "map validations" do
       Setting["feature.map"] = true
     end
 
-    after do
-      Setting["feature.map"] = nil
-    end
-
     it "is valid with a map location" do
       mappable.map_location = build(:map_location)
       mappable.skip_map = nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,9 +45,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     I18n.locale = :en
     Globalize.locale = I18n.locale
-    unless %i[controller feature request].include? example.metadata[:type]
-      Globalize.set_fallbacks_to_all_available_locales
-    end
+    Globalize.set_fallbacks_to_all_available_locales
     load Rails.root.join("db", "seeds.rb").to_s
     Setting["feature.user.skip_verification"] = nil
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,14 @@ RSpec.configure do |config|
     Bullet.end_request
   end
 
+  config.before(:each, :delay_jobs) do
+    Delayed::Worker.delay_jobs = true
+  end
+
+  config.after(:each, :delay_jobs) do
+    Delayed::Worker.delay_jobs = false
+  end
+
   config.before(:each, :with_frozen_time) do
     travel_to Time.now # TODO: use `freeze_time` after migrating to Rails 5.
   end

--- a/spec/support/verifiable.rb
+++ b/spec/support/verifiable.rb
@@ -187,10 +187,6 @@ shared_examples_for "verifiable" do
       Setting["feature.user.skip_verification"] = "true"
     end
 
-    after do
-      Setting["feature.user.skip_verification"] = nil
-    end
-
     describe "#residence_verified?" do
       it "is true if skipped" do
         expect(user.residence_verified?).to eq(true)


### PR DESCRIPTION
## Objectives

* Remove unnecessary `after` blocks cleaning up the database
* Simplify `before` and `after` blocks in tests using delayed jobs