### PR TITLE
Check page content from the user's perspective

### DIFF
--- a/app/views/admin/budget_headings/index.html.erb
+++ b/app/views/admin/budget_headings/index.html.erb
@@ -20,7 +20,7 @@
     </thead>
     <tbody>
       <% @headings.each do |heading| %>
-        <tr id="<%= dom_id(heading) %>">
+        <tr id="<%= dom_id(heading) %>" class="heading">
           <td><%= link_to heading.name, edit_admin_budget_group_heading_path(@budget, @group, heading) %></td>
           <td><%= @budget.formatted_heading_price(heading) %></td>
           <td><%= heading.population %></td>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,13 +5,13 @@ describe ApplicationController do
   describe "#current_budget" do
 
     it "returns the last budget that is not in draft phase" do
-      old_budget      = create(:budget, :finished,  created_at: 2.years.ago)
-      previous_budget = create(:budget, :accepting, created_at: 1.year.ago)
-      current_budget  = create(:budget, :accepting, created_at: 1.month.ago)
-      next_budget     = create(:budget, :drafting,  created_at: 1.week.ago)
+      create(:budget, :finished,  created_at: 2.years.ago, name: "Old")
+      create(:budget, :accepting, created_at: 1.year.ago,  name: "Previous")
+      create(:budget, :accepting, created_at: 1.month.ago, name: "Current")
+      create(:budget, :drafting,  created_at: 1.week.ago,  name: "Next")
 
       budget = subject.instance_eval { current_budget }
-      expect(budget).to eq(current_budget)
+      expect(budget.name).to eq("Current")
     end
 
   end

--- a/spec/features/admin/budget_headings_spec.rb
+++ b/spec/features/admin/budget_headings_spec.rb
@@ -129,14 +129,14 @@ describe "Admin budget headings" do
     end
 
     scenario "Try to delete a heading with investments" do
-      heading = create(:budget_heading, group: group)
-      investment = create(:budget_investment, heading: heading)
+      heading = create(:budget_heading, group: group, name: "Atlantis")
+      create(:budget_investment, heading: heading)
 
       visit admin_budget_group_headings_path(budget, group)
-      within("#budget_heading_#{heading.id}") { click_link "Delete" }
+      within(".heading", text: "Atlantis") { click_link "Delete" }
 
       expect(page).to have_content "You cannot delete a Heading that has associated investments"
-      expect(page).to have_selector "#budget_heading_#{heading.id}"
+      expect(page).to have_content "Atlantis"
     end
 
   end

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -131,17 +131,17 @@ describe "Admin polls" do
     end
 
     scenario "Can destroy poll with questions and answers", :js do
-      poll = create(:poll)
-      question = create(:poll_question, :yes_no, poll: poll)
+      poll = create(:poll, name: "Do you support CONSUL?")
+      create(:poll_question, :yes_no, poll: poll)
 
       visit admin_polls_path
 
-      within("#poll_#{poll.id}") do
+      within(".poll", text: "Do you support CONSUL?") do
         accept_confirm { click_link "Delete" }
       end
 
       expect(page).to     have_content("Poll deleted successfully")
-      expect(page).not_to have_content(poll.name)
+      expect(page).not_to have_content("Do you support CONSUL?")
 
       expect(Poll::Question.count).to eq(0)
       expect(Poll::Question::Answer.count). to eq(0)

--- a/spec/features/admin/poll/questions/answers/answers_spec.rb
+++ b/spec/features/admin/poll/questions/answers/answers_spec.rb
@@ -9,36 +9,32 @@ describe "Answers" do
 
   scenario "Create" do
     question = create(:poll_question)
-    title = "Whatever the question may be, the answer is always 42"
-    description = "The Hitchhiker's Guide To The Universe"
 
     visit admin_question_path(question)
     click_link "Add answer"
 
-    fill_in "Answer", with: title
-    fill_in "Description", with: description
+    fill_in "Answer", with: "The answer is always 42"
+    fill_in "Description", with: "The Hitchhiker's Guide To The Universe"
 
     click_button "Save"
 
-    expect(page).to have_content(title)
-    expect(page).to have_content(description)
+    expect(page).to have_content "The answer is always 42"
+    expect(page).to have_content "The Hitchhiker's Guide To The Universe"
   end
 
   scenario "Create second answer and place after the first one" do
     question = create(:poll_question)
     answer = create(:poll_question_answer, title: "First", question: question, given_order: 1)
-    title = "Second"
-    description = "Description"
 
     visit admin_question_path(question)
     click_link "Add answer"
 
-    fill_in "Answer", with: title
-    fill_in "Description", with: description
+    fill_in "Answer", with: "Second"
+    fill_in "Description", with: "Description"
 
     click_button "Save"
 
-    expect(page.body.index("First")).to be < page.body.index("Second")
+    expect("First").to appear_before("Second")
   end
 
   scenario "Update" do
@@ -50,22 +46,18 @@ describe "Answers" do
 
     click_link "Edit answer"
 
-    old_title = answer.title
-    new_title = "Ex Machina"
-
-    fill_in "Answer", with: new_title
+    fill_in "Answer", with: "New title"
 
     click_button "Save"
 
-    expect(page).to have_content("Changes saved")
-    expect(page).to have_content(new_title)
+    expect(page).to have_content "Changes saved"
+    expect(page).to have_content "New title"
 
     visit admin_question_path(question)
 
-    expect(page).to have_content(new_title)
-    expect(page).not_to have_content(old_title)
+    expect(page).not_to have_content "Answer title"
 
-    expect(answer2.title).to appear_before(new_title)
+    expect("Another title").to appear_before("New title")
   end
 
 end

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -1,27 +1,29 @@
 require "rails_helper"
 
 describe "Admin settings" do
-
   before do
-    @setting1 = create(:setting)
-    @setting2 = create(:setting)
-    @setting3 = create(:setting)
     login_as(create(:administrator).user)
   end
 
   scenario "Index" do
+    create(:setting, key: "super.users.first")
+    create(:setting, key: "super.users.second")
+    create(:setting, key: "super.users.third")
+
     visit admin_settings_path
 
-    expect(page).to have_content @setting1.key
-    expect(page).to have_content @setting2.key
-    expect(page).to have_content @setting3.key
+    expect(page).to have_content "First"
+    expect(page).to have_content "Second"
+    expect(page).to have_content "Third"
   end
 
   scenario "Update" do
+    setting = create(:setting, key: "super.users.first")
+
     visit admin_settings_path
 
-    within("#edit_setting_#{@setting2.id}") do
-      fill_in "setting_#{@setting2.id}", with: "Super Users of level 2"
+    within("#edit_setting_#{setting.id}") do
+      fill_in "setting_#{setting.id}", with: "Super Users of level 1"
       click_button "Update"
     end
 

--- a/spec/features/admin/tags_spec.rb
+++ b/spec/features/admin/tags_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Admin tags" do
 
   before do
-    @tag1 = create(:tag, :category)
+    create(:tag, :category, name: "Existence")
     login_as(create(:administrator).user)
   end
 
@@ -12,7 +12,7 @@ describe "Admin tags" do
     debate.tag_list.add(create(:tag, :category, name: "supertag"))
     visit admin_tags_path
 
-    expect(page).to have_content @tag1.name
+    expect(page).to have_content "Existence"
     expect(page).to have_content "supertag"
   end
 
@@ -33,38 +33,39 @@ describe "Admin tags" do
 
   scenario "Delete" do
     tag2 = create(:tag, :category, name: "bad tag")
-    create(:debate, tag_list: tag2.name)
+    create(:debate, tag_list: "bad tag")
+
     visit admin_tags_path
 
-    expect(page).to have_content @tag1.name
-    expect(page).to have_content tag2.name
+    expect(page).to have_content "Existence"
+    expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
       click_link "Delete topic"
     end
 
     visit admin_tags_path
-    expect(page).to have_content @tag1.name
-    expect(page).not_to have_content tag2.name
+    expect(page).to have_content "Existence"
+    expect(page).not_to have_content "bad tag"
   end
 
   scenario "Delete tag with hidden taggables" do
     tag2 = create(:tag, :category, name: "bad tag")
-    debate = create(:debate, tag_list: tag2.name)
+    debate = create(:debate, tag_list: "bad tag")
     debate.hide
 
     visit admin_tags_path
 
-    expect(page).to have_content @tag1.name
-    expect(page).to have_content tag2.name
+    expect(page).to have_content "Existence"
+    expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
       click_link "Delete topic"
     end
 
     visit admin_tags_path
-    expect(page).to have_content @tag1.name
-    expect(page).not_to have_content tag2.name
+    expect(page).to have_content "Existence"
+    expect(page).not_to have_content "bad tag"
   end
 
   context "Manage only tags of kind category" do
@@ -73,7 +74,7 @@ describe "Admin tags" do
 
       visit admin_tags_path
 
-      expect(page).to have_content @tag1.name
+      expect(page).to have_content "Existence"
       expect(page).not_to have_content "Not a category"
     end
 

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -94,24 +94,24 @@ describe "Ballots" do
       end
 
       scenario "Investments" do
-        city_heading1     = create(:budget_heading, group: city,      name: "Investments Type1")
-        city_heading2     = create(:budget_heading, group: city,      name: "Investments Type2")
+        city_heading1     = create(:budget_heading, group: city,      name: "Above the city")
+        city_heading2     = create(:budget_heading, group: city,      name: "Under the city")
         district_heading1 = create(:budget_heading, group: districts, name: "District 1")
         district_heading2 = create(:budget_heading, group: districts, name: "District 2")
 
-        city_investment1      = create(:budget_investment, :selected, heading: city_heading1)
-        city_investment2      = create(:budget_investment, :selected, heading: city_heading1)
-        district1_investment1 = create(:budget_investment, :selected, heading: district_heading1)
-        district1_investment2 = create(:budget_investment, :selected, heading: district_heading1)
-        district2_investment1 = create(:budget_investment, :selected, heading: district_heading2)
+        create(:budget_investment, :selected, heading: city_heading1, title: "Solar panels")
+        create(:budget_investment, :selected, heading: city_heading1, title: "Observatory")
+        create(:budget_investment, :selected, heading: district_heading1, title: "New park")
+        create(:budget_investment, :selected, heading: district_heading1, title: "Zero-emission zone")
+        create(:budget_investment, :selected, heading: district_heading2, title: "Climbing wall")
 
         visit budget_path(budget)
         click_link "City"
-        click_link "Investments Type1"
+        click_link "Above the city"
 
         expect(page).to have_css(".budget-investment", count: 2)
-        expect(page).to have_content city_investment1.title
-        expect(page).to have_content city_investment2.title
+        expect(page).to have_content "Solar panels"
+        expect(page).to have_content "Observatory"
 
         visit budget_path(budget)
 
@@ -119,15 +119,15 @@ describe "Ballots" do
         click_link "District 1"
 
         expect(page).to have_css(".budget-investment", count: 2)
-        expect(page).to have_content district1_investment1.title
-        expect(page).to have_content district1_investment2.title
+        expect(page).to have_content "New park"
+        expect(page).to have_content "Zero-emission zone"
 
         visit budget_path(budget)
         click_link "Districts"
         click_link "District 2"
 
         expect(page).to have_css(".budget-investment", count: 1)
-        expect(page).to have_content district2_investment1.title
+        expect(page).to have_content "Climbing wall"
       end
 
       scenario "Redirect to first heading if there is only one" do

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -39,19 +39,17 @@ describe "Ballots" do
   end
 
   context "Lines Load" do
-
-    let!(:investment) { create(:budget_investment, :selected, heading: california) }
-
     before do
+      create(:budget_investment, :selected, heading: california, title: "More rain")
       budget.update(slug: "budget_slug")
       login_as(user)
     end
 
     scenario "finds ballot lines using budget slug", :js do
       visit budget_investments_path("budget_slug", states, california)
-      add_to_ballot(investment)
+      add_to_ballot("More rain")
 
-      within("#sidebar") { expect(page).to have_content investment.title }
+      within("#sidebar") { expect(page).to have_content "More rain" }
     end
 
   end
@@ -147,31 +145,31 @@ describe "Ballots" do
     context "Adding and Removing Investments" do
 
       scenario "Add a investment", :js do
-        investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000)
-        investment2 = create(:budget_investment, :selected, heading: new_york, price: 20000)
+        create(:budget_investment, :selected, heading: new_york, price: 10000, title: "Bring back King Kong")
+        create(:budget_investment, :selected, heading: new_york, price: 20000, title: "Paint cabs black")
 
         visit budget_path(budget)
         click_link "States"
         click_link "New York"
 
-        add_to_ballot(investment1)
+        add_to_ballot("Bring back King Kong")
 
         expect(page).to have_css("#amount-spent", text: "€10,000")
         expect(page).to have_css("#amount-available", text: "€990,000")
 
         within("#sidebar") do
-          expect(page).to have_content investment1.title
+          expect(page).to have_content "Bring back King Kong"
           expect(page).to have_content "€10,000"
           expect(page).to have_link("Check and confirm my ballot")
         end
 
-        add_to_ballot(investment2)
+        add_to_ballot("Paint cabs black")
 
         expect(page).to have_css("#amount-spent", text: "€30,000")
         expect(page).to have_css("#amount-available", text: "€970,000")
 
         within("#sidebar") do
-          expect(page).to have_content investment2.title
+          expect(page).to have_content "Paint cabs black"
           expect(page).to have_content "€20,000"
           expect(page).to have_link("Check and confirm my ballot")
         end
@@ -209,7 +207,7 @@ describe "Ballots" do
       end
 
       scenario "the Map shoud be visible before and after", :js do
-        investment = create(:budget_investment, :selected, heading: new_york, price: 10000)
+        create(:budget_investment, :selected, heading: new_york, price: 10000, title: "More bridges")
 
         visit budget_path(budget)
         click_link "States"
@@ -219,19 +217,19 @@ describe "Ballots" do
           expect(page).to have_content "OpenStreetMap"
         end
 
-        add_to_ballot(investment)
+        add_to_ballot("More bridges")
 
         within("#sidebar") do
-          expect(page).to have_content investment.title
+          expect(page).to have_content "More bridges"
           expect(page).to have_content "OpenStreetMap"
         end
 
-        within("#budget_investment_#{investment.id}") do
+        within(".budget-investment", text: "More bridges") do
           click_link "Remove vote"
         end
 
         within("#sidebar") do
-          expect(page).not_to have_content investment.title
+          expect(page).not_to have_content "More bridges"
           expect(page).to have_content "OpenStreetMap"
         end
       end
@@ -246,20 +244,20 @@ describe "Ballots" do
         district_heading1 = create(:budget_heading, group: districts, name: "District 1", price: 1000000)
         district_heading2 = create(:budget_heading, group: districts, name: "District 2", price: 2000000)
 
-        investment1 = create(:budget_investment, :selected, heading: city_heading,      price: 10000)
-        investment2 = create(:budget_investment, :selected, heading: district_heading1, price: 20000)
-        investment3 = create(:budget_investment, :selected, heading: district_heading2, price: 30000)
+        create(:budget_investment, :selected, heading: city_heading,      price: 10000, title: "Cheap")
+        create(:budget_investment, :selected, heading: district_heading1, price: 20000, title: "Average")
+        create(:budget_investment, :selected, heading: district_heading2, price: 30000, title: "Expensive")
 
         visit budget_path(budget)
         click_link "City"
 
-        add_to_ballot(investment1)
+        add_to_ballot("Cheap")
 
         expect(page).to have_css("#amount-spent",     text: "€10,000")
         expect(page).to have_css("#amount-available", text: "€9,990,000")
 
         within("#sidebar") do
-          expect(page).to have_content investment1.title
+          expect(page).to have_content "Cheap"
           expect(page).to have_content "€10,000"
         end
 
@@ -270,16 +268,16 @@ describe "Ballots" do
         expect(page).to have_css("#amount-spent", text: "€0")
         expect(page).to have_css("#amount-spent", text: "€1,000,000")
 
-        add_to_ballot(investment2)
+        add_to_ballot("Average")
 
         expect(page).to have_css("#amount-spent",     text: "€20,000")
         expect(page).to have_css("#amount-available", text: "€980,000")
 
         within("#sidebar") do
-          expect(page).to have_content investment2.title
+          expect(page).to have_content "Average"
           expect(page).to have_content "€20,000"
 
-          expect(page).not_to have_content investment1.title
+          expect(page).not_to have_content "Cheap"
           expect(page).not_to have_content "€10,000"
         end
 
@@ -290,10 +288,10 @@ describe "Ballots" do
         expect(page).to have_css("#amount-available", text: "€9,990,000")
 
         within("#sidebar") do
-          expect(page).to have_content investment1.title
+          expect(page).to have_content "Cheap"
           expect(page).to have_content "€10,000"
 
-          expect(page).not_to have_content investment2.title
+          expect(page).not_to have_content "Average"
           expect(page).not_to have_content "€20,000"
         end
 
@@ -306,12 +304,11 @@ describe "Ballots" do
     end
 
     scenario "Display progress bar after first vote", :js do
-      investment = create(:budget_investment, :selected, heading: new_york, price: 10000)
+      create(:budget_investment, :selected, heading: new_york, price: 10000, title: "Park expansion")
 
       visit budget_investments_path(budget, heading_id: new_york.id)
 
-      expect(page).to have_content investment.title
-      add_to_ballot(investment)
+      add_to_ballot("Park expansion")
 
       within("#progress_bar") do
         expect(page).to have_css("#amount-spent", text: "€10,000")
@@ -320,17 +317,16 @@ describe "Ballots" do
   end
 
   context "Groups" do
-
-    let!(:investment) { create(:budget_investment, :selected, heading: california) }
-
     before { login_as(user) }
 
     scenario "Select my heading", :js do
+      create(:budget_investment, :selected, heading: california, title: "Green beach")
+
       visit budget_path(budget)
       click_link "States"
       click_link "California"
 
-      add_to_ballot(investment)
+      add_to_ballot("Green beach")
 
       visit budget_path(budget)
       click_link "States"
@@ -340,19 +336,19 @@ describe "Ballots" do
     end
 
     scenario "Change my heading", :js do
-      investment1 = create(:budget_investment, :selected, heading: california, balloters: [user])
-      investment2 = create(:budget_investment, :selected, heading: new_york)
+      create(:budget_investment, :selected, heading: california, title: "Early ShakeAlert", balloters: [user])
+      create(:budget_investment, :selected, heading: new_york, title: "Avengers Tower")
 
       visit budget_investments_path(budget, heading_id: california.id)
 
-      within("#budget_investment_#{investment1.id}") do
+      within(".budget-investment", text: "Early ShakeAlert") do
         find(".remove a").click
         expect(page).to have_link "Vote"
       end
 
       visit budget_investments_path(budget, heading_id: new_york.id)
 
-      add_to_ballot(investment2)
+      add_to_ballot("Avengers Tower")
 
       visit budget_path(budget)
       click_link "States"
@@ -483,11 +479,11 @@ describe "Ballots" do
   end
 
   scenario "Back link after removing an investment from Ballot", :js do
-    investment = create(:budget_investment, :selected, heading: new_york, price: 10)
+    create(:budget_investment, :selected, heading: new_york, price: 10, title: "Sully monument")
 
     login_as(user)
     visit budget_investments_path(budget, heading_id: new_york.id)
-    add_to_ballot(investment)
+    add_to_ballot("Sully monument")
 
     within(".budget-heading") do
       click_link "Check and confirm my ballot"
@@ -495,7 +491,7 @@ describe "Ballots" do
 
     expect(page).to have_content("You have voted one investment")
 
-    within("#budget_investment_#{investment.id}") do
+    within(".ballot-list li", text: "Sully monument") do
       find(".icon-x").click
     end
 
@@ -603,21 +599,21 @@ describe "Ballots" do
     end
 
     scenario "Insufficient funds (added after create)", :js do
-      bi1 = create(:budget_investment, :selected, heading: california, price: 600)
-      bi2 = create(:budget_investment, :selected, heading: california, price: 500)
+      create(:budget_investment, :selected, heading: california, price: 600, title: "Build replicants")
+      create(:budget_investment, :selected, heading: california, price: 500, title: "Build terminators")
 
       login_as(user)
       visit budget_investments_path(budget, heading_id: california.id)
 
-      within("#budget_investment_#{bi1.id}") do
+      within(".budget-investment", text: "Build replicants") do
         find("div.ballot").hover
         expect(page).not_to have_content("You have already assigned the available budget")
         expect(page).to have_selector(".in-favor a", visible: true)
       end
 
-      add_to_ballot(bi1)
+      add_to_ballot("Build replicants")
 
-      within("#budget_investment_#{bi2.id}") do
+      within(".budget-investment", text: "Build terminators") do
         find("div.ballot").hover
         expect(page).to have_content("You have already assigned the available budget")
         expect(page).to have_selector(".in-favor a", visible: false)

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -454,9 +454,9 @@ describe "Budget Investments" do
           ana  = create :user, official_level: 1
           john = create :user, official_level: 1
 
-          bdgt_invest1 = create(:budget_investment, heading: heading, title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
-          bdgt_invest2 = create(:budget_investment, heading: heading, title: "Hello Schwifty", author: john, created_at: 2.days.ago)
-          bdgt_invest3 = create(:budget_investment, heading: heading, title: "Save the forest")
+          create(:budget_investment, heading: heading, title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
+          create(:budget_investment, heading: heading, title: "Hello Schwifty", author: john, created_at: 2.days.ago)
+          create(:budget_investment, heading: heading, title: "Save the forest")
 
           visit budget_investments_path(budget)
 
@@ -470,7 +470,7 @@ describe "Budget Investments" do
           expect(page).to have_content("There is 1 investment")
 
           within("#budget-investments") do
-            expect(page).to have_content(bdgt_invest1.title)
+            expect(page).to have_content "Get Schwifty"
           end
         end
 
@@ -1336,13 +1336,13 @@ describe "Budget Investments" do
         carabanchel = create(:budget_heading, group: group)
         salamanca   = create(:budget_heading, group: group)
 
-        carabanchel_investment = create(:budget_investment, :selected, heading: carabanchel)
-        salamanca_investment   = create(:budget_investment, :selected, heading: salamanca)
+        create(:budget_investment, :selected, title: "In Carabanchel", heading: carabanchel)
+        create(:budget_investment, :selected, title: "In Salamanca", heading: salamanca)
 
         login_as(author)
         visit budget_investments_path(budget, heading_id: carabanchel.id)
 
-        within("#budget_investment_#{carabanchel_investment.id}") do
+        within(".budget-investment", text: "In Carabanchel") do
           expect(page).to have_css(".in-favor a[data-confirm]")
         end
       end
@@ -1351,13 +1351,13 @@ describe "Budget Investments" do
         carabanchel = create(:budget_heading, group: group)
         salamanca   = create(:budget_heading, group: group)
 
-        carabanchel_investment = create(:budget_investment, heading: carabanchel, voters: [author])
-        salamanca_investment   = create(:budget_investment, heading: salamanca)
+        create(:budget_investment, title: "In Carabanchel", heading: carabanchel, voters: [author])
+        create(:budget_investment, title: "In Salamanca", heading: salamanca)
 
         login_as(author)
         visit budget_investments_path(budget, heading_id: carabanchel.id)
 
-        within("#budget_investment_#{carabanchel_investment.id}") do
+        within(".budget-investment", text: "In Carabanchel") do
           expect(page).not_to have_css(".in-favor a[data-confirm]")
         end
       end

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1547,12 +1547,12 @@ describe "Budget Investments" do
       new_york_heading    = create(:budget_heading, group: group, name: "New York",
                                    latitude: -43.223412, longitude: 12.009423)
 
-      investment1 = create(:budget_investment, :selected, price: 1, heading: global_heading)
-      investment2 = create(:budget_investment, :selected, price: 10, heading: global_heading)
-      investment3 = create(:budget_investment, :selected, price: 100, heading: global_heading)
-      investment4 = create(:budget_investment, :selected, price: 1000, heading: carabanchel_heading)
-      investment5 = create(:budget_investment, :selected, price: 10000, heading: carabanchel_heading)
-      investment6 = create(:budget_investment, :selected, price: 100000, heading: new_york_heading)
+      create(:budget_investment, :selected, price: 1, heading: global_heading, title: "World T-Shirt")
+      create(:budget_investment, :selected, price: 10, heading: global_heading, title: "Eco pens")
+      create(:budget_investment, :selected, price: 100, heading: global_heading, title: "Free tablet")
+      create(:budget_investment, :selected, price: 1000, heading: carabanchel_heading, title: "Fireworks")
+      create(:budget_investment, :selected, price: 10000, heading: carabanchel_heading, title: "Bus pass")
+      create(:budget_investment, :selected, price: 100000, heading: new_york_heading, title: "NASA base")
 
       login_as(user)
       visit budget_path(budget)
@@ -1561,16 +1561,16 @@ describe "Budget Investments" do
       # No need to click_link "Global Heading" because the link of a group with a single heading
       # points to the list of investments directly
 
-      add_to_ballot(investment1)
-      add_to_ballot(investment2)
+      add_to_ballot("World T-Shirt")
+      add_to_ballot("Eco pens")
 
       visit budget_path(budget)
 
       click_link "Health"
       click_link "Carabanchel"
 
-      add_to_ballot(investment4)
-      add_to_ballot(investment5)
+      add_to_ballot("Fireworks")
+      add_to_ballot("Bus pass")
 
       visit budget_ballot_path(budget)
 
@@ -1578,24 +1578,24 @@ describe "Budget Investments" do
                                    "until this phase is closed."
 
       within("#budget_group_#{global_group.id}") do
-        expect(page).to have_content investment1.title
-        expect(page).to have_content "€#{investment1.price}"
+        expect(page).to have_content "World T-Shirt"
+        expect(page).to have_content "€1"
 
-        expect(page).to have_content investment2.title
-        expect(page).to have_content "€#{investment2.price}"
+        expect(page).to have_content "Eco pens"
+        expect(page).to have_content "€10"
 
-        expect(page).not_to have_content investment3.title
-        expect(page).not_to have_content "€#{investment3.price}"
+        expect(page).not_to have_content "Free tablet"
+        expect(page).not_to have_content "€100"
       end
 
       within("#budget_group_#{group.id}") do
-        expect(page).to have_content investment4.title
+        expect(page).to have_content "Fireworks"
         expect(page).to have_content "€1,000"
 
-        expect(page).to have_content investment5.title
+        expect(page).to have_content "Bus pass"
         expect(page).to have_content "€10,000"
 
-        expect(page).not_to have_content investment6.title
+        expect(page).not_to have_content "NASA base"
         expect(page).not_to have_content "€100,000"
       end
     end
@@ -1606,7 +1606,8 @@ describe "Budget Investments" do
 
       heading_1 = create(:budget_heading, group: group, name: "Heading 1")
       heading_2 = create(:budget_heading, group: group, name: "Heading 2")
-      investment = create(:budget_investment, :selected, heading: heading_1)
+
+      create(:budget_investment, :selected, heading: heading_1, title: "Zero-emission zone")
 
       login_as(user)
       visit budget_path(budget)
@@ -1614,7 +1615,7 @@ describe "Budget Investments" do
       click_link "Health"
       click_link "Heading 1"
 
-      add_to_ballot(investment)
+      add_to_ballot("Zero-emission zone")
 
       visit budget_group_path(budget, group)
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1369,13 +1369,13 @@ describe "Budget Investments" do
         another_heading1 = create(:budget_heading, group: group2)
         another_heading2 = create(:budget_heading, group: group2)
 
-        heading_investment = create(:budget_investment, heading: heading, voters: [author])
-        another_group_investment = create(:budget_investment, heading: another_heading1)
+        create(:budget_investment, heading: heading, title: "Investment", voters: [author])
+        create(:budget_investment, heading: another_heading1, title: "Another investment")
 
         login_as(author)
         visit budget_investments_path(budget, heading_id: another_heading1.id)
 
-        within("#budget_investment_#{another_group_investment.id}") do
+        within(".budget-investment", text: "Another investment") do
           expect(page).to have_css(".in-favor a[data-confirm]")
         end
       end

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -552,18 +552,28 @@ describe "Budget Investments" do
     scenario "by unfeasibilty link for group with many headings" do
       budget.update(phase: :balloting)
       group = create(:budget_group, name: "Districts", budget: budget)
-      heading1 = create(:budget_heading, name: "Carabanchel", group: group)
-      heading2 = create(:budget_heading, name: "Barajas",     group: group)
+
+      barajas = create(:budget_heading, name: "Barajas", group: group)
+      carabanchel = create(:budget_heading, name: "Carabanchel", group: group)
+
+      create(:budget_investment, :feasible, heading: barajas, title: "Terminal 5")
+      create(:budget_investment, :unfeasible, heading: barajas, title: "Seaport")
+      create(:budget_investment, :unfeasible, heading: carabanchel, title: "Airport")
 
       visit budget_path(budget)
 
       click_link "See unfeasible investments"
 
       click_link "Districts"
-      click_link "Carabanchel"
+      click_link "Barajas"
 
-      expected_path = budget_investments_path(budget, heading_id: heading1.id, filter: "unfeasible")
-      expect(page).to have_current_path(expected_path)
+      within("#budget-investments") do
+        expect(page).to have_css(".budget-investment", count: 1)
+
+        expect(page).to have_content "Seaport"
+        expect(page).not_to have_content "Terminal 5"
+        expect(page).not_to have_content "Airport"
+      end
     end
 
     context "Results Phase" do
@@ -1681,18 +1691,28 @@ describe "Budget Investments" do
 
     scenario "Shows unselected link for group with many headings" do
       group = create(:budget_group, name: "Districts", budget: budget)
-      heading1 = create(:budget_heading, name: "Carabanchel", group: group)
-      heading2 = create(:budget_heading, name: "Barajas",     group: group)
+
+      barajas = create(:budget_heading, name: "Barajas", group: group)
+      carabanchel = create(:budget_heading, name: "Carabanchel", group: group)
+
+      create(:budget_investment, :selected, heading: barajas, title: "Terminal 5")
+      create(:budget_investment, :unselected, heading: barajas, title: "Seaport")
+      create(:budget_investment, :unselected, heading: carabanchel, title: "Airport")
 
       visit budget_path(budget)
 
       click_link "See investments not selected for balloting phase"
 
       click_link "Districts"
-      click_link "Carabanchel"
+      click_link "Barajas"
 
-      expected_path = budget_investments_path(budget, heading_id: heading1.id, filter: "unselected")
-      expect(page).to have_current_path(expected_path)
+      within("#budget-investments") do
+        expect(page).to have_css(".budget-investment", count: 1)
+
+        expect(page).to have_content "Seaport"
+        expect(page).not_to have_content "Terminal 5"
+        expect(page).not_to have_content "Airport"
+      end
     end
 
     scenario "Do not display vote button for unselected investments in index" do

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -860,9 +860,9 @@ describe "Debates" do
           ana  = create :user, official_level: 1
           john = create :user, official_level: 1
 
-          debate1 = create(:debate, title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
-          debate2 = create(:debate, title: "Hello Schwifty", author: john, created_at: 2.days.ago)
-          debate3 = create(:debate, title: "Save the forest")
+          create(:debate, title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
+          create(:debate, title: "Hello Schwifty", author: john, created_at: 2.days.ago)
+          create(:debate, title: "Save the forest")
 
           visit debates_path
 
@@ -875,7 +875,7 @@ describe "Debates" do
 
           within("#debates") do
             expect(page).to have_css(".debate", count: 1)
-            expect(page).to have_content(debate1.title)
+            expect(page).to have_content "Get Schwifty"
           end
         end
 
@@ -978,12 +978,12 @@ describe "Debates" do
     end
 
     scenario "After a search do not show featured debates" do
-      featured_debates = create_featured_debates
-      debate = create(:debate, title: "Abcdefghi")
+      create_featured_debates
+      create(:debate, title: "Abcdefghi")
 
       visit debates_path
       within(".expanded #search_form") do
-        fill_in "search", with: debate.title
+        fill_in "search", with: "Abcdefghi"
         click_button "Search"
       end
 

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -1017,16 +1017,14 @@ describe "Debates" do
   end
 
   context "Filter" do
-
     context "By geozone" do
+      let(:california) { Geozone.create(name: "California") }
+      let(:new_york)   { Geozone.create(name: "New York") }
 
       before do
-        @california = Geozone.create(name: "California")
-        @new_york   = Geozone.create(name: "New York")
-
-        @debate1 = create(:debate, geozone: @california)
-        @debate2 = create(:debate, geozone: @california)
-        @debate3 = create(:debate, geozone: @new_york)
+        create(:debate, geozone: california, title: "Bigger sequoias")
+        create(:debate, geozone: california, title: "Green beach")
+        create(:debate, geozone: new_york, title: "Sully monument")
       end
 
       pending "From map" do
@@ -1040,9 +1038,9 @@ describe "Debates" do
 
         within("#debates") do
           expect(page).to have_css(".debate", count: 2)
-          expect(page).to have_content(@debate1.title)
-          expect(page).to have_content(@debate2.title)
-          expect(page).not_to have_content(@debate3.title)
+          expect(page).to have_content("Bigger sequoias")
+          expect(page).to have_content("Green beach")
+          expect(page).not_to have_content("Sully monument")
         end
       end
 
@@ -1055,24 +1053,27 @@ describe "Debates" do
         end
         within("#debates") do
           expect(page).to have_css(".debate", count: 2)
-          expect(page).to have_content(@debate1.title)
-          expect(page).to have_content(@debate2.title)
-          expect(page).not_to have_content(@debate3.title)
+          expect(page).to have_content("Bigger sequoias")
+          expect(page).to have_content("Green beach")
+          expect(page).not_to have_content("Sully monument")
         end
       end
 
       pending "From debate" do
-        visit debate_path(@debate1)
+        debate = create(:debate, geozone: california, title: "Surf college")
+
+        visit debate_path(debate)
 
         within("#geozone") do
           click_link "California"
         end
 
         within("#debates") do
-          expect(page).to have_css(".debate", count: 2)
-          expect(page).to have_content(@debate1.title)
-          expect(page).to have_content(@debate2.title)
-          expect(page).not_to have_content(@debate3.title)
+          expect(page).to have_css(".debate", count: 3)
+          expect(page).to have_content("Surf college")
+          expect(page).to have_content("Bigger sequoias")
+          expect(page).to have_content("Green beach")
+          expect(page).not_to have_content("Sully monument")
         end
       end
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1370,9 +1370,9 @@ describe "Proposals" do
           ana  = create :user, official_level: 1
           john = create :user, official_level: 1
 
-          proposal1 = create(:proposal, title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
-          proposal2 = create(:proposal, title: "Hello Schwifty", author: john, created_at: 2.days.ago)
-          proposal3 = create(:proposal, title: "Save the forest")
+          create(:proposal, title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
+          create(:proposal, title: "Hello Schwifty", author: john, created_at: 2.days.ago)
+          create(:proposal, title: "Save the forest")
 
           visit proposals_path
 
@@ -1386,7 +1386,7 @@ describe "Proposals" do
           expect(page).to have_content("There is 1 citizen proposal")
 
           within("#proposals") do
-            expect(page).to have_content(proposal1.title)
+            expect(page).to have_content "Get Schwifty"
           end
         end
 
@@ -1498,12 +1498,12 @@ describe "Proposals" do
 
     scenario "After a search do not show featured proposals" do
       Setting["feature.featured_proposals"] = true
-      featured_proposals = create_featured_proposals
-      proposal = create(:proposal, title: "Abcdefghi")
+      create_featured_proposals
+      create(:proposal, title: "Abcdefghi")
 
       visit proposals_path
       within(".expanded #search_form") do
-        fill_in "search", with: proposal.title
+        fill_in "search", with: "Abcdefghi"
         click_button "Search"
       end
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1654,16 +1654,14 @@ describe "Proposals" do
   end
 
   context "Filter" do
-
     context "By geozone" do
+      let(:california) { Geozone.create(name: "California") }
+      let(:new_york)   { Geozone.create(name: "New York") }
 
       before do
-        @california = Geozone.create(name: "California")
-        @new_york   = Geozone.create(name: "New York")
-
-        @proposal1 = create(:proposal, geozone: @california)
-        @proposal2 = create(:proposal, geozone: @california)
-        @proposal3 = create(:proposal, geozone: @new_york)
+        create(:proposal, geozone: california, title: "Bigger sequoias")
+        create(:proposal, geozone: california, title: "Green beach")
+        create(:proposal, geozone: new_york, title: "Sully monument")
       end
 
       scenario "From map" do
@@ -1677,9 +1675,9 @@ describe "Proposals" do
 
         within("#proposals") do
           expect(page).to have_css(".proposal", count: 2)
-          expect(page).to have_content(@proposal1.title)
-          expect(page).to have_content(@proposal2.title)
-          expect(page).not_to have_content(@proposal3.title)
+          expect(page).to have_content("Bigger sequoias")
+          expect(page).to have_content("Green beach")
+          expect(page).not_to have_content("Sully monument")
         end
       end
 
@@ -1692,24 +1690,27 @@ describe "Proposals" do
         end
         within("#proposals") do
           expect(page).to have_css(".proposal", count: 2)
-          expect(page).to have_content(@proposal1.title)
-          expect(page).to have_content(@proposal2.title)
-          expect(page).not_to have_content(@proposal3.title)
+          expect(page).to have_content("Bigger sequoias")
+          expect(page).to have_content("Green beach")
+          expect(page).not_to have_content("Sully monument")
         end
       end
 
       scenario "From proposal" do
-        visit proposal_path(@proposal1)
+        proposal = create(:proposal, geozone: california, title: "Surf college")
+
+        visit proposal_path(proposal)
 
         within("#geozone") do
           click_link "California"
         end
 
         within("#proposals") do
-          expect(page).to have_css(".proposal", count: 2)
-          expect(page).to have_content(@proposal1.title)
-          expect(page).to have_content(@proposal2.title)
-          expect(page).not_to have_content(@proposal3.title)
+          expect(page).to have_css(".proposal", count: 3)
+          expect(page).to have_content("Surf college")
+          expect(page).to have_content("Bigger sequoias")
+          expect(page).to have_content("Green beach")
+          expect(page).not_to have_content("Sully monument")
         end
       end
 

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -206,16 +206,16 @@ describe "Tags" do
     end
 
     scenario "From show" do
-      investment1 = create(:budget_investment, heading: heading, tag_list: tag_economia.name)
-      investment2 = create(:budget_investment, heading: heading, tag_list: "Health")
+      investment = create(:budget_investment, heading: heading, tag_list: "Economy", title: "New bank")
+      create(:budget_investment, heading: heading, tag_list: "Health", title: "New hospital")
 
-      visit budget_investment_path(budget, investment1)
+      visit budget_investment_path(budget, investment)
 
-      click_link tag_economia.name
+      click_link "Economy"
 
       within("#budget-investments") do
         expect(page).to have_css(".budget-investment", count: 1)
-        expect(page).to have_content(investment1.title)
+        expect(page).to have_content "New bank"
       end
     end
 

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -190,19 +190,18 @@ describe "Tags" do
   context "Filter" do
 
     scenario "From index" do
-
-      investment1 = create(:budget_investment, heading: heading, tag_list: tag_economia.name)
-      investment2 = create(:budget_investment, heading: heading, tag_list: "Health")
+      create(:budget_investment, heading: heading, tag_list: "Economy", title: "New bank")
+      create(:budget_investment, heading: heading, tag_list: "Health", title: "New hospital")
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
-      within "#budget_investment_#{investment1.id}" do
-        click_link tag_economia.name
+      within ".budget-investment", text: "New bank" do
+        click_link "Economy"
       end
 
       within("#budget-investments") do
         expect(page).to have_css(".budget-investment", count: 1)
-        expect(page).to have_content(investment1.title)
+        expect(page).to have_content "New bank"
       end
     end
 

--- a/spec/features/tags/debates_spec.rb
+++ b/spec/features/tags/debates_spec.rb
@@ -152,18 +152,18 @@ describe "Tags" do
   context "Filter" do
 
     scenario "From index" do
-      debate1 = create(:debate, tag_list: "Education")
-      debate2 = create(:debate, tag_list: "Health")
+      create(:debate, tag_list: "Health", title: "Public hospitals?")
+      create(:debate, tag_list: "Education", title: "Status of our schools")
 
-      visit debates_path
+      visit debates_path(order: :created_at)
 
-      within "#debate_#{debate1.id}" do
+      within ".debate", text: "Status of our schools" do
         click_link "Education"
       end
 
       within("#debates") do
         expect(page).to have_css(".debate", count: 1)
-        expect(page).to have_content(debate1.title)
+        expect(page).to have_content "Status of our schools"
       end
     end
 

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -186,18 +186,18 @@ describe "Tags" do
   context "Filter" do
 
     scenario "From index" do
-      proposal1 = create(:proposal, tag_list: "Education")
-      proposal2 = create(:proposal, tag_list: "Health")
+      create(:proposal, tag_list: "Health", title: "More green spaces")
+      create(:proposal, tag_list: "Education", title: "Online teachers")
 
       visit proposals_path
 
-      within "#proposal_#{proposal1.id}" do
+      within ".proposal", text: "Online teachers" do
         click_link "Education"
       end
 
       within("#proposals") do
         expect(page).to have_css(".proposal", count: 1)
-        expect(page).to have_content(proposal1.title)
+        expect(page).to have_content "Online teachers"
       end
     end
 

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -133,13 +133,13 @@ describe "Consul Schema" do
 
   describe "Proposals" do
     it "does not include hidden proposals" do
-      visible_proposal = create(:proposal)
-      hidden_proposal  = create(:proposal, :hidden)
+      create(:proposal, title: "Visible")
+      create(:proposal, :hidden, title: "Hidden")
 
       response = execute("{ proposals { edges { node { title } } } }")
       received_titles = extract_fields(response, "proposals", "title")
 
-      expect(received_titles).to match_array [visible_proposal.title]
+      expect(received_titles).to match_array ["Visible"]
     end
 
     it "includes proposals of authors even if public activity is set to false" do
@@ -156,13 +156,13 @@ describe "Consul Schema" do
     end
 
     it "does not link author if public activity is set to false" do
-      visible_author = create(:user, :with_proposal, public_activity: true)
-      hidden_author  = create(:user, :with_proposal, public_activity: false)
+      create(:user, :with_proposal, username: "public",  public_activity: true)
+      create(:user, :with_proposal, username: "private", public_activity: false)
 
       response = execute("{ proposals { edges { node { public_author { username } } } } }")
       received_authors = extract_fields(response, "proposals", "public_author.username")
 
-      expect(received_authors).to match_array [visible_author.username]
+      expect(received_authors).to match_array ["public"]
     end
 
     it "only returns date and hour for created_at" do
@@ -201,13 +201,13 @@ describe "Consul Schema" do
 
   describe "Debates" do
     it "does not include hidden debates" do
-      visible_debate = create(:debate)
-      hidden_debate  = create(:debate, :hidden)
+      create(:debate, title: "Visible")
+      create(:debate, :hidden, title: "Hidden")
 
       response = execute("{ debates { edges { node { title } } } }")
       received_titles = extract_fields(response, "debates", "title")
 
-      expect(received_titles).to match_array [visible_debate.title]
+      expect(received_titles).to match_array ["Visible"]
     end
 
     it "includes debates of authors even if public activity is set to false" do
@@ -224,13 +224,13 @@ describe "Consul Schema" do
     end
 
     it "does not link author if public activity is set to false" do
-      visible_author = create(:user, :with_debate, public_activity: true)
-      hidden_author  = create(:user, :with_debate, public_activity: false)
+      create(:user, :with_debate, username: "public",  public_activity: true)
+      create(:user, :with_debate, username: "private", public_activity: false)
 
       response = execute("{ debates { edges { node { public_author { username } } } } }")
       received_authors = extract_fields(response, "debates", "public_author.username")
 
-      expect(received_authors).to match_array [visible_author.username]
+      expect(received_authors).to match_array ["public"]
     end
 
     it "only returns date and hour for created_at" do
@@ -284,62 +284,62 @@ describe "Consul Schema" do
     end
 
     it "does not link author if public activity is set to false" do
-      visible_author = create(:user, :with_comment, public_activity: true)
-      hidden_author  = create(:user, :with_comment, public_activity: false)
+      create(:user, :with_comment, username: "public",  public_activity: true)
+      create(:user, :with_comment, username: "private", public_activity: false)
 
       response = execute("{ comments { edges { node { public_author { username } } } } }")
       received_authors = extract_fields(response, "comments", "public_author.username")
 
-      expect(received_authors).to match_array [visible_author.username]
+      expect(received_authors).to match_array ["public"]
     end
 
     it "does not include hidden comments" do
-      visible_comment = create(:comment)
-      hidden_comment  = create(:comment, :hidden)
+      create(:comment, body: "Visible")
+      create(:comment, :hidden, body: "Hidden")
 
       response = execute("{ comments { edges { node { body } } } }")
       received_comments = extract_fields(response, "comments", "body")
 
-      expect(received_comments).to match_array [visible_comment.body]
+      expect(received_comments).to match_array ["Visible"]
     end
 
     it "does not include comments from hidden proposals" do
       visible_proposal = create(:proposal)
       hidden_proposal  = create(:proposal, :hidden)
 
-      visible_proposal_comment = create(:comment, commentable: visible_proposal)
-      hidden_proposal_comment  = create(:comment, commentable: hidden_proposal)
+      create(:comment, commentable: visible_proposal, body: "I can see the proposal")
+      create(:comment, commentable: hidden_proposal, body: "Someone hid the proposal!")
 
       response = execute("{ comments { edges { node { body } } } }")
       received_comments = extract_fields(response, "comments", "body")
 
-      expect(received_comments).to match_array [visible_proposal_comment.body]
+      expect(received_comments).to match_array ["I can see the proposal"]
     end
 
     it "does not include comments from hidden debates" do
       visible_debate = create(:debate)
       hidden_debate  = create(:debate, :hidden)
 
-      visible_debate_comment = create(:comment, commentable: visible_debate)
-      hidden_debate_comment  = create(:comment, commentable: hidden_debate)
+      create(:comment, commentable: visible_debate, body: "I can see the debate")
+      create(:comment, commentable: hidden_debate, body: "Someone hid the debate!")
 
       response = execute("{ comments { edges { node { body } } } }")
       received_comments = extract_fields(response, "comments", "body")
 
-      expect(received_comments).to match_array [visible_debate_comment.body]
+      expect(received_comments).to match_array ["I can see the debate"]
     end
 
     it "does not include comments from hidden polls" do
       visible_poll = create(:poll)
       hidden_poll  = create(:poll, :hidden)
 
-      visible_poll_comment = create(:comment, commentable: visible_poll)
-      hidden_poll_comment  = create(:comment, commentable: hidden_poll)
+      create(:comment, commentable: visible_poll, body: "I can see the poll")
+      create(:comment, commentable: hidden_poll, body: "This poll is hidden!")
 
       response = execute("{ comments { edges { node { body } } } }")
       received_comments = extract_fields(response, "comments", "body")
 
-      expect(received_comments).to match_array [visible_poll_comment.body]
+      expect(received_comments).to match_array ["I can see the poll"]
     end
 
     it "does not include comments of debates that are not public" do
@@ -386,13 +386,13 @@ describe "Consul Schema" do
     end
 
     it "does not include valuation comments" do
-      visible_comment = create(:comment)
-      valuation_comment = create(:comment, :valuation)
+      create(:comment, body: "Regular comment")
+      create(:comment, :valuation, body: "Valuation comment")
 
       response = execute("{ comments { edges { node { body } } } }")
       received_comments = extract_fields(response, "comments", "body")
 
-      expect(received_comments).not_to include(valuation_comment.body)
+      expect(received_comments).not_to include "Valuation comment"
     end
   end
 
@@ -413,13 +413,13 @@ describe "Consul Schema" do
       visible_proposal = create(:proposal)
       hidden_proposal  = create(:proposal, :hidden)
 
-      visible_proposal_notification = create(:proposal_notification, proposal: visible_proposal)
-      hidden_proposal_notification  = create(:proposal_notification, proposal: hidden_proposal)
+      create(:proposal_notification, proposal: visible_proposal, title: "I can see the proposal")
+      create(:proposal_notification, proposal: hidden_proposal, title: "Someone hid the proposal!")
 
       response = execute("{ proposal_notifications { edges { node { title } } } }")
       received_notifications = extract_fields(response, "proposal_notifications", "title")
 
-      expect(received_notifications).to match_array [visible_proposal_notification.title]
+      expect(received_notifications).to match_array ["I can see the proposal"]
     end
 
     it "does not include proposal notifications for proposals that are not public" do
@@ -444,16 +444,16 @@ describe "Consul Schema" do
     end
 
     it "only links proposal if public" do
-      visible_proposal = create(:proposal)
-      hidden_proposal  = create(:proposal, :hidden)
+      visible_proposal = create(:proposal, title: "Visible")
+      hidden_proposal  = create(:proposal, :hidden, title: "Hidden")
 
-      visible_proposal_notification = create(:proposal_notification, proposal: visible_proposal)
-      hidden_proposal_notification  = create(:proposal_notification, proposal: hidden_proposal)
+      create(:proposal_notification, proposal: visible_proposal)
+      create(:proposal_notification, proposal: hidden_proposal)
 
       response = execute("{ proposal_notifications { edges { node { proposal { title } } } } }")
       received_proposals = extract_fields(response, "proposal_notifications", "proposal.title")
 
-      expect(received_proposals).to match_array [visible_proposal.title]
+      expect(received_proposals).to match_array ["Visible"]
     end
 
   end

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -546,59 +546,59 @@ describe "Consul Schema" do
     end
 
     it "does not include votes from hidden debates" do
-      visible_debate = create(:debate, voters: [create(:user)])
-      hidden_debate  = create(:debate, :hidden, voters: [create(:user)])
+      create(:debate, id: 1, voters: [create(:user)])
+      create(:debate, :hidden, id: 2, voters: [create(:user)])
 
       response = execute("{ votes { edges { node { votable_id } } } }")
       received_debates = extract_fields(response, "votes", "votable_id")
 
-      expect(received_debates).to match_array [visible_debate.id]
+      expect(received_debates).to match_array [1]
     end
 
     it "does not include votes of hidden proposals" do
-      visible_proposal = create(:proposal, voters: [create(:user)])
-      hidden_proposal  = create(:proposal, :hidden, voters: [create(:user)])
+      create(:proposal, id: 1, voters: [create(:user)])
+      create(:proposal, :hidden, id: 2, voters: [create(:user)])
 
       response = execute("{ votes { edges { node { votable_id } } } }")
       received_proposals = extract_fields(response, "votes", "votable_id")
 
-      expect(received_proposals).to match_array [visible_proposal.id]
+      expect(received_proposals).to match_array [1]
     end
 
     it "does not include votes of hidden comments" do
-      visible_comment = create(:comment, voters: [create(:user)])
-      hidden_comment  = create(:comment, :hidden, voters: [create(:user)])
+      create(:comment, id: 1, voters: [create(:user)])
+      create(:comment, :hidden, id: 2, voters: [create(:user)])
 
       response = execute("{ votes { edges { node { votable_id } } } }")
       received_comments = extract_fields(response, "votes", "votable_id")
 
-      expect(received_comments).to match_array [visible_comment.id]
+      expect(received_comments).to match_array [1]
     end
 
     it "does not include votes of comments from a hidden proposal" do
       visible_proposal = create(:proposal)
       hidden_proposal  = create(:proposal, :hidden)
 
-      visible_proposal_comment = create(:comment, commentable: visible_proposal, voters: [create(:user)])
-      hidden_proposal_comment  = create(:comment, commentable: hidden_proposal, voters: [create(:user)])
+      create(:comment, id: 1, commentable: visible_proposal, voters: [create(:user)])
+      create(:comment, id: 2, commentable: hidden_proposal, voters: [create(:user)])
 
       response = execute("{ votes { edges { node { votable_id } } } }")
       received_votables = extract_fields(response, "votes", "votable_id")
 
-      expect(received_votables).to match_array [visible_proposal_comment.id]
+      expect(received_votables).to match_array [1]
     end
 
     it "does not include votes of comments from a hidden debate" do
       visible_debate = create(:debate)
       hidden_debate  = create(:debate, :hidden)
 
-      visible_debate_comment = create(:comment, commentable: visible_debate, voters: [create(:user)])
-      hidden_debate_comment  = create(:comment, commentable: hidden_debate, voters: [create(:user)])
+      create(:comment, id: 1, commentable: visible_debate, voters: [create(:user)])
+      create(:comment, id: 2, commentable: hidden_debate, voters: [create(:user)])
 
       response = execute("{ votes { edges { node { votable_id } } } }")
       received_votables = extract_fields(response, "votes", "votable_id")
 
-      expect(received_votables).to match_array [visible_debate_comment.id]
+      expect(received_votables).to match_array [1]
     end
 
     it "does not include votes of debates that are not public" do

--- a/spec/models/budget/result_spec.rb
+++ b/spec/models/budget/result_spec.rb
@@ -29,59 +29,59 @@ describe Budget::Result do
       end
 
       it "excludes incompatible investments" do
-        investment1 = create(:budget_investment, :selected, heading: heading, price: 200, ballot_lines_count: 900, winner: false)
-        investment2 = create(:budget_investment, :selected, heading: heading, price: 300, ballot_lines_count: 800, winner: false)
-        investment3 = create(:budget_investment, :incompatible, heading: heading, price: 500, ballot_lines_count: 700, winner: false)
-        investment4 = create(:budget_investment, :selected, heading: heading, price: 500, ballot_lines_count: 600, winner: false)
-        investment5 = create(:budget_investment, :selected, heading: heading, price: 100, ballot_lines_count: 500, winner: false)
+        create(:budget_investment, :selected, heading: heading, price: 200, ballot_lines_count: 900)
+        create(:budget_investment, :selected, heading: heading, price: 300, ballot_lines_count: 800)
+        create(:budget_investment, :incompatible, heading: heading, price: 500, ballot_lines_count: 700)
+        create(:budget_investment, :selected, heading: heading, price: 500, ballot_lines_count: 600)
+        create(:budget_investment, :selected, heading: heading, price: 100, ballot_lines_count: 500)
 
         Budget::Result.new(budget, heading).calculate_winners
 
-        expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment4.id])
+        expect(heading.investments.winners.pluck(:ballot_lines_count)).to match_array([900, 800, 600])
       end
     end
 
     context "When there are winners" do
       it "removes winners and recalculates" do
-        investment1 = create(:budget_investment, :winner, heading: heading, price: 200, ballot_lines_count: 900)
-        investment2 = create(:budget_investment, :winner, heading: heading, price: 300, ballot_lines_count: 800)
-        investment3 = create(:budget_investment, :incompatible, heading: heading, price: 500, ballot_lines_count: 700, winner: true)
-        investment4 = create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 600)
-        investment5 = create(:budget_investment, :winner, heading: heading, price: 100, ballot_lines_count: 500)
+        create(:budget_investment, :selected, heading: heading, price: 200, ballot_lines_count: 900)
+        create(:budget_investment, :winner, heading: heading, price: 300, ballot_lines_count: 800)
+        create(:budget_investment, :winner, :incompatible, heading: heading, price: 500, ballot_lines_count: 700)
+        create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 600)
+        create(:budget_investment, :winner, heading: heading, price: 100, ballot_lines_count: 500)
 
         Budget::Result.new(budget, heading).calculate_winners
 
-        expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment4.id])
+        expect(heading.investments.winners.pluck(:ballot_lines_count)).to match_array([900, 800, 600])
       end
     end
 
     context "When a winner is flagged as incompatible" do
       it "recalculates winners leaving it out" do
-        investment1 = create(:budget_investment, :winner, heading: heading, price: 200, ballot_lines_count: 900)
-        investment2 = create(:budget_investment, :winner, heading: heading, price: 300, ballot_lines_count: 800)
-        investment3 = create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 700)
-        investment4 = create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 600)
-        investment5 = create(:budget_investment, :winner, heading: heading, price: 100, ballot_lines_count: 500)
+        wrong_win = create(:budget_investment, :winner, heading: heading, price: 200, ballot_lines_count: 900)
 
-        investment3.incompatible = true
-        investment3.save
+        create(:budget_investment, :winner, heading: heading, price: 300, ballot_lines_count: 800)
+        create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 700)
+        create(:budget_investment, :winner, heading: heading, price: 200, ballot_lines_count: 600)
+        create(:budget_investment, :winner, heading: heading, price: 100, ballot_lines_count: 500)
 
-        expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment4.id])
+        wrong_win.update(incompatible: true)
+
+        expect(heading.investments.winners.pluck(:ballot_lines_count)).to match_array([800, 700, 600])
       end
     end
 
     context "When an incompatible is flagged as compatible again" do
       it "recalculates winners taking it in consideration" do
-        investment1 = create(:budget_investment, :winner, heading: heading, price: 200, ballot_lines_count: 900)
-        investment2 = create(:budget_investment, :winner, heading: heading, price: 300, ballot_lines_count: 800)
-        investment3 = create(:budget_investment, :incompatible, heading: heading, price: 500, ballot_lines_count: 700)
-        investment4 = create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 600)
-        investment5 = create(:budget_investment, :winner, heading: heading, price: 100, ballot_lines_count: 500)
+        miss = create(:budget_investment, :incompatible, heading: heading, price: 200, ballot_lines_count: 900)
 
-        investment3.incompatible = false
-        investment3.save
+        create(:budget_investment, :winner, heading: heading, price: 300, ballot_lines_count: 800)
+        create(:budget_investment, :winner, heading: heading, price: 500, ballot_lines_count: 700)
+        create(:budget_investment, :winner, heading: heading, price: 200, ballot_lines_count: 600)
+        create(:budget_investment, :winner, heading: heading, price: 100, ballot_lines_count: 500)
 
-        expect(heading.investments.winners.pluck(:id)).to match_array([investment1.id, investment2.id, investment3.id])
+        miss.update(incompatible: false)
+
+        expect(heading.investments.winners.pluck(:ballot_lines_count)).to match_array([900, 800, 700])
       end
     end
   end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -166,12 +166,12 @@ describe Budget do
     end
 
     it "returns the last budget created that is not in drafting phase" do
-      old_budget      = create(:budget, :finished,  created_at: 2.years.ago)
-      previous_budget = create(:budget, :accepting, created_at: 1.year.ago)
-      current_budget  = create(:budget, :accepting, created_at: 1.month.ago)
-      next_budget     = create(:budget, :drafting,  created_at: 1.week.ago)
+      create(:budget, :finished,  created_at: 2.years.ago, name: "Old")
+      create(:budget, :accepting, created_at: 1.year.ago,  name: "Previous")
+      create(:budget, :accepting, created_at: 1.month.ago, name: "Current")
+      create(:budget, :drafting,  created_at: 1.week.ago,  name: "Next")
 
-      expect(Budget.current).to eq(current_budget)
+      expect(Budget.current.name).to eq "Current"
     end
 
   end

--- a/spec/support/common_actions/budgets.rb
+++ b/spec/support/common_actions/budgets.rb
@@ -4,8 +4,8 @@ module Budgets
     expect(page).to have_selector(".in-favor a", visible: false)
   end
 
-  def add_to_ballot(budget_investment)
-    within("#budget_investment_#{budget_investment.id}") do
+  def add_to_ballot(investment_title)
+    within(".budget-investment", text: investment_title) do
       find(".add a").click
       expect(page).to have_content "Remove"
     end


### PR DESCRIPTION
## Background

Our tests vary in style: sometimes we create a proposal and check the view for the proposal's title writing `expect(page).to have_content proposal.title`, and sometimes we create a proposal with a title like "More schools" and check the view with `expect(page).to have_content "More schools"`.

We unanimously prefer the latter style unless there's a good reason to use the former.

## Objectives

* Write tests checking page content form the user's perspective
* Reduce the number of useless assignments given by the Ruby interpreter

## Notes

We're not changing every existing test because it would be overkill. For now we're changing the ones were the Ruby interpreter