### PR TITLE
Use a block to travel in time in specs

### DIFF
--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -420,17 +420,15 @@ describe "Proposal Notifications" do
 
       expect(page).to have_content "Your message has been sent correctly."
 
-      travel 3.days + 1.second
+      travel(3.days + 1.second) do
+        visit new_proposal_notification_path(proposal_id: proposal.id)
+        fill_in "Title", with: "Thank you again for supporting my proposal"
+        fill_in "Message", with: "Please share it again with others so we can make it happen!"
+        click_button "Send message"
 
-      visit new_proposal_notification_path(proposal_id: proposal.id)
-      fill_in "Title", with: "Thank you again for supporting my proposal"
-      fill_in "Message", with: "Please share it again with others so we can make it happen!"
-      click_button "Send message"
-
-      expect(page).to have_content "Your message has been sent correctly."
-      expect(page).not_to have_content "You have to wait a minimum of 3 days between notifications"
-
-      travel_back
+        expect(page).to have_content "Your message has been sent correctly."
+        expect(page).not_to have_content "You have to wait a minimum of 3 days between notifications"
+      end
     end
   end
 end


### PR DESCRIPTION
## Background

Since 15 hours ago a test is failing on Travis, for unknown causes. It's making many tests fail because it travels in time but never travels back.

## Objectives

Make tests travelling in time go back even if they fail.

## Notes

The following test is failing on every Travis build in the last hours, no matter if the build is based on an old branch:

```
1) Proposal Notifications Use time traveling to make sure notifications can be sent after time interval
     Failure/Error: expect(page).to have_content "Your message has been sent correctly."
       expected to find text "Your message has been sent correctly." in "CONSUL Language: Deutsch English Español Français Nederlands Português brasileiro 中文 Menu Notifications You don't have new notifications My content My account Sign out Debates Proposals Voting Collaborative legislation Participatory budgeting Help Debates Proposals Voting Collaborative legislation Participatory budgeting Help Go back Send message This message will be sent to 0 people and it will be visible in the proposal's page. Messages are not sent immediately, users will receive periodically an email with all proposal notifications. × 1 error prevented this Notification from being saved. Please check the marked fields to know how to correct them: TitleYou have to wait a minimum of 3 days between notifications Message Please share it again with others so we can make it happen! Open government This portal uses the CONSUL application which is open-source software. For technical assistance visit Participation Decide how to shape the city you want to live in. CONSUL, 2019 | Privacy Policy | Terms and conditions of use | Accessibility"
     # ./spec/features/proposal_notifications_spec.rb:23:in `block (3 levels) in <top (required)>'
     # ./spec/features/proposal_notifications_spec.rb:17:in `block (2 levels) in <top (required)>'
```