### PR TITLE
Fix duplicate usernames in dev seeds task

### DIFF
--- a/db/dev_seeds/users.rb
+++ b/db/dev_seeds/users.rb
@@ -1,5 +1,5 @@
 section "Creating Users" do
-  def create_user(email, username = Faker::Name.name)
+  def create_user(email, username)
     password = "12345678"
     User.create!(
       username:               username,
@@ -79,12 +79,12 @@ section "Creating Users" do
   end
 
   5.times do |i|
-    official = create_user("official#{i}@consul.dev")
+    official = create_user("official#{i}@consul.dev", "Official #{i}")
     official.update(official_level: i, official_position: "Official position #{i}")
   end
 
   30.times do |i|
-    user = create_user("user#{i}@consul.dev")
+    user = create_user("user#{i}@consul.dev", "Regular user #{i}")
     level = [1, 2, 3].sample
     if level >= 2
       user.update(residence_verified_at: Time.current,


### PR DESCRIPTION
## References

* Failure in [Travis build 31428, job3](https://travis-ci.org/consul/consul/jobs/584555386)

## Objectives

Fix a bug caused by Faker::Name.name generating the same name for two different users, causing the task to crash in development or a test to fail while testing.