### PR TITLE
Allow managers to read investment suggestions

### DIFF
--- a/app/models/abilities/manager.rb
+++ b/app/models/abilities/manager.rb
@@ -1,0 +1,11 @@
+module Abilities
+  class Manager
+    include CanCan::Ability
+
+    def initialize(user)
+      merge Abilities::Common.new(user)
+
+      can :suggest, Budget::Investment
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,8 @@ class Ability
         merge Abilities::Administrator.new(user)
       elsif user.moderator?
         merge Abilities::Moderator.new(user)
+      elsif user.manager?
+        merge Abilities::Manager.new(user)
       else
         merge Abilities::Common.new(user)
       end

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -94,6 +94,29 @@ describe "Budget Investments" do
 
       expect(page).to have_content "User is not verified"
     end
+
+    scenario "Shows suggestions to unverified managers", :js do
+      expect(manager.user.level_two_or_three_verified?).to be false
+
+      create(:budget_investment, budget: budget, title: "More parks")
+      create(:budget_investment, budget: budget, title: "No more parks")
+      create(:budget_investment, budget: budget, title: "Plant trees")
+      login_managed_user(create(:user, :level_two))
+
+      click_link "Create budget investment"
+      within "#budget_#{budget.id}" do
+        click_link "Create budget investment"
+      end
+
+      fill_in "Title", with: "Park"
+      fill_in_ckeditor "Description", with: "Wish I had one"
+
+      within(".js-suggest") do
+        expect(page).to have_content "More parks"
+        expect(page).to have_content "No more parks"
+        expect(page).not_to have_content "Plant trees"
+      end
+    end
   end
 
   context "Searching" do


### PR DESCRIPTION
## References

Closes #3660

## Background

When creating a budget investment with an unverified manager (for example, a manager who isn't part of the local census), there's a request to `Budgets::InvestmentsController#suggest`. Since the manager isn't verified, suggestions can't be obtained.

## Objectives

Make suggestions for budget investments in the management section show up normally.

## Visual Changes

Before these changes:

![Message denying permissin](https://user-images.githubusercontent.com/35156/61062715-ff320680-a3fe-11e9-88c9-70657120c2bc.png)
![A whole web page loaded where suggestions should be](https://user-images.githubusercontent.com/35156/61062828-386a7680-a3ff-11e9-99a1-ce4a2403fda7.png)

After these changes:

![Suggestions are inserted below the title](https://user-images.githubusercontent.com/35156/61062943-69e34200-a3ff-11e9-82b9-9fc6b15bd1eb.png)