### PR TITLE
Apply rubocop basic rules

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -261,5 +261,8 @@ Style/BlockDelimiters:
 Style/PercentLiteralDelimiters:
   Enabled: true
 
+Style/SafeNavigation:
+  Enabled: true
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/app/controllers/admin/site_customization/content_blocks_controller.rb
+++ b/app/controllers/admin/site_customization/content_blocks_controller.rb
@@ -67,8 +67,7 @@ class Admin::SiteCustomization::ContentBlocksController < Admin::SiteCustomizati
   end
 
   def delete_heading_content_block
-    heading_content_block = Budget::ContentBlock.find(params[:id])
-    heading_content_block.destroy if heading_content_block
+    Budget::ContentBlock.find(params[:id]).destroy
     notice = t("admin.site_customization.content_blocks.destroy.notice")
     redirect_to admin_site_customization_content_blocks_path, notice: notice
   end

--- a/app/controllers/legislation/draft_versions_controller.rb
+++ b/app/controllers/legislation/draft_versions_controller.rb
@@ -30,7 +30,7 @@ class Legislation::DraftVersionsController < Legislation::BaseController
   private
 
     def visible_draft_versions
-      if current_user && current_user.administrator?
+      if current_user&.administrator?
         @process.draft_versions
       else
         @process.draft_versions.published

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -47,7 +47,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     set_process
     @phase = :debate_phase
 
-    if @process.debate_phase.started? || (current_user && current_user.administrator?)
+    if @process.debate_phase.started? || (current_user&.administrator?)
       render :debate
     else
       render :phase_not_open
@@ -139,7 +139,7 @@ class Legislation::ProcessesController < Legislation::BaseController
       @proposals = @proposals.send(@current_filter).page(params[:page])
     end
 
-    if @process.proposals_phase.started? || (current_user && current_user.administrator?)
+    if @process.proposals_phase.started? || (current_user&.administrator?)
       legislation_proposal_votes(@proposals)
       render :proposals
     else

--- a/app/controllers/verification/letter_controller.rb
+++ b/app/controllers/verification/letter_controller.rb
@@ -51,7 +51,7 @@ class Verification::LetterController < ApplicationController
 
     def login_via_form
       user = User.find_by email: letter_params[:email]
-      if user && user.valid_password?(letter_params[:password])
+      if user&.valid_password?(letter_params[:password])
         sign_in(user)
       end
     end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -37,32 +37,32 @@ module UsersHelper
   end
 
   def current_administrator?
-    current_user && current_user.administrator?
+    current_user&.administrator?
   end
 
   def current_moderator?
-    current_user && current_user.moderator?
+    current_user&.moderator?
   end
 
   def current_valuator?
-    current_user && current_user.valuator?
+    current_user&.valuator?
   end
 
   def current_manager?
-    current_user && current_user.manager?
+    current_user&.manager?
   end
 
   def current_poll_officer?
-    current_user && current_user.poll_officer?
+    current_user&.poll_officer?
   end
 
   def current_tracker?
-    current_user && current_user.tracker?
+    current_user&.tracker?
   end
 
   def show_admin_menu?(user = nil)
     current_administrator? || current_moderator? || current_valuator? || current_manager? ||
-      current_tracker? || (user && user.administrator?) || current_poll_officer?
+      current_tracker? || (user&.administrator?) || current_poll_officer?
   end
 
   def interests_title_text(user)

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -25,7 +25,7 @@ module WelcomeHelper
   end
 
   def calculate_image_path(recommended, image_default)
-    if recommended.try(:image) && recommended.image.present? && recommended.image.attachment.exists?
+    if recommended.respond_to?(:image) && recommended.image.present? && recommended.image.attachment.exists?
       recommended.image.attachment.send("url", :medium)
     elsif image_default.present?
       image_default

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -120,7 +120,7 @@ class Comment < ApplicationRecord
   end
 
   def call_after_commented
-    commentable.try(:after_commented)
+    commentable.after_commented if commentable.respond_to?(:after_commented)
   end
 
   def self.body_max_length

--- a/app/models/concerns/notifiable.rb
+++ b/app/models/concerns/notifiable.rb
@@ -29,8 +29,8 @@ module Notifiable
 
   def check_availability(resource)
     resource.present? &&
-      resource.try(:hidden_at).nil? &&
-      resource.try(:retired_at).nil?
+      !(resource.respond_to?(:hidden?) && resource.hidden?) &&
+      !(resource.respond_to?(:retired?) && resource.retired?)
   end
 
   def linkable_resource

--- a/app/models/legislation/people_proposal.rb
+++ b/app/models/legislation/people_proposal.rb
@@ -107,7 +107,7 @@ class Legislation::PeopleProposal < ApplicationRecord
   end
 
   def votable_by?(user)
-    user && user.level_two_or_three_verified?
+    user&.level_two_or_three_verified?
   end
 
   def register_vote(user, vote_value)
@@ -145,7 +145,7 @@ class Legislation::PeopleProposal < ApplicationRecord
   protected
 
     def set_responsible_name
-      if author && author.document_number?
+      if author&.document_number?
         self.responsible_name = author.document_number
       end
     end

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -108,7 +108,7 @@ class Legislation::Proposal < ApplicationRecord
   end
 
   def votable_by?(user)
-    user && user.level_two_or_three_verified?
+    user&.level_two_or_three_verified?
   end
 
   def register_vote(user, vote_value)
@@ -142,7 +142,7 @@ class Legislation::Proposal < ApplicationRecord
   protected
 
     def set_responsible_name
-      if author && author.document_number?
+      if author&.document_number?
         self.responsible_name = author.document_number
       end
     end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -183,7 +183,7 @@ class Proposal < ApplicationRecord
   end
 
   def votable_by?(user)
-    user && user.level_two_or_three_verified?
+    user&.level_two_or_three_verified?
   end
 
   def retired?
@@ -269,7 +269,7 @@ class Proposal < ApplicationRecord
   protected
 
     def set_responsible_name
-      if author && author.document_number?
+      if author&.document_number?
         self.responsible_name = author.document_number
       end
     end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -37,7 +37,7 @@ class Signature < ApplicationRecord
 
   def assign_signature_to_vote
     vote = Vote.where(votable: signable, voter: user).first
-    vote.update(signature: self) if vote
+    vote&.update(signature: self)
   end
 
   def user_exists?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -172,7 +172,7 @@ class User < ApplicationRecord
   end
 
   def verified_organization?
-    organization && organization.verified?
+    organization&.verified?
   end
 
   def official?

--- a/lib/score_calculator.rb
+++ b/lib/score_calculator.rb
@@ -6,7 +6,7 @@ module ScoreCalculator
     period = [1, [max_period, resource_age(resource)].min].max
 
     votes_total = resource.votes_for.where("created_at >= ?", period.days.ago).count
-    votes_up = resource.get_upvotes.where("created_at >= ?", period.days.ago).count
+    votes_up    = resource.get_upvotes.where("created_at >= ?", period.days.ago).count
     votes_down  = votes_total - votes_up
     votes_score = votes_up - votes_down
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -930,7 +930,7 @@ describe "Budget Investments" do
     scenario "Edit", :js do
       daniel = create(:user, :level_two)
 
-      create(:budget_investment, heading: heading,title: "Get Schwifty", author: daniel, created_at: 1.day.ago)
+      create(:budget_investment, heading: heading, title: "Get Schwifty", author: daniel, created_at: 1.day.ago)
 
       login_as(daniel)
 
@@ -949,7 +949,7 @@ describe "Budget Investments" do
     scenario "Trigger validation errors in edit view" do
       daniel = create(:user, :level_two)
       message_error = "is too short (minimum is 4 characters), can't be blank"
-      create(:budget_investment, heading: heading,title: "Get SH", author: daniel, created_at: 1.day.ago)
+      create(:budget_investment, heading: heading, title: "Get SH", author: daniel, created_at: 1.day.ago)
 
       login_as(daniel)
 

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -217,6 +217,7 @@ describe "Notifications" do
       Notification.send_pending
 
       now = Notification.first_batch_run_at
+
       first_batch_run_at  = now.change(usec: 0)
       second_batch_run_at = (now + 1.second).change(usec: 0)
       third_batch_run_at  = (now + 2.seconds).change(usec: 0)

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -100,6 +100,7 @@ describe Newsletter do
       newsletter.deliver
 
       now = newsletter.first_batch_run_at
+
       first_batch_run_at  = now.change(usec: 0)
       second_batch_run_at = (now + 1.second).change(usec: 0)
       third_batch_run_at  = (now + 2.seconds).change(usec: 0)

--- a/spec/models/poll/officer_spec.rb
+++ b/spec/models/poll/officer_spec.rb
@@ -124,20 +124,19 @@ describe Poll::Officer do
     end
   end
 
-  describe "todays_booths" do
+  describe "todays_booths", :application_zone_west_of_system_zone do
     let(:officer) { create(:poll_officer) }
 
-    it "returns booths for the application's time zone date", :application_zone_west_of_system_zone do
-      assignment_with_local_time_zone = create(:poll_officer_assignment,
-                                               date:    Date.today,
-                                               officer: officer)
+    it "returns today's booths" do
+      todays_assignment = create(:poll_officer_assignment, date: Date.current, officer: officer)
+      expect(officer.todays_booths).to eq [todays_assignment.booth]
+    end
 
-      assignment_with_application_time_zone = create(:poll_officer_assignment,
-                                                     date:    Date.current,
-                                                     officer: officer)
+    it "does not return booths for different dates" do
+      create(:poll_officer_assignment, date: Date.yesterday, officer: officer)
+      create(:poll_officer_assignment, date: Date.tomorrow, officer: officer)
 
-      expect(officer.todays_booths).to eq [assignment_with_application_time_zone.booth]
-      expect(officer.todays_booths).not_to include(assignment_with_local_time_zone.booth)
+      expect(officer.todays_booths).to be_empty
     end
   end
 end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -607,11 +607,11 @@ describe Proposal do
       end
 
       it "orders by weight and then by votes" do
-        title_some_votes    = create(:proposal, title: "stop corruption", cached_votes_up: 5)
-        title_least_voted   = create(:proposal, title: "stop corruption", cached_votes_up: 2)
-        title_most_voted    = create(:proposal, title: "stop corruption", cached_votes_up: 10)
+        title_some_votes   = create(:proposal, title: "stop corruption", cached_votes_up: 5)
+        title_least_voted  = create(:proposal, title: "stop corruption", cached_votes_up: 2)
+        title_most_voted   = create(:proposal, title: "stop corruption", cached_votes_up: 10)
 
-        summary_most_voted  = create(:proposal, summary: "stop corruption", cached_votes_up: 10)
+        summary_most_voted = create(:proposal, summary: "stop corruption", cached_votes_up: 10)
 
         results = Proposal.search("stop corruption")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,7 +102,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :with_frozen_time) do
-    travel_to Time.now # TODO: use `freeze_time` after migrating to Rails 5.
+    travel_to Time.current # TODO: use `freeze_time` after migrating to Rails 5.2.
   end
 
   config.after(:each, :with_frozen_time) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,8 +114,11 @@ RSpec.configure do |config|
     system_zone = ActiveSupport::TimeZone.new("Madrid")
 
     allow(Time).to receive(:zone).and_return(application_zone)
-    allow(Time).to receive(:now).and_return(Date.current.end_of_day.in_time_zone(system_zone))
-    allow(Date).to receive(:today).and_return(Time.now.to_date)
+
+    system_time_at_application_end_of_day = Date.current.end_of_day.in_time_zone(system_zone)
+
+    allow(Time).to receive(:now).and_return(system_time_at_application_end_of_day)
+    allow(Date).to receive(:today).and_return(system_time_at_application_end_of_day.to_date)
   end
 
   config.before(:each, :with_non_utc_time_zone) do


### PR DESCRIPTION
## Objectives

* Apply rules we've agreed upon to existing code
* Have zero reports when running `rubocop --config .rubocop_basic.yml --fail-level convention --display-only-fail-level-offenses`

## Notes 

* The file `.rubocop.yml` contains rules we haven't agreed upon (yet). We don't follow some of the rules defined there, and this pull request doesn't adress those rules.
* The rule with `Severity: refactor` (that is, `Metrics/LineLength`) is not addressed in this pull request either. We might address it in the future.