### PR TITLE
Fix blank space in admin content

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -292,21 +292,10 @@ $sidebar-active: #f4fcd0;
   }
 
   .side-menu-and-admin-content {
-    display: flex;
-  }
-
-  .side-menu {
-    flex: 25%;
-    min-width: 250px;
-
-    .admin-sidebar {
-      height: 100%;
-    }
+    @include side-menu-and-content;
   }
 
   .admin-content {
-    flex: 75%;
-
     .proposal-form {
       padding-top: 0;
     }
@@ -323,11 +312,6 @@ $sidebar-active: #f4fcd0;
 
 .for-print-only {
   display: none;
-}
-
-.admin-content {
-  overflow: scroll;
-  padding: $line-height !important;
 }
 
 @include breakpoint(medium) {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -291,7 +291,29 @@ $sidebar-active: #f4fcd0;
     margin-right: rem-calc(12);
   }
 
+  .side-menu-and-admin-content {
+    display: flex;
+
+    @include breakpoint(small only) {
+      flex-direction: column;
+    }
+  }
+
+  .side-menu {
+    flex: 25%;
+    min-width: 250px;
+
+    > :last-child {
+      height: 100%;
+
+      .admin-sidebar {
+        height: 100%;
+      }
+    }
+  }
+
   .admin-content {
+    flex: 75%;
 
     .proposal-form {
       padding-top: 0;
@@ -430,10 +452,6 @@ code {
   background: $sidebar;
   background: linear-gradient(to bottom, #245b80 0%, #488fb5 100%);
   border-right: 1px solid $border;
-
-  @include breakpoint(medium) {
-    min-height: rem-calc(1100);
-  }
 
   ul {
     list-style-type: none;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -293,22 +293,14 @@ $sidebar-active: #f4fcd0;
 
   .side-menu-and-admin-content {
     display: flex;
-
-    @include breakpoint(small only) {
-      flex-direction: column;
-    }
   }
 
   .side-menu {
     flex: 25%;
     min-width: 250px;
 
-    > :last-child {
+    .admin-sidebar {
       height: 100%;
-
-      .admin-sidebar {
-        height: 100%;
-      }
     }
   }
 

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -16,6 +16,10 @@
 // 01. Dashboard global
 // --------------------
 
+.dashboard-menu-and-content {
+  @include side-menu-and-content;
+}
+
 .proposal-title {
   display: inline-block;
 
@@ -287,10 +291,6 @@
 .dashboard-sidebar {
   background: #fbfbfb;
   border-right: 1px solid $border;
-
-  @include breakpoint(medium) {
-    min-height: $line-height * 45;
-  }
 
   [class^="icon-"] {
     color: $text;

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -1,8 +1,9 @@
 // Table of Contents
 //
 // 01. Logo
-// 02. Orbit bullets
-// 03. Direct uploads
+// 02. Side menu and content
+// 03. Orbit bullets
+// 04. Direct uploads
 // ------------------
 
 // 01. Logo
@@ -21,7 +22,29 @@
   }
 }
 
-// 02. Orbit bullet
+// 02. Side menu and content
+// -------------------------
+
+@mixin side-menu-and-content {
+  display: flex;
+
+  > :first-child {
+    flex: 25%;
+    min-width: 250px;
+
+    > :first-child {
+      height: 100%;
+    }
+  }
+
+  > :last-child {
+    flex: 75%;
+    overflow-x: auto;
+    padding: $line-height !important;
+  }
+}
+
+// 03. Orbit bullet
 // ----------------
 
 @mixin orbit-bullets {
@@ -49,7 +72,7 @@
   }
 }
 
-// 03. Direct uploads
+// 04. Direct uploads
 // ------------------
 
 @mixin direct-uploads {

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -1,4 +1,4 @@
-<div class="admin-sidebar" data-equalizer-watch>
+<div class="admin-sidebar">
   <ul id="admin_menu" data-accordion-menu data-multi-open="false">
     <% if feature?(:proposals) %>
       <li class="section-title">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -19,9 +19,8 @@
         <div class="off-canvas-content" data-off-canvas-content>
           <%= render "layouts/admin_header" %>
 
-          <div class="no-margin-top row expanded collapse" data-equalizer>
-            <div class="small-12 medium-3 column" data-equalizer-watch>
-
+          <div class="side-menu-and-admin-content no-margin-top">
+            <div class="side-menu">
               <div class="show-for-small-only">
                 <button type="button" class="button hollow expanded" data-toggle="offCanvas"><%= t("admin.menu.admin") %></button>
               </div>
@@ -31,7 +30,7 @@
               </div>
             </div>
 
-            <div class="admin-content small-12 medium-9 column" data-equalizer-watch>
+            <div class="admin-content">
               <%= render "layouts/flash" %>
               <%= render "layouts/officing_booth" if controller.class.parent == Officing && session[:booth_id].present? %>
               <%= yield %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -20,7 +20,7 @@
           <%= render "layouts/admin_header" %>
 
           <div class="side-menu-and-admin-content no-margin-top">
-            <div id="side_menu" class="side-menu hide-for-small-only">
+            <div id="side_menu" class="hide-for-small-only">
               <%= side_menu %>
             </div>
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -20,17 +20,15 @@
           <%= render "layouts/admin_header" %>
 
           <div class="side-menu-and-admin-content no-margin-top">
-            <div class="side-menu">
+            <div id="side_menu" class="side-menu hide-for-small-only">
+              <%= side_menu %>
+            </div>
+
+            <div class="admin-content">
               <div class="show-for-small-only">
                 <button type="button" class="button hollow expanded" data-toggle="offCanvas"><%= t("admin.menu.admin") %></button>
               </div>
 
-              <div id="side_menu" class="hide-for-small-only">
-                <%= side_menu %>
-              </div>
-            </div>
-
-            <div class="admin-content">
               <%= render "layouts/flash" %>
               <%= render "layouts/officing_booth" if controller.class.parent == Officing && session[:booth_id].present? %>
               <%= yield %>

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -29,7 +29,7 @@
       <div class="off-canvas-wrapper-inner" data-off-canvas-wrapper>
         <div class="off-canvas position-left" id="offCanvas" data-off-canvas>
           <div class="show-for-small-only">
-            <div class="dashboard-sidebar" data-equalizer-watch>
+            <div class="dashboard-sidebar">
               <%= render "dashboard/menu" %>
             </div>
           </div>
@@ -38,22 +38,20 @@
         <div class="off-canvas-content" data-off-canvas-content>
           <%= render "layouts/header", with_subnavigation: false %>
 
-          <div class="no-margin-top row expanded collapse" data-equalizer>
-            <div class="small-12 medium-3 column" data-equalizer-watch>
+          <div class="dashboard-menu-and-content no-margin-top">
+            <div id="side_menu" class="hide-for-small-only">
+              <div class="dashboard-sidebar">
+                <%= render "dashboard/menu" %>
+              </div>
+            </div>
 
+            <div class="admin-content">
               <div class="show-for-small-only">
                 <button type="button" class="button hollow expanded" data-toggle="offCanvas">
                   <%= t("admin.menu.admin") %>
                 </button>
               </div>
 
-              <div id="side_menu" class="hide-for-small-only">
-                <div class="dashboard-sidebar" data-equalizer-watch>
-                  <%= render "dashboard/menu" %>
-                </div>
-              </div>
-            </div>
-            <div class="admin-content small-12 medium-9 column" data-equalizer-watch>
               <%= render "layouts/flash" %>
               <%= render "layouts/dashboard/proposal_totals" %>
               <%= render "layouts/dashboard/proposal_header" %>

--- a/app/views/officing/_menu.html.erb
+++ b/app/views/officing/_menu.html.erb
@@ -1,4 +1,4 @@
-<div class="admin-sidebar" data-equalizer-watch>
+<div class="admin-sidebar">
   <ul id="officing_menu">
     <% if vote_collection_shift? %>
       <li class="<%= "js-vote-collection" %>


### PR DESCRIPTION
## References

* Closes #3283
* Closes #3885

## Objectives

* Fix a bug which made blank space appear at the bottom of the page in the administration  some cases
* Fix a bug using the browser's back button which resulted in only the top of the page being visible
* Fix a bug making the bottom of the navigation bar becoming inaccessible
* Use CSS code instead of JavaScript to make two elements have the same height
* Remove the need of a double scroll bar in the administration content
* Reduce the amount of blank space at the top of the page in the admininstration section on mobile phones

## Visual Changes

Before this change:

![There's blank space between the end of the content and the end of the page](https://user-images.githubusercontent.com/35156/67116723-56572c80-f1e1-11e9-86f9-486750c314f4.png)

![The bottom of the navigation cannot be seen](https://user-images.githubusercontent.com/35156/68039740-0c844100-fccd-11e9-9be9-ffa024431abc.png)

Using the browser's back button:

![Only the top of the page can be seen](https://user-images.githubusercontent.com/35156/68039438-66d0d200-fccc-11e9-8dea-029a8932834a.png)


After this change:

![The page finishes when the content finishes](https://user-images.githubusercontent.com/35156/67120534-c49fed00-f1e9-11e9-840e-ded2588c57f3.png)

![The whole navigation bar can be seen](https://user-images.githubusercontent.com/35156/68039783-2887e280-fccd-11e9-9b20-4105bc859ff9.png)


Using the browser's back button:

![The whole page can be seen](https://user-images.githubusercontent.com/35156/68039484-849e3700-fccc-11e9-9215-f59966eeb2b5.png)