### PR TITLE
Remove duplicate rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,9 +45,6 @@ Rails/InverseOf:
 Rails/NotNullColumn:
   Enabled: true
 
-Rails/OutputSafety:
-  Enabled: true
-
 Rails/ReversibleMigration:
   Enabled: true
 


### PR DESCRIPTION
## References

* Commit b1b449b1 moved the rule to `.rubocop_basic.yml` without removing the original rule

## Objectives

Remove a duplicate rule left by accident.