### PR TITLE
Fix flaky officing results spec

### DIFF
--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -111,7 +111,11 @@ describe "Officing Results", :with_frozen_time do
       click_link "See results"
     end
 
-    expect(page).not_to have_content("7777")
+    within("#question_#{question_1.id}_0_result") do
+      expect(page).to have_content("5555")
+      expect(page).not_to have_content("7777")
+    end
+
     within("#white_results") { expect(page).to have_content("6") }
     within("#null_results")  { expect(page).to have_content("7") }
     within("#total_results") { expect(page).to have_content("8") }


### PR DESCRIPTION
## References

* [Travis build 31814, job 2](https://travis-ci.org/consul/consul/jobs/594218930)

## Objectives

Fix a flay spec in `spec/features/officing/results_spec.rb:114`: "Officing Results Edit result".

## Notes

The spec failed failed with the following message if the name of the poll created for that test contained the string "7777":

```
  1) Officing Results Edit result
     Failure/Error: expect(page).not_to have_content("7777")

       expected not to find text "7777" in "Total recounts and results Language: Deutsch English Español Français Nederlands Português brasileiro 中文 Go back to CONSUL Menu CONSUL Polling Menu Notifications You don't have new notifications My content My account Sign out Admin menu Total recounts and results Go back Poll 0a3f377fb8cc543f6390c77771270676 - Results Booth 35 - October 06, 2019 Totally blank ballots Invalid ballots Valid ballots 6 7 8 Question title 64 Answer Votes Yes 5555 No 200 Question title 65 Answer Votes Today 0 Tomorrow 0"

     # ./spec/features/officing/results_spec.rb:114:in `block (2 levels) in <top (required)>'
```