### PR TITLE
Fix adding blank comments to existing annotations

### DIFF
--- a/app/controllers/legislation/annotations_controller.rb
+++ b/app/controllers/legislation/annotations_controller.rb
@@ -39,8 +39,8 @@ class Legislation::AnnotationsController < Legislation::BaseController
 
     @annotation = existing_annotation
     if @annotation.present?
-      comment = @annotation.comments.create(body: annotation_params[:text], user: current_user)
-      if comment.present?
+      comment = @annotation.comments.build(body: annotation_params[:text], user: current_user)
+      if comment.save
         render json: @annotation.to_json
       else
         render json: comment.errors.full_messages, status: :unprocessable_entity

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -226,6 +226,17 @@ describe "Legislation Draft Versions" do
       click_button "Publish comment"
       expect(page).to have_content "My interesting comment"
     end
+
+    scenario "Publish new comment with errors for an existing annotation" do
+      create(:legislation_annotation, draft_version: draft_version)
+
+      visit legislation_process_draft_version_path(draft_version.process, draft_version)
+      find(:css, ".annotator-hl").double_click
+      find(:css, ".annotator-adder button").click
+      click_button "Publish Comment"
+
+      expect(page).to have_content "Comment can't be blank"
+    end
   end
 
   context "Merged annotations", :js do


### PR DESCRIPTION
## Objectives

Fix a bug adding blank comments to existing annotations. Adding a blank comment was silently failing instead of showing a form with errors.