### PR TITLE
Add missing spanish translations

### DIFF
--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -4,7 +4,7 @@ en:
       verification:
         residence: "Residence"
         sms: "SMS"
-      local_census_record/import:
+      local_census_records/import:
         one: Local census record import
         other: Local census records imports
     attributes:
@@ -36,7 +36,7 @@ en:
         document_type: "Document type"
         document_number: "Document number (including letters)"
         year_of_birth: "Year born"
-      local_census_record/import:
+      local_census_records/import:
         file: File
     errors:
       models:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -682,6 +682,8 @@ es:
       multiple: "Puedes seleccionar un máximo de %{maximum} respuestas"
       answer_couples_open: "Elige una opción entre el siguiente par. Puedes elegir un máximo de %{maximum} respuestas"
       answer_couples_closed: "Elige una opción entre el siguiente par. Puedes elegir un máximo de %{maximum} respuestas"
+      answer_set_open: "Puede elegir un máximo de %{maximum} respuestas."
+      answer_set_closed: "Puede elegir un máximo de %{maximum} respuestas."
       prioritized: "Puedes seleccionar un máximo de %{maximum} respuestas. Esta pregunta utilizara el método %{system} para el recuento."
       positive_open: "Puedes seleccionar un máximo de %{maximum} respuestas y añadir tus propias respuestas."
       unique: ""


### PR DESCRIPTION
## References

* Pull Requests: #3500
* Commit e06bbaed missed these translations

## Objectives

Add spanish missing translations.

Running `i18n-tasks` for `es` locale i realized some translations were missing. After this change both `i18n-tasks` (unused and missing) are passing without errors.