### PR TITLE
Apply Rails/InverseOf rubocop rule 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,9 +21,6 @@ Rails/HasAndBelongsToMany:
 Rails/HasManyOrHasOneDependent:
   Enabled: true
 
-Rails/InverseOf:
-  Enabled: true
-
 Rails/SkipsModelValidations:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,9 +15,6 @@ Performance/EndWith:
 Performance/StartWith:
   Enabled: true
 
-Rails/HasAndBelongsToMany:
-  Enabled: true
-
 Rails/HasManyOrHasOneDependent:
   Enabled: true
 

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -206,6 +206,11 @@ Rails/FindEach:
 Rails/HttpPositionalArguments:
   Enabled: true
 
+Rails/InverseOf:
+  Enabled: true
+  Exclude:
+    - "app/models/related_content.rb"
+
 Rails/NotNullColumn:
   Enabled: true
   Exclude:

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -206,6 +206,9 @@ Rails/FindEach:
 Rails/HttpPositionalArguments:
   Enabled: true
 
+Rails/HasAndBelongsToMany:
+  Enabled: true
+
 Rails/InverseOf:
   Enabled: true
   Exclude:

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,6 +1,6 @@
 class Activity < ApplicationRecord
   belongs_to :actionable, -> { with_hidden }, polymorphic: true
-  belongs_to :user, -> { with_hidden }
+  belongs_to :user, -> { with_hidden }, inverse_of: :activities
 
   VALID_ACTIONS = %w[hide block restore valuate email]
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -32,7 +32,7 @@ class Budget
     translates :description, touch: true
     include Globalizable
 
-    belongs_to :author, -> { with_hidden }, class_name: "User"
+    belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :budget_investments
     belongs_to :heading
     belongs_to :group
     belongs_to :budget
@@ -44,8 +44,11 @@ class Budget
     has_many :valuator_group_assignments, dependent: :destroy
     has_many :valuator_groups, through: :valuator_group_assignments
 
-    has_many :comments, -> { where(valuation: false) }, as: :commentable
-    has_many :valuations, -> { where(valuation: true) }, as: :commentable, class_name: "Comment"
+    has_many :comments, -> { where(valuation: false) }, as: :commentable, inverse_of: :commentable
+    has_many :valuations, -> { where(valuation: true) },
+      as:         :commentable,
+      inverse_of: :commentable,
+      class_name: "Comment"
 
     has_many :tracker_assignments, dependent: :destroy
     has_many :trackers, through: :tracker_assignments

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -32,7 +32,7 @@ class Budget
     translates :description, touch: true
     include Globalizable
 
-    belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+    belongs_to :author, -> { with_hidden }, class_name: "User"
     belongs_to :heading
     belongs_to :group
     belongs_to :budget

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -44,7 +44,7 @@ class Budget
     has_many :valuator_group_assignments, dependent: :destroy
     has_many :valuator_groups, through: :valuator_group_assignments
 
-    has_many :comments, -> { where(valuation: false) }, as: :commentable, class_name: "Comment"
+    has_many :comments, -> { where(valuation: false) }, as: :commentable
     has_many :valuations, -> { where(valuation: true) }, as: :commentable, class_name: "Comment"
 
     has_many :tracker_assignments, dependent: :destroy

--- a/app/models/budget/investment/change_log.rb
+++ b/app/models/budget/investment/change_log.rb
@@ -1,5 +1,9 @@
 class Budget::Investment::ChangeLog < ApplicationRecord
-  belongs_to :author, -> { with_hidden }, class_name: "User", required: false
+  belongs_to :author, -> { with_hidden },
+    class_name:  "User",
+    foreign_key: "author_id",
+    inverse_of:  :budget_investment_change_logs,
+    required:    false
 
   validates :old_value, presence: true
   validates :new_value, presence: true

--- a/app/models/budget/investment/change_log.rb
+++ b/app/models/budget/investment/change_log.rb
@@ -1,5 +1,5 @@
 class Budget::Investment::ChangeLog < ApplicationRecord
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id", required: false
+  belongs_to :author, -> { with_hidden }, class_name: "User", required: false
 
   validates :old_value, presence: true
   validates :new_value, presence: true

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -12,7 +12,7 @@ class Budget
     include Sanitizable
 
     belongs_to :budget
-    belongs_to :next_phase, class_name: "Budget::Phase", foreign_key: :next_phase_id
+    belongs_to :next_phase, class_name: "Budget::Phase"
     has_one :prev_phase, class_name: "Budget::Phase", foreign_key: :next_phase_id
 
     validates_translation :summary, length: { maximum: SUMMARY_MAX_LENGTH }

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -12,8 +12,8 @@ class Budget
     include Sanitizable
 
     belongs_to :budget
-    belongs_to :next_phase, class_name: "Budget::Phase"
-    has_one :prev_phase, class_name: "Budget::Phase", foreign_key: :next_phase_id
+    belongs_to :next_phase, class_name: self.name
+    has_one :prev_phase, class_name: self.name, foreign_key: :next_phase_id
 
     validates_translation :summary, length: { maximum: SUMMARY_MAX_LENGTH }
     validates_translation :description, length: { maximum: DESCRIPTION_MAX_LENGTH }

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -12,8 +12,8 @@ class Budget
     include Sanitizable
 
     belongs_to :budget
-    belongs_to :next_phase, class_name: self.name
-    has_one :prev_phase, class_name: self.name, foreign_key: :next_phase_id
+    belongs_to :next_phase, class_name: self.name, inverse_of: :prev_phase
+    has_one :prev_phase, class_name: self.name, foreign_key: :next_phase_id, inverse_of: :next_phase
 
     validates_translation :summary, length: { maximum: SUMMARY_MAX_LENGTH }
     validates_translation :description, length: { maximum: DESCRIPTION_MAX_LENGTH }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -30,7 +30,7 @@ class Comment < ApplicationRecord
   validate :comment_valuation, if: -> { valuation }
 
   belongs_to :commentable, -> { with_hidden }, polymorphic: true, counter_cache: true, touch: true
-  belongs_to :user, -> { with_hidden }
+  belongs_to :user, -> { with_hidden }, inverse_of: :comments
 
   before_save :calculate_confidence_score
 

--- a/app/models/concerns/documentable.rb
+++ b/app/models/concerns/documentable.rb
@@ -2,7 +2,7 @@ module Documentable
   extend ActiveSupport::Concern
 
   included do
-    has_many :documents, as: :documentable, dependent: :destroy
+    has_many :documents, as: :documentable, inverse_of: :documentable, dependent: :destroy
     accepts_nested_attributes_for :documents, allow_destroy: true
   end
 

--- a/app/models/concerns/flaggable.rb
+++ b/app/models/concerns/flaggable.rb
@@ -2,7 +2,7 @@ module Flaggable
   extend ActiveSupport::Concern
 
   included do
-    has_many :flags, as: :flaggable
+    has_many :flags, as: :flaggable, inverse_of: :flaggable
     scope :flagged, -> { where("flags_count > 0") }
     scope :pending_flag_review, -> { flagged.where(ignored_flag_at: nil, hidden_at: nil) }
     scope :with_ignored_flag, -> { flagged.where.not(ignored_flag_at: nil).where(hidden_at: nil) }

--- a/app/models/concerns/followable.rb
+++ b/app/models/concerns/followable.rb
@@ -2,7 +2,7 @@ module Followable
   extend ActiveSupport::Concern
 
   included do
-    has_many :follows, as: :followable, dependent: :destroy
+    has_many :follows, as: :followable, inverse_of: :followable, dependent: :destroy
     has_many :followers, through: :follows, source: :user
 
     scope :followed_by_user, ->(user) {

--- a/app/models/concerns/galleryable.rb
+++ b/app/models/concerns/galleryable.rb
@@ -2,7 +2,7 @@ module Galleryable
   extend ActiveSupport::Concern
 
   included do
-    has_many :images, as: :imageable, dependent: :destroy
+    has_many :images, as: :imageable, inverse_of: :imageable, dependent: :destroy
     accepts_nested_attributes_for :images, allow_destroy: true, update_only: true
 
     def image_url(style)

--- a/app/models/concerns/imageable.rb
+++ b/app/models/concerns/imageable.rb
@@ -2,7 +2,7 @@ module Imageable
   extend ActiveSupport::Concern
 
   included do
-    has_one :image, as: :imageable, dependent: :destroy
+    has_one :image, as: :imageable, inverse_of: :imageable, dependent: :destroy
     accepts_nested_attributes_for :image, allow_destroy: true, update_only: true
 
     def image_url(style)

--- a/app/models/concerns/linkable.rb
+++ b/app/models/concerns/linkable.rb
@@ -2,7 +2,7 @@ module Linkable
   extend ActiveSupport::Concern
 
   included do
-    has_many :links, as: :linkable, dependent: :destroy
+    has_many :links, as: :linkable, inverse_of: :linkable, dependent: :destroy
     accepts_nested_attributes_for :links, allow_destroy: true
   end
 end

--- a/app/models/concerns/milestoneable.rb
+++ b/app/models/concerns/milestoneable.rb
@@ -2,11 +2,11 @@ module Milestoneable
   extend ActiveSupport::Concern
 
   included do
-    has_many :milestones, as: :milestoneable, dependent: :destroy
+    has_many :milestones, as: :milestoneable, inverse_of: :milestoneable, dependent: :destroy
 
     scope :with_milestones, -> { joins(:milestones).distinct }
 
-    has_many :progress_bars, as: :progressable
+    has_many :progress_bars, as: :progressable, inverse_of: :progressable
 
     acts_as_taggable_on :milestone_tags
 

--- a/app/models/concerns/relationable.rb
+++ b/app/models/concerns/relationable.rb
@@ -2,7 +2,10 @@ module Relationable
   extend ActiveSupport::Concern
 
   included do
-    has_many :related_contents, as: :parent_relationable, dependent: :destroy
+    has_many :related_contents,
+      as:         :parent_relationable,
+      inverse_of: :parent_relationable,
+      dependent:  :destroy
   end
 
   def find_related_content(relationable)

--- a/app/models/concerns/reportable.rb
+++ b/app/models/concerns/reportable.rb
@@ -2,7 +2,7 @@ module Reportable
   extend ActiveSupport::Concern
 
   included do
-    has_one :report, as: :process, dependent: :destroy
+    has_one :report, as: :process, inverse_of: :process, dependent: :destroy
     accepts_nested_attributes_for :report
   end
 

--- a/app/models/concerns/stats_versionable.rb
+++ b/app/models/concerns/stats_versionable.rb
@@ -2,7 +2,7 @@ module StatsVersionable
   extend ActiveSupport::Concern
 
   included do
-    has_one :stats_version, as: :process
+    has_one :stats_version, as: :process, inverse_of: :process
   end
 
   def find_or_create_stats_version

--- a/app/models/dashboard/executed_action.rb
+++ b/app/models/dashboard/executed_action.rb
@@ -1,9 +1,8 @@
 class Dashboard::ExecutedAction < ApplicationRecord
   belongs_to :proposal
-  belongs_to :action, class_name: "Dashboard::Action"
+  belongs_to :action
 
-  has_many :administrator_tasks, as: :source, dependent: :destroy,
-                                              class_name: "Dashboard::AdministratorTask"
+  has_many :administrator_tasks, as: :source, dependent: :destroy
 
   validates :proposal, presence: true, uniqueness: { scope: :action }
   validates :action, presence: true

--- a/app/models/dashboard/executed_action.rb
+++ b/app/models/dashboard/executed_action.rb
@@ -2,7 +2,7 @@ class Dashboard::ExecutedAction < ApplicationRecord
   belongs_to :proposal
   belongs_to :action
 
-  has_many :administrator_tasks, as: :source, dependent: :destroy
+  has_many :administrator_tasks, as: :source, inverse_of: :source, dependent: :destroy
 
   validates :proposal, presence: true, uniqueness: { scope: :action }
   validates :action, presence: true

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -24,9 +24,9 @@ class Debate < ApplicationRecord
   translates :description, touch: true
   include Globalizable
 
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :debates
   belongs_to :geozone
-  has_many :comments, as: :commentable
+  has_many :comments, as: :commentable, inverse_of: :commentable
 
   extend DownloadSettings::DebateCsv
   delegate :name, :email, to: :author, prefix: true

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -24,7 +24,7 @@ class Debate < ApplicationRecord
   translates :description, touch: true
   include Globalizable
 
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
   belongs_to :geozone
   has_many :comments, as: :commentable
 

--- a/app/models/direct_message.rb
+++ b/app/models/direct_message.rb
@@ -1,6 +1,6 @@
 class DirectMessage < ApplicationRecord
-  belongs_to :sender,   class_name: "User", foreign_key: "sender_id"
-  belongs_to :receiver, class_name: "User", foreign_key: "receiver_id"
+  belongs_to :sender,   class_name: "User"
+  belongs_to :receiver, class_name: "User"
 
   validates :title,    presence: true
   validates :body,     presence: true

--- a/app/models/direct_message.rb
+++ b/app/models/direct_message.rb
@@ -1,6 +1,6 @@
 class DirectMessage < ApplicationRecord
-  belongs_to :sender,   class_name: "User"
-  belongs_to :receiver, class_name: "User"
+  belongs_to :sender,   class_name: "User", inverse_of: :direct_messages_sent
+  belongs_to :receiver, class_name: "User", inverse_of: :direct_messages_received
 
   validates :title,    presence: true
   validates :body,     presence: true

--- a/app/models/geozones_poll.rb
+++ b/app/models/geozones_poll.rb
@@ -1,0 +1,4 @@
+class GeozonesPoll < ApplicationRecord
+  belongs_to :geozone
+  belongs_to :poll
+end

--- a/app/models/legislation/annotation.rb
+++ b/app/models/legislation/annotation.rb
@@ -6,7 +6,7 @@ class Legislation::Annotation < ApplicationRecord
   serialize :ranges, Array
 
   belongs_to :draft_version, class_name: "Legislation::DraftVersion", foreign_key: "legislation_draft_version_id"
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
   has_many :comments, as: :commentable, dependent: :destroy
 
   validates :text, presence: true

--- a/app/models/legislation/annotation.rb
+++ b/app/models/legislation/annotation.rb
@@ -6,7 +6,7 @@ class Legislation::Annotation < ApplicationRecord
   serialize :ranges, Array
 
   belongs_to :draft_version, foreign_key: "legislation_draft_version_id"
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :legislation_annotations
   has_many :comments, as: :commentable, dependent: :destroy
 
   validates :text, presence: true

--- a/app/models/legislation/annotation.rb
+++ b/app/models/legislation/annotation.rb
@@ -5,9 +5,9 @@ class Legislation::Annotation < ApplicationRecord
 
   serialize :ranges, Array
 
-  belongs_to :draft_version, foreign_key: "legislation_draft_version_id"
+  belongs_to :draft_version, foreign_key: "legislation_draft_version_id", inverse_of: :annotations
   belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :legislation_annotations
-  has_many :comments, as: :commentable, dependent: :destroy
+  has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :destroy
 
   validates :text, presence: true
   validates :quote, presence: true

--- a/app/models/legislation/annotation.rb
+++ b/app/models/legislation/annotation.rb
@@ -5,7 +5,7 @@ class Legislation::Annotation < ApplicationRecord
 
   serialize :ranges, Array
 
-  belongs_to :draft_version, class_name: "Legislation::DraftVersion", foreign_key: "legislation_draft_version_id"
+  belongs_to :draft_version, foreign_key: "legislation_draft_version_id"
   belongs_to :author, -> { with_hidden }, class_name: "User"
   has_many :comments, as: :commentable, dependent: :destroy
 

--- a/app/models/legislation/answer.rb
+++ b/app/models/legislation/answer.rb
@@ -2,9 +2,8 @@ class Legislation::Answer < ApplicationRecord
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
-  belongs_to :question, class_name: "Legislation::Question", foreign_key: "legislation_question_id",
-                        inverse_of: :answers, counter_cache: true
-  belongs_to :question_option, class_name: "Legislation::QuestionOption", foreign_key: "legislation_question_option_id",
+  belongs_to :question, foreign_key: "legislation_question_id", inverse_of: :answers, counter_cache: true
+  belongs_to :question_option, foreign_key: "legislation_question_option_id",
                                inverse_of: :answers, counter_cache: true
   belongs_to :user, dependent: :destroy, inverse_of: :legislation_answers
 

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -9,8 +9,11 @@ class Legislation::DraftVersion < ApplicationRecord
   translates :body,      touch: true
   include Globalizable
 
-  belongs_to :process, foreign_key: "legislation_process_id"
-  has_many :annotations, foreign_key: "legislation_draft_version_id", dependent: :destroy
+  belongs_to :process, foreign_key: "legislation_process_id", inverse_of: :draft_versions
+  has_many :annotations,
+    foreign_key: "legislation_draft_version_id",
+    inverse_of:  :draft_version,
+    dependent:   :destroy
 
   validates_translation :title, presence: true
   validates_translation :body, presence: true

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -9,8 +9,8 @@ class Legislation::DraftVersion < ApplicationRecord
   translates :body,      touch: true
   include Globalizable
 
-  belongs_to :process, class_name: "Legislation::Process", foreign_key: "legislation_process_id"
-  has_many :annotations, class_name: "Legislation::Annotation", foreign_key: "legislation_draft_version_id", dependent: :destroy
+  belongs_to :process, foreign_key: "legislation_process_id"
+  has_many :annotations, foreign_key: "legislation_draft_version_id", dependent: :destroy
 
   validates_translation :title, presence: true
   validates_translation :body, presence: true

--- a/app/models/legislation/people_proposal.rb
+++ b/app/models/legislation/people_proposal.rb
@@ -19,7 +19,7 @@ class Legislation::PeopleProposal < ApplicationRecord
   acts_as_votable
   acts_as_paranoid column: :hidden_at
 
-  belongs_to :process, class_name: "Legislation::Process", foreign_key: "legislation_process_id"
+  belongs_to :process, foreign_key: "legislation_process_id"
   belongs_to :author, -> { with_hidden }, class_name: "User"
   has_many :comments, as: :commentable
 

--- a/app/models/legislation/people_proposal.rb
+++ b/app/models/legislation/people_proposal.rb
@@ -19,9 +19,9 @@ class Legislation::PeopleProposal < ApplicationRecord
   acts_as_votable
   acts_as_paranoid column: :hidden_at
 
-  belongs_to :process, foreign_key: "legislation_process_id"
-  belongs_to :author, -> { with_hidden }, class_name: "User"
-  has_many :comments, as: :commentable
+  belongs_to :process, foreign_key: "legislation_process_id", inverse_of: :people_proposals
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :people_proposals
+  has_many :comments, as: :commentable, inverse_of: :commentable
 
   validates :title, presence: true
   validates :summary, presence: true

--- a/app/models/legislation/people_proposal.rb
+++ b/app/models/legislation/people_proposal.rb
@@ -20,7 +20,7 @@ class Legislation::PeopleProposal < ApplicationRecord
   acts_as_paranoid column: :hidden_at
 
   belongs_to :process, class_name: "Legislation::Process", foreign_key: "legislation_process_id"
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
   has_many :comments, as: :commentable
 
   validates :title, presence: true

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -25,18 +25,13 @@ class Legislation::Process < ApplicationRecord
 
   CSS_HEX_COLOR = /\A#?(?:[A-F0-9]{3}){1,2}\z/i
 
-  has_many :draft_versions, -> { order(:id) }, class_name: "Legislation::DraftVersion",
-                                               foreign_key: "legislation_process_id",
-                                               dependent: :destroy
+  has_many :draft_versions, -> { order(:id) }, foreign_key: "legislation_process_id", dependent: :destroy
   has_one :final_draft_version, -> { where final_version: true, status: "published" },
                                            class_name: "Legislation::DraftVersion",
                                            foreign_key: "legislation_process_id"
-  has_many :questions, -> { order(:id) }, class_name: "Legislation::Question",
-                                          foreign_key: "legislation_process_id", dependent: :destroy
-  has_many :proposals, -> { order(:id) }, class_name: "Legislation::Proposal",
-                                          foreign_key: "legislation_process_id", dependent: :destroy
-  has_many :people_proposals, -> { order(:id) }, class_name: "Legislation::PeopleProposal",
-                                          foreign_key: "legislation_process_id", dependent: :destroy
+  has_many :questions, -> { order(:id) }, foreign_key: "legislation_process_id", dependent: :destroy
+  has_many :proposals, -> { order(:id) }, foreign_key: "legislation_process_id", dependent: :destroy
+  has_many :people_proposals, -> { order(:id) }, foreign_key: "legislation_process_id", dependent: :destroy
 
   validates_translation :title, presence: true
   validates :start_date, presence: true

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -25,13 +25,26 @@ class Legislation::Process < ApplicationRecord
 
   CSS_HEX_COLOR = /\A#?(?:[A-F0-9]{3}){1,2}\z/i
 
-  has_many :draft_versions, -> { order(:id) }, foreign_key: "legislation_process_id", dependent: :destroy
+  has_many :draft_versions, -> { order(:id) },
+    foreign_key: "legislation_process_id",
+    inverse_of:  :process,
+    dependent:   :destroy
   has_one :final_draft_version, -> { where final_version: true, status: "published" },
-                                           class_name: "Legislation::DraftVersion",
-                                           foreign_key: "legislation_process_id"
-  has_many :questions, -> { order(:id) }, foreign_key: "legislation_process_id", dependent: :destroy
-  has_many :proposals, -> { order(:id) }, foreign_key: "legislation_process_id", dependent: :destroy
-  has_many :people_proposals, -> { order(:id) }, foreign_key: "legislation_process_id", dependent: :destroy
+    class_name:  "Legislation::DraftVersion",
+    foreign_key: "legislation_process_id",
+    inverse_of:  :process
+  has_many :questions, -> { order(:id) },
+    foreign_key: "legislation_process_id",
+    inverse_of:  :process,
+    dependent:   :destroy
+  has_many :proposals, -> { order(:id) },
+    foreign_key: "legislation_process_id",
+    inverse_of:  :process,
+    dependent:   :destroy
+  has_many :people_proposals, -> { order(:id) },
+    foreign_key: "legislation_process_id",
+    inverse_of:  :process,
+    dependent:   :destroy
 
   validates_translation :title, presence: true
   validates :start_date, presence: true

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -19,7 +19,7 @@ class Legislation::Proposal < ApplicationRecord
   acts_as_votable
   acts_as_paranoid column: :hidden_at
 
-  belongs_to :process, class_name: "Legislation::Process", foreign_key: "legislation_process_id"
+  belongs_to :process, foreign_key: "legislation_process_id"
   belongs_to :author, -> { with_hidden }, class_name: "User"
   belongs_to :geozone
   has_many :comments, as: :commentable

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -20,7 +20,7 @@ class Legislation::Proposal < ApplicationRecord
   acts_as_paranoid column: :hidden_at
 
   belongs_to :process, class_name: "Legislation::Process", foreign_key: "legislation_process_id"
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
   belongs_to :geozone
   has_many :comments, as: :commentable
 

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -20,7 +20,7 @@ class Legislation::Proposal < ApplicationRecord
   acts_as_paranoid column: :hidden_at
 
   belongs_to :process, foreign_key: "legislation_process_id"
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :legislation_proposals
   belongs_to :geozone
   has_many :comments, as: :commentable
 

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -19,10 +19,10 @@ class Legislation::Proposal < ApplicationRecord
   acts_as_votable
   acts_as_paranoid column: :hidden_at
 
-  belongs_to :process, foreign_key: "legislation_process_id"
+  belongs_to :process, foreign_key: "legislation_process_id", inverse_of: :proposals
   belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :legislation_proposals
   belongs_to :geozone
-  has_many :comments, as: :commentable
+  has_many :comments, as: :commentable, inverse_of: :commentable
 
   validates :title, presence: true
   validates :summary, presence: true

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -7,7 +7,7 @@ class Legislation::Question < ApplicationRecord
   include Globalizable
 
   belongs_to :author, -> { with_hidden }, class_name: "User"
-  belongs_to :process, class_name: "Legislation::Process", foreign_key: "legislation_process_id"
+  belongs_to :process, foreign_key: "legislation_process_id"
 
   has_many :question_options, -> { order(:id) }, class_name: "Legislation::QuestionOption", foreign_key: "legislation_question_id",
                                                  dependent: :destroy, inverse_of: :question

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -6,7 +6,7 @@ class Legislation::Question < ApplicationRecord
   translates :title, touch: true
   include Globalizable
 
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :legislation_questions
   belongs_to :process, foreign_key: "legislation_process_id"
 
   has_many :question_options, -> { order(:id) }, class_name: "Legislation::QuestionOption", foreign_key: "legislation_question_id",

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -6,7 +6,7 @@ class Legislation::Question < ApplicationRecord
   translates :title, touch: true
   include Globalizable
 
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
   belongs_to :process, class_name: "Legislation::Process", foreign_key: "legislation_process_id"
 
   has_many :question_options, -> { order(:id) }, class_name: "Legislation::QuestionOption", foreign_key: "legislation_question_id",

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -7,12 +7,12 @@ class Legislation::Question < ApplicationRecord
   include Globalizable
 
   belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :legislation_questions
-  belongs_to :process, foreign_key: "legislation_process_id"
+  belongs_to :process, foreign_key: "legislation_process_id", inverse_of: :questions
 
   has_many :question_options, -> { order(:id) }, class_name: "Legislation::QuestionOption", foreign_key: "legislation_question_id",
                                                  dependent: :destroy, inverse_of: :question
   has_many :answers, class_name: "Legislation::Answer", foreign_key: "legislation_question_id", dependent: :destroy, inverse_of: :question
-  has_many :comments, as: :commentable, dependent: :destroy
+  has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :destroy
 
   accepts_nested_attributes_for :question_options, reject_if: proc { |attributes| attributes.all? { |k, v| v.blank? } }, allow_destroy: true
 

--- a/app/models/legislation/question_option.rb
+++ b/app/models/legislation/question_option.rb
@@ -5,8 +5,8 @@ class Legislation::QuestionOption < ApplicationRecord
   translates :value, touch: true
   include Globalizable
 
-  belongs_to :question, class_name: "Legislation::Question", foreign_key: "legislation_question_id", inverse_of: :question_options
-  has_many :answers, class_name: "Legislation::Answer", foreign_key: "legislation_question_id", dependent: :destroy, inverse_of: :question
+  belongs_to :question, foreign_key: "legislation_question_id", inverse_of: :question_options
+  has_many :answers, foreign_key: "legislation_question_id", dependent: :destroy, inverse_of: :question
 
   validates :question, presence: true
   validates_translation :value, presence: true

--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -1,5 +1,5 @@
 class Newsletter < ApplicationRecord
-  has_many :activities, as: :actionable
+  has_many :activities, as: :actionable, inverse_of: :actionable
 
   validates :subject, presence: true
   validates :segment_recipient, presence: true

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -27,7 +27,8 @@ class Poll < ApplicationRecord
   has_many :comments, as: :commentable, inverse_of: :commentable
   has_many :ballot_sheets
 
-  has_and_belongs_to_many :geozones
+  has_many :geozones_polls
+  has_many :geozones, through: :geozones_polls
   belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :polls
   belongs_to :related, polymorphic: true
   belongs_to :budget

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -28,7 +28,7 @@ class Poll < ApplicationRecord
   has_many :ballot_sheets
 
   has_and_belongs_to_many :geozones
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
   belongs_to :related, polymorphic: true
   belongs_to :budget
 

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -28,7 +28,7 @@ class Poll < ApplicationRecord
   has_many :ballot_sheets
 
   has_and_belongs_to_many :geozones
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :polls
   belongs_to :related, polymorphic: true
   belongs_to :budget
 

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -24,7 +24,7 @@ class Poll < ApplicationRecord
   has_many :officer_assignments, through: :booth_assignments
   has_many :officers, through: :officer_assignments
   has_many :questions, inverse_of: :poll, dependent: :destroy
-  has_many :comments, as: :commentable
+  has_many :comments, as: :commentable, inverse_of: :commentable
   has_many :ballot_sheets
 
   has_and_belongs_to_many :geozones

--- a/app/models/poll/answer.rb
+++ b/app/models/poll/answer.rb
@@ -1,5 +1,5 @@
 class Poll::Answer < ApplicationRecord
-  belongs_to :question, -> { with_hidden }
+  belongs_to :question, -> { with_hidden }, inverse_of: :answers
   belongs_to :author, ->   { with_hidden }, class_name: "User", inverse_of: :poll_answers
 
   delegate :poll, :poll_id, to: :question

--- a/app/models/poll/answer.rb
+++ b/app/models/poll/answer.rb
@@ -1,6 +1,6 @@
 class Poll::Answer < ApplicationRecord
   belongs_to :question, -> { with_hidden }
-  belongs_to :author, ->   { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, ->   { with_hidden }, class_name: "User"
 
   delegate :poll, :poll_id, to: :question
 

--- a/app/models/poll/answer.rb
+++ b/app/models/poll/answer.rb
@@ -1,6 +1,6 @@
 class Poll::Answer < ApplicationRecord
   belongs_to :question, -> { with_hidden }
-  belongs_to :author, ->   { with_hidden }, class_name: "User"
+  belongs_to :author, ->   { with_hidden }, class_name: "User", inverse_of: :poll_answers
 
   delegate :poll, :poll_id, to: :question
 

--- a/app/models/poll/ballot.rb
+++ b/app/models/poll/ballot.rb
@@ -1,5 +1,5 @@
 class Poll::Ballot < ApplicationRecord
-  belongs_to :ballot_sheet, class_name: "Poll::BallotSheet"
+  belongs_to :ballot_sheet
 
   validates :ballot_sheet_id, presence: true
 

--- a/app/models/poll/ballot_sheet.rb
+++ b/app/models/poll/ballot_sheet.rb
@@ -1,7 +1,7 @@
 class Poll::BallotSheet < ApplicationRecord
   belongs_to :poll
   belongs_to :officer_assignment
-  has_many :ballots, class_name: "Poll::Ballot"
+  has_many :ballots
 
   validates :data, presence: true
   validates :poll_id, presence: true

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -1,6 +1,6 @@
 class Poll
   class Booth < ApplicationRecord
-    has_many :booth_assignments, class_name: "Poll::BoothAssignment"
+    has_many :booth_assignments
     has_many :polls, through: :booth_assignments
     has_many :shifts
 

--- a/app/models/poll/booth_assignment.rb
+++ b/app/models/poll/booth_assignment.rb
@@ -5,7 +5,7 @@ class Poll
 
     before_destroy :destroy_poll_shifts, only: :destroy
 
-    has_many :officer_assignments, class_name: "Poll::OfficerAssignment", dependent: :destroy
+    has_many :officer_assignments, dependent: :destroy
     has_many :officers, through: :officer_assignments
     has_many :voters
     has_many :partial_results

--- a/app/models/poll/officer.rb
+++ b/app/models/poll/officer.rb
@@ -1,8 +1,8 @@
 class Poll
   class Officer < ApplicationRecord
     belongs_to :user
-    has_many :officer_assignments, class_name: "Poll::OfficerAssignment"
-    has_many :shifts, class_name: "Poll::Shift"
+    has_many :officer_assignments
+    has_many :shifts
     has_many :failed_census_calls, foreign_key: :poll_officer_id
 
     validates :user_id, presence: true, uniqueness: true

--- a/app/models/poll/officer.rb
+++ b/app/models/poll/officer.rb
@@ -3,7 +3,7 @@ class Poll
     belongs_to :user
     has_many :officer_assignments
     has_many :shifts
-    has_many :failed_census_calls, foreign_key: :poll_officer_id
+    has_many :failed_census_calls, foreign_key: :poll_officer_id, inverse_of: :poll_officer
 
     validates :user_id, presence: true, uniqueness: true
 

--- a/app/models/poll/pair_answer.rb
+++ b/app/models/poll/pair_answer.rb
@@ -1,8 +1,8 @@
 class Poll::PairAnswer < ApplicationRecord
   belongs_to :question, -> { with_hidden }
-  belongs_to :author, ->   { with_hidden }, class_name: "User", foreign_key: "author_id"
-  belongs_to :answer_right, class_name: "Poll::Question::Answer", foreign_key: "answer_rigth_id"
-  belongs_to :answer_left, class_name: "Poll::Question::Answer", foreign_key: "answer_left_id"
+  belongs_to :author, ->   { with_hidden }, class_name: "User"
+  belongs_to :answer_right, class_name: "Poll::Question::Answer"
+  belongs_to :answer_left, class_name: "Poll::Question::Answer"
 
   delegate :poll, :poll_id, to: :question
 

--- a/app/models/poll/pair_answer.rb
+++ b/app/models/poll/pair_answer.rb
@@ -1,6 +1,6 @@
 class Poll::PairAnswer < ApplicationRecord
   belongs_to :question, -> { with_hidden }
-  belongs_to :author, ->   { with_hidden }, class_name: "User"
+  belongs_to :author, ->   { with_hidden }, class_name: "User", inverse_of: :poll_pair_answers
   belongs_to :answer_right, class_name: "Poll::Question::Answer"
   belongs_to :answer_left, class_name: "Poll::Question::Answer"
 

--- a/app/models/poll/pair_answer.rb
+++ b/app/models/poll/pair_answer.rb
@@ -1,5 +1,5 @@
 class Poll::PairAnswer < ApplicationRecord
-  belongs_to :question, -> { with_hidden }
+  belongs_to :question, -> { with_hidden }, inverse_of: :pair_answers
   belongs_to :author, ->   { with_hidden }, class_name: "User", inverse_of: :poll_pair_answers
   belongs_to :answer_right, class_name: "Poll::Question::Answer"
   belongs_to :answer_left, class_name: "Poll::Question::Answer"

--- a/app/models/poll/partial_result.rb
+++ b/app/models/poll/partial_result.rb
@@ -2,7 +2,7 @@ class Poll::PartialResult < ApplicationRecord
   VALID_ORIGINS = %w[web booth]
 
   belongs_to :question, -> { with_hidden }
-  belongs_to :author, ->   { with_hidden }, class_name: "User"
+  belongs_to :author, ->   { with_hidden }, class_name: "User", inverse_of: :poll_partial_results
   belongs_to :booth_assignment
   belongs_to :officer_assignment
 

--- a/app/models/poll/partial_result.rb
+++ b/app/models/poll/partial_result.rb
@@ -2,7 +2,7 @@ class Poll::PartialResult < ApplicationRecord
   VALID_ORIGINS = %w[web booth]
 
   belongs_to :question, -> { with_hidden }
-  belongs_to :author, ->   { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, ->   { with_hidden }, class_name: "User"
   belongs_to :booth_assignment
   belongs_to :officer_assignment
 

--- a/app/models/poll/partial_result.rb
+++ b/app/models/poll/partial_result.rb
@@ -1,7 +1,7 @@
 class Poll::PartialResult < ApplicationRecord
   VALID_ORIGINS = %w[web booth]
 
-  belongs_to :question, -> { with_hidden }
+  belongs_to :question, -> { with_hidden }, inverse_of: :partial_results
   belongs_to :author, ->   { with_hidden }, class_name: "User", inverse_of: :poll_partial_results
   belongs_to :booth_assignment
   belongs_to :officer_assignment

--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -9,7 +9,7 @@ class Poll::Question < ApplicationRecord
   include Globalizable
 
   belongs_to :poll
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :poll_questions
 
   has_many :comments, as: :commentable
   has_many :answers, class_name: "Poll::Answer"

--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -11,12 +11,15 @@ class Poll::Question < ApplicationRecord
   belongs_to :poll
   belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :poll_questions
 
-  has_many :comments, as: :commentable
+  has_many :comments, as: :commentable, inverse_of: :commentable
   has_many :answers, class_name: "Poll::Answer"
-  has_many :question_answers, -> { order "given_order asc" }, class_name: "Poll::Question::Answer", dependent: :destroy
+  has_many :question_answers, -> { order "given_order asc" },
+    class_name: "Poll::Question::Answer",
+    inverse_of: :question,
+    dependent:  :destroy
   has_many :partial_results
   has_many :pair_answers
-  has_one :votation_type, as: :questionable
+  has_one :votation_type, as: :questionable, inverse_of: :questionable
   belongs_to :proposal
 
   attr_accessor :enum_type, :max_votes, :prioritization_type

--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -15,7 +15,7 @@ class Poll::Question < ApplicationRecord
   has_many :answers, class_name: "Poll::Answer"
   has_many :question_answers, -> { order "given_order asc" }, class_name: "Poll::Question::Answer", dependent: :destroy
   has_many :partial_results
-  has_many :pair_answers, class_name: "Poll::PairAnswer"
+  has_many :pair_answers
   has_one :votation_type, as: :questionable
   belongs_to :proposal
 

--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -9,7 +9,7 @@ class Poll::Question < ApplicationRecord
   include Globalizable
 
   belongs_to :poll
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
 
   has_many :comments, as: :commentable
   has_many :answers, class_name: "Poll::Answer"

--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -9,7 +9,7 @@ class Poll::Question::Answer < ApplicationRecord
 
   accepts_nested_attributes_for :documents, allow_destroy: true
 
-  belongs_to :question, class_name: "Poll::Question", foreign_key: "question_id"
+  belongs_to :question, class_name: "Poll::Question"
   has_many :videos, class_name: "Poll::Question::Answer::Video"
 
   validates_translation :title, presence: true

--- a/app/models/poll/question/answer/video.rb
+++ b/app/models/poll/question/answer/video.rb
@@ -1,5 +1,5 @@
 class Poll::Question::Answer::Video < ApplicationRecord
-  belongs_to :answer, class_name: "Poll::Question::Answer", foreign_key: "answer_id"
+  belongs_to :answer, class_name: "Poll::Question::Answer"
 
   VIMEO_REGEX = /vimeo.*(staffpicks\/|channels\/|videos\/|video\/|\/)([^#\&\?]*).*/
   YOUTUBE_REGEX = /youtu.*(be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/

--- a/app/models/poll/recount.rb
+++ b/app/models/poll/recount.rb
@@ -1,7 +1,7 @@
 class Poll::Recount < ApplicationRecord
   VALID_ORIGINS = %w[web booth letter].freeze
 
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
   belongs_to :booth_assignment
   belongs_to :officer_assignment
 

--- a/app/models/poll/recount.rb
+++ b/app/models/poll/recount.rb
@@ -1,7 +1,7 @@
 class Poll::Recount < ApplicationRecord
   VALID_ORIGINS = %w[web booth letter].freeze
 
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :poll_recounts
   belongs_to :booth_assignment
   belongs_to :officer_assignment
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -35,13 +35,13 @@ class Proposal < ApplicationRecord
   include Globalizable
   translation_class_delegate :retired_at
 
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :proposals
   belongs_to :geozone
-  has_many :comments, as: :commentable, dependent: :destroy
+  has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :destroy
   has_many :proposal_notifications, dependent: :destroy
   has_many :dashboard_executed_actions, dependent: :destroy, class_name: "Dashboard::ExecutedAction"
   has_many :dashboard_actions, through: :dashboard_executed_actions, class_name: "Dashboard::Action"
-  has_many :polls, as: :related
+  has_many :polls, as: :related, inverse_of: :related
 
   extend DownloadSettings::ProposalCsv
   delegate :name, :email, to: :author, prefix: true

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -35,7 +35,7 @@ class Proposal < ApplicationRecord
   include Globalizable
   translation_class_delegate :retired_at
 
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
   belongs_to :geozone
   has_many :comments, as: :commentable, dependent: :destroy
   has_many :proposal_notifications, dependent: :destroy

--- a/app/models/proposal_notification.rb
+++ b/app/models/proposal_notification.rb
@@ -2,7 +2,7 @@ class ProposalNotification < ApplicationRecord
   include Graphqlable
   include Notifiable
 
-  belongs_to :author, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, class_name: "User"
   belongs_to :proposal
 
   validates :title, presence: true

--- a/app/models/related_content.rb
+++ b/app/models/related_content.rb
@@ -8,7 +8,7 @@ class RelatedContent < ApplicationRecord
   belongs_to :author, class_name: "User"
   belongs_to :parent_relationable, polymorphic: true, touch: true
   belongs_to :child_relationable, polymorphic: true, touch: true
-  has_one :opposite_related_content, class_name: "RelatedContent", foreign_key: :related_content_id
+  has_one :opposite_related_content, class_name: self.name, foreign_key: :related_content_id
   has_many :related_content_scores
 
   validates :parent_relationable_id, presence: true

--- a/app/models/related_content.rb
+++ b/app/models/related_content.rb
@@ -5,7 +5,7 @@ class RelatedContent < ApplicationRecord
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
-  belongs_to :author, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, class_name: "User"
   belongs_to :parent_relationable, polymorphic: true, touch: true
   belongs_to :child_relationable, polymorphic: true, touch: true
   has_one :opposite_related_content, class_name: "RelatedContent", foreign_key: :related_content_id

--- a/app/models/signature_sheet.rb
+++ b/app/models/signature_sheet.rb
@@ -1,6 +1,6 @@
 class SignatureSheet < ApplicationRecord
   belongs_to :signable, polymorphic: true
-  belongs_to :author, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, class_name: "User"
 
   VALID_SIGNABLES = %w[Proposal Budget::Investment]
 

--- a/app/models/site_customization/page.rb
+++ b/app/models/site_customization/page.rb
@@ -1,6 +1,9 @@
 class SiteCustomization::Page < ApplicationRecord
   VALID_STATUSES = %w[draft published]
-  has_many :cards, class_name: "Widget::Card", foreign_key: "site_customization_page_id"
+  has_many :cards,
+    class_name:  "Widget::Card",
+    foreign_key: "site_customization_page_id",
+    inverse_of:  :page
 
   translates :title,       touch: true
   translates :subtitle,    touch: true

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -6,7 +6,7 @@ class Topic < ApplicationRecord
   belongs_to :community
   belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :topics
 
-  has_many :comments, as: :commentable
+  has_many :comments, as: :commentable, inverse_of: :commentable
 
   validates :title, presence: true
   validates :description, presence: true

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -4,7 +4,7 @@ class Topic < ApplicationRecord
   include Notifiable
 
   belongs_to :community
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
 
   has_many :comments, as: :commentable
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -4,7 +4,7 @@ class Topic < ApplicationRecord
   include Notifiable
 
   belongs_to :community
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :topics
 
   has_many :comments, as: :commentable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,12 @@ class User < ApplicationRecord
   has_many :debates, -> { with_hidden }, foreign_key: :author_id
   has_many :proposals, -> { with_hidden }, foreign_key: :author_id
   has_many :people_proposals, -> { with_hidden }, foreign_key: :author_id
+  has_many :activities
   has_many :budget_investments, -> { with_hidden }, foreign_key: :author_id, class_name: "Budget::Investment"
+  has_many :budget_investment_change_logs,
+    foreign_key: :author_id,
+    inverse_of:  :author,
+    class_name:  "Budget::Investment::ChangeLog"
   has_many :comments, -> { with_hidden }
   has_many :failed_census_calls
   has_many :notifications
@@ -33,6 +38,40 @@ class User < ApplicationRecord
   has_many :legislation_answers, class_name: "Legislation::Answer", dependent: :destroy, inverse_of: :user
   has_many :follows
   has_many :budget_rol_assignments
+  has_many :legislation_annotations,
+    class_name:  "Legislation::Annotation",
+    foreign_key: :author_id,
+    inverse_of:  :author
+  has_many :legislation_proposals,
+    class_name:  "Legislation::Proposal",
+    foreign_key: :author_id,
+    inverse_of:  :author
+  has_many :legislation_questions,
+    class_name:  "Legislation::Question",
+    foreign_key: :author_id,
+    inverse_of:  :author
+  has_many :polls, foreign_key: :author_id, inverse_of: :author
+  has_many :poll_answers,
+    class_name:  "Poll::Answer",
+    foreign_key: :author_id,
+    inverse_of:  :author
+  has_many :poll_pair_answers,
+    class_name:  "Poll::PairAnswer",
+    foreign_key: :author_id,
+    inverse_of:  :author
+  has_many :poll_partial_results,
+    class_name:  "Poll::PartialResult",
+    foreign_key: :author_id,
+    inverse_of:  :author
+  has_many :poll_questions,
+    class_name:  "Poll::Question",
+    foreign_key: :author_id,
+    inverse_of:  :author
+  has_many :poll_recounts,
+    class_name:  "Poll::Recount",
+    foreign_key: :author_id,
+    inverse_of:  :author
+  has_many :topics, foreign_key: :author_id, inverse_of: :author
   has_many :budgets, through: :budget_rol_assignments
   has_many :votation_set_answers
   belongs_to :geozone

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,20 +21,29 @@ class User < ApplicationRecord
   has_one :lock
   has_many :flags
   has_many :identities, dependent: :destroy
-  has_many :debates, -> { with_hidden }, foreign_key: :author_id
-  has_many :proposals, -> { with_hidden }, foreign_key: :author_id
-  has_many :people_proposals, -> { with_hidden }, foreign_key: :author_id
+  has_many :debates, -> { with_hidden }, foreign_key: :author_id, inverse_of: :author
+  has_many :proposals, -> { with_hidden }, foreign_key: :author_id, inverse_of: :author
+  has_many :people_proposals, -> { with_hidden }, foreign_key: :author_id, inverse_of: :author
   has_many :activities
-  has_many :budget_investments, -> { with_hidden }, foreign_key: :author_id, class_name: "Budget::Investment"
+  has_many :budget_investments, -> { with_hidden },
+    class_name:  "Budget::Investment",
+    foreign_key: :author_id,
+    inverse_of:  :author
   has_many :budget_investment_change_logs,
     foreign_key: :author_id,
     inverse_of:  :author,
     class_name:  "Budget::Investment::ChangeLog"
-  has_many :comments, -> { with_hidden }
+  has_many :comments, -> { with_hidden }, inverse_of: :user
   has_many :failed_census_calls
   has_many :notifications
-  has_many :direct_messages_sent,     class_name: "DirectMessage", foreign_key: :sender_id
-  has_many :direct_messages_received, class_name: "DirectMessage", foreign_key: :receiver_id
+  has_many :direct_messages_sent,
+    class_name:  "DirectMessage",
+    foreign_key: :sender_id,
+    inverse_of:  :sender
+  has_many :direct_messages_received,
+    class_name:  "DirectMessage",
+    foreign_key: :receiver_id,
+    inverse_of:  :receiver
   has_many :legislation_answers, class_name: "Legislation::Answer", dependent: :destroy, inverse_of: :user
   has_many :follows
   has_many :budget_rol_assignments

--- a/app/models/votation_set_answer.rb
+++ b/app/models/votation_set_answer.rb
@@ -1,6 +1,6 @@
 class VotationSetAnswer < ApplicationRecord
   belongs_to :votation_type
-  belongs_to :author, -> { with_hidden }, class_name: "User"
+  belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :votation_set_answers
 
   scope :by_author, -> (author) { where(author: author) }
 end

--- a/app/models/votation_set_answer.rb
+++ b/app/models/votation_set_answer.rb
@@ -1,6 +1,6 @@
 class VotationSetAnswer < ApplicationRecord
   belongs_to :votation_type
-  belongs_to :author, -> { with_hidden }, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, -> { with_hidden }, class_name: "User"
 
   scope :by_author, -> (author) { where(author: author) }
 end

--- a/app/models/widget/card.rb
+++ b/app/models/widget/card.rb
@@ -1,6 +1,9 @@
 class Widget::Card < ApplicationRecord
   include Imageable
-  belongs_to :page, class_name: "SiteCustomization::Page", foreign_key: "site_customization_page_id"
+  belongs_to :page,
+    class_name:  "SiteCustomization::Page",
+    foreign_key: "site_customization_page_id",
+    inverse_of:  :cards
 
   # table_name must be set before calls to 'translates'
   self.table_name = "widget_cards"

--- a/db/migrate/20191024025634_rename_rigth_id_to_right_id.rb
+++ b/db/migrate/20191024025634_rename_rigth_id_to_right_id.rb
@@ -1,0 +1,5 @@
+class RenameRigthIdToRightId < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :poll_pair_answers, :answer_rigth_id, :answer_right_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191020153455) do
+ActiveRecord::Schema.define(version: 20191024025634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1141,12 +1141,12 @@ ActiveRecord::Schema.define(version: 20191020153455) do
   create_table "poll_pair_answers", force: :cascade do |t|
     t.integer  "question_id"
     t.integer  "author_id"
-    t.integer  "answer_rigth_id"
+    t.integer  "answer_right_id"
     t.integer  "answer_left_id"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.index ["answer_left_id"], name: "index_poll_pair_answers_on_answer_left_id", using: :btree
-    t.index ["answer_rigth_id"], name: "index_poll_pair_answers_on_answer_rigth_id", using: :btree
+    t.index ["answer_right_id"], name: "index_poll_pair_answers_on_answer_right_id", using: :btree
     t.index ["author_id"], name: "index_poll_pair_answers_on_author_id", using: :btree
     t.index ["question_id"], name: "index_poll_pair_answers_on_question_id", using: :btree
   end


### PR DESCRIPTION
## Objectives

* Avoid potential issues building objects and relations, particularly before storing them in the database
* Simplify `foreign_key` and `class_name` options when defining relations