### PR TITLE
Apply explict RSpec/DescribedClass rubocop rule

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -176,6 +176,10 @@ RSpec/AroundBlock:
 RSpec/BeforeAfterAll:
   Enabled: true
 
+RSpec/DescribedClass:
+  Enabled: true
+  EnforcedStyle: explicit
+
 RSpec/EmptyExampleGroup:
   Enabled: true
   Exclude:

--- a/spec/lib/age_spec.rb
+++ b/spec/lib/age_spec.rb
@@ -3,56 +3,56 @@ require "rails_helper"
 describe Age do
   describe ".in_years" do
     it "handles nils" do
-      expect(described_class.in_years(nil)).to be_nil
+      expect(Age.in_years(nil)).to be_nil
     end
 
     it "calculates age correctly for common dates" do
       d = Date.new(1980, 3, 13)
-      expect(described_class.in_years(d, Date.new(2000, 3, 12))).to eq(19)
-      expect(described_class.in_years(d, Date.new(2000, 3, 13))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2000, 3, 14))).to eq(20)
+      expect(Age.in_years(d, Date.new(2000, 3, 12))).to eq(19)
+      expect(Age.in_years(d, Date.new(2000, 3, 13))).to eq(20)
+      expect(Age.in_years(d, Date.new(2000, 3, 14))).to eq(20)
     end
 
     it "calculates age correctly for people born near a year's limit" do
       d = Date.new(1980, 12, 31)
-      expect(described_class.in_years(d, Date.new(2000, 12, 30))).to eq(19)
-      expect(described_class.in_years(d, Date.new(2000, 12, 31))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001, 1,  1))).to eq(20)
+      expect(Age.in_years(d, Date.new(2000, 12, 30))).to eq(19)
+      expect(Age.in_years(d, Date.new(2000, 12, 31))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001, 1,  1))).to eq(20)
 
       d = Date.new(1980, 1, 1)
-      expect(described_class.in_years(d, Date.new(2000, 12, 31))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001,  1,  1))).to eq(21)
-      expect(described_class.in_years(d, Date.new(2001,  1,  2))).to eq(21)
+      expect(Age.in_years(d, Date.new(2000, 12, 31))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001,  1,  1))).to eq(21)
+      expect(Age.in_years(d, Date.new(2001,  1,  2))).to eq(21)
     end
 
     it "calculates age correctly for people born around February the 29th" do
       # 1980 and 2000 are leap years. 2001 is a regular year
       d = Date.new(1980, 2, 29)
-      expect(described_class.in_years(d, Date.new(2000,  2, 27))).to eq(19)
-      expect(described_class.in_years(d, Date.new(2000,  2, 28))).to eq(19)
-      expect(described_class.in_years(d, Date.new(2000,  2, 29))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2000,  3, 1))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001,  2, 27))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001,  2, 28))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001,  3, 1))).to eq(21)
+      expect(Age.in_years(d, Date.new(2000,  2, 27))).to eq(19)
+      expect(Age.in_years(d, Date.new(2000,  2, 28))).to eq(19)
+      expect(Age.in_years(d, Date.new(2000,  2, 29))).to eq(20)
+      expect(Age.in_years(d, Date.new(2000,  3, 1))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001,  2, 27))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001,  2, 28))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001,  3, 1))).to eq(21)
 
       d = Date.new(1980, 2, 28)
-      expect(described_class.in_years(d, Date.new(2000,  2, 27))).to eq(19)
-      expect(described_class.in_years(d, Date.new(2000,  2, 28))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2000,  2, 29))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2000,  3, 1))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001,  2, 27))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001,  2, 28))).to eq(21)
-      expect(described_class.in_years(d, Date.new(2001,  3, 1))).to eq(21)
+      expect(Age.in_years(d, Date.new(2000,  2, 27))).to eq(19)
+      expect(Age.in_years(d, Date.new(2000,  2, 28))).to eq(20)
+      expect(Age.in_years(d, Date.new(2000,  2, 29))).to eq(20)
+      expect(Age.in_years(d, Date.new(2000,  3, 1))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001,  2, 27))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001,  2, 28))).to eq(21)
+      expect(Age.in_years(d, Date.new(2001,  3, 1))).to eq(21)
 
       d = Date.new(1980, 3, 1)
-      expect(described_class.in_years(d, Date.new(2000,  2, 27))).to eq(19)
-      expect(described_class.in_years(d, Date.new(2000,  2, 28))).to eq(19)
-      expect(described_class.in_years(d, Date.new(2000,  2, 29))).to eq(19)
-      expect(described_class.in_years(d, Date.new(2000,  3, 1))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001,  2, 27))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001,  2, 28))).to eq(20)
-      expect(described_class.in_years(d, Date.new(2001,  3, 1))).to eq(21)
+      expect(Age.in_years(d, Date.new(2000,  2, 27))).to eq(19)
+      expect(Age.in_years(d, Date.new(2000,  2, 28))).to eq(19)
+      expect(Age.in_years(d, Date.new(2000,  2, 29))).to eq(19)
+      expect(Age.in_years(d, Date.new(2000,  3, 1))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001,  2, 27))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001,  2, 28))).to eq(20)
+      expect(Age.in_years(d, Date.new(2001,  3, 1))).to eq(21)
     end
   end
 end

--- a/spec/lib/census_api_spec.rb
+++ b/spec/lib/census_api_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe CensusApi do
-  let(:api) { described_class.new }
+  let(:api) { CensusApi.new }
 
   describe "#call" do
     let(:invalid_body) { { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}}}} }

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe CensusCaller do
-  let(:api) { described_class.new }
+  let(:api) { CensusCaller.new }
 
   describe "#call" do
     it "returns data from local_census_records if census API is not available" do

--- a/spec/lib/email_digests_spec.rb
+++ b/spec/lib/email_digests_spec.rb
@@ -12,7 +12,7 @@ describe EmailDigest do
       notification1 = create(:notification, notifiable: proposal_notification, user: user1)
       notification2 = create(:notification, notifiable: proposal_notification, user: user2)
 
-      email_digest = described_class.new(user1)
+      email_digest = EmailDigest.new(user1)
 
       expect(email_digest.notifications).to include(notification1)
       expect(email_digest.notifications).not_to include(notification2)
@@ -27,7 +27,7 @@ describe EmailDigest do
       notification1 = create(:notification, notifiable: proposal_notification, user: user)
       notification2 = create(:notification, notifiable: comment,               user: user)
 
-      email_digest = described_class.new(user)
+      email_digest = EmailDigest.new(user)
 
       expect(email_digest.notifications).to include(notification1)
       expect(email_digest.notifications).not_to include(notification2)
@@ -43,7 +43,7 @@ describe EmailDigest do
       proposal_notification = create(:proposal_notification)
       notification = create(:notification, notifiable: proposal_notification, user: user)
 
-      email_digest = described_class.new(user)
+      email_digest = EmailDigest.new(user)
       expect(email_digest.pending_notifications?).to be
     end
 
@@ -53,13 +53,13 @@ describe EmailDigest do
       proposal_notification = create(:proposal_notification)
       notification = create(:notification, notifiable: proposal_notification, user: user, emailed_at: Time.current)
 
-      email_digest = described_class.new(user)
+      email_digest = EmailDigest.new(user)
       expect(email_digest.pending_notifications?).not_to be
     end
 
     it "returns false when there are no notifications for a user" do
       user = create(:user)
-      email_digest = described_class.new(user)
+      email_digest = EmailDigest.new(user)
       expect(email_digest.pending_notifications?).not_to be
     end
 
@@ -74,7 +74,7 @@ describe EmailDigest do
       notification = create(:notification, notifiable: proposal_notification, user: user)
 
       reset_mailer
-      email_digest = described_class.new(user)
+      email_digest = EmailDigest.new(user)
       email_digest.deliver(Time.current)
 
       email = open_last_email
@@ -88,7 +88,7 @@ describe EmailDigest do
       create(:notification, notifiable: proposal_notification, user: user, emailed_at: Time.current)
 
       reset_mailer
-      email_digest = described_class.new(user)
+      email_digest = EmailDigest.new(user)
       email_digest.deliver(Time.current)
 
       expect(all_emails.count).to eq(0)
@@ -111,7 +111,7 @@ describe EmailDigest do
       expect(notification2.emailed_at).not_to be
       expect(notification3.emailed_at).not_to be
 
-      email_digest = described_class.new(user1)
+      email_digest = EmailDigest.new(user1)
       email_digest.mark_as_emailed
 
       notification1.reload
@@ -126,8 +126,8 @@ describe EmailDigest do
       user1 = create(:user, failed_email_digests_count: 0)
       user2 = create(:user, failed_email_digests_count: 3)
 
-      email_digest_1 = described_class.new(user1)
-      email_digest_2 = described_class.new(user2)
+      email_digest_1 = EmailDigest.new(user1)
+      email_digest_2 = EmailDigest.new(user2)
       email_digest_1.mark_as_emailed
       email_digest_2.mark_as_emailed
 
@@ -142,14 +142,14 @@ describe EmailDigest do
     it "returns a MatchData if email is valid" do
       user = create(:user, email: "valid_email@email.com")
 
-      email_digest = described_class.new(user)
+      email_digest = EmailDigest.new(user)
       expect(email_digest.valid_email?).to be_a(MatchData)
     end
 
     it "returns nil if email is invalid" do
       user = create(:user, email: "invalid_email@email..com")
 
-      email_digest = described_class.new(user)
+      email_digest = EmailDigest.new(user)
       expect(email_digest.valid_email?).to be(nil)
     end
 
@@ -157,7 +157,7 @@ describe EmailDigest do
       user = create(:user)
       user.update_attribute(:email, nil)
 
-      email_digest = described_class.new(user)
+      email_digest = EmailDigest.new(user)
       expect(email_digest.valid_email?).to be(false)
     end
   end

--- a/spec/lib/graph_ql/api_types_creator_spec.rb
+++ b/spec/lib/graph_ql/api_types_creator_spec.rb
@@ -5,7 +5,7 @@ describe GraphQL::ApiTypesCreator do
 
   describe "::create_type" do
     it "creates fields for Int attributes" do
-      debate_type = described_class.create_type(Debate, { id: :integer }, created_types)
+      debate_type = GraphQL::ApiTypesCreator.create_type(Debate, { id: :integer }, created_types)
       created_field = debate_type.fields["id"]
 
       expect(created_field).to be_a(GraphQL::Field)
@@ -14,7 +14,7 @@ describe GraphQL::ApiTypesCreator do
     end
 
     it "creates fields for String attributes" do
-      debate_type = described_class.create_type(Debate, { title: :string }, created_types)
+      debate_type = GraphQL::ApiTypesCreator.create_type(Debate, { title: :string }, created_types)
       created_field = debate_type.fields["title"]
 
       expect(created_field).to be_a(GraphQL::Field)
@@ -23,8 +23,8 @@ describe GraphQL::ApiTypesCreator do
     end
 
     it "creates connections for :belongs_to associations" do
-      user_type = described_class.create_type(User, { id: :integer }, created_types)
-      debate_type = described_class.create_type(Debate, { author: User }, created_types)
+      user_type = GraphQL::ApiTypesCreator.create_type(User, { id: :integer }, created_types)
+      debate_type = GraphQL::ApiTypesCreator.create_type(Debate, { author: User }, created_types)
 
       connection = debate_type.fields["author"]
 
@@ -34,8 +34,8 @@ describe GraphQL::ApiTypesCreator do
     end
 
     it "creates connections for :has_one associations" do
-      user_type = described_class.create_type(User, { organization: Organization }, created_types)
-      organization_type = described_class.create_type(Organization, { id: :integer }, created_types)
+      user_type = GraphQL::ApiTypesCreator.create_type(User, { organization: Organization }, created_types)
+      organization_type = GraphQL::ApiTypesCreator.create_type(Organization, { id: :integer }, created_types)
 
       connection = user_type.fields["organization"]
 
@@ -45,8 +45,8 @@ describe GraphQL::ApiTypesCreator do
     end
 
     it "creates connections for :has_many associations" do
-      comment_type = described_class.create_type(Comment, { id: :integer }, created_types)
-      debate_type = described_class.create_type(Debate, { comments: [Comment] }, created_types)
+      comment_type = GraphQL::ApiTypesCreator.create_type(Comment, { id: :integer }, created_types)
+      debate_type = GraphQL::ApiTypesCreator.create_type(Debate, { comments: [Comment] }, created_types)
 
       connection = debate_type.fields["comments"]
 

--- a/spec/lib/graph_ql/query_type_creator_spec.rb
+++ b/spec/lib/graph_ql/query_type_creator_spec.rb
@@ -10,7 +10,7 @@ describe GraphQL::QueryTypeCreator do
   let(:api_types) { GraphQL::ApiTypesCreator.create(api_type_definitions) }
 
   describe "::create" do
-    let(:query_type) { described_class.create(api_types) }
+    let(:query_type) { GraphQL::QueryTypeCreator.create(api_types) }
 
     it "creates a QueryType with fields to retrieve single objects whose model fields included an ID" do
       field = query_type.fields["proposal"]

--- a/spec/lib/local_census_spec.rb
+++ b/spec/lib/local_census_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe LocalCensus do
-  let(:api) { described_class.new }
+  let(:api) { LocalCensus.new }
 
   describe "#call" do
     let(:invalid_body) { nil }

--- a/spec/lib/manager_authenticator_spec.rb
+++ b/spec/lib/manager_authenticator_spec.rb
@@ -1,21 +1,21 @@
 require "rails_helper"
 
 describe ManagerAuthenticator do
-  let(:authenticator) { described_class.new(login: "JJB033", clave_usuario: "31415926", fecha_conexion: "20151031135905") }
+  let(:authenticator) { ManagerAuthenticator.new(login: "JJB033", clave_usuario: "31415926", fecha_conexion: "20151031135905") }
 
   describe "initialization params" do
     it "causes auth to return false if blank login" do
-      blank_login_authenticator = described_class.new(login: "", clave_usuario: "31415926", fecha_conexion: "20151031135905")
+      blank_login_authenticator = ManagerAuthenticator.new(login: "", clave_usuario: "31415926", fecha_conexion: "20151031135905")
       expect(blank_login_authenticator.auth).to be false
     end
 
     it "causes auth to return false if blank user_key" do
-      blank_user_key_authenticator = described_class.new(login: "JJB033", clave_usuario: "", fecha_conexion: "20151031135905")
+      blank_user_key_authenticator = ManagerAuthenticator.new(login: "JJB033", clave_usuario: "", fecha_conexion: "20151031135905")
       expect(blank_user_key_authenticator.auth).to be false
     end
 
     it "causes auth to return false if blank date" do
-      blank_date_authenticator = described_class.new(login: "JJB033", clave_usuario: "31415926", fecha_conexion: "")
+      blank_date_authenticator = ManagerAuthenticator.new(login: "JJB033", clave_usuario: "31415926", fecha_conexion: "")
       expect(blank_date_authenticator.auth).to be false
     end
   end

--- a/spec/lib/remote_census_api_spec.rb
+++ b/spec/lib/remote_census_api_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe RemoteCensusApi do
-  let(:api) { described_class.new }
+  let(:api) { RemoteCensusApi.new }
 
   describe "#call" do
     let(:invalid_body) { { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}}}} }

--- a/spec/lib/remote_translations/caller_spec.rb
+++ b/spec/lib/remote_translations/caller_spec.rb
@@ -19,7 +19,7 @@ describe RemoteTranslations::Caller do
       let(:debate)             { create(:debate) }
       let(:remote_translation) { create(:remote_translation,
                                         remote_translatable: debate, locale: :es) }
-      let(:caller) { described_class.new(remote_translation) }
+      let(:caller) { RemoteTranslations::Caller.new(remote_translation) }
 
       it "returns the resource with new translation persisted" do
         response = ["Título traducido", "Descripción traducida"]
@@ -67,7 +67,7 @@ describe RemoteTranslations::Caller do
       let!(:proposal)          { create(:proposal) }
       let(:remote_translation) { create(:remote_translation,
                                         remote_translatable: proposal, locale: :es) }
-      let(:caller) { described_class.new(remote_translation) }
+      let(:caller) { RemoteTranslations::Caller.new(remote_translation) }
 
       it "returns the resource with new translation persisted" do
         response = ["Título traducido", "Descripción traducida", "Pregunta traducida",
@@ -118,7 +118,7 @@ describe RemoteTranslations::Caller do
       let(:remote_translation) { create(:remote_translation,
                                         remote_translatable: budget_investment,
                                         locale: :es) }
-      let(:caller) { described_class.new(remote_translation) }
+      let(:caller) { RemoteTranslations::Caller.new(remote_translation) }
 
       it "returns the resource with new translation persisted" do
         response = ["Título traducido", "Descripción traducida"]
@@ -166,7 +166,7 @@ describe RemoteTranslations::Caller do
       let(:comment)            { create(:comment) }
       let(:remote_translation) { create(:remote_translation,
                                         remote_translatable: comment, locale: :es) }
-      let(:caller) { described_class.new(remote_translation) }
+      let(:caller) { RemoteTranslations::Caller.new(remote_translation) }
 
       it "returns the resource with new translation persisted" do
         response = ["Body traducido"]

--- a/spec/lib/remote_translations/microsoft/client_spec.rb
+++ b/spec/lib/remote_translations/microsoft/client_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe RemoteTranslations::Microsoft::Client do
 
-  let(:client) { described_class.new }
+  let(:client) { RemoteTranslations::Microsoft::Client.new }
 
   describe "#call" do
 

--- a/spec/lib/tag_sanitizer_spec.rb
+++ b/spec/lib/tag_sanitizer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe TagSanitizer do
 
-  subject { described_class.new }
+  subject { TagSanitizer.new }
 
   describe "#sanitize_tag" do
     it "allows regular text, even spaces" do
@@ -14,9 +14,9 @@ describe TagSanitizer do
     end
 
     it "sets up a max length for each tag" do
-      long_tag = "1" * (described_class.tag_max_length + 100)
+      long_tag = "1" * (TagSanitizer.tag_max_length + 100)
 
-      expect(subject.sanitize_tag(long_tag).size).to eq(described_class.tag_max_length)
+      expect(subject.sanitize_tag(long_tag).size).to eq(TagSanitizer.tag_max_length)
     end
   end
 

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -10,8 +10,8 @@ describe UserSegments do
       active_user = create(:user)
       erased_user = create(:user, erased_at: Time.current)
 
-      expect(described_class.all_users).to include active_user
-      expect(described_class.all_users).not_to include erased_user
+      expect(UserSegments.all_users).to include active_user
+      expect(UserSegments.all_users).not_to include erased_user
     end
   end
 
@@ -21,9 +21,9 @@ describe UserSegments do
       active_admin = create(:administrator).user
       erased_user = create(:user, erased_at: Time.current)
 
-      expect(described_class.administrators).to include active_admin
-      expect(described_class.administrators).not_to include active_user
-      expect(described_class.administrators).not_to include erased_user
+      expect(UserSegments.administrators).to include active_admin
+      expect(UserSegments.administrators).not_to include active_user
+      expect(UserSegments.administrators).not_to include erased_user
     end
   end
 
@@ -33,7 +33,7 @@ describe UserSegments do
       create(:proposal, :archived, author: user2)
       create(:proposal, :retired, author: user3)
 
-      all_proposal_authors = described_class.all_proposal_authors
+      all_proposal_authors = UserSegments.all_proposal_authors
       expect(all_proposal_authors).to include user1
       expect(all_proposal_authors).to include user2
       expect(all_proposal_authors).to include user3
@@ -44,7 +44,7 @@ describe UserSegments do
       create(:proposal, :archived, author: user1)
       create(:proposal, :retired, author: user1)
 
-      all_proposal_authors = described_class.all_proposal_authors
+      all_proposal_authors = UserSegments.all_proposal_authors
       expect(all_proposal_authors).to contain_exactly(user1)
     end
   end
@@ -53,7 +53,7 @@ describe UserSegments do
     it "returns users that have created a proposal" do
       proposal = create(:proposal, author: user1)
 
-      proposal_authors = described_class.proposal_authors
+      proposal_authors = UserSegments.proposal_authors
       expect(proposal_authors).to include user1
       expect(proposal_authors).not_to include user2
     end
@@ -62,7 +62,7 @@ describe UserSegments do
       proposal1 = create(:proposal, author: user1)
       proposal2 = create(:proposal, author: user1)
 
-      proposal_authors = described_class.proposal_authors
+      proposal_authors = UserSegments.proposal_authors
       expect(proposal_authors).to contain_exactly(user1)
     end
   end
@@ -73,7 +73,7 @@ describe UserSegments do
       budget = create(:budget)
       investment.update(budget: budget)
 
-      investment_authors = described_class.investment_authors
+      investment_authors = UserSegments.investment_authors
       expect(investment_authors).to include user1
       expect(investment_authors).not_to include user2
     end
@@ -85,7 +85,7 @@ describe UserSegments do
       investment1.update(budget: budget)
       investment2.update(budget: budget)
 
-      investment_authors = described_class.investment_authors
+      investment_authors = UserSegments.investment_authors
       expect(investment_authors).to contain_exactly(user1)
     end
   end
@@ -111,7 +111,7 @@ describe UserSegments do
       unfeasible_investment_unfinished.update(budget: budget)
       unfeasible_investment_finished.update(budget: budget)
 
-      investment_authors = described_class.feasible_and_undecided_investment_authors
+      investment_authors = UserSegments.feasible_and_undecided_investment_authors
       expect(investment_authors).to include user1
       expect(investment_authors).to include user2
       expect(investment_authors).to include user3
@@ -127,7 +127,7 @@ describe UserSegments do
       feasible_investment.update(budget: budget)
       undecided_investment.update(budget: budget)
 
-      investment_authors = described_class.feasible_and_undecided_investment_authors
+      investment_authors = UserSegments.feasible_and_undecided_investment_authors
       expect(investment_authors).to contain_exactly(user1)
     end
   end
@@ -140,7 +140,7 @@ describe UserSegments do
       selected_investment.update(budget: budget)
       unselected_investment.update(budget: budget)
 
-      investment_authors = described_class.selected_investment_authors
+      investment_authors = UserSegments.selected_investment_authors
       expect(investment_authors).to include user1
       expect(investment_authors).not_to include user2
     end
@@ -152,7 +152,7 @@ describe UserSegments do
       selected_investment1.update(budget: budget)
       selected_investment2.update(budget: budget)
 
-      investment_authors = described_class.selected_investment_authors
+      investment_authors = UserSegments.selected_investment_authors
       expect(investment_authors).to contain_exactly(user1)
     end
   end
@@ -165,7 +165,7 @@ describe UserSegments do
       winner_investment.update(budget: budget)
       selected_investment.update(budget: budget)
 
-      investment_authors = described_class.winner_investment_authors
+      investment_authors = UserSegments.winner_investment_authors
       expect(investment_authors).to include user1
       expect(investment_authors).not_to include user2
     end
@@ -177,7 +177,7 @@ describe UserSegments do
       winner_investment1.update(budget: budget)
       winner_investment2.update(budget: budget)
 
-      investment_authors = described_class.winner_investment_authors
+      investment_authors = UserSegments.winner_investment_authors
       expect(investment_authors).to contain_exactly(user1)
     end
   end
@@ -189,7 +189,7 @@ describe UserSegments do
       budget = create(:budget)
       investment1.update(budget: budget)
 
-      current_budget_investments = described_class.current_budget_investments
+      current_budget_investments = UserSegments.current_budget_investments
       expect(current_budget_investments).to include investment1
       expect(current_budget_investments).not_to include investment2
     end
@@ -205,7 +205,7 @@ describe UserSegments do
       investment1.update(budget: budget)
       investment2.update(budget: budget)
 
-      not_supported_on_current_budget = described_class.not_supported_on_current_budget
+      not_supported_on_current_budget = UserSegments.not_supported_on_current_budget
       expect(not_supported_on_current_budget).to include user3
       expect(not_supported_on_current_budget).not_to include user1
       expect(not_supported_on_current_budget).not_to include user2
@@ -217,7 +217,7 @@ describe UserSegments do
       create(:user, email: "first@email.com", created_at: 1.day.ago)
       create(:user, email: "last@email.com")
 
-      emails = described_class.user_segment_emails(:all_users)
+      emails = UserSegments.user_segment_emails(:all_users)
       expect(emails.first).to eq "first@email.com"
       expect(emails.last).to eq "last@email.com"
     end

--- a/spec/lib/wysiwyg_sanitizer_spec.rb
+++ b/spec/lib/wysiwyg_sanitizer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe WYSIWYGSanitizer do
 
-  subject { described_class.new }
+  subject { WYSIWYGSanitizer.new }
 
   describe "#sanitize" do
 

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -7,7 +7,7 @@ describe DeviseMailer do
       user = create(:user, locale: "es")
 
       email = I18n.with_locale :en do
-        described_class.confirmation_instructions(user, "ABC")
+        DeviseMailer.confirmation_instructions(user, "ABC")
       end
 
       expect(email.subject).to include("confirmación")

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -8,7 +8,7 @@ describe Mailer do
       comment = create(:comment, commentable: proposal)
 
       email = I18n.with_locale :en do
-        described_class.comment(comment)
+        Mailer.comment(comment)
       end
 
       expect(email.subject).to include("comentado")

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -23,9 +23,9 @@ describe Activity do
       user = create(:user)
       proposal = create(:proposal)
 
-      expect { described_class.log(user, :hide, proposal) }.to change { described_class.count }.by(1)
+      expect { Activity.log(user, :hide, proposal) }.to change { Activity.count }.by(1)
 
-      activity = described_class.last
+      activity = Activity.last
       expect(activity.user_id).to eq(user.id)
       expect(activity.action).to eq("hide")
       expect(activity.actionable).to eq(proposal)
@@ -43,9 +43,9 @@ describe Activity do
       create(:activity, action: "hide", actionable: create(:comment))
       create(:activity, action: "block", actionable: create(:user))
 
-      expect(described_class.on(proposal).size).to eq 3
+      expect(Activity.on(proposal).size).to eq 3
       [activity1, activity2, activity3].each do |a|
-        expect(described_class.on(proposal)).to include(a)
+        expect(Activity.on(proposal)).to include(a)
       end
     end
   end
@@ -61,10 +61,10 @@ describe Activity do
       activity6 = create(:activity, user: user1, action: "valuate", actionable: create(:budget_investment))
       create_list(:activity, 3)
 
-      expect(described_class.by(user1).size).to eq 6
+      expect(Activity.by(user1).size).to eq 6
 
       [activity1, activity2, activity3, activity4, activity5, activity6].each do |a|
-        expect(described_class.by(user1)).to include(a)
+        expect(Activity.by(user1)).to include(a)
       end
     end
   end
@@ -77,17 +77,17 @@ describe Activity do
       on_user       = create(:activity, actionable: create(:user))
       on_investment = create(:activity, actionable: create(:budget_investment))
 
-      expect(described_class.on_proposals.size).to eq 1
-      expect(described_class.on_debates.size).to eq 1
-      expect(described_class.on_comments.size).to eq 1
-      expect(described_class.on_users.size).to eq 1
-      expect(described_class.on_budget_investments.size).to eq 1
+      expect(Activity.on_proposals.size).to eq 1
+      expect(Activity.on_debates.size).to eq 1
+      expect(Activity.on_comments.size).to eq 1
+      expect(Activity.on_users.size).to eq 1
+      expect(Activity.on_budget_investments.size).to eq 1
 
-      expect(described_class.on_proposals.first).to eq on_proposal
-      expect(described_class.on_debates.first).to eq on_debate
-      expect(described_class.on_comments.first).to eq on_comment
-      expect(described_class.on_users.first).to eq on_user
-      expect(described_class.on_budget_investments.first).to eq on_investment
+      expect(Activity.on_proposals.first).to eq on_proposal
+      expect(Activity.on_debates.first).to eq on_debate
+      expect(Activity.on_comments.first).to eq on_comment
+      expect(Activity.on_users.first).to eq on_user
+      expect(Activity.on_budget_investments.first).to eq on_investment
     end
   end
 

--- a/spec/models/ahoy/data_source_spec.rb
+++ b/spec/models/ahoy/data_source_spec.rb
@@ -16,18 +16,18 @@ describe Ahoy::DataSource do
     end
 
     it "works without data sources" do
-      ds = described_class.new
+      ds = Ahoy::DataSource.new
       expect(ds.build).to eq x: []
     end
 
     it "works with single data sources" do
-      ds = described_class.new
+      ds = Ahoy::DataSource.new
       ds.add "foo", Ahoy::Event.where(name: "foo").group_by_day(:time).count
       expect(ds.build).to eq :x => ["2015-01-01", "2015-01-02"], "foo" => [2, 1]
     end
 
     it "combines data sources" do
-      ds = described_class.new
+      ds = Ahoy::DataSource.new
       ds.add "foo", Ahoy::Event.where(name: "foo").group_by_day(:time).count
       ds.add "bar", Ahoy::Event.where(name: "bar").group_by_day(:time).count
       expect(ds.build).to eq :x => ["2015-01-01", "2015-01-02", "2015-01-03"], "foo" => [2, 1, 0], "bar" => [1, 0, 2]

--- a/spec/models/budget/ballot/line_spec.rb
+++ b/spec/models/budget/ballot/line_spec.rb
@@ -73,7 +73,7 @@ describe Budget::Ballot::Line do
         ballot_line2 = create(:budget_ballot_line, ballot: ballot2, investment: investment1)
         ballot_line3 = create(:budget_ballot_line, ballot: ballot3, investment: investment2)
 
-        ballot_lines_by_investment = described_class.by_investment(investment1.id)
+        ballot_lines_by_investment = Budget::Ballot::Line.by_investment(investment1.id)
 
         expect(ballot_lines_by_investment).to include ballot_line1
         expect(ballot_lines_by_investment).to include ballot_line2

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -333,7 +333,7 @@ describe Budget::Investment do
       investment1 = create(:budget_investment, administrator_id: 33)
       create(:budget_investment)
 
-      by_admin = described_class.by_admin(33)
+      by_admin = Budget::Investment.by_admin(33)
 
       expect(by_admin.size).to eq(1)
       expect(by_admin.first).to eq(investment1)
@@ -353,7 +353,7 @@ describe Budget::Investment do
       investment2.valuators << valuator2
       investment3.valuators << [valuator1, valuator2]
 
-      by_valuator = described_class.by_valuator(valuator1.id)
+      by_valuator = Budget::Investment.by_valuator(valuator1.id)
 
       expect(by_valuator.size).to eq(2)
       expect(by_valuator.sort).to eq([investment1, investment3].sort)
@@ -371,7 +371,7 @@ describe Budget::Investment do
       unassigned_investment = create(:budget_investment, valuators: [valuator], valuator_groups: [])
       create(:budget_investment, valuators: [valuator], valuator_groups: [create(:valuator_group)])
 
-      by_valuator_group = described_class.by_valuator_group(valuator.valuator_group_id)
+      by_valuator_group = Budget::Investment.by_valuator_group(valuator.valuator_group_id)
 
       expect(by_valuator_group.size).to eq(2)
       expect(by_valuator_group).to contain_exactly(assigned_investment, another_assigned_investment)
@@ -386,17 +386,17 @@ describe Budget::Investment do
     let!(:investment) { create(:budget_investment, :feasible, heading: heading) }
 
     it "finds budget by id or slug" do
-      result = described_class.scoped_filter({ budget_id: budget.id }, nil)
+      result = Budget::Investment.scoped_filter({ budget_id: budget.id }, nil)
       expect(result.count).to be 1
       expect(result.first.id).to be investment.id
 
-      result = described_class.scoped_filter({ budget_id: "budget_slug" }, nil)
+      result = Budget::Investment.scoped_filter({ budget_id: "budget_slug" }, nil)
       expect(result.count).to be 1
       expect(result.first.id).to be investment.id
     end
 
     it "does not raise error if budget is not found" do
-      result = described_class.scoped_filter({ budget_id: "wrong_budget" }, nil)
+      result = Budget::Investment.scoped_filter({ budget_id: "wrong_budget" }, nil)
       expect(result).to be_empty
     end
 
@@ -408,7 +408,7 @@ describe Budget::Investment do
         investment1 = create(:budget_investment, valuation_finished: true)
         investment2 = create(:budget_investment)
 
-        valuation_open = described_class.valuation_open
+        valuation_open = Budget::Investment.valuation_open
 
         expect(valuation_open.size).to eq(1)
         expect(valuation_open.first).to eq(investment2)
@@ -421,7 +421,7 @@ describe Budget::Investment do
         investment2 = create(:budget_investment, administrator: create(:administrator))
         investment3 = create(:budget_investment)
 
-        without_admin = described_class.without_admin
+        without_admin = Budget::Investment.without_admin
 
         expect(without_admin.size).to eq(1)
         expect(without_admin.first).to eq(investment3)
@@ -435,7 +435,7 @@ describe Budget::Investment do
         investment3 = create(:budget_investment, administrator: create(:administrator))
         investment1.valuators << create(:valuator)
 
-        managed = described_class.managed
+        managed = Budget::Investment.managed
 
         expect(managed.size).to eq(1)
         expect(managed.first).to eq(investment3)
@@ -451,7 +451,7 @@ describe Budget::Investment do
         investment2.valuators << create(:valuator)
         investment3.valuators << create(:valuator)
 
-        valuating = described_class.valuating
+        valuating = Budget::Investment.valuating
 
         expect(valuating.size).to eq(1)
         expect(valuating.first).to eq(investment2)
@@ -465,7 +465,7 @@ describe Budget::Investment do
         investment2.valuator_groups << create(:valuator_group)
         investment3.valuator_groups << create(:valuator_group)
 
-        valuating = described_class.valuating
+        valuating = Budget::Investment.valuating
 
         expect(valuating.size).to eq(1)
         expect(valuating.first).to eq(investment2)
@@ -481,7 +481,7 @@ describe Budget::Investment do
         investment2.valuators << create(:valuator)
         investment3.valuators << create(:valuator)
 
-        valuation_finished = described_class.valuation_finished
+        valuation_finished = Budget::Investment.valuation_finished
 
         expect(valuation_finished.size).to eq(1)
         expect(valuation_finished.first).to eq(investment3)
@@ -493,7 +493,7 @@ describe Budget::Investment do
         feasible_investment = create(:budget_investment, :feasible)
         create(:budget_investment)
 
-        expect(described_class.feasible).to eq [feasible_investment]
+        expect(Budget::Investment.feasible).to eq [feasible_investment]
       end
     end
 
@@ -502,7 +502,7 @@ describe Budget::Investment do
         unfeasible_investment = create(:budget_investment, :unfeasible)
         create(:budget_investment, :feasible)
 
-        expect(described_class.unfeasible).to eq [unfeasible_investment]
+        expect(Budget::Investment.unfeasible).to eq [unfeasible_investment]
       end
     end
 
@@ -512,7 +512,7 @@ describe Budget::Investment do
         undecided_investment = create(:budget_investment, :undecided)
         feasible_investment = create(:budget_investment, :feasible)
 
-        expect(described_class.not_unfeasible.sort).to eq [undecided_investment, feasible_investment].sort
+        expect(Budget::Investment.not_unfeasible.sort).to eq [undecided_investment, feasible_investment].sort
       end
     end
 
@@ -522,7 +522,7 @@ describe Budget::Investment do
         undecided_investment = create(:budget_investment, :undecided)
         feasible_investment = create(:budget_investment, :feasible)
 
-        expect(described_class.undecided).to eq [undecided_investment]
+        expect(Budget::Investment.undecided).to eq [undecided_investment]
       end
     end
 
@@ -531,7 +531,7 @@ describe Budget::Investment do
         selected_investment = create(:budget_investment, :selected)
         unselected_investment = create(:budget_investment, :unselected)
 
-        expect(described_class.selected).to eq [selected_investment]
+        expect(Budget::Investment.selected).to eq [selected_investment]
       end
     end
 
@@ -542,7 +542,7 @@ describe Budget::Investment do
         unselected_undecided_investment = create(:budget_investment, :unselected, :undecided)
         unselected_feasible_investment = create(:budget_investment, :unselected, :feasible)
 
-        expect(described_class.unselected.sort).to eq [unselected_undecided_investment, unselected_feasible_investment].sort
+        expect(Budget::Investment.unselected.sort).to eq [unselected_undecided_investment, unselected_feasible_investment].sort
       end
     end
 
@@ -551,7 +551,7 @@ describe Budget::Investment do
         create(:budget_investment, title_en: "CCCC", title_es: "BBBB", description_en: "CCCC", description_es: "BBBB")
         create(:budget_investment, title_en: "DDDD", title_es: "AAAA", description_en: "DDDD", description_es: "AAAA")
 
-        expect(described_class.sort_by_title.map(&:title)).to eq %w[CCCC DDDD]
+        expect(Budget::Investment.sort_by_title.map(&:title)).to eq %w[CCCC DDDD]
       end
 
       it "takes into consideration title fallbacks when there is no translation for current locale" do
@@ -562,7 +562,7 @@ describe Budget::Investment do
           end
         end
 
-        expect(described_class.sort_by_title.map(&:title)).to eq %w[AAAA BBBB]
+        expect(Budget::Investment.sort_by_title.map(&:title)).to eq %w[AAAA BBBB]
       end
     end
 
@@ -579,15 +579,15 @@ describe Budget::Investment do
         end
       end
 
-      let(:all_investments) { described_class.all }
+      let(:all_investments) { Budget::Investment.all }
 
       it "return investment by given id" do
-        expect(described_class.search_by_title_or_id(investment.id.to_s, all_investments)).
+        expect(Budget::Investment.search_by_title_or_id(investment.id.to_s, all_investments)).
           to eq([investment])
       end
 
       it "return investments by given title" do
-        expect(described_class.search_by_title_or_id("Título del proyecto de inversión", all_investments)).
+        expect(Budget::Investment.search_by_title_or_id("Título del proyecto de inversión", all_investments)).
           to eq([investment])
       end
     end
@@ -602,7 +602,7 @@ describe Budget::Investment do
       investment2 = create(:budget_investment, :feasible,   budget: budget)
       investment3 = create(:budget_investment, :unfeasible, budget: budget)
 
-      results = described_class.apply_filters_and_search(budget, {}, :feasible)
+      results = Budget::Investment.apply_filters_and_search(budget, {}, :feasible)
 
       expect(results).to     include investment1
       expect(results).to     include investment2
@@ -614,7 +614,7 @@ describe Budget::Investment do
       investment2 = create(:budget_investment, :unfeasible, budget: budget)
       investment3 = create(:budget_investment, :feasible,   budget: budget)
 
-      results = described_class.apply_filters_and_search(budget, {}, :unfeasible)
+      results = Budget::Investment.apply_filters_and_search(budget, {}, :unfeasible)
 
       expect(results).to     include investment1
       expect(results).to     include investment2
@@ -628,7 +628,7 @@ describe Budget::Investment do
       investment2 = create(:budget_investment, :feasible, :selected,   budget: budget)
       investment3 = create(:budget_investment, :feasible, :unselected, budget: budget)
 
-      results = described_class.apply_filters_and_search(budget, {}, :selected)
+      results = Budget::Investment.apply_filters_and_search(budget, {}, :selected)
 
       expect(results).to     include investment1
       expect(results).to     include investment2
@@ -642,7 +642,7 @@ describe Budget::Investment do
       investment2 = create(:budget_investment, :feasible, :unselected, budget: budget)
       investment3 = create(:budget_investment, :feasible, :selected,   budget: budget)
 
-      results = described_class.apply_filters_and_search(budget, {}, :unselected)
+      results = Budget::Investment.apply_filters_and_search(budget, {}, :unselected)
 
       expect(results).to     include investment1
       expect(results).to     include investment2
@@ -659,7 +659,7 @@ describe Budget::Investment do
       investment2 = create(:budget_investment, heading: heading1, budget: budget)
       investment3 = create(:budget_investment, heading: heading2, budget: budget)
 
-      results = described_class.apply_filters_and_search(budget, heading_id: heading1.id)
+      results = Budget::Investment.apply_filters_and_search(budget, heading_id: heading1.id)
 
       expect(results).to     include investment1
       expect(results).to     include investment2
@@ -671,7 +671,7 @@ describe Budget::Investment do
       investment2 = create(:budget_investment, title: "improved health", budget: budget)
       investment3 = create(:budget_investment, title: "finance",         budget: budget)
 
-      results = described_class.apply_filters_and_search(budget, search: "health")
+      results = Budget::Investment.apply_filters_and_search(budget, search: "health")
 
       expect(results).to     include investment1
       expect(results).to     include investment2
@@ -690,20 +690,20 @@ describe Budget::Investment do
 
       it "searches by title" do
         budget_investment = create(:budget_investment, attributes)
-        results = described_class.search("save the world")
+        results = Budget::Investment.search("save the world")
         expect(results).to eq([budget_investment])
       end
 
       it "searches by title across all languages" do
         budget_investment = create(:budget_investment, attributes)
-        results = described_class.search("salvar el mundo")
+        results = Budget::Investment.search("salvar el mundo")
         expect(results).to eq([budget_investment])
       end
 
       it "searches by author name" do
         author = create(:user, username: "Danny Trejo")
         budget_investment = create(:budget_investment, author: author)
-        results = described_class.search("Danny")
+        results = Budget::Investment.search("Danny")
         expect(results).to eq([budget_investment])
       end
 
@@ -713,10 +713,10 @@ describe Budget::Investment do
       it "searches by tags" do
         investment = create(:budget_investment, tag_list: "Latina")
 
-        results = described_class.search("Latina")
+        results = Budget::Investment.search("Latina")
         expect(results.first).to eq(investment)
 
-        results = described_class.search("Latin")
+        results = Budget::Investment.search("Latin")
         expect(results.first).to eq(investment)
       end
 
@@ -929,9 +929,9 @@ describe Budget::Investment do
         most_voted = create(:budget_investment, cached_votes_up: 10)
         some_votes = create(:budget_investment, cached_votes_up: 5)
 
-        expect(described_class.sort_by_confidence_score.first).to eq most_voted
-        expect(described_class.sort_by_confidence_score.second).to eq some_votes
-        expect(described_class.sort_by_confidence_score.third).to eq least_voted
+        expect(Budget::Investment.sort_by_confidence_score.first).to eq most_voted
+        expect(Budget::Investment.sort_by_confidence_score.second).to eq some_votes
+        expect(Budget::Investment.sort_by_confidence_score.third).to eq least_voted
       end
 
       it "orders by confidence_score and then by id" do
@@ -940,10 +940,10 @@ describe Budget::Investment do
         most_voted2  = create(:budget_investment, cached_votes_up: 10)
         least_voted2 = create(:budget_investment, cached_votes_up: 1)
 
-        expect(described_class.sort_by_confidence_score.first).to eq most_voted2
-        expect(described_class.sort_by_confidence_score.second).to eq most_voted
-        expect(described_class.sort_by_confidence_score.third).to eq least_voted2
-        expect(described_class.sort_by_confidence_score.fourth).to eq least_voted
+        expect(Budget::Investment.sort_by_confidence_score.first).to eq most_voted2
+        expect(Budget::Investment.sort_by_confidence_score.second).to eq most_voted
+        expect(Budget::Investment.sort_by_confidence_score.third).to eq least_voted2
+        expect(Budget::Investment.sort_by_confidence_score.fourth).to eq least_voted
       end
     end
   end
@@ -986,8 +986,8 @@ describe Budget::Investment do
       inv2 = create(:budget_investment)
       create(:vote, votable: inv1)
 
-      expect(described_class.with_supports).to include(inv1)
-      expect(described_class.with_supports).not_to include(inv2)
+      expect(Budget::Investment.with_supports).to include(inv1)
+      expect(Budget::Investment.with_supports).not_to include(inv2)
     end
   end
 
@@ -1223,8 +1223,8 @@ describe Budget::Investment do
           :with_administrator,
           budget: budget)
         investment3 = create(:budget_investment, budget: budget)
-        expect(described_class.scoped_filter(params, "all")).to eq([investment3])
-        expect(described_class.scoped_filter(params, "all").count).to eq(1)
+        expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment3])
+        expect(Budget::Investment.scoped_filter(params, "all").count).to eq(1)
       end
     end
 
@@ -1239,9 +1239,9 @@ describe Budget::Investment do
           budget: budget)
         investment3 = create(:budget_investment,
           budget: budget)
-        expect(described_class.scoped_filter(params, "all"))
+        expect(Budget::Investment.scoped_filter(params, "all"))
           .to contain_exactly(investment2, investment3)
-        expect(described_class.scoped_filter(params, "all").count)
+        expect(Budget::Investment.scoped_filter(params, "all").count)
         .to eq(2)
       end
     end
@@ -1258,8 +1258,8 @@ describe Budget::Investment do
         create(:budget_investment, :with_administrator, budget: budget)
         create(:budget_investment, budget: budget)
 
-        expect(described_class.scoped_filter(params, "all")).to eq([investment1])
-        expect(described_class.scoped_filter(params, "all").count).to eq(1)
+        expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment1])
+        expect(Budget::Investment.scoped_filter(params, "all").count).to eq(1)
       end
     end
 
@@ -1274,8 +1274,8 @@ describe Budget::Investment do
           budget: budget)
         create(:budget_investment,
           budget: budget)
-        expect(described_class.scoped_filter(params, "all")).to eq([investment1])
-        expect(described_class.scoped_filter(params, "all").count).to eq(1)
+        expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment1])
+        expect(Budget::Investment.scoped_filter(params, "all").count).to eq(1)
       end
     end
 
@@ -1290,8 +1290,8 @@ describe Budget::Investment do
           :with_administrator,
           budget: budget)
         create(:budget_investment, budget: budget)
-        expect(described_class.scoped_filter(params, "all")).to eq([investment1])
-        expect(described_class.scoped_filter(params, "all").count).to eq(1)
+        expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment1])
+        expect(Budget::Investment.scoped_filter(params, "all").count).to eq(1)
       end
     end
   end

--- a/spec/models/budget/result_spec.rb
+++ b/spec/models/budget/result_spec.rb
@@ -15,7 +15,7 @@ describe Budget::Result do
         investment4 = create(:budget_investment, :selected, heading: heading, price: 500, ballot_lines_count: 600, winner: false)
         investment5 = create(:budget_investment, :selected, heading: heading, price: 100, ballot_lines_count: 500, winner: false)
 
-        described_class.new(budget, heading).calculate_winners
+        Budget::Result.new(budget, heading).calculate_winners
 
         expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment4.id])
       end
@@ -29,7 +29,7 @@ describe Budget::Result do
         investment4 = create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 600)
         investment5 = create(:budget_investment, :winner, heading: heading, price: 100, ballot_lines_count: 500)
 
-        described_class.new(budget, heading).calculate_winners
+        Budget::Result.new(budget, heading).calculate_winners
 
         expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment4.id])
       end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -155,13 +155,13 @@ describe Budget do
     it "returns nil if there is only one budget and it is still in drafting phase" do
       budget = create(:budget, phase: "drafting")
 
-      expect(described_class.current).to eq(nil)
+      expect(Budget.current).to eq(nil)
     end
 
     it "returns the budget if there is only one and not in drafting phase" do
       budget = create(:budget, phase: "accepting")
 
-      expect(described_class.current).to eq(budget)
+      expect(Budget.current).to eq(budget)
     end
 
     it "returns the last budget created that is not in drafting phase" do
@@ -170,7 +170,7 @@ describe Budget do
       current_budget  = create(:budget, phase: "accepting", created_at: 1.month.ago)
       next_budget     = create(:budget, phase: "drafting",  created_at: 1.week.ago)
 
-      expect(described_class.current).to eq(current_budget)
+      expect(Budget.current).to eq(current_budget)
     end
 
   end
@@ -180,7 +180,7 @@ describe Budget do
     it "returns all budgets that are not in the finished phase" do
       (Budget::Phase::PHASE_KINDS - ["finished"]).each do |phase|
         budget = create(:budget, phase: phase)
-        expect(described_class.open).to include(budget)
+        expect(Budget.open).to include(budget)
       end
     end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -131,8 +131,8 @@ describe Comment do
       create(:comment, administrator_id: create(:administrator).id)
       create(:comment, moderator_id: create(:moderator).id)
 
-      expect(described_class.not_as_admin_or_moderator.size).to eq(1)
-      expect(described_class.not_as_admin_or_moderator.first).to eq(comment1)
+      expect(Comment.not_as_admin_or_moderator.size).to eq(1)
+      expect(Comment.not_as_admin_or_moderator.first).to eq(comment1)
     end
   end
 
@@ -140,60 +140,60 @@ describe Comment do
     it "returns comments" do
       comment = create(:comment)
 
-      expect(described_class.public_for_api).to include(comment)
+      expect(Comment.public_for_api).to include(comment)
     end
 
     it "does not return hidden comments" do
       hidden_comment = create(:comment, :hidden)
 
-      expect(described_class.public_for_api).not_to include(hidden_comment)
+      expect(Comment.public_for_api).not_to include(hidden_comment)
     end
 
     it "returns comments on debates" do
       debate = create(:debate)
       comment = create(:comment, commentable: debate)
 
-      expect(described_class.public_for_api).to include(comment)
+      expect(Comment.public_for_api).to include(comment)
     end
 
     it "does not return comments on hidden debates" do
       hidden_debate = create(:debate, :hidden)
       comment = create(:comment, commentable: hidden_debate)
 
-      expect(described_class.public_for_api).not_to include(comment)
+      expect(Comment.public_for_api).not_to include(comment)
     end
 
     it "returns comments on proposals" do
       proposal = create(:proposal)
       comment = create(:comment, commentable: proposal)
 
-      expect(described_class.public_for_api).to include(comment)
+      expect(Comment.public_for_api).to include(comment)
     end
 
     it "does not return comments on hidden proposals" do
       hidden_proposal = create(:proposal, :hidden)
       comment = create(:comment, commentable: hidden_proposal)
 
-      expect(described_class.public_for_api).not_to include(comment)
+      expect(Comment.public_for_api).not_to include(comment)
     end
 
     it "does not return comments on elements which are not debates or proposals" do
       budget_investment = create(:budget_investment)
       comment = create(:comment, commentable: budget_investment)
 
-      expect(described_class.public_for_api).not_to include(comment)
+      expect(Comment.public_for_api).not_to include(comment)
     end
 
     it "does not return comments with no commentable" do
       comment = build(:comment, commentable: nil).save!(validate: false)
 
-      expect(described_class.public_for_api).not_to include(comment)
+      expect(Comment.public_for_api).not_to include(comment)
     end
 
     it "does not return internal valuation comments" do
       valuation_comment = create(:comment, :valuation)
 
-      expect(described_class.public_for_api).not_to include(valuation_comment)
+      expect(Comment.public_for_api).not_to include(valuation_comment)
     end
   end
 end

--- a/spec/models/dashboard/action_spec.rb
+++ b/spec/models/dashboard/action_spec.rb
@@ -171,35 +171,35 @@ describe Dashboard::Action do
     let(:draft_proposal) { create :proposal, :draft }
 
     it "actions with enough supports or days are active" do
-      expect(described_class.active_for(proposal)).to include(active_action)
+      expect(Dashboard::Action.active_for(proposal)).to include(active_action)
     end
 
     it "inactive actions are not included" do
-      expect(described_class.active_for(proposal)).not_to include(inactive_action)
+      expect(Dashboard::Action.active_for(proposal)).not_to include(inactive_action)
     end
 
     it "actions without enough supports are not active" do
-      expect(described_class.active_for(proposal)).not_to include(not_enough_supports_action)
+      expect(Dashboard::Action.active_for(proposal)).not_to include(not_enough_supports_action)
     end
 
     it "actions planned to be active in the future are not active" do
-      expect(described_class.active_for(proposal)).not_to include(future_action)
+      expect(Dashboard::Action.active_for(proposal)).not_to include(future_action)
     end
 
     it "actions with published_proposal: true, are not included on draft proposal" do
-      expect(described_class.active_for(draft_proposal)).not_to include(action_published_proposal)
+      expect(Dashboard::Action.active_for(draft_proposal)).not_to include(action_published_proposal)
     end
 
     it "actions with published_proposal: true, are included on published proposal" do
-      expect(described_class.active_for(proposal)).to include(action_published_proposal)
+      expect(Dashboard::Action.active_for(proposal)).to include(action_published_proposal)
     end
 
     it "actions with published_proposal: false, are included on draft proposal" do
-      expect(described_class.active_for(draft_proposal)).to include(action_for_draft_proposal)
+      expect(Dashboard::Action.active_for(draft_proposal)).to include(action_for_draft_proposal)
     end
 
     it "actions with published_proposal: false, are included on published proposal" do
-      expect(described_class.active_for(proposal)).to include(action_for_draft_proposal)
+      expect(Dashboard::Action.active_for(proposal)).to include(action_for_draft_proposal)
     end
   end
 
@@ -212,19 +212,19 @@ describe Dashboard::Action do
     let(:proposal) { create :proposal }
 
     it "proposed actions are not part of proposal's course" do
-      expect(described_class.course_for(proposal)).not_to include(proposed_action)
+      expect(Dashboard::Action.course_for(proposal)).not_to include(proposed_action)
     end
 
     it "inactive resources are not part of proposal's course" do
-      expect(described_class.course_for(proposal)).not_to include(inactive_resource)
+      expect(Dashboard::Action.course_for(proposal)).not_to include(inactive_resource)
     end
 
     it "achievements are not part of the proposal's course" do
-      expect(described_class.course_for(proposal)).not_to include(achieved_resource)
+      expect(Dashboard::Action.course_for(proposal)).not_to include(achieved_resource)
     end
 
     it "active resources are part of proposal's course" do
-      expect(described_class.course_for(proposal)).to include(resource)
+      expect(Dashboard::Action.course_for(proposal)).to include(resource)
     end
   end
 
@@ -240,7 +240,7 @@ describe Dashboard::Action do
         action.update(published_proposal: true)
         resource.update(published_proposal: true)
 
-        expect(described_class.detect_new_actions_since(Date.yesterday, proposal)).to eq []
+        expect(Dashboard::Action.detect_new_actions_since(Date.yesterday, proposal)).to eq []
       end
 
       it "when there are news actions actived for draft_proposal but proposal is published" do
@@ -248,7 +248,7 @@ describe Dashboard::Action do
         action.update(published_proposal: false, day_offset: 0)
         resource.update(published_proposal: false, day_offset: 0)
 
-        expect(described_class.detect_new_actions_since(Date.yesterday, proposal)).to eq []
+        expect(Dashboard::Action.detect_new_actions_since(Date.yesterday, proposal)).to eq []
       end
 
       it "when there are not news actions actived for draft proposals" do
@@ -256,7 +256,7 @@ describe Dashboard::Action do
         action.update(published_proposal: false)
         resource.update(published_proposal: false)
 
-        expect(described_class.detect_new_actions_since(Date.yesterday, proposal)).to eq []
+        expect(Dashboard::Action.detect_new_actions_since(Date.yesterday, proposal)).to eq []
       end
 
       it "when there are news actions actived for published_proposal but proposal is draft" do
@@ -264,7 +264,7 @@ describe Dashboard::Action do
         action.update(published_proposal: true, day_offset: 0)
         resource.update(published_proposal: true, day_offset: 0)
 
-        expect(described_class.detect_new_actions_since(Date.yesterday, proposal)).to eq []
+        expect(Dashboard::Action.detect_new_actions_since(Date.yesterday, proposal)).to eq []
       end
 
     end
@@ -280,9 +280,9 @@ describe Dashboard::Action do
                                                      published_proposal: true) }
 
         it "when proposal has been created today and day_offset is valid only for today" do
-          expect(described_class.detect_new_actions_since(Date.yesterday,
+          expect(Dashboard::Action.detect_new_actions_since(Date.yesterday,
                                                           proposal)).to include(resource.id)
-          expect(described_class.detect_new_actions_since(Date.yesterday,
+          expect(Dashboard::Action.detect_new_actions_since(Date.yesterday,
                                                           proposal)).to include(action.id)
         end
 
@@ -292,9 +292,9 @@ describe Dashboard::Action do
           resource.update(required_supports: 0)
           create(:vote, voter: proposal.author, votable: proposal)
 
-          expect(described_class.detect_new_actions_since(Date.yesterday,
+          expect(Dashboard::Action.detect_new_actions_since(Date.yesterday,
                                                           proposal)).to include(action.id)
-          expect(described_class.detect_new_actions_since(Date.yesterday,
+          expect(Dashboard::Action.detect_new_actions_since(Date.yesterday,
                                                           proposal)).not_to include(resource.id)
         end
 
@@ -309,9 +309,9 @@ describe Dashboard::Action do
                                                      published_proposal: false) }
 
         it "when day_offset field is valid for today and invalid for yesterday" do
-          expect(described_class.detect_new_actions_since(Date.yesterday,
+          expect(Dashboard::Action.detect_new_actions_since(Date.yesterday,
                                                           proposal)).to include(resource.id)
-          expect(described_class.detect_new_actions_since(Date.yesterday,
+          expect(Dashboard::Action.detect_new_actions_since(Date.yesterday,
                                                           proposal)).to include(action.id)
         end
 
@@ -321,9 +321,9 @@ describe Dashboard::Action do
           resource.update(required_supports: 2)
           create(:vote, voter: proposal.author, votable: proposal)
 
-          expect(described_class.detect_new_actions_since(Date.yesterday,
+          expect(Dashboard::Action.detect_new_actions_since(Date.yesterday,
                                                           proposal)).to include(action.id)
-          expect(described_class.detect_new_actions_since(Date.yesterday,
+          expect(Dashboard::Action.detect_new_actions_since(Date.yesterday,
                                                           proposal)).not_to include(resource.id)
         end
 

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -471,39 +471,39 @@ describe Debate do
 
       it "searches by title" do
         debate = create(:debate, attributes)
-        results = described_class.search("save the world")
+        results = Debate.search("save the world")
         expect(results).to eq([debate])
       end
 
       it "searches by title across all languages translations" do
         debate = create(:debate, attributes)
-        results = described_class.search("salvar el mundo")
+        results = Debate.search("salvar el mundo")
         expect(results).to eq([debate])
       end
 
       it "searches by description" do
         debate = create(:debate, attributes)
-        results = described_class.search("one must think")
+        results = Debate.search("one must think")
         expect(results).to eq([debate])
       end
 
       it "searches by description across all languages translations" do
         debate = create(:debate, attributes)
-        results = described_class.search("uno debe pensar")
+        results = Debate.search("uno debe pensar")
         expect(results).to eq([debate])
       end
 
       it "searches by author name" do
         author = create(:user, username: "Danny Trejo")
         debate = create(:debate, author: author)
-        results = described_class.search("Danny")
+        results = Debate.search("Danny")
         expect(results).to eq([debate])
       end
 
       it "searches by geozone" do
         geozone = create(:geozone, name: "California")
         debate = create(:debate, geozone: geozone)
-        results = described_class.search("California")
+        results = Debate.search("California")
         expect(results).to eq([debate])
       end
 
@@ -514,13 +514,13 @@ describe Debate do
       it "searches word stems" do
         debate = create(:debate, title: "limpiar")
 
-        results = described_class.search("limpiará")
+        results = Debate.search("limpiará")
         expect(results).to eq([debate])
 
-        results = described_class.search("limpiémos")
+        results = Debate.search("limpiémos")
         expect(results).to eq([debate])
 
-        results = described_class.search("limpió")
+        results = Debate.search("limpió")
         expect(results).to eq([debate])
       end
 
@@ -531,15 +531,15 @@ describe Debate do
       it "searches with accents" do
         debate = create(:debate, title: "difusión")
 
-        results = described_class.search("difusion")
+        results = Debate.search("difusion")
         expect(results).to eq([debate])
 
         debate2 = create(:debate, title: "estadisticas")
-        results = described_class.search("estadísticas")
+        results = Debate.search("estadísticas")
         expect(results).to eq([debate2])
 
         debate3 = create(:debate, title: "público")
-        results = described_class.search("publico")
+        results = Debate.search("publico")
         expect(results).to eq([debate3])
       end
 
@@ -549,11 +549,11 @@ describe Debate do
       it "searches case insensite" do
         debate = create(:debate, title: "SHOUT")
 
-        results = described_class.search("shout")
+        results = Debate.search("shout")
         expect(results).to eq([debate])
 
         debate2 = create(:debate, title: "scream")
-        results = described_class.search("SCREAM")
+        results = Debate.search("SCREAM")
         expect(results).to eq([debate2])
       end
     end
@@ -562,10 +562,10 @@ describe Debate do
       it "searches by tags" do
         debate = create(:debate, tag_list: "Latina")
 
-        results = described_class.search("Latina")
+        results = Debate.search("Latina")
         expect(results.first).to eq(debate)
 
-        results = described_class.search("Latin")
+        results = Debate.search("Latin")
         expect(results.first).to eq(debate)
       end
     end
@@ -576,7 +576,7 @@ describe Debate do
         debate_description = create(:debate,  description: "stop corruption")
         debate_title       = create(:debate,  title:       "stop corruption")
 
-        results = described_class.search("stop corruption")
+        results = Debate.search("stop corruption")
 
         expect(results.first).to eq(debate_title)
         expect(results.second).to eq(debate_description)
@@ -588,7 +588,7 @@ describe Debate do
         title_most_voted    = create(:debate, title: "stop corruption", cached_votes_up: 10)
         description_most_voted = create(:debate, description: "stop corruption", cached_votes_up: 10)
 
-        results = described_class.search("stop corruption")
+        results = Debate.search("stop corruption")
 
         expect(results.first).to eq(title_most_voted)
         expect(results.second).to eq(title_some_votes)
@@ -600,7 +600,7 @@ describe Debate do
         exact_title_few_votes    = create(:debate, title: "stop corruption", cached_votes_up: 5)
         similar_title_many_votes = create(:debate, title: "stop some of the corruption", cached_votes_up: 500)
 
-        results = described_class.search("stop corruption")
+        results = Debate.search("stop corruption")
 
         expect(results.first).to eq(exact_title_few_votes)
         expect(results.second).to eq(similar_title_many_votes)
@@ -619,7 +619,7 @@ describe Debate do
         highest_score.update_column(:hot_score, 100)
         average_score.update_column(:hot_score, 10)
 
-        results = described_class.search("stop corruption")
+        results = Debate.search("stop corruption")
 
         expect(results.first).to eq(average_score)
         expect(results.second).to eq(highest_score)
@@ -641,7 +641,7 @@ describe Debate do
         highest_score.update_column(:confidence_score, 100)
         average_score.update_column(:confidence_score, 10)
 
-        results = described_class.search("stop corruption")
+        results = Debate.search("stop corruption")
 
         expect(results.first).to eq(average_score)
         expect(results.second).to eq(highest_score)
@@ -659,7 +659,7 @@ describe Debate do
         newest  = create(:debate,  title: "stop corruption", cached_votes_up: 2, created_at: Time.current)
         oldest  = create(:debate,  title: "stop corruption", cached_votes_up: 3, created_at: 1.month.ago)
 
-        results = described_class.search("stop corruption")
+        results = Debate.search("stop corruption")
 
         expect(results.first).to eq(oldest)
         expect(results.second).to eq(newest)
@@ -677,7 +677,7 @@ describe Debate do
         most_commented  = create(:debate,  title: "stop corruption",  cached_votes_up: 2, comments_count: 100)
         some_comments   = create(:debate,  title: "stop corruption",  cached_votes_up: 3, comments_count: 10)
 
-        results = described_class.search("stop corruption")
+        results = Debate.search("stop corruption")
 
         expect(results.first).to eq(some_comments)
         expect(results.second).to eq(most_commented)
@@ -697,28 +697,28 @@ describe Debate do
       it "no words match" do
         debate = create(:debate, title: "save world")
 
-        results = described_class.search("destroy planet")
+        results = Debate.search("destroy planet")
         expect(results).to eq([])
       end
 
       it "too many typos" do
         debate = create(:debate, title: "fantastic")
 
-        results = described_class.search("frantac")
+        results = Debate.search("frantac")
         expect(results).to eq([])
       end
 
       it "too much stemming" do
         debate = create(:debate, title: "reloj")
 
-        results = described_class.search("superrelojimetro")
+        results = Debate.search("superrelojimetro")
         expect(results).to eq([])
       end
 
       it "empty" do
         debate = create(:debate, title: "great")
 
-        results = described_class.search("")
+        results = Debate.search("")
         expect(results).to eq([])
       end
 
@@ -728,12 +728,12 @@ describe Debate do
   describe "#last_week" do
     it "returns debates created this week" do
       debate = create(:debate)
-      expect(described_class.last_week.all).to include debate
+      expect(Debate.last_week.all).to include debate
     end
 
     it "does not show debates created more than a week ago" do
       debate = create(:debate, created_at: 8.days.ago)
-      expect(described_class.last_week.all).not_to include debate
+      expect(Debate.last_week.all).not_to include debate
     end
   end
 
@@ -746,12 +746,12 @@ describe Debate do
   describe "public_for_api scope" do
     it "returns debates" do
       debate = create(:debate)
-      expect(described_class.public_for_api).to include(debate)
+      expect(Debate.public_for_api).to include(debate)
     end
 
     it "does not return hidden debates" do
       debate = create(:debate, :hidden)
-      expect(described_class.public_for_api).not_to include(debate)
+      expect(Debate.public_for_api).not_to include(debate)
     end
   end
 
@@ -762,7 +762,7 @@ describe Debate do
     it "does not return any debates when user has not interests" do
       create(:debate)
 
-      expect(described_class.recommendations(user).size).to eq 0
+      expect(Debate.recommendations(user).size).to eq 0
     end
 
     it "returns debates ordered by cached_votes_total" do
@@ -772,7 +772,7 @@ describe Debate do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal, user: user)
 
-      result = described_class.recommendations(user).sort_by_recommendations
+      result = Debate.recommendations(user).sort_by_recommendations
 
       expect(result.first).to eq debate3
       expect(result.second).to eq debate2
@@ -785,7 +785,7 @@ describe Debate do
       proposal1 = create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal1, user: user)
 
-      result = described_class.recommendations(user)
+      result = Debate.recommendations(user)
 
       expect(result.size).to eq 1
       expect(result).to eq [debate1]
@@ -797,7 +797,7 @@ describe Debate do
       proposal = create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal, user: user)
 
-      result = described_class.recommendations(user)
+      result = Debate.recommendations(user)
 
       expect(result.size).to eq 1
       expect(result).to eq [debate2]

--- a/spec/models/direct_message_spec.rb
+++ b/spec/models/direct_message_spec.rb
@@ -81,14 +81,14 @@ describe DirectMessage do
         create(:direct_message, created_at: Time.current)
         create(:direct_message, created_at: Date.current.end_of_day)
 
-        expect(described_class.today.count).to eq 3
+        expect(DirectMessage.today.count).to eq 3
       end
 
       it "does not return direct messages created another day" do
         direct_message1 = create(:direct_message, created_at: 1.day.ago)
         direct_message2 = create(:direct_message, created_at: 1.day.from_now)
 
-        expect(described_class.today.count).to eq 0
+        expect(DirectMessage.today.count).to eq 0
       end
     end
 

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -8,48 +8,48 @@ describe Flag do
   describe ".flag" do
 
     it "creates a flag when there is none" do
-      expect { described_class.flag(user, comment) }.to change { described_class.count }.by(1)
-      expect(described_class.last.user).to eq(user)
-      expect(described_class.last.flaggable).to eq(comment)
+      expect { Flag.flag(user, comment) }.to change { Flag.count }.by(1)
+      expect(Flag.last.user).to eq(user)
+      expect(Flag.last.flaggable).to eq(comment)
     end
 
     it "does nothing if the flag already exists" do
-      described_class.flag(user, comment)
-      expect(described_class.flag(user, comment)).to eq(false)
-      expect(described_class.by_user_and_flaggable(user, comment).count).to eq(1)
+      Flag.flag(user, comment)
+      expect(Flag.flag(user, comment)).to eq(false)
+      expect(Flag.by_user_and_flaggable(user, comment).count).to eq(1)
     end
 
     it "increases the flag count" do
-      expect { described_class.flag(user, comment) }.to change { comment.reload.flags_count }.by(1)
+      expect { Flag.flag(user, comment) }.to change { comment.reload.flags_count }.by(1)
     end
   end
 
   describe ".unflag" do
     it "raises an error if the flag does not exist" do
-      expect(described_class.unflag(user, comment)).to eq(false)
+      expect(Flag.unflag(user, comment)).to eq(false)
     end
 
     describe "when the flag already exists" do
-      before { described_class.flag(user, comment) }
+      before { Flag.flag(user, comment) }
 
       it "removes an existing flag" do
-        expect { described_class.unflag(user, comment) }.to change { described_class.count }.by(-1)
+        expect { Flag.unflag(user, comment) }.to change { Flag.count }.by(-1)
       end
 
       it "decreases the flag count" do
-        expect { described_class.unflag(user, comment) }.to change { comment.reload.flags_count }.by(-1)
+        expect { Flag.unflag(user, comment) }.to change { comment.reload.flags_count }.by(-1)
       end
     end
   end
 
   describe ".flagged?" do
     it "returns false when the user has not flagged the comment" do
-      expect(described_class.flagged?(user, comment)).not_to be
+      expect(Flag.flagged?(user, comment)).not_to be
     end
 
     it "returns true when the user has flagged the comment" do
-      described_class.flag(user, comment)
-      expect(described_class.flagged?(user, comment)).to be
+      Flag.flag(user, comment)
+      expect(Flag.flagged?(user, comment)).to be
     end
   end
 

--- a/spec/models/legislation/question_spec.rb
+++ b/spec/models/legislation/question_spec.rb
@@ -19,7 +19,7 @@ describe Legislation::Question do
 
       expect do
         question.destroy
-      end.to change { described_class.count }.by(-1)
+      end.to change { Legislation::Question.count }.by(-1)
     end
 
     example "when it has options but no answers" do
@@ -28,7 +28,7 @@ describe Legislation::Question do
 
       expect do
         question.destroy
-      end.to change { described_class.count }.by(-1)
+      end.to change { Legislation::Question.count }.by(-1)
     end
 
     example "when it has options and answers" do
@@ -39,7 +39,7 @@ describe Legislation::Question do
 
       expect do
         question.destroy
-      end.to change { described_class.count }.by(-1)
+      end.to change { Legislation::Question.count }.by(-1)
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -25,9 +25,9 @@ describe Notification do
         read_notification2 = create(:notification, :read)
         unread_notification = create(:notification)
 
-        expect(described_class.read).to include read_notification1
-        expect(described_class.read).to include read_notification2
-        expect(described_class.read).not_to include unread_notification
+        expect(Notification.read).to include read_notification1
+        expect(Notification.read).to include read_notification2
+        expect(Notification.read).not_to include unread_notification
       end
     end
 
@@ -37,9 +37,9 @@ describe Notification do
         unread_notification1 = create(:notification)
         unread_notification2 = create(:notification)
 
-        expect(described_class.unread).to include unread_notification1
-        expect(described_class.unread).to include unread_notification2
-        expect(described_class.unread).not_to include read_notification
+        expect(Notification.unread).to include unread_notification1
+        expect(Notification.unread).to include unread_notification2
+        expect(Notification.unread).not_to include read_notification
       end
     end
 
@@ -48,7 +48,7 @@ describe Notification do
         old_notification = create :notification
         new_notification = create :notification
 
-        sorted_notifications = described_class.recent
+        sorted_notifications = Notification.recent
         expect(sorted_notifications.size).to be 2
         expect(sorted_notifications.first).to eq new_notification
         expect(sorted_notifications.last).to eq old_notification
@@ -57,8 +57,8 @@ describe Notification do
 
     describe "#for_render" do
       it "returns notifications including notifiable and user" do
-        allow(described_class).to receive(:includes).with(:notifiable).exactly(:once)
-        described_class.for_render
+        allow(Notification).to receive(:includes).with(:notifiable).exactly(:once)
+        Notification.for_render
       end
     end
 
@@ -67,24 +67,24 @@ describe Notification do
   describe "#mark_as_read" do
     it "destroys notification" do
       notification = create(:notification)
-      expect(described_class.read.size).to eq 0
-      expect(described_class.unread.size).to eq 1
+      expect(Notification.read.size).to eq 0
+      expect(Notification.unread.size).to eq 1
 
       notification.mark_as_read
-      expect(described_class.read.size).to eq 1
-      expect(described_class.unread.size).to eq 0
+      expect(Notification.read.size).to eq 1
+      expect(Notification.unread.size).to eq 0
     end
   end
 
   describe "#mark_as_unread" do
     it "destroys notification" do
       notification = create(:notification, :read)
-      expect(described_class.unread.size).to eq 0
-      expect(described_class.read.size).to eq 1
+      expect(Notification.unread.size).to eq 0
+      expect(Notification.read.size).to eq 1
 
       notification.mark_as_unread
-      expect(described_class.unread.size).to eq 1
-      expect(described_class.read.size).to eq 0
+      expect(Notification.unread.size).to eq 1
+      expect(Notification.read.size).to eq 0
     end
   end
 
@@ -103,7 +103,7 @@ describe Notification do
       comment = create(:comment)
       notification = create(:notification, user: user, notifiable: comment)
 
-      expect(described_class.existent(user, comment)).to eq(notification)
+      expect(Notification.existent(user, comment)).to eq(notification)
     end
 
     it "returns nil when there are no notifications of that notifiable for a user" do
@@ -112,7 +112,7 @@ describe Notification do
       comment2 = create(:comment)
       create(:notification, user: user, notifiable: comment1)
 
-      expect(described_class.existent(user, comment2)).to eq(nil)
+      expect(Notification.existent(user, comment2)).to eq(nil)
     end
 
     it "returns nil when there are notifications of a notifiable for another user" do
@@ -121,7 +121,7 @@ describe Notification do
       comment = create(:comment)
       notification = create(:notification, user: user1, notifiable: comment)
 
-      expect(described_class.existent(user2, comment)).to eq(nil)
+      expect(Notification.existent(user2, comment)).to eq(nil)
     end
   end
 
@@ -130,7 +130,7 @@ describe Notification do
       user = create(:user)
       comment = create(:comment)
 
-      described_class.add(user, comment)
+      Notification.add(user, comment)
       expect(user.notifications.count).to eq(1)
     end
 
@@ -138,8 +138,8 @@ describe Notification do
       user = create(:user)
       comment = create(:comment)
 
-      described_class.add(user, comment)
-      described_class.add(user, comment)
+      Notification.add(user, comment)
+      Notification.add(user, comment)
 
       expect(user.notifications.count).to eq(1)
       expect(user.notifications.first.counter).to eq(2)
@@ -149,10 +149,10 @@ describe Notification do
       user = create(:user)
       comment = create(:comment)
 
-      first_notification = described_class.add(user, comment)
+      first_notification = Notification.add(user, comment)
       first_notification.update(read_at: Time.current)
 
-      second_notification = described_class.add(user, comment)
+      second_notification = Notification.add(user, comment)
 
       expect(user.notifications.count).to eq(2)
       expect(first_notification.counter).to eq(1)

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -88,14 +88,14 @@ describe Officing::Residence do
 
       describe "dates" do
         it "is valid with a valid date of birth" do
-          custom_residence = described_class.new("date_of_birth(3i)" => "1",
+          custom_residence = Officing::Residence.new("date_of_birth(3i)" => "1",
                                                  "date_of_birth(2i)" => "1",
                                                  "date_of_birth(1i)" => "1980")
           expect(custom_residence.errors[:date_of_birth].size).to eq(0)
         end
 
         it "is not valid without a date of birth" do
-          custom_residence = described_class.new("date_of_birth(3i)" => "",
+          custom_residence = Officing::Residence.new("date_of_birth(3i)" => "",
                                                  "date_of_birth(2i)" => "",
                                                  "date_of_birth(1i)" => "")
           expect(custom_residence).not_to be_valid
@@ -128,13 +128,13 @@ describe Officing::Residence do
 
     describe "allowed age" do
       it "is not valid if user is under allowed age" do
-        allow_any_instance_of(described_class).to receive(:response_date_of_birth).and_return(15.years.ago)
+        allow_any_instance_of(Officing::Residence).to receive(:response_date_of_birth).and_return(15.years.ago)
         expect(residence).not_to be_valid
         expect(residence.errors[:year_of_birth]).to include("You don't have the required age to participate")
       end
 
       it "is valid if user is above allowed age" do
-        allow_any_instance_of(described_class).to receive(:response_date_of_birth).and_return(16.years.ago)
+        allow_any_instance_of(Officing::Residence).to receive(:response_date_of_birth).and_return(16.years.ago)
         expect(residence).to be_valid
         expect(residence.errors[:year_of_birth]).to be_empty
       end
@@ -144,12 +144,12 @@ describe Officing::Residence do
 
   describe "new" do
     it "upcases document number" do
-      residence = described_class.new(document_number: "x1234567z")
+      residence = Officing::Residence.new(document_number: "x1234567z")
       expect(residence.document_number).to eq("X1234567Z")
     end
 
     it "removes all characters except numbers and letters" do
-      residence = described_class.new(document_number: " 12.345.678 - B")
+      residence = Officing::Residence.new(document_number: " 12.345.678 - B")
       expect(residence.document_number).to eq("12345678B")
     end
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -48,24 +48,24 @@ describe Organization do
     let!(:organization) { create(:organization, name: "Watershed", user: create(:user, phone_number: "333")) }
 
     it "returns no results if search term is empty" do
-      expect(described_class.search(" ").size).to eq(0)
+      expect(Organization.search(" ").size).to eq(0)
     end
 
     it "finds fuzzily by name" do
-      expect(described_class.search("Greenpeace").size).to eq 0
-      search = described_class.search("Tershe")
+      expect(Organization.search("Greenpeace").size).to eq 0
+      search = Organization.search("Tershe")
       expect(search.size).to eq 1
       expect(search.first).to eq organization
     end
 
     scenario "finds by users email" do
-      search = described_class.search(organization.user.email)
+      search = Organization.search(organization.user.email)
       expect(search.size).to eq 1
       expect(search.first).to eq organization
     end
 
     scenario "finds by users phone number" do
-      search = described_class.search(organization.user.phone_number)
+      search = Organization.search(organization.user.phone_number)
       expect(search.size).to eq 1
       expect(search.first).to eq organization
     end

--- a/spec/models/poll/booth_spec.rb
+++ b/spec/models/poll/booth_spec.rb
@@ -18,9 +18,9 @@ describe Poll::Booth do
       booth1 = create(:poll_booth, name: "Booth number 1", location: "City center")
       booth2 = create(:poll_booth, name: "Central", location: "Town hall")
 
-      expect(described_class.search("number")).to eq([booth1])
-      expect(described_class.search("hall")).to eq([booth2])
-      expect(described_class.search("cen").size).to eq 2
+      expect(Poll::Booth.search("number")).to eq([booth1])
+      expect(Poll::Booth.search("hall")).to eq([booth2])
+      expect(Poll::Booth.search("cen").size).to eq 2
     end
   end
 
@@ -36,8 +36,8 @@ describe Poll::Booth do
       create(:poll_booth_assignment, poll: current_poll,  booth: booth_for_current_poll)
       create(:poll_booth_assignment, poll: expired_poll,  booth: booth_for_expired_poll)
 
-      expect(described_class.available).to include(booth_for_current_poll)
-      expect(described_class.available).not_to include(booth_for_expired_poll)
+      expect(Poll::Booth.available).to include(booth_for_current_poll)
+      expect(Poll::Booth.available).not_to include(booth_for_expired_poll)
     end
 
     it "returns polls with multiple translations only once" do

--- a/spec/models/poll/pair_answer_spec.rb
+++ b/spec/models/poll/pair_answer_spec.rb
@@ -54,8 +54,8 @@ describe Poll::PairAnswer do
       it "returns pair_answers associated to an user" do
         author = pair_answer_1.author
 
-        expect(described_class.by_author(author)).to include(pair_answer_1)
-        expect(described_class.by_author(author)).not_to include(pair_answer_2)
+        expect(Poll::PairAnswer.by_author(author)).to include(pair_answer_1)
+        expect(Poll::PairAnswer.by_author(author)).not_to include(pair_answer_2)
       end
 
     end
@@ -65,8 +65,8 @@ describe Poll::PairAnswer do
       it "returns pair_answers associated to a question" do
         question = pair_answer_1.question
 
-        expect(described_class.by_question(question)).to include(pair_answer_1)
-        expect(described_class.by_question(question)).not_to include(pair_answer_2)
+        expect(Poll::PairAnswer.by_question(question)).to include(pair_answer_1)
+        expect(Poll::PairAnswer.by_question(question)).not_to include(pair_answer_2)
       end
     end
 
@@ -79,7 +79,7 @@ describe Poll::PairAnswer do
     context "without question_answers" do
 
       it "assigns nil value to pair_answers" do
-        pair_answer = described_class.generate_pair(question, user)
+        pair_answer = Poll::PairAnswer.generate_pair(question, user)
 
         expect(pair_answer).to be_a Poll::PairAnswer
         expect(pair_answer.question).to eq(question)
@@ -93,7 +93,7 @@ describe Poll::PairAnswer do
       let!(:answer1) { create(:poll_question_answer, question: question) }
 
       it "assigns only right question if only has one question_answer" do
-        pair_answer = described_class.generate_pair(question, user)
+        pair_answer = Poll::PairAnswer.generate_pair(question, user)
 
         expect(pair_answer).to be_a Poll::PairAnswer
         expect(pair_answer.question).to eq(question)
@@ -105,7 +105,7 @@ describe Poll::PairAnswer do
       it "assigns random values if question has some question_answer" do
         create(:poll_question_answer, question: question)
 
-        pair_answer = described_class.generate_pair(question, user)
+        pair_answer = Poll::PairAnswer.generate_pair(question, user)
 
         expect(pair_answer).to be_a Poll::PairAnswer
         expect(pair_answer.question).to eq(question)

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -116,7 +116,7 @@ describe Poll do
       expired = create(:poll, :expired)
       recounting = create(:poll, :recounting)
 
-      recounting_polls = described_class.recounting
+      recounting_polls = Poll.recounting
 
       expect(recounting_polls).not_to include(current)
       expect(recounting_polls).not_to include(expired)
@@ -130,7 +130,7 @@ describe Poll do
       expired = create(:poll, :expired)
       recounting = create(:poll, :recounting)
 
-      current_or_recounting = described_class.current_or_recounting
+      current_or_recounting = Poll.current_or_recounting
 
       expect(current_or_recounting).to include(current)
       expect(current_or_recounting).to include(recounting)
@@ -186,16 +186,16 @@ describe Poll do
 
     describe "class method" do
       it "returns no polls for non-users and level 1 users" do
-        expect(described_class.answerable_by(nil)).to be_empty
-        expect(described_class.answerable_by(level1)).to be_empty
+        expect(Poll.answerable_by(nil)).to be_empty
+        expect(Poll.answerable_by(level1)).to be_empty
       end
 
       it "returns unrestricted polls for level 2 users" do
-        expect(described_class.answerable_by(level2).to_a).to eq([current_poll])
+        expect(Poll.answerable_by(level2).to_a).to eq([current_poll])
       end
 
       it "returns restricted & unrestricted polls for level 2 users of the correct geozone" do
-        list = described_class.answerable_by(level2_from_geozone)
+        list = Poll.answerable_by(level2_from_geozone)
                               .order(:geozone_restricted)
         expect(list.to_a).to eq([current_poll, current_restricted_poll])
       end

--- a/spec/models/poll/shift_spec.rb
+++ b/spec/models/poll/shift_spec.rb
@@ -81,7 +81,7 @@ describe Poll::Shift do
 
       create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment1, date: Date.tomorrow)
 
-      expect { described_class.last.destroy }.to change { Poll::OfficerAssignment.all.count }.by(-2)
+      expect { Poll::Shift.last.destroy }.to change { Poll::OfficerAssignment.all.count }.by(-2)
     end
 
     it "creates final officer_assignments" do

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -139,7 +139,7 @@ describe Poll::Voter do
         voter2 = create(:poll_voter, :from_web)
         voter3 = create(:poll_voter, :from_booth)
 
-        web_voters = described_class.web
+        web_voters = Poll::Voter.web
 
         expect(web_voters.count).to eq(2)
         expect(web_voters).to     include(voter1)
@@ -154,7 +154,7 @@ describe Poll::Voter do
         voter2 = create(:poll_voter, :from_booth)
         voter3 = create(:poll_voter, :from_web)
 
-        booth_voters = described_class.booth
+        booth_voters = Poll::Voter.booth
 
         expect(booth_voters.count).to eq(2)
         expect(booth_voters).to     include(voter1)

--- a/spec/models/proposal_notification_spec.rb
+++ b/spec/models/proposal_notification_spec.rb
@@ -27,20 +27,20 @@ describe ProposalNotification do
       proposal = create(:proposal)
       notification = create(:proposal_notification, proposal: proposal)
 
-      expect(described_class.public_for_api).to include(notification)
+      expect(ProposalNotification.public_for_api).to include(notification)
     end
 
     it "blocks proposal notifications whose proposal is hidden" do
       proposal = create(:proposal, :hidden)
       notification = create(:proposal_notification, proposal: proposal)
 
-      expect(described_class.public_for_api).not_to include(notification)
+      expect(ProposalNotification.public_for_api).not_to include(notification)
     end
 
     it "blocks proposal notifications without proposal" do
       proposal = build(:proposal_notification, proposal: nil).save!(validate: false)
 
-      expect(described_class.public_for_api).not_to include(notification)
+      expect(ProposalNotification.public_for_api).not_to include(notification)
     end
   end
 
@@ -80,7 +80,7 @@ describe ProposalNotification do
 
   describe "notifications in-app" do
 
-    let(:notifiable) { create(model_name(described_class)) }
+    let(:notifiable) { create(model_name(ProposalNotification)) }
     let(:proposal) { notifiable.proposal }
 
     describe "#notification_title" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -495,51 +495,51 @@ describe Proposal do
 
       it "searches by title" do
         proposal = create(:proposal, attributes)
-        results = described_class.search("save the world")
+        results = Proposal.search("save the world")
         expect(results).to eq([proposal])
       end
 
       it "searches by title across all languages translations" do
         proposal = create(:proposal, attributes)
-        results = described_class.search("salvar el mundo")
+        results = Proposal.search("salvar el mundo")
         expect(results).to eq([proposal])
       end
 
       it "searches by summary" do
         proposal = create(:proposal, attributes)
-        results = described_class.search("basically")
+        results = Proposal.search("basically")
         expect(results).to eq([proposal])
       end
 
       it "searches by summary across all languages translations" do
         proposal = create(:proposal, attributes)
-        results = described_class.search("basicamente")
+        results = Proposal.search("basicamente")
         expect(results).to eq([proposal])
       end
 
       it "searches by description" do
         proposal = create(:proposal, attributes)
-        results = described_class.search("one must think")
+        results = Proposal.search("one must think")
         expect(results).to eq([proposal])
       end
 
       it "searches by description across all languages translations" do
         proposal = create(:proposal, attributes)
-        results = described_class.search("uno debe pensar")
+        results = Proposal.search("uno debe pensar")
         expect(results).to eq([proposal])
       end
 
       it "searches by author name" do
         author = create(:user, username: "Danny Trejo")
         proposal = create(:proposal, author: author)
-        results = described_class.search("Danny")
+        results = Proposal.search("Danny")
         expect(results).to eq([proposal])
       end
 
       it "searches by geozone" do
         geozone = create(:geozone, name: "California")
         proposal = create(:proposal, geozone: geozone)
-        results = described_class.search("California")
+        results = Proposal.search("California")
         expect(results).to eq([proposal])
       end
 
@@ -550,13 +550,13 @@ describe Proposal do
       it "searches word stems" do
         proposal = create(:proposal, summary: "Economía")
 
-        results = described_class.search("economía")
+        results = Proposal.search("economía")
         expect(results).to eq([proposal])
 
-        results = described_class.search("econo")
+        results = Proposal.search("econo")
         expect(results).to eq([proposal])
 
-        results = described_class.search("eco")
+        results = Proposal.search("eco")
         expect(results).to eq([proposal])
       end
 
@@ -566,15 +566,15 @@ describe Proposal do
       it "searches with accents" do
         proposal = create(:proposal, summary: "difusión")
 
-        results = described_class.search("difusion")
+        results = Proposal.search("difusion")
         expect(results).to eq([proposal])
 
         proposal2 = create(:proposal, summary: "estadisticas")
-        results = described_class.search("estadísticas")
+        results = Proposal.search("estadísticas")
         expect(results).to eq([proposal2])
 
         proposal3 = create(:proposal, summary: "público")
-        results = described_class.search("publico")
+        results = Proposal.search("publico")
         expect(results).to eq([proposal3])
       end
     end
@@ -583,11 +583,11 @@ describe Proposal do
       it "searches case insensite" do
         proposal = create(:proposal, title: "SHOUT")
 
-        results = described_class.search("shout")
+        results = Proposal.search("shout")
         expect(results).to eq([proposal])
 
         proposal2 = create(:proposal, title: "scream")
-        results = described_class.search("SCREAM")
+        results = Proposal.search("SCREAM")
         expect(results).to eq([proposal2])
       end
     end
@@ -596,10 +596,10 @@ describe Proposal do
       it "searches by tags" do
         proposal = create(:proposal, tag_list: "Latina")
 
-        results = described_class.search("Latina")
+        results = Proposal.search("Latina")
         expect(results.first).to eq(proposal)
 
-        results = described_class.search("Latin")
+        results = Proposal.search("Latin")
         expect(results.first).to eq(proposal)
       end
     end
@@ -611,7 +611,7 @@ describe Proposal do
         proposal_description = create(:proposal,  description: "stop corruption")
         proposal_summary     = create(:proposal,  summary:     "stop corruption")
 
-        results = described_class.search("stop corruption")
+        results = Proposal.search("stop corruption")
 
         expect(results.first).to eq(proposal_title)
         expect(results.second).to eq(proposal_summary)
@@ -625,7 +625,7 @@ describe Proposal do
 
         summary_most_voted  = create(:proposal, summary: "stop corruption", cached_votes_up: 10)
 
-        results = described_class.search("stop corruption")
+        results = Proposal.search("stop corruption")
 
         expect(results.first).to eq(title_most_voted)
         expect(results.second).to eq(title_some_votes)
@@ -637,7 +637,7 @@ describe Proposal do
         exact_title_few_votes    = create(:proposal, title: "stop corruption", cached_votes_up: 5)
         similar_title_many_votes = create(:proposal, title: "stop some of the corruption", cached_votes_up: 500)
 
-        results = described_class.search("stop corruption")
+        results = Proposal.search("stop corruption")
 
         expect(results.first).to eq(exact_title_few_votes)
         expect(results.second).to eq(similar_title_many_votes)
@@ -656,7 +656,7 @@ describe Proposal do
         highest_score.update_column(:hot_score, 100)
         average_score.update_column(:hot_score, 10)
 
-        results = described_class.search("stop corruption")
+        results = Proposal.search("stop corruption")
 
         expect(results.first).to eq(average_score)
         expect(results.second).to eq(highest_score)
@@ -678,7 +678,7 @@ describe Proposal do
         highest_score.update_column(:confidence_score, 100)
         average_score.update_column(:confidence_score, 10)
 
-        results = described_class.search("stop corruption")
+        results = Proposal.search("stop corruption")
 
         expect(results.first).to eq(average_score)
         expect(results.second).to eq(highest_score)
@@ -696,7 +696,7 @@ describe Proposal do
         newest  = create(:proposal,  title: "stop corruption", cached_votes_up: 2, created_at: Time.current)
         oldest  = create(:proposal,  title: "stop corruption", cached_votes_up: 3, created_at: 1.month.ago)
 
-        results = described_class.search("stop corruption")
+        results = Proposal.search("stop corruption")
 
         expect(results.first).to eq(oldest)
         expect(results.second).to eq(newest)
@@ -714,7 +714,7 @@ describe Proposal do
         most_commented  = create(:proposal,  title: "stop corruption",  cached_votes_up: 2, comments_count: 100)
         some_comments   = create(:proposal,  title: "stop corruption",  cached_votes_up: 3, comments_count: 10)
 
-        results = described_class.search("stop corruption")
+        results = Proposal.search("stop corruption")
 
         expect(results.first).to eq(some_comments)
         expect(results.second).to eq(most_commented)
@@ -734,28 +734,28 @@ describe Proposal do
       it "no words match" do
         create(:proposal, title: "save world")
 
-        results = described_class.search("destroy planet")
+        results = Proposal.search("destroy planet")
         expect(results).to eq([])
       end
 
       it "too many typos" do
         create(:proposal, title: "fantastic")
 
-        results = described_class.search("frantac")
+        results = Proposal.search("frantac")
         expect(results).to eq([])
       end
 
       it "too much stemming" do
         create(:proposal, title: "reloj")
 
-        results = described_class.search("superrelojimetro")
+        results = Proposal.search("superrelojimetro")
         expect(results).to eq([])
       end
 
       it "empty" do
         create(:proposal, title: "great")
 
-        results = described_class.search("")
+        results = Proposal.search("")
         expect(results).to eq([])
       end
 
@@ -765,12 +765,12 @@ describe Proposal do
   describe "#last_week" do
     it "returns proposals created this week" do
       proposal = create(:proposal)
-      expect(described_class.last_week).to include(proposal)
+      expect(Proposal.last_week).to include(proposal)
     end
 
     it "does not return proposals created more than a week ago" do
       proposal = create(:proposal, created_at: 8.days.ago)
-      expect(described_class.last_week).not_to include(proposal)
+      expect(Proposal.last_week).not_to include(proposal)
     end
   end
 
@@ -782,14 +782,14 @@ describe Proposal do
         create(:tag, :category, name: "culture")
         proposal = create(:proposal, tag_list: "culture")
 
-        expect(described_class.for_summary.values.flatten).to include(proposal)
+        expect(Proposal.for_summary.values.flatten).to include(proposal)
       end
 
       it "does not return proposals tagged without a category" do
         create(:tag, :category, name: "culture")
         proposal = create(:proposal, tag_list: "parks")
 
-        expect(described_class.for_summary.values.flatten).not_to include(proposal)
+        expect(Proposal.for_summary.values.flatten).not_to include(proposal)
       end
     end
 
@@ -799,27 +799,27 @@ describe Proposal do
         california = create(:geozone, name: "california")
         proposal   = create(:proposal, geozone: california)
 
-        expect(described_class.for_summary.values.flatten).to include(proposal)
+        expect(Proposal.for_summary.values.flatten).to include(proposal)
       end
 
       it "does not return proposals without a geozone" do
         create(:geozone, name: "california")
         proposal = create(:proposal)
 
-        expect(described_class.for_summary.values.flatten).not_to include(proposal)
+        expect(Proposal.for_summary.values.flatten).not_to include(proposal)
       end
     end
 
     it "returns proposals created this week" do
       create(:tag, :category, name: "culture")
       proposal = create(:proposal, tag_list: "culture")
-      expect(described_class.for_summary.values.flatten).to include(proposal)
+      expect(Proposal.for_summary.values.flatten).to include(proposal)
     end
 
     it "does not return proposals created more than a week ago" do
       create(:tag, :category, name: "culture")
       proposal = create(:proposal, tag_list: "culture", created_at: 8.days.ago)
-      expect(described_class.for_summary.values.flatten).not_to include(proposal)
+      expect(Proposal.for_summary.values.flatten).not_to include(proposal)
     end
 
     it "orders proposals by votes" do
@@ -828,7 +828,7 @@ describe Proposal do
       create(:proposal, tag_list: "culture").update_column(:confidence_score, 10)
       create(:proposal, tag_list: "culture").update_column(:confidence_score, 5)
 
-      results = described_class.for_summary.values.flatten
+      results = Proposal.for_summary.values.flatten
 
       expect(results.first.confidence_score).to  be(10)
       expect(results.second.confidence_score).to be(5)
@@ -844,7 +844,7 @@ describe Proposal do
       culture_proposal = create(:proposal,  tag_list: "culture")
       social_proposal  = create(:proposal,  tag_list: "social services")
 
-      results = described_class.for_summary.values.flatten
+      results = Proposal.for_summary.values.flatten
 
       expect(results.first).to  eq(culture_proposal)
       expect(results.second).to eq(health_proposal)
@@ -863,7 +863,7 @@ describe Proposal do
       proposal1.update_column(:confidence_score, 10)
       proposal2.update_column(:confidence_score, 9)
 
-      expect(described_class.for_summary).to include("culture" => [proposal1, proposal2], "health" => [proposal3])
+      expect(Proposal.for_summary).to include("culture" => [proposal1, proposal2], "health" => [proposal3])
     end
   end
 
@@ -883,14 +883,14 @@ describe Proposal do
     end
 
     it "scope retired" do
-      retired = described_class.retired
+      retired = Proposal.retired
 
       expect(retired.size).to eq(1)
       expect(retired.first).to eq(proposal2)
     end
 
     it "scope not_retired" do
-      not_retired = described_class.not_retired
+      not_retired = Proposal.not_retired
 
       expect(not_retired.size).to eq(1)
       expect(not_retired.first).to eq(proposal1)
@@ -907,14 +907,14 @@ describe Proposal do
     end
 
     it "scope archived" do
-      archived = described_class.archived
+      archived = Proposal.archived
 
       expect(archived.size).to eq(1)
       expect(archived.first).to eq(archived_proposal)
     end
 
     it "scope not archived" do
-      not_archived = described_class.not_archived
+      not_archived = Proposal.not_archived
 
       expect(not_archived.size).to eq(1)
       expect(not_archived.first).to eq(new_proposal)
@@ -948,12 +948,12 @@ describe Proposal do
   describe "public_for_api scope" do
     it "returns proposals" do
       proposal = create(:proposal)
-      expect(described_class.public_for_api).to include(proposal)
+      expect(Proposal.public_for_api).to include(proposal)
     end
 
     it "does not return hidden proposals" do
       proposal = create(:proposal, :hidden)
-      expect(described_class.public_for_api).not_to include(proposal)
+      expect(Proposal.public_for_api).not_to include(proposal)
     end
   end
 
@@ -1000,7 +1000,7 @@ describe Proposal do
     it "does not return any proposals when user has not interests" do
       create(:proposal)
 
-      expect(described_class.recommendations(user).size).to eq 0
+      expect(Proposal.recommendations(user).size).to eq 0
     end
 
     it "returns proposals ordered by cached_votes_up" do
@@ -1010,7 +1010,7 @@ describe Proposal do
       proposal4 = create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal4, user: user)
 
-      result = described_class.recommendations(user).sort_by_recommendations
+      result = Proposal.recommendations(user).sort_by_recommendations
 
       expect(result.first).to eq proposal3
       expect(result.second).to eq proposal2
@@ -1023,7 +1023,7 @@ describe Proposal do
       proposal3 =  create(:proposal, tag_list: "Politics")
       create(:follow, followable: proposal1, user: user)
 
-      result = described_class.recommendations(user)
+      result = Proposal.recommendations(user)
 
       expect(result.size).to eq 1
       expect(result).to eq [proposal2]
@@ -1033,7 +1033,7 @@ describe Proposal do
       proposal1 = create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal1, user: user)
 
-      result = described_class.recommendations(user)
+      result = Proposal.recommendations(user)
 
       expect(result.size).to eq 0
     end
@@ -1044,7 +1044,7 @@ describe Proposal do
       proposal3 =  create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal3, user: user)
 
-      result = described_class.recommendations(user)
+      result = Proposal.recommendations(user)
 
       expect(result.size).to eq 1
       expect(result).to eq [proposal2]
@@ -1056,7 +1056,7 @@ describe Proposal do
       archived_proposal = create(:proposal, :archived)
       create(:follow, followable: proposal1, user: user)
 
-      result = described_class.recommendations(user)
+      result = Proposal.recommendations(user)
       expect(result.size).to eq(1)
       expect(result).to eq([proposal2])
     end
@@ -1068,7 +1068,7 @@ describe Proposal do
       create(:vote, votable: proposal1, voter: user)
       create(:follow, followable: proposal2, user: user)
 
-      result = described_class.recommendations(user)
+      result = Proposal.recommendations(user)
       expect(result.size).to eq(1)
       expect(result).to eq([proposal3])
     end

--- a/spec/models/related_content_spec.rb
+++ b/spec/models/related_content_spec.rb
@@ -29,7 +29,7 @@ describe RelatedContent do
     let(:related_content) { build(:related_content, parent_relationable: parent_relationable, child_relationable: child_relationable, author: build(:user)) }
 
     it "creates an opposite related_content" do
-      expect { related_content.save }.to change { described_class.count }.by(2)
+      expect { related_content.save }.to change { RelatedContent.count }.by(2)
       expect(related_content.opposite_related_content.child_relationable_id).to eq(parent_relationable.id)
       expect(related_content.opposite_related_content.child_relationable_type).to eq(parent_relationable.class.name)
       expect(related_content.opposite_related_content.parent_relationable_id).to eq(child_relationable.id)

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -2,19 +2,19 @@ require "rails_helper"
 
 describe Setting do
   before do
-    described_class["official_level_1_name"] = "Stormtrooper"
+    Setting["official_level_1_name"] = "Stormtrooper"
   end
 
   it "returns the overriden setting" do
-    expect(described_class["official_level_1_name"]).to eq("Stormtrooper")
+    expect(Setting["official_level_1_name"]).to eq("Stormtrooper")
   end
 
   it "returns nil" do
-    expect(described_class["undefined_key"]).to eq(nil)
+    expect(Setting["undefined_key"]).to eq(nil)
   end
 
   it "persists a setting on the db" do
-    expect(described_class.where(key: "official_level_1_name", value: "Stormtrooper")).to exist
+    expect(Setting.where(key: "official_level_1_name", value: "Stormtrooper")).to exist
   end
 
   describe "#prefix" do
@@ -76,7 +76,7 @@ describe Setting do
 
   describe "#enabled?" do
     it "is true if value is present" do
-      setting = described_class.create(key: "feature.whatever", value: 1)
+      setting = Setting.create(key: "feature.whatever", value: 1)
       expect(setting.enabled?).to eq true
 
       setting.value = "true"
@@ -87,7 +87,7 @@ describe Setting do
     end
 
     it "is false if value is blank" do
-      setting = described_class.create(key: "feature.whatever")
+      setting = Setting.create(key: "feature.whatever")
       expect(setting.enabled?).to eq false
 
       setting.value = ""

--- a/spec/models/tag_cloud_spec.rb
+++ b/spec/models/tag_cloud_spec.rb
@@ -8,7 +8,7 @@ describe TagCloud do
       create(:proposal, tag_list: "participation")
       create(:debate,   tag_list: "world hunger")
 
-      tag_cloud = described_class.new(Proposal)
+      tag_cloud = TagCloud.new(Proposal)
 
       expect(tag_names(tag_cloud)).to contain_exactly("participation")
     end
@@ -17,7 +17,7 @@ describe TagCloud do
       create(:proposal, tag_list: "participation")
       create(:debate,   tag_list: "world hunger")
 
-      tag_cloud = described_class.new(Debate)
+      tag_cloud = TagCloud.new(Debate)
 
       expect(tag_names(tag_cloud)).to contain_exactly("world hunger")
     end
@@ -26,7 +26,7 @@ describe TagCloud do
       create(:budget_investment, tag_list: "participation")
       create(:debate, tag_list: "world hunger")
 
-      tag_cloud = described_class.new(Budget::Investment)
+      tag_cloud = TagCloud.new(Budget::Investment)
 
       expect(tag_names(tag_cloud)).to contain_exactly("participation")
     end
@@ -35,7 +35,7 @@ describe TagCloud do
       create(:proposal, tag_list: "participation", created_at: 1.day.ago)
       create(:proposal, tag_list: "corruption",    created_at: 2.weeks.ago)
 
-      tag_cloud = described_class.new(Proposal)
+      tag_cloud = TagCloud.new(Proposal)
 
       expect(tag_names(tag_cloud)).to contain_exactly("participation")
     end
@@ -47,7 +47,7 @@ describe TagCloud do
       create(:proposal, tag_list: "education, parks")
       create(:proposal, tag_list: "participation, water")
 
-      tag_cloud = described_class.new(Proposal)
+      tag_cloud = TagCloud.new(Proposal)
 
       expect(tag_names(tag_cloud)).to contain_exactly("parks", "water")
     end
@@ -59,7 +59,7 @@ describe TagCloud do
       create(:proposal, tag_list: "parks, California")
       create(:proposal, tag_list: "water, New York")
 
-      tag_cloud = described_class.new(Proposal)
+      tag_cloud = TagCloud.new(Proposal)
 
       expect(tag_names(tag_cloud)).to contain_exactly("parks", "water")
     end
@@ -71,7 +71,7 @@ describe TagCloud do
       create(:proposal, tag_list: "education, parks")
       create(:proposal, tag_list: "participation, water")
 
-      tag_cloud = described_class.new(Proposal, "Education")
+      tag_cloud = TagCloud.new(Proposal, "Education")
 
       expect(tag_names(tag_cloud)).to contain_exactly("parks")
     end
@@ -83,7 +83,7 @@ describe TagCloud do
       create(:proposal, tag_list: "parks, California")
       create(:proposal, tag_list: "water, New York")
 
-      tag_cloud = described_class.new(Proposal, "California")
+      tag_cloud = TagCloud.new(Proposal, "California")
 
       expect(tag_names(tag_cloud)).to contain_exactly("parks")
     end
@@ -95,7 +95,7 @@ describe TagCloud do
       3.times { create(:proposal, tag_list: "participation") }
       create(:proposal, tag_list: "corruption")
 
-      tag_cloud = described_class.new(Proposal)
+      tag_cloud = TagCloud.new(Proposal)
 
       expect(tag_names(tag_cloud).first).to eq "participation"
       expect(tag_names(tag_cloud).second).to eq "corruption"
@@ -106,7 +106,7 @@ describe TagCloud do
       3.times { create(:proposal, tag_list: "health") }
       create(:proposal, tag_list: "corruption")
 
-      tag_cloud = described_class.new(Proposal)
+      tag_cloud = TagCloud.new(Proposal)
 
       expect(tag_names(tag_cloud).first).to  eq "health"
       expect(tag_names(tag_cloud).second).to eq "participation"
@@ -116,7 +116,7 @@ describe TagCloud do
     it "returns a maximum of 10 tags" do
       12.times { |i| create(:proposal, tag_list: "Tag #{i}") }
 
-      tag_cloud = described_class.new(Proposal)
+      tag_cloud = TagCloud.new(Proposal)
 
       expect(tag_names(tag_cloud).count).to eq(10)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -322,7 +322,7 @@ describe User do
       create(:user, official_position: "Manager", official_level: 5)
       2.times { create(:user) }
 
-      officials = described_class.officials
+      officials = User.officials
       expect(officials.size).to eq(4)
       officials.each do |user|
         expect(user.official_level).to be > 0
@@ -397,9 +397,9 @@ describe User do
         user2 = create(:user, erased_at: nil)
         user3 = create(:user, erased_at: Time.current)
 
-        expect(described_class.active).to include(user1)
-        expect(described_class.active).to include(user2)
-        expect(described_class.active).not_to include(user3)
+        expect(User.active).to include(user1)
+        expect(User.active).to include(user2)
+        expect(User.active).not_to include(user3)
       end
 
       it "returns users that have not been blocked" do
@@ -408,9 +408,9 @@ describe User do
         user3 = create(:user)
         user3.block
 
-        expect(described_class.active).to include(user1)
-        expect(described_class.active).to include(user2)
-        expect(described_class.active).not_to include(user3)
+        expect(User.active).to include(user1)
+        expect(User.active).to include(user2)
+        expect(User.active).not_to include(user3)
       end
 
     end
@@ -422,9 +422,9 @@ describe User do
         user2 = create(:user, erased_at: Time.current)
         user3 = create(:user, erased_at: nil)
 
-        expect(described_class.erased).to include(user1)
-        expect(described_class.erased).to include(user2)
-        expect(described_class.erased).not_to include(user3)
+        expect(User.erased).to include(user1)
+        expect(User.erased).to include(user2)
+        expect(User.erased).not_to include(user3)
       end
 
     end
@@ -434,7 +434,7 @@ describe User do
     it "find users by email" do
       user1 = create(:user, email: "larry@consul.dev")
       create(:user, email: "bird@consul.dev")
-      search = described_class.search("larry@consul.dev")
+      search = User.search("larry@consul.dev")
       expect(search.size).to eq(1)
       expect(search.first).to eq(user1)
     end
@@ -442,13 +442,13 @@ describe User do
     it "find users by name" do
       user1 = create(:user, username: "Larry Bird")
       create(:user, username: "Robert Parish")
-      search = described_class.search("larry")
+      search = User.search("larry")
       expect(search.size).to eq(1)
       expect(search.first).to eq(user1)
     end
 
     it "returns no results if no search term provided" do
-      expect(described_class.search("    ").size).to eq(0)
+      expect(User.search("    ").size).to eq(0)
     end
   end
 
@@ -478,13 +478,13 @@ describe User do
 
   describe "document_number" do
     it "upcases document number" do
-      user = described_class.new(document_number: "x1234567z")
+      user = User.new(document_number: "x1234567z")
       user.valid?
       expect(user.document_number).to eq("X1234567Z")
     end
 
     it "removes all characters except numbers and letters" do
-      user = described_class.new(document_number: " 12.345.678 - B")
+      user = User.new(document_number: " 12.345.678 - B")
       user.valid?
       expect(user.document_number).to eq("12345678B")
     end

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -71,14 +71,14 @@ describe Verification::Management::Document do
 
       describe "dates" do
         it "is valid with a valid date of birth" do
-          verification_document = described_class.new("date_of_birth(3i)" => "1",
+          verification_document = Verification::Management::Document.new("date_of_birth(3i)" => "1",
                                                       "date_of_birth(2i)" => "1",
                                                       "date_of_birth(1i)" => "1980")
           expect(verification_document.errors[:date_of_birth].size).to eq(0)
         end
 
         it "is not valid without a date of birth" do
-          verification_document = described_class.new("date_of_birth(3i)" => "",
+          verification_document = Verification::Management::Document.new("date_of_birth(3i)" => "",
                                                       "date_of_birth(2i)" => "",
                                                       "date_of_birth(1i)" => "")
           expect(verification_document).not_to be_valid
@@ -97,34 +97,34 @@ describe Verification::Management::Document do
       describe "#valid_age?" do
         it "returns false when the user is younger than the user's minimum required age" do
           census_response = instance_double("CensusApi::Response", date_of_birth: under_minium_age_date_of_birth)
-          expect(described_class.new.valid_age?(census_response)).to be false
+          expect(Verification::Management::Document.new.valid_age?(census_response)).to be false
         end
 
         it "returns true when the user has the user's minimum required age" do
           census_response = instance_double("CensusApi::Response", date_of_birth: just_minium_age_date_of_birth)
-          expect(described_class.new.valid_age?(census_response)).to be true
+          expect(Verification::Management::Document.new.valid_age?(census_response)).to be true
         end
 
         it "returns true when the user is older than the user's minimum required age" do
           census_response = instance_double("CensusApi::Response", date_of_birth: over_minium_age_date_of_birth)
-          expect(described_class.new.valid_age?(census_response)).to be true
+          expect(Verification::Management::Document.new.valid_age?(census_response)).to be true
         end
       end
 
       describe "#under_age?" do
         it "returns true when the user is younger than the user's minimum required age" do
           census_response = instance_double("CensusApi::Response", date_of_birth: under_minium_age_date_of_birth)
-          expect(described_class.new.under_age?(census_response)).to be true
+          expect(Verification::Management::Document.new.under_age?(census_response)).to be true
         end
 
         it "returns false when the user is user's minimum required age" do
           census_response = instance_double("CensusApi::Response", date_of_birth: just_minium_age_date_of_birth)
-          expect(described_class.new.under_age?(census_response)).to be false
+          expect(Verification::Management::Document.new.under_age?(census_response)).to be false
         end
 
         it "returns false when the user is older than user's minimum required age" do
           census_response = instance_double("CensusApi::Response", date_of_birth: over_minium_age_date_of_birth)
-          expect(described_class.new.under_age?(census_response)).to be false
+          expect(Verification::Management::Document.new.under_age?(census_response)).to be false
         end
       end
     end

--- a/spec/models/verification/management/email_spec.rb
+++ b/spec/models/verification/management/email_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Verification::Management::Email do
 
   describe "#user" do
-    subject { described_class.new(document_type: "1", document_number: "1234", email: "inexisting@gmail.com") }
+    subject { Verification::Management::Email.new(document_type: "1", document_number: "1234", email: "inexisting@gmail.com") }
 
     it "returns nil/false when the user does not exist" do
       expect(subject.user).to be_nil
@@ -13,28 +13,28 @@ describe Verification::Management::Email do
 
   describe "validations" do
     it "is not valid if the user does not exist" do
-      expect(described_class.new(document_type: "1", document_number: "1234", email: "inexisting@gmail.com")).not_to be_valid
+      expect(Verification::Management::Email.new(document_type: "1", document_number: "1234", email: "inexisting@gmail.com")).not_to be_valid
     end
 
     it "is not valid if the user is already level 3" do
       user = create(:user, :level_three)
-      expect(described_class.new(document_type: "1", document_number: "1234", email: user.email)).not_to be_valid
+      expect(Verification::Management::Email.new(document_type: "1", document_number: "1234", email: user.email)).not_to be_valid
     end
 
     it "is not valid if the user already has a different document number" do
       user = create(:user, document_number: "1234", document_type: "1")
-      expect(described_class.new(document_type: "1", document_number: "5678", email: user.email)).not_to be_valid
+      expect(Verification::Management::Email.new(document_type: "1", document_number: "5678", email: user.email)).not_to be_valid
     end
   end
 
   describe "#save" do
     it "does nothing if not valid" do
-      expect(described_class.new(document_type: "1", document_number: "1234", email: "inexisting@gmail.com").save).to eq(false)
+      expect(Verification::Management::Email.new(document_type: "1", document_number: "1234", email: "inexisting@gmail.com").save).to eq(false)
     end
 
     it "updates the user and sends an email" do
       user = create(:user)
-      validation = described_class.new(document_type: "1", document_number: "1234", email: user.email)
+      validation = Verification::Management::Email.new(document_type: "1", document_number: "1234", email: user.email)
 
       mail = double(:mail)
 

--- a/spec/models/verification/residence_spec.rb
+++ b/spec/models/verification/residence_spec.rb
@@ -13,19 +13,19 @@ describe Verification::Residence do
 
     describe "dates" do
       it "is valid with a valid date of birth" do
-        residence = described_class.new("date_of_birth(3i)" => "1", "date_of_birth(2i)" => "1", "date_of_birth(1i)" => "1980")
+        residence = Verification::Residence.new("date_of_birth(3i)" => "1", "date_of_birth(2i)" => "1", "date_of_birth(1i)" => "1980")
         expect(residence.errors[:date_of_birth].size).to eq(0)
       end
 
       it "is not valid without a date of birth" do
-        residence = described_class.new("date_of_birth(3i)" => "", "date_of_birth(2i)" => "", "date_of_birth(1i)" => "")
+        residence = Verification::Residence.new("date_of_birth(3i)" => "", "date_of_birth(2i)" => "", "date_of_birth(1i)" => "")
         expect(residence).not_to be_valid
         expect(residence.errors[:date_of_birth]).to include("can't be blank")
       end
     end
 
     it "validates user has allowed age" do
-      residence = described_class.new("date_of_birth(3i)" => "1",
+      residence = Verification::Residence.new("date_of_birth(3i)" => "1",
                                       "date_of_birth(2i)" => "1",
                                       "date_of_birth(1i)" => 5.years.ago.year.to_s)
       expect(residence).not_to be_valid
@@ -52,12 +52,12 @@ describe Verification::Residence do
 
   describe "new" do
     it "upcases document number" do
-      residence = described_class.new(document_number: "x1234567z")
+      residence = Verification::Residence.new(document_number: "x1234567z")
       expect(residence.document_number).to eq("X1234567Z")
     end
 
     it "removes all characters except numbers and letters" do
-      residence = described_class.new(document_number: " 12.345.678 - B")
+      residence = Verification::Residence.new(document_number: " 12.345.678 - B")
       expect(residence.document_number).to eq("12345678B")
     end
   end

--- a/spec/models/verification/sms_spec.rb
+++ b/spec/models/verification/sms_spec.rb
@@ -8,7 +8,7 @@ describe Verification::Sms do
 
   it "validates uniqness of phone" do
     create(:user, confirmed_phone: "699999999")
-    sms = described_class.new(phone: "699999999")
+    sms = Verification::Sms.new(phone: "699999999")
     expect(sms).not_to be_valid
   end
 

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -8,7 +8,7 @@ describe Vote do
       comment = create(:comment)
       create(:vote, votable: comment)
 
-      expect(described_class.for_debates(debate).count).to eq(0)
+      expect(Vote.for_debates(debate).count).to eq(0)
     end
 
     it "returns votes only for debates in parameters" do
@@ -16,8 +16,8 @@ describe Vote do
       debate2 = create(:debate)
       create(:vote, votable: debate1)
 
-      expect(described_class.for_debates(debate1).count).to eq(1)
-      expect(described_class.for_debates(debate2).count).to eq(0)
+      expect(Vote.for_debates(debate1).count).to eq(1)
+      expect(Vote.for_debates(debate2).count).to eq(0)
     end
 
     it "accepts more than 1 debate" do
@@ -27,7 +27,7 @@ describe Vote do
       create(:vote, votable: debate1)
       create(:vote, votable: debate3)
 
-      expect(described_class.for_debates([debate1, debate2]).count).to eq(1)
+      expect(Vote.for_debates([debate1, debate2]).count).to eq(1)
     end
   end
 
@@ -46,42 +46,42 @@ describe Vote do
       debate = create(:debate)
       vote = create(:vote, votable: debate)
 
-      expect(described_class.public_for_api).to include(vote)
+      expect(Vote.public_for_api).to include(vote)
     end
 
     it "blocks votes on hidden debates" do
       debate = create(:debate, :hidden)
       vote = create(:vote, votable: debate)
 
-      expect(described_class.public_for_api).not_to include(vote)
+      expect(Vote.public_for_api).not_to include(vote)
     end
 
     it "returns votes on proposals" do
       proposal = create(:proposal)
       vote = create(:vote, votable: proposal)
 
-      expect(described_class.public_for_api).to include(vote)
+      expect(Vote.public_for_api).to include(vote)
     end
 
     it "blocks votes on hidden proposals" do
       proposal = create(:proposal, :hidden)
       vote = create(:vote, votable: proposal)
 
-      expect(described_class.public_for_api).not_to include(vote)
+      expect(Vote.public_for_api).not_to include(vote)
     end
 
     it "returns votes on comments" do
       comment = create(:comment)
       vote = create(:vote, votable: comment)
 
-      expect(described_class.public_for_api).to include(vote)
+      expect(Vote.public_for_api).to include(vote)
     end
 
     it "blocks votes on hidden comments" do
       comment = create(:comment, :hidden)
       vote = create(:vote, votable: comment)
 
-      expect(described_class.public_for_api).not_to include(vote)
+      expect(Vote.public_for_api).not_to include(vote)
     end
 
     it "blocks votes on comments on hidden proposals" do
@@ -89,7 +89,7 @@ describe Vote do
       comment_on_hidden_proposal = create(:comment, commentable: hidden_proposal)
       vote = create(:vote, votable: comment_on_hidden_proposal)
 
-      expect(described_class.public_for_api).not_to include(vote)
+      expect(Vote.public_for_api).not_to include(vote)
     end
 
     it "blocks votes on comments on hidden debates" do
@@ -97,20 +97,20 @@ describe Vote do
       comment_on_hidden_debate = create(:comment, commentable: hidden_debate)
       vote = create(:vote, votable: comment_on_hidden_debate)
 
-      expect(described_class.public_for_api).not_to include(vote)
+      expect(Vote.public_for_api).not_to include(vote)
     end
 
     it "blocks any other kind of votes" do
       budget_investment = create(:budget_investment)
       vote = create(:vote, votable: budget_investment)
 
-      expect(described_class.public_for_api).not_to include(vote)
+      expect(Vote.public_for_api).not_to include(vote)
     end
 
     it "blocks votes without votable" do
       vote = build(:vote, votable: nil).save!(validate: false)
 
-      expect(described_class.public_for_api).not_to include(vote)
+      expect(Vote.public_for_api).not_to include(vote)
     end
   end
 end


### PR DESCRIPTION
## References

* We decided to use this style in pull request #2990.

## Objectives

* Remove remaining `described_class` usages still present in old code
* Add a rubocop rule so we get a warning when we add `described_class` in the future