### PR TITLE
Fix warnings in several environments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,7 +383,7 @@ GEM
     parallel (1.17.0)
     paranoia (2.4.2)
       activerecord (>= 4.0, < 6.1)
-    parser (2.6.4.1)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (0.21.0)
     pg_search (2.0.1)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -55,6 +55,7 @@ class Budget < ApplicationRecord
   scope :reviewing_ballots, -> { where(phase: "reviewing_ballots") }
   scope :finished, -> { where(phase: "finished") }
 
+  class << self; undef :open; end
   scope :open, -> { where.not(phase: "finished") }
 
   def self.current

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -54,6 +54,7 @@ class Legislation::Process < ApplicationRecord
   validates :background_color, format: { allow_blank: true, with: CSS_HEX_COLOR }
   validates :font_color, format: { allow_blank: true, with: CSS_HEX_COLOR }
 
+  class << self; undef :open; end
   scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current) }
   scope :active, -> { where("end_date >= ?", Date.current) }
   scope :past, -> { where("end_date < ?", Date.current) }

--- a/app/models/poll/shift.rb
+++ b/app/models/poll/shift.rb
@@ -10,8 +10,6 @@ class Poll
 
     enum task: { vote_collection: 0, recount_scrutiny: 1 }
 
-    scope :vote_collection,  -> { where(task: "vote_collection") }
-    scope :recount_scrutiny, -> { where(task: "recount_scrutiny") }
     scope :current, -> { where(date: Date.current) }
 
     before_create :persist_data

--- a/spec/features/admin/poll/questions/answers/documents/documents_spec.rb
+++ b/spec/features/admin/poll/questions/answers/documents/documents_spec.rb
@@ -34,9 +34,7 @@ describe "Documents" do
     visit admin_answer_documents_path(answer)
     expect(page).to have_content(document.title)
 
-    accept_confirm "Are you sure?" do
-      click_link "Delete"
-    end
+    accept_confirm { click_link "Delete" }
 
     expect(page).not_to have_content(document.title)
   end

--- a/spec/features/budget_polls/budgets_spec.rb
+++ b/spec/features/budget_polls/budgets_spec.rb
@@ -51,7 +51,7 @@ describe "Admin Budgets" do
       visit admin_budgets_path
 
       within "#budget_#{budget.id}" do
-        expect(page).to have_link("Admin ballots", admin_poll_path(poll))
+        expect(page).to have_link "Admin ballots", href: admin_poll_booth_assignments_path(poll)
       end
     end
 


### PR DESCRIPTION
## Objectives

* Remove warnings because of redefining existing methods in the production environment
* Fix wrong link and modal dialog references in tests
* Make the parser gem compatible with Ruby 2.4.9