### PR TITLE
Fix typos in legacy code

### DIFF
--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -9,11 +9,6 @@ module ImagesHelper
     end
   end
 
-  def image_first_recommendation(image)
-    t "images.#{image.imageable.class.name.parameterize.underscore}.recommendation_one_html",
-      title: image.imageable.title
-  end
-
   def image_attachment_file_name(image)
     image.attachment_file_name
   end

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -736,14 +736,14 @@ en:
     followable:
       budget_investment:
         create:
-          notice_html: "You are now following this investment project! </br> We will notify you of changes as they occur so that you are up-to-date."
+          notice_html: "You are now following this investment project! <br> We will notify you of changes as they occur so that you are up-to-date."
         destroy:
-          notice_html: "You have stopped following this investment project! </br> You will no longer receive notifications related to this project."
+          notice_html: "You have stopped following this investment project! <br> You will no longer receive notifications related to this project."
       proposal:
           create:
-            notice_html: "Now you are following this citizen proposal! </br> We will notify you of changes as they occur so that you are up-to-date."
+            notice_html: "Now you are following this citizen proposal! <br> We will notify you of changes as they occur so that you are up-to-date."
           destroy:
-            notice_html: "You have stopped following this citizen proposal! </br> You will no longer receive notifications related to this proposal."
+            notice_html: "You have stopped following this citizen proposal! <br> You will no longer receive notifications related to this proposal."
     hide: Hide
     print:
       print_button: Print this info

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -331,8 +331,6 @@ es:
         link: "Descargar comentarios"
         title: Comentarios
         no_comments: No hay comentarios.
-        hidden_debate: Debate oculto
-        hidden_proposal: Propuesta oculta
         table_link: "Link"
     hidden_comments:
       index:
@@ -1294,6 +1292,9 @@ es:
       proposal_search:
         button: Buscar
         placeholder: Buscar propuestas por título, código, descripción o pregunta
+      debate_search:
+        button: Buscar
+        placeholder: Buscar debates por título o descripción
       user_search:
         button: Buscar
         placeholder: Buscar usuario por nombre o email

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -733,14 +733,14 @@ es:
     followable:
       budget_investment:
         create:
-          notice_html: "¡Ahora estás siguiendo este proyecto de gasto! </br> Te notificaremos los cambios a medida que se produzcan para que estés al día."
+          notice_html: "¡Ahora estás siguiendo este proyecto de gasto! <br> Te notificaremos los cambios a medida que se produzcan para que estés al día."
         destroy:
-          notice_html: "¡Has dejado de seguir este proyecto de gasto! </br> Ya no recibirás más notificaciones relacionadas con este proyecto."
+          notice_html: "¡Has dejado de seguir este proyecto de gasto! <br> Ya no recibirás más notificaciones relacionadas con este proyecto."
       proposal:
         create:
-          notice_html: "¡Ahora estás siguiendo esta propuesta ciudadana! </br> Te notificaremos los cambios a medida que se produzcan para que estés al día."
+          notice_html: "¡Ahora estás siguiendo esta propuesta ciudadana! <br> Te notificaremos los cambios a medida que se produzcan para que estés al día."
         destroy:
-          notice_html: "¡Has dejado de seguir esta propuesta ciudadana! </br> Ya no recibirás más notificaciones relacionadas con esta propuesta."
+          notice_html: "¡Has dejado de seguir esta propuesta ciudadana! <br> Ya no recibirás más notificaciones relacionadas con esta propuesta."
     hide: Ocultar
     print:
       print_button: Imprimir esta información

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -968,8 +968,6 @@ es:
     help:
       alt: Selecciona el texto que quieres comentar y pulsa en el botón con el lápiz.
       text: Para comentar este documento debes %{sign_in} o %{sign_up}. Después selecciona el texto que quieres comentar y pulsa en el botón con el lápiz.
-      text_sign_in: iniciar sesión
-      text_sign_up: registrarte
       title: '¿Cómo puedo comentar este documento?'
   links:
     form:


### PR DESCRIPTION
## References

* Commit 9d1ca3bf
* Commit 78c6f6f7
* Commit eef8ad1b

## Objectives

* Fix missing and unused Spanish translations
* Remove an obsolete method
* Fix typos in translations