### PR TITLE
Don't count errors for the same field twice

### DIFF
--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -5,7 +5,9 @@
     </button>
 
     <strong>
-      <%= pluralize resource.errors.count, t("form.error"), t("form.errors") %>
+      <% errors_count = resource.errors.messages.reject { |attribute| attribute == :base }.count %>
+
+      <%= pluralize errors_count, t("form.error"), t("form.errors") %>
 
       <% if local_assigns[:message].present? %>
         <%= message %>

--- a/spec/system/admin/dashboard/actions_spec.rb
+++ b/spec/system/admin/dashboard/actions_spec.rb
@@ -63,7 +63,8 @@ describe "Admin dashboard actions" do
 
     scenario "Renders create form in case data is invalid" do
       click_button "Save"
-      expect(page).to have_content("errors prevented this Dashboard/Action from being saved.")
+
+      expect(page).to have_content("error prevented this Dashboard/Action from being saved.")
     end
   end
 

--- a/spec/views/shared/errors_spec.rb
+++ b/spec/views/shared/errors_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe "shared errors" do
+  class DummyModel
+    include ActiveModel::Model
+    attr_accessor :title, :description, :days
+
+    validates :title, presence: true
+    validates :description, presence: true, length: { in: 10..100 }
+    validates :days, numericality: { greater_than: 10 }
+  end
+
+  it "counts the number of fields with errors" do
+    resource = DummyModel.new(title: "Present", description: "", days: 3)
+    resource.valid?
+
+    render "shared/errors", resource: resource
+
+    expect(rendered).to have_content "2 errors"
+  end
+
+  it "doesn't include `base` errors in new records" do
+    resource = build(:debate, title: "", description: "")
+    resource.valid?
+
+    render "shared/errors", resource: resource
+
+    expect(rendered).to have_content "2 errors"
+  end
+
+  it "doesn't include `base` errors in existing records" do
+    resource = create(:debate)
+    resource.translations << Debate::Translation.new(title: "Title", description: "", locale: "es")
+    resource.valid?
+
+    render "shared/errors", resource: resource
+
+    expect(rendered).to have_content "1 error"
+  end
+end


### PR DESCRIPTION
## Background

The number of errors in a form includes several errors for the same field. For example, if a title is mandatory and has to have at least 5 characters, leaving the title blank will result in two errors. So users will be invited to look for two errors, but they'll only find one field with errors.

## Objectives

* Make it more intuitive for users to find how many fields with errors there are in a form

## Visual Changes

Before this change:

![Two errors are reported when there are two errors in the title field](https://user-images.githubusercontent.com/35156/66666051-1ed00980-ec50-11e9-993f-83f70da50f23.png)

After this change:

![One error is reported when there are two errors in the title field](https://user-images.githubusercontent.com/35156/66666055-2099cd00-ec50-11e9-8598-cac27d42742c.png)