### PR TITLE
Sanitize texts instead of using html_safe

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,5 +1,7 @@
 ---
 linters:
+  ErbSafety:
+    enabled: true
   ExtraNewline:
     enabled: true
   FinalNewline:

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -160,6 +160,12 @@ Rails/Date:
 Rails/HttpPositionalArguments:
   Enabled: true
 
+Rails/OutputSafety:
+  Enabled: true
+  Severity: warning
+  Exclude:
+    - app/helpers/text_with_links_helper.rb
+
 Rails/PluralizationGrammar:
   Enabled: true
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
       actionmailer (>= 3.2)
       letter_opener (~> 1.0)
       railties (>= 3.2)
-    loofah (2.3.0)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/app/controllers/admin/legislation/draft_versions_controller.rb
+++ b/app/controllers/admin/legislation/draft_versions_controller.rb
@@ -10,7 +10,7 @@ class Admin::Legislation::DraftVersionsController < Admin::Legislation::BaseCont
 
   def create
     if @draft_version.save
-      link = legislation_process_draft_version_path(@process, @draft_version).html_safe
+      link = legislation_process_draft_version_path(@process, @draft_version)
       notice = t("admin.legislation.draft_versions.create.notice", link: link)
       redirect_to admin_legislation_process_draft_versions_path, notice: notice
     else
@@ -21,7 +21,7 @@ class Admin::Legislation::DraftVersionsController < Admin::Legislation::BaseCont
 
   def update
     if @draft_version.update(draft_version_params)
-      link = legislation_process_draft_version_path(@process, @draft_version).html_safe
+      link = legislation_process_draft_version_path(@process, @draft_version)
       notice = t("admin.legislation.draft_versions.update.notice", link: link)
       edit_path = edit_admin_legislation_process_draft_version_path(@process, @draft_version)
       redirect_to edit_path, notice: notice

--- a/app/controllers/admin/legislation/homepages_controller.rb
+++ b/app/controllers/admin/legislation/homepages_controller.rb
@@ -8,7 +8,7 @@ class Admin::Legislation::HomepagesController < Admin::Legislation::BaseControll
 
   def update
     if @process.update(process_params)
-      link = legislation_process_path(@process).html_safe
+      link = legislation_process_path(@process)
       redirect_back(fallback_location: (request.referer || root_path),
                     notice: t("admin.legislation.processes.update.notice", link: link))
     else

--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -23,7 +23,7 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
 
   def create
     if @process.save
-      link = legislation_process_path(@process).html_safe
+      link = legislation_process_path(@process)
       notice = t("admin.legislation.processes.create.notice", link: link)
       redirect_to edit_admin_legislation_process_path(@process), notice: notice
     else
@@ -36,7 +36,7 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
     if @process.update(process_params)
       set_tag_list
 
-      link = legislation_process_path(@process).html_safe
+      link = legislation_process_path(@process)
       redirect_back(fallback_location: (request.referer || root_path),
                     notice: t("admin.legislation.processes.update.notice", link: link))
     else

--- a/app/controllers/admin/legislation/questions_controller.rb
+++ b/app/controllers/admin/legislation/questions_controller.rb
@@ -41,7 +41,7 @@ class Admin::Legislation::QuestionsController < Admin::Legislation::BaseControll
   private
 
     def question_path
-      legislation_process_question_path(@process, @question).html_safe
+      legislation_process_question_path(@process, @question)
     end
 
     def question_params

--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -17,7 +17,7 @@ class DirectUploadsController < ApplicationController
 
       render json: { cached_attachment: @direct_upload.relation.cached_attachment,
                      filename: @direct_upload.relation.attachment.original_filename,
-                     destroy_link: render_destroy_upload_link(@direct_upload).html_safe,
+                     destroy_link: render_destroy_upload_link(@direct_upload),
                      attachment_url: @direct_upload.relation.attachment.url }
     else
       @direct_upload.destroy_attachment

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,7 +32,8 @@ module ApplicationHelper
       strikethrough:      true,
       superscript:        true
     }
-    Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
+
+    sanitize(Redcarpet::Markdown.new(renderer, extensions).render(text))
   end
 
   def author_of?(authorable, user)

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -10,7 +10,7 @@ module BudgetInvestmentsHelper
     translation = t("admin.budget_investments.index.list.#{column}")
 
     link_to(
-      "#{translation} <span class='icon-sortable #{icon}'></span>".html_safe,
+      safe_join([translation, content_tag(:span, "", class: "icon-sortable #{icon}")]),
       admin_budget_budget_investments_path(sort_by: column, direction: direction)
     )
   end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -54,6 +54,6 @@ module DocumentsHelper
              #{number_to_human_size(document.attachment_file_size)}</small>)".html_safe,
              document.attachment.url,
              target: "_blank",
-             title: t("shared.target_blank_html")
+             title: t("shared.target_blank")
   end
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -50,10 +50,11 @@ module DocumentsHelper
   end
 
   def document_item_link(document)
-    link_to "#{document.title} <small>(#{document.humanized_content_type} | \
-             #{number_to_human_size(document.attachment_file_size)}</small>)".html_safe,
-             document.attachment.url,
-             target: "_blank",
-             title: t("shared.target_blank")
+    info_text = "#{document.humanized_content_type} | #{number_to_human_size(document.attachment_file_size)}"
+
+    link_to safe_join([document.title, content_tag(:small, "(#{info_text})")], " "),
+            document.attachment.url,
+            target: "_blank",
+            title: t("shared.target_blank")
   end
 end

--- a/app/helpers/proposals_dashboard_helper.rb
+++ b/app/helpers/proposals_dashboard_helper.rb
@@ -65,7 +65,7 @@ module ProposalsDashboardHelper
                 supports: number_with_delimiter(resource.required_supports,
                 delimiter: ".")) if resource.required_supports > 0
 
-    label.join(" #{t("dashboard.resource.and")}<br>")
+    safe_join label, h(" #{t("dashboard.resource.and")})") + tag(:br)
   end
 
   def daily_selected_class

--- a/app/helpers/proposals_dashboard_helper.rb
+++ b/app/helpers/proposals_dashboard_helper.rb
@@ -97,7 +97,7 @@ module ProposalsDashboardHelper
   end
 
   def proposed_action_description(proposed_action)
-    raw proposed_action.description.truncate(200)
+    sanitize proposed_action.description.truncate(200)
   end
 
   def proposed_action_long_description?(proposed_action)

--- a/app/helpers/signature_sheets_helper.rb
+++ b/app/helpers/signature_sheets_helper.rb
@@ -24,10 +24,10 @@ module SignatureSheetsHelper
       text_help += t("admin.signature_sheets.new.text_help.postal_code_note")
     end
 
-    text_help += "<br/>"
+    text_help += tag(:br)
     text_help += t("admin.signature_sheets.new.text_help.required_fields_structure_note")
 
-    return text_help.html_safe
+    return text_help
   end
 
   def example_text_help

--- a/app/helpers/text_with_links_helper.rb
+++ b/app/helpers/text_with_links_helper.rb
@@ -10,7 +10,7 @@ module TextWithLinksHelper
     return if html.nil?
     raise "Could not add links because the content is not safe" unless html.html_safe?
 
-    Rinku.auto_link(html, :all, 'target="_blank" rel="nofollow"').html_safe
+    raw Rinku.auto_link(html, :all, 'target="_blank" rel="nofollow"')
   end
 
   def simple_format_no_tags_no_sanitize(html)

--- a/app/helpers/text_with_links_helper.rb
+++ b/app/helpers/text_with_links_helper.rb
@@ -1,12 +1,12 @@
 module TextWithLinksHelper
 
-  def text_with_links(text)
+  def sanitize_and_auto_link(text)
     return unless text
     sanitized = sanitize(text, tags: [], attributes: [])
     Rinku.auto_link(sanitized, :all, 'target="_blank" rel="nofollow"').html_safe
   end
 
-  def safe_html_with_links(html)
+  def auto_link_already_sanitized_html(html)
     return if html.nil?
     html = ActiveSupport::SafeBuffer.new(html) if html.is_a?(String)
     return html.html_safe unless html.html_safe?

--- a/app/helpers/text_with_links_helper.rb
+++ b/app/helpers/text_with_links_helper.rb
@@ -8,8 +8,8 @@ module TextWithLinksHelper
 
   def auto_link_already_sanitized_html(html)
     return if html.nil?
-    html = ActiveSupport::SafeBuffer.new(html) if html.is_a?(String)
-    return html.html_safe unless html.html_safe?
+    raise "Could not add links because the content is not safe" unless html.html_safe?
+
     Rinku.auto_link(html, :all, 'target="_blank" rel="nofollow"').html_safe
   end
 

--- a/app/helpers/text_with_links_helper.rb
+++ b/app/helpers/text_with_links_helper.rb
@@ -3,7 +3,7 @@ module TextWithLinksHelper
   def sanitize_and_auto_link(text)
     return unless text
     sanitized = sanitize(text, tags: [], attributes: [])
-    Rinku.auto_link(sanitized, :all, 'target="_blank" rel="nofollow"').html_safe
+    auto_link_already_sanitized_html(sanitized)
   end
 
   def auto_link_already_sanitized_html(html)

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -26,9 +26,9 @@ module TranslatableFormHelper
       visible_locales.map do |locale|
         @translations[locale] = translation_for(locale)
       end
-      visible_locales.map do |locale|
+      safe_join(visible_locales.map do |locale|
         Globalize.with_locale(locale) { fields_for_locale(locale, &block) }
-      end.join.html_safe
+      end)
     end
 
     private

--- a/app/helpers/valuation_helper.rb
+++ b/app/helpers/valuation_helper.rb
@@ -14,7 +14,7 @@ module ValuationHelper
   end
 
   def explanation_field(field)
-    simple_format_no_tags_no_sanitize(text_with_links(field)) if field.present?
+    simple_format_no_tags_no_sanitize(sanitize_and_auto_link(field)) if field.present?
   end
 
 end

--- a/app/helpers/valuation_helper.rb
+++ b/app/helpers/valuation_helper.rb
@@ -14,7 +14,7 @@ module ValuationHelper
   end
 
   def explanation_field(field)
-    simple_format_no_tags_no_sanitize(safe_html_with_links(field.html_safe)) if field.present?
+    simple_format_no_tags_no_sanitize(text_with_links(field)) if field.present?
   end
 
 end

--- a/app/views/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/admin/budget_investments/_select_investment.html.erb
@@ -31,7 +31,7 @@
 <td class="small" data-field="valuator">
   <% valuators = [investment.assigned_valuation_groups, investment.assigned_valuators].compact %>
   <% no_valuators_assigned = t("admin.budget_investments.index.no_valuators_assigned") %>
-  <%= raw valuators.present? ? valuators.join(", ") : no_valuators_assigned %>
+  <%= valuators.present? ? valuators.join(", ") : no_valuators_assigned %>
 </td>
 
 <td class="small" data-field="geozone">

--- a/app/views/admin/budget_investments/_written_by_author.html.erb
+++ b/app/views/admin/budget_investments/_written_by_author.html.erb
@@ -55,6 +55,6 @@
 
 <% if @investment.external_url.present? %>
   <p>
-    <%= text_with_links @investment.external_url %>&nbsp;<span class="icon-external small"></span>
+    <%= sanitize_and_auto_link @investment.external_url %>&nbsp;<span class="icon-external small"></span>
   </p>
 <% end %>

--- a/app/views/admin/debates/show.html.erb
+++ b/app/views/admin/debates/show.html.erb
@@ -25,7 +25,7 @@
           </span>
   </div>
 
-  <%= safe_html_with_links @debate.description %>
+  <%= auto_link_already_sanitized_html @debate.description %>
 
   <h3><%= t("votes.supports") %></h3>
 

--- a/app/views/admin/hidden_comments/index.html.erb
+++ b/app/views/admin/hidden_comments/index.html.erb
@@ -15,7 +15,7 @@
     <% @comments.each do |comment| %>
       <tr id="<%= dom_id(comment) %>">
         <td>
-          <%= text_with_links comment.body %><br>
+          <%= sanitize_and_auto_link comment.body %><br>
           <% if comment.commentable.hidden? %>
             (<%= t("admin.hidden_comments.index.hidden_#{comment.commentable_type.downcase}") %>: <%= comment.commentable.title %>)
           <% else %>

--- a/app/views/admin/hidden_proposals/index.html.erb
+++ b/app/views/admin/hidden_proposals/index.html.erb
@@ -23,7 +23,7 @@
             <p><small><%= proposal.summary %></small></p>
             <%= proposal.description %>
             <% if proposal.video_url.present? %>
-              <p><%= text_with_links proposal.video_url %></p>
+              <p><%= sanitize_and_auto_link proposal.video_url %></p>
             <% end %>
           </div>
         </td>

--- a/app/views/admin/hidden_users/show.html.erb
+++ b/app/views/admin/hidden_users/show.html.erb
@@ -30,7 +30,7 @@
   <% @comments.each do |comment| %>
     <tr id="<%= dom_id(comment) %>">
       <td>
-        <%= text_with_links comment.body %>
+        <%= sanitize_and_auto_link comment.body %>
       </td>
     </tr>
   <% end %>

--- a/app/views/admin/site_customization/content_blocks/index.html.erb
+++ b/app/views/admin/site_customization/content_blocks/index.html.erb
@@ -32,7 +32,7 @@
     <% @content_blocks.each do |content_block| %>
       <tr id="<%= dom_id(content_block) %>">
         <td><%= link_to "#{content_block.name} (#{content_block.locale})", edit_admin_site_customization_content_block_path(content_block) %></td>
-        <td><%= content_block.body.html_safe %></td>
+        <td><%= raw content_block.body %></td>
         <td>
           <%= link_to t("admin.site_customization.content_blocks.index.delete"),
                         admin_site_customization_content_block_path(content_block),
@@ -43,7 +43,7 @@
     <% @headings_content_blocks.each do |content_block| %>
       <tr id="<%= dom_id(content_block) %>">
         <td><%= link_to "#{content_block.heading.name} (#{content_block.locale})", admin_site_customization_edit_heading_content_block_path(content_block) %></td>
-        <td><%= content_block.body.html_safe %></td>
+        <td><%= raw content_block.body %></td>
         <td>
           <%= link_to t("admin.site_customization.content_blocks.index.delete"),
                         admin_site_customization_delete_heading_content_block_path(content_block.id),

--- a/app/views/budgets/_phases.html.erb
+++ b/app/views/budgets/_phases.html.erb
@@ -7,7 +7,7 @@
         -
         <%= l(phase.ends_at.to_date - 1.day, format: :long) if phase.ends_at.present? %>
       </span>
-      <p><%= safe_html_with_links(WYSIWYGSanitizer.new.sanitize(phase.summary)) %></p>
+      <p><%= auto_link_already_sanitized_html(WYSIWYGSanitizer.new.sanitize(phase.summary)) %></p>
     </li>
   <% end %>
 </ul>

--- a/app/views/budgets/_phases.html.erb
+++ b/app/views/budgets/_phases.html.erb
@@ -7,7 +7,7 @@
         -
         <%= l(phase.ends_at.to_date - 1.day, format: :long) if phase.ends_at.present? %>
       </span>
-      <p><%= safe_html_with_links(phase.summary) %></p>
+      <p><%= safe_html_with_links(WYSIWYGSanitizer.new.sanitize(phase.summary)) %></p>
     </li>
   <% end %>
 </ul>

--- a/app/views/budgets/ballot/_ballot.html.erb
+++ b/app/views/budgets/ballot/_ballot.html.erb
@@ -10,7 +10,7 @@
             count: @ballot.investments.count) %>
       </h2>
       <p class="confirmed">
-        <%= t("budgets.ballots.show.voted_info_html") %>
+        <%= t("budgets.ballots.show.voted_info") %>
       <p>
       <p><%= t("budgets.ballots.show.voted_info_2") %></p>
     </div>

--- a/app/views/budgets/ballot/_ballot.html.erb
+++ b/app/views/budgets/ballot/_ballot.html.erb
@@ -26,8 +26,8 @@
           <h3>
             <%= group.name %> - <%= @ballot.heading_for_group(group).name %>
           </h3>
-          <%= link_to t("budgets.ballots.show.remaining",
-                      amount: @ballot.formatted_amount_available(@ballot.heading_for_group(group))).html_safe,
+          <%= link_to sanitize(t("budgets.ballots.show.remaining",
+                      amount: @ballot.formatted_amount_available(@ballot.heading_for_group(group)))),
                       budget_group_path(@budget, group) %>
         </div>
         <% if @ballot.has_lines_in_group?(group) %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -15,7 +15,7 @@
 
           <h1><%= current_budget.name %></h1>
           <div class="description">
-            <%= safe_html_with_links(current_budget.description) %>
+            <%= auto_link_already_sanitized_html(current_budget.description) %>
           </div>
           <p>
             <%= link_to t("budgets.index.section_header.help"), "#section_help" %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -37,14 +37,14 @@
                             class: "button margin-top expanded" %>
               <% else %>
                 <div class="callout warning margin-top">
-                  <%= t("budgets.investments.index.sidebar.verified_only",
-                        verify: link_to_verify_account).html_safe %>
+                  <%= sanitize(t("budgets.investments.index.sidebar.verified_only",
+                        verify: link_to_verify_account)) %>
                 </div>
               <% end %>
             <% else %>
               <div class="callout primary margin-top">
-                <%= t("budgets.investments.index.sidebar.not_logged_in",
-                      sign_in: link_to_signin, sign_up: link_to_signup).html_safe %>
+                <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+                      sign_in: link_to_signin, sign_up: link_to_signup)) %>
               </div>
             <% end %>
           <% end %>

--- a/app/views/budgets/investments/_ballot.html.erb
+++ b/app/views/budgets/investments/_ballot.html.erb
@@ -51,11 +51,11 @@
 
       <p>
         <small>
-          <%= t("budgets.ballots.reasons_for_not_balloting.#{reason}",
+          <%= sanitize(t("budgets.ballots.reasons_for_not_balloting.#{reason}",
                 verify_account: link_to_verify_account, signin: link_to_signin,
                 signup: link_to_signup, my_heading: my_heading,
                 change_ballot: change_ballot,
-                heading_link: heading_link(@assigned_heading, @budget)).html_safe %>
+                heading_link: heading_link(@assigned_heading, @budget))) %>
         </small>
       </p>
     </div>

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -93,7 +93,8 @@
           title: t("form.accept_terms_title"),
           label: t("form.accept_terms",
                    policy: link_to(t("form.policy"), "/privacy", target: "blank"),
-                   conditions: link_to(t("form.conditions"), "/conditions", target: "blank")).html_safe %>
+                   conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
+                  ) %>
       </div>
 
     <% end %>

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -40,9 +40,9 @@
                         heading_link: heading_link(@assigned_heading, @budget)) %>
                   <br>
                   <small>
-                    <%= t("budgets.investments.header.change_ballot",
+                    <%= sanitize(t("budgets.investments.header.change_ballot",
                         check_ballot: link_to(t("budgets.investments.header.check_ballot_link"),
-                                      budget_ballot_path(@budget))).html_safe %>
+                                      budget_ballot_path(@budget)))) %>
                   </small>
                 </div>
               </div>

--- a/app/views/budgets/investments/_investment_detail.erb
+++ b/app/views/budgets/investments/_investment_detail.erb
@@ -22,7 +22,7 @@
   <%= t("budgets.investments.show.code_html", code: investment.id) %>
 </p>
 
-<%= safe_html_with_links investment.description %>
+<%= auto_link_already_sanitized_html investment.description %>
 
 <% if feature?(:map) && map_location_available?(@investment.map_location) %>
   <div class="margin">
@@ -52,7 +52,7 @@
 
 <% if investment.external_url.present? %>
   <div class="document-link">
-    <%= text_with_links investment.external_url %>
+    <%= sanitize_and_auto_link investment.external_url %>
   </div>
 <% end %>
 

--- a/app/views/budgets/investments/_investment_detail.erb
+++ b/app/views/budgets/investments/_investment_detail.erb
@@ -22,7 +22,7 @@
   <%= t("budgets.investments.show.code_html", code: investment.id) %>
 </p>
 
-<%= safe_html_with_links investment.description.html_safe %>
+<%= safe_html_with_links investment.description %>
 
 <% if feature?(:map) && map_location_available?(@investment.map_location) %>
   <div class="margin">

--- a/app/views/budgets/investments/_sidebar.html.erb
+++ b/app/views/budgets/investments/_sidebar.html.erb
@@ -6,17 +6,17 @@
                new_budget_investment_path(budget_id: @budget.id), class: "button budget expanded" %>
   <% else %>
     <div class="callout warning">
-      <%= t("budgets.investments.index.sidebar.verified_only",
-          verify: link_to_verify_account).html_safe %>
+      <%= sanitize(t("budgets.investments.index.sidebar.verified_only",
+          verify: link_to_verify_account)) %>
     </div>
   <% end %>
 <% end %>
 
 <% if @heading && can?(:show, @ballot) %>
   <p class="callout">
-    <%= t("budgets.investments.index.sidebar.voted_info",
+    <%= sanitize(t("budgets.investments.index.sidebar.voted_info",
         link: link_to(t("budgets.investments.index.sidebar.voted_info_link"),
-            budget_ballot_path(@budget))).html_safe %>
+            budget_ballot_path(@budget)))) %>
   </p>
 <% end %>
 
@@ -52,9 +52,9 @@
             ) %>
       <br>
       <small>
-        <%= t("budgets.investments.index.sidebar.change_ballot",
+        <%= sanitize(t("budgets.investments.index.sidebar.change_ballot",
             check_ballot: link_to(t("budgets.investments.index.sidebar.check_ballot_link"),
-                          budget_ballot_path(@budget))).html_safe %>
+                          budget_ballot_path(@budget)))) %>
       </small>
     </p>
   <% else %>

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -31,13 +31,13 @@
     <div class="js-participation-not-allowed participation-not-allowed" style="display:none" aria-hidden="false">
       <p>
         <small>
-          <%= t("votes.budget_investments.#{reason}",
+          <%= sanitize(t("votes.budget_investments.#{reason}",
                 count: investment.group.max_votable_headings,
                 verify_account: link_to_verify_account,
                 signin: link_to_signin,
                 signup: link_to_signup,
                 supported_headings: (current_user && current_user.headings_voted_within_group(investment.group).map(&:name).sort.to_sentence)
-               ).html_safe %>
+               )) %>
         </small>
       </p>
     </div>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -23,14 +23,14 @@
             <%= link_to t("budgets.investments.index.sidebar.create"), new_budget_investment_path(@budget), class: "button margin-top expanded" %>
           <% else %>
             <div class="callout warning margin-top">
-              <%= t("budgets.investments.index.sidebar.verified_only",
-                  verify: link_to_verify_account).html_safe %>
+              <%= sanitize(t("budgets.investments.index.sidebar.verified_only",
+                  verify: link_to_verify_account)) %>
             </div>
           <% end %>
         <% else %>
           <div class="callout primary margin-top">
-            <%= t("budgets.investments.index.sidebar.not_logged_in",
-                  sign_in: link_to_signin, sign_up: link_to_signup).html_safe %>
+            <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+                  sign_in: link_to_signin, sign_up: link_to_signup)) %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -9,7 +9,7 @@
 
       <h1><%= @budget.name %></h1>
 
-      <%= safe_html_with_links(@budget.description) %>
+      <%= auto_link_already_sanitized_html(@budget.description) %>
     </div>
     <div class="small-12 medium-3 column info padding" data-equalizer-watch>
       <p>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -80,7 +80,7 @@
         <div class="comment-user
                   <%= user_level_class comment %>
                   <%= comment_author_class comment, comment.commentable.author_id %>">
-          <%= simple_format text_with_links(comment.body), {}, sanitize: false %>
+          <%= simple_format sanitize_and_auto_link(comment.body), {}, sanitize: false %>
         </div>
 
         <div id="<%= dom_id(comment) %>_reply" class="reply">

--- a/app/views/comments/_comment_tree.html.erb
+++ b/app/views/comments/_comment_tree.html.erb
@@ -24,7 +24,7 @@
           <% elsif require_verified_resident_for_commentable?(commentable, current_user) %>
             <br>
             <div data-alert class="callout primary">
-              <%= t("comments.verified_only", verify_account: link_to_verify_account).html_safe %>
+              <%= sanitize(t("comments.verified_only", verify_account: link_to_verify_account)) %>
             </div>
           <% elsif allow_comments %>
             <%= render "comments/form", { commentable: commentable,

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,7 +1,7 @@
 <% valuation = local_assigns.fetch(:valuation, false) %>
 <% cache [locale_and_user_status, parent_id, commentable_cache_key(commentable), valuation] do %>
   <% css_id = parent_or_commentable_dom_id(parent_id, commentable) %>
-  <div id="js-comment-form-<%= css_id %>" <%= "style='display:none'".html_safe if toggeable %> class="comment-form">
+  <div id="js-comment-form-<%= css_id %>" <%= raw("style='display:none'") if toggeable %> class="comment-form">
     <%= form_for Comment.new, remote: true do |f| %>
       <%= f.text_area :body,
         id: "comment-body-#{css_id}",

--- a/app/views/comments/_votes.html.erb
+++ b/app/views/comments/_votes.html.erb
@@ -81,9 +81,7 @@
     </div>
 
     <div class="participation-not-allowed" style="display:none" aria-hidden="false">
-      <%= t("votes.comment_unauthenticated",
-        signin: link_to_signin,
-        signup: link_to_signup).html_safe %>
+      <%= sanitize(t("votes.comment_unauthenticated", signin: link_to_signin, signup: link_to_signup)) %>
     </div>
   <% end %>
 </div>

--- a/app/views/dashboard/_proposed_action.html.erb
+++ b/app/views/dashboard/_proposed_action.html.erb
@@ -38,10 +38,10 @@
             <small><%= t("dashboard.recommended_actions.show_description") %></small>
           </a>
           <div id="proposed_action_description_<%= dom_id(proposed_action) %>" class="hide" data-toggler=".hide">
-            <%= proposed_action.description.html_safe %>
+            <%= WYSIWYGSanitizer.new.sanitize(proposed_action.description) %>
           </div>
         <% else %>
-          <%= proposed_action.description.html_safe %>
+          <%= WYSIWYGSanitizer.new.sanitize(proposed_action.description) %>
         <% end %>
       <% end %>
 

--- a/app/views/dashboard/_resource.html.erb
+++ b/app/views/dashboard/_resource.html.erb
@@ -23,7 +23,7 @@
                     class: "button expanded" %>
       <% else %>
         <strong>
-          <%== resource_availability_label(resource) %>
+          <%= resource_availability_label(resource) %>
         </strong>
       <% end %>
     </div>

--- a/app/views/dashboard/actions/new_request.html.erb
+++ b/app/views/dashboard/actions/new_request.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row expanded">
   <div class="small-12 medium-8 column">
-    <%== dashboard_action.description %>
+    <%= WYSIWYGSanitizer.new.sanitize(dashboard_action.description) %>
     <%= render "dashboard/form" %>
   </div>
 

--- a/app/views/dashboard/mailer/new_actions_notification_on_create.html.erb
+++ b/app/views/dashboard/mailer/new_actions_notification_on_create.html.erb
@@ -6,7 +6,7 @@
   <p>
     <%= t("mailers.new_actions_notification_on_create.text_1") %>
     <br>
-    <%= t("mailers.new_actions_notification_on_create.text_2", link: proposal_dashboard_url(@proposal)).html_safe %>
+    <%= sanitize(t("mailers.new_actions_notification_on_create.text_2", link: proposal_dashboard_url(@proposal))) %>
   </p>
   <p><%= t("mailers.new_actions_notification_on_create.text_3") %></p>
   <p><%= t("mailers.new_actions_notification_on_create.text_4") %></p>

--- a/app/views/dashboard/mailer/new_actions_notification_on_published.html.erb
+++ b/app/views/dashboard/mailer/new_actions_notification_on_published.html.erb
@@ -36,7 +36,7 @@
     <ul>
       <li><%= first_proposed_action.title %></li>
       <% if first_proposed_action.short_description.present? %>
-        <p><%= first_proposed_action.short_description.html_safe %></p>
+        <p><%= first_proposed_action.short_description %></p>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/dashboard/mailer/new_actions_notification_rake_created.html.erb
+++ b/app/views/dashboard/mailer/new_actions_notification_rake_created.html.erb
@@ -10,9 +10,9 @@
            title: @proposal.title) %>
   </p>
   <p>
-    <%= t("mailers.new_actions_notification_rake_created.text_1",
+    <%= sanitize(t("mailers.new_actions_notification_rake_created.text_1",
            link_to_published: link_to(proposal_dashboard_url(@proposal),
-                                      proposal_dashboard_url(@proposal))).html_safe %>
+                                      proposal_dashboard_url(@proposal)))) %>
   </p>
   <p><%= t("mailers.new_actions_notification_rake_created.text_2") %></p>
   <br>

--- a/app/views/dashboard/mailer/new_actions_notification_rake_created.html.erb
+++ b/app/views/dashboard/mailer/new_actions_notification_rake_created.html.erb
@@ -35,7 +35,7 @@
     <ul>
       <li><%= first_proposed_action.title %></li>
       <% if first_proposed_action.description.present? %>
-        <p><%= first_proposed_action.description.html_safe %></p>
+        <p><%= WYSIWYGSanitizer.new.sanitize(first_proposed_action.description) %></p>
       <% end %>
     </ul>
     <br>

--- a/app/views/dashboard/mailer/new_actions_notification_rake_published.html.erb
+++ b/app/views/dashboard/mailer/new_actions_notification_rake_published.html.erb
@@ -36,7 +36,7 @@
     <ul>
       <li><%= first_proposed_action.title %></li>
       <% if first_proposed_action.description.present? %>
-        <p><%= first_proposed_action.description.html_safe %></p>
+        <p><%= WYSIWYGSanitizer.new.sanitize(first_proposed_action.description) %></p>
       <% end %>
     </ul>
     <br>

--- a/app/views/dashboard/mailing/new.html.erb
+++ b/app/views/dashboard/mailing/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for :action_title, t("dashboard.mailing.new.title") %>
 <div class="row expanded">
   <div class="small-12 medium-9 column">
-    <%== Setting["proposals.email_description"] %>
+    <%= Setting["proposals.email_description"] %>
   </div>
 
   <%= render "mailing_options" %>

--- a/app/views/dashboard/polls/index.html.erb
+++ b/app/views/dashboard/polls/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :action_title, t("dashboard.polls.index.title") %>
 <div class="row expanded">
   <div class="small-12 medium-9 column">
-    <%== Setting["proposals.poll_description"] %>
+    <%= Setting["proposals.poll_description"] %>
 
     <% if @polls.any? %>
       <div class="row expanded margin-top" data-equalizer="poll-cards" data-equalize-on="medium">

--- a/app/views/dashboard/poster/new.html.erb
+++ b/app/views/dashboard/poster/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for :action_title, t("dashboard.poster.new.title") %>
 <div class="row expanded">
   <div class="small-12 medium-9 column">
-    <%== Setting["proposals.poster_description"] %>
+    <%= Setting["proposals.poster_description"] %>
   </div>
 
   <%= render "poster_options" %>

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -39,7 +39,7 @@
           label: t("form.accept_terms",
                    policy: link_to(t("form.policy"), "/privacy", target: "blank"),
                    conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
-                  ).html_safe %>
+                  ) %>
       <% end %>
     </div>
 

--- a/app/views/debates/_votes.html.erb
+++ b/app/views/debates/_votes.html.erb
@@ -52,7 +52,7 @@
   <% elsif user_signed_in? && !debate.votable_by?(current_user) %>
     <div class="participation-not-allowed" style="display:none" aria-hidden="false">
       <p>
-        <%= t("votes.anonymous", verify_account: link_to_verify_account).html_safe %>
+        <%= sanitize(t("votes.anonymous", verify_account: link_to_verify_account)) %>
       </p>
     </div>
   <% elsif !user_signed_in? %>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -86,8 +86,8 @@
           </p>
           <p><%= t("debates.index.section_footer.description") %></p>
           <p><%= t("debates.index.section_footer.help_text_1") %></p>
-          <p><%= t("debates.index.section_footer.help_text_2",
-                    org: link_to(setting["org_name"], new_user_registration_path)).html_safe %></p>
+          <p><%= sanitize(t("debates.index.section_footer.help_text_2",
+                    org: link_to(setting["org_name"], new_user_registration_path))) %></p>
           </p>
         </div>
       <% end %>

--- a/app/views/debates/new.html.erb
+++ b/app/views/debates/new.html.erb
@@ -9,7 +9,7 @@
       info_link: link_to(t("debates.new.info_link"), new_proposal_path)).html_safe %>
 
       <% if feature?(:help_page) %>
-        <%= link_to help_path, title: t("shared.target_blank_html"), target: "_blank" do %>
+        <%= link_to help_path, title: t("shared.target_blank"), target: "_blank" do %>
           <strong><%= t("debates.new.more_info") %></strong>
         <% end %>
       <% end %>

--- a/app/views/debates/new.html.erb
+++ b/app/views/debates/new.html.erb
@@ -5,8 +5,8 @@
 
     <h1><%= t("debates.new.start_new") %></h1>
     <div data-alert class="callout primary">
-      <%= t("debates.new.info",
-      info_link: link_to(t("debates.new.info_link"), new_proposal_path)).html_safe %>
+      <%= sanitize(t("debates.new.info",
+      info_link: link_to(t("debates.new.info_link"), new_proposal_path))) %>
 
       <% if feature?(:help_page) %>
         <%= link_to help_path, title: t("shared.target_blank"), target: "_blank" do %>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -30,7 +30,7 @@
           </span>
         </div>
 
-        <%= safe_html_with_links @debate.description %>
+        <%= auto_link_already_sanitized_html @debate.description %>
 
         <%= render "shared/tags", taggable: @debate %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,8 +4,8 @@
 <%= render "devise/omniauth_form" %>
 
 <p>
-  <%= t("devise_views.shared.links.signup",
-      signup_link: link_to(t("devise_views.shared.links.signup_link"), new_user_registration_path)).html_safe %>
+  <%= sanitize(t("devise_views.shared.links.signup",
+      signup_link: link_to(t("devise_views.shared.links.signup_link"), new_user_registration_path))) %>
 </p>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>

--- a/app/views/direct_messages/new.html.erb
+++ b/app/views/direct_messages/new.html.erb
@@ -9,8 +9,8 @@
     <% if not current_user %>
       <div class="callout primary">
         <p>
-          <%= t("users.login_to_continue",
-            signin: link_to_signin, signup: link_to_signup).html_safe %>
+          <%= sanitize(t("users.login_to_continue",
+            signin: link_to_signin, signup: link_to_signup)) %>
         </p>
       </div>
     <% elsif not @receiver.email_on_direct_message? %>
@@ -33,8 +33,8 @@
     <% else %>
       <div class="callout warning">
         <p>
-          <%= t("users.direct_messages.new.verified_only",
-                verify_account: link_to_verify_account).html_safe %>
+          <%= sanitize(t("users.direct_messages.new.verified_only",
+                verify_account: link_to_verify_account)) %>
         </p>
       </div>
     <% end %>

--- a/app/views/direct_messages/show.html.erb
+++ b/app/views/direct_messages/show.html.erb
@@ -10,6 +10,6 @@
     </div>
 
     <h1><%= @direct_message.title %></h1>
-    <p><%= simple_format text_with_links(@direct_message.body), {}, sanitize: false %></p>
+    <p><%= simple_format sanitize_and_auto_link(@direct_message.body), {}, sanitize: false %></p>
   </div>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to t("views.pagination.first").html_safe, kaminari_path(url), :remote => remote %>
+  <%= link_to t("views.pagination.first"), kaminari_path(url), :remote => remote %>
 </li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,3 +1,3 @@
 <li class="ellipsis" aria-hidden="true">
-  <%= t("views.pagination.truncate").html_safe %>
+  <%= sanitize(t("views.pagination.truncate")) %>
 </li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to t("views.pagination.last").html_safe, kaminari_path(url), :remote => remote %>
+  <%= link_to t("views.pagination.last"), kaminari_path(url), :remote => remote %>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,3 @@
 <li class="pagination-next">
-  <%= link_to t("views.pagination.next").html_safe, kaminari_path(url), :rel => "next", :remote => remote %>
+  <%= link_to t("views.pagination.next"), kaminari_path(url), :rel => "next", :remote => remote %>
 </li>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,3 @@
 <li class="pagination-previous">
-  <%= link_to t("views.pagination.previous").html_safe, kaminari_path(url), :rel => "prev", :remote => remote %>
+  <%= link_to t("views.pagination.previous"), kaminari_path(url), :rel => "prev", :remote => remote %>
 </li>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -5,7 +5,7 @@
         <span aria-hidden="true">&times;</span>
       </button>
       <div class="notice-text">
-        <%= flash_message.try(:html_safe) %>
+        <%= sanitize(flash_message) %>
       </div>
     </div>
   </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -38,7 +38,7 @@
           <% if setting["twitter_handle"] %>
             <li class="inline-block">
               <%= link_to "https://twitter.com/#{setting["twitter_handle"]}", target: "_blank",
-                           title: t("shared.go_to_page") + t("social.twitter", org: setting["org_name"]) + t("shared.target_blank_html") do %>
+                           title: t("shared.go_to_page") + t("social.twitter", org: setting["org_name"]) + t("shared.target_blank") do %>
                               <span class="show-for-sr"><%= t("social.twitter", org: setting["org_name"]) %></span>
                               <span class="icon-twitter" aria-hidden="true"></span>
               <% end %>
@@ -47,7 +47,7 @@
           <% if setting["facebook_handle"] %>
             <li class="inline-block">
               <%= link_to "https://www.facebook.com/#{setting["facebook_handle"]}/", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.facebook", org: setting["org_name"]) + t("shared.target_blank_html") do %>
+                          title: t("shared.go_to_page") + t("social.facebook", org: setting["org_name"]) + t("shared.target_blank") do %>
                           <span class="show-for-sr"><%= t("social.facebook", org: setting["org_name"]) %></span>
                           <span class="icon-facebook" aria-hidden="true"></span>
               <% end %>
@@ -56,7 +56,7 @@
           <% if setting["youtube_handle"] %>
             <li class="inline-block">
               <%= link_to "https://www.youtube.com/#{setting["youtube_handle"]}", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.youtube", org: setting["org_name"]) + t("shared.target_blank_html") do %>
+                          title: t("shared.go_to_page") + t("social.youtube", org: setting["org_name"]) + t("shared.target_blank") do %>
                           <span class="show-for-sr"><%= t("social.youtube", org: setting["org_name"]) %></span>
                           <span class="icon-youtube" aria-hidden="true"></span>
               <% end %>
@@ -65,7 +65,7 @@
           <% if setting["telegram_handle"] %>
             <li class="inline-block">
               <%= link_to "https://www.telegram.me/#{setting["telegram_handle"]}", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.telegram", org: setting["org_name"]) + t("shared.target_blank_html") do %>
+                          title: t("shared.go_to_page") + t("social.telegram", org: setting["org_name"]) + t("shared.target_blank") do %>
                           <span class="show-for-sr"><%= t("social.telegram", org: setting["org_name"]) %></span>
                           <span class="icon-telegram" aria-hidden="true"></span>
               <% end %>
@@ -74,7 +74,7 @@
           <% if setting["instagram_handle"] %>
             <li class="inline-block">
               <%= link_to "https://www.instagram.com/#{setting["instagram_handle"]}", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.instagram", org: setting["org_name"]) + t("shared.target_blank_html") do %>
+                          title: t("shared.go_to_page") + t("social.instagram", org: setting["org_name"]) + t("shared.target_blank") do %>
                           <span class="show-for-sr"><%= t("social.instagram", org: setting["org_name"]) %></span>
                           <span class="icon-instagram" aria-hidden="true"></span>
               <% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="small-12 large-4 column">
       <h1 class="logo">
-        <%= link_to t("layouts.header.open_gov", open: "#{t("layouts.header.open")}").html_safe %>
+        <%= link_to t("layouts.header.open_gov", open: t("layouts.header.open")), root_path %>
       </h1>
 
       <p class="info">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -6,10 +6,9 @@
       </h1>
 
       <p class="info">
-        <%= t("layouts.footer.description",
+        <%= sanitize(t("layouts.footer.description",
           open_source: link_to(t("layouts.footer.open_source"), t("layouts.footer.open_source_url"), target: "blank", rel: "nofollow"),
-          consul:  link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), target: "blank", rel: "nofollow")).html_safe
-        %>
+          consul:  link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), target: "blank", rel: "nofollow"))) %>
         <%= t("layouts.footer.contact_us") %>
       </p>
     </div>

--- a/app/views/layouts/_notification_item.html.erb
+++ b/app/views/layouts/_notification_item.html.erb
@@ -10,11 +10,11 @@
         <span class="icon-circle" aria-hidden="true"></span>
         <span class="icon-notification" aria-hidden="true"
               title="<%= t("layouts.header.notification_item.new_notifications",
-                         count: current_user.notifications_count).html_safe %>">
+                         count: current_user.notifications_count) %>">
         </span>
         <span class="show-for-small-only">
           <%= t("layouts.header.notification_item.new_notifications",
-              count: current_user.notifications_count).html_safe %>
+              count: current_user.notifications_count) %>
         </span>
       <% else %>
         <span class="icon-no-notification" aria-hidden="true"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,10 +11,10 @@
                      type: "image/png" %>
     <%= content_for :social_media_meta_tags %>
 
-    <%= setting["html.per_page_code_head"].try(:html_safe) %>
+    <%= raw setting["html.per_page_code_head"] %>
   </head>
   <body class="<%= yield (:body_class) %>">
-    <%= setting["html.per_page_code_body"].try(:html_safe) %>
+    <%= raw setting["html.per_page_code_body"] %>
 
     <h1 class="show-for-sr"><%= setting["org_name"] %></h1>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,12 +30,12 @@
           </button>
           <h2><%= t("layouts.application.ie_title") %></h2>
           <p>
-            <%= t("layouts.application.ie",
+            <%= sanitize(t("layouts.application.ie",
             chrome: link_to(
                     t("layouts.application.chrome"), "https://www.google.com/chrome/browser/desktop/", title: t("shared.target_blank"), target: "_blank"),
             firefox: link_to(
                      t("layouts.application.firefox"), "https://www.mozilla.org/firefox", title: t("shared.target_blank"), target: "_blank")
-            ).html_safe %>
+            )) %>
           </p>
         </div>
       <![endif]-->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,8 +21,8 @@
     <div class="wrapper <%= yield (:wrapper_class) %>">
       <%= render "layouts/header", with_subnavigation: true %>
 
-      <!--[if lt IE 9]>
       <% if browser.ie? && cookies["ie_alert_closed"] != "true" %>
+      <!--[if lt IE 9]>
         <div data-alert class="callout primary ie-callout" data-closable>
           <button class="close-button ie-callout-close-js"
                   aria-label="<%= t("application.close") %>" type="button" data-close>
@@ -38,8 +38,8 @@
             ).html_safe %>
           </p>
         </div>
-      <% end %>
       <![endif]-->
+      <% end %>
 
       <%= render "layouts/flash" %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,9 +32,9 @@
           <p>
             <%= t("layouts.application.ie",
             chrome: link_to(
-                    t("layouts.application.chrome"), "https://www.google.com/chrome/browser/desktop/", title: t("shared.target_blank_html"), target: "_blank"),
+                    t("layouts.application.chrome"), "https://www.google.com/chrome/browser/desktop/", title: t("shared.target_blank"), target: "_blank"),
             firefox: link_to(
-                     t("layouts.application.firefox"), "https://www.mozilla.org/firefox", title: t("shared.target_blank_html"), target: "_blank")
+                     t("layouts.application.firefox"), "https://www.mozilla.org/firefox", title: t("shared.target_blank"), target: "_blank")
             ).html_safe %>
           </p>
         </div>

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -18,10 +18,10 @@
                      type: "image/png" %>
     <%= content_for :social_media_meta_tags %>
 
-    <%= setting["per_page_code_head"].try(:html_safe) %>
+    <%= raw setting["per_page_code_head"] %>
   </head>
   <body class="proposal-dashboard">
-    <%= setting["per_page_code_body"].try(:html_safe) %>
+    <%= raw setting["per_page_code_body"] %>
 
     <h1 class="show-for-sr"><%= setting["org_name"] %></h1>
 

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -3,11 +3,11 @@
   <head>
     <%= render "layouts/common_head", default_title: "Gobierno abierto" %>
     <%= render "layouts/meta_tags" %>
-    <%= setting["html.per_page_code_head"].try(:html_safe) %>
+    <%= raw setting["html.per_page_code_head"] %>
   </head>
 
   <body class="auth-page">
-    <%= setting["html.per_page_code_body"].try(:html_safe) %>
+    <%= raw setting["html.per_page_code_body"] %>
     <div class="wrapper">
       <div class="auth-image small-12 medium-3 column">
         <h1 class="logo margin">

--- a/app/views/layouts/proposals_dashboard.html.erb
+++ b/app/views/layouts/proposals_dashboard.html.erb
@@ -18,10 +18,10 @@
                      type: "image/png" %>
     <%= content_for :social_media_meta_tags %>
 
-    <%= setting["per_page_code_head"].try(:html_safe) %>
+    <%= raw setting["per_page_code_head"] %>
   </head>
   <body class="proposal-dashboard">
-    <%= setting["per_page_code_body"].try(:html_safe) %>
+    <%= raw setting["per_page_code_body"] %>
 
     <h1 class="show-for-sr"><%= setting["org_name"] %></h1>
 

--- a/app/views/legislation/annotations/_comments_box.html.erb
+++ b/app/views/legislation/annotations/_comments_box.html.erb
@@ -37,8 +37,8 @@
 
       <div>
         <div class="participation-not-allowed" style="display: none;" aria-hidden="false">
-          <%= t("users.login_to_comment",
-              signin: link_to_signin, signup: link_to_signup).html_safe %>
+          <%= sanitize(t("users.login_to_comment",
+              signin: link_to_signin, signup: link_to_signup)) %>
         </div>
       </div>
 

--- a/app/views/legislation/annotations/index.html.erb
+++ b/app/views/legislation/annotations/index.html.erb
@@ -22,7 +22,7 @@
           <% end %>
         </span>
         <div class="comment-section">
-          <%= annotation.context.try(:html_safe).presence || annotation.quote %>
+          <%= sanitize(annotation.context).presence || annotation.quote %>
         </div>
         <%= link_to legislation_process_draft_version_annotation_path(@process, @draft_version, annotation) do %>
           <span class="icon-comments" aria-hidden="true"></span> <span><%= t(".comments_count", count: annotation.comments_count) %></span></a>

--- a/app/views/legislation/annotations/show.html.erb
+++ b/app/views/legislation/annotations/show.html.erb
@@ -19,7 +19,7 @@
             <div class="comment-section">
               <div class="row">
                 <div class="small-12 medium-9 column legislation-comment">
-                  <%= @annotation.context.try(:html_safe).presence || @annotation.quote %>
+                  <%= sanitize(@annotation.context).presence || @annotation.quote %>
                 </div>
                 <div class="small-12 medium-3 column legislation-comment">
                   <span class="float-right">

--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -49,7 +49,7 @@
 
         <div data-sticky-container>
           <div data-sticky data-anchor="sticky-panel" class="draft-index sticky" data-tree-navigator>
-            <%= @draft_version.toc_html.html_safe %>
+            <%= sanitize(@draft_version.toc_html) %>
           </div>
         </div>
       </div>
@@ -66,7 +66,7 @@
                    data-legislation-annotatable-base-url="<%= legislation_process_draft_version_path(@process, @draft_version) %>"
                    data-legislation-open-phase="<%= @process.allegations_phase.open? %>">
           <% end %>
-            <%= @draft_version.body_html.html_safe %>
+            <%= sanitize(@draft_version.body_html) %>
           </section>
         </div>
       </div>

--- a/app/views/legislation/processes/_help_gif.html.erb
+++ b/app/views/legislation/processes/_help_gif.html.erb
@@ -11,8 +11,8 @@
           <%= t("annotator.help.alt") %>
         <% else %>
           <p>
-            <%= t("annotator.help.text",
-                sign_in: link_to_signin, sign_up: link_to_signup).html_safe %>
+            <%= sanitize(t("annotator.help.text",
+                sign_in: link_to_signin, sign_up: link_to_signup)) %>
           </p>
         <% end %>
 

--- a/app/views/legislation/proposals/_featured_votes.html.erb
+++ b/app/views/legislation/proposals/_featured_votes.html.erb
@@ -22,7 +22,7 @@
   <% elsif user_signed_in? && !proposal.votable_by?(current_user) %>
     <div class="participation-not-allowed" style="display:none" aria-hidden="false">
       <p>
-        <%= t("votes.verified_only", verify_account: link_to_verify_account).html_safe %>
+        <%= sanitize(t("votes.verified_only", verify_account: link_to_verify_account)) %>
       </p>
     </div>
   <% elsif !user_signed_in? %>

--- a/app/views/legislation/proposals/_form.html.erb
+++ b/app/views/legislation/proposals/_form.html.erb
@@ -65,7 +65,7 @@
           label: t("form.accept_terms",
                    policy: link_to(t("form.policy"), "/privacy", target: "blank"),
                    conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
-                  ).html_safe %>
+                  ) %>
       <% end %>
     </div>
 

--- a/app/views/legislation/proposals/_votes.html.erb
+++ b/app/views/legislation/proposals/_votes.html.erb
@@ -54,8 +54,8 @@
   <% elsif user_signed_in? && !proposal.votable_by?(current_user) %>
     <div class="participation-not-allowed" style="display:none" aria-hidden="false">
       <p>
-        <%= t("legislation.proposals.not_verified",
-            verify_account: link_to_verify_account).html_safe %>
+        <%= sanitize(t("legislation.proposals.not_verified",
+            verify_account: link_to_verify_account)) %>
       </p>
     </div>
   <% elsif !user_signed_in? %>

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -68,7 +68,7 @@
           </div>
         <% end %>
 
-        <%= safe_html_with_links @proposal.description %>
+        <%= auto_link_already_sanitized_html @proposal.description %>
 
         <% if @proposal.video_url.present? %>
           <div class="video-link">
@@ -76,7 +76,7 @@
               <span class="icon-video"></span>&nbsp;
               <strong><%= t("proposals.show.title_video_url") %></strong>
             </p>
-            <%= text_with_links @proposal.video_url %>
+            <%= sanitize_and_auto_link @proposal.video_url %>
           </div>
 
         <% end %>

--- a/app/views/legislation/questions/_participation_not_allowed.html.erb
+++ b/app/views/legislation/questions/_participation_not_allowed.html.erb
@@ -7,14 +7,14 @@
 <% elsif user_signed_in? && current_user.unverified? %>
   <div class="participation-not-allowed" style="display:none" aria-hidden="false">
     <p>
-      <%= t("legislation.questions.participation.verified_only",
-          verify_account: link_to_verify_account).html_safe %>
+      <%= sanitize(t("legislation.questions.participation.verified_only",
+          verify_account: link_to_verify_account)) %>
     </p>
   </div>
 <% elsif !user_signed_in? %>
   <div class="participation-not-allowed" style="display:none" aria-hidden="false">
-    <%= t("legislation.questions.participation.unauthenticated",
-          signin: link_to_signin, signup: link_to_signup).html_safe %>
+    <%= sanitize(t("legislation.questions.participation.unauthenticated",
+          signin: link_to_signin, signup: link_to_signup)) %>
   </div>
 <% elsif !@process.debate_phase.open? %>
   <div class="participation-not-allowed" style="display:none" aria-hidden="false">

--- a/app/views/mailer/budget_investment_created.html.erb
+++ b/app/views/mailer/budget_investment_created.html.erb
@@ -5,14 +5,14 @@
   </h1>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_created.intro_html",
-           author: @investment.author.name).html_safe %>
+    <%= sanitize(t("mailers.budget_investment_created.intro",
+           author: @investment.author.name)) %>
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_created.text_html",
+    <%= sanitize(t("mailers.budget_investment_created.text",
            investment: @investment.title,
-           budget: @investment.budget.name).html_safe %>
+           budget: @investment.budget.name)) %>
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">

--- a/app/views/mailer/budget_investment_created.html.erb
+++ b/app/views/mailer/budget_investment_created.html.erb
@@ -16,8 +16,8 @@
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.budget_investment_created.follow_html",
-           link: link_to(t("mailers.budget_investment_created.follow_link"), budgets_url)).html_safe %>
+    <%= sanitize(t("mailers.budget_investment_created.follow_html",
+           link: link_to(t("mailers.budget_investment_created.follow_link"), budgets_url))) %>
   </p>
 
   <table style="width: 100%;">

--- a/app/views/mailer/comment.html.erb
+++ b/app/views/mailer/comment.html.erb
@@ -13,7 +13,7 @@
   </p>
 
   <p style="border-left: 2px solid #DEE0E3;font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-style: italic;font-weight: normal;line-height: 24px;margin-left: 20px;padding: 10px;">
-    <%= text_with_links @comment.body %>
+    <%= sanitize_and_auto_link @comment.body %>
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 20px;">

--- a/app/views/mailer/direct_message_for_receiver.html.erb
+++ b/app/views/mailer/direct_message_for_receiver.html.erb
@@ -4,7 +4,7 @@
   </h1>
 
   <div style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= simple_format text_with_links(@direct_message.body), {}, sanitize: false %>
+    <%= simple_format sanitize_and_auto_link(@direct_message.body), {}, sanitize: false %>
   </div>
 
   <table style="width: 100%; border-top: 1px solid #DEE0E3; margin-top: 60px;">

--- a/app/views/mailer/direct_message_for_receiver.html.erb
+++ b/app/views/mailer/direct_message_for_receiver.html.erb
@@ -26,9 +26,9 @@
       <tr>
         <td style="padding-left: 10px;">
           <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; margin: 0; font-style: italic; padding-bottom: 20px;">
-            <%= t("mailers.direct_message_for_receiver.unsubscribe",
+            <%= sanitize(t("mailers.direct_message_for_receiver.unsubscribe",
                 account: link_to(t("mailers.direct_message_for_receiver.unsubscribe_account"),
-                                account_url, style: "color: #2895F1; text-decoration: none;")).html_safe %>
+                                account_url, style: "color: #2895F1; text-decoration: none;"))) %>
           </p>
         </td>
       </tr>

--- a/app/views/mailer/direct_message_for_sender.html.erb
+++ b/app/views/mailer/direct_message_for_sender.html.erb
@@ -10,6 +10,6 @@
   </h2>
 
   <div style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= simple_format text_with_links(@direct_message.body), {}, sanitize: false %>
+    <%= simple_format sanitize_and_auto_link(@direct_message.body), {}, sanitize: false %>
   </div>
 </td>

--- a/app/views/mailer/evaluation_comment.html.erb
+++ b/app/views/mailer/evaluation_comment.html.erb
@@ -14,6 +14,6 @@
 
   <%= t("mailers.evaluation_comment.commenter_info", commenter: @email.comment.author.name, time: l(@email.comment.created_at)) %>
   <div style="border-left: 2px solid #DEE0E3;font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-style: italic;font-weight: normal;line-height: 24px;margin-left: 20px;padding: 10px;">
-    <%= simple_format text_with_links(@email.comment.body), {}, sanitize: false %>
+    <%= simple_format sanitize_and_auto_link(@email.comment.body), {}, sanitize: false %>
   </div>
 </td>

--- a/app/views/mailer/newsletter.html.erb
+++ b/app/views/mailer/newsletter.html.erb
@@ -1,5 +1,5 @@
 <td style="padding-bottom: 20px; padding-left: 10px;">
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;line-height: 24px;">
-    <%= safe_html_with_links WYSIWYGSanitizer.new.sanitize(@newsletter.body) %>
+    <%= auto_link_already_sanitized_html WYSIWYGSanitizer.new.sanitize(@newsletter.body) %>
   </p>
 </td>

--- a/app/views/mailer/newsletter.html.erb
+++ b/app/views/mailer/newsletter.html.erb
@@ -1,5 +1,5 @@
 <td style="padding-bottom: 20px; padding-left: 10px;">
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;line-height: 24px;">
-    <%= safe_html_with_links @newsletter.body.html_safe %>
+    <%= safe_html_with_links WYSIWYGSanitizer.new.sanitize(@newsletter.body) %>
   </p>
 </td>

--- a/app/views/mailer/proposal_notification_digest.html.erb
+++ b/app/views/mailer/proposal_notification_digest.html.erb
@@ -61,9 +61,9 @@
       <tr>
         <td style="padding-left: 10px;">
           <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; margin: 0; font-style: italic; padding-bottom: 20px;">
-            <%= t("mailers.proposal_notification_digest.unsubscribe",
+            <%= sanitize(t("mailers.proposal_notification_digest.unsubscribe",
                 account: link_to(t("mailers.proposal_notification_digest.unsubscribe_account"),
-                                account_url, style: "color: #2895F1; text-decoration: none;")).html_safe %>
+                                account_url, style: "color: #2895F1; text-decoration: none;"))) %>
           </p>
         </td>
       </tr>

--- a/app/views/mailer/reply.html.erb
+++ b/app/views/mailer/reply.html.erb
@@ -13,7 +13,7 @@
   </p>
 
   <div style="border-left: 2px solid #DEE0E3;font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-style: italic;font-weight: normal;line-height: 24px;margin-left: 20px;padding: 10px;">
-    <%= simple_format text_with_links(@email.reply.body), {}, sanitize: false %>
+    <%= simple_format sanitize_and_auto_link(@email.reply.body), {}, sanitize: false %>
   </div>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 20px;">

--- a/app/views/management/document_verifications/invalid_document.html.erb
+++ b/app/views/management/document_verifications/invalid_document.html.erb
@@ -11,6 +11,6 @@
       permissions: [:debates, :create_proposals] %>
 
 <p>
-  <%= t("management.document_verifications.has_no_account_html",
-      link: link_to(t("management.document_verifications.link"), root_path, target: "_blank")).html_safe %>
+  <%= sanitize(t("management.document_verifications.has_no_account_html",
+      link: link_to(t("management.document_verifications.link"), root_path, target: "_blank"))) %>
 </p>

--- a/app/views/milestones/_milestone.html.erb
+++ b/app/views/milestones/_milestone.html.erb
@@ -25,7 +25,7 @@
     <%= image_tag(milestone.image_url(:large), { id: "image_#{milestone.id}", alt: milestone.image.title, class: "margin" }) if milestone.image.present? %>
 
     <p>
-      <%= text_with_links milestone.description %>
+      <%= sanitize_and_auto_link milestone.description %>
     </p>
 
     <% if milestone.documents.present? %>

--- a/app/views/organizations/registrations/new.html.erb
+++ b/app/views/organizations/registrations/new.html.erb
@@ -32,7 +32,7 @@
         label: t("devise_views.users.registrations.new.terms",
                  terms: link_to(t("devise_views.users.registrations.new.terms_link"),
                                 "/conditions",
-                                title: t("shared.target_blank_html"),
+                                title: t("shared.target_blank"),
                                 target: "_blank")
                 ).html_safe %>
 

--- a/app/views/organizations/registrations/new.html.erb
+++ b/app/views/organizations/registrations/new.html.erb
@@ -34,7 +34,7 @@
                                 "/conditions",
                                 title: t("shared.target_blank"),
                                 target: "_blank")
-                ).html_safe %>
+                ) %>
 
       <div class="small-12 medium-6 small-centered">
         <%= f.submit t("devise_views.organizations.registrations.new.submit"), class: "button expanded" %>

--- a/app/views/organizations/registrations/success.html.erb
+++ b/app/views/organizations/registrations/success.html.erb
@@ -2,7 +2,7 @@
 <p><%= t("devise_views.organizations.registrations.success.thank_you_html") %></p>
 <p><%= t("devise_views.organizations.registrations.success.instructions_1_html") %></p>
 <p><%= t("devise_views.organizations.registrations.success.instructions_2_html") %></p>
-<p><%= t("devise_views.organizations.registrations.success.instructions_3_html") %></p>
+<p><%= t("devise_views.organizations.registrations.success.instructions_3") %></p>
 <p>
   <%= link_to t("devise_views.organizations.registrations.success.back_to_index"),
       root_path, class: "button margin-top expanded" %>

--- a/app/views/pages/custom_page.html.erb
+++ b/app/views/pages/custom_page.html.erb
@@ -9,7 +9,7 @@
       <h2><%= @custom_page.subtitle %></h2>
     <% end %>
 
-    <%= safe_html_with_links AdminWYSIWYGSanitizer.new.sanitize(@custom_page.content) %>
+    <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@custom_page.content) %>
   </div>
 
   <% if @custom_page.print_content_flag %>

--- a/app/views/pages/help/_budgets.html.erb
+++ b/app/views/pages/help/_budgets.html.erb
@@ -4,8 +4,8 @@
       <%= t("pages.help.budgets.title") %>
     </h3>
     <p>
-      <%= t("pages.help.budgets.description",
-           link: link_to(t("pages.help.budgets.link"), budgets_path)).html_safe %>
+      <%= sanitize(t("pages.help.budgets.description",
+           link: link_to(t("pages.help.budgets.link"), budgets_path))) %>
     </p>
 
     <figure>

--- a/app/views/pages/help/_budgets.html.erb
+++ b/app/views/pages/help/_budgets.html.erb
@@ -10,7 +10,7 @@
 
     <figure>
       <%= image_tag "help/budgets_#{I18n.locale}.png", alt: t("pages.help.budgets.image_alt") %>
-      <figcaption><%= t("pages.help.budgets.figcaption_html") %></figcaption>
+      <figcaption><%= t("pages.help.budgets.figcaption") %></figcaption>
     </figure>
   </div>
 </div>

--- a/app/views/pages/help/_debates.html.erb
+++ b/app/views/pages/help/_debates.html.erb
@@ -4,16 +4,16 @@
       <%= t("pages.help.debates.title") %>
     </h3>
     <p>
-      <%= t("pages.help.debates.description",
+      <%= sanitize(t("pages.help.debates.description",
           org: setting["org_name"],
           link: link_to(t("pages.help.debates.link"),
-                              debates_path)).html_safe %>
+                              debates_path))) %>
     </p>
     <ul class="features">
       <li>
-        <%= t("pages.help.debates.feature_html",
+        <%= sanitize(t("pages.help.debates.feature_html",
               link: link_to(t("pages.help.debates.feature_link", org: setting["org_name"]),
-                               new_user_registration_path)).html_safe %>
+                               new_user_registration_path))) %>
       </li>
     </ul>
 

--- a/app/views/pages/help/_polls.html.erb
+++ b/app/views/pages/help/_polls.html.erb
@@ -2,14 +2,14 @@
   <div class="small-12 column">
     <h3 id="polls" data-magellan-target="polls"><%= t("pages.help.polls.title") %></h3>
     <p>
-      <%= t("pages.help.polls.description",
-            link: link_to(t("pages.help.polls.link"), polls_path)).html_safe %>
+      <%= sanitize(t("pages.help.polls.description",
+            link: link_to(t("pages.help.polls.link"), polls_path))) %>
     </p>
     <ul class="features">
       <li>
-        <%= t("pages.help.polls.feature_1",
+        <%= sanitize(t("pages.help.polls.feature_1",
               link: link_to(t("pages.help.polls.feature_1_link", org_name: setting["org_name"]),
-                               new_user_registration_path)).html_safe %>
+                               new_user_registration_path))) %>
       </li>
     </ul>
   </div>

--- a/app/views/pages/help/_processes.html.erb
+++ b/app/views/pages/help/_processes.html.erb
@@ -6,7 +6,7 @@
 
     <p>
       <% link = link_to(t("pages.help.processes.link"), legislation_processes_path) %>
-      <%= t("pages.help.processes.description", link: link).html_safe %>
+      <%= sanitize(t("pages.help.processes.description", link: link)) %>
     </p>
     <ul class="features">
       <li>

--- a/app/views/pages/help/_proposals.html.erb
+++ b/app/views/pages/help/_proposals.html.erb
@@ -4,8 +4,8 @@
       <%= t("pages.help.proposals.title") %>
     </h3>
     <p>
-      <%= t("pages.help.proposals.description",
-              link: link_to(t("pages.help.proposals.link"), proposals_path)).html_safe %>
+      <%= sanitize(t("pages.help.proposals.description",
+              link: link_to(t("pages.help.proposals.link"), proposals_path))) %>
     </p>
 
     <figure>

--- a/app/views/pages/help/_proposals.html.erb
+++ b/app/views/pages/help/_proposals.html.erb
@@ -10,7 +10,7 @@
 
     <figure>
       <%= image_tag "help/proposals_#{I18n.locale}.png", alt: t("pages.help.proposals.image_alt") %>
-      <figcaption><%= t("pages.help.proposals.figcaption_html") %></figcaption>
+      <figcaption><%= t("pages.help.proposals.figcaption") %></figcaption>
     </figure>
   </div>
 </div>

--- a/app/views/polls/_callout.html.erb
+++ b/app/views/polls/_callout.html.erb
@@ -1,9 +1,9 @@
 <% unless can?(:answer, @poll) %>
   <% if current_user.nil? %>
     <div class="callout primary">
-      <%= t("polls.show.cant_answer_not_logged_in",
+      <%= sanitize(t("polls.show.cant_answer_not_logged_in",
             signin: link_to_signin(class: "probe-message"),
-            signup: link_to_signup(class: "probe-message")).html_safe %>
+            signup: link_to_signup(class: "probe-message"))) %>
     </div>
   <% elsif current_user.unverified? %>
     <div class="callout warning">

--- a/app/views/polls/_poll_header.html.erb
+++ b/app/views/polls/_poll_header.html.erb
@@ -9,7 +9,7 @@
 
       <h1><%= @poll.name %></h1>
 
-      <%= safe_html_with_links simple_format(@poll.summary) %>
+      <%= auto_link_already_sanitized_html simple_format(@poll.summary) %>
 
       <% if @poll.geozones.any? %>
         <ul class="no-bullet margin-top tags">

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -14,7 +14,7 @@
   <div class="small-12 column">
     <% if show_polls_description? %>
       <div class="polls-description">
-        <%= safe_html_with_links WYSIWYGSanitizer.new.sanitize(@active_poll.description) %>
+        <%= auto_link_already_sanitized_html WYSIWYGSanitizer.new.sanitize(@active_poll.description) %>
       </div>
     <% end %>
 

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -41,7 +41,7 @@
     <div class="row margin">
       <div class="small-12 medium-9 column">
         <h3><%= t("polls.show.more_info_title") %></h3>
-        <%= safe_html_with_links simple_format(@poll.description) %>
+        <%= auto_link_already_sanitized_html simple_format(@poll.description) %>
       </div>
 
       <% if false %>

--- a/app/views/proposal_notifications/new.html.erb
+++ b/app/views/proposal_notifications/new.html.erb
@@ -6,10 +6,10 @@
 
     <div class="callout primary">
       <p>
-        <%= t("proposal_notifications.new.info_about_receivers_html",
+        <%= sanitize(t("proposal_notifications.new.info_about_receivers_html",
               count: @proposal.users_to_notify.count,
               proposal_page: link_to(t("proposal_notifications.new.proposal_page"),
-                                     proposal_path(@proposal, anchor: "comments"))).html_safe %>
+                                     proposal_path(@proposal, anchor: "comments")))) %>
       </p>
     </div>
   </div>

--- a/app/views/proposals/_featured_votes.html.erb
+++ b/app/views/proposals/_featured_votes.html.erb
@@ -22,7 +22,7 @@
   <% elsif user_signed_in? && !proposal.votable_by?(current_user) %>
     <div class="participation-not-allowed" style="display:none" aria-hidden="false">
       <p>
-        <%= t("votes.verified_only", verify_account: link_to_verify_account).html_safe %>
+        <%= sanitize(t("votes.verified_only", verify_account: link_to_verify_account)) %>
       </p>
     </div>
   <% elsif !user_signed_in? %>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -100,7 +100,7 @@
           label: t("form.accept_terms",
                    policy: link_to(t("form.policy"), "/privacy", target: "blank"),
                    conditions: link_to(t("form.conditions"), "/conditions", target: "blank")
-                  ).html_safe %>
+                  ) %>
       <% end %>
     </div>
 

--- a/app/views/proposals/_info.html.erb
+++ b/app/views/proposals/_info.html.erb
@@ -39,7 +39,7 @@
   </div>
 <% end %>
 
-<%= safe_html_with_links @proposal.description %>
+<%= auto_link_already_sanitized_html @proposal.description %>
 
 <% if feature?(:map) && map_location_available?(@proposal.map_location) %>
   <div class="margin">
@@ -53,7 +53,7 @@
       <span class="icon-video"></span>&nbsp;
       <strong><%= t("proposals.show.title_video_url") %></strong>
     </p>
-    <%= text_with_links @proposal.video_url %>
+    <%= sanitize_and_auto_link @proposal.video_url %>
   </div>
 <% end %>
 
@@ -63,7 +63,7 @@
       <%= t("proposals.show.retired") %>:
       <%= t("proposals.retire_options.#{@proposal.retired_reason}") unless @proposal.retired_reason == "other" %>
     </h2>
-    <%= simple_format text_with_links(@proposal.retired_explanation), {}, sanitize: false %>
+    <%= simple_format sanitize_and_auto_link(@proposal.retired_explanation), {}, sanitize: false %>
   </div>
 <% end %>
 

--- a/app/views/proposals/_notifications.html.erb
+++ b/app/views/proposals/_notifications.html.erb
@@ -11,7 +11,7 @@
         <div id="<%= dom_id(notification) %>">
           <h3><%= notification.title %></h3>
           <p class="more-info"><%= notification.created_at.to_date %></p>
-          <%= simple_format text_with_links(notification.body), {}, sanitize: false %>
+          <%= simple_format sanitize_and_auto_link(notification.body), {}, sanitize: false %>
 
           <span class="js-flag-actions">
             <%= render "proposal_notifications/actions", notification: notification %>

--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -29,7 +29,7 @@
     <div tabindex="0">
       <div class="participation-not-allowed" style="display:none" aria-hidden="false">
         <p>
-          <%= t("votes.verified_only", verify_account: link_to_verify_account).html_safe %>
+          <%= sanitize(t("votes.verified_only", verify_account: link_to_verify_account)) %>
         </p>
       </div>
     </div>

--- a/app/views/proposals/new.html.erb
+++ b/app/views/proposals/new.html.erb
@@ -5,7 +5,7 @@
 
     <h1><%= t("proposals.new.start_new") %></h1>
     <div data-alert class="callout primary">
-      <%= link_to help_path(anchor: "proposals"), title: t("shared.target_blank_html"), target: "_blank" do %>
+      <%= link_to help_path(anchor: "proposals"), title: t("shared.target_blank"), target: "_blank" do %>
         <%= t("proposals.new.more_info") %>
       <% end %>
     </div>

--- a/app/views/shared/_login_to_comment.html.erb
+++ b/app/views/shared/_login_to_comment.html.erb
@@ -1,3 +1,3 @@
 <div data-alert class="callout primary">
-  <%= t("users.login_to_comment", signin: link_to_signin, signup: link_to_signup).html_safe %>
+  <%= sanitize(t("users.login_to_comment", signin: link_to_signin, signup: link_to_signup)) %>
 </div>

--- a/app/views/shared/_login_to_vote.html.erb
+++ b/app/views/shared/_login_to_vote.html.erb
@@ -1,3 +1,3 @@
 <div class="participation-not-allowed" style="display:none" aria-hidden="false">
-  <%= t("users.login_to_continue", signin: link_to_signin, signup: link_to_signup).html_safe %>
+  <%= sanitize(t("users.login_to_continue", signin: link_to_signin, signup: link_to_signup)) %>
 </div>

--- a/app/views/topics/_informative_text.html.erb
+++ b/app/views/topics/_informative_text.html.erb
@@ -6,7 +6,7 @@
   </div>
 <% else %>
   <div class="callout primary">
-    <%= t("community.show.create_first_community_topic.sub_first_theme",
-          sign_in: link_to_signin, sign_up: link_to_signup).html_safe %>
+    <%= sanitize(t("community.show.create_first_community_topic.sub_first_theme",
+          sign_in: link_to_signin, sign_up: link_to_signup)) %>
   </div>
 <% end %>

--- a/app/views/tracking/budget_investments/edit.html.erb
+++ b/app/views/tracking/budget_investments/edit.html.erb
@@ -7,6 +7,6 @@
 
 <h1><%= @investment.title %></h1>
 
-<%= safe_html_with_links @investment.description %>
+<%= auto_link_already_sanitized_html @investment.description %>
 
 <%= render "tracking/milestones/milestones", milestoneable: @investment %>

--- a/app/views/tracking/budget_investments/show.html.erb
+++ b/app/views/tracking/budget_investments/show.html.erb
@@ -3,10 +3,10 @@
 <h2><%= t("tracking.budget_investments.show.title") %> <%= @investment.id %> </h2>
 <h1><%= @investment.title %></h1>
 
-<%= safe_html_with_links @investment.description %>
+<%= auto_link_already_sanitized_html @investment.description %>
 
 <% if @investment.external_url.present? %>
-  <p><%= text_with_links @investment.external_url %></p>
+  <p><%= sanitize_and_auto_link @investment.external_url %></p>
 <% end %>
 
 <h2><%= t("tracking.budget_investments.show.info") %></h2>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -40,7 +40,7 @@
         title: t("devise_views.users.registrations.new.terms_title"),
         label: t("devise_views.users.registrations.new.terms",
                  terms: link_to(t("devise_views.users.registrations.new.terms_link"), "/conditions",
-                                title: t("shared.target_blank_html"),
+                                title: t("shared.target_blank"),
                                 target: "_blank")
                 ).html_safe %>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -42,7 +42,7 @@
                  terms: link_to(t("devise_views.users.registrations.new.terms_link"), "/conditions",
                                 title: t("shared.target_blank"),
                                 target: "_blank")
-                ).html_safe %>
+                ) %>
 
       <div class="small-12 medium-6 small-centered">
         <%= f.submit t("devise_views.users.registrations.new.submit"), class: "button expanded" %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -7,8 +7,8 @@
   <%= render "shared/errors", resource: resource %>
 
   <p>
-    <%= t("devise_views.users.registrations.new.organization_signup",
-        signup_link: link_to(t("devise_views.users.registrations.new.organization_signup_link"), new_organization_registration_path)).html_safe %>
+    <%= sanitize(t("devise_views.users.registrations.new.organization_signup",
+        signup_link: link_to(t("devise_views.users.registrations.new.organization_signup_link"), new_organization_registration_path))) %>
   </p>
 
   <div class="row">

--- a/app/views/users/registrations/success.html.erb
+++ b/app/views/users/registrations/success.html.erb
@@ -1,7 +1,7 @@
 <h2><%= t("devise_views.users.registrations.success.title") %></h2>
 <p><%= t("devise_views.users.registrations.success.thank_you_html") %></p>
 <p><%= t("devise_views.users.registrations.success.instructions_1_html") %></p>
-<p><%= t("devise_views.users.registrations.success.instructions_2_html") %></p>
+<p><%= t("devise_views.users.registrations.success.instructions_2") %></p>
 <p>
   <%= link_to t("devise_views.users.registrations.success.back_to_index"),
       root_path, class: "button margin-top expanded" %>

--- a/app/views/valuation/budget_investments/show.html.erb
+++ b/app/views/valuation/budget_investments/show.html.erb
@@ -18,7 +18,7 @@
 </hr>
 
 <% if @investment.external_url.present? %>
-  <p><%= text_with_links @investment.external_url %></p>
+  <p><%= sanitize_and_auto_link @investment.external_url %></p>
 <% end %>
 
 <hr>

--- a/app/views/verification/residence/new.html.erb
+++ b/app/views/verification/residence/new.html.erb
@@ -78,7 +78,7 @@
           title: t("verification.residence.new.accept_terms_text_title"),
           label: t("verification.residence.new.accept_terms_text",
                    terms_url: link_to(t("verification.residence.new.terms"), "/census_terms",
-                                      title: t("shared.target_blank_html"),
+                                      title: t("shared.target_blank"),
                                       target: "_blank")
                   ).html_safe %>
       </div>

--- a/app/views/verification/residence/new.html.erb
+++ b/app/views/verification/residence/new.html.erb
@@ -80,7 +80,7 @@
                    terms_url: link_to(t("verification.residence.new.terms"), "/census_terms",
                                       title: t("shared.target_blank"),
                                       target: "_blank")
-                  ).html_safe %>
+                  ) %>
       </div>
 
       <div class="small-12 medium-3 clear">

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -10,7 +10,7 @@ en:
         voted_html:
           one: "You have voted <span>one</span> investment."
           other: "You have voted <span>%{count}</span> investments."
-        voted_info_html: "Your ballot is confirmed!"
+        voted_info: "Your ballot is confirmed!"
         voted_info_2: "But you can change your vote at any time until this phase is closed."
         zero: You have not voted any investment project.
       reasons_for_not_balloting:

--- a/config/locales/en/devise_views.yml
+++ b/config/locales/en/devise_views.yml
@@ -52,7 +52,7 @@ en:
           back_to_index: I understand; go back to main page
           instructions_1_html: "<strong>We will contact you soon</strong> to verify that you do in fact represent this collective."
           instructions_2_html: While your <strong>email is reviewed</strong>, we have sent you a <strong>link to confirm your account</strong>.
-          instructions_3_html: Once confirmed, you may begin to participate as an unverified collective.
+          instructions_3: Once confirmed, you may begin to participate as an unverified collective.
           thank_you_html: Thank you for registering your collective on the website. It is now <strong>pending verification</strong>.
           title: Registration of organisation / collective
     passwords:
@@ -124,6 +124,6 @@ en:
         success:
           back_to_index: I understand; go back to main page
           instructions_1_html: Please <b>check your email</b> - we have sent you a <b>link to confirm your account</b>.
-          instructions_2_html: Once confirmed, you may begin participation.
+          instructions_2: Once confirmed, you may begin participation.
           thank_you_html: Thank you for registering for the website. You must now <b>confirm your email address</b>.
           title: Confirm your email address

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -773,7 +773,7 @@ en:
       districts: "Districts"
       districts_list: "Districts list"
       categories: "Categories"
-    target_blank_html: " (link opens in new window)"
+    target_blank: " (link opens in new window)"
     you_are_in: "You are in"
     unflag: Unflag
     unfollow_entity: "Unfollow %{entity}"

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -46,8 +46,8 @@ en:
     budget_investment_created:
       subject: "Thank you for creating an investment!"
       title: "Thank you for creating an investment!"
-      intro_html: "Hi <strong>%{author}</strong>,"
-      text_html: "Thank you for creating your investment <strong>%{investment}</strong> for Participatory Budgets <strong>%{budget}</strong>."
+      intro: "Hi <strong>%{author}</strong>,"
+      text: "Thank you for creating your investment <strong>%{investment}</strong> for Participatory Budgets <strong>%{budget}</strong>."
       follow_html: "We will inform you about how the process progresses, which you can also follow on <strong>%{link}</strong>."
       follow_link: "Participatory Budgets"
       sincerely: "Sincerely,"

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -27,13 +27,13 @@ en:
         description: "In the %{link} section you can make proposals for the City Council to carry them out. The proposals require support, and if they reach sufficient support, they are put to a public vote. The proposals approved in these citizens' votes are accepted by the City Council and carried out."
         link: "citizen proposals"
         image_alt: "Button to support a proposal"
-        figcaption_html: 'Button to "Support" a proposal.'
+        figcaption: 'Button to "Support" a proposal.'
       budgets:
         title: "Participatory Budgeting"
         description: "The %{link} section helps people make a direct decision on what part of the municipal budget is spent on."
         link: "participative budgets"
         image_alt: "Different phases of a participatory budget"
-        figcaption_html: '"Support" and "Voting" phases of participatory budgets.'
+        figcaption: '"Support" and "Voting" phases of participatory budgets.'
       polls:
         title: "Polls"
         description: "The %{link} section is activated each time a proposal reaches 1% support and goes to the vote or when the City Council proposes an issue for people to decide on."

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -10,7 +10,7 @@ es:
         voted_html:
           one: "Has votado <span>un</span> proyecto."
           other: "Has votado <span>%{count}</span> proyectos."
-        voted_info_html: "¡Tus votos están confirmados!"
+        voted_info: "¡Tus votos están confirmados!"
         voted_info_2: "Pero puedes cambiarlos en cualquier momento hasta el cierre de esta fase."
         zero: Todavía no has votado ningún proyecto de gasto.
       reasons_for_not_balloting:

--- a/config/locales/es/devise_views.yml
+++ b/config/locales/es/devise_views.yml
@@ -52,7 +52,7 @@ es:
           back_to_index: Entendido, volver a la página principal
           instructions_1_html: "En breve <b>nos pondremos en contacto contigo</b> para verificar que realmente representas a este colectivo."
           instructions_2_html: Mientras <b>revisa tu correo electrónico</b>, te hemos enviado un <b>enlace para confirmar tu cuenta</b>.
-          instructions_3_html: Una vez confirmado, podrás empezar a participar como colectivo no verificado.
+          instructions_3: Una vez confirmado, podrás empezar a participar como colectivo no verificado.
           thank_you_html: Gracias por registrar tu colectivo en la web. Ahora está <b>pendiente de verificación</b>.
           title: Registro de organización / colectivo
     passwords:
@@ -124,6 +124,6 @@ es:
         success:
           back_to_index: Entendido, volver a la página principal
           instructions_1_html: Por favor <b>revisa tu correo electrónico</b> - te hemos enviado un <b>enlace para confirmar tu cuenta</b>.
-          instructions_2_html: Una vez confirmado, podrás empezar a participar.
+          instructions_2: Una vez confirmado, podrás empezar a participar.
           thank_you_html: Gracias por registrarte en la web. Ahora debes <b>confirmar tu correo</b>.
           title: Revisa tu correo

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -770,7 +770,7 @@ es:
       districts: "Distritos"
       districts_list: "Listado de distritos"
       categories: "Categorías"
-    target_blank_html: " (se abre en ventana nueva)"
+    target_blank: " (se abre en ventana nueva)"
     you_are_in: "Estás en"
     unflag: Deshacer denuncia
     unfollow_entity: "Dejar de seguir %{entity}"

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -46,8 +46,8 @@ es:
     budget_investment_created:
       subject: "¡Gracias por crear un proyecto!"
       title: "¡Gracias por crear un proyecto!"
-      intro_html: "Hola <strong>%{author}</strong>,"
-      text_html: "Muchas gracias por crear tu proyecto <strong>%{investment}</strong> para los Presupuestos Participativos <strong>%{budget}</strong>."
+      intro: "Hola <strong>%{author}</strong>,"
+      text: "Muchas gracias por crear tu proyecto <strong>%{investment}</strong> para los Presupuestos Participativos <strong>%{budget}</strong>."
       follow_html: "Te informaremos de cómo avanza el proceso, que también puedes seguir en la página de <strong>%{link}</strong>."
       follow_link: "Presupuestos participativos"
       sincerely: "Atentamente,"

--- a/config/locales/es/pages.yml
+++ b/config/locales/es/pages.yml
@@ -27,13 +27,13 @@ es:
         description: "En la sección de %{link} puedes plantear propuestas para que el Ayuntamiento las lleve a cabo. Las propuestas recaban apoyos, y si alcanzan los apoyos suficientes se someten a votación ciudadana. Las propuestas aprobadas en estas votaciones ciudadanas son asumidas por el Ayuntamiento y se llevan a cabo."
         link: "propuestas ciudadanas"
         image_alt: "Botón para apoyar una propuesta"
-        figcaption_html: 'Botón para "Apoyar" una propuesta.'
+        figcaption: 'Botón para "Apoyar" una propuesta.'
       budgets:
         title: "Presupuestos participativos"
         description: "La sección de %{link} sirve para que la gente decida de manera directa a qué se destina una parte del presupuesto municipal."
         link: "presupuestos participativos"
         image_alt: "Diferentes fases de un presupuesto participativo"
-        figcaption_html: 'Fase de "Apoyos" y fase de "Votación" de los presupuestos participativos.'
+        figcaption: 'Fase de "Apoyos" y fase de "Votación" de los presupuestos participativos.'
       polls:
         title: "Votaciones"
         description: "La sección de %{link} se activa cada vez que una propuesta alcanza el 1% de apoyos y pasa a votación o cuando el Ayuntamiento propone un tema para que la gente decida sobre él."

--- a/lib/consul_form_builder.rb
+++ b/lib/consul_form_builder.rb
@@ -1,4 +1,6 @@
 class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
+  include ActionView::Helpers::SanitizeHelper
+
   def enum_select(attribute, options = {}, html_options = {})
     choices = object.class.send(attribute.to_s.pluralize).keys.map do |name|
       [object.class.human_attribute_name("#{attribute}.#{name}"), name]
@@ -34,6 +36,14 @@ class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
   end
 
   private
+
+    def custom_label(attribute, text, options)
+      if text == false
+        super
+      else
+        super(attribute, sanitize(label_text(object, attribute, text)), options)
+      end
+    end
 
     def label_with_hint(attribute, options)
       custom_label(attribute, options[:label], options[:label_options]) +

--- a/lib/tasks/proposals.rake
+++ b/lib/tasks/proposals.rake
@@ -12,7 +12,7 @@ namespace :proposals do
       model.find_each do |resource|
         if resource.external_url.present?
           Globalize.with_locale(I18n.default_locale) do
-            new_description = "#{resource.description} <p>#{text_with_links(resource.external_url)}</p>"
+            new_description = "#{resource.description} <p>#{sanitize_and_auto_link(resource.external_url)}</p>"
             resource.description = new_description
             resource.external_url = ""
             resource.updated_at = Time.current

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -40,6 +40,15 @@ describe "Cross-Site Scripting protection", :js do
     expect(page.text).not_to be_empty
   end
 
+  scenario "link to sign in" do
+    I18nContent.create(key: "budgets.investments.index.sidebar.not_logged_in", value: attack_code)
+    create(:budget, phase: "accepting")
+
+    visit budgets_path
+
+    expect(page.text).not_to be_empty
+  end
+
   scenario "proposal actions in dashboard" do
     proposal = create(:proposal)
 

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -30,4 +30,15 @@ describe "Cross-Site Scripting protection", :js do
 
     expect(page.text).not_to be_empty
   end
+
+  scenario "proposal actions in dashboard" do
+    proposal = create(:proposal)
+
+    create(:dashboard_action, description: attack_code)
+
+    login_as(proposal.author)
+    visit recommended_actions_proposal_dashboard_path(proposal)
+
+    expect(page.text).not_to be_empty
+  end
 end

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -60,6 +60,16 @@ describe "Cross-Site Scripting protection", :js do
     expect(page.text).not_to be_empty
   end
 
+  scenario "poll description setting in dashboard" do
+    Setting["proposals.poll_description"] = attack_code
+    proposal = create(:proposal)
+
+    login_as(proposal.author)
+    visit proposal_dashboard_polls_path(proposal)
+
+    expect(page.text).not_to be_empty
+  end
+
   scenario "annotation context" do
     annotation = create(:legislation_annotation)
     annotation.update_column(:context, attack_code)

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -50,4 +50,14 @@ describe "Cross-Site Scripting protection", :js do
 
     expect(page.text).not_to be_empty
   end
+
+  scenario "valuation explanations" do
+    investment = create(:budget_investment, price_explanation: attack_code)
+    valuator = create(:valuator, investments: [investment])
+
+    login_as(valuator.user)
+    visit valuation_budget_budget_investment_path(investment.budget, investment)
+
+    expect(page.text).not_to be_empty
+  end
 end

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -31,6 +31,15 @@ describe "Cross-Site Scripting protection", :js do
     expect(page.text).not_to be_empty
   end
 
+  scenario "accept terms label" do
+    I18nContent.create(key: "form.accept_terms", value: attack_code)
+
+    login_as(create(:user))
+    visit new_debate_path
+
+    expect(page.text).not_to be_empty
+  end
+
   scenario "proposal actions in dashboard" do
     proposal = create(:proposal)
 

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -60,6 +60,16 @@ describe "Cross-Site Scripting protection", :js do
     expect(page.text).not_to be_empty
   end
 
+  scenario "new request for proposal action in dashboard" do
+    proposal = create(:proposal)
+    action = create(:dashboard_action, description: attack_code)
+
+    login_as(proposal.author)
+    visit new_request_proposal_dashboard_action_path(proposal, action)
+
+    expect(page.text).not_to be_empty
+  end
+
   scenario "poll description setting in dashboard" do
     Setting["proposals.poll_description"] = attack_code
     proposal = create(:proposal)

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -41,4 +41,13 @@ describe "Cross-Site Scripting protection", :js do
 
     expect(page.text).not_to be_empty
   end
+
+  scenario "annotation context" do
+    annotation = create(:legislation_annotation)
+    annotation.update_column(:context, attack_code)
+
+    visit polymorphic_hierarchy_path(annotation)
+
+    expect(page.text).not_to be_empty
+  end
 end

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -12,4 +12,22 @@ describe "Cross-Site Scripting protection", :js do
 
     expect(page.text).not_to be_empty
   end
+
+  scenario "document title" do
+    process = create(:legislation_process)
+    create(:document, documentable: process, title: attack_code)
+
+    visit legislation_process_path(process)
+
+    expect(page.text).not_to be_empty
+  end
+
+  scenario "hacked translations" do
+    I18nContent.create(key: "admin.budget_investments.index.list.title", value: attack_code)
+
+    login_as(create(:administrator).user)
+    visit admin_budget_budget_investments_path(create(:budget_investment).budget)
+
+    expect(page.text).not_to be_empty
+  end
 end

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe "Cross-Site Scripting protection", :js do
+  let(:attack_code) { "<script>document.body.remove()</script>" }
+
+  scenario "valuators in admin investments index" do
+    hacker = create(:user, username: attack_code)
+    investment = create(:budget_investment, valuators: [create(:valuator, user: hacker)])
+
+    login_as(create(:administrator).user)
+    visit admin_budget_budget_investments_path(investment.budget)
+
+    expect(page.text).not_to be_empty
+  end
+end

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -78,4 +78,12 @@ describe "Cross-Site Scripting protection", :js do
 
     expect(page.text).not_to be_empty
   end
+
+  scenario "markdown conversion" do
+    process = create(:legislation_process, description: attack_code)
+
+    visit legislation_process_path(process)
+
+    expect(page.text).not_to be_empty
+  end
 end

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -182,8 +182,8 @@ describe Dashboard::Mailer do
                                       "successfully created.")
       expect(email).to have_body_text("Take advantage that your proposal is not public yet and "\
                                       "get ready to contact a lot of people.")
-      expect(email).to have_body_text(I18n.t("mailers.new_actions_notification_on_create.text_2",
-                                      link: proposal_dashboard_url(proposal)).html_safe)
+      expect(email).to have_body_text("When you are ready publish your citizen proposal from this")
+      expect(email).to have_link "link", href: proposal_dashboard_url(proposal)
       expect(email).to have_body_text("We know that creating a proposal with a hook and getting "\
                                       "the necessary support can seem complicated. But dont "\
                                       "worry because we are going to help you!")


### PR DESCRIPTION
## Objectives

* Make it easier to understand when a text is considered safe
* Add rubocop and erb-lint rules so we don't use `html_safe` in the future