### PR TITLE
Use traits to simplify specs

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,10 +5,10 @@ describe ApplicationController do
   describe "#current_budget" do
 
     it "returns the last budget that is not in draft phase" do
-      old_budget      = create(:budget, phase: "finished",  created_at: 2.years.ago)
-      previous_budget = create(:budget, phase: "accepting", created_at: 1.year.ago)
-      current_budget  = create(:budget, phase: "accepting", created_at: 1.month.ago)
-      next_budget     = create(:budget, phase: "drafting",  created_at: 1.week.ago)
+      old_budget      = create(:budget, :finished,  created_at: 2.years.ago)
+      previous_budget = create(:budget, :accepting, created_at: 1.year.ago)
+      current_budget  = create(:budget, :accepting, created_at: 1.month.ago)
+      next_budget     = create(:budget, :drafting,  created_at: 1.week.ago)
 
       budget = subject.instance_eval { current_budget }
       expect(budget).to eq(current_budget)

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -114,6 +114,10 @@ FactoryBot.define do
       valuation_finished { true }
     end
 
+    trait :unfinished do
+      valuation_finished { false }
+    end
+
     trait :selected do
       selected { true }
       feasibility { "feasible" }

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -129,6 +129,10 @@ FactoryBot.define do
       visible_to_valuators { true }
     end
 
+    trait :invisible_to_valuators do
+      visible_to_valuators { false }
+    end
+
     trait :incompatible do
       selected
       incompatible { true }

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -171,6 +171,10 @@ FactoryBot.define do
     trait :with_milestone_tags do
       after(:create) { |investment| investment.milestone_tags << create(:tag, :milestone) }
     end
+
+    trait :with_image do
+      after(:create) { |investment| create(:image, imageable: investment) }
+    end
   end
 
   factory :budget_phase, class: "Budget::Phase" do

--- a/spec/factories/milestones.rb
+++ b/spec/factories/milestones.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
     description          { "Milestone description" }
     publication_date     { Date.current }
 
+    trait :with_image do
+      after(:create) { |milestone| create(:image, imageable: milestone) }
+    end
+
     factory :milestone_with_description do
       status { nil }
     end

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -41,8 +41,8 @@ FactoryBot.define do
     association :author, factory: :user
     sequence(:title) { |n| "Question title #{n}" }
 
-    trait :with_answers do
-      after(:create) do |question, _evaluator|
+    trait :yes_no do
+      after(:create) do |question|
         create(:poll_question_answer, question: question, title: "Yes")
         create(:poll_question_answer, question: question, title: "No")
       end
@@ -197,13 +197,13 @@ FactoryBot.define do
   end
 
   factory :poll_answer, class: "Poll::Answer" do
-    association :question, factory: [:poll_question, :with_answers]
+    association :question, factory: [:poll_question, :yes_no]
     association :author, factory: [:user, :level_two]
     answer { question.question_answers.sample.title }
   end
 
   factory :poll_partial_result, class: "Poll::PartialResult" do
-    association :question, factory: [:poll_question, :with_answers]
+    association :question, factory: [:poll_question, :yes_no]
     association :author, factory: :user
     origin { "web" }
     answer { question.question_answers.sample.title }

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -34,6 +34,10 @@ FactoryBot.define do
     trait :hidden do
       hidden_at { Time.current }
     end
+
+    trait :for_budget do
+      association :budget
+    end
   end
 
   factory :poll_question, class: "Poll::Question" do

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -38,6 +38,10 @@ FactoryBot.define do
     trait :for_budget do
       association :budget
     end
+
+    trait :with_image do
+      after(:create) { |poll| create(:image, imageable: poll) }
+    end
   end
 
   factory :poll_question, class: "Poll::Question" do

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
     trait :published do
       published { true }
     end
+
+    trait :hidden do
+      hidden_at { Time.current }
+    end
   end
 
   factory :poll_question, class: "Poll::Question" do

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -74,6 +74,10 @@ FactoryBot.define do
       after(:create) { |proposal| proposal.milestone_tags << create(:tag, :milestone) }
     end
 
+    trait :with_image do
+      after(:create) { |proposal| create(:image, imageable: proposal) }
+    end
+
     factory :retired_proposal, traits: [:retired]
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -51,6 +51,18 @@ FactoryBot.define do
       document_type { "1" }
       verified_at { Time.current }
     end
+
+    trait :with_proposal do
+      after(:create) { |user| create(:proposal, author: user) }
+    end
+
+    trait :with_debate do
+      after(:create) { |user| create(:debate, author: user) }
+    end
+
+    trait :with_comment do
+      after(:create) { |user| create(:comment, author: user) }
+    end
   end
 
   factory :identity do

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Admin budget groups" do
 
-  let(:budget) { create(:budget, phase: "drafting") }
+  let(:budget) { create(:budget, :drafting) }
 
   before do
     admin = create(:administrator)

--- a/spec/features/admin/budget_headings_spec.rb
+++ b/spec/features/admin/budget_headings_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Admin budget headings" do
 
-  let(:budget) { create(:budget, phase: "drafting") }
+  let(:budget) { create(:budget, :drafting) }
   let(:group) { create(:budget_group, budget: budget) }
 
   before do

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -407,7 +407,7 @@ describe "Admin budget investments" do
     scenario "Filtering by winners", :js do
       create(:budget_investment,
         :winner,
-        valuation_finished: true,
+        :finished,
         title: "Investment winner",
         budget: budget)
       create(:budget_investment,
@@ -483,8 +483,7 @@ describe "Admin budget investments" do
 
     scenario "Filtering by valuation status" do
       valuating = create(:budget_investment, :with_administrator, budget: budget, title: "Ongoing valuation")
-      valuated = create(:budget_investment, budget: budget, title: "Old idea",
-                                                             valuation_finished: true)
+      valuated = create(:budget_investment, :finished, budget: budget, title: "Old idea")
       valuating.valuators.push(create(:valuator))
       valuated.valuators.push(create(:valuator))
 
@@ -701,10 +700,10 @@ describe "Admin budget investments" do
     end
 
     scenario "Combination of select with text search", :js do
-      create(:budget_investment, budget: budget, title: "Educate the children",
-                                 feasibility: "feasible", valuation_finished: true)
-      create(:budget_investment, budget: budget, title: "More schools",
-                                 feasibility: "feasible", valuation_finished: true)
+      create(:budget_investment, :finished, budget: budget, title: "Educate the children",
+                                 feasibility: "feasible")
+      create(:budget_investment, :finished, budget: budget, title: "More schools",
+                                 feasibility: "feasible")
       create(:budget_investment, budget: budget, title: "More hospitals")
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
@@ -741,11 +740,11 @@ describe "Admin budget investments" do
       user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
 
-      create(:budget_investment, budget: budget, title: "Educate the children",
-                                 feasibility: "feasible", valuation_finished: true,
+      create(:budget_investment, :finished, budget: budget, title: "Educate the children",
+                                 feasibility: "feasible",
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: "More schools",
-                                 feasibility: "feasible", valuation_finished: true,
+      create(:budget_investment, :finished, budget: budget, title: "More schools",
+                                 feasibility: "feasible",
                                  administrator: administrator)
       create(:budget_investment, budget: budget, title: "More hospitals",
                                  administrator: administrator)

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -700,10 +700,8 @@ describe "Admin budget investments" do
     end
 
     scenario "Combination of select with text search", :js do
-      create(:budget_investment, :finished, budget: budget, title: "Educate the children",
-                                 feasibility: "feasible")
-      create(:budget_investment, :finished, budget: budget, title: "More schools",
-                                 feasibility: "feasible")
+      create(:budget_investment, :feasible, :finished, budget: budget, title: "Educate the children")
+      create(:budget_investment, :feasible, :finished, budget: budget, title: "More schools")
       create(:budget_investment, budget: budget, title: "More hospitals")
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
@@ -740,11 +738,9 @@ describe "Admin budget investments" do
       user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
 
-      create(:budget_investment, :finished, budget: budget, title: "Educate the children",
-                                 feasibility: "feasible",
+      create(:budget_investment, :feasible, :finished, budget: budget, title: "Educate the children",
                                  administrator: administrator)
-      create(:budget_investment, :finished, budget: budget, title: "More schools",
-                                 feasibility: "feasible",
+      create(:budget_investment, :feasible, :finished, budget: budget, title: "More schools",
                                  administrator: administrator)
       create(:budget_investment, budget: budget, title: "More hospitals",
                                  administrator: administrator)
@@ -984,10 +980,10 @@ describe "Admin budget investments" do
       user = create(:user, username: "Rachel", email: "rachel@valuators.org")
       valuator = create(:valuator, user: user)
       budget_investment = create(:budget_investment,
+                                  :unfeasible,
+                                  unfeasibility_explanation: "It is impossible",
                                   price: 1234,
                                   price_first_year: 1000,
-                                  feasibility: "unfeasible",
-                                  unfeasibility_explanation: "It is impossible",
                                   administrator: administrator)
       budget_investment.valuators << valuator
 
@@ -1015,10 +1011,10 @@ describe "Admin budget investments" do
 
     scenario "Show image and documents on investment details" do
       budget_investment = create(:budget_investment,
+                                  :unfeasible,
+                                  unfeasibility_explanation: "It is impossible",
                                   price: 1234,
                                   price_first_year: 1000,
-                                  feasibility: "unfeasible",
-                                  unfeasibility_explanation: "It is impossible",
                                   administrator: administrator)
       create(:image, imageable: budget_investment)
       document = create(:document, documentable: budget_investment)
@@ -1045,10 +1041,9 @@ describe "Admin budget investments" do
 
     scenario "Not show related content or hide links on preview" do
       budget_investment = create(:budget_investment,
+                                  :unfeasible,
                                   price: 1234,
                                   price_first_year: 1000,
-                                  feasibility: "unfeasible",
-                                  unfeasibility_explanation: "It is impossible",
                                   administrator: administrator)
 
       visit admin_budget_budget_investments_path(budget_investment.budget)

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1011,12 +1011,12 @@ describe "Admin budget investments" do
 
     scenario "Show image and documents on investment details" do
       budget_investment = create(:budget_investment,
+                                  :with_image,
                                   :unfeasible,
                                   unfeasibility_explanation: "It is impossible",
                                   price: 1234,
                                   price_first_year: 1000,
                                   administrator: administrator)
-      create(:image, imageable: budget_investment)
       document = create(:document, documentable: budget_investment)
 
       visit admin_budget_budget_investments_path(budget_investment.budget)

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -346,7 +346,7 @@ describe "Admin budget investments" do
       valuator = create(:valuator, user: user)
       create(:budget_investment,
         :with_administrator,
-        valuation_finished: false,
+        :unfinished,
         title: "Investment without valuation",
         budget: budget,
         valuators: [valuator])

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1659,8 +1659,8 @@ describe "Admin budget investments" do
     end
 
     scenario "Showing the valuating checkbox" do
-      investment1 = create(:budget_investment, :with_administrator, budget: budget, visible_to_valuators: true)
-      investment2 = create(:budget_investment, :with_administrator, budget: budget, visible_to_valuators: false)
+      investment1 = create(:budget_investment, :with_administrator, :visible_to_valuators, budget: budget)
+      investment2 = create(:budget_investment, :with_administrator, :invisible_to_valuators, budget: budget)
 
       investment1.valuators << create(:valuator)
       investment2.valuators << create(:valuator)
@@ -1737,8 +1737,8 @@ describe "Admin budget investments" do
     let!(:investment) do
       create(:budget_investment,
               :winner,
+              :visible_to_valuators,
               budget: budget,
-              visible_to_valuators: true,
               author: create(:user, username: "Jon Doe")
             )
     end

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -454,8 +454,7 @@ describe "Admin budget investments" do
     end
 
     scenario "Filtering by assignment status" do
-      create(:budget_investment, title: "Assigned idea", budget: budget,
-             administrator: create(:administrator))
+      create(:budget_investment, :with_administrator, title: "Assigned idea", budget: budget)
       create(:budget_investment, title: "Evaluating...", budget: budget,
              valuators: [create(:valuator)])
       create(:budget_investment, title: "With group", budget: budget,
@@ -483,8 +482,7 @@ describe "Admin budget investments" do
     end
 
     scenario "Filtering by valuation status" do
-      valuating = create(:budget_investment, budget: budget, title: "Ongoing valuation",
-                                                             administrator: create(:administrator))
+      valuating = create(:budget_investment, :with_administrator, budget: budget, title: "Ongoing valuation")
       valuated = create(:budget_investment, budget: budget, title: "Old idea",
                                                              valuation_finished: true)
       valuating.valuators.push(create(:valuator))
@@ -1667,14 +1665,12 @@ describe "Admin budget investments" do
     end
 
     scenario "Showing the valuating checkbox" do
-      investment1 = create(:budget_investment, budget: budget, visible_to_valuators: true)
-      investment2 = create(:budget_investment, budget: budget, visible_to_valuators: false)
+      investment1 = create(:budget_investment, :with_administrator, budget: budget, visible_to_valuators: true)
+      investment2 = create(:budget_investment, :with_administrator, budget: budget, visible_to_valuators: false)
 
       investment1.valuators << create(:valuator)
       investment2.valuators << create(:valuator)
       investment2.valuators << create(:valuator)
-      investment1.update(administrator: create(:administrator))
-      investment2.update(administrator: create(:administrator))
 
       visit admin_budget_budget_investments_path(budget)
 

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -264,7 +264,7 @@ describe "Admin budgets" do
   context "Calculate Budget's Winner Investments" do
 
     scenario "For a Budget in reviewing balloting", :js do
-      budget = create(:budget, phase: "reviewing_ballots")
+      budget = create(:budget, :reviewing_ballots)
       heading = create(:budget_heading, budget: budget, price: 4)
       unselected = create(:budget_investment, :unselected, heading: heading, price: 1,
                                                            ballot_lines_count: 3)

--- a/spec/features/admin/change_log_spec.rb
+++ b/spec/features/admin/change_log_spec.rb
@@ -15,10 +15,10 @@ describe "Admin change log" do
 
     scenario "No changes" do
       budget_investment = create(:budget_investment,
+                                 :unfeasible,
+                                 unfeasibility_explanation: "It is impossible",
                                  price: 1234,
                                  price_first_year: 1000,
-                                 feasibility: "unfeasible",
-                                 unfeasibility_explanation: "It is impossible",
                                  administrator: administrator)
 
       visit admin_budget_budget_investments_path(budget_investment.budget)
@@ -34,10 +34,10 @@ describe "Admin change log" do
 
     scenario "Changes" do
       budget_investment = create(:budget_investment,
+                                 :unfeasible,
+                                 unfeasibility_explanation: "It is impossible",
                                  price: 1234,
                                  price_first_year: 1000,
-                                 feasibility: "unfeasible",
-                                 unfeasibility_explanation: "It is impossible",
                                  administrator: administrator)
 
       visit admin_budget_budget_investments_path(budget_investment.budget)

--- a/spec/features/admin/download_settings_spec.rb
+++ b/spec/features/admin/download_settings_spec.rb
@@ -260,7 +260,7 @@ describe "Admin download settings" do
   end
 
   context "Download budgets" do
-    let(:budget_finished)  { create(:budget, phase: "finished") }
+    let(:budget_finished)  { create(:budget, :finished) }
     let(:heading) { create(:budget_heading, budget: budget_finished, price: 1000) }
 
     let(:investment1) { create(:budget_investment,

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -239,9 +239,7 @@ describe "Admin booths assignments" do
       booth_assignment = create(:poll_booth_assignment, poll: poll)
       other_booth_assignment = create(:poll_booth_assignment, poll: poll)
 
-      question_1 = create(:poll_question, poll: poll)
-      create(:poll_question_answer, title: "Yes", question: question_1)
-      create(:poll_question_answer, title: "No", question: question_1)
+      question_1 = create(:poll_question, :yes_no, poll: poll)
 
       question_2 = create(:poll_question, poll: poll)
       create(:poll_question_answer, title: "Today", question: question_2)

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -85,8 +85,7 @@ describe "Admin polls" do
   end
 
   scenario "Edit" do
-    poll = create(:poll)
-    create(:image, imageable: poll)
+    poll = create(:poll, :with_image)
 
     visit admin_poll_path(poll)
     click_link "Edit poll"

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -133,9 +133,7 @@ describe "Admin polls" do
 
     scenario "Can destroy poll with questions and answers", :js do
       poll = create(:poll)
-      question = create(:poll_question, poll: poll)
-      create(:poll_question_answer, question: question, title: "Yes")
-      create(:poll_question_answer, question: question, title: "No")
+      question = create(:poll_question, :yes_no, poll: poll)
 
       visit admin_polls_path
 
@@ -438,9 +436,7 @@ describe "Admin polls" do
         booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
         booth_assignment_3 = create(:poll_booth_assignment, poll: poll)
 
-        question_1 = create(:poll_question, poll: poll)
-        create(:poll_question_answer, title: "Yes", question: question_1)
-        create(:poll_question_answer, title: "No", question: question_1)
+        question_1 = create(:poll_question, :yes_no, poll: poll)
 
         question_2 = create(:poll_question, poll: poll)
         create(:poll_question_answer, title: "Today", question: question_2)
@@ -494,9 +490,7 @@ describe "Admin polls" do
         booth_assignment1 = create(:poll_booth_assignment, poll: poll)
         booth_assignment2 = create(:poll_booth_assignment, poll: poll)
 
-        question = create(:poll_question, poll: poll)
-        create(:poll_question_answer, title: "Yes", question: question)
-        create(:poll_question_answer, title: "No", question: question)
+        question = create(:poll_question, :yes_no, poll: poll)
 
         create(:poll_partial_result,
                booth_assignment: booth_assignment1,

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -419,8 +419,8 @@ describe "Stats" do
 
       poll = create(:poll)
 
-      question1 = create(:poll_question, :with_answers, poll: poll)
-      question2 = create(:poll_question, :with_answers, poll: poll)
+      question1 = create(:poll_question, :yes_no, poll: poll)
+      question2 = create(:poll_question, :yes_no, poll: poll)
 
       create(:poll_answer, question: question1, author: user1)
       create(:poll_answer, question: question2, author: user1)

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -75,9 +75,9 @@ describe "Stats" do
     end
 
     scenario "Do not count hidden users" do
-      1.times { create(:user, :level_three, hidden_at: Time.current) }
-      2.times { create(:user, :level_two, hidden_at: Time.current) }
-      3.times { create(:user, hidden_at: Time.current) }
+      1.times { create(:user, :hidden, :level_three) }
+      2.times { create(:user, :hidden, :level_two) }
+      3.times { create(:user, :hidden) }
 
       visit admin_stats_path
 

--- a/spec/features/budget_polls/ballot_sheets_spec.rb
+++ b/spec/features/budget_polls/ballot_sheets_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 describe "Poll budget ballot sheets" do
-  let(:budget) { create(:budget) }
-  let(:poll) { create(:poll, budget: budget, ends_at: 1.day.ago) }
+  let(:poll) { create(:poll, :for_budget, ends_at: 1.day.ago) }
   let(:booth) { create(:poll_booth) }
   let(:poll_officer) { create(:poll_officer) }
 

--- a/spec/features/budget_polls/budgets_spec.rb
+++ b/spec/features/budget_polls/budgets_spec.rb
@@ -60,8 +60,7 @@ describe "Admin Budgets" do
   context "Show" do
 
     scenario "Do not show questions section if the budget have a poll associated" do
-      budget = create(:budget)
-      poll = create(:poll, budget: budget)
+      poll = create(:poll, :for_budget)
 
       visit admin_poll_path(poll)
 

--- a/spec/features/budget_polls/polls_spec.rb
+++ b/spec/features/budget_polls/polls_spec.rb
@@ -6,7 +6,7 @@ describe "Polls" do
 
     scenario "Budget polls should not be listed" do
       poll = create(:poll)
-      budget_poll = create(:poll, budget: create(:budget))
+      budget_poll = create(:poll, :for_budget)
 
       visit polls_path
 
@@ -22,7 +22,7 @@ describe "Polls" do
       login_as(create(:administrator).user)
 
       poll = create(:poll)
-      budget_poll = create(:poll, budget: create(:budget))
+      budget_poll = create(:poll, :for_budget)
 
       visit admin_polls_path
 

--- a/spec/features/budget_polls/questions_spec.rb
+++ b/spec/features/budget_polls/questions_spec.rb
@@ -8,10 +8,8 @@ describe "Poll Questions" do
   end
 
   scenario "Do not display polls associated to a budget" do
-    budget = create(:budget)
-
     poll1 = create(:poll, name: "Citizen Proposal Poll")
-    poll2 = create(:poll, budget: budget, name: "Participatory Budget Poll")
+    poll2 = create(:poll, :for_budget, name: "Participatory Budget Poll")
 
     visit admin_questions_path
 

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Ballots" do
 
   let!(:user)       { create(:user, :level_two) }
-  let!(:budget)     { create(:budget, phase: "balloting") }
+  let!(:budget)     { create(:budget, :balloting) }
   let!(:states)     { create(:budget_group, budget: budget, name: "States") }
   let!(:california) { create(:budget_heading, group: states, name: "California", price: 1000) }
   let!(:new_york)   { create(:budget_heading, group: states, name: "New York", price: 1000000) }

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -577,7 +577,7 @@ describe "Ballots" do
     end
 
     scenario "Investments with feasibility undecided are not shown" do
-      investment = create(:budget_investment, feasibility: "undecided", heading: new_york)
+      investment = create(:budget_investment, :undecided, heading: new_york)
 
       login_as(user)
       visit budget_path(budget)

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -79,8 +79,7 @@ describe "Executions" do
   context "Images" do
 
     scenario "renders milestone image if available" do
-      milestone1 = create(:milestone, milestoneable: investment1)
-      create(:image, imageable: milestone1)
+      milestone1 = create(:milestone, :with_image, milestoneable: investment1)
 
       visit budget_path(budget)
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1263,7 +1263,7 @@ describe "Budget Investments" do
 
     investment = create(:budget_investment,
                         :unfeasible,
-                        valuation_finished: false,
+                        :unfinished,
                         budget: budget,
                         group: group,
                         heading: heading,

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -127,8 +127,7 @@ describe "Budget Investments" do
 
   scenario "Index should show investment descriptive image only when is defined" do
     investment = create(:budget_investment, heading: heading)
-    investment_with_image = create(:budget_investment, heading: heading)
-    image = create(:image, imageable: investment_with_image)
+    investment_with_image = create(:budget_investment, :with_image, heading: heading)
 
     visit budget_investments_path(budget, heading_id: heading.id)
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -519,7 +519,7 @@ describe "Budget Investments" do
   context("Filters") do
 
     scenario "by unfeasibility" do
-      investment1 = create(:budget_investment, :unfeasible, heading: heading, valuation_finished: true)
+      investment1 = create(:budget_investment, :unfeasible, :finished, heading: heading)
       investment2 = create(:budget_investment, :feasible, heading: heading)
       investment3 = create(:budget_investment, heading: heading)
       investment4 = create(:budget_investment, :feasible, heading: heading)
@@ -596,8 +596,7 @@ describe "Budget Investments" do
       end
 
       scenario "unfeasible", :js do
-        investment1 = create(:budget_investment, :unfeasible, heading: heading,
-                             valuation_finished: true)
+        investment1 = create(:budget_investment, :unfeasible, :finished, heading: heading)
         investment2 = create(:budget_investment, :feasible, heading: heading)
 
         visit budget_results_path(budget)
@@ -1670,10 +1669,10 @@ describe "Budget Investments" do
     end
 
     scenario "Show unselected budget investments" do
-      investment1 = create(:budget_investment, :unselected, :feasible, heading: heading, valuation_finished: true)
-      investment2 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
-      investment3 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
-      investment4 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
+      investment1 = create(:budget_investment, :unselected, :feasible, :finished, heading: heading)
+      investment2 = create(:budget_investment, :selected,   :feasible, :finished, heading: heading)
+      investment3 = create(:budget_investment, :selected,   :feasible, :finished, heading: heading)
+      investment4 = create(:budget_investment, :selected,   :feasible, :finished, heading: heading)
 
       visit budget_investments_path(budget, heading_id: heading.id, filter: "unselected")
 

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -4,7 +4,7 @@ describe "Votes" do
 
   describe "Investments" do
     let(:manuela) { create(:user, verified_at: Time.current) }
-    let(:budget)  { create(:budget, phase: "selecting") }
+    let(:budget)  { create(:budget, :selecting) }
     let(:group)   { create(:budget_group, budget: budget) }
     let(:heading) { create(:budget_heading, group: group) }
 

--- a/spec/features/dashboard/polls_spec.rb
+++ b/spec/features/dashboard/polls_spec.rb
@@ -129,9 +129,7 @@ describe "Polls" do
 
   scenario "Edit poll should allow to remove answers", :js do
     poll = create(:poll, related: proposal, starts_at: 1.week.from_now)
-    question = create(:poll_question, poll: poll)
-    create(:poll_question_answer, question: question)
-    create(:poll_question_answer, question: question)
+    create(:poll_question, :yes_no, poll: poll)
     visit proposal_dashboard_polls_path(proposal)
     within "div#poll_#{poll.id}" do
       click_link "Edit survey"

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -483,14 +483,10 @@ describe "Emails" do
   context "Newsletter" do
 
     scenario "Send newsletter email to selected users" do
-      user_with_newsletter_in_segment_1 = create(:user, newsletter: true)
-      user_with_newsletter_in_segment_2 = create(:user, newsletter: true)
+      user_with_newsletter_in_segment_1 = create(:user, :with_proposal, newsletter: true)
+      user_with_newsletter_in_segment_2 = create(:user, :with_proposal, newsletter: true)
       user_with_newsletter_not_in_segment = create(:user, newsletter: true)
-      user_without_newsletter_in_segment = create(:user, newsletter: false)
-
-      create(:proposal, author: user_with_newsletter_in_segment_1)
-      create(:proposal, author: user_with_newsletter_in_segment_2)
-      create(:proposal, author: user_without_newsletter_in_segment)
+      user_without_newsletter_in_segment = create(:user, :with_proposal, newsletter: false)
 
       admin = create(:administrator)
       login_as(admin.user)

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Budget Investments" do
 
   let(:manager) { create(:manager) }
-  let(:budget)  { create(:budget, phase: "selecting", name: "2033", slug: "budget_slug") }
+  let(:budget)  { create(:budget, :selecting, name: "2033", slug: "budget_slug") }
   let(:group)   { create(:budget_group, budget: budget, name: "Whole city") }
   let(:heading) { create(:budget_heading, group: group, name: "Health") }
 
@@ -208,13 +208,13 @@ describe "Budget Investments" do
   end
 
   scenario "Listing - managers can see budgets in accepting phase" do
-    accepting_budget = create(:budget, phase: "accepting")
-    reviewing_budget = create(:budget, phase: "reviewing")
-    selecting_budget = create(:budget, phase: "selecting")
-    valuating_budget = create(:budget, phase: "valuating")
-    balloting_budget = create(:budget, phase: "balloting")
-    reviewing_ballots_budget = create(:budget, phase: "reviewing_ballots")
-    finished = create(:budget, phase: "finished")
+    accepting_budget = create(:budget, :accepting)
+    reviewing_budget = create(:budget, :reviewing)
+    selecting_budget = create(:budget, :selecting)
+    valuating_budget = create(:budget, :valuating)
+    balloting_budget = create(:budget, :balloting)
+    reviewing_ballots_budget = create(:budget, :reviewing_ballots)
+    finished = create(:budget, :finished)
 
     user = create(:user, :level_two)
     login_managed_user(user)
@@ -232,13 +232,13 @@ describe "Budget Investments" do
   end
 
   scenario "Listing - admins can see budgets in accepting, reviewing and selecting phases" do
-    accepting_budget = create(:budget, phase: "accepting")
-    reviewing_budget = create(:budget, phase: "reviewing")
-    selecting_budget = create(:budget, phase: "selecting")
-    valuating_budget = create(:budget, phase: "valuating")
-    balloting_budget = create(:budget, phase: "balloting")
-    reviewing_ballots_budget = create(:budget, phase: "reviewing_ballots")
-    finished = create(:budget, phase: "finished")
+    accepting_budget = create(:budget, :accepting)
+    reviewing_budget = create(:budget, :reviewing)
+    selecting_budget = create(:budget, :selecting)
+    valuating_budget = create(:budget, :valuating)
+    balloting_budget = create(:budget, :balloting)
+    reviewing_ballots_budget = create(:budget, :reviewing_ballots)
+    finished = create(:budget, :finished)
 
     visit root_path
     click_link "Sign out"

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -25,10 +25,7 @@ describe "Polls" do
       visit polls_path
       expect(page).to have_content("There are no open votings")
 
-      polls = create_list(:poll, 3)
-      create(:image, imageable: polls[0])
-      create(:image, imageable: polls[1])
-      create(:image, imageable: polls[2])
+      polls = create_list(:poll, 3, :with_image)
 
       visit polls_path
 

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -98,9 +98,7 @@ describe "Polls" do
       expect(page).to have_content("This poll is not available on your geozone")
 
       poll_with_question = create(:poll)
-      question = create(:poll_question, poll: poll_with_question)
-      answer1 = create(:poll_question_answer, question: question, title: "Yes")
-      answer2 = create(:poll_question_answer, question: question, title: "No")
+      question = create(:poll_question, :yes_no, poll: poll_with_question)
       vote_for_poll_via_web(poll_with_question, question, "Yes")
 
       visit polls_path
@@ -188,15 +186,13 @@ describe "Polls" do
     end
 
     scenario "Non-logged in users" do
-      question = create(:poll_question, poll: poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Han Solo")
-      answer2 = create(:poll_question_answer, question: question, title: "Chewbacca")
+      create(:poll_question, :yes_no, poll: poll)
 
       visit poll_path(poll)
 
       expect(page).to have_content("You must Sign in or Sign up to participate")
-      expect(page).to have_link("Han Solo", href: new_user_session_path)
-      expect(page).to have_link("Chewbacca", href: new_user_session_path)
+      expect(page).to have_link("Yes", href: new_user_session_path)
+      expect(page).to have_link("No", href: new_user_session_path)
     end
 
     scenario "Level 1 users" do
@@ -206,36 +202,32 @@ describe "Polls" do
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 
-      question = create(:poll_question, poll: poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Han Solo")
-      answer2 = create(:poll_question_answer, question: question, title: "Chewbacca")
+      create(:poll_question, :yes_no, poll: poll)
 
       login_as(create(:user, geozone: geozone))
       visit poll_path(poll)
 
       expect(page).to have_content("You must verify your account in order to answer")
 
-      expect(page).to have_link("Han Solo", href: verification_path)
-      expect(page).to have_link("Chewbacca", href: verification_path)
+      expect(page).to have_link("Yes", href: verification_path)
+      expect(page).to have_link("No", href: verification_path)
     end
 
     scenario "Level 2 users in an expired poll" do
       expired_poll = create(:poll, :expired, geozone_restricted: true)
       expired_poll.geozones << geozone
 
-      question = create(:poll_question, poll: expired_poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Luke")
-      answer2 = create(:poll_question_answer, question: question, title: "Leia")
+      question = create(:poll_question, :yes_no, poll: expired_poll)
 
       login_as(create(:user, :level_two, geozone: geozone))
 
       visit poll_path(expired_poll)
 
       within("#poll_question_#{question.id}_answers") do
-        expect(page).to have_content("Luke")
-        expect(page).to have_content("Leia")
-        expect(page).not_to have_link("Luke")
-        expect(page).not_to have_link("Leia")
+        expect(page).to have_content("Yes")
+        expect(page).to have_content("No")
+        expect(page).not_to have_link("Yes")
+        expect(page).not_to have_link("No")
       end
       expect(page).to have_content("This poll has finished")
     end
@@ -244,19 +236,17 @@ describe "Polls" do
       poll.update(geozone_restricted: true)
       poll.geozones << create(:geozone)
 
-      question = create(:poll_question, poll: poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Vader")
-      answer2 = create(:poll_question_answer, question: question, title: "Palpatine")
+      question = create(:poll_question, :yes_no, poll: poll)
 
       login_as(create(:user, :level_two))
 
       visit poll_path(poll)
 
       within("#poll_question_#{question.id}_answers") do
-        expect(page).to have_content("Vader")
-        expect(page).to have_content("Palpatine")
-        expect(page).not_to have_link("Vader")
-        expect(page).not_to have_link("Palpatine")
+        expect(page).to have_content("Yes")
+        expect(page).to have_content("No")
+        expect(page).not_to have_link("Yes")
+        expect(page).not_to have_link("No")
       end
     end
 
@@ -264,46 +254,40 @@ describe "Polls" do
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 
-      question = create(:poll_question, poll: poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Han Solo")
-      answer2 = create(:poll_question_answer, question: question, title: "Chewbacca")
+      question = create(:poll_question, :yes_no, poll: poll)
 
       login_as(create(:user, :level_two, geozone: geozone))
       visit poll_path(poll)
 
       within("#poll_question_#{question.id}_answers") do
-        expect(page).to have_link("Han Solo")
-        expect(page).to have_link("Chewbacca")
+        expect(page).to have_link("Yes")
+        expect(page).to have_link("No")
       end
     end
 
     scenario "Level 2 users reading a all-geozones poll" do
-      question = create(:poll_question, poll: poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Han Solo")
-      answer2 = create(:poll_question_answer, question: question, title: "Chewbacca")
+      question = create(:poll_question, :yes_no, poll: poll)
 
       login_as(create(:user, :level_two))
       visit poll_path(poll)
 
       within("#poll_question_#{question.id}_answers") do
-        expect(page).to have_link("Han Solo")
-        expect(page).to have_link("Chewbacca")
+        expect(page).to have_link("Yes")
+        expect(page).to have_link("No")
       end
     end
 
     scenario "Level 2 users who have already answered" do
-      question = create(:poll_question, poll: poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Han Solo")
-      answer2 = create(:poll_question_answer, question: question, title: "Chewbacca")
+      question = create(:poll_question, :yes_no, poll: poll)
       user = create(:user, :level_two)
-      create(:poll_answer, question: question, author: user, answer: "Chewbacca")
+      create(:poll_answer, question: question, author: user, answer: "No")
 
       login_as user
       visit poll_path(poll)
 
       within("#poll_question_#{question.id}_answers") do
-        expect(page).to have_link("Han Solo")
-        expect(page).to have_link("Chewbacca")
+        expect(page).to have_link("Yes")
+        expect(page).to have_link("No")
       end
     end
 
@@ -311,20 +295,17 @@ describe "Polls" do
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 
-      question = create(:poll_question, poll: poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Han Solo")
-      answer2 = create(:poll_question_answer, question: question, title: "Chewbacca")
-
+      question = create(:poll_question, :yes_no, poll: poll)
       user = create(:user, :level_two, geozone: geozone)
 
       login_as user
       visit poll_path(poll)
 
       within("#poll_question_#{question.id}_answers") do
-        click_link "Han Solo"
+        click_link "Yes"
 
-        expect(page).not_to have_link("Han Solo")
-        expect(page).to have_link("Chewbacca")
+        expect(page).not_to have_link("Yes")
+        expect(page).to have_link("No")
       end
     end
 
@@ -332,25 +313,22 @@ describe "Polls" do
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 
-      question = create(:poll_question, poll: poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Han Solo")
-      answer2 = create(:poll_question_answer, question: question, title: "Chewbacca")
-
+      question = create(:poll_question, :yes_no, poll: poll)
       user = create(:user, :level_two, geozone: geozone)
 
       login_as user
       visit poll_path(poll)
 
       within("#poll_question_#{question.id}_answers") do
-        click_link "Han Solo"
+        click_link "Yes"
 
-        expect(page).not_to have_link("Han Solo")
-        expect(page).to have_link("Chewbacca")
+        expect(page).not_to have_link("Yes")
+        expect(page).to have_link("No")
 
-        click_link "Chewbacca"
+        click_link "No"
 
-        expect(page).not_to have_link("Chewbacca")
-        expect(page).to have_link("Han Solo")
+        expect(page).not_to have_link("No")
+        expect(page).to have_link("Yes")
       end
     end
 
@@ -358,40 +336,37 @@ describe "Polls" do
       poll.update(geozone_restricted: true)
       poll.geozones << geozone
 
-      question = create(:poll_question, poll: poll)
-      answer1 = create(:poll_question_answer, question: question, title: "Han Solo")
-      answer2 = create(:poll_question_answer, question: question, title: "Chewbacca")
-
+      question = create(:poll_question, :yes_no, poll: poll)
       user = create(:user, :level_two, geozone: geozone)
 
       login_as user
       visit poll_path(poll)
 
       within("#poll_question_#{question.id}_answers") do
-        click_link "Han Solo"
+        click_link "Yes"
 
-        expect(page).not_to have_link("Han Solo")
-        expect(page).to have_link("Chewbacca")
+        expect(page).not_to have_link("Yes")
+        expect(page).to have_link("No")
       end
 
       click_link "Sign out"
       login_as user
       visit poll_path(poll)
       within("#poll_question_#{question.id}_answers") do
-        click_link "Han Solo"
+        click_link "Yes"
 
-        expect(page).not_to have_link("Han Solo")
-        expect(page).to have_link("Chewbacca")
+        expect(page).not_to have_link("Yes")
+        expect(page).to have_link("No")
       end
 
       click_link "Sign out"
       login_as user
       visit poll_path(poll)
       within("#poll_question_#{question.id}_answers") do
-        click_link "Chewbacca"
+        click_link "No"
 
-        expect(page).not_to have_link("Chewbacca")
-        expect(page).to have_link("Han Solo")
+        expect(page).not_to have_link("No")
+        expect(page).to have_link("Yes")
       end
     end
   end
@@ -407,9 +382,7 @@ describe "Polls" do
       create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
       booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
       create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.current)
-      question = create(:poll_question, poll: poll)
-      create(:poll_question_answer, question: question, title: "Han Solo")
-      create(:poll_question_answer, question: question, title: "Chewbacca")
+      question = create(:poll_question, :yes_no, poll: poll)
       user = create(:user, :level_two, :in_census)
 
       login_as(officer.user)
@@ -427,11 +400,11 @@ describe "Polls" do
       expect(page).to have_content "You have already participated in a physical booth. You can not participate again."
 
       within("#poll_question_#{question.id}_answers") do
-        expect(page).to have_content("Han Solo")
-        expect(page).to have_content("Chewbacca")
+        expect(page).to have_content("Yes")
+        expect(page).to have_content("No")
 
-        expect(page).not_to have_link("Han Solo")
-        expect(page).not_to have_link("Chewbacca")
+        expect(page).not_to have_link("Yes")
+        expect(page).not_to have_link("No")
       end
     end
 

--- a/spec/features/polls/votation_type_spec.rb
+++ b/spec/features/polls/votation_type_spec.rb
@@ -15,7 +15,7 @@ describe "Poll Votation Type" do
     end
 
     scenario "response question without votation type" do
-      question = create(:poll_question, :with_answers, poll: poll_current)
+      question = create(:poll_question, :yes_no, poll: poll_current)
       visit poll_path(poll_current)
 
       expect(page).to have_content(question.title)

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 describe "Proposal Notifications" do
 
   scenario "Send a notification" do
-    author = create(:user)
-    create(:proposal, author: author)
+    author = create(:user, :with_proposal)
 
     login_as(author)
     visit root_path

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -114,8 +114,7 @@ describe "Proposals" do
 
     scenario "Index should show proposal descriptive image only when is defined" do
       proposal = create(:proposal)
-      proposal_with_image = create(:proposal)
-      image = create(:image, imageable: proposal_with_image)
+      proposal_with_image = create(:proposal, :with_image)
 
       visit proposals_path
 

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -116,7 +116,7 @@ describe "Users" do
 
     scenario "Show alert when user wants to delete a budget investment", :js do
       user = create(:user, :level_two)
-      budget = create(:budget, phase: "accepting")
+      budget = create(:budget, :accepting)
       budget_investment = create(:budget_investment, author_id: user.id, budget: budget)
 
       login_as(user)

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -210,9 +210,9 @@ describe "Valuation budget investments" do
     scenario "Index filtering by valuation status" do
       valuating = create(:budget_investment, :visible_to_valuators, budget: budget,
                                                                     title: "Ongoing valuation")
-      valuated  = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                    title: "Old idea",
-                                                                    valuation_finished: true)
+      valuated  = create(:budget_investment, :visible_to_valuators, :finished,
+                                                                    budget: budget,
+                                                                    title: "Old idea")
       valuating.valuators << valuator
       valuated.valuators << valuator
 

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -241,7 +241,7 @@ describe "Valuation budget investments" do
       create(:valuator, user: create(:user, username: "Rick", email: "rick@valuators.org"))
     end
     let(:investment) do
-      create(:budget_investment, budget: budget, price: 1234, feasibility: "unfeasible",
+      create(:budget_investment, :unfeasible, budget: budget, price: 1234,
                                  unfeasibility_explanation: "It is impossible",
                                  administrator: administrator,)
     end

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -156,11 +156,8 @@ describe "Consul Schema" do
     end
 
     it "does not link author if public activity is set to false" do
-      visible_author = create(:user, public_activity: true)
-      hidden_author  = create(:user, public_activity: false)
-
-      visible_proposal = create(:proposal, author: visible_author)
-      hidden_proposal  = create(:proposal, author: hidden_author)
+      visible_author = create(:user, :with_proposal, public_activity: true)
+      hidden_author  = create(:user, :with_proposal, public_activity: false)
 
       response = execute("{ proposals { edges { node { public_author { username } } } } }")
       received_authors = extract_fields(response, "proposals", "public_author.username")
@@ -228,11 +225,8 @@ describe "Consul Schema" do
     end
 
     it "does not link author if public activity is set to false" do
-      visible_author = create(:user, public_activity: true)
-      hidden_author  = create(:user, public_activity: false)
-
-      visible_debate = create(:debate, author: visible_author)
-      hidden_debate  = create(:debate, author: hidden_author)
+      visible_author = create(:user, :with_debate, public_activity: true)
+      hidden_author  = create(:user, :with_debate, public_activity: false)
 
       response = execute("{ debates { edges { node { public_author { username } } } } }")
       received_authors = extract_fields(response, "debates", "public_author.username")
@@ -291,11 +285,8 @@ describe "Consul Schema" do
     end
 
     it "does not link author if public activity is set to false" do
-      visible_author = create(:user, public_activity: true)
-      hidden_author  = create(:user, public_activity: false)
-
-      visible_comment = create(:comment, author: visible_author)
-      hidden_comment  = create(:comment, author: hidden_author)
+      visible_author = create(:user, :with_comment, public_activity: true)
+      hidden_author  = create(:user, :with_comment, public_activity: false)
 
       response = execute("{ comments { edges { node { public_author { username } } } } }")
       received_authors = extract_fields(response, "comments", "public_author.username")

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -305,7 +305,7 @@ describe "Consul Schema" do
 
     it "does not include hidden comments" do
       visible_comment = create(:comment)
-      hidden_comment  = create(:comment, hidden_at: Time.current)
+      hidden_comment  = create(:comment, :hidden)
 
       response = execute("{ comments { edges { node { body } } } }")
       received_comments = extract_fields(response, "comments", "body")
@@ -315,7 +315,7 @@ describe "Consul Schema" do
 
     it "does not include comments from hidden proposals" do
       visible_proposal = create(:proposal)
-      hidden_proposal  = create(:proposal, hidden_at: Time.current)
+      hidden_proposal  = create(:proposal, :hidden)
 
       visible_proposal_comment = create(:comment, commentable: visible_proposal)
       hidden_proposal_comment  = create(:comment, commentable: hidden_proposal)
@@ -328,7 +328,7 @@ describe "Consul Schema" do
 
     it "does not include comments from hidden debates" do
       visible_debate = create(:debate)
-      hidden_debate  = create(:debate, hidden_at: Time.current)
+      hidden_debate  = create(:debate, :hidden)
 
       visible_debate_comment = create(:comment, commentable: visible_debate)
       hidden_debate_comment  = create(:comment, commentable: hidden_debate)
@@ -341,7 +341,7 @@ describe "Consul Schema" do
 
     it "does not include comments from hidden polls" do
       visible_poll = create(:poll)
-      hidden_poll  = create(:poll, hidden_at: Time.current)
+      hidden_poll  = create(:poll, :hidden)
 
       visible_poll_comment = create(:comment, commentable: visible_poll)
       hidden_poll_comment  = create(:comment, commentable: hidden_poll)
@@ -575,7 +575,7 @@ describe "Consul Schema" do
 
     it "does not include votes of hidden proposals" do
       visible_proposal = create(:proposal)
-      hidden_proposal  = create(:proposal, hidden_at: Time.current)
+      hidden_proposal  = create(:proposal, :hidden)
 
       visible_proposal_vote = create(:vote, votable: visible_proposal)
       hidden_proposal_vote  = create(:vote, votable: hidden_proposal)
@@ -588,7 +588,7 @@ describe "Consul Schema" do
 
     it "does not include votes of hidden comments" do
       visible_comment = create(:comment)
-      hidden_comment  = create(:comment, hidden_at: Time.current)
+      hidden_comment  = create(:comment, :hidden)
 
       visible_comment_vote = create(:vote, votable: visible_comment)
       hidden_comment_vote  = create(:vote, votable: hidden_comment)

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -76,8 +76,8 @@ describe Abilities::Administrator do
   it { should be_able_to(:update, Budget::Investment) }
   it { should be_able_to(:hide,   Budget::Investment) }
 
-  it { should be_able_to(:valuate, create(:budget_investment, budget: create(:budget, phase: "valuating"))) }
-  it { should be_able_to(:valuate, create(:budget_investment, budget: create(:budget, phase: "finished"))) }
+  it { should be_able_to(:valuate, create(:budget_investment, budget: create(:budget, :valuating))) }
+  it { should be_able_to(:valuate, create(:budget_investment, budget: create(:budget, :finished))) }
 
   it { should be_able_to(:destroy, proposal_image) }
   it { should be_able_to(:destroy, proposal_document) }

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -15,10 +15,10 @@ describe Abilities::Common do
   let(:own_comment)  { create(:comment,  author: user) }
   let(:own_proposal) { create(:proposal, author: user) }
 
-  let(:accepting_budget) { create(:budget, phase: "accepting") }
-  let(:reviewing_budget) { create(:budget, phase: "reviewing") }
-  let(:selecting_budget) { create(:budget, phase: "selecting") }
-  let(:balloting_budget) { create(:budget, phase: "balloting") }
+  let(:accepting_budget) { create(:budget, :accepting) }
+  let(:reviewing_budget) { create(:budget, :reviewing) }
+  let(:selecting_budget) { create(:budget, :selecting) }
+  let(:balloting_budget) { create(:budget, :balloting) }
 
   let(:investment_in_accepting_budget) { create(:budget_investment, budget: accepting_budget) }
   let(:investment_in_reviewing_budget) { create(:budget_investment, budget: reviewing_budget) }

--- a/spec/models/abilities/everyone_spec.rb
+++ b/spec/models/abilities/everyone_spec.rb
@@ -71,7 +71,7 @@ describe Abilities::Everyone do
 
   context "when accessing budget results" do
     context "budget is not finished" do
-      let(:budget) { create(:budget, phase: "reviewing_ballots", results_enabled: true) }
+      let(:budget) { create(:budget, :reviewing_ballots, results_enabled: true) }
 
       it { should_not be_able_to(:read_results, budget) }
     end
@@ -91,19 +91,19 @@ describe Abilities::Everyone do
 
   context "when accessing budget stats" do
     context "supports phase is not finished" do
-      let(:budget) { create(:budget, phase: "selecting", stats_enabled: true) }
+      let(:budget) { create(:budget, :selecting, stats_enabled: true) }
 
       it { should_not be_able_to(:read_stats, budget) }
     end
 
     context "supports phase is finished" do
-      let(:budget) { create(:budget, phase: "valuating", stats_enabled: true) }
+      let(:budget) { create(:budget, :valuating, stats_enabled: true) }
 
       it { should be_able_to(:read_stats, budget) }
     end
 
     context "stats disabled" do
-      let(:budget) { create(:budget, phase: "valuating", stats_enabled: false) }
+      let(:budget) { create(:budget, :valuating, stats_enabled: false) }
 
       it { should_not be_able_to(:read_stats, budget) }
     end

--- a/spec/models/abilities/valuator_spec.rb
+++ b/spec/models/abilities/valuator_spec.rb
@@ -8,9 +8,9 @@ describe Abilities::Valuator do
   let(:valuator) { create(:valuator) }
   let(:group) { create(:valuator_group) }
   let(:non_assigned_investment) { create(:budget_investment) }
-  let(:assigned_investment) { create(:budget_investment, budget: create(:budget, phase: "valuating")) }
-  let(:group_assigned_investment) { create(:budget_investment, budget: create(:budget, phase: "valuating")) }
-  let(:finished_assigned_investment) { create(:budget_investment, budget: create(:budget, phase: "finished")) }
+  let(:assigned_investment) { create(:budget_investment, budget: create(:budget, :valuating)) }
+  let(:group_assigned_investment) { create(:budget_investment, budget: create(:budget, :valuating)) }
+  let(:finished_assigned_investment) { create(:budget_investment, budget: create(:budget, :finished)) }
 
   before do
     assigned_investment.valuators << valuator

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -130,7 +130,7 @@ describe Budget::Investment do
 
   describe "#should_show_votes?" do
     it "returns true in selecting phase" do
-      budget = create(:budget, phase: "selecting")
+      budget = create(:budget, :selecting)
       investment = create(:budget_investment, budget: budget)
 
       expect(investment.should_show_votes?).to eq(true)
@@ -148,7 +148,7 @@ describe Budget::Investment do
 
   describe "#should_show_vote_count?" do
     it "returns true in valuating phase" do
-      budget = create(:budget, phase: "valuating")
+      budget = create(:budget, :valuating)
       investment = create(:budget_investment, budget: budget)
 
       expect(investment.should_show_vote_count?).to eq(true)
@@ -166,14 +166,14 @@ describe Budget::Investment do
 
   describe "#should_show_ballots?" do
     it "returns true in balloting phase for selected investments" do
-      budget = create(:budget, phase: "balloting")
+      budget = create(:budget, :balloting)
       investment = create(:budget_investment, :selected, budget: budget)
 
       expect(investment.should_show_ballots?).to eq(true)
     end
 
     it "returns false for unselected investments" do
-      budget = create(:budget, phase: "balloting")
+      budget = create(:budget, :balloting)
       investment = create(:budget_investment, :unselected, budget: budget)
 
       expect(investment.should_show_ballots?).to eq(false)
@@ -1050,7 +1050,7 @@ describe Budget::Investment do
 
   describe "Reclassification" do
 
-    let(:budget)   { create(:budget, phase: "balloting")   }
+    let(:budget)   { create(:budget, :balloting)   }
     let(:group)    { create(:budget_group, budget: budget) }
     let(:heading1) { create(:budget_heading, group: group) }
     let(:heading2) { create(:budget_heading, group: group) }
@@ -1189,7 +1189,7 @@ describe Budget::Investment do
   end
 
   describe "scoped_filter" do
-    let(:budget)   { create(:budget, phase: "balloting")   }
+    let(:budget)   { create(:budget, :balloting)   }
     let(:investment) { create(:budget_investment, budget: budget) }
 
     describe "with without_admin filter" do

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -1228,10 +1228,7 @@ describe Budget::Investment do
       let(:params) { { advanced_filters: ["under_valuation"], budget_id: budget.id } }
       it "returns only investment under valuation" do
         valuator1 = create(:valuator)
-        investment1 = create(:budget_investment,
-          :with_administrator,
-          valuation_finished: false,
-          budget: budget)
+        investment1 = create(:budget_investment, :with_administrator, :unfinished, budget: budget)
         investment1.valuators << valuator1
         create(:budget_investment, :with_administrator, budget: budget)
         create(:budget_investment, budget: budget)

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -262,9 +262,8 @@ describe Budget::Investment do
   describe "#should_show_unfeasibility_explanation?" do
     let(:budget) { create(:budget) }
     let(:investment) do
-      create(:budget_investment, budget: budget,
+      create(:budget_investment, :finished, budget: budget,
              unfeasibility_explanation: "because of reasons",
-             valuation_finished: true,
              feasibility: "unfeasible")
     end
 
@@ -401,7 +400,7 @@ describe Budget::Investment do
   describe "scopes" do
     describe "valuation_open" do
       it "returns all investments with false valuation_finished" do
-        investment1 = create(:budget_investment, valuation_finished: true)
+        investment1 = create(:budget_investment, :finished)
         investment2 = create(:budget_investment)
 
         valuation_open = Budget::Investment.valuation_open
@@ -412,7 +411,7 @@ describe Budget::Investment do
 
     describe "without_admin" do
       it "returns all open investments without assigned admin" do
-        investment1 = create(:budget_investment, valuation_finished: true)
+        investment1 = create(:budget_investment, :finished)
         investment2 = create(:budget_investment, :with_administrator)
         investment3 = create(:budget_investment)
 
@@ -425,7 +424,7 @@ describe Budget::Investment do
     describe "managed" do
       it "returns all open investments with assigned admin but without assigned valuators" do
         investment1 = create(:budget_investment, :with_administrator)
-        investment2 = create(:budget_investment, :with_administrator, valuation_finished: true)
+        investment2 = create(:budget_investment, :with_administrator, :finished)
         investment3 = create(:budget_investment, :with_administrator)
         investment1.valuators << create(:valuator)
 
@@ -439,7 +438,7 @@ describe Budget::Investment do
       it "returns all investments with assigned valuator but valuation not finished" do
         investment1 = create(:budget_investment)
         investment2 = create(:budget_investment)
-        investment3 = create(:budget_investment, valuation_finished: true)
+        investment3 = create(:budget_investment, :finished)
 
         investment2.valuators << create(:valuator)
         investment3.valuators << create(:valuator)
@@ -452,7 +451,7 @@ describe Budget::Investment do
       it "returns all investments with assigned valuator groups but valuation not finished" do
         investment1 = create(:budget_investment)
         investment2 = create(:budget_investment)
-        investment3 = create(:budget_investment, valuation_finished: true)
+        investment3 = create(:budget_investment, :finished)
 
         investment2.valuator_groups << create(:valuator_group)
         investment3.valuator_groups << create(:valuator_group)
@@ -467,7 +466,7 @@ describe Budget::Investment do
       it "returns all investments with valuation finished" do
         investment1 = create(:budget_investment)
         investment2 = create(:budget_investment)
-        investment3 = create(:budget_investment, valuation_finished: true)
+        investment3 = create(:budget_investment, :finished)
 
         investment2.valuators << create(:valuator)
         investment3.valuators << create(:valuator)
@@ -1262,13 +1261,8 @@ describe Budget::Investment do
     describe "with winners filter" do
       let(:params) { { advanced_filters: ["winners"], budget_id: budget.id } }
       it "returns only investment winners" do
-        investment1 = create(:budget_investment,
-          :winner,
-          valuation_finished: true,
-          budget: budget)
-        create(:budget_investment,
-          :with_administrator,
-          budget: budget)
+        investment1 = create(:budget_investment, :winner, :finished, budget: budget)
+        create(:budget_investment, :with_administrator, budget: budget)
         create(:budget_investment, budget: budget)
 
         expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment1])

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -262,9 +262,7 @@ describe Budget::Investment do
   describe "#should_show_unfeasibility_explanation?" do
     let(:budget) { create(:budget) }
     let(:investment) do
-      create(:budget_investment, :finished, budget: budget,
-             unfeasibility_explanation: "because of reasons",
-             feasibility: "unfeasible")
+      create(:budget_investment, :unfeasible, :finished, budget: budget)
     end
 
     it "returns true for unfeasible investments with unfeasibility explanation and valuation finished" do

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -413,7 +413,7 @@ describe Budget::Investment do
     describe "without_admin" do
       it "returns all open investments without assigned admin" do
         investment1 = create(:budget_investment, valuation_finished: true)
-        investment2 = create(:budget_investment, administrator: create(:administrator))
+        investment2 = create(:budget_investment, :with_administrator)
         investment3 = create(:budget_investment)
 
         without_admin = Budget::Investment.without_admin
@@ -424,9 +424,9 @@ describe Budget::Investment do
 
     describe "managed" do
       it "returns all open investments with assigned admin but without assigned valuators" do
-        investment1 = create(:budget_investment, administrator: create(:administrator))
-        investment2 = create(:budget_investment, administrator: create(:administrator), valuation_finished: true)
-        investment3 = create(:budget_investment, administrator: create(:administrator))
+        investment1 = create(:budget_investment, :with_administrator)
+        investment2 = create(:budget_investment, :with_administrator, valuation_finished: true)
+        investment3 = create(:budget_investment, :with_administrator)
         investment1.valuators << create(:valuator)
 
         managed = Budget::Investment.managed

--- a/spec/models/budget/stats_spec.rb
+++ b/spec/models/budget/stats_spec.rb
@@ -7,10 +7,10 @@ describe Budget::Stats do
 
   describe "#participants" do
     let(:author) { investment.author }
-    let(:author_and_voter) { create(:user, hidden_at: Time.current) }
+    let(:author_and_voter) { create(:user, :hidden) }
     let(:voter) { create(:user) }
     let(:voter_and_balloter) { create(:user) }
-    let(:balloter) { create(:user, hidden_at: Time.current) }
+    let(:balloter) { create(:user, :hidden) }
     let(:poll_balloter) { create(:user, :level_two) }
     let(:non_participant) { create(:user, :level_two) }
 

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -154,22 +154,22 @@ describe Budget do
   describe "#current" do
 
     it "returns nil if there is only one budget and it is still in drafting phase" do
-      budget = create(:budget, phase: "drafting")
+      create(:budget, :drafting)
 
       expect(Budget.current).to eq(nil)
     end
 
     it "returns the budget if there is only one and not in drafting phase" do
-      budget = create(:budget, phase: "accepting")
+      budget = create(:budget, :accepting)
 
       expect(Budget.current).to eq(budget)
     end
 
     it "returns the last budget created that is not in drafting phase" do
-      old_budget      = create(:budget, phase: "finished",  created_at: 2.years.ago)
-      previous_budget = create(:budget, phase: "accepting", created_at: 1.year.ago)
-      current_budget  = create(:budget, phase: "accepting", created_at: 1.month.ago)
-      next_budget     = create(:budget, phase: "drafting",  created_at: 1.week.ago)
+      old_budget      = create(:budget, :finished,  created_at: 2.years.ago)
+      previous_budget = create(:budget, :accepting, created_at: 1.year.ago)
+      current_budget  = create(:budget, :accepting, created_at: 1.month.ago)
+      next_budget     = create(:budget, :drafting,  created_at: 1.week.ago)
 
       expect(Budget.current).to eq(current_budget)
     end

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -131,11 +131,8 @@ describe Newsletter do
       valid_email = "john@gmail.com"
       invalid_email = "john@gmail..com"
 
-      valid_email_user = create(:user, email: valid_email)
-      proposal = create(:proposal, author: valid_email_user)
-
-      invalid_email_user = create(:user, email: invalid_email)
-      proposal = create(:proposal, author: invalid_email_user)
+      valid_email_user = create(:user, :with_proposal, email: valid_email)
+      invalid_email_user = create(:user, :with_proposal, email: invalid_email)
 
       newsletter.deliver
 

--- a/spec/models/poll/answer_spec.rb
+++ b/spec/models/poll/answer_spec.rb
@@ -43,7 +43,7 @@ describe Poll::Answer do
 
     let(:author) { create(:user, :level_two) }
     let(:poll) { create(:poll) }
-    let(:question) { create(:poll_question, :with_answers, poll: poll) }
+    let(:question) { create(:poll_question, :yes_no, poll: poll) }
 
     it "creates a poll_voter with user and poll data" do
       answer = create(:poll_answer, question: question, author: author, answer: "Yes")

--- a/spec/models/poll/ballot_sheet_spec.rb
+++ b/spec/models/poll/ballot_sheet_spec.rb
@@ -39,8 +39,7 @@ describe Poll::BallotSheet do
 
   describe "#verify_ballots" do
     it "creates ballots for each document number" do
-      budget = create(:budget)
-      poll = create(:poll, budget: budget)
+      poll = create(:poll, :for_budget)
       poll_ballot = create(:poll_ballot_sheet, poll: poll, data: "1,2,3;4,5,6")
       poll_ballot.verify_ballots
 

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -346,11 +346,9 @@ describe Poll do
     describe "#not_budget" do
 
       it "returns polls not associated to a budget" do
-        budget = create(:budget)
-
         poll1 = create(:poll)
         poll2 = create(:poll)
-        poll3 = create(:poll, budget: budget)
+        poll3 = create(:poll, :for_budget)
 
         expect(Poll.not_budget).to include(poll1)
         expect(Poll.not_budget).to include(poll2)

--- a/spec/models/poll/stats_spec.rb
+++ b/spec/models/poll/stats_spec.rb
@@ -7,7 +7,7 @@ describe Poll::Stats do
   describe "#participants" do
     it "includes hidden users" do
       create(:poll_voter, poll: poll)
-      create(:poll_voter, poll: poll, user: create(:user, :level_two, hidden_at: Time.current))
+      create(:poll_voter, poll: poll, user: create(:user, :level_two, :hidden))
 
       expect(stats.participants.count).to eq(2)
     end

--- a/spec/shared/features/admin_milestoneable.rb
+++ b/spec/shared/features/admin_milestoneable.rb
@@ -7,8 +7,7 @@ shared_examples "admin_milestoneable" do |factory_name, path_name|
 
     context "Index" do
       scenario "Displaying milestones" do
-        milestone = create(:milestone, milestoneable: milestoneable)
-        create(:image, imageable: milestone)
+        milestone = create(:milestone, :with_image, milestoneable: milestoneable)
         document = create(:document, documentable: milestone)
 
         visit path
@@ -85,8 +84,7 @@ shared_examples "admin_milestoneable" do |factory_name, path_name|
 
     context "Edit" do
       scenario "Change title, description and document names" do
-        milestone = create(:milestone, milestoneable: milestoneable)
-        create(:image, imageable: milestone)
+        milestone = create(:milestone, :with_image, milestoneable: milestoneable)
         document = create(:document, documentable: milestone)
 
         visit path


### PR DESCRIPTION
## Objectives

* Make specs easier to read
* Use existing traits to make specs more consistent
* Reduce the number of unused variable warnings given by the Ruby interpreter
