### PR TITLE
Use jQuery's text() instead of html() where safer

### DIFF
--- a/app/assets/javascripts/banners.js
+++ b/app/assets/javascripts/banners.js
@@ -4,12 +4,12 @@
     initialize: function() {
       $("[data-js-banner-title]").on({
         change: function() {
-          $("#js-banner-title").html($(this).val());
+          $("#js-banner-title").text($(this).val());
         }
       });
       $("[data-js-banner-description]").on({
         change: function() {
-          $("#js-banner-description").html($(this).val());
+          $("#js-banner-description").text($(this).val());
         }
       });
       $("[name='banner[background_color]']").on({

--- a/app/assets/javascripts/globalize.js
+++ b/app/assets/javascripts/globalize.js
@@ -77,9 +77,10 @@
     update_description: function() {
       var count, description;
       count = App.Globalize.enabled_locales().length;
-      description = App.Globalize.language_description(count);
-      $(".js-languages-description").html(description);
-      $(".js-languages-count").text(count);
+      description = $(App.Globalize.language_description(count)).filter(".description").text();
+
+      $(".js-languages-description .description").text(description);
+      $(".js-languages-description .count").text(count);
     },
     language_description: function(count) {
       switch (count) {

--- a/app/assets/javascripts/markdown_editor.js
+++ b/app/assets/javascripts/markdown_editor.js
@@ -33,10 +33,10 @@
           editor.toggleClass("fullscreen");
           $(".fullscreen-container").toggleClass("medium-8", "medium-12");
           span = $(this).find("span");
-          if (span.html() === span.data("open-text")) {
-            span.html(span.data("closed-text"));
+          if (span.text() === span.data("open-text")) {
+            span.text(span.data("closed-text"));
           } else {
-            span.html(span.data("open-text"));
+            span.text(span.data("open-text"));
           }
           if (editor.hasClass("fullscreen")) {
             App.MarkdownEditor.find_textarea(editor).height($(window).height() - 100);

--- a/app/views/shared/_common_globalize_locales.html.erb
+++ b/app/views/shared/_common_globalize_locales.html.erb
@@ -1,7 +1,7 @@
 <div class="row globalize-languages column padding-top <%= highlight_translation_html_class %>"
-     data-zero-languages-description="<%= sanitize(t("shared.translations.languages_in_use", count: 0)) %>"
-     data-one-languages-description="<%= sanitize(t("shared.translations.languages_in_use", count: 1)) %>"
-     data-other-languages-description="<%= sanitize(t("shared.translations.languages_in_use", count: 2)) %>">
+     data-zero-languages-description="<%= t("shared.translations.languages_in_use", count: 0) %>"
+     data-one-languages-description="<%= t("shared.translations.languages_in_use", count: 1) %>"
+     data-other-languages-description="<%= t("shared.translations.languages_in_use", count: 2) %>">
   <div class="small-6 large-3 column">
     <span class="small">
       <strong class="js-languages-description"><%= selected_languages_description(resource) %></strong>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -806,9 +806,9 @@ en:
       remove_language: Remove language
       add_language: Add language
       languages_in_use:
-        zero: "<span class='js-languages-count'>0</span> languages in use"
-        one: "<span class='js-languages-count'>1</span> language in use"
-        other: "<span class='js-languages-count'>%{count}</span> languages in use"
+        zero: "<span class='count'>0</span> <span class='description'>languages in use</span>"
+        one: "<span class='count'>1</span> <span class='description'>language in use</span>"
+        other: "<span class='count'>%{count}</span> <span class='description'>languages in use</span>"
   social:
     facebook: "%{org} Facebook"
     twitter: "%{org} Twitter"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -803,9 +803,9 @@ es:
       remove_language: Eliminar idioma
       add_language: Añadir idioma
       languages_in_use:
-        zero: "<span class='js-languages-count'>0</span> idiomas en uso"
-        one: "<span class='js-languages-count'>1</span> idioma en uso"
-        other: "<span class='js-languages-count'>%{count}</span> idiomas en uso"
+        zero: "<span class='count'>0</span> <span class='description'>idiomas en uso</span>"
+        one: "<span class='count'>1</span> <span class='description'> idioma en uso</span>"
+        other: "<span class='count'>%{count}</span> <span class='description'>idiomas en uso</span>"
   social:
     facebook: "Facebook de %{org}"
     twitter: "Twitter de %{org}"

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -61,6 +61,16 @@ describe "Cross-Site Scripting protection", :js do
     expect(page.text).not_to be_empty
   end
 
+  scenario "languages in use" do
+    I18nContent.create(key: "shared.translations.languages_in_use", value: attack_code)
+
+    login_as(create(:administrator).user)
+    visit edit_admin_budget_path(create(:budget))
+    click_link "Remove language"
+
+    expect(page.text).not_to be_empty
+  end
+
   scenario "proposal actions in dashboard" do
     proposal = create(:proposal)
 

--- a/spec/features/xss_spec.rb
+++ b/spec/features/xss_spec.rb
@@ -13,6 +13,18 @@ describe "Cross-Site Scripting protection", :js do
     expect(page.text).not_to be_empty
   end
 
+  scenario "edit banner" do
+    banner = create(:banner, title: attack_code)
+
+    login_as(create(:administrator).user)
+    visit edit_admin_banner_path(banner)
+
+    title_id = find_field("Title")[:id]
+    execute_script "document.getElementById('#{title_id}').dispatchEvent(new Event('change'))"
+
+    expect(page.text).not_to be_empty
+  end
+
   scenario "document title" do
     process = create(:legislation_process)
     create(:document, documentable: process, title: attack_code)


### PR DESCRIPTION
## Background

Using `html()` makes it possible to insert <script> tags in the DOM, so it shouldn't be done unless we're 100% sure the content is safe. While the content is safe in most cases, since it's already escaped by Rails, there are a couple of places where there's a remote chance of the content not being safe.

## Objectives

Reduce the (small) chances of XSS attacks because of the way we manipulate the DOM.

## Notes

The same happens with many jQuery methods, like `append` or `insertBefore`. After reviewing the code, I haven't identified a place where these methods might be potentially dangerous.