### PR TITLE
Don't let valuators update investments

### DIFF
--- a/app/models/abilities/valuator.rb
+++ b/app/models/abilities/valuator.rb
@@ -7,9 +7,9 @@ module Abilities
       assigned_investment_ids = valuator.assigned_investment_ids
       finished = { phase: "finished" }
 
-      can [:read, :update], Budget::Investment, id: assigned_investment_ids
+      can [:read], Budget::Investment, id: assigned_investment_ids
       can [:valuate], Budget::Investment, { id: assigned_investment_ids, valuation_finished: false }
-      cannot [:update, :valuate, :comment_valuation], Budget::Investment, budget: finished
+      cannot [:valuate, :comment_valuation], Budget::Investment, budget: finished
 
       if valuator.can_edit_dossier?
         can [:edit_dossier], Budget::Investment, id: assigned_investment_ids

--- a/spec/models/abilities/valuator_spec.rb
+++ b/spec/models/abilities/valuator_spec.rb
@@ -18,16 +18,12 @@ describe Abilities::Valuator do
     should_not be_able_to(:valuate, assigned_investment)
   end
 
-  it { should_not be_able_to(:update, non_assigned_investment) }
-  it { should_not be_able_to(:valuate, non_assigned_investment) }
+  it { should_not be_able_to(:update, assigned_investment) }
 
-  it { should be_able_to(:update, assigned_investment) }
   it { should be_able_to(:valuate, assigned_investment) }
-
-  it { should be_able_to(:update, group_assigned_investment) }
   it { should be_able_to(:valuate, group_assigned_investment) }
 
-  it { should_not be_able_to(:update, finished_assigned_investment) }
+  it { should_not be_able_to(:valuate, non_assigned_investment) }
   it { should_not be_able_to(:valuate, finished_assigned_investment) }
 
   it "can update dossier information if not set can_edit_dossier attribute" do


### PR DESCRIPTION
## References

* Refines pull request #3716 for valuators

## Background 

There were some confusing definitions regarding the valuation of budget investments. In the controller, `CommentableActions` was included, which includes the update action, and in the abilities, a valuator was given permission to update an investment.

However, the action to update an investment didn't work because there is no route defined to do so. The ability was defined so valuators could access the "edit" action.

But then we added permission for regular users to update budget investments, and these permissions were allowing valuators to update another user's investment.

## Objectives

Don't let valuators update other user's investments in the public area.

## Notes

After this change, everything seems to work properly because the valuation budget investments controller has its own authorization rules, not depending on abilities. We should probably change that, but it's out of the scope of this pull request.