### PR TITLE
Simplify investments creation in specs

### DIFF
--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -35,10 +35,7 @@ describe "Admin budget investments" do
   end
 
   context "Load" do
-
-    let(:group)      { create(:budget_group, budget: budget) }
-    let(:heading)    { create(:budget_heading, group: group) }
-    let!(:investment) { create(:budget_investment, heading: heading) }
+    let!(:investment) { create(:budget_investment, budget: budget) }
 
     before { budget.update(slug: "budget_slug") }
 
@@ -1596,8 +1593,7 @@ describe "Admin budget investments" do
     let(:valuator) { create(:valuator) }
     let(:admin) { create(:administrator) }
 
-    let(:group) { create(:budget_group, budget: budget) }
-    let(:heading) { create(:budget_heading, group: group) }
+    let(:heading) { create(:budget_heading, budget: budget) }
 
     let(:investment1) { create(:budget_investment, heading: heading) }
     let(:investment2) { create(:budget_investment, heading: heading) }

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -153,7 +153,7 @@ describe "Admin budgets" do
   context "Destroy" do
 
     let!(:budget) { create(:budget) }
-    let(:heading) { create(:budget_heading, group: create(:budget_group, budget: budget)) }
+    let(:heading) { create(:budget_heading, budget: budget) }
 
     scenario "Destroy a budget without investments" do
       visit admin_budgets_path
@@ -270,8 +270,7 @@ describe "Admin budgets" do
 
     scenario "For a Budget in reviewing balloting", :js do
       budget = create(:budget, phase: "reviewing_ballots")
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group, price: 4)
+      heading = create(:budget_heading, budget: budget, price: 4)
       unselected = create(:budget_investment, :unselected, heading: heading, price: 1,
                                                            ballot_lines_count: 3)
       winner = create(:budget_investment, :selected, heading: heading, price: 3,
@@ -302,9 +301,7 @@ describe "Admin budgets" do
 
     scenario "Recalculate for a finished Budget" do
       budget = create(:budget, :finished)
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
-      create(:budget_investment, :winner, heading: heading)
+      create(:budget_investment, :winner, budget: budget)
 
       visit edit_admin_budget_path(budget)
 

--- a/spec/features/admin/download_settings_spec.rb
+++ b/spec/features/admin/download_settings_spec.rb
@@ -261,8 +261,7 @@ describe "Admin download settings" do
 
   context "Download budgets" do
     let(:budget_finished)  { create(:budget, phase: "finished") }
-    let(:group)   { create(:budget_group, budget: budget_finished) }
-    let(:heading) { create(:budget_heading, group: group, price: 1000) }
+    let(:heading) { create(:budget_heading, budget: budget_finished, price: 1000) }
 
     let(:investment1) { create(:budget_investment,
                                :selected,

--- a/spec/features/admin/hidden_budget_investments_spec.rb
+++ b/spec/features/admin/hidden_budget_investments_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 describe "Admin hidden budget investments" do
 
   let(:budget)  { create(:budget) }
-  let(:group)   { create(:budget_group, name: "Music", budget: budget) }
-  let(:heading) { create(:budget_heading, name: "Black metal", price: 666666, group: group) }
+  let(:heading) { create(:budget_heading, budget: budget, price: 666666) }
 
   before do
     admin = create(:administrator)

--- a/spec/features/admin/system_emails_spec.rb
+++ b/spec/features/admin/system_emails_spec.rb
@@ -76,8 +76,7 @@ describe "System Emails" do
 
     let(:user)    { create(:user, :level_two, username: "John Doe") }
     let(:budget)  { create(:budget, name: "Budget for 2019") }
-    let(:group)   { create(:budget_group, budget: budget) }
-    let(:heading) { create(:budget_heading, group: group) }
+    let(:heading) { create(:budget_heading, budget: budget) }
 
     scenario "#proposal_notification_digest" do
       proposal_a = create(:proposal, title: "Proposal A")

--- a/spec/features/budget_polls/voter_spec.rb
+++ b/spec/features/budget_polls/voter_spec.rb
@@ -2,9 +2,7 @@ require "rails_helper"
 
 describe "BudgetPolls", :with_frozen_time do
   let(:budget) { create(:budget, :balloting) }
-  let(:group) { create(:budget_group, budget: budget) }
-  let(:heading) { create(:budget_heading, group: group) }
-  let(:investment) { create(:budget_investment, :selected, heading: heading) }
+  let(:investment) { create(:budget_investment, :selected, budget: budget) }
   let(:poll) { create(:poll, :current, budget: budget) }
   let(:booth) { create(:poll_booth) }
   let(:officer) { create(:poll_officer) }

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -115,8 +115,7 @@ describe "Budgets" do
 
     scenario "Show informing index without links" do
       budget.update_attributes(phase: "informing")
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
+      heading = create(:budget_heading, budget: budget)
 
       visit budgets_path
 
@@ -134,8 +133,7 @@ describe "Budgets" do
 
     scenario "Show finished index without heading links" do
       budget.update_attributes(phase: "finished")
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
+      heading = create(:budget_heading, budget: budget)
 
       visit budgets_path
 
@@ -157,10 +155,8 @@ describe "Budgets" do
     end
 
     scenario "Show investment links only on balloting or later" do
-
       budget = create(:budget)
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
+      create(:budget_heading, budget: budget)
 
       allowed_phase_list.each do |phase|
         budget.update(phase: phase)
@@ -174,10 +170,8 @@ describe "Budgets" do
     end
 
     scenario "Not show investment links earlier of balloting " do
-
       budget = create(:budget)
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
+      create(:budget_heading, budget: budget)
       phases_without_links = ["drafting", "informing"]
       not_allowed_phase_list = Budget::Phase::PHASE_KINDS -
                                phases_without_links -
@@ -278,9 +272,7 @@ describe "Budgets" do
   end
 
   context "Index map" do
-
-    let(:group)   { create(:budget_group, budget: budget) }
-    let(:heading) { create(:budget_heading, group: group) }
+    let(:heading) { create(:budget_heading, budget: budget) }
 
     before do
       Setting["feature.map"] = true

--- a/spec/features/budgets/stats_spec.rb
+++ b/spec/features/budgets/stats_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 describe "Stats" do
 
   let(:budget)  { create(:budget, :finished) }
-  let(:group)   { create(:budget_group, budget: budget) }
-  let(:heading) { create(:budget_heading, group: group, price: 1000) }
+  let(:heading) { create(:budget_heading, budget: budget, price: 1000) }
 
   context "Load" do
 

--- a/spec/features/comments/budget_investments_valuation_spec.rb
+++ b/spec/features/comments/budget_investments_valuation_spec.rb
@@ -5,9 +5,7 @@ describe "Internal valuation comments on Budget::Investments" do
   let(:valuator_user) { create(:valuator).user }
   let(:admin_user) { create(:administrator).user }
   let(:budget) { create(:budget, :valuating) }
-  let(:group) { create(:budget_group, budget: budget) }
-  let(:heading) { create(:budget_heading, group: group) }
-  let(:investment) { create(:budget_investment, budget: budget, group: group, heading: heading) }
+  let(:investment) { create(:budget_investment, budget: budget) }
 
   before do
     investment.valuators << valuator_user.valuator

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -352,8 +352,7 @@ describe "Emails" do
   context "Budgets" do
     let(:author)   { create(:user, :level_two) }
     let(:budget)   { create(:budget) }
-    let(:group)    { create(:budget_group, name: "Health", budget: budget) }
-    let!(:heading) { create(:budget_heading, name: "More hospitals", group: group) }
+    let!(:heading) { create(:budget_heading, name: "More hospitals", budget: budget) }
 
     scenario "Investment created" do
       login_as(author)
@@ -380,7 +379,7 @@ describe "Emails" do
 
     scenario "Unfeasible investment" do
       budget.update(phase: "valuating")
-      investment = create(:budget_investment, author: author, budget: budget, heading: heading)
+      investment = create(:budget_investment, author: author, budget: budget)
 
       valuator = create(:valuator)
       investment.valuators << valuator

--- a/spec/features/moderation/budget_investments_spec.rb
+++ b/spec/features/moderation/budget_investments_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 describe "Moderate budget investments" do
 
   let(:budget)  { create(:budget) }
-  let(:group)   { create(:budget_group, name: "Culture", budget: budget) }
-  let(:heading) { create(:budget_heading, name: "More libraries", price: 666666, group: group) }
+  let(:heading) { create(:budget_heading, budget: budget, price: 666666) }
 
   before do
     @mod        = create(:moderator)

--- a/spec/features/tracking/budget_investments_spec.rb
+++ b/spec/features/tracking/budget_investments_spec.rb
@@ -171,9 +171,7 @@ describe "Valuation budget investments" do
   describe "Milestones" do
     let(:admin) { create(:administrator) }
     let(:investment) do
-      heading = create(:budget_heading)
-      create(:budget_investment, heading: heading, budget: budget,
-                                 administrator: admin)
+      create(:budget_investment, budget: budget, administrator: admin)
     end
 
     before do
@@ -254,9 +252,7 @@ describe "Valuation budget investments" do
 
     let(:admin) { create(:administrator) }
     let(:investment) do
-      heading = create(:budget_heading)
-      create(:budget_investment, heading: heading, budget: budget,
-             administrator: admin)
+      create(:budget_investment, budget: budget, administrator: admin)
     end
 
     before do

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -324,10 +324,7 @@ describe "Valuation budget investments" do
   describe "Valuate" do
     let(:admin) { create(:administrator) }
     let(:investment) do
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
-      create(:budget_investment, heading: heading, group: group, budget: budget, price: nil,
-                                 administrator: admin)
+      create(:budget_investment, budget: budget, price: nil, administrator: admin)
     end
 
     before do

--- a/spec/models/budget/ballot_spec.rb
+++ b/spec/models/budget/ballot_spec.rb
@@ -13,8 +13,7 @@ describe Budget::Ballot do
 
     it "is not valid with the same investment twice" do
       budget = create(:budget)
-      group  = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
+      heading = create(:budget_heading, budget: budget)
       investment = create(:budget_investment, :selected, heading: heading)
 
       ballot = create(:budget_ballot, budget: budget)

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -381,8 +381,7 @@ describe Budget::Investment do
   describe "scoped_filter" do
 
     let!(:budget)     { create(:budget, slug: "budget_slug") }
-    let!(:group)      { create(:budget_group, budget: budget) }
-    let!(:heading)    { create(:budget_heading, group: group) }
+    let!(:heading)    { create(:budget_heading, budget: budget) }
     let!(:investment) { create(:budget_investment, :feasible, heading: heading) }
 
     it "finds budget by id or slug" do
@@ -967,16 +966,14 @@ describe Budget::Investment do
 
   describe "total votes" do
     it "takes into account physical votes in addition to web votes" do
-      b = create(:budget, :selecting)
-      g = create(:budget_group, budget: b)
-      h = create(:budget_heading, group: g)
-      i = create(:budget_investment, budget: b, group: g, heading: h)
+      budget = create(:budget, :selecting)
+      investment = create(:budget_investment, budget: budget)
 
-      i.register_selection(create(:user, :level_two))
-      expect(i.total_votes).to eq(1)
+      investment.register_selection(create(:user, :level_two))
+      expect(investment.total_votes).to eq(1)
 
-      i.physical_votes = 10
-      expect(i.total_votes).to eq(11)
+      investment.physical_votes = 10
+      expect(investment.total_votes).to eq(11)
     end
   end
 
@@ -995,8 +992,7 @@ describe Budget::Investment do
 
     describe "Permissions" do
       let(:budget)      { create(:budget) }
-      let(:group)       { create(:budget_group, budget: budget) }
-      let(:heading)     { create(:budget_heading, group: group) }
+      let(:heading)     { create(:budget_heading, budget: budget) }
       let(:user)        { create(:user, :level_two) }
       let(:luser)       { create(:user) }
       let(:ballot)      { create(:budget_ballot, budget: budget) }

--- a/spec/models/budget/result_spec.rb
+++ b/spec/models/budget/result_spec.rb
@@ -4,8 +4,7 @@ describe Budget::Result do
 
   describe "calculate_winners" do
     let(:budget) { create(:budget) }
-    let(:group) { create(:budget_group, budget: budget) }
-    let(:heading) { create(:budget_heading, group: group, price: 1000) }
+    let(:heading) { create(:budget_heading, budget: budget, price: 1000) }
 
     context "When there is no winners" do
       it "calculates the correct winner set" do

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -187,10 +187,8 @@ describe Budget do
   end
 
   describe "heading_price" do
-    let(:group) { create(:budget_group, budget: budget) }
-
     it "returns the heading price if the heading provided is part of the budget" do
-      heading = create(:budget_heading, price: 100, group: group)
+      heading = create(:budget_heading, price: 100, budget: budget)
       expect(budget.heading_price(heading)).to eq(100)
     end
 


### PR DESCRIPTION
## References

* Commit 20b1085 made these changes possible

## Objectives

Simplify the code creating budget headings and budget investments in specs, now that creating an investment automatically assigns a heading for the same budget and creating a heading automatically assigns a group for the same budget.