### PR TITLE
Remove isolated useless assignments

### DIFF
--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -84,13 +84,13 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
                               }
                             ]
 
-      filters = investment_headings.inject(all_headings_filter) do |filters, heading|
-                  filters << {
-                               name: heading.name,
-                               id: heading.id,
-                               count: investments.select { |i| i.heading_id == heading.id }.size
-                             }
-                end
+      investment_headings.inject(all_headings_filter) do |filters, heading|
+        filters << {
+                     name: heading.name,
+                     id: heading.id,
+                     count: investments.select { |i| i.heading_id == heading.id }.size
+                   }
+      end
     end
 
     def params_for_current_valuator

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -41,17 +41,17 @@ module WelcomeHelper
   def calculate_centered(debates, proposals)
     if (debates.blank? && proposals.any?) ||
        (debates.any? && proposals.blank?)
-      centered = "medium-centered large-centered"
+      "medium-centered large-centered"
     end
   end
 
   def calculate_offset(debates, proposals, apply_offset)
     if debates.any? && proposals.any?
-      offset = if apply_offset
-                 "medium-offset-2 large-offset-2"
-               else
-                 "end"
-               end
+      if apply_offset
+        "medium-offset-2 large-offset-2"
+      else
+        "end"
+      end
     end
   end
 

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -67,7 +67,7 @@ describe "Account" do
              " complete the confirmation of your new email address."
     expect(page).to have_content notice
 
-    email = open_last_email
+    open_last_email
     visit_in_email("Confirm my account")
 
     logout

--- a/spec/features/admin/admin_notifications_spec.rb
+++ b/spec/features/admin/admin_notifications_spec.rb
@@ -3,9 +3,8 @@ require "rails_helper"
 describe "Admin Notifications" do
 
   before do
-    admin = create(:administrator)
-    login_as(admin.user)
     create(:budget)
+    login_as(create(:administrator).user)
   end
 
   context "Show" do

--- a/spec/features/admin/emails/newsletters_spec.rb
+++ b/spec/features/admin/emails/newsletters_spec.rb
@@ -3,9 +3,8 @@ require "rails_helper"
 describe "Admin newsletter emails" do
 
   before do
-    admin = create(:administrator)
-    login_as(admin.user)
     create(:budget)
+    login_as(create(:administrator).user)
   end
 
   context "Show" do

--- a/spec/features/admin/homepage/homepage_spec.rb
+++ b/spec/features/admin/homepage/homepage_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 describe "Homepage" do
 
   before do
-    admin = create(:administrator).user
-    login_as(admin)
-
     Setting["homepage.widgets.feeds.proposals"] = false
     Setting["homepage.widgets.feeds.debates"] = false
     Setting["homepage.widgets.feeds.processes"] = false
     Setting["feature.user.recommendations"] = false
+
+    admin = create(:administrator).user
+    login_as(admin)
   end
 
   let!(:proposals_feed)    { create(:widget_feed, kind: "proposals") }

--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -36,7 +36,7 @@ describe "Admin legislation draft versions" do
 
   context "Create" do
     scenario "Valid legislation draft version" do
-      process = create(:legislation_process, title: "An example legislation process")
+      create(:legislation_process, title: "An example legislation process")
 
       visit admin_root_path
 

--- a/spec/features/admin/legislation/questions_spec.rb
+++ b/spec/features/admin/legislation/questions_spec.rb
@@ -24,8 +24,8 @@ describe "Admin legislation questions" do
   context "Index" do
 
     scenario "Displaying legislation process questions" do
-      question = create(:legislation_question, process: process, title: "Question 1")
-      question = create(:legislation_question, process: process, title: "Question 2")
+      create(:legislation_question, process: process, title: "Question 1")
+      create(:legislation_question, process: process, title: "Question 2")
 
       visit admin_legislation_processes_path(filter: "all")
 
@@ -63,7 +63,7 @@ describe "Admin legislation questions" do
 
   context "Update" do
     scenario "Valid legislation question", :js do
-      question = create(:legislation_question, title: "Question 2", process: process)
+      create(:legislation_question, title: "Question 2", process: process)
 
       visit admin_root_path
 

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -79,7 +79,7 @@ describe "Admin booths assignments" do
     end
 
     scenario "Unassign booth from poll", :js do
-      assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+      create(:poll_booth_assignment, poll: poll, booth: booth)
 
       visit admin_poll_path(poll)
       within("#poll-resources") do

--- a/spec/features/admin/site_customization/content_blocks_spec.rb
+++ b/spec/features/admin/site_customization/content_blocks_spec.rb
@@ -42,7 +42,7 @@ describe "Admin custom content blocks" do
     end
 
     scenario "Invalid custom block" do
-      block = create(:site_customization_content_block)
+      create(:site_customization_content_block)
 
       visit admin_root_path
 
@@ -68,7 +68,8 @@ describe "Admin custom content blocks" do
 
   context "Update" do
     scenario "Valid custom block" do
-      block = create(:site_customization_content_block)
+      create(:site_customization_content_block)
+
       visit admin_root_path
 
       within("#side_menu") do

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -357,7 +357,7 @@ describe "Stats" do
   context "Polls" do
 
     scenario "Total participants by origin" do
-      oa = create(:poll_officer_assignment)
+      create(:poll_officer_assignment)
       3.times { create(:poll_voter, origin: "web") }
 
       visit admin_stats_path

--- a/spec/features/admin/tags_spec.rb
+++ b/spec/features/admin/tags_spec.rb
@@ -69,7 +69,8 @@ describe "Admin tags" do
 
   context "Manage only tags of kind category" do
     scenario "Index shows only categories" do
-      not_category_tag = create(:tag, name: "Not a category")
+      create(:tag, name: "Not a category")
+
       visit admin_tags_path
 
       expect(page).to have_content @tag1.name

--- a/spec/features/admin/translatable_spec.rb
+++ b/spec/features/admin/translatable_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 describe "Admin edit translatable records" do
   before do
-    login_as(create(:administrator).user)
     translatable.update(attributes)
+    login_as(create(:administrator).user)
   end
 
   let(:fields) { translatable.translated_attribute_names }

--- a/spec/features/admin/valuator_groups_spec.rb
+++ b/spec/features/admin/valuator_groups_spec.rb
@@ -57,7 +57,7 @@ describe "Valuator groups" do
   end
 
   scenario "Update" do
-    group = create(:valuator_group, name: "Health")
+    create(:valuator_group, name: "Health")
 
     visit admin_valuator_groups_path
     click_link "Edit"
@@ -70,7 +70,7 @@ describe "Valuator groups" do
   end
 
   scenario "Delete" do
-    group = create(:valuator_group)
+    create(:valuator_group)
 
     visit admin_valuator_groups_path
     click_link "Delete"

--- a/spec/features/admin/verifications_spec.rb
+++ b/spec/features/admin/verifications_spec.rb
@@ -22,9 +22,9 @@ describe "Incomplete verifications" do
   end
 
   scenario "Search" do
-    verified_user = create(:user, :level_two, username: "Juan Carlos")
-    unverified_user = create(:user, :incomplete_verification, username: "Juan_anonymous")
-    unverified_user = create(:user, :incomplete_verification, username: "Isabel_anonymous")
+    create(:user, :level_two, username: "Juan Carlos")
+    create(:user, :incomplete_verification, username: "Juan_anonymous")
+    create(:user, :incomplete_verification, username: "Isabel_anonymous")
 
     visit admin_verifications_path
 

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -47,8 +47,7 @@ describe "Admin" do
   end
 
   scenario "Access as poll officer is not authorized" do
-    create(:poll_officer, user: user)
-    login_as(user)
+    login_as(create(:poll_officer).user)
     visit admin_root_path
 
     expect(page).not_to have_current_path(admin_root_path)

--- a/spec/features/budget_polls/officing_spec.rb
+++ b/spec/features/budget_polls/officing_spec.rb
@@ -5,13 +5,11 @@ describe "Budget Poll Officing" do
   scenario "Show sidebar menus if officer has shifts assigned" do
     booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, booth: booth)
-
-    user = create(:user)
-    officer = create(:poll_officer, user: user)
+    officer = create(:poll_officer)
 
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
 
-    login_as user
+    login_as officer.user
     visit officing_root_path
 
     expect(page).not_to have_content("You don't have officing shifts today")
@@ -32,10 +30,8 @@ describe "Budget Poll Officing" do
   end
 
   scenario "Do not show sidebar menus if officer has no shifts assigned" do
-    user = create(:user)
-    officer = create(:poll_officer, user: user)
+    login_as(create(:poll_officer).user)
 
-    login_as user
     visit officing_root_path
 
     expect(page).to have_content("You don't have officing shifts today")

--- a/spec/features/budget_polls/officing_spec.rb
+++ b/spec/features/budget_polls/officing_spec.rb
@@ -17,10 +17,7 @@ describe "Budget Poll Officing" do
     expect(page).not_to have_content("Total recounts and results")
 
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :recount_scrutiny)
-
-    officer_assignment = create(:poll_officer_assignment,
-                                 booth_assignment: booth_assignment,
-                                 officer: officer)
+    create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer)
 
     visit officing_root_path
 

--- a/spec/features/budget_polls/polls_spec.rb
+++ b/spec/features/budget_polls/polls_spec.rb
@@ -19,11 +19,10 @@ describe "Polls" do
   context "Admin index" do
 
     scenario "Budget polls should not appear in the list" do
-      login_as(create(:administrator).user)
-
       poll = create(:poll)
       budget_poll = create(:poll, :for_budget)
 
+      login_as(create(:administrator).user)
       visit admin_polls_path
 
       expect(page).to have_content(poll.name)

--- a/spec/features/budget_polls/questions_spec.rb
+++ b/spec/features/budget_polls/questions_spec.rb
@@ -8,8 +8,8 @@ describe "Poll Questions" do
   end
 
   scenario "Do not display polls associated to a budget" do
-    poll1 = create(:poll, name: "Citizen Proposal Poll")
-    poll2 = create(:poll, :for_budget, name: "Participatory Budget Poll")
+    create(:poll, name: "Citizen Proposal Poll")
+    create(:poll, :for_budget, name: "Participatory Budget Poll")
 
     visit admin_questions_path
 

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -77,10 +77,10 @@ describe "Ballots" do
       end
 
       scenario "Headings" do
-        city_heading1     = create(:budget_heading, group: city,      name: "Investments Type1")
-        city_heading2     = create(:budget_heading, group: city,      name: "Investments Type2")
-        district_heading1 = create(:budget_heading, group: districts, name: "District 1")
-        district_heading2 = create(:budget_heading, group: districts, name: "District 2")
+        create(:budget_heading, group: city,      name: "Investments Type1")
+        create(:budget_heading, group: city,      name: "Investments Type2")
+        create(:budget_heading, group: districts, name: "District 1")
+        create(:budget_heading, group: districts, name: "District 2")
 
         visit budget_path(budget)
         click_link "City"

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -367,8 +367,8 @@ describe "Budgets" do
   context "Show" do
 
     scenario "List all groups" do
-      group1 = create(:budget_group, budget: budget)
-      group2 = create(:budget_group, budget: budget)
+      create(:budget_group, budget: budget)
+      create(:budget_group, budget: budget)
 
       visit budget_path(budget)
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -786,7 +786,6 @@ describe "Budget Investments" do
 
     scenario "Set votes for investments randomized with a seed" do
       voter = create(:user, :level_two)
-      login_as(voter)
 
       per_page.times { create(:budget_investment, heading: heading) }
 
@@ -797,6 +796,7 @@ describe "Budget Investments" do
         voted_investments << investment
       end
 
+      login_as(voter)
       visit budget_investments_path(budget, heading_id: heading.id)
 
       voted_investments.each do |investment|
@@ -927,13 +927,12 @@ describe "Budget Investments" do
       factory = :budget_investment
 
       scenario "Show up to 5 suggestions", :js do
-        login_as(author)
-
         %w[first second third fourth fifth sixth].each do |ordinal|
           create(factory, title: "#{ordinal.titleize} #{factory}, has search term", budget: budget)
         end
         create(factory, title: "This is the last #{factory}", budget: budget)
 
+        login_as(author)
         visit new_budget_investment_path(budget)
         fill_in "Title", with: "search"
 
@@ -943,12 +942,11 @@ describe "Budget Investments" do
       end
 
       scenario "No found suggestions", :js do
-        login_as(author)
-
         %w[first second third fourth fifth sixth].each do |ordinal|
           create(factory, title: "#{ordinal.titleize} #{factory}, has search term", budget: budget)
         end
 
+        login_as(author)
         visit new_budget_investment_path(budget)
         fill_in "Title", with: "item"
 
@@ -958,12 +956,11 @@ describe "Budget Investments" do
       end
 
       scenario "Don't show suggestions from a different budget", :js do
-        login_as(author)
-
         %w[first second third fourth fifth sixth].each do |ordinal|
           create(factory, title: "#{ordinal.titleize} #{factory}, has search term", budget: budget)
         end
 
+        login_as(author)
         visit new_budget_investment_path(other_budget)
         fill_in "Title", with: "search"
 
@@ -1005,10 +1002,10 @@ describe "Budget Investments" do
   end
 
   scenario "Show" do
+    investment = create(:budget_investment, heading: heading)
+
     user = create(:user)
     login_as(user)
-
-    investment = create(:budget_investment, heading: heading)
 
     visit budget_investment_path(budget, id: investment.id)
 
@@ -1146,9 +1143,6 @@ describe "Budget Investments" do
   end
 
   scenario "Show (unfeasible budget investment) only when valuation finished" do
-    user = create(:user)
-    login_as(user)
-
     investment = create(:budget_investment,
                         :unfeasible,
                         budget: budget,
@@ -1163,6 +1157,9 @@ describe "Budget Investments" do
                         group: group,
                         heading: heading,
                         unfeasibility_explanation: "The unfeasible explanation")
+
+    user = create(:user)
+    login_as(user)
 
     visit budget_investment_path(budget, id: investment.id)
 
@@ -1180,9 +1177,6 @@ describe "Budget Investments" do
   end
 
   scenario "Show (selected budget investment)" do
-    user = create(:user)
-    login_as(user)
-
     investment = create(:budget_investment,
                         :feasible,
                         :finished,
@@ -1191,6 +1185,9 @@ describe "Budget Investments" do
                         group: group,
                         heading: heading)
 
+    user = create(:user)
+    login_as(user)
+
     visit budget_investment_path(budget, id: investment.id)
 
     expect(page).to have_content("This investment project has been selected for balloting phase")
@@ -1198,8 +1195,6 @@ describe "Budget Investments" do
 
   scenario "Show (winner budget investment) only if budget is finished" do
     budget.update(phase: "balloting")
-    user = create(:user)
-    login_as(user)
 
     investment = create(:budget_investment,
                         :feasible,
@@ -1209,6 +1204,9 @@ describe "Budget Investments" do
                         budget: budget,
                         group: group,
                         heading: heading)
+
+    user = create(:user)
+    login_as(user)
 
     visit budget_investment_path(budget, id: investment.id)
 
@@ -1223,8 +1221,6 @@ describe "Budget Investments" do
 
   scenario "Show (not selected budget investment)" do
     budget.update(phase: "balloting")
-    user = create(:user)
-    login_as(user)
 
     investment = create(:budget_investment,
                         :feasible,
@@ -1232,6 +1228,9 @@ describe "Budget Investments" do
                         budget: budget,
                         group: group,
                         heading: heading)
+
+    user = create(:user)
+    login_as(user)
 
     visit budget_investment_path(budget, id: investment.id)
 
@@ -1239,15 +1238,15 @@ describe "Budget Investments" do
   end
 
   scenario "Show title (no message)" do
-    user = create(:user)
-    login_as(user)
-
     investment = create(:budget_investment,
                         :feasible,
                         :finished,
                         budget: budget,
                         group: group,
                         heading: heading)
+
+    user = create(:user)
+    login_as(user)
 
     visit budget_investment_path(budget, id: investment.id)
 
@@ -1258,9 +1257,6 @@ describe "Budget Investments" do
   end
 
   scenario "Show (unfeasible budget investment with valuation not finished)" do
-    user = create(:user)
-    login_as(user)
-
     investment = create(:budget_investment,
                         :unfeasible,
                         :unfinished,
@@ -1268,6 +1264,9 @@ describe "Budget Investments" do
                         group: group,
                         heading: heading,
                         unfeasibility_explanation: "Local government is not competent in this matter")
+
+    user = create(:user)
+    login_as(user)
 
     visit budget_investment_path(budget, id: investment.id)
 
@@ -1309,11 +1308,10 @@ describe "Budget Investments" do
   context "Destroy" do
 
     scenario "Admin cannot destroy budget investments" do
-      admin = create(:administrator)
       user = create(:user, :level_two)
       investment = create(:budget_investment, heading: heading, author: user)
 
-      login_as(admin.user)
+      login_as(create(:administrator).user)
       visit user_path(user)
 
       within("#budget_investment_#{investment.id}") do

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -86,12 +86,11 @@ describe "Votes" do
     end
 
     scenario "Disable voting on investments", :js do
-      manuela = create(:user, verified_at: Time.current)
-
-      login_as(manuela)
-
       budget.update(phase: "reviewing")
       investment = create(:budget_investment, budget: budget, heading: heading)
+
+      manuela = create(:user, verified_at: Time.current)
+      login_as(manuela)
 
       visit budget_investments_path(budget, heading_id: heading.id)
 

--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -7,7 +7,7 @@ describe "Commenting Budget::Investments" do
 
   scenario "Index" do
     3.times { create(:comment, commentable: investment) }
-    valuation_comment = create(:comment, :valuation, commentable: investment, subject: "Not viable")
+    create(:comment, :valuation, commentable: investment, subject: "Not viable")
 
     visit budget_investment_path(investment.budget, investment)
 

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -205,9 +205,10 @@ describe "Commenting topics from proposals" do
   end
 
   scenario "Create", :js do
-    login_as(user)
     community = proposal.community
     topic = create(:topic, community: community)
+
+    login_as(user)
     visit community_topic_path(community, topic)
 
     fill_in "comment-body-topic_#{topic.id}", with: "Have you thought about...?"
@@ -223,9 +224,10 @@ describe "Commenting topics from proposals" do
   end
 
   scenario "Errors on create", :js do
-    login_as(user)
     community = proposal.community
     topic = create(:topic, community: community)
+
+    login_as(user)
     visit community_topic_path(community, topic)
 
     click_button "Publish comment"
@@ -754,9 +756,10 @@ describe "Commenting topics from budget investments" do
   end
 
   scenario "Create", :js do
-    login_as(user)
     community = investment.community
     topic = create(:topic, community: community)
+
+    login_as(user)
     visit community_topic_path(community, topic)
 
     fill_in "comment-body-topic_#{topic.id}", with: "Have you thought about...?"
@@ -772,9 +775,10 @@ describe "Commenting topics from budget investments" do
   end
 
   scenario "Errors on create", :js do
-    login_as(user)
     community = investment.community
     topic = create(:topic, community: community)
+
+    login_as(user)
     visit community_topic_path(community, topic)
 
     click_button "Publish comment"

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -922,9 +922,9 @@ describe "Debates" do
     end
 
     scenario "Order by relevance by default", :js do
-      debate1 = create(:debate, title: "Show you got",      cached_votes_up: 10)
-      debate2 = create(:debate, title: "Show what you got", cached_votes_up: 1)
-      debate3 = create(:debate, title: "Show you got",      cached_votes_up: 100)
+      create(:debate, title: "Show you got",      cached_votes_up: 10)
+      create(:debate, title: "Show what you got", cached_votes_up: 1)
+      create(:debate, title: "Show you got",      cached_votes_up: 100)
 
       visit debates_path
       fill_in "search", with: "Show you got"
@@ -940,10 +940,10 @@ describe "Debates" do
     end
 
     scenario "Reorder results maintaing search", :js do
-      debate1 = create(:debate, title: "Show you got",      cached_votes_up: 10,  created_at: 1.week.ago)
-      debate2 = create(:debate, title: "Show what you got", cached_votes_up: 1,   created_at: 1.month.ago)
-      debate3 = create(:debate, title: "Show you got",      cached_votes_up: 100, created_at: Time.current)
-      debate4 = create(:debate, title: "Do not display",    cached_votes_up: 1,   created_at: 1.week.ago)
+      create(:debate, title: "Show you got",      cached_votes_up: 10,  created_at: 1.week.ago)
+      create(:debate, title: "Show what you got", cached_votes_up: 1,   created_at: 1.month.ago)
+      create(:debate, title: "Show you got",      cached_votes_up: 100, created_at: Time.current)
+      create(:debate, title: "Do not display",    cached_votes_up: 1,   created_at: 1.week.ago)
 
       visit debates_path
       fill_in "search", with: "Show you got"
@@ -1088,13 +1088,13 @@ describe "Debates" do
 
   context "Suggesting debates" do
     scenario "Shows up to 5 suggestions", :js do
-      debate1 = create(:debate, title: "First debate has 1 vote", cached_votes_up: 1)
-      debate2 = create(:debate, title: "Second debate has 2 votes", cached_votes_up: 2)
-      debate3 = create(:debate, title: "Third debate has 3 votes", cached_votes_up: 3)
-      debate4 = create(:debate, title: "This one has 4 votes", description: "This is the fourth debate", cached_votes_up: 4)
-      debate5 = create(:debate, title: "Fifth debate has 5 votes", cached_votes_up: 5)
-      debate6 = create(:debate, title: "Sixth debate has 6 votes", description: "This is the sixth debate",  cached_votes_up: 6)
-      debate7 = create(:debate, title: "This has seven votes, and is not suggest", description: "This is the seven", cached_votes_up: 7)
+      create(:debate, title: "First debate has 1 vote", cached_votes_up: 1)
+      create(:debate, title: "Second debate has 2 votes", cached_votes_up: 2)
+      create(:debate, title: "Third debate has 3 votes", cached_votes_up: 3)
+      create(:debate, title: "This one has 4 votes", description: "This is the fourth debate", cached_votes_up: 4)
+      create(:debate, title: "Fifth debate has 5 votes", cached_votes_up: 5)
+      create(:debate, title: "Sixth debate has 6 votes", description: "This is the sixth debate",  cached_votes_up: 6)
+      create(:debate, title: "This has seven votes, and is not suggest", description: "This is the seven", cached_votes_up: 7)
 
       login_as(create(:user))
       visit new_debate_path
@@ -1107,8 +1107,8 @@ describe "Debates" do
     end
 
     scenario "No found suggestions", :js do
-      debate1 = create(:debate, title: "First debate has 10 vote", cached_votes_up: 10)
-      debate2 = create(:debate, title: "Second debate has 2 votes", cached_votes_up: 2)
+      create(:debate, title: "First debate has 10 vote", cached_votes_up: 10)
+      create(:debate, title: "Second debate has 2 votes", cached_votes_up: 2)
 
       login_as(create(:user))
       visit new_debate_path
@@ -1153,8 +1153,8 @@ describe "Debates" do
   end
 
   scenario "Index include featured debates" do
-    debate1 = create(:debate, featured_at: Time.current)
-    debate2 = create(:debate)
+    create(:debate, featured_at: Time.current)
+    create(:debate)
 
     login_as(create(:administrator).user)
     visit debates_path
@@ -1164,8 +1164,8 @@ describe "Debates" do
   end
 
   scenario "Index do not show featured debates if none is marked as featured" do
-    debate1 = create(:debate)
-    debate2 = create(:debate)
+    create(:debate)
+    create(:debate)
 
     login_as(create(:administrator).user)
     visit debates_path

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -961,7 +961,6 @@ describe "Debates" do
 
     scenario "Reorder by recommendations results maintaing search" do
       user = create(:user, recommended_debates: true)
-      login_as(user)
 
       debate1 = create(:debate, title: "Show you got",      cached_votes_total: 10,  tag_list: "Sport")
       debate2 = create(:debate, title: "Show what you got", cached_votes_total: 1,   tag_list: "Sport")
@@ -970,6 +969,7 @@ describe "Debates" do
       proposal1 = create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal1, user: user)
 
+      login_as(user)
       visit debates_path
       fill_in "search", with: "Show you got"
       click_button "Search"
@@ -1088,9 +1088,6 @@ describe "Debates" do
 
   context "Suggesting debates" do
     scenario "Shows up to 5 suggestions", :js do
-      author = create(:user)
-      login_as(author)
-
       debate1 = create(:debate, title: "First debate has 1 vote", cached_votes_up: 1)
       debate2 = create(:debate, title: "Second debate has 2 votes", cached_votes_up: 2)
       debate3 = create(:debate, title: "Third debate has 3 votes", cached_votes_up: 3)
@@ -1099,6 +1096,7 @@ describe "Debates" do
       debate6 = create(:debate, title: "Sixth debate has 6 votes", description: "This is the sixth debate",  cached_votes_up: 6)
       debate7 = create(:debate, title: "This has seven votes, and is not suggest", description: "This is the seven", cached_votes_up: 7)
 
+      login_as(create(:user))
       visit new_debate_path
       fill_in "Debate title", with: "debate"
       check "debate_terms_of_service"
@@ -1109,12 +1107,10 @@ describe "Debates" do
     end
 
     scenario "No found suggestions", :js do
-      author = create(:user)
-      login_as(author)
-
       debate1 = create(:debate, title: "First debate has 10 vote", cached_votes_up: 10)
       debate2 = create(:debate, title: "Second debate has 2 votes", cached_votes_up: 2)
 
+      login_as(create(:user))
       visit new_debate_path
       fill_in "Debate title", with: "proposal"
       check "debate_terms_of_service"
@@ -1126,11 +1122,9 @@ describe "Debates" do
   end
 
   scenario "Mark/Unmark a debate as featured" do
-    admin = create(:administrator)
-    login_as(admin.user)
-
     debate = create(:debate)
 
+    login_as(create(:administrator).user)
     visit debates_path
     within("#debates") do
       expect(page).not_to have_content "Featured"
@@ -1159,12 +1153,10 @@ describe "Debates" do
   end
 
   scenario "Index include featured debates" do
-    admin = create(:administrator)
-    login_as(admin.user)
-
     debate1 = create(:debate, featured_at: Time.current)
     debate2 = create(:debate)
 
+    login_as(create(:administrator).user)
     visit debates_path
     within("#debates") do
       expect(page).to have_content("Featured")
@@ -1172,12 +1164,10 @@ describe "Debates" do
   end
 
   scenario "Index do not show featured debates if none is marked as featured" do
-    admin = create(:administrator)
-    login_as(admin.user)
-
     debate1 = create(:debate)
     debate2 = create(:debate)
 
+    login_as(create(:administrator).user)
     visit debates_path
     within("#debates") do
       expect(page).not_to have_content("Featured")

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -11,7 +11,7 @@ describe "Home" do
     end
 
     scenario "Not display recommended section" do
-      debate = create(:debate)
+      create(:debate)
 
       visit root_path
 
@@ -32,13 +32,15 @@ describe "Home" do
       end
 
       scenario "Display recommended section when feature flag recommended is active" do
-        debate = create(:debate, tag_list: "Sport")
+        create(:debate, tag_list: "Sport")
+
         visit root_path
+
         expect(page).to have_content "Recommendations that may interest you"
       end
 
       scenario "Not display recommended section when feature flag recommended is not active" do
-        debate = create(:debate, tag_list: "Sport")
+        create(:debate, tag_list: "Sport")
         Setting["feature.user.recommendations"] = false
 
         visit root_path
@@ -56,8 +58,10 @@ describe "Home" do
       end
 
       scenario "Display all recommended debates link" do
-        debate = create(:debate, tag_list: "Sport")
+        create(:debate, tag_list: "Sport")
+
         visit root_path
+
         expect(page).to have_link("All recommended debates", href: debates_path(order: "recommendations"))
       end
 
@@ -71,8 +75,10 @@ describe "Home" do
       end
 
       scenario "Display all recommended proposals link" do
-        debate = create(:proposal, tag_list: "Sport")
+        create(:proposal, tag_list: "Sport")
+
         visit root_path
+
         expect(page).to have_link("All recommended proposals", href: proposals_path(order: "recommendations"))
       end
 
@@ -140,7 +146,7 @@ describe "Home" do
   end
 
   scenario "if there are cards, the 'featured' title will render" do
-    card = create(:widget_card,
+    create(:widget_card,
       title: "Card text",
       description: "Card description",
       link_text: "Link text",

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -16,7 +16,7 @@ describe "Budget Investments" do
                   "",
                   "management_budget_investment_path",
                   { "budget_id": "budget_id" },
-                  management = true
+                  management: true
 
   context "Load" do
 

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -69,8 +69,7 @@ describe "Notifications" do
   end
 
   scenario "Mark all as read" do
-    notification1 = create(:notification, user: user)
-    notification2 = create(:notification, user: user)
+    2.times { create(:notification, user: user) }
 
     click_notifications_icon
 

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -123,19 +123,20 @@ describe "Officing Results", :with_frozen_time do
   end
 
   scenario "Index lists all questions and answers" do
-    partial_result = create(:poll_partial_result,
-                      officer_assignment: poll_officer.officer_assignments.first,
-                      booth_assignment: poll_officer.officer_assignments.first.booth_assignment,
-                      date: poll.ends_at,
-                      question: @question_1,
-                      amount: 33)
-    poll_recount = create(:poll_recount,
-                      officer_assignment: poll_officer.officer_assignments.first,
-                      booth_assignment: poll_officer.officer_assignments.first.booth_assignment,
-                      date: poll.ends_at,
-                      white_amount: 21,
-                      null_amount: 44,
-                      total_amount: 66)
+    create(:poll_partial_result,
+      officer_assignment: poll_officer.officer_assignments.first,
+      booth_assignment: poll_officer.officer_assignments.first.booth_assignment,
+      date: poll.ends_at,
+      question: @question_1,
+      amount: 33)
+
+    create(:poll_recount,
+      officer_assignment: poll_officer.officer_assignments.first,
+      booth_assignment: poll_officer.officer_assignments.first.booth_assignment,
+      date: poll.ends_at,
+      white_amount: 21,
+      null_amount: 44,
+      total_amount: 66)
 
     visit officing_poll_results_path(poll,
                                      date: I18n.l(poll.ends_at.to_date),

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -7,10 +7,10 @@ describe "Voters" do
   let(:officer) { create(:poll_officer) }
 
   before do
-    login_as(officer.user)
     create(:geozone, :in_census)
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
     create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
+    login_as(officer.user)
     set_officing_booth(booth)
   end
 

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -135,8 +135,8 @@ describe "Poll Officing" do
     create(:poll_shift, officer: officer1, booth: booth, date: Date.current, task: :vote_collection)
     create(:poll_shift, officer: officer2, booth: booth, date: Date.current, task: :vote_collection)
 
-    officer_assignment_1 = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer1)
-    officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer2)
+    create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer1)
+    create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer2)
 
     in_browser(:one) do
       login_as officer1.user

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -129,10 +129,8 @@ describe "Poll Officing" do
     booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
 
-    user1 = create(:user)
-    user2 = create(:user)
-    officer1 = create(:poll_officer, user: user1)
-    officer2 = create(:poll_officer, user: user2)
+    officer1 = create(:poll_officer)
+    officer2 = create(:poll_officer)
 
     create(:poll_shift, officer: officer1, booth: booth, date: Date.current, task: :vote_collection)
     create(:poll_shift, officer: officer2, booth: booth, date: Date.current, task: :vote_collection)
@@ -141,12 +139,12 @@ describe "Poll Officing" do
     officer_assignment_2 = create(:poll_officer_assignment, booth_assignment: booth_assignment, officer: officer2)
 
     in_browser(:one) do
-      login_as user1
+      login_as officer1.user
       visit officing_root_path
     end
 
     in_browser(:two) do
-      login_as user2
+      login_as officer2.user
       visit officing_root_path
     end
 

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -70,7 +70,7 @@ describe "Polls" do
     end
 
     scenario "Displays icon correctly", :js do
-      polls = create_list(:poll, 3)
+      create_list(:poll, 3)
 
       visit polls_path
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -483,10 +483,9 @@ describe "Proposals" do
     end
 
     scenario "Specific geozone" do
-      geozone = create(:geozone, name: "California")
-      geozone = create(:geozone, name: "New York")
-      author = create(:user)
-      login_as(author)
+      create(:geozone, name: "California")
+      create(:geozone, name: "New York")
+      login_as(create(:user))
 
       visit new_proposal_path
 
@@ -1438,9 +1437,9 @@ describe "Proposals" do
     end
 
     scenario "Order by relevance by default", :js do
-      proposal1 = create(:proposal, title: "Show you got",      cached_votes_up: 10)
-      proposal2 = create(:proposal, title: "Show what you got", cached_votes_up: 1)
-      proposal3 = create(:proposal, title: "Show you got",      cached_votes_up: 100)
+      create(:proposal, title: "Show you got",      cached_votes_up: 10)
+      create(:proposal, title: "Show what you got", cached_votes_up: 1)
+      create(:proposal, title: "Show you got",      cached_votes_up: 100)
 
       visit proposals_path
       fill_in "search", with: "Show what you got"
@@ -1456,10 +1455,10 @@ describe "Proposals" do
     end
 
     scenario "Reorder results maintaing search", :js do
-      proposal1 = create(:proposal, title: "Show you got",      cached_votes_up: 10,  created_at: 1.week.ago)
-      proposal2 = create(:proposal, title: "Show what you got", cached_votes_up: 1,   created_at: 1.month.ago)
-      proposal3 = create(:proposal, title: "Show you got",      cached_votes_up: 100, created_at: Time.current)
-      proposal4 = create(:proposal, title: "Do not display",    cached_votes_up: 1,   created_at: 1.week.ago)
+      create(:proposal, title: "Show you got",      cached_votes_up: 10,  created_at: 1.week.ago)
+      create(:proposal, title: "Show what you got", cached_votes_up: 1,   created_at: 1.month.ago)
+      create(:proposal, title: "Show you got",      cached_votes_up: 100, created_at: Time.current)
+      create(:proposal, title: "Do not display",    cached_votes_up: 1,   created_at: 1.week.ago)
 
       visit proposals_path
       fill_in "search", with: "Show what you got"

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1481,7 +1481,6 @@ describe "Proposals" do
 
     scenario "Reorder by recommendations results maintaing search" do
       user = create(:user, recommended_proposals: true)
-      login_as(user)
 
       proposal1 = create(:proposal, title: "Show you got",      cached_votes_up: 10,  tag_list: "Sport")
       proposal2 = create(:proposal, title: "Show what you got", cached_votes_up: 1,   tag_list: "Sport")
@@ -1490,6 +1489,7 @@ describe "Proposals" do
       proposal5 = create(:proposal, tag_list: "Sport")
       create(:follow, followable: proposal5, user: user)
 
+      login_as(user)
       visit proposals_path
       fill_in "search", with: "Show you got"
       click_button "Search"
@@ -1726,9 +1726,6 @@ describe "Proposals" do
 
   context "Suggesting proposals" do
     scenario "Show up to 5 suggestions", :js do
-      author = create(:user)
-      login_as(author)
-
       create(:proposal, title: "First proposal, has search term")
       create(:proposal, title: "Second title")
       create(:proposal, title: "Third proposal, has search term")
@@ -1737,6 +1734,7 @@ describe "Proposals" do
       create(:proposal, title: "Sixth proposal, has search term")
       create(:proposal, title: "Seventh proposal, has search term")
 
+      login_as(create(:user))
       visit new_proposal_path
       fill_in "Proposal title", with: "search"
       check "proposal_terms_of_service"
@@ -1747,12 +1745,10 @@ describe "Proposals" do
     end
 
     scenario "No found suggestions", :js do
-      author = create(:user)
-      login_as(author)
-
       create(:proposal, title: "First proposal").update_column(:confidence_score, 10)
       create(:proposal, title: "Second proposal").update_column(:confidence_score, 8)
 
+      login_as(create(:user))
       visit new_proposal_path
       fill_in "Proposal title", with: "debate"
       check "proposal_terms_of_service"

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -73,7 +73,7 @@ describe "Custom Pages" do
       end
 
       scenario "Listed in more information page" do
-        custom_page = create(:site_customization_page, :published,
+        create(:site_customization_page, :published,
           slug: "another-slug",
           title_en: "Another custom page",
           subtitle_en: "Subtitle for custom page",

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -101,8 +101,8 @@ describe "Tags" do
   end
 
   scenario "Turbolinks sanity check from budget's show", :js do
-    education = create(:tag, name: "Education", kind: "category")
-    health    = create(:tag, name: "Health",    kind: "category")
+    create(:tag, name: "Education", kind: "category")
+    create(:tag, name: "Health",    kind: "category")
 
     login_as(author)
     visit budget_path(budget)
@@ -125,8 +125,8 @@ describe "Tags" do
   end
 
   scenario "Turbolinks sanity check from budget heading's show", :js do
-    education = create(:tag, name: "Education", kind: "category")
-    health    = create(:tag, name: "Health",    kind: "category")
+    create(:tag, name: "Education", kind: "category")
+    create(:tag, name: "Health",    kind: "category")
 
     login_as(author)
     visit budget_investments_path(budget, heading_id: heading.id)

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -101,11 +101,10 @@ describe "Tags" do
   end
 
   scenario "Turbolinks sanity check from budget's show", :js do
-    login_as(author)
-
     education = create(:tag, name: "Education", kind: "category")
     health    = create(:tag, name: "Health",    kind: "category")
 
+    login_as(author)
     visit budget_path(budget)
     click_link "Create a budget investment"
 
@@ -126,11 +125,10 @@ describe "Tags" do
   end
 
   scenario "Turbolinks sanity check from budget heading's show", :js do
-    login_as(author)
-
     education = create(:tag, name: "Education", kind: "category")
     health    = create(:tag, name: "Health",    kind: "category")
 
+    login_as(author)
     visit budget_investments_path(budget, heading_id: heading.id)
     click_link "Create a budget investment"
 

--- a/spec/features/tags/debates_spec.rb
+++ b/spec/features/tags/debates_spec.rb
@@ -43,8 +43,8 @@ describe "Tags" do
   end
 
   scenario "Index tag does not show featured debates" do
-    featured_debates = create_featured_debates
-    debates = create(:debate, tag_list: "123")
+    create_featured_debates
+    create(:debate, tag_list: "123")
 
     visit debates_path(tag: "123")
 
@@ -186,8 +186,8 @@ describe "Tags" do
   context "Tag cloud" do
 
     scenario "Display user tags" do
-      earth = create(:debate, tag_list: "Medio Ambiente")
-      money = create(:debate, tag_list: "Economía")
+      create(:debate, tag_list: "Medio Ambiente")
+      create(:debate, tag_list: "Economía")
 
       visit debates_path
 

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -29,7 +29,7 @@ describe "Tags" do
   end
 
   scenario "Index featured proposals does not show tags" do
-    proposal = create(:proposal, tag_list: "123")
+    create(:proposal, tag_list: "123")
 
     visit proposals_path(tag: "123")
 
@@ -83,8 +83,8 @@ describe "Tags" do
   end
 
   scenario "Category with category tags", :js do
-    education = create(:tag, :category, name: "Education")
-    health    = create(:tag, :category, name: "Health")
+    create(:tag, :category, name: "Education")
+    create(:tag, :category, name: "Health")
 
     login_as(create(:user))
     visit new_proposal_path
@@ -220,8 +220,8 @@ describe "Tags" do
   context "Tag cloud" do
 
     scenario "Display user tags" do
-      earth = create(:proposal, tag_list: "Medio Ambiente")
-      money = create(:proposal, tag_list: "Economía")
+      create(:proposal, tag_list: "Medio Ambiente")
+      create(:proposal, tag_list: "Economía")
 
       visit proposals_path
 
@@ -256,8 +256,8 @@ describe "Tags" do
       create(:tag, :category, name: "Medio Ambiente")
       create(:tag, :category, name: "Economía")
 
-      earth = create(:proposal, tag_list: "Medio Ambiente")
-      money = create(:proposal, tag_list: "Economía")
+      create(:proposal, tag_list: "Medio Ambiente")
+      create(:proposal, tag_list: "Economía")
 
       visit proposals_path
 

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -83,12 +83,10 @@ describe "Tags" do
   end
 
   scenario "Category with category tags", :js do
-    user = create(:user)
-    login_as(user)
-
     education = create(:tag, :category, name: "Education")
     health    = create(:tag, :category, name: "Health")
 
+    login_as(create(:user))
     visit new_proposal_path
 
     fill_in "Proposal title", with: "Help refugees"

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -124,8 +124,8 @@ describe "Tags" do
   context "Tag cloud" do
 
     scenario "Proposals" do
-      earth = create(:proposal, tag_list: "Medio Ambiente")
-      money = create(:proposal, tag_list: "Economía")
+      create(:proposal, tag_list: "Medio Ambiente")
+      create(:proposal, tag_list: "Economía")
 
       visit proposals_path
 
@@ -136,8 +136,8 @@ describe "Tags" do
     end
 
     scenario "Debates" do
-      earth = create(:debate, tag_list: "Medio Ambiente")
-      money = create(:debate, tag_list: "Economía")
+      create(:debate, tag_list: "Medio Ambiente")
+      create(:debate, tag_list: "Economía")
 
       visit debates_path
 
@@ -151,8 +151,8 @@ describe "Tags" do
       create(:tag, :category, name: "Medio Ambiente")
       create(:tag, :category, name: "Economía")
 
-      earth = create(:proposal, tag_list: "Medio Ambiente, Agua")
-      money = create(:proposal, tag_list: "Economía, Corrupción")
+      create(:proposal, tag_list: "Medio Ambiente, Agua")
+      create(:proposal, tag_list: "Economía, Corrupción")
 
       visit proposals_path(search: "Economía")
 
@@ -167,8 +167,8 @@ describe "Tags" do
       create(:geozone, name: "Madrid")
       create(:geozone, name: "Barcelona")
 
-      earth = create(:proposal, tag_list: "Madrid, Agua")
-      money = create(:proposal, tag_list: "Barcelona, Playa")
+      create(:proposal, tag_list: "Madrid, Agua")
+      create(:proposal, tag_list: "Barcelona, Playa")
 
       visit proposals_path(search: "Barcelona")
 

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -260,10 +260,10 @@ describe "Consul Schema" do
 
   describe "Comments" do
     it "only returns comments from proposals, debates and polls" do
-      proposal_comment          = create(:comment, commentable: create(:proposal))
-      debate_comment            = create(:comment, commentable: create(:debate))
-      poll_comment              = create(:comment, commentable: create(:poll))
-      budget_investment_comment = build(:comment, commentable: create(:budget_investment)).save(skip_validation: true)
+      create(:comment, commentable: create(:proposal))
+      create(:comment, commentable: create(:debate))
+      create(:comment, commentable: create(:poll))
+      build(:comment, commentable: create(:budget_investment)).save(skip_validation: true)
 
       response = execute("{ comments { edges { node { commentable_type } } } }")
       received_commentables = extract_fields(response, "comments", "commentable_type")
@@ -461,13 +461,13 @@ describe "Consul Schema" do
 
   describe "Tags" do
     it "only display tags with kind nil or category" do
-      tag           = create(:tag, name: "Parks")
-      category_tag  = create(:tag, :category, name: "Health")
-      admin_tag     = create(:tag, name: "Admin tag", kind: "admin")
+      create(:tag, name: "Parks")
+      create(:tag, :category, name: "Health")
+      create(:tag, name: "Admin tag", kind: "admin")
 
-      proposal = create(:proposal, tag_list: "Parks")
-      proposal = create(:proposal, tag_list: "Health")
-      proposal = create(:proposal, tag_list: "Admin tag")
+      create(:proposal, tag_list: "Parks")
+      create(:proposal, tag_list: "Health")
+      create(:proposal, tag_list: "Admin tag")
 
       response = execute("{ tags { edges { node { name } } } }")
       received_tags = extract_fields(response, "tags", "name")
@@ -501,8 +501,8 @@ describe "Consul Schema" do
     end
 
     it "does not display tags for hidden proposals" do
-      proposal = create(:proposal, tag_list: "Health")
-      hidden_proposal = create(:proposal, :hidden, tag_list: "SPAM")
+      create(:proposal, tag_list: "Health")
+      create(:proposal, :hidden, tag_list: "SPAM")
 
       response = execute("{ tags { edges { node { name } } } }")
       received_tags = extract_fields(response, "tags", "name")
@@ -511,8 +511,8 @@ describe "Consul Schema" do
     end
 
     it "does not display tags for hidden debates" do
-      debate = create(:debate, tag_list: "Health, Transportation")
-      hidden_debate = create(:debate, :hidden, tag_list: "SPAM")
+      create(:debate, tag_list: "Health, Transportation")
+      create(:debate, :hidden, tag_list: "SPAM")
 
       response = execute("{ tags { edges { node { name } } } }")
       received_tags = extract_fields(response, "tags", "name")
@@ -521,7 +521,7 @@ describe "Consul Schema" do
     end
 
     it "does not display tags for taggings that are not public" do
-      proposal = create(:proposal, tag_list: "Health")
+      create(:proposal, tag_list: "Health")
       allow(ActsAsTaggableOn::Tag).to receive(:public_for_api).and_return([])
 
       response = execute("{ tags { edges { node { name } } } }")

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -51,7 +51,7 @@ describe UserSegments do
 
   describe "#proposal_authors" do
     it "returns users that have created a proposal" do
-      proposal = create(:proposal, author: user1)
+      create(:proposal, author: user1)
 
       proposal_authors = UserSegments.proposal_authors
       expect(proposal_authors).to include user1
@@ -59,8 +59,8 @@ describe UserSegments do
     end
 
     it "does not return duplicated users" do
-      proposal1 = create(:proposal, author: user1)
-      proposal2 = create(:proposal, author: user1)
+      create(:proposal, author: user1)
+      create(:proposal, author: user1)
 
       proposal_authors = UserSegments.proposal_authors
       expect(proposal_authors).to contain_exactly(user1)

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -695,28 +695,28 @@ describe Debate do
     context "no results" do
 
       it "no words match" do
-        debate = create(:debate, title: "save world")
+        create(:debate, title: "save world")
 
         results = Debate.search("destroy planet")
         expect(results).to eq([])
       end
 
       it "too many typos" do
-        debate = create(:debate, title: "fantastic")
+        create(:debate, title: "fantastic")
 
         results = Debate.search("frantac")
         expect(results).to eq([])
       end
 
       it "too much stemming" do
-        debate = create(:debate, title: "reloj")
+        create(:debate, title: "reloj")
 
         results = Debate.search("superrelojimetro")
         expect(results).to eq([])
       end
 
       it "empty" do
-        debate = create(:debate, title: "great")
+        create(:debate, title: "great")
 
         results = Debate.search("")
         expect(results).to eq([])

--- a/spec/models/direct_message_spec.rb
+++ b/spec/models/direct_message_spec.rb
@@ -85,8 +85,8 @@ describe DirectMessage do
       end
 
       it "does not return direct messages created another day" do
-        direct_message1 = create(:direct_message, created_at: 1.day.ago)
-        direct_message2 = create(:direct_message, created_at: 1.day.from_now)
+        create(:direct_message, created_at: 1.day.ago)
+        create(:direct_message, created_at: 1.day.from_now)
 
         expect(DirectMessage.today.count).to eq 0
       end

--- a/spec/models/i18n_content_spec.rb
+++ b/spec/models/i18n_content_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 RSpec.describe I18nContent, type: :model do
-  let(:i18n_content) { build(:i18n_content) }
+  let(:i18n_content) { build(:i18n_content, key: "awe.so.me") }
 
   it "is valid" do
     expect(i18n_content).to be_valid
   end
 
   it "is not valid if key is not unique" do
-    new_content = create(:i18n_content)
+    create(:i18n_content, key: "awe.so.me")
 
     expect(i18n_content).not_to be_valid
     expect(i18n_content.errors.size).to eq(1)

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -186,12 +186,12 @@ describe Legislation::Process do
 
     it "invalid format colors" do
       expect {
-        process = create(:legislation_process, background_color: "#123ghi", font_color: "#fff")
+        create(:legislation_process, background_color: "#123ghi", font_color: "#fff")
       }.to raise_error(ActiveRecord::RecordInvalid,
                        "Validation failed: Background color is invalid")
 
       expect {
-        process = create(:legislation_process, background_color: "#fff", font_color: "ggg")
+        create(:legislation_process, background_color: "#fff", font_color: "ggg")
       }.to raise_error(ActiveRecord::RecordInvalid,
                        "Validation failed: Font color is invalid")
     end

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -127,17 +127,13 @@ describe Newsletter do
 
     it "skips invalid emails" do
       Proposal.destroy_all
-
-      valid_email = "john@gmail.com"
-      invalid_email = "john@gmail..com"
-
-      valid_email_user = create(:user, :with_proposal, email: valid_email)
-      invalid_email_user = create(:user, :with_proposal, email: invalid_email)
+      create(:user, :with_proposal, email: "valid@consul.dev")
+      create(:user, :with_proposal, email: "invalid@consul..dev")
 
       newsletter.deliver
 
       expect(Activity.count).to eq(1)
-      expect(Activity.first.user_id).to eq(valid_email_user.id)
+      expect(Activity.first.user.email).to eq("valid@consul.dev")
       expect(Activity.first.action).to eq("email")
       expect(Activity.first.actionable).to eq(newsletter)
     end

--- a/spec/models/proposal_notification_spec.rb
+++ b/spec/models/proposal_notification_spec.rb
@@ -38,7 +38,7 @@ describe ProposalNotification do
     end
 
     it "blocks proposal notifications without proposal" do
-      proposal = build(:proposal_notification, proposal: nil).save!(validate: false)
+      build(:proposal_notification, proposal: nil).save!(validate: false)
 
       expect(ProposalNotification.public_for_api).not_to include(notification)
     end

--- a/spec/shared/features/mappable.rb
+++ b/spec/shared/features/mappable.rb
@@ -1,4 +1,4 @@
-shared_examples "mappable" do |mappable_factory_name, mappable_association_name, mappable_new_path, mappable_edit_path, mappable_show_path, mappable_path_arguments, management = false|
+shared_examples "mappable" do |mappable_factory_name, mappable_association_name, mappable_new_path, mappable_edit_path, mappable_show_path, mappable_path_arguments, management: false|
 
   include ActionView::Helpers
 

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -253,8 +253,8 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
     if path.include? "edit"
 
       scenario "Should show persisted documents and remove nested_field" do
-        login_as user_to_login
         create(:document, documentable: documentable)
+        login_as user_to_login
         visit send(path, arguments)
 
         expect(page).to have_css ".document", count: 1
@@ -262,16 +262,16 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
 
       scenario "Should not show add document button when
                 documentable has reached maximum of documents allowed", :js do
-        login_as user_to_login
         create_list(:document, documentable.class.max_documents_allowed, documentable: documentable)
+        login_as user_to_login
         visit send(path, arguments)
 
         expect(page).to have_css "#new_document_link", visible: false
       end
 
       scenario "Should show add document button after destroy one document", :js do
-        login_as user_to_login
         create_list(:document, documentable.class.max_documents_allowed, documentable: documentable)
+        login_as user_to_login
         visit send(path, arguments)
         last_document = all("#nested-documents .document").last
         within last_document do
@@ -282,8 +282,8 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       end
 
       scenario "Should remove nested field after remove document", :js do
-        login_as user_to_login
         create(:document, documentable: documentable)
+        login_as user_to_login
         visit send(path, arguments)
         click_on "Remove document"
 

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -216,24 +216,24 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
     if path.include? "edit"
 
       scenario "Should show persisted image" do
-        login_as user
         create(:image, imageable: imageable)
+        login_as user
         visit send(path, arguments)
 
         expect(page).to have_css ".image", count: 1
       end
 
       scenario "Should not show add image button when image already exists", :js do
-        login_as user
         create(:image, imageable: imageable)
+        login_as user
         visit send(path, arguments)
 
         expect(page).to have_css "a#new_image_link", visible: false
       end
 
       scenario "Should remove nested field after remove image", :js do
-        login_as user
         create(:image, imageable: imageable)
+        login_as user
         visit send(path, arguments)
         click_on "Remove image"
 
@@ -241,8 +241,8 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       end
 
       scenario "Should show add image button after remove image", :js do
-        login_as user
         create(:image, imageable: imageable)
+        login_as user
         visit send(path, arguments)
         click_on "Remove image"
 

--- a/spec/shared/features/notifiable_in_app.rb
+++ b/spec/shared/features/notifiable_in_app.rb
@@ -4,7 +4,7 @@ shared_examples "notifiable in-app" do |described_class|
   let!(:notifiable) { create(model_name(described_class), author: author) }
 
   scenario "Notification icon is shown" do
-    notification = create(:notification, notifiable: notifiable, user: author)
+    create(:notification, notifiable: notifiable, user: author)
 
     login_as author
     visit root_path

--- a/spec/shared/features/relationable.rb
+++ b/spec/shared/features/relationable.rb
@@ -6,7 +6,7 @@ shared_examples "relationable" do |relationable_model_name|
   let(:user) { create(:user) }
 
   scenario "related contents are listed" do
-    related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
+    create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     visit relationable.url
     within("#related-content-list") do


### PR DESCRIPTION
## Objectives

* Reduce the number of useless assignment warnings given by the Ruby interpreter
* Make it easier to find warnings which happen due to actual bugs in the code

## Notes

In this pull request we're only removing the useless assignments which don't affect code legibility at all.