### PR TITLE
Do not call CensusAPI when endpoint is not defined

### DIFF
--- a/lib/census_api.rb
+++ b/lib/census_api.rb
@@ -79,8 +79,12 @@ class CensusApi
           nivel: 3 }}
     end
 
+    def end_point_defined?
+      Rails.application.secrets.census_api_end_point.present?
+    end
+
     def end_point_available?
-      Rails.env.staging? || Rails.env.preproduction? || Rails.env.production?
+      (Rails.env.staging? || Rails.env.preproduction? || Rails.env.production?) && end_point_defined?
     end
 
     def stubbed_response(document_type, document_number)

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -4,103 +4,72 @@ describe CensusCaller do
   let(:api) { CensusCaller.new }
 
   describe "#call" do
-    it "returns data from local_census_records if census API is not available" do
-      census_api_response = CensusApi::Response.new(get_habita_datos_response: {
-          get_habita_datos_return: { datos_habitante: {}, datos_vivienda: {}}
-        }
-      )
+    let(:valid_body) do
+      { get_habita_datos_response: {
+        get_habita_datos_return: { datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" }}}
+      }}
+    end
+    let(:invalid_body) do
+      { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}}}}
+    end
 
+    it "returns local census response when census api response is invalid" do
+      census_api_response = CensusApi::Response.new(invalid_body)
+      allow_any_instance_of(CensusApi).to receive(:call).and_return(census_api_response)
       local_census_response = LocalCensus::Response.new(create(:local_census_record))
-
-      expect_any_instance_of(CensusApi).to   receive(:call).and_return(census_api_response)
-      expect_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
-
-      allow(CensusApi).to   receive(:call).with(1, "12345678A")
-      allow(LocalCensus).to receive(:call).with(1, "12345678A")
-
+      allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
       response = api.call(1, "12345678A", nil, nil)
 
       expect(response).to eq(local_census_response)
     end
 
-    it "returns data from census API if it's available and valid" do
-      census_api_response = CensusApi::Response.new(get_habita_datos_response: {
-        get_habita_datos_return: {
-          datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" }}
-        }
-      })
+    describe "CensusApi" do
+      it "returns census api response when it's available and census api response is valid" do
+        census_api_response = CensusApi::Response.new(valid_body)
+        allow_any_instance_of(CensusApi).to receive(:call).and_return(census_api_response)
 
-      local_census_response = LocalCensus::Response.new(create(:local_census_record))
+        response = api.call(1, "12345678A", nil, nil)
 
-      expect_any_instance_of(CensusApi).to  receive(:call).and_return(census_api_response)
-      allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
-
-      allow(CensusApi).to receive(:call).with(1, "12345678A")
-      allow(LocalCensus).to receive(:call).with(1, "12345678A")
-
-      response = api.call(1, "12345678A", nil, nil)
-
-      expect(response).to eq(census_api_response)
+        expect(response).to eq(census_api_response)
+      end
     end
 
     describe "RemoteCensusApi" do
-
       before do
+        Setting["feature.remote_census"] = true
         access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-        access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-        Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-        Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
         Setting["remote_census.response.valid"] = access_user_data
       end
 
-      it "returns data from Remote Census API if it's available and valid" do
-        Setting["feature.remote_census"] = true
-
-        remote_census_api_response = RemoteCensusApi::Response.new(get_habita_datos_response: {
-          get_habita_datos_return: {
-            datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" }}
-          }
-        })
-
-        local_census_response = LocalCensus::Response.new(create(:local_census_record))
-
-        expect_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)
-        allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
-
-        allow(RemoteCensusApi).to receive(:call).with(1, "12345678A", Date.parse("01/01/1983"), "28001")
-        allow(LocalCensus).to receive(:call).with(1, "12345678A")
+      it "returns remote census api response when it's available and response is valid" do
+        remote_census_api_response = RemoteCensusApi::Response.new(valid_body)
+        allow_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)
 
         response = api.call(1, "12345678A", Date.parse("01/01/1983"), "28001")
 
         expect(response).to eq(remote_census_api_response)
-
-        Setting["feature.remote_census"] = nil
       end
 
-      it "returns data from Remote Census API if it's available and valid without send date_of_birth and postal_code" do
-        Setting["feature.remote_census"] = true
-
-        remote_census_api_response = RemoteCensusApi::Response.new(get_habita_datos_response: {
-          get_habita_datos_return: {
-            datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" }}
-          }
-        })
-
-        local_census_response = LocalCensus::Response.new(create(:local_census_record))
-
-        expect_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)
-        allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
-
-        allow(RemoteCensusApi).to receive(:call).with(1, "12345678A", nil, nil)
-        allow(LocalCensus).to receive(:call).with(1, "12345678A")
+      it "returns remote census api response when it's available and valid without send
+          date_of_birth and postal_code" do
+        remote_census_api_response = RemoteCensusApi::Response.new(valid_body)
+        allow_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)
 
         response = api.call(1, "12345678A", nil, nil)
 
         expect(response).to eq(remote_census_api_response)
+      end
 
-        Setting["feature.remote_census"] = nil
+      it "returns local census record when remote census api it's available but invalid" do
+        remote_census_api_response = RemoteCensusApi::Response.new(invalid_body)
+        allow_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)
+        local_census_response = LocalCensus::Response.new(create(:local_census_record))
+        allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
+
+        response = api.call(1, "12345678A", nil, nil)
+
+        expect(response).to eq(local_census_response)
       end
     end
   end
-
 end


### PR DESCRIPTION

## References
Related Issues: https://github.com/consul/consul/issues/3742#issuecomment-539495975

## Objectives
Do not call CensusAPI when endpoint at secrets is not defined.

Prior to this change, CensusAPI was called when the endpoint is not defined in the production, staging, and pre-production environments, resulting in an error when the secrets of the census API were not defined.

## Visual Changes
None

## Notes
If you do not want to call CensusAPI on production, staging or preproduction environment ensure your `Rails.application.secrets.census_api_end_point` is empty.
