### PR TITLE
Use `let` to remove duplication in specs

### DIFF
--- a/spec/features/admin/valuator_groups_spec.rb
+++ b/spec/features/admin/valuator_groups_spec.rb
@@ -81,10 +81,10 @@ describe "Valuator groups" do
   end
 
   context "Assign valuators to groups" do
+    let(:valuator) { create(:valuator) }
 
     scenario "Add a valuator to a group" do
-      valuator = create(:valuator)
-      group = create(:valuator_group, name: "Health")
+      create(:valuator_group, name: "Health")
 
       visit edit_admin_valuator_path(valuator)
 
@@ -96,10 +96,8 @@ describe "Valuator groups" do
     end
 
     scenario "Update a valuator's group" do
-      valuator = create(:valuator)
-      group1 = create(:valuator_group, name: "Health")
-      group2 = create(:valuator_group, name: "Economy")
-      valuator.update(valuator_group: group1)
+      valuator.update(valuator_group: create(:valuator_group, name: "Economy"))
+      create(:valuator_group, name: "Health")
 
       visit edit_admin_valuator_path(valuator)
       select "Economy", from: "valuator_valuator_group_id"
@@ -110,9 +108,7 @@ describe "Valuator groups" do
     end
 
     scenario "Remove a valuator from a group" do
-      valuator = create(:valuator)
-      group1 = create(:valuator_group, name: "Health")
-      valuator.update(valuator_group: group1)
+      valuator.update(valuator_group: create(:valuator_group, name: "Health"))
 
       visit edit_admin_valuator_path(valuator)
       select "", from: "valuator_valuator_group_id"

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -198,8 +198,8 @@ describe "Legislation Draft Versions" do
     end
 
     scenario "Publish new comment for an annotation from comments box" do
-      annotation = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
-                                                   ranges: [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11 }])
+      create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
+                                      ranges: [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11 }])
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
@@ -221,10 +221,10 @@ describe "Legislation Draft Versions" do
     before { login_as user }
 
     scenario "View annotations and comments in an included range" do
-      annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
-                                                    ranges: [{ "start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5 }])
-      annotation2 = create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
-                                                    ranges: [{ "start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10 }])
+      create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
+                                      ranges: [{ "start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5 }])
+      create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
+                                      ranges: [{ "start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 10 }])
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -142,12 +142,12 @@ describe "Legislation Draft Versions" do
 
   context "Annotations", :js do
     let(:user) { create(:user) }
+    let(:draft_version) { create(:legislation_draft_version, :published) }
 
     before { login_as user }
 
     scenario "Visit as anonymous" do
       logout
-      draft_version = create(:legislation_draft_version, :published)
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
@@ -158,8 +158,6 @@ describe "Legislation Draft Versions" do
     end
 
     scenario "Create" do
-      draft_version = create(:legislation_draft_version, :published)
-
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
       page.find(:css, ".legislation-annotatable").double_click
@@ -182,7 +180,6 @@ describe "Legislation Draft Versions" do
     end
 
     scenario "View annotations and comments" do
-      draft_version = create(:legislation_draft_version, :published)
       annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
                                                     ranges: [{ "start" => "/p[1]", "startOffset" => 5, "end" => "/p[1]", "endOffset" => 10 }])
       create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
@@ -201,7 +198,6 @@ describe "Legislation Draft Versions" do
     end
 
     scenario "Publish new comment for an annotation from comments box" do
-      draft_version = create(:legislation_draft_version, :published)
       annotation = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
                                                    ranges: [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11 }])
 
@@ -219,13 +215,12 @@ describe "Legislation Draft Versions" do
   end
 
   context "Merged annotations", :js do
-
     let(:user) { create(:user) }
+    let(:draft_version) { create(:legislation_draft_version, :published) }
 
     before { login_as user }
 
     scenario "View annotations and comments in an included range" do
-      draft_version = create(:legislation_draft_version, :published)
       annotation1 = create(:legislation_annotation, draft_version: draft_version, text: "my annotation",
                                                     ranges: [{ "start" => "/p[1]", "startOffset" => 1, "end" => "/p[1]", "endOffset" => 5 }])
       annotation2 = create(:legislation_annotation, draft_version: draft_version, text: "my other annotation",
@@ -246,16 +241,17 @@ describe "Legislation Draft Versions" do
   end
 
   context "Annotations page" do
+    let(:draft_version) { create(:legislation_draft_version, :published) }
+
     before do
-      @draft_version = create(:legislation_draft_version, :published)
-      create(:legislation_annotation, draft_version: @draft_version, text: "my annotation",       quote: "ipsum",
+      create(:legislation_annotation, draft_version: draft_version, text: "my annotation",       quote: "ipsum",
                                       ranges: [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11 }])
-      create(:legislation_annotation, draft_version: @draft_version, text: "my other annotation", quote: "audiam",
+      create(:legislation_annotation, draft_version: draft_version, text: "my other annotation", quote: "audiam",
                                       ranges: [{ "start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11 }])
     end
 
     scenario "See all annotations for a draft version" do
-      visit legislation_process_draft_version_annotations_path(@draft_version.process, @draft_version)
+      visit legislation_process_draft_version_annotations_path(draft_version.process, draft_version)
 
       expect(page).to have_content "ipsum"
       expect(page).to have_content "audiam"
@@ -298,16 +294,17 @@ describe "Legislation Draft Versions" do
   end
 
   context "Annotation comments page" do
+    let(:draft_version) { create(:legislation_draft_version, :published) }
+
     before do
-      @draft_version = create(:legislation_draft_version, :published)
-      create(:legislation_annotation, draft_version: @draft_version, text: "my annotation", quote: "ipsum",
+      create(:legislation_annotation, draft_version: draft_version, text: "my annotation", quote: "ipsum",
                                       ranges: [{ "start" => "/p[1]", "startOffset" => 6, "end" => "/p[1]", "endOffset" => 11 }])
-      @annotation = create(:legislation_annotation, draft_version: @draft_version, text: "my other annotation", quote: "audiam",
+      @annotation = create(:legislation_annotation, draft_version: draft_version, text: "my other annotation", quote: "audiam",
                                                     ranges: [{ "start" => "/p[3]", "startOffset" => 6, "end" => "/p[3]", "endOffset" => 11 }])
     end
 
     scenario "See one annotation with replies for a draft version" do
-      visit legislation_process_draft_version_annotation_path(@draft_version.process, @draft_version, @annotation)
+      visit legislation_process_draft_version_annotation_path(draft_version.process, draft_version, @annotation)
 
       expect(page).not_to have_content "ipsum"
       expect(page).not_to have_content "my annotation"

--- a/spec/lib/email_digests_spec.rb
+++ b/spec/lib/email_digests_spec.rb
@@ -33,27 +33,23 @@ describe EmailDigest do
   end
 
   describe "pending_notifications?" do
+    let(:user) { create(:user) }
 
     it "returns true when notifications have not been emailed" do
-      user = create(:user)
-
-      notification = create(:notification, :for_proposal_notification, user: user)
+      create(:notification, :for_proposal_notification, user: user)
 
       email_digest = EmailDigest.new(user)
       expect(email_digest.pending_notifications?).to be
     end
 
     it "returns false when notifications have been emailed" do
-      user = create(:user)
-
-      notification = create(:notification, :for_proposal_notification, user: user, emailed_at: Time.current)
+      create(:notification, :for_proposal_notification, user: user, emailed_at: Time.current)
 
       email_digest = EmailDigest.new(user)
       expect(email_digest.pending_notifications?).not_to be
     end
 
     it "returns false when there are no notifications for a user" do
-      user = create(:user)
       email_digest = EmailDigest.new(user)
       expect(email_digest.pending_notifications?).not_to be
     end
@@ -61,11 +57,10 @@ describe EmailDigest do
   end
 
   describe "deliver" do
+    let(:user) { create(:user) }
 
     it "delivers email if notifications pending" do
-      user = create(:user)
-
-      notification = create(:notification, :for_proposal_notification, user: user)
+      create(:notification, :for_proposal_notification, user: user)
 
       reset_mailer
       email_digest = EmailDigest.new(user)
@@ -76,8 +71,6 @@ describe EmailDigest do
     end
 
     it "does not deliver email if no notifications pending" do
-      user = create(:user)
-
       create(:notification, :for_proposal_notification, user: user, emailed_at: Time.current)
 
       reset_mailer

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -1,13 +1,11 @@
 require "rails_helper"
 
 describe Poll::Voter do
-
-  let(:poll) { create(:poll) }
-  let(:booth) { create(:poll_booth) }
-  let(:booth_assignment) { create(:poll_booth_assignment, poll: poll, booth: booth) }
-  let(:voter) { create(:poll_voter) }
-
   describe "validations" do
+    let(:poll) { create(:poll) }
+    let(:booth) { create(:poll_booth) }
+    let(:booth_assignment) { create(:poll_booth_assignment, poll: poll, booth: booth) }
+    let(:voter) { create(:poll_voter) }
     let(:user) { create(:user, :level_two) }
 
     it "is valid" do

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -9,6 +9,7 @@ describe Poll::Voter do
   let(:officer_assignment) { create(:poll_officer_assignment) }
 
   describe "validations" do
+    let(:user) { create(:user, :level_two) }
 
     it "is valid" do
       expect(voter).to be_valid
@@ -31,8 +32,6 @@ describe Poll::Voter do
     end
 
     it "is not valid if the user has already voted in the same poll or booth_assignment" do
-      user = create(:user, :level_two)
-
       voter1 = create(:poll_voter, user: user, poll: poll)
       voter2 = build(:poll_voter, user: user, poll: poll)
 
@@ -41,8 +40,6 @@ describe Poll::Voter do
     end
 
     it "is not valid if the user has already voted in the same poll/booth" do
-      user = create(:user, :level_two)
-
       voter1 = create(:poll_voter, user: user, poll: poll, booth_assignment: booth_assignment)
       voter2 = build(:poll_voter, user: user, poll: poll, booth_assignment: booth_assignment)
 
@@ -51,8 +48,6 @@ describe Poll::Voter do
     end
 
     it "is not valid if the user has already voted in different booth in the same poll" do
-      user = create(:user, :level_two)
-
       create(:poll_voter, :from_booth, user: user, poll: poll, booth: create(:poll_booth))
 
       voter = build(:poll_voter, :from_booth, user: user, poll: poll, booth: booth)
@@ -62,8 +57,6 @@ describe Poll::Voter do
     end
 
     it "is valid if the user has already voted in the same booth in different poll" do
-      user = create(:user, :level_two)
-
       create(:poll_voter, :from_booth, user: user, booth: booth, poll: create(:poll))
 
       voter = build(:poll_voter, :from_booth, user: user, booth: booth, poll: poll)

--- a/spec/models/poll/voter_spec.rb
+++ b/spec/models/poll/voter_spec.rb
@@ -6,7 +6,6 @@ describe Poll::Voter do
   let(:booth) { create(:poll_booth) }
   let(:booth_assignment) { create(:poll_booth_assignment, poll: poll, booth: booth) }
   let(:voter) { create(:poll_voter) }
-  let(:officer_assignment) { create(:poll_officer_assignment) }
 
   describe "validations" do
     let(:user) { create(:user, :level_two) }
@@ -87,7 +86,7 @@ describe Poll::Voter do
 
       it "is valid with a booth origin" do
         voter.origin = "booth"
-        voter.officer_assignment = officer_assignment
+        voter.officer_assignment = create(:poll_officer_assignment)
         expect(voter).to be_valid
       end
 


### PR DESCRIPTION
## Objectives

* Simplify data setup in specs
* Make it easier to remove useless assignments while maintaining the code vertically aligned