### PR TITLE
Fix assigning staff members to budgets

### DIFF
--- a/app/assets/javascripts/budget_edit_associations.js
+++ b/app/assets/javascripts/budget_edit_associations.js
@@ -2,13 +2,13 @@
   "use strict";
   App.BudgetEditAssociations = {
     initialize: function() {
-      $(".js-budget-list-checkbox-user").on({
-        click: function() {
+      $(".js-budget-users-list [type='checkbox']").on({
+        change: function() {
           var admin_count, tracker_count, valuator_count;
 
-          admin_count = $(".js-budget-list-checkbox-administrators:checkbox:checked").length;
-          valuator_count = $(".js-budget-list-checkbox-valuators:checkbox:checked").length;
-          tracker_count = $(".js-budget-list-checkbox-trackers:checkbox:checked").length;
+          admin_count = $("#administrators_list :checked").length;
+          valuator_count = $("#valuators_list :checked").length;
+          tracker_count = $("#trackers_list :checked").length;
 
           App.I18n.set_pluralize($(".js-budget-show-administrators-list"), admin_count);
           App.I18n.set_pluralize($(".js-budget-show-valuators-list"), valuator_count);

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -110,7 +110,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_tags
-      @tags = Budget::Investment.tags_on(:valuation).order(:name).distinct
+      @tags = Budget::Investment.tags_on(:valuation_tags).order(:name).distinct
     end
 
     def load_ballot

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -104,16 +104,16 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_admins
-      @admins = @budget.administrators.includes(:user).all
+      @admins = @budget.administrators.includes(:user)
     end
 
     def load_trackers
-      @trackers = @budget.trackers.includes(:user).all.order(description: :asc)
+      @trackers = @budget.trackers.includes(:user).order(description: :asc)
                     .order("users.email ASC")
     end
 
     def load_valuators
-      @valuators = @budget.valuators.includes(:user).all.order(description: :asc)
+      @valuators = @budget.valuators.includes(:user).order(description: :asc)
                      .order("users.email ASC")
     end
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -36,10 +36,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
   end
 
   def edit
-    load_admins
-    load_valuators
+    load_staff
     load_valuator_groups
-    load_trackers
     load_tags
   end
 
@@ -51,10 +49,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
                                                       Budget::Investment.filter_params(params).to_h),
                   notice: t("flash.actions.update.budget_investment")
     else
-      load_admins
-      load_valuators
+      load_staff
       load_valuator_groups
-      load_trackers
       load_tags
       render :edit
     end
@@ -103,18 +99,10 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
       @investment = @budget.investments.find(params[:id])
     end
 
-    def load_admins
+    def load_staff
       @admins = @budget.administrators.includes(:user)
-    end
-
-    def load_trackers
-      @trackers = @budget.trackers.includes(:user).order(description: :asc)
-                    .order("users.email ASC")
-    end
-
-    def load_valuators
-      @valuators = @budget.valuators.includes(:user).order(description: :asc)
-                     .order("users.email ASC")
+      @trackers = @budget.trackers.includes(:user).order(description: :asc).order("users.email ASC")
+      @valuators = @budget.valuators.includes(:user).order(description: :asc).order("users.email ASC")
     end
 
     def load_valuator_groups

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -17,15 +17,11 @@ class Admin::BudgetsController < Admin::BaseController
   end
 
   def new
-    load_admins
-    load_valuators
-    load_trackers
+    load_staff
   end
 
   def edit
-    load_admins
-    load_valuators
-    load_trackers
+    load_staff
   end
 
   def calculate_winners
@@ -42,9 +38,7 @@ class Admin::BudgetsController < Admin::BaseController
     if @budget.update(budget_params)
       redirect_to admin_budgets_path, notice: t("admin.budgets.update.notice")
     else
-      load_admins
-      load_valuators
-      load_trackers
+      load_staff
       render :edit
     end
   end
@@ -54,9 +48,7 @@ class Admin::BudgetsController < Admin::BaseController
     if @budget.save
       redirect_to admin_budget_path(@budget), notice: t("admin.budgets.create.notice")
     else
-      load_admins
-      load_valuators
-      load_trackers
+      load_staff
       render :new
     end
   end
@@ -92,15 +84,9 @@ class Admin::BudgetsController < Admin::BaseController
       @budget = Budget.find_by_slug_or_id! params[:id]
     end
 
-    def load_admins
+    def load_staff
       @admins = Administrator.includes(:user)
-    end
-
-    def load_trackers
       @trackers = Tracker.includes(:user).order(description: :asc).order("users.email ASC")
-    end
-
-    def load_valuators
       @valuators = Valuator.includes(:user).order(description: :asc).order("users.email ASC")
     end
 end

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -70,9 +70,6 @@ class Admin::BudgetsController < Admin::BaseController
       descriptions = Budget::Phase::PHASE_KINDS.map { |p| "description_#{p}" }.map(&:to_sym)
       valid_attributes = [:phase,
                           :currency_symbol,
-                          :help_link,
-                          :milestone_tag_list,
-                          :valuation_tag_list,
                           administrator_ids: [],
                           valuator_ids: [],
                           tracker_ids: []

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -93,14 +93,14 @@ class Admin::BudgetsController < Admin::BaseController
     end
 
     def load_admins
-      @admins = Administrator.includes(:user).all
+      @admins = Administrator.includes(:user)
     end
 
     def load_trackers
-      @trackers = Tracker.includes(:user).all.order(description: :asc).order("users.email ASC")
+      @trackers = Tracker.includes(:user).order(description: :asc).order("users.email ASC")
     end
 
     def load_valuators
-      @valuators = Valuator.includes(:user).all.order(description: :asc).order("users.email ASC")
+      @valuators = Valuator.includes(:user).order(description: :asc).order("users.email ASC")
     end
 end

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -71,8 +71,8 @@ class Admin::BudgetsController < Admin::BaseController
       valid_attributes = [:phase,
                           :currency_symbol,
                           :help_link,
-                          :budget_milestone_tags,
-                          :budget_valuation_tags,
+                          :milestone_tag_list,
+                          :valuation_tag_list,
                           administrator_ids: [],
                           valuator_ids: [],
                           tracker_ids: []

--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -4,7 +4,7 @@ module BudgetExecutionsHelper
   end
 
   def options_for_milestone_tags
-    @budget.milestone_tags.map do |tag|
+    @budget.investments_milestone_tags.map do |tag|
       ["#{tag} (#{@budget.investments.winners.tagged_with(tag).count})", tag]
     end
   end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -54,13 +54,13 @@ module BudgetsHelper
   end
 
   def investment_tags_select_options(budget)
-    tags = Budget::Investment.by_budget(budget).tags_on(:valuation).order(:name).pluck(:name)
+    tags = budget.investments.tags_on(:valuation).order(:name).pluck(:name)
     tags = tags.concat budget.budget_valuation_tags.split(",") if budget.budget_valuation_tags.present?
     tags.uniq
   end
 
   def investment_milestone_tags_select_options(budget)
-    tags = Budget::Investment.by_budget(budget).tags_on(:milestone).order(:name).pluck(:name)
+    tags = budget.investments.tags_on(:milestone).order(:name).pluck(:name)
     tags = tags.concat budget.budget_milestone_tags.split(",") if budget.budget_milestone_tags.present?
     tags.uniq
   end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -55,13 +55,13 @@ module BudgetsHelper
 
   def investment_tags_select_options(budget)
     tags = budget.investments.tags_on(:valuation_tags).order(:name).pluck(:name)
-    tags = tags.concat budget.budget_valuation_tags.split(",") if budget.budget_valuation_tags.present?
+    tags = tags.concat budget.valuation_tag_list
     tags.uniq
   end
 
   def investment_milestone_tags_select_options(budget)
     tags = budget.investments.tags_on(:milestone_tags).order(:name).pluck(:name)
-    tags = tags.concat budget.budget_milestone_tags.split(",") if budget.budget_milestone_tags.present?
+    tags = tags.concat budget.milestone_tag_list
     tags.uniq
   end
 

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -54,10 +54,7 @@ module BudgetsHelper
   end
 
   def investment_tags_select_options(budget, context)
-    taggables = [budget] + budget.investments
-    Tag.joins(:taggings)
-       .merge(Tagging.where(taggable: taggables, context: context))
-       .distinct.order(:name).pluck(:name)
+    budget.investments.tags_on(context).order(:name).pluck(:name)
   end
 
   def unfeasible_or_unselected_filter

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -60,7 +60,7 @@ module BudgetsHelper
   end
 
   def investment_milestone_tags_select_options(budget)
-    tags = budget.investments.tags_on(:milestone).order(:name).pluck(:name)
+    tags = budget.investments.tags_on(:milestone_tags).order(:name).pluck(:name)
     tags = tags.concat budget.budget_milestone_tags.split(",") if budget.budget_milestone_tags.present?
     tags.uniq
   end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -53,15 +53,9 @@ module BudgetsHelper
     Budget::Ballot.where(user: current_user, budget: @budget).first
   end
 
-  def investment_tags_select_options(budget)
-    tags = budget.investments.tags_on(:valuation_tags).order(:name).pluck(:name)
-    tags = tags.concat budget.valuation_tag_list
-    tags.uniq
-  end
-
-  def investment_milestone_tags_select_options(budget)
-    tags = budget.investments.tags_on(:milestone_tags).order(:name).pluck(:name)
-    tags = tags.concat budget.milestone_tag_list
+  def investment_tags_select_options(budget, context)
+    tags = budget.investments.tags_on(context).order(:name).pluck(:name)
+    tags = tags.concat budget.tag_list_on(context)
     tags.uniq
   end
 

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -54,7 +54,7 @@ module BudgetsHelper
   end
 
   def investment_tags_select_options(budget)
-    tags = budget.investments.tags_on(:valuation).order(:name).pluck(:name)
+    tags = budget.investments.tags_on(:valuation_tags).order(:name).pluck(:name)
     tags = tags.concat budget.budget_valuation_tags.split(",") if budget.budget_valuation_tags.present?
     tags.uniq
   end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -54,9 +54,10 @@ module BudgetsHelper
   end
 
   def investment_tags_select_options(budget, context)
-    tags = budget.investments.tags_on(context).order(:name).pluck(:name)
-    tags = tags.concat budget.tag_list_on(context)
-    tags.uniq
+    taggables = [budget] + budget.investments
+    Tag.joins(:taggings)
+       .merge(Tagging.where(taggable: taggables, context: context))
+       .distinct.order(:name).pluck(:name)
   end
 
   def unfeasible_or_unselected_filter

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -1,7 +1,6 @@
 module TranslatableFormHelper
   def translatable_form_for(record, options = {})
-    options_full = options.merge(builder: TranslatableFormBuilder)
-    form_for(record, options_full) do |f|
+    form_for(record, options.merge(builder: TranslatableFormBuilder)) do |f|
       yield(f)
     end
   end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -4,6 +4,9 @@ class Budget < ApplicationRecord
   include StatsVersionable
   include Reportable
 
+  acts_as_taggable_on :valuation_tags
+  acts_as_taggable_on :milestone_tags
+
   translates :name, touch: true
   include Globalizable
 

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -4,9 +4,6 @@ class Budget < ApplicationRecord
   include StatsVersionable
   include Reportable
 
-  acts_as_taggable_on :valuation_tags
-  acts_as_taggable_on :milestone_tags
-
   translates :name, touch: true
   include Globalizable
 

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -197,7 +197,7 @@ class Budget < ApplicationRecord
     investments.winners.any?
   end
 
-  def milestone_tags
+  def investments_milestone_tags
     investments.winners.map(&:milestone_tag_list).flatten.uniq.sort
   end
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -16,6 +16,7 @@ class Budget
     include Mappable
     include Documentable
 
+    acts_as_taggable_on :valuation_tags
     acts_as_votable
     acts_as_paranoid column: :hidden_at
     include ActsAsParanoidAliases
@@ -381,14 +382,6 @@ class Budget
 
     def assigned_valuation_groups
       self.valuator_groups.map(&:name).compact.join(", ").presence
-    end
-
-    def valuation_tag_list
-      tag_list_on(:valuation)
-    end
-
-    def valuation_tag_list=(tags)
-      set_tag_list_on(:valuation, tags)
     end
 
     def self.with_milestone_status_id(status_id)

--- a/app/models/budget_rol_assignment.rb
+++ b/app/models/budget_rol_assignment.rb
@@ -1,4 +1,0 @@
-class BudgetRolAssignment < ApplicationRecord
-  belongs_to :budget
-  belongs_to :user
-end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,2 @@
+class Tagging < ActsAsTaggableOn::Tagging
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,6 @@ class User < ApplicationRecord
     inverse_of:  :receiver
   has_many :legislation_answers, class_name: "Legislation::Answer", dependent: :destroy, inverse_of: :user
   has_many :follows
-  has_many :budget_rol_assignments
   has_many :legislation_annotations,
     class_name:  "Legislation::Annotation",
     foreign_key: :author_id,
@@ -80,7 +79,6 @@ class User < ApplicationRecord
     foreign_key: :author_id,
     inverse_of:  :author
   has_many :topics, foreign_key: :author_id, inverse_of: :author
-  has_many :budgets, through: :budget_rol_assignments
   belongs_to :geozone
 
   validates :username, presence: true, if: :username_required?

--- a/app/views/admin/budget_investments/_search_form.html.erb
+++ b/app/views/admin/budget_investments/_search_form.html.erb
@@ -49,13 +49,13 @@
   </div>
   <div class="small-12 medium-3 column">
     <%= select_tag :tag_name,
-                   options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
+                   options_for_select(investment_tags_select_options(@budget, "valuation_tags"), params[:tag_name]),
                    { prompt: t("admin.budget_investments.index.tags_filter_all") } %>
   </div>
 
   <div class="small-12 medium-3 column">
     <%= select_tag :milestone_tag_name,
-                   options_for_select(investment_milestone_tags_select_options(@budget), params[:milestone_tag_name]),
+                   options_for_select(investment_tags_select_options(@budget, "milestone_tags"), params[:milestone_tag_name]),
                    { prompt: t("admin.budget_investments.index.milestone_tags_filter_all") } %>
   </div>
 

--- a/app/views/admin/budget_investments/show.html.erb
+++ b/app/views/admin/budget_investments/show.html.erb
@@ -29,7 +29,7 @@
 <p id="tags">
   <strong><%= t("admin.budget_investments.show.tags") %>:</strong>
 
-  <%= @investment.tags_on(:valuation).pluck(:name).sort.join(", ") %>
+  <%= @investment.valuation_tags.pluck(:name).sort.join(", ") %>
 </p>
 
 <p id="assigned_valuator_groups">

--- a/app/views/admin/budgets/_association.html.erb
+++ b/app/views/admin/budgets/_association.html.erb
@@ -3,23 +3,9 @@
     <p><%= t("admin.budgets.edit.empty_#{assignable_type}") %></p>
   <% else %>
     <h3><%= t("admin.budgets.edit.#{assignable_type}", count: 0) %></h3>
-    <table class="table-for-mobile">
-      <thead>
-      <tr>
-        <th class="small-8"><%= t("admin.budgets.edit.name") %></th>
-        <th class="small-4"><%= t("admin.budgets.edit.selected") %></th>
-      </tr>
-      </thead>
-      <tbody>
-      <% assignables.each do |assignable| %>
-        <tr>
-          <td class="small-8"><%= assignable.name %></td>
-          <td class="small-4 text-center">
-            <input type="checkbox" id="<%= assignable_type.singularize %>_<%= assignable.user.id %>" name="budget[<%= assignable_type.singularize %>_ids][]" value="<%= assignable.id %>" <%= "checked" if @budget.send(assignable_type).include? assignable %> class="js-budget-list-checkbox-<%= assignable_type %> js-budget-list-checkbox-user">
-          </td>
-        </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <% field = "#{assignable_type.chomp("s")}_ids" %>
+    <%= form.collection_check_boxes field, assignables, :id, :name do |box| %>
+      <%= box.label { box.check_box + box.text } %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -33,9 +33,9 @@
   </div>
 
   <div class="margin-top">
-      <%= render "/admin/budgets/association", assignable_type: "administrators", assignables: @admins, budget: @budget %>
-      <%= render "/admin/budgets/association", assignable_type: "valuators", assignables: @valuators, budget: @budget %>
-      <%= render "/admin/budgets/association", assignable_type: "trackers", assignables: @trackers, budget: @budget %>
+    <%= render "/admin/budgets/association", assignable_type: "administrators", assignables: @admins, form: f %>
+    <%= render "/admin/budgets/association", assignable_type: "valuators", assignables: @valuators, form: f %>
+    <%= render "/admin/budgets/association", assignable_type: "trackers", assignables: @trackers, form: f %>
   </div>
 
   <div class="margin-top">

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -40,10 +40,14 @@
 
   <div class="margin-top">
     <div class="small-12 medium-9 column end">
-      <%= f.text_field :budget_milestone_tags, placeholder: t("admin.budget_investments.edit.tags_placeholder") %>
+      <%= f.text_field :milestone_tag_list,
+        value: @budget.milestone_tag_list.sort.join(","),
+        placeholder: t("admin.budget_investments.edit.tags_placeholder") %>
     </div>
     <div class="small-12 medium-9 column end">
-      <%= f.text_field :budget_valuation_tags, placeholder: t("admin.budget_investments.edit.tags_placeholder") %>
+      <%= f.text_field :valuation_tag_list,
+        value: @budget.valuation_tag_list.sort.join(","),
+        placeholder: t("admin.budget_investments.edit.tags_placeholder") %>
     </div>
     <div class="small-12 medium-9 column end">
       <%= f.text_field :help_link %>

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -38,22 +38,6 @@
     <%= render "/admin/budgets/association", assignable_type: "trackers", assignables: @trackers, form: f %>
   </div>
 
-  <div class="margin-top">
-    <div class="small-12 medium-9 column end">
-      <%= f.text_field :milestone_tag_list,
-        value: @budget.milestone_tag_list.sort.join(","),
-        placeholder: t("admin.budget_investments.edit.tags_placeholder") %>
-    </div>
-    <div class="small-12 medium-9 column end">
-      <%= f.text_field :valuation_tag_list,
-        value: @budget.valuation_tag_list.sort.join(","),
-        placeholder: t("admin.budget_investments.edit.tags_placeholder") %>
-    </div>
-    <div class="small-12 medium-9 column end">
-      <%= f.text_field :help_link %>
-    </div>
-  </div>
-
   <% if @budget.phases.present? %>
     <div class="row">
       <div class="small-12 column">

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -141,9 +141,6 @@ en:
         description_finished: "Description when the budget is finished"
         phase: "Phase"
         currency_symbol: "Currency"
-        milestone_tag_list: "Milestone tags"
-        valuation_tag_list: "Valuation tags"
-        help_link: "Help link"
       budget/translation:
         name: "Name"
       budget/investment:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -141,8 +141,8 @@ en:
         description_finished: "Description when the budget is finished"
         phase: "Phase"
         currency_symbol: "Currency"
-        budget_milestone_tags: "Milestone tags"
-        budget_valuation_tags: "Valuation tags"
+        milestone_tag_list: "Milestone tags"
+        valuation_tag_list: "Valuation tags"
         help_link: "Help link"
       budget/translation:
         name: "Name"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -111,8 +111,6 @@ en:
         empty_trackers: "There are no trackers"
         name: "Name"
         selected: "Selected"
-        cancel: "Cancel"
-        save: "Save"
       destroy:
         success_notice: Budget deleted successfully
         unable_notice: You cannot delete a budget that has associated investments

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -109,8 +109,6 @@ en:
         empty_administrators: "There are no administrators"
         empty_valuators: "There are no valuators"
         empty_trackers: "There are no trackers"
-        name: "Name"
-        selected: "Selected"
       destroy:
         success_notice: Budget deleted successfully
         unable_notice: You cannot delete a budget that has associated investments

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -143,8 +143,8 @@ es:
         description_finished: "Descripción cuando el presupuesto ha finalizado / Resultados"
         phase: "Fase"
         currency_symbol: "Divisa"
-        budget_milestone_tags: "Etiquetas de seguimiento"
-        budget_valuation_tags: "Etiquetas de evaluación"
+        milestone_tag_list: "Etiquetas de seguimiento"
+        valuation_tag_list: "Etiquetas de evaluación"
         help_link: "Enlace de ayuda"
       budget/translation:
         name: "Nombre"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -143,9 +143,6 @@ es:
         description_finished: "Descripción cuando el presupuesto ha finalizado / Resultados"
         phase: "Fase"
         currency_symbol: "Divisa"
-        milestone_tag_list: "Etiquetas de seguimiento"
-        valuation_tag_list: "Etiquetas de evaluación"
-        help_link: "Enlace de ayuda"
       budget/translation:
         name: "Nombre"
       budget/investment:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -109,8 +109,6 @@ es:
         empty_administrators: "No hay administradores"
         empty_valuators: "No hay evaluadores"
         empty_trackers: "No hay gestores de seguimiento"
-        name: "Nombre"
-        selected: "Seleccionado"
       destroy:
         success_notice: Presupuesto eliminado correctamente
         unable_notice: No se puede eliminar un presupuesto con proyectos asociados

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -111,8 +111,6 @@ es:
         empty_trackers: "No hay gestores de seguimiento"
         name: "Nombre"
         selected: "Seleccionado"
-        cancel: "Cancelar"
-        save: "Guardar"
       destroy:
         success_notice: Presupuesto eliminado correctamente
         unable_notice: No se puede eliminar un presupuesto con proyectos asociados

--- a/db/migrate/20191031172132_drop_budget_rol_assignments.rb
+++ b/db/migrate/20191031172132_drop_budget_rol_assignments.rb
@@ -1,0 +1,9 @@
+class DropBudgetRolAssignments < ActiveRecord::Migration[5.0]
+  def up
+    drop_table :budget_rol_assignments
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20191031173943_use_acts_as_taggable_in_budgets.rb
+++ b/db/migrate/20191031173943_use_acts_as_taggable_in_budgets.rb
@@ -1,0 +1,9 @@
+class UseActsAsTaggableInBudgets < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :budgets, :budget_milestone_tags, :string
+    remove_column :budgets, :budget_valuation_tags, :string
+
+    add_column :tags, :budgets_count, :integer, default: 0
+    add_index :tags, :budgets_count
+  end
+end

--- a/db/migrate/20191031210734_remove_help_link_from_budgets.rb
+++ b/db/migrate/20191031210734_remove_help_link_from_budgets.rb
@@ -1,0 +1,6 @@
+class RemoveHelpLinkFromBudgets < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :budgets, :help_link, :string
+    remove_column :tags, :budgets_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191030160347) do
+ActiveRecord::Schema.define(version: 20191031172132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -338,16 +338,6 @@ ActiveRecord::Schema.define(version: 20191030160347) do
     t.string   "reason"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
-  end
-
-  create_table "budget_rol_assignments", force: :cascade do |t|
-    t.integer  "budget_id"
-    t.integer  "user_id"
-    t.string   "rol"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["budget_id"], name: "index_budget_rol_assignments_on_budget_id", using: :btree
-    t.index ["user_id"], name: "index_budget_rol_assignments_on_user_id", using: :btree
   end
 
   create_table "budget_tracker_assignments", force: :cascade do |t|
@@ -1713,8 +1703,6 @@ ActiveRecord::Schema.define(version: 20191030160347) do
   add_foreign_key "budget_administrators", "administrators"
   add_foreign_key "budget_administrators", "budgets"
   add_foreign_key "budget_investments", "communities"
-  add_foreign_key "budget_rol_assignments", "budgets"
-  add_foreign_key "budget_rol_assignments", "users"
   add_foreign_key "budget_tracker_assignments", "trackers"
   add_foreign_key "budget_trackers", "budgets"
   add_foreign_key "budget_trackers", "trackers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191031173943) do
+ActiveRecord::Schema.define(version: 20191031210734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -407,7 +407,6 @@ ActiveRecord::Schema.define(version: 20191031173943) do
     t.text     "description_drafting"
     t.text     "description_publishing_prices"
     t.text     "description_informing"
-    t.string   "help_link"
   end
 
   create_table "campaigns", force: :cascade do |t|
@@ -1485,8 +1484,6 @@ ActiveRecord::Schema.define(version: 20191031173943) do
     t.integer "budget/investments_count",                default: 0
     t.integer "legislation/proposals_count",             default: 0
     t.integer "legislation/processes_count",             default: 0
-    t.integer "budgets_count",                           default: 0
-    t.index ["budgets_count"], name: "index_tags_on_budgets_count", using: :btree
     t.index ["debates_count"], name: "index_tags_on_debates_count", using: :btree
     t.index ["legislation/processes_count"], name: "index_tags_on_legislation/processes_count", using: :btree
     t.index ["legislation/proposals_count"], name: "index_tags_on_legislation/proposals_count", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191031172132) do
+ActiveRecord::Schema.define(version: 20191031173943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -408,8 +408,6 @@ ActiveRecord::Schema.define(version: 20191031172132) do
     t.text     "description_publishing_prices"
     t.text     "description_informing"
     t.string   "help_link"
-    t.string   "budget_milestone_tags"
-    t.string   "budget_valuation_tags"
   end
 
   create_table "campaigns", force: :cascade do |t|
@@ -1487,6 +1485,8 @@ ActiveRecord::Schema.define(version: 20191031172132) do
     t.integer "budget/investments_count",                default: 0
     t.integer "legislation/proposals_count",             default: 0
     t.integer "legislation/processes_count",             default: 0
+    t.integer "budgets_count",                           default: 0
+    t.index ["budgets_count"], name: "index_tags_on_budgets_count", using: :btree
     t.index ["debates_count"], name: "index_tags_on_debates_count", using: :btree
     t.index ["legislation/processes_count"], name: "index_tags_on_legislation/processes_count", using: :btree
     t.index ["legislation/proposals_count"], name: "index_tags_on_legislation/proposals_count", using: :btree

--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -4,6 +4,7 @@ namespace :consul do
 
   desc "Runs tasks needed to upgrade from 1.0.0 to 1.1.0"
   task "execute_release_1.1.0_tasks": [
-    "budgets:set_original_heading_id"
+    "budgets:set_original_heading_id",
+    "migrations:valuation_taggings"
   ]
 end

--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -5,6 +5,7 @@ namespace :consul do
   desc "Runs tasks needed to upgrade from 1.0.0 to 1.1.0"
   task "execute_release_1.1.0_tasks": [
     "budgets:set_original_heading_id",
-    "migrations:valuation_taggings"
+    "migrations:valuation_taggings",
+    "migrations:budget_admins_and_valuators"
   ]
 end

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -4,4 +4,17 @@ namespace :migrations do
     ApplicationLogger.new.info "Updating valuation taggings context"
     Tagging.where(context: "valuation").update_all(context: "valuation_tags")
   end
+
+  desc "Migrates budget staff"
+  task budget_admins_and_valuators: :environment do
+    ApplicationLogger.new.info "Updating budget administrators and valuators"
+    Budget.find_each do |budget|
+      investments = budget.investments.with_hidden
+
+      budget.update!(
+        administrator_ids: investments.where.not(administrator: nil).distinct.pluck(:administrator_id),
+        valuator_ids: Budget::ValuatorAssignment.where(investment: investments).distinct.pluck(:valuator_id)
+      )
+    end
+  end
 end

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -1,0 +1,7 @@
+namespace :migrations do
+  desc "Migrates context of valuation taggings"
+  task valuation_taggings: :environment do
+    ApplicationLogger.new.info "Updating valuation taggings context"
+    Tagging.where(context: "valuation").update_all(context: "valuation_tags")
+  end
+end

--- a/spec/factories/classifications.rb
+++ b/spec/factories/classifications.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     end
   end
 
-  factory :tagging, class: "ActsAsTaggableOn::Tagging" do
+  factory :tagging do
     context { "tags" }
     association :taggable, factory: :proposal
     tag

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -510,8 +510,8 @@ describe "Admin budget investments" do
       investment1 = create(:budget_investment, budget: budget, tag_list: "Education")
       investment2 = create(:budget_investment, budget: budget, tag_list: "Health")
 
-      investment1.set_tag_list_on(:valuation, "Teachers")
-      investment2.set_tag_list_on(:valuation, "Hospitals")
+      investment1.set_tag_list_on(:valuation_tags, "Teachers")
+      investment2.set_tag_list_on(:valuation_tags, "Hospitals")
 
       investment1.save!
       investment2.save!
@@ -526,8 +526,8 @@ describe "Admin budget investments" do
       investment1 = create(:budget_investment, budget: budget, tag_list: "Roads")
       investment2 = create(:budget_investment, budget: new_budget, tag_list: "Accessibility")
 
-      investment1.set_tag_list_on(:valuation, "Roads")
-      investment2.set_tag_list_on(:valuation, "Accessibility")
+      investment1.set_tag_list_on(:valuation_tags, "Roads")
+      investment2.set_tag_list_on(:valuation_tags, "Accessibility")
 
       investment1.save!
       investment2.save!
@@ -1192,7 +1192,7 @@ describe "Admin budget investments" do
 
     scenario "Adds existing valuation tags", :js do
       budget_investment1 = create(:budget_investment)
-      budget_investment1.set_tag_list_on(:valuation, "Education, Health")
+      budget_investment1.set_tag_list_on(:valuation_tags, "Education, Health")
       budget_investment1.save!
 
       budget_investment2 = create(:budget_investment)
@@ -1230,7 +1230,7 @@ describe "Admin budget investments" do
 
     scenario "Changes valuation and user generated tags" do
       budget_investment = create(:budget_investment, tag_list: "Park")
-      budget_investment.set_tag_list_on(:valuation, "Education")
+      budget_investment.set_tag_list_on(:valuation_tags, "Education")
       budget_investment.save!
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -1671,7 +1671,7 @@ describe "Admin budget investments" do
     end
 
     scenario "Keeps the valuation tags", :js do
-      investment1.set_tag_list_on(:valuation, %w[Possimpible Truthiness])
+      investment1.set_tag_list_on(:valuation_tags, %w[Possimpible Truthiness])
       investment1.save!
 
       visit admin_budget_budget_investments_path(budget)

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1086,14 +1086,15 @@ describe "Admin budget investments" do
       expect(page).not_to have_content "Mark as incompatible"
     end
 
-    scenario "Add administrator" do
+    scenario "Add administrator", :js do
       budget_investment = create(:budget_investment)
       user = create(:user, username: "Marta", email: "marta@admins.org")
       create(:administrator, user: user, description: "Marta desc")
 
       visit edit_admin_budget_path(budget_investment.budget)
 
-      check "administrator_#{user.id}"
+      click_link "Select administrators"
+      check "Marta"
       click_button "Update Budget"
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -1119,8 +1120,8 @@ describe "Admin budget investments" do
 
       visit edit_admin_budget_path(budget_investment.budget)
 
-      check "valuator_#{user1.id}"
-      check "valuator_#{user3.id}"
+      check "Valentina"
+      check "Val"
       click_button "Update Budget"
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -232,19 +232,45 @@ describe "Admin budgets" do
   end
 
   context "Update" do
-    before do
-      create(:budget)
-    end
-
     scenario "Update budget" do
-      visit admin_budgets_path
-      click_link "Edit budget"
+      visit edit_admin_budget_path(create(:budget))
 
       fill_in "Name", with: "More trees on the streets"
       click_button "Update Budget"
 
       expect(page).to have_content("More trees on the streets")
       expect(page).to have_current_path(admin_budgets_path)
+    end
+
+    scenario "Deselect all selected staff", :js do
+      admin = Administrator.first
+      valuator = create(:valuator)
+      tracker = create(:tracker)
+
+      budget = create(:budget, administrators: [admin], valuators: [valuator], trackers: [tracker])
+
+      visit edit_admin_budget_path(budget)
+      click_link "1 administrator selected"
+      uncheck admin.name
+
+      expect(page).to have_link "Select administrators"
+
+      click_link "1 valuator selected"
+      uncheck valuator.name
+
+      expect(page).to have_link "Select valuators"
+
+      click_link "1 tracker selected"
+      uncheck tracker.name
+
+      expect(page).to have_link "Select trackers"
+
+      click_button "Update Budget"
+      visit edit_admin_budget_path(budget)
+
+      expect(page).to have_link "Select administrators"
+      expect(page).to have_link "Select valuators"
+      expect(page).to have_link "Select trackers"
     end
   end
 

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -334,7 +334,7 @@ describe "Tags" do
 
     scenario "Valuators do not see user tags" do
       investment = create(:budget_investment, heading: heading, tag_list: "Park")
-      investment.set_tag_list_on(:valuation, "Education")
+      investment.set_tag_list_on(:valuation_tags, "Education")
       investment.save!
 
       login_as(admin)

--- a/spec/lib/tasks/migrations_spec.rb
+++ b/spec/lib/tasks/migrations_spec.rb
@@ -1,22 +1,68 @@
 require "rails_helper"
 
 describe "Migration tasks" do
-  let(:run_rake_task) do
-    Rake::Task["migrations:valuation_taggings"].reenable
-    Rake.application.invoke_task("migrations:valuation_taggings")
+  describe "valuation_taggins" do
+    let(:run_rake_task) do
+      Rake::Task["migrations:valuation_taggings"].reenable
+      Rake.application.invoke_task("migrations:valuation_taggings")
+    end
+
+    it "updates taggings" do
+      valuation_tagging = create(:tagging, context: "valuation")
+      another_valuation_tagging = create(:tagging, context: "valuation")
+      valuation_tags_tagging = create(:tagging, context: "valuation_tags")
+      tags_tagging = create(:tagging)
+
+      run_rake_task
+
+      expect(valuation_tagging.reload.context).to eq "valuation_tags"
+      expect(another_valuation_tagging.reload.context).to eq "valuation_tags"
+      expect(valuation_tags_tagging.reload.context).to eq "valuation_tags"
+      expect(tags_tagging.reload.context).to eq "tags"
+    end
   end
 
-  it "updates taggings" do
-    valuation_tagging = create(:tagging, context: "valuation")
-    another_valuation_tagging = create(:tagging, context: "valuation")
-    valuation_tags_tagging = create(:tagging, context: "valuation_tags")
-    tags_tagging = create(:tagging)
+  describe "budget_admins_and_valuators" do
+    let(:run_rake_task) do
+      Rake::Task["migrations:budget_admins_and_valuators"].reenable
+      Rake.application.invoke_task("migrations:budget_admins_and_valuators")
+    end
 
-    run_rake_task
+    let(:old_budget) { create(:budget) }
+    let(:current_budget) { create(:budget) }
 
-    expect(valuation_tagging.reload.context).to eq "valuation_tags"
-    expect(another_valuation_tagging.reload.context).to eq "valuation_tags"
-    expect(valuation_tags_tagging.reload.context).to eq "valuation_tags"
-    expect(tags_tagging.reload.context).to eq "tags"
+    it "assigns administrators from existing investments" do
+      harold = create(:administrator)
+      john = create(:administrator)
+      root = create(:administrator)
+
+      create(:budget_investment, budget: old_budget, administrator: john)
+      create(:budget_investment, budget: old_budget, administrator: harold)
+      create(:budget_investment, budget: old_budget, administrator: nil)
+
+      create(:budget_investment, budget: current_budget, administrator: root)
+
+      run_rake_task
+
+      expect(old_budget.administrators).to match_array [john, harold]
+      expect(current_budget.administrators).to match_array [root]
+    end
+
+    it "assigns valuators from existing investments" do
+      tyrion = create(:valuator)
+      cersei = create(:valuator)
+      jaime = create(:valuator)
+
+      create(:budget_investment, budget: old_budget, valuators: [cersei])
+      create(:budget_investment, budget: old_budget, valuators: [jaime, cersei])
+      create(:budget_investment, budget: old_budget, valuators: [])
+
+      create(:budget_investment, budget: current_budget, valuators: [tyrion, jaime])
+
+      run_rake_task
+
+      expect(old_budget.valuators).to match_array [cersei, jaime]
+      expect(current_budget.valuators).to match_array [tyrion, jaime]
+    end
   end
 end

--- a/spec/lib/tasks/migrations_spec.rb
+++ b/spec/lib/tasks/migrations_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe "Migration tasks" do
+  let(:run_rake_task) do
+    Rake::Task["migrations:valuation_taggings"].reenable
+    Rake.application.invoke_task("migrations:valuation_taggings")
+  end
+
+  it "updates taggings" do
+    valuation_tagging = create(:tagging, context: "valuation")
+    another_valuation_tagging = create(:tagging, context: "valuation")
+    valuation_tags_tagging = create(:tagging, context: "valuation_tags")
+    tags_tagging = create(:tagging)
+
+    run_rake_task
+
+    expect(valuation_tagging.reload.context).to eq "valuation_tags"
+    expect(another_valuation_tagging.reload.context).to eq "valuation_tags"
+    expect(valuation_tags_tagging.reload.context).to eq "valuation_tags"
+    expect(tags_tagging.reload.context).to eq "tags"
+  end
+end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -296,7 +296,7 @@ describe Budget do
     end
   end
 
-  describe "#milestone_tags" do
+  describe "#investments_milestone_tags" do
     let(:investment1) { build(:budget_investment, :winner) }
     let(:investment2) { build(:budget_investment, :winner) }
     let(:investment3) { build(:budget_investment) }
@@ -304,7 +304,7 @@ describe Budget do
     it "returns an empty array if not investments milestone_tags" do
       budget.investments << investment1
 
-      expect(budget.milestone_tags).to eq([])
+      expect(budget.investments_milestone_tags).to eq([])
     end
 
     it "returns array of investments milestone_tags" do
@@ -312,7 +312,7 @@ describe Budget do
       investment1.save!
       budget.investments << investment1
 
-      expect(budget.milestone_tags).to eq(["tag1"])
+      expect(budget.investments_milestone_tags).to eq(["tag1"])
     end
 
     it "returns uniq list of investments milestone_tags" do
@@ -323,7 +323,7 @@ describe Budget do
       budget.investments << investment1
       budget.investments << investment2
 
-      expect(budget.milestone_tags).to eq(["tag1"])
+      expect(budget.investments_milestone_tags).to eq(["tag1"])
     end
 
     it "returns tags only for winner investments" do
@@ -334,7 +334,7 @@ describe Budget do
       budget.investments << investment1
       budget.investments << investment3
 
-      expect(budget.milestone_tags).to eq(["tag1"])
+      expect(budget.investments_milestone_tags).to eq(["tag1"])
     end
   end
 end


### PR DESCRIPTION
## References

* Fixes issues from pull request #3514

## Objectives

* Make it possible to deselect all staff members assigned to a budget
* Fix searching investments by milestone tags
* Remove unused tags and help link attributes in budgets
* Remove unused `BudgetRolAssignment` model
* Assign administrators and valuators to existing budgets so we don't lose data

## Notes

Before removing tags from budgets, I made them work the way we usually use tags in the application. So if we want to add them back in the future, we can use this implementation as a reference.