### PR TITLE
Fix typos in translatable spec

### DIFF
--- a/spec/features/translatable_spec.rb
+++ b/spec/features/translatable_spec.rb
@@ -124,7 +124,7 @@ describe "Public area translatable records" do
     end
 
     scenario "Select a locale and add it to the form" do
-      visit new_budget_investment_path(create(:budget_investment))
+      visit new_budget_investment_path(create(:budget))
 
       select "Français", from: :add_language
 
@@ -132,7 +132,7 @@ describe "Public area translatable records" do
     end
 
     scenario "Remove a translation" do
-      visit new_budget_investment_path(create(:budget_investment))
+      visit new_budget_investment_path(create(:budget))
 
       expect(find("#select_language").value).to eq "en"
       click_link "Remove language"


### PR DESCRIPTION
## References

* Failures in [Travis build 31581, job 2](https://travis-ci.org/consul/consul/jobs/590661260) and [Travis build 31797, job 4](https://travis-ci.org/consul/consul/jobs/594032707)

## Objectives

Fix typos in translatable spec, which created an investment instead of a budget.