### PR TITLE
Use rubocop 0.74 with code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,7 @@
 engines:
   rubocop:
     enabled: true
+    channel: rubocop-0-74
   duplication:
     enabled: true
     config:


### PR DESCRIPTION
## Background

It looks like rubocop 0.75 isn't available yet on code climate, and their default rubocop version isn't compatible with our configuration.

## Objectives

Make code climate work with CONSUL again.