### PR TITLE
Fix duplicate given order creating answers

### DIFF
--- a/app/controllers/polls/answers_controller.rb
+++ b/app/controllers/polls/answers_controller.rb
@@ -9,7 +9,7 @@ class Polls::AnswersController < ApplicationController
     if @question.votation_type.open? && !check_question_answer_exist
       @question.question_answers.create(
         title: params[:answer],
-        given_order: @question.question_answers.count + 1,
+        given_order: @question.question_answers.maximum(:given_order).to_i + 1,
         hidden: false
       )
       flash.now[:notice] = t("dashboard.polls.index.succesfull")

--- a/spec/features/polls/votation_type_spec.rb
+++ b/spec/features/polls/votation_type_spec.rb
@@ -320,6 +320,17 @@ describe "Poll Votation Type" do
         expect(page).to have_link "Added answer", class: "answered"
       end
     end
+
+    scenario "existing given order is bigger than the number of answers", :js do
+      answer1.update(given_order: question.question_answers.count + 1)
+
+      visit poll_path(poll_current)
+
+      fill_in "answer", with: "Added answer"
+      click_button "Add answer"
+
+      expect(page).to have_link "Added answer"
+    end
   end
 
   context "Answers set" do


### PR DESCRIPTION
## References

This bug was detected thanks to failures in:

* [Travis build 31618, job 4](https://travis-ci.org/consul/consul/jobs/590796881)
* [Travis build 31786, job 4](https://travis-ci.org/consul/consul/jobs/593915127)
* [Travis build 31804, job 4](https://travis-ci.org/consul/consul/jobs/594172981)
* [Travis build 31848, job 1](https://travis-ci.org/consul/consul/jobs/595105574)

## Objectives

Fix a bug which caused two answers to have the same given order in some cases.

## Notes

Even after this change the action is not thread-safe, as it is possible to create two questions with the same given order with two simultaneous requests.

Due to this bug a test failed sometimes with the following message:

```
  1) Poll Votation Type Positive open add answer
     Failure/Error: expect(page).to have_link "Added answer"
       expected to find visible link "Added answer" but there were no matches
     # ./spec/features/polls/votation_type_spec.rb:313:in `block (3 levels) in <top (required)>'
```