### PR TITLE
Reduce security risk on remote_census_api

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,9 +57,6 @@ Rails/SaveBang:
 Rails/SkipsModelValidations:
   Enabled: true
 
-Security/Eval:
-  Enabled: true
-
 Security/JSONLoad:
   Enabled: true
 

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -255,6 +255,9 @@ RSpec/ScatteredSetup:
 RSpec/VoidExpect:
   Enabled: true
 
+Security/Eval:
+  Enabled: true
+
 Style/BlockDelimiters:
   Enabled: true
 

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -132,7 +132,7 @@ en:
         method_name: "Request method name"
         method_name_description: "Request method name accepted by the City Census WebService."
         structure: "Request Structure"
-        structure_description: 'Request Structure that receives the Census WebService of the City council. The "static" values of this request should be filled. Values related to Document Type, Document Number, Date of Birth and Postal Code should be blank.'
+        structure_description: 'Request Structure that receives the Census WebService of the City council. The "static" values of this request should be filled. Values related to Document Type, Document Number, Date of Birth and Postal Code should be null. Example of a valid format: { "request": { "codigo_institucion": 1, "codigo_portal": 1, "codigo_usuario": 1, "documento": null, "tipo_documento": null, "codigo_idioma": 102, "nivel": 3 } }'
         document_type: "Path for Document Type"
         document_type_description: "Path in the request structure that sends the Document Type. DO NOT FILL IN if the WebService does not require the Document Type to verify a user."
         document_number: "Path for Document Number"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -132,7 +132,7 @@ es:
         method_name: "Nombre del método de la petición"
         method_name_description: "Nombre del método qe acepta el WebService del Censo del Ayuntamiento."
         structure: "Estructura de la petición"
-        structure_description: 'Estructura de la petición que recibe el WebService del Censo del Ayuntamiento. Los valores "fijos" de esta petición deberan informarse. Los valores relacionado con Tipo de Documento, Número de Documento, Fecha de Nacimiento y Código Postal deberán dejarse en blanco.'
+        structure_description: 'Estructura de la petición que recibe el WebService del Censo del Ayuntamiento. Los valores "fijos" de esta petición deberan informarse. Los valores relacionado con Tipo de Documento, Número de Documento, Fecha de Nacimiento y Código Postal deberán dejarse con valor null. Ejemplo de formato válido: { "request": { "codigo_institucion": 1, "codigo_portal": 1, "codigo_usuario": 1, "documento": null, "tipo_documento": null, "codigo_idioma": 102, "nivel": 3 } }'
         document_type: "Ruta para Tipo de Documento"
         document_type_description: "Ruta donde se encuentra el campo en la estructura de la petición que envia el Tipo de Documento. NO RELLENAR en caso de que el WebService no requiera el Tipo de Documento para verificar un usuario."
         document_number: "Ruta para Número de Documento"

--- a/lib/remote_census_api.rb
+++ b/lib/remote_census_api.rb
@@ -84,7 +84,7 @@ class RemoteCensusApi
     end
 
     def request(document_type, document_number, date_of_birth, postal_code)
-      structure = eval(Setting["remote_census.request.structure"])
+      structure = JSON.parse(Setting["remote_census.request.structure"])
 
       fill_in(structure, Setting["remote_census.request.document_type"], document_type)
       fill_in(structure, Setting["remote_census.request.document_number"], document_number)
@@ -100,12 +100,11 @@ class RemoteCensusApi
 
     def fill_in(structure, path_value, value)
       path = parse_path(path_value)
-
       update_value(structure, path, value) if path.present?
     end
 
     def parse_path(path_value)
-      path_value.split(".").map { |section| section.to_sym } if path_value.present?
+      path_value.split(".") if path_value.present?
     end
 
     def update_value(structure, path, value)

--- a/lib/remote_census_api.rb
+++ b/lib/remote_census_api.rb
@@ -16,7 +16,7 @@ class RemoteCensusApi
     end
 
     def extract_value(path_value)
-      path = parse_path(path_value)
+      path = parse_response_path(path_value)
       return nil unless path.present?
       @body.dig(*path)
     end
@@ -63,7 +63,7 @@ class RemoteCensusApi
       "#{extract_value(path_value_name)} #{extract_value(path_value_surname)}"
     end
 
-    def parse_path(path_value)
+    def parse_response_path(path_value)
       path_value.split(".").map { |section| section.to_sym } if path_value.present?
     end
   end
@@ -99,11 +99,11 @@ class RemoteCensusApi
     end
 
     def fill_in(structure, path_value, value)
-      path = parse_path(path_value)
+      path = parse_request_path(path_value)
       update_value(structure, path, value) if path.present?
     end
 
-    def parse_path(path_value)
+    def parse_request_path(path_value)
       path_value.split(".") if path_value.present?
     end
 

--- a/spec/lib/remote_census_api_spec.rb
+++ b/spec/lib/remote_census_api_spec.rb
@@ -65,15 +65,15 @@ describe RemoteCensusApi do
 
     before do
       Setting["feature.remote_census"] = true
-      Setting["remote_census.request.structure"] = "{ request:
-                                                      { codigo_institucion: 1,
-                                                        codigo_portal: 1,
-                                                        codigo_usuario: 1,
-                                                        documento: 'xxx',
-                                                        tipo_documento: 'xxx',
-                                                        codigo_idioma: '102',
-                                                        nivel: '3' }
-                                                    }"
+      Setting["remote_census.request.structure"] = '{ "request":
+                                                      { "codigo_institucion": 1,
+                                                        "codigo_portal": 1,
+                                                        "codigo_usuario": 1,
+                                                        "documento": null,
+                                                        "tipo_documento": null,
+                                                        "codigo_idioma": 102,
+                                                        "nivel": 3 }
+                                                    }'
       Setting["remote_census.request.document_type"] = "request.tipo_documento"
       Setting["remote_census.request.document_number"] = "request.documento"
       Setting["remote_census.request.date_of_birth"] = nil
@@ -86,14 +86,14 @@ describe RemoteCensusApi do
 
       request = RemoteCensusApi.new.send(:request, document_type, document_number, nil, nil)
 
-      expect(request).to eq({ :request =>
-                             { :codigo_institucion => 1,
-                              :codigo_portal => 1,
-                              :codigo_usuario => 1,
-                              :documento => "0123456",
-                              :tipo_documento => "1",
-                              :codigo_idioma => "102",
-                              :nivel => "3" }
+      expect(request).to eq({ "request" =>
+                             { "codigo_institucion" => 1,
+                               "codigo_portal" => 1,
+                               "codigo_usuario" => 1,
+                               "documento" => "0123456",
+                               "tipo_documento" => "1",
+                               "codigo_idioma" => 102,
+                               "nivel" => 3 }
                              })
     end
 
@@ -105,29 +105,29 @@ describe RemoteCensusApi do
 
       request = RemoteCensusApi.new.send(:request, document_type, document_number, date_of_birth, postal_code)
 
-      expect(request).to eq({ :request =>
-                             { :codigo_institucion => 1,
-                              :codigo_portal => 1,
-                              :codigo_usuario => 1,
-                              :documento => "0123456",
-                              :tipo_documento => "1",
-                              :codigo_idioma => "102",
-                              :nivel => "3" }
-                             })
+      expect(request).to eq({ "request" =>
+                            { "codigo_institucion" => 1,
+                              "codigo_portal" => 1,
+                              "codigo_usuario" => 1,
+                              "documento" => "0123456",
+                              "tipo_documento" => "1",
+                              "codigo_idioma" => 102,
+                              "nivel" => 3 }
+                            })
     end
 
     it "when send date_of_birth and postal_code but are configured" do
-      Setting["remote_census.request.structure"] = "{ request:
-                                                      { codigo_institucion: 1,
-                                                        codigo_portal: 1,
-                                                        codigo_usuario: 1,
-                                                        documento: nil,
-                                                        tipo_documento: nil,
-                                                        fecha_nacimiento: nil,
-                                                        codigo_postal: nil,
-                                                        codigo_idioma: '102',
-                                                        nivel: '3' }
-                                                    }"
+      Setting["remote_census.request.structure"] = '{ "request":
+                                                      { "codigo_institucion": 1,
+                                                        "codigo_portal": 1,
+                                                        "codigo_usuario": 1,
+                                                        "documento": "nil",
+                                                        "tipo_documento": "null",
+                                                        "fecha_nacimiento": "null",
+                                                        "codigo_postal": "nil",
+                                                        "codigo_idioma": 102,
+                                                        "nivel": 3 }
+                                                    }'
       Setting["remote_census.request.date_of_birth"] = "request.fecha_nacimiento"
       Setting["remote_census.request.postal_code"] = "request.codigo_postal"
       document_type = "1"
@@ -137,17 +137,17 @@ describe RemoteCensusApi do
 
       request = RemoteCensusApi.new.send(:request, document_type, document_number, date_of_birth, postal_code)
 
-      expect(request).to eq({ :request =>
-                             { :codigo_institucion => 1,
-                              :codigo_portal => 1,
-                              :codigo_usuario => 1,
-                              :documento => "0123456",
-                              :tipo_documento => "1",
-                              :fecha_nacimiento => "1980-01-01",
-                              :codigo_postal => "28001",
-                              :codigo_idioma => "102",
-                              :nivel => "3" }
-                             })
+      expect(request).to eq({ "request" =>
+                            { "codigo_institucion" => 1,
+                              "codigo_portal" => 1,
+                              "codigo_usuario" => 1,
+                              "documento" => "0123456",
+                              "tipo_documento" => "1",
+                              "fecha_nacimiento" => "1980-01-01",
+                              "codigo_postal" => "28001",
+                              "codigo_idioma" => 102,
+                              "nivel" => 3 }
+                            })
     end
 
   end


### PR DESCRIPTION
## References
Related PR: #3498 
Related Documentation PR: [Update remote census doc #86](https://github.com/consul/docs/pull/86) 

## Objectives
The use of eval is a serious security risk, so we change by JSON.parse method.
Describe expected format for Setting["remote_census.request.structure"]

## Visual Changes
![Captura de pantalla 2019-10-21 a las 17 39 38](https://user-images.githubusercontent.com/16189/67220288-cc4dd480-f429-11e9-972c-60cbe08654b2.png)

## Notes
⚠️ If your installation is using the "Remote Census configuration" feature and you have already configured the "Request Structure" field, please be sure to update the format of this field.
You can find this section on:  `Settings` > `Global Settings` > `Remote Census configuration`

Example for old expected format value:
```
{
  request: {
    codigo_institucion: 12,
    codigo_portal: 5,
    documento:   ,
    tipo_documento:  ,
  }
}
```

Example for new expected format value:
```
{
  "request": {
    "codigo_institucion": 12,
    "codigo_portal":  5,
    "documento":  null,
    "tipo_documento":  null,
  }
}
```


