### PR TITLE
Use relative URLs where possible

### DIFF
--- a/app/controllers/admin/poll/active_polls_controller.rb
+++ b/app/controllers/admin/poll/active_polls_controller.rb
@@ -5,7 +5,7 @@ class Admin::Poll::ActivePollsController < Admin::Poll::BaseController
 
   def create
     if @active_poll.update(active_poll_params)
-      redirect_to admin_polls_url, notice: t("flash.actions.update.active_poll")
+      redirect_to admin_polls_path, notice: t("flash.actions.update.active_poll")
     else
       render :edit
     end
@@ -16,7 +16,7 @@ class Admin::Poll::ActivePollsController < Admin::Poll::BaseController
 
   def update
     if @active_poll.update(active_poll_params)
-      redirect_to admin_polls_url, notice: t("flash.actions.update.active_poll")
+      redirect_to admin_polls_path, notice: t("flash.actions.update.active_poll")
     else
       render :edit
     end

--- a/app/controllers/admin/widget/cards_controller.rb
+++ b/app/controllers/admin/widget/cards_controller.rb
@@ -60,7 +60,7 @@ class Admin::Widget::CardsController < Admin::BaseController
       if @card.site_customization_page_id
         redirect_to admin_site_customization_page_cards_path(page), notice: notice
       else
-        redirect_to admin_homepage_url, notice: notice
+        redirect_to admin_homepage_path, notice: notice
       end
     end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,4 @@
 class CommentsController < ApplicationController
-  include CustomUrlsHelper
-
   before_action :authenticate_user!, only: :create
   before_action :load_commentable, only: :create
   before_action :verify_resident_for_commentable!, only: :create
@@ -104,7 +102,7 @@ class CommentsController < ApplicationController
       return if current_user.administrator? || current_user.moderator?
 
       if @commentable.respond_to?(:comments_closed?) && @commentable.comments_closed?
-        redirect_to @commentable, alert: t("comments.comments_closed")
+        redirect_to polymorphic_hierarchy_path(@commentable), alert: t("comments.comments_closed")
       end
     end
 

--- a/app/controllers/concerns/access_denied_handler.rb
+++ b/app/controllers/concerns/access_denied_handler.rb
@@ -4,7 +4,7 @@ module AccessDeniedHandler
   included do
     rescue_from CanCan::AccessDenied do |exception|
       respond_to do |format|
-        format.html { redirect_to main_app.root_url, alert: exception.message }
+        format.html { redirect_to main_app.root_path, alert: exception.message }
         format.json { render json: { error: exception.message }, status: :forbidden }
       end
     end

--- a/app/controllers/management/users_controller.rb
+++ b/app/controllers/management/users_controller.rb
@@ -32,7 +32,7 @@ class Management::UsersController < Management::BaseController
 
   def logout
     destroy_session
-    redirect_to management_root_url, notice: t("management.sessions.signed_out_managed_user")
+    redirect_to management_root_path, notice: t("management.sessions.signed_out_managed_user")
   end
 
   private

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,4 @@
 class NotificationsController < ApplicationController
-  include CustomUrlsHelper
-
   before_action :authenticate_user!
   skip_authorization_check
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -36,7 +36,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         set_flash_message(:notice, :success, kind: provider.to_s.capitalize) if is_navigational_format?
       else
         session["devise.#{provider}_data"] = auth
-        redirect_to new_user_registration_url
+        redirect_to new_user_registration_path
       end
     end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -26,7 +26,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def delete
     current_user.erase(erase_params[:erase_reason])
     sign_out
-    redirect_to root_url, notice: t("devise.registrations.destroyed")
+    redirect_to root_path, notice: t("devise.registrations.destroyed")
   end
 
   def success

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,10 +55,6 @@ module ApplicationHelper
     SiteCustomization::ContentBlock.block_for(name, locale)
   end
 
-  def kaminari_path(url)
-    "#{root_url.chomp("\/")}#{url}"
-  end
-
   def self.asset_data_base64(path)
     asset = (Rails.application.assets || ::Sprockets::Railtie.build_environment(Rails.application))
                                                              .find_asset(path)

--- a/app/helpers/custom_urls_helper.rb
+++ b/app/helpers/custom_urls_helper.rb
@@ -1,9 +1,0 @@
-module CustomUrlsHelper
-  def legislation_question_url(question)
-    legislation_process_question_url(question.process, question)
-  end
-
-  def legislation_annotation_url(annotation)
-    legislation_process_question_url(annotation.draft_version.process, annotation.draft_version, annotation)
-  end
-end

--- a/app/helpers/direct_uploads_helper.rb
+++ b/app/helpers/direct_uploads_helper.rb
@@ -3,11 +3,13 @@ module DirectUploadsHelper
   def render_destroy_upload_link(direct_upload)
     label = direct_upload.resource_relation == "image" ? "images" : "documents"
     link_to t("#{label}.form.delete_button"),
-            direct_upload_destroy_url("direct_upload[resource_type]": direct_upload.resource_type,
-                                      "direct_upload[resource_id]": direct_upload.resource_id,
-                                      "direct_upload[resource_relation]": direct_upload.resource_relation,
-                                      "direct_upload[cached_attachment]": direct_upload.relation.cached_attachment,
-                                      format: :json),
+            direct_upload_destroy_path(
+              "direct_upload[resource_type]": direct_upload.resource_type,
+              "direct_upload[resource_id]": direct_upload.resource_id,
+              "direct_upload[resource_relation]": direct_upload.resource_relation,
+              "direct_upload[cached_attachment]": direct_upload.relation.cached_attachment,
+              format: :json
+            ),
             method: :delete,
             remote: true,
             class: "delete remove-cached-attachment"

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -19,13 +19,15 @@ module DocumentsHelper
   def render_destroy_document_link(builder, document)
     if !document.persisted? && document.cached_attachment.present?
       link_to t("documents.form.delete_button"),
-                  direct_upload_destroy_url("direct_upload[resource_type]": document.documentable_type,
-                                            "direct_upload[resource_id]": document.documentable_id,
-                                            "direct_upload[resource_relation]": "documents",
-                                            "direct_upload[cached_attachment]": document.cached_attachment),
-                  method: :delete,
-                  remote: true,
-                  class: "delete remove-cached-attachment"
+              direct_upload_destroy_path(
+                "direct_upload[resource_type]": document.documentable_type,
+                "direct_upload[resource_id]": document.documentable_id,
+                "direct_upload[resource_relation]": "documents",
+                "direct_upload[cached_attachment]": document.cached_attachment
+              ),
+              method: :delete,
+              remote: true,
+              class: "delete remove-cached-attachment"
     else
       link_to_remove_association document.new_record? ? t("documents.form.cancel_button") : t("documents.form.delete_button"), builder, class: "delete remove-document"
     end
@@ -38,15 +40,15 @@ module DocumentsHelper
                        accept: accepted_content_types_extensions(document.documentable_type.constantize),
                        class: "js-document-attachment",
                        data: {
-                         url: document_direct_upload_url(document),
+                         url: document_direct_upload_path(document),
                          nested_document: true
                        }
   end
 
-  def document_direct_upload_url(document)
-    direct_uploads_url("direct_upload[resource_type]": document.documentable_type,
-                       "direct_upload[resource_id]": document.documentable_id,
-                       "direct_upload[resource_relation]": "documents")
+  def document_direct_upload_path(document)
+    direct_uploads_path("direct_upload[resource_type]": document.documentable_type,
+                        "direct_upload[resource_id]": document.documentable_id,
+                        "direct_upload[resource_relation]": "documents")
   end
 
   def document_item_link(document)

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -28,10 +28,12 @@ module ImagesHelper
   def render_destroy_image_link(builder, image)
     if !image.persisted? && image.cached_attachment.present?
       link_to t("images.form.delete_button"),
-              direct_upload_destroy_url("direct_upload[resource_type]": image.imageable_type,
-                                        "direct_upload[resource_id]": image.imageable_id,
-                                        "direct_upload[resource_relation]": "image",
-                                        "direct_upload[cached_attachment]": image.cached_attachment),
+              direct_upload_destroy_path(
+                "direct_upload[resource_type]": image.imageable_type,
+                "direct_upload[resource_id]": image.imageable_id,
+                "direct_upload[resource_relation]": "image",
+                "direct_upload[cached_attachment]": image.cached_attachment
+              ),
               method: :delete,
               remote: true,
               class: "delete remove-cached-attachment"
@@ -47,7 +49,7 @@ module ImagesHelper
                        accept: imageable_accepted_content_types_extensions,
                        class: "js-image-attachment",
                        data: {
-                         url: image_direct_upload_url(imageable),
+                         url: image_direct_upload_path(imageable),
                          nested_image: true
                        }
   end
@@ -59,10 +61,10 @@ module ImagesHelper
                            show_caption: show_caption
   end
 
-  def image_direct_upload_url(imageable)
-    direct_uploads_url("direct_upload[resource_type]": imageable.class.name,
-                       "direct_upload[resource_id]": imageable.id,
-                       "direct_upload[resource_relation]": "image")
+  def image_direct_upload_path(imageable)
+    direct_uploads_path("direct_upload[resource_type]": imageable.class.name,
+                        "direct_upload[resource_id]": imageable.id,
+                        "direct_upload[resource_relation]": "image")
   end
 
 end

--- a/app/views/admin/poll/active_polls/edit.html.erb
+++ b/app/views/admin/poll/active_polls/edit.html.erb
@@ -3,5 +3,5 @@
 <h2><%= t("admin.active_polls.edit.title") %></h2>
 
 <div class="polls-form">
-  <%= render "form", form_url: admin_active_polls_url(@active_poll) %>
+  <%= render "form", form_url: admin_active_polls_path(@active_poll) %>
 </div>

--- a/app/views/budgets/ballot/_investment_for_sidebar.html.erb
+++ b/app/views/budgets/ballot/_investment_for_sidebar.html.erb
@@ -3,8 +3,8 @@
   <span><%= investment.formatted_price %></span>
 
   <% if @budget.balloting? %>
-    <%= link_to budget_ballot_line_url(id: investment.id,
-                                       investments_ids: investment_ids),
+    <%= link_to budget_ballot_line_path(id: investment.id,
+                                        investments_ids: investment_ids),
                 title: t("budgets.ballots.show.remove"),
                 class: "remove-investment-project",
                 method: :delete,

--- a/app/views/budgets/investments/_ballot.html.erb
+++ b/app/views/budgets/investments/_ballot.html.erb
@@ -28,9 +28,9 @@
       </p>
       <% if investment.should_show_ballots? %>
         <%= link_to t("budgets.investments.investment.add"),
-                    budget_ballot_lines_url(investment_id: investment.id,
-                                            budget_id: investment.budget_id,
-                                            investments_ids: investment_ids),
+                    budget_ballot_lines_path(investment_id: investment.id,
+                                             budget_id: investment.budget_id,
+                                             investments_ids: investment_ids),
                     class: "button button-support small expanded",
                     title: t("budgets.investments.investment.support_title"),
                     method: :post,

--- a/app/views/budgets/investments/index.html.erb
+++ b/app/views/budgets/investments/index.html.erb
@@ -55,7 +55,7 @@
         </div>
       <% end %>
 
-      <%= render("shared/advanced_search", search_path: budget_investments_url(@budget)) %>
+      <%= render("shared/advanced_search", search_path: budget_investments_path(@budget)) %>
 
       <% if unfeasible_or_unselected_filter %>
         <ul class="no-bullet submenu">

--- a/app/views/dashboard/_form.html.erb
+++ b/app/views/dashboard/_form.html.erb
@@ -11,8 +11,7 @@
 <% else %>
   <% if dashboard_action.request_to_administrators && !dashboard_action.requested_for?(proposal) %>
     <%= form_for @dashboard_executed_action,
-                 url: create_request_proposal_dashboard_action_url(proposal,
-                                                                   dashboard_action) do |f| %>
+                 url: create_request_proposal_dashboard_action_path(proposal, dashboard_action) do |f| %>
       <%= f.submit(class: "button", value: t("dashboard.form.request")) %>
     <% end %>
   <% end %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to t("views.pagination.first"), kaminari_path(url), :remote => remote %>
+  <%= link_to t("views.pagination.first"), url, :remote => remote %>
 </li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to t("views.pagination.last"), kaminari_path(url), :remote => remote %>
+  <%= link_to t("views.pagination.last"), url, :remote => remote %>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,3 @@
 <li class="pagination-next">
-  <%= link_to t("views.pagination.next"), kaminari_path(url), :rel => "next", :remote => remote %>
+  <%= link_to t("views.pagination.next"), url, :rel => "next", :remote => remote %>
 </li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -5,6 +5,6 @@
   </li>
 <% else %>
   <li>
-    <%= link_to page, kaminari_path(url), { :remote => remote, :rel => page.next? ? "next" : page.prev? ? "prev" : nil } %>
+    <%= link_to page, url, { :remote => remote, :rel => page.next? ? "next" : page.prev? ? "prev" : nil } %>
   </li>
 <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,3 @@
 <li class="pagination-previous">
-  <%= link_to t("views.pagination.previous"), kaminari_path(url), :rel => "prev", :remote => remote %>
+  <%= link_to t("views.pagination.previous"), url, :rel => "prev", :remote => remote %>
 </li>

--- a/app/views/legislation/proposals/edit.html.erb
+++ b/app/views/legislation/proposals/edit.html.erb
@@ -9,6 +9,6 @@
 
     <h1><%= t("proposals.edit.editing") %></h1>
 
-    <%= render "form", form_url: legislation_process_proposal_url(@proposal.legislation_process_id, @proposal) %>
+    <%= render "form", form_url: legislation_process_proposal_path(@proposal.legislation_process_id, @proposal) %>
   </div>
 </div>

--- a/app/views/legislation/proposals/new.html.erb
+++ b/app/views/legislation/proposals/new.html.erb
@@ -5,6 +5,6 @@
 
     <h1><%= t("proposals.new.start_new") %></h1>
 
-    <%= render "legislation/proposals/form", form_url: legislation_process_proposals_url, id: @proposal.id %>
+    <%= render "legislation/proposals/form", form_url: legislation_process_proposals_path, id: @proposal.id %>
   </div>
 </div>

--- a/app/views/management/proposals/new.html.erb
+++ b/app/views/management/proposals/new.html.erb
@@ -6,7 +6,7 @@
 
   <div class="small-12 medium-9 column end">
     <h2><%= t("management.proposals.create_proposal") %></h2>
-    <%= render "proposals/form", form_url: management_proposals_url %>
+    <%= render "proposals/form", form_url: management_proposals_path %>
   </div>
 
 </div>

--- a/app/views/proposals/edit.html.erb
+++ b/app/views/proposals/edit.html.erb
@@ -9,6 +9,6 @@
 
     <h1><%= t("proposals.edit.editing") %></h1>
 
-    <%= render "form", form_url: proposal_url(@proposal) %>
+    <%= render "form", form_url: proposal_path(@proposal) %>
   </div>
 </div>

--- a/app/views/proposals/new.html.erb
+++ b/app/views/proposals/new.html.erb
@@ -9,7 +9,7 @@
         <%= t("proposals.new.more_info") %>
       <% end %>
     </div>
-    <%= render "proposals/form", form_url: proposals_url %>
+    <%= render "proposals/form", form_url: proposals_path %>
   </div>
 
   <div class="small-12 medium-3 column">

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -20,7 +20,7 @@
         <% @geozones.each do |geozone| %>
           <area shape="poly"
                 coords="<%= geozone.html_map_coordinates %>"
-                href="<%= polymorphic_url(@resource, search: geozone.name) %>"
+                href="<%= polymorphic_path(@resource, search: geozone.name) %>"
                 title="<%= geozone.name %>"
                 alt="<%= geozone.name %>">
         <% end %>

--- a/app/views/shared/_suggest.html.erb
+++ b/app/views/shared/_suggest.html.erb
@@ -24,7 +24,7 @@
                 limit: @limit) %>
           </strong>
           <%= link_to t("shared.suggest.#{resource_name}.see_all"),
-                      polymorphic_url(resource_model, search: @search_terms) %>
+                      polymorphic_path(resource_model, search: @search_terms) %>
         </p>
       <% end %>
 

--- a/spec/features/admin/site_customization/documents_spec.rb
+++ b/spec/features/admin/site_customization/documents_spec.rb
@@ -47,7 +47,7 @@ describe "Documents" do
 
     within("ul.pagination") do
       expect(page).to have_content("1")
-      expect(page).to have_link("2", href: admin_site_customization_documents_url(page: 2))
+      expect(page).to have_link("2", href: admin_site_customization_documents_path(page: 2))
       expect(page).not_to have_content("3")
       click_link "Next", exact: false
     end

--- a/spec/features/campaigns_spec.rb
+++ b/spec/features/campaigns_spec.rb
@@ -9,8 +9,8 @@ describe "Email campaigns" do
   end
 
   scenario "Track email templates" do
-    3.times { visit root_url(track_id: campaign1.track_id) }
-    5.times { visit root_url(track_id: campaign2.track_id) }
+    3.times { visit root_path(track_id: campaign1.track_id) }
+    5.times { visit root_path(track_id: campaign2.track_id) }
 
     visit admin_stats_path
     click_link campaign1.name
@@ -24,8 +24,8 @@ describe "Email campaigns" do
   end
 
   scenario "Do not track erroneous track_ids" do
-    visit root_url(track_id: campaign1.track_id)
-    visit root_url(track_id: "999")
+    visit root_path(track_id: campaign1.track_id)
+    visit root_path(track_id: "999")
 
     visit admin_stats_path
     click_link campaign1.name

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -103,7 +103,7 @@ describe "Proposals" do
 
       within("ul.pagination") do
         expect(page).to have_content("1")
-        expect(page).to have_link("2", href: "http://www.example.com/proposals?page=2")
+        expect(page).to have_link("2", href: "/proposals?page=2")
         expect(page).not_to have_content("3")
         click_link "Next", exact: false
       end


### PR DESCRIPTION
## References

* [Pagination and SEO](https://www.contentkingapp.com/academy/pagination/#important-note-on-googles-support-for-rel-nextprev)
* Issue #1644
* Closes #3348

## Objectives

* Simlify the code while making it more consistent
* Remove obsolete URL helpers
* Remove no longer needed absolute URLs in `<a>` tags in pagination, which were probably added thinking search engines used them the same way the use `<llink>` tags (in any case, the `rel=prev/next` tag doesn't need absolute URLs anymore)