### PR TITLE
Fix extra records in investments and polls

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -42,7 +42,7 @@ class Poll < ApplicationRecord
   scope :public_polls, -> { where(related: nil) }
   scope :current,  -> { where("starts_at <= ? and ? <= ends_at", Date.current.beginning_of_day, Date.current.beginning_of_day) }
   scope :expired,  -> { where("ends_at < ?", Date.current.beginning_of_day) }
-  scope :recounting, -> { Poll.where(ends_at: (Date.current.beginning_of_day - RECOUNT_DURATION)..Date.current.beginning_of_day) }
+  scope :recounting, -> { where(ends_at: (Date.current.beginning_of_day - RECOUNT_DURATION)..Date.current.beginning_of_day) }
   scope :published, -> { where("published = ?", true) }
   scope :by_geozone_id, ->(geozone_id) { where(geozones: { id: geozone_id }.joins(:geozones)) }
   scope :public_for_api, -> { all }
@@ -86,7 +86,7 @@ class Poll < ApplicationRecord
   end
 
   def self.current_or_recounting
-    current + recounting
+    current.or(recounting)
   end
 
   def answerable_by?(user)

--- a/app/models/valuator.rb
+++ b/app/models/valuator.rb
@@ -18,7 +18,7 @@ class Valuator < ApplicationRecord
   end
 
   def assigned_investment_ids
-    investment_ids + [valuator_group&.investment_ids].flatten
+    investment_ids + valuator_group&.investment_ids.to_a
   end
 
 end

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -119,9 +119,9 @@ describe Poll do
 
       recounting_polls = Poll.recounting
 
+      expect(recounting_polls).to eq [recounting]
       expect(recounting_polls).not_to include(current)
       expect(recounting_polls).not_to include(expired)
-      expect(recounting_polls).to include(recounting)
     end
   end
 
@@ -133,8 +133,7 @@ describe Poll do
 
       current_or_recounting = Poll.current_or_recounting
 
-      expect(current_or_recounting).to include(current)
-      expect(current_or_recounting).to include(recounting)
+      expect(current_or_recounting).to match_array [current, recounting]
       expect(current_or_recounting).not_to include(expired)
     end
   end

--- a/spec/models/valuator_spec.rb
+++ b/spec/models/valuator_spec.rb
@@ -28,8 +28,8 @@ describe Valuator do
       investment2.valuators << valuator
 
       assigned_investment_ids = valuator.assigned_investment_ids
-      expect(assigned_investment_ids).to include investment1.id
-      expect(assigned_investment_ids).to include investment2.id
+
+      expect(assigned_investment_ids).to match_array [investment1.id, investment2.id]
       expect(assigned_investment_ids).not_to include investment3.id
     end
 
@@ -45,8 +45,8 @@ describe Valuator do
       investment2.valuator_groups << group
 
       assigned_investment_ids = valuator.assigned_investment_ids
-      expect(assigned_investment_ids).to include investment1.id
-      expect(assigned_investment_ids).to include investment2.id
+
+      expect(assigned_investment_ids).to match_array [investment1.id, investment2.id]
       expect(assigned_investment_ids).not_to include investment3.id
     end
   end


### PR DESCRIPTION
## Objectives

Fix the `Poll.current_or_recounting` returning duplicate records and the `Valuator#assigned_investment_ids` returning extra `nil` records.