### PR TITLE
Fix investments search with numbers in their title

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -151,8 +151,8 @@ class Budget
       results = results.by_valuator(params[:valuator_id])                  if params[:valuator_id].present?
       results = results.by_valuator_group(params[:valuator_group_id])      if params[:valuator_group_id].present?
       results = results.by_admin(params[:administrator_id])                if params[:administrator_id].present?
+      results = results.search_by_title_or_id(params[:title_or_id].strip)  if params[:title_or_id]
       results = advanced_filters(params, results)                          if params[:advanced_filters].present?
-      results = search_by_title_or_id(params[:title_or_id].strip, results) if params[:title_or_id]
 
       results = results.send(current_filter)                        if current_filter.present?
       results.includes(:heading, :group, :budget, administrator: :user, valuators: :user)
@@ -200,10 +200,10 @@ class Budget
       results.where("budget_investments.id IN (?)", ids)
     end
 
-    def self.search_by_title_or_id(title_or_id, results)
-      return results.where(id: title_or_id) if title_or_id =~ /^[0-9]+$/
+    def self.search_by_title_or_id(title_or_id)
+      return where(id: title_or_id) if title_or_id =~ /^[0-9]+$/
 
-      results.with_translations(Globalize.fallbacks(I18n.locale)).
+      with_translations(Globalize.fallbacks(I18n.locale)).
         where("budget_investment_translations.title ILIKE ?", "%#{title_or_id}%")
     end
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -201,10 +201,10 @@ class Budget
     end
 
     def self.search_by_title_or_id(title_or_id)
-      return where(id: title_or_id) if title_or_id =~ /^[0-9]+$/
+      with_joins = with_translations(Globalize.fallbacks(I18n.locale))
 
-      with_translations(Globalize.fallbacks(I18n.locale)).
-        where("budget_investment_translations.title ILIKE ?", "%#{title_or_id}%")
+      with_joins.where(id: title_or_id).
+        or(with_joins.where("budget_investment_translations.title ILIKE ?", "%#{title_or_id}%"))
     end
 
     def searchable_values

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -648,26 +648,22 @@ describe Budget::Investment do
     end
 
     describe "search_by_title_or_id" do
-      before { create(:budget_investment) }
+      it "does not return investments by description" do
+        create(:budget_investment, title: "Something", description: "Awesome")
 
-      let!(:investment) do
-        I18n.with_locale(:es) do
-          create(:budget_investment,
-            title_es: "Título del proyecto de inversión",
-            description_es: "Descripción del proyecto de inversión")
-        end
+        expect(Budget::Investment.search_by_title_or_id("Awesome")).to be_empty
       end
 
-      let(:all_investments) { Budget::Investment.all }
+      it "returns investment by given id" do
+        investment = create(:budget_investment)
 
-      it "return investment by given id" do
-        expect(Budget::Investment.search_by_title_or_id(investment.id.to_s, all_investments)).
-          to eq([investment])
+        expect(Budget::Investment.search_by_title_or_id(investment.id.to_s)).to eq([investment])
       end
 
-      it "return investments by given title" do
-        expect(Budget::Investment.search_by_title_or_id("Título del proyecto de inversión", all_investments)).
-          to eq([investment])
+      it "returns investments by given title" do
+        investment = create(:budget_investment, title: "Investment title")
+
+        expect(Budget::Investment.search_by_title_or_id("Investment title")).to eq([investment])
       end
     end
   end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -665,6 +665,12 @@ describe Budget::Investment do
 
         expect(Budget::Investment.search_by_title_or_id("Investment title")).to eq([investment])
       end
+
+      it "finds investments with numbers in their title" do
+        investment = create(:budget_investment, title: "99 red balloons")
+
+        expect(Budget::Investment.search_by_title_or_id("99")).to eq([investment])
+      end
     end
   end
 


### PR DESCRIPTION
## References

* Continues pull request #2417

## Objectives

Fix searching investments with numbers in their title. Until now, if we searched for a number, we would only find investments by their ID.