### PR TITLE
Fix booth search with blank text

### DIFF
--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -9,7 +9,7 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
 
   def search_booths
     load_search
-    @booths = ::Poll::Booth.search(@search)
+    @booths = ::Poll::Booth.quick_search(@search)
     respond_to do |format|
       format.js
     end

--- a/app/controllers/admin/poll/booths_controller.rb
+++ b/app/controllers/admin/poll/booths_controller.rb
@@ -2,7 +2,7 @@ class Admin::Poll::BoothsController < Admin::Poll::BaseController
   load_and_authorize_resource class: "Poll::Booth"
 
   def index
-    @booths = @booths.search params[:search] if params[:search]
+    @booths = @booths.search(params[:search])
     @booths = @booths.order(name: :asc).page(params[:page])
   end
 

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -7,8 +7,15 @@ class Poll
     validates :name, presence: true, uniqueness: true
 
     def self.search(terms)
-      return Booth.none if terms.blank?
       Booth.where("name ILIKE ? OR location ILIKE ?", "%#{terms}%", "%#{terms}%")
+    end
+
+    def self.quick_search(terms)
+      if terms.blank?
+        Booth.none
+      else
+        search(terms)
+      end
     end
 
     def self.available

--- a/app/views/admin/poll/booths/index.html.erb
+++ b/app/views/admin/poll/booths/index.html.erb
@@ -4,13 +4,13 @@
   <%= link_to t("admin.booths.index.add_booth"), new_admin_booth_path, class: "button float-right" %>
 <% end %>
 
+<%= render "/admin/shared/booth_search", url: admin_booths_path %>
+
 <% if @booths.empty? %>
   <div class="callout primary">
     <%= t("admin.booths.index.no_booths") %>
   </div>
 <% end %>
-
-<%= render "/admin/shared/booth_search", url: admin_booths_path %>
 
 <% if @booths.any? %>
   <h3><%= page_entries_info @booths %></h3>

--- a/spec/models/poll/booth_spec.rb
+++ b/spec/models/poll/booth_spec.rb
@@ -13,7 +13,7 @@ describe Poll::Booth do
     expect(booth).not_to be_valid
   end
 
-  describe "#search" do
+  describe ".search" do
     it "finds booths searching by name or location" do
       booth1 = create(:poll_booth, name: "Booth number 1", location: "City center")
       booth2 = create(:poll_booth, name: "Central", location: "Town hall")
@@ -21,6 +21,26 @@ describe Poll::Booth do
       expect(Poll::Booth.search("number")).to eq([booth1])
       expect(Poll::Booth.search("hall")).to eq([booth2])
       expect(Poll::Booth.search("cen")).to match_array [booth1, booth2]
+    end
+
+    it "returns all booths if search term is blank" do
+      2.times { create(:poll_booth) }
+
+      expect(Poll::Booth.search("").count).to eq 2
+    end
+
+    it "returns all booths if search term is nil" do
+      2.times { create(:poll_booth) }
+
+      expect(Poll::Booth.search(nil).count).to eq 2
+    end
+  end
+
+  describe ".quick_search" do
+    it "returns no booths if search term is blank" do
+      create(:poll_booth)
+
+      expect(Poll::Booth.quick_search("")).to be_empty
     end
   end
 


### PR DESCRIPTION
## References

* Fix a bug I forgot about in pull request #3693.

## Objectives

Return all booths when an empty string is introduced as a search term.

## Notes

* Previously no booths were being returned because we use the same method in another AJAX call where we display all booth in one section of the page and the results matching the search in another section of the page
* The method `quick_search` could have a better name :thinking: