### PR TITLE
Remove attachment useless code to show errors

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -32,7 +32,6 @@ module DocumentsHelper
   end
 
   def render_attachment(builder, document)
-    klass = document.errors[:attachment].any? ? "error" : ""
     klass = document.persisted? || document.cached_attachment.present? ? " hide" : ""
     html = builder.label :attachment,
                          t("documents.form.attachment_label"),

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -46,7 +46,6 @@ module ImagesHelper
   end
 
   def render_image_attachment(builder, imageable, image)
-    klass = image.errors[:attachment].any? ? "error" : ""
     klass = image.persisted? || image.cached_attachment.present? ? " hide" : ""
     html = builder.label :attachment,
                           t("images.form.attachment_label"),


### PR DESCRIPTION
## References
Related Pull Requests: #1915

## Objectives
Rails form helper already adds an `error` css class to attachment label when it has any validation errors. Furthermore these lines was always overwritten by the next one so it has no sense to keep them.

## Visual Changes
None

## Notes
None
