### PR TITLE
Simplify testing array contents

### DIFF
--- a/spec/features/admin/emails/emails_download_spec.rb
+++ b/spec/features/admin/emails/emails_download_spec.rb
@@ -37,13 +37,7 @@ describe "Admin download user emails" do
       expect(header).to match /filename="Administrators.csv"$/
 
       file_contents = page.body.split(",")
-      expect(file_contents.count).to eq(2)
-      expect(file_contents).to include("admin_news1@consul.dev")
-      expect(file_contents).to include("admin_news2@consul.dev")
-      expect(file_contents).not_to include("admin@consul.dev")
-      expect(file_contents).not_to include("user@consul.dev")
-      expect(file_contents).not_to include("no_news@consul.dev")
-      expect(file_contents).not_to include("no_email@consul.dev")
+      expect(file_contents).to match_array ["admin_news1@consul.dev", "admin_news2@consul.dev"]
     end
   end
 end

--- a/spec/lib/acts_as_paranoid_aliases_spec.rb
+++ b/spec/lib/acts_as_paranoid_aliases_spec.rb
@@ -9,7 +9,7 @@ describe "Paranoid methods" do
       debate3 = create(:debate)
       debate4 = create(:debate)
 
-      expect(Debate.all.sort).to eq([debate1, debate2, debate3, debate4].sort)
+      expect(Debate.all).to match_array [debate1, debate2, debate3, debate4]
 
       Debate.hide_all [debate1, debate2, debate4].map(&:id)
 
@@ -30,7 +30,7 @@ describe "Paranoid methods" do
 
       Debate.restore_all [debate1, debate3].map(&:id)
 
-      expect(Debate.all.sort).to eq([debate1, debate2, debate3].sort)
+      expect(Debate.all).to match_array [debate1, debate2, debate3]
     end
   end
 

--- a/spec/lib/email_digests_spec.rb
+++ b/spec/lib/email_digests_spec.rb
@@ -91,7 +91,7 @@ describe EmailDigest do
       email_digest = EmailDigest.new(user)
       email_digest.deliver(Time.current)
 
-      expect(all_emails.count).to eq(0)
+      expect(all_emails).to be_empty
     end
 
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -43,10 +43,7 @@ describe Activity do
       create(:activity, action: "hide", actionable: create(:comment))
       create(:activity, action: "block", actionable: create(:user))
 
-      expect(Activity.on(proposal).size).to eq 3
-      [activity1, activity2, activity3].each do |a|
-        expect(Activity.on(proposal)).to include(a)
-      end
+      expect(Activity.on(proposal)).to match_array [activity1, activity2, activity3]
     end
   end
 
@@ -61,11 +58,9 @@ describe Activity do
       activity6 = create(:activity, user: user1, action: "valuate", actionable: create(:budget_investment))
       create_list(:activity, 3)
 
-      expect(Activity.by(user1).size).to eq 6
-
-      [activity1, activity2, activity3, activity4, activity5, activity6].each do |a|
-        expect(Activity.by(user1)).to include(a)
-      end
+      expect(Activity.by(user1)).to match_array(
+        [activity1, activity2, activity3, activity4, activity5, activity6]
+      )
     end
   end
 
@@ -77,17 +72,11 @@ describe Activity do
       on_user       = create(:activity, actionable: create(:user))
       on_investment = create(:activity, actionable: create(:budget_investment))
 
-      expect(Activity.on_proposals.size).to eq 1
-      expect(Activity.on_debates.size).to eq 1
-      expect(Activity.on_comments.size).to eq 1
-      expect(Activity.on_users.size).to eq 1
-      expect(Activity.on_budget_investments.size).to eq 1
-
-      expect(Activity.on_proposals.first).to eq on_proposal
-      expect(Activity.on_debates.first).to eq on_debate
-      expect(Activity.on_comments.first).to eq on_comment
-      expect(Activity.on_users.first).to eq on_user
-      expect(Activity.on_budget_investments.first).to eq on_investment
+      expect(Activity.on_proposals).to eq [on_proposal]
+      expect(Activity.on_debates).to eq [on_debate]
+      expect(Activity.on_comments).to eq [on_comment]
+      expect(Activity.on_users).to eq [on_user]
+      expect(Activity.on_budget_investments).to eq [on_investment]
     end
   end
 

--- a/spec/models/budget/group_spec.rb
+++ b/spec/models/budget/group_spec.rb
@@ -66,7 +66,6 @@ describe Budget::Group do
           create(:budget_group, budget: budget, name: "Bravo")
         end
 
-        expect(Budget::Group.sort_by_name.count).to eq 4
         expect(Budget::Group.sort_by_name).to eq [bravo, charlie, delta, zulu]
       end
     end

--- a/spec/models/budget/heading_spec.rb
+++ b/spec/models/budget/heading_spec.rb
@@ -301,9 +301,7 @@ describe Budget::Heading do
       last_heading = create(:budget_heading, group: last_group, name: "Name")
       first_heading = create(:budget_heading, group: first_group, name: "Name")
 
-      expect(Budget::Heading.sort_by_name.size).to be 2
-      expect(Budget::Heading.sort_by_name.first).to eq first_heading
-      expect(Budget::Heading.sort_by_name.last).to eq last_heading
+      expect(Budget::Heading.sort_by_name).to eq [first_heading, last_heading]
     end
 
   end
@@ -314,9 +312,7 @@ describe Budget::Heading do
       last_heading     = create(:budget_heading, allow_custom_content: true, name: "Name C")
       first_heading    = create(:budget_heading, allow_custom_content: true, name: "Name B")
 
-      expect(Budget::Heading.allow_custom_content.count).to be 2
-      expect(Budget::Heading.allow_custom_content.first).to eq first_heading
-      expect(Budget::Heading.allow_custom_content.last).to eq last_heading
+      expect(Budget::Heading.allow_custom_content).to eq [first_heading, last_heading]
     end
 
     it "returns headings with multiple translations only once" do

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -335,8 +335,7 @@ describe Budget::Investment do
 
       by_admin = Budget::Investment.by_admin(33)
 
-      expect(by_admin.size).to eq(1)
-      expect(by_admin.first).to eq(investment1)
+      expect(by_admin).to eq [investment1]
     end
   end
 
@@ -383,13 +382,13 @@ describe Budget::Investment do
     let!(:investment) { create(:budget_investment, :feasible, heading: heading) }
 
     it "finds budget by id or slug" do
-      result = Budget::Investment.scoped_filter({ budget_id: budget.id }, nil)
-      expect(result.count).to be 1
-      expect(result.first.id).to be investment.id
+      results = Budget::Investment.scoped_filter({ budget_id: budget.id }, nil)
 
-      result = Budget::Investment.scoped_filter({ budget_id: "budget_slug" }, nil)
-      expect(result.count).to be 1
-      expect(result.first.id).to be investment.id
+      expect(results).to eq [investment]
+
+      results = Budget::Investment.scoped_filter({ budget_id: "budget_slug" }, nil)
+
+      expect(results).to eq [investment]
     end
 
     it "does not raise error if budget is not found" do
@@ -407,8 +406,7 @@ describe Budget::Investment do
 
         valuation_open = Budget::Investment.valuation_open
 
-        expect(valuation_open.size).to eq(1)
-        expect(valuation_open.first).to eq(investment2)
+        expect(valuation_open).to eq [investment2]
       end
     end
 
@@ -420,8 +418,7 @@ describe Budget::Investment do
 
         without_admin = Budget::Investment.without_admin
 
-        expect(without_admin.size).to eq(1)
-        expect(without_admin.first).to eq(investment3)
+        expect(without_admin).to eq [investment3]
       end
     end
 
@@ -434,8 +431,7 @@ describe Budget::Investment do
 
         managed = Budget::Investment.managed
 
-        expect(managed.size).to eq(1)
-        expect(managed.first).to eq(investment3)
+        expect(managed).to eq [investment3]
       end
     end
 
@@ -450,8 +446,7 @@ describe Budget::Investment do
 
         valuating = Budget::Investment.valuating
 
-        expect(valuating.size).to eq(1)
-        expect(valuating.first).to eq(investment2)
+        expect(valuating).to eq [investment2]
       end
 
       it "returns all investments with assigned valuator groups but valuation not finished" do
@@ -464,8 +459,7 @@ describe Budget::Investment do
 
         valuating = Budget::Investment.valuating
 
-        expect(valuating.size).to eq(1)
-        expect(valuating.first).to eq(investment2)
+        expect(valuating).to eq [investment2]
       end
     end
 
@@ -480,8 +474,7 @@ describe Budget::Investment do
 
         valuation_finished = Budget::Investment.valuation_finished
 
-        expect(valuation_finished.size).to eq(1)
-        expect(valuation_finished.first).to eq(investment3)
+        expect(valuation_finished).to eq [investment3]
       end
     end
 
@@ -933,10 +926,9 @@ describe Budget::Investment do
         most_voted2  = create(:budget_investment, cached_votes_up: 10)
         least_voted2 = create(:budget_investment, cached_votes_up: 1)
 
-        expect(Budget::Investment.sort_by_confidence_score.first).to eq most_voted2
-        expect(Budget::Investment.sort_by_confidence_score.second).to eq most_voted
-        expect(Budget::Investment.sort_by_confidence_score.third).to eq least_voted2
-        expect(Budget::Investment.sort_by_confidence_score.fourth).to eq least_voted
+        expect(Budget::Investment.sort_by_confidence_score).to eq [
+          most_voted2, most_voted, least_voted2, least_voted
+        ]
       end
     end
   end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -355,7 +355,7 @@ describe Budget::Investment do
 
       by_valuator = Budget::Investment.by_valuator(valuator1.id)
 
-      expect(by_valuator.sort).to eq([investment1, investment3].sort)
+      expect(by_valuator).to match_array [investment1, investment3]
     end
   end
 
@@ -509,7 +509,7 @@ describe Budget::Investment do
         undecided_investment = create(:budget_investment, :undecided)
         feasible_investment = create(:budget_investment, :feasible)
 
-        expect(Budget::Investment.not_unfeasible.sort).to eq [undecided_investment, feasible_investment].sort
+        expect(Budget::Investment.not_unfeasible).to match_array [undecided_investment, feasible_investment]
       end
     end
 
@@ -539,7 +539,7 @@ describe Budget::Investment do
         unselected_undecided_investment = create(:budget_investment, :unselected, :undecided)
         unselected_feasible_investment = create(:budget_investment, :unselected, :feasible)
 
-        expect(Budget::Investment.unselected.sort).to eq [unselected_undecided_investment, unselected_feasible_investment].sort
+        expect(Budget::Investment.unselected).to match_array [unselected_undecided_investment, unselected_feasible_investment]
       end
     end
 

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -355,7 +355,6 @@ describe Budget::Investment do
 
       by_valuator = Budget::Investment.by_valuator(valuator1.id)
 
-      expect(by_valuator.size).to eq(2)
       expect(by_valuator.sort).to eq([investment1, investment3].sort)
     end
   end
@@ -373,7 +372,6 @@ describe Budget::Investment do
 
       by_valuator_group = Budget::Investment.by_valuator_group(valuator.valuator_group_id)
 
-      expect(by_valuator_group.size).to eq(2)
       expect(by_valuator_group).to contain_exactly(assigned_investment, another_assigned_investment)
     end
   end
@@ -1215,8 +1213,8 @@ describe Budget::Investment do
           :with_administrator,
           budget: budget)
         investment3 = create(:budget_investment, budget: budget)
+
         expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment3])
-        expect(Budget::Investment.scoped_filter(params, "all").count).to eq(1)
       end
     end
 
@@ -1231,10 +1229,9 @@ describe Budget::Investment do
           budget: budget)
         investment3 = create(:budget_investment,
           budget: budget)
+
         expect(Budget::Investment.scoped_filter(params, "all"))
           .to contain_exactly(investment2, investment3)
-        expect(Budget::Investment.scoped_filter(params, "all").count)
-        .to eq(2)
       end
     end
 
@@ -1251,7 +1248,6 @@ describe Budget::Investment do
         create(:budget_investment, budget: budget)
 
         expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment1])
-        expect(Budget::Investment.scoped_filter(params, "all").count).to eq(1)
       end
     end
 
@@ -1266,8 +1262,8 @@ describe Budget::Investment do
           budget: budget)
         create(:budget_investment,
           budget: budget)
+
         expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment1])
-        expect(Budget::Investment.scoped_filter(params, "all").count).to eq(1)
       end
     end
 
@@ -1282,8 +1278,8 @@ describe Budget::Investment do
           :with_administrator,
           budget: budget)
         create(:budget_investment, budget: budget)
+
         expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment1])
-        expect(Budget::Investment.scoped_filter(params, "all").count).to eq(1)
       end
     end
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -131,8 +131,7 @@ describe Comment do
       create(:comment, administrator_id: create(:administrator).id)
       create(:comment, moderator_id: create(:moderator).id)
 
-      expect(Comment.not_as_admin_or_moderator.size).to eq(1)
-      expect(Comment.not_as_admin_or_moderator.first).to eq(comment1)
+      expect(Comment.not_as_admin_or_moderator).to eq [comment1]
     end
   end
 

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe Community, type: :model do
       create(:comment, commentable: topic1, author: user2)
       topic2 = create(:topic, community: community, author: user2)
 
-      expect(community.participants).to include(user1)
-      expect(community.participants).to include(user2)
-      expect(community.participants).to include(proposal.author)
+      expect(community.participants).to match_array [user1, user2, proposal.author]
     end
   end
 end

--- a/spec/models/custom/verification/residence_spec.rb
+++ b/spec/models/custom/verification/residence_spec.rb
@@ -10,11 +10,11 @@ describe Verification::Residence do
       it "is valid with postal codes starting with 280" do
         residence.postal_code = "28012"
         residence.valid?
-        expect(residence.errors[:postal_code].size).to eq(0)
+        expect(residence.errors[:postal_code]).to be_empty
 
         residence.postal_code = "28023"
         residence.valid?
-        expect(residence.errors[:postal_code].size).to eq(0)
+        expect(residence.errors[:postal_code]).to be_empty
       end
 
       it "is not valid with postal codes not starting with 280" do

--- a/spec/models/custom/verification/residence_spec.rb
+++ b/spec/models/custom/verification/residence_spec.rb
@@ -24,8 +24,7 @@ describe Verification::Residence do
 
         residence.postal_code = "13280"
         residence.valid?
-        expect(residence.errors[:postal_code].size).to eq(1)
-        expect(residence.errors[:postal_code]).to include("In order to be verified, you must be registered.")
+        expect(residence.errors[:postal_code]).to eq ["In order to be verified, you must be registered."]
       end
     end
 

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -787,7 +787,6 @@ describe Debate do
 
       result = Debate.recommendations(user)
 
-      expect(result.size).to eq 1
       expect(result).to eq [debate1]
     end
 
@@ -799,7 +798,6 @@ describe Debate do
 
       result = Debate.recommendations(user)
 
-      expect(result.size).to eq 1
       expect(result).to eq [debate2]
     end
 

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -762,7 +762,7 @@ describe Debate do
     it "does not return any debates when user has not interests" do
       create(:debate)
 
-      expect(Debate.recommendations(user).size).to eq 0
+      expect(Debate.recommendations(user)).to be_empty
     end
 
     it "returns debates ordered by cached_votes_total" do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -15,11 +15,7 @@ describe Document do
         admin_document2 = create(:document, :admin)
         admin_document3 = create(:document, :admin)
 
-        expect(Document.admin.count).to eq(3)
-        expect(Document.admin).to include admin_document1
-        expect(Document.admin).to include admin_document2
-        expect(Document.admin).to include admin_document3
-        expect(Document.admin).not_to include user_document
+        expect(Document.admin).to match_array [admin_document1, admin_document2, admin_document3]
       end
 
     end

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -57,10 +57,7 @@ describe Newsletter do
     end
 
     it "returns list of recipients excluding users with disabled newsletter" do
-      expect(newsletter.list_of_recipient_emails.count).to eq(1)
-      expect(newsletter.list_of_recipient_emails).to include("newsletter_user@consul.dev")
-      expect(newsletter.list_of_recipient_emails).not_to include("no_news_user@consul.dev")
-      expect(newsletter.list_of_recipient_emails).not_to include("erased_user@consul.dev")
+      expect(newsletter.list_of_recipient_emails).to eq ["newsletter_user@consul.dev"]
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -48,10 +48,7 @@ describe Notification do
         old_notification = create :notification
         new_notification = create :notification
 
-        sorted_notifications = Notification.recent
-        expect(sorted_notifications.size).to be 2
-        expect(sorted_notifications.first).to eq new_notification
-        expect(sorted_notifications.last).to eq old_notification
+        expect(Notification.recent).to eq [new_notification, old_notification]
       end
     end
 

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -91,7 +91,8 @@ describe Officing::Residence do
           custom_residence = Officing::Residence.new("date_of_birth(3i)" => "1",
                                                  "date_of_birth(2i)" => "1",
                                                  "date_of_birth(1i)" => "1980")
-          expect(custom_residence.errors[:date_of_birth].size).to eq(0)
+
+          expect(custom_residence.errors[:date_of_birth]).to be_empty
         end
 
         it "is not valid without a date of birth" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -53,21 +53,15 @@ describe Organization do
 
     it "finds fuzzily by name" do
       expect(Organization.search("Greenpeace")).to be_empty
-      search = Organization.search("Tershe")
-      expect(search.size).to eq 1
-      expect(search.first).to eq organization
+      expect(Organization.search("Tershe")).to eq [organization]
     end
 
     scenario "finds by users email" do
-      search = Organization.search(organization.user.email)
-      expect(search.size).to eq 1
-      expect(search.first).to eq organization
+      expect(Organization.search(organization.user.email)).to eq [organization]
     end
 
     scenario "finds by users phone number" do
-      search = Organization.search(organization.user.phone_number)
-      expect(search.size).to eq 1
-      expect(search.first).to eq organization
+      expect(Organization.search(organization.user.phone_number)).to eq [organization]
     end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -48,11 +48,11 @@ describe Organization do
     let!(:organization) { create(:organization, name: "Watershed", user: create(:user, phone_number: "333")) }
 
     it "returns no results if search term is empty" do
-      expect(Organization.search(" ").size).to eq(0)
+      expect(Organization.search(" ")).to be_empty
     end
 
     it "finds fuzzily by name" do
-      expect(Organization.search("Greenpeace").size).to eq 0
+      expect(Organization.search("Greenpeace")).to be_empty
       search = Organization.search("Tershe")
       expect(search.size).to eq 1
       expect(search.first).to eq organization

--- a/spec/models/poll/ballot_spec.rb
+++ b/spec/models/poll/ballot_spec.rb
@@ -21,7 +21,6 @@ describe Poll::Ballot do
       poll_ballot.update(data: [investment.id, investment2.id, investment3.id, investment4.id].join(","))
       poll_ballot.verify
 
-      expect(poll_ballot.ballot.lines.count).to eq(3)
       expect(poll_ballot.ballot.lines.pluck(:investment_id).sort).to eq([investment.id, investment2.id, investment3.id].sort)
     end
 
@@ -35,7 +34,6 @@ describe Poll::Ballot do
       poll_ballot.update(data: [investment.id, investment2.id, investment3.id, investment4.id].join(","))
       poll_ballot.verify
 
-      expect(poll_ballot.ballot.lines.count).to eq(3)
       expect(poll_ballot.ballot.lines.pluck(:investment_id).sort).to eq([investment.id, investment2.id, investment3.id].sort)
     end
 
@@ -47,7 +45,6 @@ describe Poll::Ballot do
       poll_ballot.update(data: [investment.id, investment2.id, investment3.id, investment4.id].join(","))
       poll_ballot.verify
 
-      expect(poll_ballot.ballot.lines.count).to eq(3)
       expect(poll_ballot.ballot.lines.pluck(:investment_id).sort).to eq([investment.id, investment2.id, investment3.id].sort)
     end
 

--- a/spec/models/poll/ballot_spec.rb
+++ b/spec/models/poll/ballot_spec.rb
@@ -21,7 +21,7 @@ describe Poll::Ballot do
       poll_ballot.update(data: [investment.id, investment2.id, investment3.id, investment4.id].join(","))
       poll_ballot.verify
 
-      expect(poll_ballot.ballot.lines.pluck(:investment_id).sort).to eq([investment.id, investment2.id, investment3.id].sort)
+      expect(poll_ballot.ballot.lines.pluck(:investment_id)).to match_array [investment.id, investment2.id, investment3.id]
     end
 
     it "adds ballot lines if they are from valid headings" do
@@ -34,7 +34,7 @@ describe Poll::Ballot do
       poll_ballot.update(data: [investment.id, investment2.id, investment3.id, investment4.id].join(","))
       poll_ballot.verify
 
-      expect(poll_ballot.ballot.lines.pluck(:investment_id).sort).to eq([investment.id, investment2.id, investment3.id].sort)
+      expect(poll_ballot.ballot.lines.pluck(:investment_id)).to match_array [investment.id, investment2.id, investment3.id]
     end
 
     it "adds ballot lines if they are from selectable" do
@@ -45,7 +45,7 @@ describe Poll::Ballot do
       poll_ballot.update(data: [investment.id, investment2.id, investment3.id, investment4.id].join(","))
       poll_ballot.verify
 
-      expect(poll_ballot.ballot.lines.pluck(:investment_id).sort).to eq([investment.id, investment2.id, investment3.id].sort)
+      expect(poll_ballot.ballot.lines.pluck(:investment_id)).to match_array [investment.id, investment2.id, investment3.id]
     end
 
   end

--- a/spec/models/poll/booth_spec.rb
+++ b/spec/models/poll/booth_spec.rb
@@ -20,7 +20,7 @@ describe Poll::Booth do
 
       expect(Poll::Booth.search("number")).to eq([booth1])
       expect(Poll::Booth.search("hall")).to eq([booth2])
-      expect(Poll::Booth.search("cen").size).to eq 2
+      expect(Poll::Booth.search("cen")).to match_array [booth1, booth2]
     end
   end
 

--- a/spec/models/poll/officer_spec.rb
+++ b/spec/models/poll/officer_spec.rb
@@ -47,10 +47,8 @@ describe Poll::Officer do
       create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer)
 
       assigned_polls = officer.voting_days_assigned_polls
-      expect(assigned_polls.size).to eq 2
-      expect(assigned_polls.include?(poll_1)).to eq(true)
-      expect(assigned_polls.include?(poll_2)).to eq(true)
-      expect(assigned_polls.include?(poll_3)).to eq(false)
+
+      expect(assigned_polls).to match_array [poll_1, poll_2]
     end
 
     it "does not return polls with this officer assigned for final recount/results" do
@@ -66,9 +64,8 @@ describe Poll::Officer do
       create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer, final: true)
 
       assigned_polls = officer.voting_days_assigned_polls
-      expect(assigned_polls.size).to eq 1
-      expect(assigned_polls.include?(poll_1)).to eq(true)
-      expect(assigned_polls.include?(poll_2)).to eq(false)
+
+      expect(assigned_polls).to eq [poll_1]
     end
 
     it "returns polls ordered by end date (desc)" do
@@ -107,10 +104,8 @@ describe Poll::Officer do
       create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer, final: true)
 
       assigned_polls = officer.final_days_assigned_polls
-      expect(assigned_polls.size).to eq 2
-      expect(assigned_polls.include?(poll_1)).to eq(true)
-      expect(assigned_polls.include?(poll_2)).to eq(true)
-      expect(assigned_polls.include?(poll_3)).to eq(false)
+
+      expect(assigned_polls).to match_array [poll_1, poll_2]
     end
 
     it "does not return polls with this officer assigned for voting days" do
@@ -126,9 +121,8 @@ describe Poll::Officer do
       create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer, final: true)
 
       assigned_polls = officer.final_days_assigned_polls
-      expect(assigned_polls.size).to eq 1
-      expect(assigned_polls.include?(poll_1)).to eq(false)
-      expect(assigned_polls.include?(poll_2)).to eq(true)
+
+      expect(assigned_polls).to eq [poll_2]
     end
 
     it "returns polls ordered by end date (desc)" do

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -410,7 +410,6 @@ describe Poll do
           create(:poll, starts_at: starts_at, name: "Bravo")
         end
 
-        expect(Poll.sort_for_list.count).to eq 4
         expect(Poll.sort_for_list).to eq [poll4, poll1, poll2, poll3]
       end
     end

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -141,10 +141,7 @@ describe Poll::Voter do
 
         web_voters = Poll::Voter.web
 
-        expect(web_voters.count).to eq(2)
-        expect(web_voters).to     include(voter1)
-        expect(web_voters).to     include(voter2)
-        expect(web_voters).not_to include(voter3)
+        expect(web_voters).to match_array [voter1, voter2]
       end
     end
 
@@ -156,10 +153,7 @@ describe Poll::Voter do
 
         booth_voters = Poll::Voter.booth
 
-        expect(booth_voters.count).to eq(2)
-        expect(booth_voters).to     include(voter1)
-        expect(booth_voters).to     include(voter2)
-        expect(booth_voters).not_to include(voter3)
+        expect(booth_voters).to match_array [voter1, voter2]
       end
     end
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -1000,7 +1000,7 @@ describe Proposal do
     it "does not return any proposals when user has not interests" do
       create(:proposal)
 
-      expect(Proposal.recommendations(user).size).to eq 0
+      expect(Proposal.recommendations(user)).to be_empty
     end
 
     it "returns proposals ordered by cached_votes_up" do
@@ -1034,7 +1034,7 @@ describe Proposal do
 
       result = Proposal.recommendations(user)
 
-      expect(result.size).to eq 0
+      expect(result).to be_empty
     end
 
     it "does not return proposals when user is the author" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -883,17 +883,11 @@ describe Proposal do
     end
 
     it "scope retired" do
-      retired = Proposal.retired
-
-      expect(retired.size).to eq(1)
-      expect(retired.first).to eq(proposal2)
+      expect(Proposal.retired).to eq [proposal2]
     end
 
     it "scope not_retired" do
-      not_retired = Proposal.not_retired
-
-      expect(not_retired.size).to eq(1)
-      expect(not_retired.first).to eq(proposal1)
+      expect(Proposal.not_retired).to eq [proposal1]
     end
   end
 
@@ -907,17 +901,11 @@ describe Proposal do
     end
 
     it "scope archived" do
-      archived = Proposal.archived
-
-      expect(archived.size).to eq(1)
-      expect(archived.first).to eq(archived_proposal)
+      expect(Proposal.archived).to eq [archived_proposal]
     end
 
     it "scope not archived" do
-      not_archived = Proposal.not_archived
-
-      expect(not_archived.size).to eq(1)
-      expect(not_archived.first).to eq(new_proposal)
+      expect(Proposal.not_archived).to eq [new_proposal]
     end
   end
 
@@ -931,17 +919,11 @@ describe Proposal do
     end
 
     it "scope selected" do
-      selected = Proposal.selected
-
-      expect(selected.size).to be 1
-      expect(selected.first).to eq selected_proposal
+      expect(Proposal.selected).to eq [selected_proposal]
     end
 
     it "scope not_selected" do
-      not_selected = Proposal.not_selected
-
-      expect(not_selected.size).to be 1
-      expect(not_selected.first).to eq not_selected_proposal
+      expect(Proposal.not_selected).to eq [not_selected_proposal]
     end
   end
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -1025,7 +1025,6 @@ describe Proposal do
 
       result = Proposal.recommendations(user)
 
-      expect(result.size).to eq 1
       expect(result).to eq [proposal2]
     end
 
@@ -1046,7 +1045,6 @@ describe Proposal do
 
       result = Proposal.recommendations(user)
 
-      expect(result.size).to eq 1
       expect(result).to eq [proposal2]
     end
 
@@ -1057,7 +1055,7 @@ describe Proposal do
       create(:follow, followable: proposal1, user: user)
 
       result = Proposal.recommendations(user)
-      expect(result.size).to eq(1)
+
       expect(result).to eq([proposal2])
     end
 
@@ -1069,7 +1067,7 @@ describe Proposal do
       create(:follow, followable: proposal2, user: user)
 
       result = Proposal.recommendations(user)
-      expect(result.size).to eq(1)
+
       expect(result).to eq([proposal3])
     end
 

--- a/spec/models/related_content_spec.rb
+++ b/spec/models/related_content_spec.rb
@@ -53,9 +53,7 @@ describe RelatedContent do
     end
 
     it "returns not hidden by reports related contents" do
-      expect(parent_relationable.relationed_contents.count).to eq(1)
-      expect(parent_relationable.relationed_contents.first.class.name).to eq(child_relationable.class.name)
-      expect(parent_relationable.relationed_contents.first.id).to eq(child_relationable.id)
+      expect(parent_relationable.relationed_contents).to eq [child_relationable]
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -448,7 +448,7 @@ describe User do
     end
 
     it "returns no results if no search term provided" do
-      expect(User.search("    ").size).to eq(0)
+      expect(User.search("    ")).to be_empty
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -435,16 +435,16 @@ describe User do
       user1 = create(:user, email: "larry@consul.dev")
       create(:user, email: "bird@consul.dev")
       search = User.search("larry@consul.dev")
-      expect(search.size).to eq(1)
-      expect(search.first).to eq(user1)
+
+      expect(search).to eq [user1]
     end
 
     it "find users by name" do
       user1 = create(:user, username: "Larry Bird")
       create(:user, username: "Robert Parish")
       search = User.search("larry")
-      expect(search.size).to eq(1)
-      expect(search.first).to eq(user1)
+
+      expect(search).to eq [user1]
     end
 
     it "returns no results if no search term provided" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -580,7 +580,7 @@ describe User do
       user.take_votes_from other_user
 
       expect(other_user.votes.count).to eq(0)
-      expect(user.vote_ids.sort).to eq([v1.id, v2.id, v3.id].sort)
+      expect(user.vote_ids).to match_array [v1.id, v2.id, v3.id]
     end
 
     it "reassigns budget ballots from other user" do
@@ -598,7 +598,7 @@ describe User do
       user.take_votes_from other_user
 
       expect(Budget::Ballot.where(user: other_user).count).to eq(0)
-      expect(Budget::Ballot.where(user: user).sort).to eq([b1, b2].sort)
+      expect(Budget::Ballot.where(user: user)).to match_array [b1, b2]
     end
 
     it "reassigns poll voters from other user" do
@@ -616,7 +616,7 @@ describe User do
       user.take_votes_from other_user
 
       expect(Poll::Voter.where(user: other_user).count).to eq(0)
-      expect(Poll::Voter.where(user: user).sort).to eq([v1, v2].sort)
+      expect(Poll::Voter.where(user: user)).to match_array [v1, v2]
     end
   end
 

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -74,7 +74,8 @@ describe Verification::Management::Document do
           verification_document = Verification::Management::Document.new("date_of_birth(3i)" => "1",
                                                       "date_of_birth(2i)" => "1",
                                                       "date_of_birth(1i)" => "1980")
-          expect(verification_document.errors[:date_of_birth].size).to eq(0)
+
+          expect(verification_document.errors[:date_of_birth]).to be_empty
         end
 
         it "is not valid without a date of birth" do

--- a/spec/models/verification/residence_spec.rb
+++ b/spec/models/verification/residence_spec.rb
@@ -14,7 +14,8 @@ describe Verification::Residence do
     describe "dates" do
       it "is valid with a valid date of birth" do
         residence = Verification::Residence.new("date_of_birth(3i)" => "1", "date_of_birth(2i)" => "1", "date_of_birth(1i)" => "1980")
-        expect(residence.errors[:date_of_birth].size).to eq(0)
+
+        expect(residence.errors[:date_of_birth]).to be_empty
       end
 
       it "is not valid without a date of birth" do


### PR DESCRIPTION
## Background

We usually check the contents of an array with `eq` or `match_array`. However, in a few places we were checking the size of the array and the contents of each of the elements, making the tests harder to read.

## Objectives

Make tests checking array contents easier to read.