### PR TITLE
Simplify data creation in poll factories

### DIFF
--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -145,8 +145,14 @@ FactoryBot.define do
 
   factory :poll_officer_assignment, class: "Poll::OfficerAssignment" do
     association :officer, factory: :poll_officer
-    association :booth_assignment, factory: :poll_booth_assignment
     date { Date.current }
+
+    transient { poll { association(:poll) } }
+    transient { booth { association(:poll_booth) } }
+
+    booth_assignment do
+      association :poll_booth_assignment, poll: poll, booth: booth
+    end
 
     trait :final do
       final { true }

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -118,9 +118,8 @@ describe "Admin booths assignments" do
     end
 
     scenario "Unassing booth whith associated shifts", :js do
-      assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
       officer = create(:poll_officer)
-      create(:poll_officer_assignment, officer: officer, booth_assignment: assignment)
+      create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
       create(:poll_shift, booth: booth, officer: officer)
 
       visit manage_admin_poll_booth_assignments_path(poll)
@@ -157,12 +156,10 @@ describe "Admin booths assignments" do
     scenario "Lists all assigned poll officers" do
       poll = create(:poll)
       booth = create(:poll_booth)
-      booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-      officer_assignment = create(:poll_officer_assignment, booth_assignment: booth_assignment)
+      officer_assignment = create(:poll_officer_assignment, poll: poll, booth: booth)
       officer = officer_assignment.officer
 
-      booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
-      officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment_2)
+      officer_assignment_2 = create(:poll_officer_assignment, poll: poll)
       officer_2 = officer_assignment_2.officer
 
       visit admin_poll_path(poll)

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -137,8 +137,7 @@ describe "Admin booths assignments" do
     end
 
     scenario "Cannot unassing booth if poll is expired" do
-      poll_expired = create(:poll, :expired)
-      create(:poll_booth_assignment, poll: poll_expired, booth: booth)
+      poll_expired = create(:poll, :expired, booths: [booth])
 
       visit manage_admin_poll_booth_assignments_path(poll_expired)
 

--- a/spec/features/admin/poll/booths_spec.rb
+++ b/spec/features/admin/poll/booths_spec.rb
@@ -37,14 +37,8 @@ describe "Admin booths" do
   end
 
   scenario "Available" do
-    booth_for_current_poll  = create(:poll_booth)
-    booth_for_expired_poll  = create(:poll_booth)
-
-    current_poll  = create(:poll, :current)
-    expired_poll  = create(:poll, :expired)
-
-    create(:poll_booth_assignment, poll: current_poll,  booth: booth_for_current_poll)
-    create(:poll_booth_assignment, poll: expired_poll,  booth: booth_for_expired_poll)
+    booth_for_current_poll = create(:poll_booth, polls: [create(:poll, :current)])
+    booth_for_expired_poll = create(:poll_booth, polls: [create(:poll, :expired)])
 
     visit admin_root_path
 
@@ -85,8 +79,7 @@ describe "Admin booths" do
 
   scenario "Edit" do
     poll = create(:poll, :current)
-    booth = create(:poll_booth)
-    assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    booth = create(:poll_booth, polls: [poll])
 
     visit admin_booths_path
 
@@ -111,8 +104,7 @@ describe "Admin booths" do
 
   scenario "Back link go back to available list when manage shifts" do
     poll = create(:poll, :current)
-    booth = create(:poll_booth)
-    assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    booth = create(:poll_booth, polls: [poll])
 
     visit available_admin_booths_path
 

--- a/spec/features/admin/poll/officer_assignments_spec.rb
+++ b/spec/features/admin/poll/officer_assignments_spec.rb
@@ -9,17 +9,13 @@ describe "Officer Assignments" do
 
   scenario "Index" do
     poll = create(:poll)
-    booth = create(:poll_booth)
 
     officer1 = create(:poll_officer)
     officer2 = create(:poll_officer)
     officer3 = create(:poll_officer)
 
-    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-    officer_assignment = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer1)
-
-    booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
-    officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer2)
+    officer_assignment = create(:poll_officer_assignment, poll: poll, officer: officer1)
+    officer_assignment_2 = create(:poll_officer_assignment, poll: poll, officer: officer2)
 
     visit admin_poll_path(poll)
 
@@ -34,7 +30,6 @@ describe "Officer Assignments" do
 
   scenario "Search", :js do
     poll = create(:poll)
-    booth = create(:poll_booth)
 
     user1 = create(:user, username: "John Snow")
     user2 = create(:user, username: "John Silver")
@@ -44,11 +39,8 @@ describe "Officer Assignments" do
     officer2 = create(:poll_officer, user: user2)
     officer3 = create(:poll_officer, user: user3)
 
-    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-    officer_assignment = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer1)
-
-    booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
-    officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer2)
+    officer_assignment = create(:poll_officer_assignment, poll: poll, officer: officer1)
+    officer_assignment_2 = create(:poll_officer_assignment, poll: poll, officer: officer2)
 
     visit admin_poll_path(poll)
 

--- a/spec/features/admin/poll/shifts_spec.rb
+++ b/spec/features/admin/poll/shifts_spec.rb
@@ -34,9 +34,7 @@ describe "Admin shifts" do
   scenario "Create Vote Collection Shift and Recount & Scrutiny Shift on same date", :js do
     create(:poll)
     poll = create(:poll, :current)
-    booth = create(:poll_booth)
-    create(:poll_booth_assignment, poll: poll, booth: booth)
-    create(:poll_booth_assignment, poll: create(:poll, :expired), booth: booth)
+    booth = create(:poll_booth, polls: [poll, create(:poll, :expired)])
     officer = create(:poll_officer)
     vote_collection_dates = (Date.current..poll.ends_at.to_date).to_a.map { |date| I18n.l(date, format: :long) }
     recount_scrutiny_dates = (poll.ends_at.to_date..poll.ends_at.to_date + 1.week).to_a.map { |date| I18n.l(date, format: :long) }
@@ -98,8 +96,7 @@ describe "Admin shifts" do
 
   scenario "Vote Collection Shift and Recount & Scrutiny Shift don't include already assigned dates to officer", :js do
     poll = create(:poll, :current)
-    booth = create(:poll_booth)
-    assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    booth = create(:poll_booth, polls: [poll])
     officer = create(:poll_officer)
 
     shift1 = create(:poll_shift, :vote_collection_task, officer: officer, booth: booth, date: Date.current)
@@ -149,8 +146,7 @@ describe "Admin shifts" do
 
   scenario "Error on create", :js do
     poll = create(:poll, :current)
-    booth = create(:poll_booth)
-    assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    booth = create(:poll_booth, polls: [poll])
     officer = create(:poll_officer)
 
     visit available_admin_booths_path
@@ -171,8 +167,7 @@ describe "Admin shifts" do
 
   scenario "Destroy" do
     poll = create(:poll, :current)
-    booth = create(:poll_booth)
-    assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    booth = create(:poll_booth, polls: [poll])
     officer = create(:poll_officer)
 
     shift = create(:poll_shift, officer: officer, booth: booth)

--- a/spec/features/budget_polls/ballot_sheets_spec.rb
+++ b/spec/features/budget_polls/ballot_sheets_spec.rb
@@ -2,13 +2,12 @@ require "rails_helper"
 
 describe "Poll budget ballot sheets" do
   let(:poll) { create(:poll, :for_budget, ends_at: 1.day.ago) }
-  let(:booth) { create(:poll_booth) }
+  let(:booth) { create(:poll_booth, polls: [poll]) }
   let(:poll_officer) { create(:poll_officer) }
 
   context "Officing recounts and results view" do
 
     before do
-      create(:poll_booth_assignment, poll: poll, booth: booth)
       create(:poll_shift, :recount_scrutiny_task, officer: poll_officer, booth: booth,
                                                   date: Date.current)
       create(:poll_officer_assignment, officer: poll_officer)
@@ -44,7 +43,6 @@ describe "Poll budget ballot sheets" do
     end
 
     scenario "Access ballot sheets officing with one booth assignment" do
-      create(:poll_booth_assignment, poll: poll, booth: booth)
       create(:poll_shift, :recount_scrutiny_task, officer: poll_officer, booth: booth,
                                                   date: Date.current)
       create(:poll_officer_assignment, officer: poll_officer)
@@ -58,9 +56,7 @@ describe "Poll budget ballot sheets" do
     end
 
     scenario "Access ballot sheets officing with multiple booth assignments", :with_frozen_time do
-      booth_2 = create(:poll_booth)
-      create(:poll_booth_assignment, poll: poll, booth: booth)
-      create(:poll_booth_assignment, poll: poll, booth: booth_2)
+      booth_2 = create(:poll_booth, polls: [poll])
       create(:poll_shift, :recount_scrutiny_task, officer: poll_officer, booth: booth,
                                                   date: Date.current)
       create(:poll_shift, :recount_scrutiny_task, officer: poll_officer, booth: booth_2,
@@ -80,7 +76,6 @@ describe "Poll budget ballot sheets" do
   context "Index" do
 
     before do
-      create(:poll_booth_assignment, poll: poll, booth: booth)
       create(:poll_shift, :recount_scrutiny_task, officer: poll_officer, booth: booth,
                                                   date: Date.current)
 
@@ -102,7 +97,6 @@ describe "Poll budget ballot sheets" do
   context "New" do
 
     before do
-      create(:poll_booth_assignment, poll: poll, booth: booth)
       create(:poll_shift, :recount_scrutiny_task, officer: poll_officer, booth: booth,
                                                   date: Date.current)
       create(:poll_officer_assignment, officer: poll_officer)
@@ -150,7 +144,6 @@ describe "Poll budget ballot sheets" do
   context "Show" do
 
     before do
-      create(:poll_booth_assignment, poll: poll, booth: booth)
       create(:poll_shift, :recount_scrutiny_task, officer: poll_officer, booth: booth,
                                                   date: Date.current)
 

--- a/spec/features/budget_polls/voter_spec.rb
+++ b/spec/features/budget_polls/voter_spec.rb
@@ -11,8 +11,7 @@ describe "BudgetPolls", :with_frozen_time do
 
   before do
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
-    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth, date: Date.current)
   end
 
   context "Offline" do

--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -25,8 +25,7 @@ describe "Booth", :with_frozen_time do
 
     booth = create(:poll_booth)
 
-    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth, date: Date.current)
 
     login_through_form_as_officer(officer.user)
 
@@ -42,11 +41,8 @@ describe "Booth", :with_frozen_time do
     booth1 = create(:poll_booth)
     booth2 = create(:poll_booth)
 
-    ba1 = create(:poll_booth_assignment, poll: poll, booth: booth1)
-    ba2 = create(:poll_booth_assignment, poll: poll, booth: booth2)
-
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.current)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth1, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth2, date: Date.current)
 
     login_through_form_as_officer(officer.user)
 
@@ -69,13 +65,9 @@ describe "Booth", :with_frozen_time do
     poll1 = create(:poll)
     poll2 = create(:poll)
 
-    ba1 = create(:poll_booth_assignment, poll: poll1, booth: booth1)
-    ba2 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
-    ba3 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
-
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.current)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.current)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba3, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, poll: poll1, booth: booth1, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, poll: poll2, booth: booth2, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, poll: poll2, booth: booth2, date: Date.current)
 
     login_through_form_as_officer(officer.user)
 

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -97,8 +97,7 @@ describe "Residence", :with_frozen_time do
     booth = create(:poll_booth)
     poll = create(:poll)
 
-    ba = create(:poll_booth_assignment, poll: poll, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba)
+    create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
     create(:poll_shift, officer: officer, booth: booth, date: Date.current)
 
     login_as(officer.user)

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -2,11 +2,10 @@ require "rails_helper"
 
 describe "Officing Results", :with_frozen_time do
   let(:poll) { create(:poll, ends_at: 1.day.ago) }
-  let(:booth) { create(:poll_booth) }
+  let(:booth) { create(:poll_booth, polls: [poll]) }
   let(:poll_officer) { create(:poll_officer) }
 
   before do
-    create(:poll_booth_assignment, poll: poll, booth: booth)
     create(:poll_shift, :recount_scrutiny_task, officer: poll_officer, booth: booth, date: Date.current)
     @question_1 = create(:poll_question, poll: poll)
     create(:poll_question_answer, title: "Yes", question: @question_1, given_order: 1)

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -10,8 +10,7 @@ describe "Voters" do
     login_as(officer.user)
     create(:geozone, :in_census)
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
-    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+    create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
     set_officing_booth(booth)
   end
 
@@ -38,8 +37,7 @@ describe "Voters" do
 
   scenario "Cannot vote" do
     unvotable_poll = create(:poll, :current, geozone_restricted: true, geozones: [create(:geozone, census_code: "02")])
-    booth_assignment = create(:poll_booth_assignment, poll: unvotable_poll, booth: booth)
-    officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+    officer_assignment = create(:poll_officer_assignment, officer: officer, poll: unvotable_poll, booth: booth)
 
     set_officing_booth(booth)
     visit new_officing_residence_path
@@ -53,8 +51,7 @@ describe "Voters" do
 
   scenario "Already voted" do
     poll2 = create(:poll, :current)
-    booth_assignment = create(:poll_booth_assignment, poll: poll2, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+    create(:poll_officer_assignment, officer: officer, poll: poll2, booth: booth)
 
     user = create(:user, :level_two)
     voter = create(:poll_voter, poll: poll, user: user)
@@ -90,8 +87,7 @@ describe "Voters" do
 
     scenario "Display current polls assigned to a booth" do
       poll = create(:poll, :current)
-      booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-      officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      officer_assignment = create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
 
       set_officing_booth(booth)
       visit new_officing_residence_path
@@ -103,8 +99,7 @@ describe "Voters" do
 
     scenario "Display polls that the user can vote" do
       votable_poll = create(:poll, :current, geozone_restricted: true, geozones: [Geozone.first])
-      booth_assignment = create(:poll_booth_assignment, poll: votable_poll, booth: booth)
-      officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      officer_assignment = create(:poll_officer_assignment, officer: officer, poll: votable_poll, booth: booth)
 
       set_officing_booth(booth)
       visit new_officing_residence_path
@@ -116,8 +111,7 @@ describe "Voters" do
 
     scenario "Display polls that the user cannot vote" do
       unvotable_poll = create(:poll, :current, geozone_restricted: true, geozones: [create(:geozone, census_code: "02")])
-      booth_assignment = create(:poll_booth_assignment, poll: unvotable_poll, booth: booth)
-      officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      officer_assignment = create(:poll_officer_assignment, officer: officer, poll: unvotable_poll, booth: booth)
 
       set_officing_booth(booth)
       visit new_officing_residence_path
@@ -129,8 +123,7 @@ describe "Voters" do
 
     scenario "Do not display expired polls" do
       expired_poll = create(:poll, :expired)
-      booth_assignment = create(:poll_booth_assignment, poll: expired_poll, booth: booth)
-      officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      officer_assignment = create(:poll_officer_assignment, officer: officer, poll: expired_poll, booth: booth)
 
       set_officing_booth(booth)
       visit new_officing_residence_path
@@ -147,11 +140,8 @@ describe "Voters" do
       booth1 = create(:poll_booth)
       booth2 = create(:poll_booth)
 
-      booth_assignment1 = create(:poll_booth_assignment, poll: poll1, booth: booth1)
-      booth_assignment2 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
-
-      officer_assignment1 = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment1)
-      officer_assignment2 = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment2)
+      officer_assignment1 = create(:poll_officer_assignment, officer: officer, poll: poll1, booth: booth1)
+      officer_assignment2 = create(:poll_officer_assignment, officer: officer, poll: poll2, booth: booth2)
 
       set_officing_booth(booth1)
       visit new_officing_residence_path

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -375,10 +375,8 @@ describe "Polls" do
     let(:officer) { create(:poll_officer) }
 
     scenario "Already voted on booth cannot vote on website", :js do
-
       create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
-      booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-      create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.current)
+      create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth, date: Date.current)
       question = create(:poll_question, :yes_no, poll: poll)
       user = create(:user, :level_two, :in_census)
 

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -15,8 +15,7 @@ describe "Voter" do
     before do
       create(:geozone, :in_census)
       create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
-      booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-      create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
     end
 
     scenario "Voting via web - Standard", :js do

--- a/spec/models/poll/booth_spec.rb
+++ b/spec/models/poll/booth_spec.rb
@@ -27,14 +27,8 @@ describe Poll::Booth do
   describe ".available" do
 
     it "returns booths associated to current polls" do
-      booth_for_current_poll  = create(:poll_booth)
-      booth_for_expired_poll  = create(:poll_booth)
-
-      current_poll  = create(:poll, :current)
-      expired_poll  = create(:poll, :expired)
-
-      create(:poll_booth_assignment, poll: current_poll,  booth: booth_for_current_poll)
-      create(:poll_booth_assignment, poll: expired_poll,  booth: booth_for_expired_poll)
+      booth_for_current_poll = create(:poll_booth, polls: [create(:poll, :current)])
+      booth_for_expired_poll = create(:poll_booth, polls: [create(:poll, :expired)])
 
       expect(Poll::Booth.available).to include(booth_for_current_poll)
       expect(Poll::Booth.available).not_to include(booth_for_expired_poll)

--- a/spec/models/poll/officer_spec.rb
+++ b/spec/models/poll/officer_spec.rb
@@ -38,13 +38,9 @@ describe Poll::Officer do
       poll_2 = create(:poll)
       poll_3 = create(:poll)
 
-      booth_assignment_1a = create(:poll_booth_assignment, poll: poll_1)
-      booth_assignment_1b = create(:poll_booth_assignment, poll: poll_1)
-      booth_assignment_2  = create(:poll_booth_assignment, poll: poll_2)
-
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_1a, officer: officer, date: poll_1.starts_at)
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_1b, officer: officer, date: poll_1.ends_at)
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer)
+      create(:poll_officer_assignment, poll: poll_1, officer: officer, date: poll_1.starts_at)
+      create(:poll_officer_assignment, poll: poll_1, officer: officer, date: poll_1.ends_at)
+      create(:poll_officer_assignment, poll: poll_2, officer: officer)
 
       assigned_polls = officer.voting_days_assigned_polls
 
@@ -57,11 +53,8 @@ describe Poll::Officer do
       poll_1 = create(:poll)
       poll_2 = create(:poll)
 
-      booth_assignment_1 = create(:poll_booth_assignment, poll: poll_1)
-      booth_assignment_2 = create(:poll_booth_assignment, poll: poll_2)
-
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_1, officer: officer, date: poll_1.starts_at)
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer, final: true)
+      create(:poll_officer_assignment, poll: poll_1, officer: officer, date: poll_1.starts_at)
+      create(:poll_officer_assignment, poll: poll_2, officer: officer, final: true)
 
       assigned_polls = officer.voting_days_assigned_polls
 
@@ -75,8 +68,8 @@ describe Poll::Officer do
       poll_2 = create(:poll, ends_at: 10.days.from_now)
       poll_3 = create(:poll, ends_at: 10.days.ago)
 
-      [poll_1, poll_2, poll_3].each do |p|
-        create(:poll_officer_assignment, officer: officer, booth_assignment: create(:poll_booth_assignment, poll: p))
+      [poll_1, poll_2, poll_3].each do |poll|
+        create(:poll_officer_assignment, officer: officer, poll: poll)
       end
 
       assigned_polls = officer.voting_days_assigned_polls
@@ -95,13 +88,9 @@ describe Poll::Officer do
       poll_2 = create(:poll)
       poll_3 = create(:poll)
 
-      booth_assignment_1a = create(:poll_booth_assignment, poll: poll_1)
-      booth_assignment_1b = create(:poll_booth_assignment, poll: poll_1)
-      booth_assignment_2  = create(:poll_booth_assignment, poll: poll_2)
-
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_1a, officer: officer, date: poll_1.starts_at, final: true)
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_1b, officer: officer, date: poll_1.ends_at, final: true)
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer, final: true)
+      create(:poll_officer_assignment, poll: poll_1, officer: officer, date: poll_1.starts_at, final: true)
+      create(:poll_officer_assignment, poll: poll_1, officer: officer, date: poll_1.ends_at, final: true)
+      create(:poll_officer_assignment, poll: poll_2, officer: officer, final: true)
 
       assigned_polls = officer.final_days_assigned_polls
 
@@ -114,11 +103,8 @@ describe Poll::Officer do
       poll_1 = create(:poll)
       poll_2 = create(:poll)
 
-      booth_assignment_1 = create(:poll_booth_assignment, poll: poll_1)
-      booth_assignment_2 = create(:poll_booth_assignment, poll: poll_2)
-
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_1, officer: officer, date: poll_1.starts_at)
-      create(:poll_officer_assignment, booth_assignment: booth_assignment_2, officer: officer, final: true)
+      create(:poll_officer_assignment, poll: poll_1, officer: officer, date: poll_1.starts_at)
+      create(:poll_officer_assignment, poll: poll_2, officer: officer, final: true)
 
       assigned_polls = officer.final_days_assigned_polls
 
@@ -132,8 +118,8 @@ describe Poll::Officer do
       poll_2 = create(:poll, ends_at: 10.days.from_now)
       poll_3 = create(:poll, ends_at: 10.days.ago)
 
-      [poll_1, poll_2, poll_3].each do |p|
-        create(:poll_officer_assignment, officer: officer, booth_assignment: create(:poll_booth_assignment, poll: p), final: true)
+      [poll_1, poll_2, poll_3].each do |poll|
+        create(:poll_officer_assignment, officer: officer, poll: poll, final: true)
       end
 
       assigned_polls = officer.final_days_assigned_polls


### PR DESCRIPTION
## References

* Inspired by commit 20b1085

## Objectives

* Make it easier to associate booths and poll officers to polls in specs
* Reduce the number of unused variable warnings given by the Ruby interpreter