### PR TITLE
Add rubocop lint rules

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -120,6 +120,9 @@ Layout/TrailingWhitespace:
 Lint/AmbiguousRegexpLiteral:
   Enabled: true
 
+Lint/DuplicateMethods:
+  Enabled: true
+
 Lint/LiteralAsCondition:
   Enabled: true
 

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -126,6 +126,9 @@ Lint/DuplicateMethods:
 Lint/LiteralAsCondition:
   Enabled: true
 
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -126,6 +126,9 @@ Lint/LiteralAsCondition:
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
+Lint/StringConversionInInterpolation:
+  Enabled: true
+
 Lint/UselessAssignment:
   Enabled: true
 

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -120,6 +120,9 @@ Layout/TrailingWhitespace:
 Lint/LiteralAsCondition:
   Enabled: true
 
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
 Lint/UselessAssignment:
   Enabled: true
 

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -117,6 +117,9 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
 Lint/LiteralAsCondition:
   Enabled: true
 

--- a/app/controllers/tracking/budget_investments_controller.rb
+++ b/app/controllers/tracking/budget_investments_controller.rb
@@ -58,14 +58,13 @@ class Tracking::BudgetInvestmentsController < Tracking::BaseController
                               }
                             ]
 
-      filters = investment_headings.inject(all_headings_filter) do |filters, heading|
+      investment_headings.inject(all_headings_filter) do |filters, heading|
         filters << {
           name: heading.name,
           id: heading.id,
           count: investments.select { |i| i.heading_id == heading.id }.size
         }
-      end
-      filters.uniq
+      end.uniq
     end
 
     def restrict_access_to_assigned_items

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -131,7 +131,7 @@ module GlobalizeHelper
     hidden_field_tag("enabled_translations[#{locale}]", (enabled ? 1 : 0))
   end
 
-  def globalize(locale, &block)
+  def globalize(locale)
     Globalize.with_locale(locale) do
       yield
     end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -33,7 +33,7 @@ module TranslatableFormHelper
 
     private
 
-      def fields_for_locale(locale, &block)
+      def fields_for_locale(locale)
         fields_for_translation(@translations[locale]) do |translations_form|
           @template.content_tag :div, translations_options(translations_form.object, locale) do
             @template.concat translations_form.hidden_field(
@@ -49,7 +49,7 @@ module TranslatableFormHelper
         end
       end
 
-      def fields_for_translation(translation, &block)
+      def fields_for_translation(translation)
         fields_for(:translations, translation, builder: TranslationsFieldsBuilder) do |f|
           yield f
         end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -129,7 +129,7 @@ class Mailer < ApplicationMailer
 
   private
 
-    def with_user(user, &block)
+    def with_user(user)
       I18n.with_locale(user.locale) do
         yield
       end

--- a/app/models/budget/result.rb
+++ b/app/models/budget/result.rb
@@ -1,7 +1,7 @@
 class Budget
   class Result
 
-    attr_accessor :budget, :heading, :money_spent, :current_investment
+    attr_accessor :budget, :heading, :current_investment
 
     def initialize(budget, heading)
       @budget = budget

--- a/app/models/poll/partial_result.rb
+++ b/app/models/poll/partial_result.rb
@@ -21,9 +21,9 @@ class Poll::PartialResult < ApplicationRecord
 
   def update_logs
     if amount_changed? && amount_was.present?
-      self.amount_log += ":#{amount_was.to_s}"
-      self.officer_assignment_id_log += ":#{officer_assignment_id_was.to_s}"
-      self.author_id_log += ":#{author_id_was.to_s}"
+      self.amount_log += ":#{amount_was}"
+      self.officer_assignment_id_log += ":#{officer_assignment_id_was}"
+      self.author_id_log += ":#{author_id_was}"
     end
   end
 end

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -222,10 +222,10 @@ section "Creating Poll Questions from Proposals" do
     poll = Poll.current.first
     question = Poll::Question.new(poll: poll)
     question.copy_attributes_from_proposal(proposal)
-    title = question.title
+    question_title = question.title
     I18n.available_locales.map do |locale|
       Globalize.with_locale(locale) do
-        question.title = "#{title} (#{locale})"
+        question.title = "#{question_title} (#{locale})"
       end
     end
     question.save!
@@ -252,10 +252,10 @@ section "Creating Successful Proposals" do
     poll = Poll.current.first
     question = Poll::Question.new(poll: poll)
     question.copy_attributes_from_proposal(proposal)
-    title = question.title
+    question_title = question.title
     I18n.available_locales.map do |locale|
       Globalize.with_locale(locale) do
-        question.title = "#{title} (#{locale})"
+        question.title = "#{question_title} (#{locale})"
       end
     end
     question.save!

--- a/lib/comment_tree.rb
+++ b/lib/comment_tree.rb
@@ -2,7 +2,7 @@ class CommentTree
 
   ROOT_COMMENTS_PER_PAGE = 10
 
-  attr_reader :root_comments, :commentable, :page, :order
+  attr_reader :commentable, :page, :order
 
   def initialize(commentable, page, order = "confidence_score", valuations: false)
     @commentable = commentable

--- a/lib/email_digest.rb
+++ b/lib/email_digest.rb
@@ -1,6 +1,6 @@
 class EmailDigest
 
-  attr_accessor :user, :notifications
+  attr_accessor :user
 
   def initialize(user)
     @user = user

--- a/lib/remote_translations/microsoft/available_locales.rb
+++ b/lib/remote_translations/microsoft/available_locales.rb
@@ -34,13 +34,13 @@ class RemoteTranslations::Microsoft::AvailableLocales
       host = "https://api.cognitive.microsofttranslator.com"
       path = "/languages?api-version=3.0"
 
-      uri = URI (host + path)
+      uri = URI(host + path)
 
       request = Net::HTTP::Get.new(uri)
       request["Ocp-Apim-Subscription-Key"] = Rails.application.secrets.microsoft_api_key
 
       response = Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == "https") do |http|
-        http.request (request)
+        http.request(request)
       end
 
       result = response.body.force_encoding("utf-8")

--- a/spec/factories/administration.rb
+++ b/spec/factories/administration.rb
@@ -81,7 +81,7 @@ FactoryBot.define do
       header { true }
       sequence(:button_text)   { |n| "Button text #{n}" }
       sequence(:button_url)    { |n| "Button url #{n}" }
-      sequence(:alignment)   { |n| "background" }
+      alignment { "background" }
     end
 
     after :create do |widget_card|

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1773,8 +1773,8 @@ describe "Admin budget investments" do
       visit admin_budget_budget_investments_path(budget)
 
       cookies = page.driver.browser.manage.all_cookies
-      cookie = cookies.find { |cookie| cookie[:name] == "investments-columns" }
-      cookie_value = cookie[:value]
+      columns_cookie = cookies.find { |cookie| cookie[:name] == "investments-columns" }
+      cookie_value = columns_cookie[:value]
 
       expect(cookie_value).to eq("id,title,supports,admin,valuator,geozone," +
         "feasibility,price,valuation_finished,visible_to_valuators,selected,incompatible")
@@ -1827,8 +1827,8 @@ describe "Admin budget investments" do
       end
 
       cookies = page.driver.browser.manage.all_cookies
-      cookie = cookies.find { |cookie| cookie[:name] == "investments-columns" }
-      cookie_value = cookie[:value]
+      columns_cookie = cookies.find { |cookie| cookie[:name] == "investments-columns" }
+      cookie_value = columns_cookie[:value]
 
       expect(cookie_value).to eq("id,supports,admin,geozone," +
         "feasibility,valuation_finished,visible_to_valuators,selected,incompatible,author")
@@ -1836,8 +1836,8 @@ describe "Admin budget investments" do
       visit admin_budget_budget_investments_path(budget)
 
       cookies = page.driver.browser.manage.all_cookies
-      cookie = cookies.find { |cookie| cookie[:name] == "investments-columns" }
-      cookie_value = cookie[:value]
+      columns_cookie = cookies.find { |cookie| cookie[:name] == "investments-columns" }
+      cookie_value = columns_cookie[:value]
 
       expect(cookie_value).to eq("id,supports,admin,geozone,feasibility,valuation_finished," +
         "visible_to_valuators,selected,incompatible,author")

--- a/spec/features/admin/dashboard/actions_spec.rb
+++ b/spec/features/admin/dashboard/actions_spec.rb
@@ -73,7 +73,7 @@ describe "Admin dashboard actions" do
 
     before do
       visit admin_dashboard_actions_path
-      within ("#dashboard_action_#{action.id}") do
+      within "#dashboard_action_#{action.id}" do
         click_link "Edit"
       end
     end

--- a/spec/features/admin/emails/emails_download_spec.rb
+++ b/spec/features/admin/emails/emails_download_spec.rb
@@ -33,8 +33,8 @@ describe "Admin download user emails" do
       end
 
       header = page.response_headers["Content-Disposition"]
-      expect(header).to match /^attachment/
-      expect(header).to match /filename="Administrators.csv"$/
+      expect(header).to match(/^attachment/)
+      expect(header).to match(/filename="Administrators.csv"$/)
 
       file_contents = page.body.split(",")
       expect(file_contents).to match_array ["admin_news1@consul.dev", "admin_news2@consul.dev"]

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -51,13 +51,13 @@ describe "Admin collaborative legislation" do
 
       visit admin_legislation_processes_path(filter: "all")
 
-      expect(page).to have_content (process_1.start_date)
-      expect(page).to have_content (process_2.start_date)
-      expect(page).to have_content (process_3.start_date)
+      expect(page).to have_content process_1.start_date
+      expect(page).to have_content process_2.start_date
+      expect(page).to have_content process_3.start_date
 
-      expect(page).to have_content (process_1.end_date)
-      expect(page).to have_content (process_2.end_date)
-      expect(page).to have_content (process_3.end_date)
+      expect(page).to have_content process_1.end_date
+      expect(page).to have_content process_2.end_date
+      expect(page).to have_content process_3.end_date
 
       expect(process_3.title).to appear_before(process_2.title)
       expect(process_2.title).to appear_before(process_1.title)

--- a/spec/features/admin/widgets/cards_spec.rb
+++ b/spec/features/admin/widgets/cards_spec.rb
@@ -161,7 +161,7 @@ describe "Cards" do
         card_2 = create(:widget_card, page: custom_page, title: "Card medium", columns: 4)
         card_3 = create(:widget_card, page: custom_page, title: "Card small", columns: 2)
 
-        visit (custom_page).url
+        visit custom_page.url
 
         expect(page).to have_css(".card", count: 3)
 
@@ -174,7 +174,7 @@ describe "Cards" do
         card_1 = create(:widget_card, page: custom_page, title: "Card one", label: "My label")
         card_2 = create(:widget_card, page: custom_page, title: "Card two")
 
-        visit (custom_page).url
+        visit custom_page.url
 
         within("#widget_card_#{card_1.id}") do
           expect(page).to have_selector("span", text: "My label")

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -690,7 +690,7 @@ describe "Budget Investments" do
     end
 
     scenario "Random order maintained when going back from show" do
-      per_page.times { |i| create(:budget_investment, heading: heading) }
+      per_page.times { create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
 

--- a/spec/lib/remote_census_api_spec.rb
+++ b/spec/lib/remote_census_api_spec.rb
@@ -86,15 +86,15 @@ describe RemoteCensusApi do
 
       request = RemoteCensusApi.new.send(:request, document_type, document_number, nil, nil)
 
-      expect(request).to eq ({ :request =>
-                              { :codigo_institucion => 1,
-                               :codigo_portal => 1,
-                               :codigo_usuario => 1,
-                               :documento => "0123456",
-                               :tipo_documento => "1",
-                               :codigo_idioma => "102",
-                               :nivel => "3" }
-                              })
+      expect(request).to eq({ :request =>
+                             { :codigo_institucion => 1,
+                              :codigo_portal => 1,
+                              :codigo_usuario => 1,
+                              :documento => "0123456",
+                              :tipo_documento => "1",
+                              :codigo_idioma => "102",
+                              :nivel => "3" }
+                             })
     end
 
     it "when send date_of_birth and postal_code but are not configured" do
@@ -105,15 +105,15 @@ describe RemoteCensusApi do
 
       request = RemoteCensusApi.new.send(:request, document_type, document_number, date_of_birth, postal_code)
 
-      expect(request).to eq ({ :request =>
-                              { :codigo_institucion => 1,
-                               :codigo_portal => 1,
-                               :codigo_usuario => 1,
-                               :documento => "0123456",
-                               :tipo_documento => "1",
-                               :codigo_idioma => "102",
-                               :nivel => "3" }
-                              })
+      expect(request).to eq({ :request =>
+                             { :codigo_institucion => 1,
+                              :codigo_portal => 1,
+                              :codigo_usuario => 1,
+                              :documento => "0123456",
+                              :tipo_documento => "1",
+                              :codigo_idioma => "102",
+                              :nivel => "3" }
+                             })
     end
 
     it "when send date_of_birth and postal_code but are configured" do
@@ -137,17 +137,17 @@ describe RemoteCensusApi do
 
       request = RemoteCensusApi.new.send(:request, document_type, document_number, date_of_birth, postal_code)
 
-      expect(request).to eq ({ :request =>
-                              { :codigo_institucion => 1,
-                               :codigo_portal => 1,
-                               :codigo_usuario => 1,
-                               :documento => "0123456",
-                               :tipo_documento => "1",
-                               :fecha_nacimiento => "1980-01-01",
-                               :codigo_postal => "28001",
-                               :codigo_idioma => "102",
-                               :nivel => "3" }
-                              })
+      expect(request).to eq({ :request =>
+                             { :codigo_institucion => 1,
+                              :codigo_portal => 1,
+                              :codigo_usuario => 1,
+                              :documento => "0123456",
+                              :tipo_documento => "1",
+                              :fecha_nacimiento => "1980-01-01",
+                              :codigo_postal => "28001",
+                              :codigo_idioma => "102",
+                              :nivel => "3" }
+                             })
     end
 
   end
@@ -164,26 +164,26 @@ describe RemoteCensusApi do
 
       response = RemoteCensusApi.new.send(:get_response_body, document_type, document_number, nil, nil)
 
-      expect(response).to eq ({ get_habita_datos_response: {
-                                  get_habita_datos_return: {
-                                    datos_habitante: {
-                                      item: {
-                                        fecha_nacimiento_string: "31-12-1980",
-                                        identificador_documento: "12345678Z",
-                                        descripcion_sexo: "Varón",
-                                        nombre: "José",
-                                        apellido1: "García"
-                                      }
-                                    },
-                                    datos_vivienda: {
-                                      item: {
-                                        codigo_postal: "28013",
-                                        codigo_distrito: "01"
-                                      }
-                                    }
-                                  }
-                                }
-                              })
+      expect(response).to eq({ get_habita_datos_response: {
+                                 get_habita_datos_return: {
+                                   datos_habitante: {
+                                     item: {
+                                       fecha_nacimiento_string: "31-12-1980",
+                                       identificador_documento: "12345678Z",
+                                       descripcion_sexo: "Varón",
+                                       nombre: "José",
+                                       apellido1: "García"
+                                     }
+                                   },
+                                   datos_vivienda: {
+                                     item: {
+                                       codigo_postal: "28013",
+                                       codigo_distrito: "01"
+                                     }
+                                   }
+                                 }
+                               }
+                             })
     end
 
   end

--- a/spec/models/budget/phase_spec.rb
+++ b/spec/models/budget/phase_spec.rb
@@ -171,7 +171,7 @@ describe Budget::Phase do
           second_phase.update_attributes(enabled: false,
                                          starts_at: Date.current,
                                          ends_at:  Date.current + 2.days)
-        end.not_to (change { prev_enabled_phase.ends_at })
+        end.not_to change { prev_enabled_phase.ends_at }
       end
 
       it "adjusts next enabled phase start date to its own start date" do

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -277,28 +277,28 @@ describe Budget do
       budget.update(currency_symbol: "€")
       I18n.locale = :es
 
-      expect(budget.formatted_amount(1000.00)).to eq ("1.000 €")
+      expect(budget.formatted_amount(1000.00)).to eq "1.000 €"
     end
 
     it "correctly formats Dollars with Spanish" do
       budget.update(currency_symbol: "$")
       I18n.locale = :es
 
-      expect(budget.formatted_amount(1000.00)).to eq ("1.000 $")
+      expect(budget.formatted_amount(1000.00)).to eq "1.000 $"
     end
 
     it "correctly formats Dollars with English" do
       budget.update(currency_symbol: "$")
       I18n.locale = :en
 
-      expect(budget.formatted_amount(1000.00)).to eq ("$1,000")
+      expect(budget.formatted_amount(1000.00)).to eq "$1,000"
     end
 
     it "correctly formats Euros with English" do
       budget.update(currency_symbol: "€")
       I18n.locale = :en
 
-      expect(budget.formatted_amount(1000.00)).to eq ("€1,000")
+      expect(budget.formatted_amount(1000.00)).to eq "€1,000"
     end
   end
 

--- a/spec/models/concerns/sluggable.rb
+++ b/spec/models/concerns/sluggable.rb
@@ -23,7 +23,7 @@ shared_examples_for "sluggable" do |updatable_slug_trait:|
     context "slug updating condition is false" do
       it "slug isn't updated" do
         expect { sluggable.update_attributes(name: "New Name") }
-          .not_to (change { sluggable.slug })
+          .not_to change { sluggable.slug }
       end
     end
   end

--- a/spec/shared/features/remotely_translatable.rb
+++ b/spec/shared/features/remotely_translatable.rb
@@ -253,5 +253,5 @@ end
 
 def generate_response(resource)
   field_text = Faker::Lorem.characters(10)
-  resource.translated_attribute_names.map { |field| field_text }
+  resource.translated_attribute_names.map { field_text }
 end


### PR DESCRIPTION
## Background

The Ruby interpreter issues warnings on code having patterns which could easily result in bugs. Rubocop has rules to detect all those warnings and some more.

## Objectives

* Fix existing warnings which make code confusing
* Add rubocop rules to prevent future warnings

## Notes

There's one Ruby warning I haven't fixed: the autoload trigger in `PollsController`. We'll have to investigate whether the issue loading classes is still present after upgrading to Rails 5.

There are also several rubocop rules I haven't added; they either give false positives, or are a bit overkill.