### PR TITLE
Update chromeOptions for newer versions of chromedriver

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,7 +32,7 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: {
+    "goog:chromeOptions" => {
       args: %W[headless no-sandbox window-size=1200,600 proxy-server=127.0.0.1:#{Capybara::Webmock.port_number}]
     }
   )


### PR DESCRIPTION
## Objectives

- Be able to run the tests normally.

When using a newer version of `chromedriver`, the attribute name for `chromeOptions` has changed, so a new attribute name (`goog:chromeOptions`) needs to be used.

## Notes
We don't have to merge this PR, but I wanted to create it so people using a newer version of `chromedriver` can have a reference. ☺️ 