### PR TITLE
Simplify JavaScript to pluralize translations

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -80,6 +80,7 @@
 //= require investment_report_alert
 //= require send_newsletter_alert
 //= require managers
+//= require i18n
 //= require globalize
 //= require send_admin_notification_alert
 //= require modal_download

--- a/app/assets/javascripts/budget_edit_associations.js
+++ b/app/assets/javascripts/budget_edit_associations.js
@@ -1,28 +1,18 @@
 (function() {
   "use strict";
   App.BudgetEditAssociations = {
-    set_text: function(response) {
-      $(".js-budget-show-administrators-list").text(response.administrators);
-      $(".js-budget-show-valuators-list").text(response.valuators);
-      $(".js-budget-show-trackers-list").text(response.trackers);
-    },
     initialize: function() {
       $(".js-budget-list-checkbox-user").on({
         click: function() {
-          var admin_count, budget, params, tracker_count, url, valuator_count;
+          var admin_count, tracker_count, valuator_count;
+
           admin_count = $(".js-budget-list-checkbox-administrators:checkbox:checked").length;
           valuator_count = $(".js-budget-list-checkbox-valuators:checkbox:checked").length;
           tracker_count = $(".js-budget-list-checkbox-trackers:checkbox:checked").length;
-          budget = $(".js-budget-id").attr("id");
-          url = "/admin/budgets/" + budget + "/assigned_users_translation.json";
-          params = {
-            administrators: admin_count,
-            valuators: valuator_count,
-            trackers: tracker_count
-          };
-          $.get(url, params, function(response) {
-            App.BudgetEditAssociations.set_text(response, "json");
-          });
+
+          App.I18n.set_pluralize($(".js-budget-show-administrators-list"), admin_count);
+          App.I18n.set_pluralize($(".js-budget-show-valuators-list"), valuator_count);
+          App.I18n.set_pluralize($(".js-budget-show-trackers-list"), tracker_count);
         }
       });
       $(".js-budget-show-users-list").on({

--- a/app/assets/javascripts/budget_edit_associations.js
+++ b/app/assets/javascripts/budget_edit_associations.js
@@ -26,8 +26,10 @@
         }
       });
       $(".js-budget-show-users-list").on({
-        click: function() {
+        click: function(e) {
           var div_id;
+
+          e.preventDefault();
           div_id = $(this).data().toggle;
           $(".js-budget-users-list").each(function() {
             if (this.id !== div_id && !$(this).hasClass("is-hidden")) {

--- a/app/assets/javascripts/globalize.js
+++ b/app/assets/javascripts/globalize.js
@@ -75,11 +75,9 @@
       App.Globalize.display_translations(locale);
     },
     update_description: function() {
-      var count, description;
+      var count;
       count = App.Globalize.enabled_locales().length;
-      description = App.I18n.pluralize($(".globalize-languages").data("languages-description"), count);
-
-      $(".js-languages-description").text(description);
+      App.I18n.set_pluralize($(".js-languages-description"), count);
     },
     initialize: function() {
       $(".js-add-language").on("change", function() {

--- a/app/assets/javascripts/globalize.js
+++ b/app/assets/javascripts/globalize.js
@@ -77,19 +77,9 @@
     update_description: function() {
       var count, description;
       count = App.Globalize.enabled_locales().length;
-      description = App.Globalize.language_description(count);
+      description = App.I18n.pluralize($(".globalize-languages").data("languages-description"), count);
 
-      $(".js-languages-description").text(description.replace("%{count}", count));
-    },
-    language_description: function(count) {
-      switch (count) {
-      case 0:
-        return $(".globalize-languages").data("languages-description").zero;
-      case 1:
-        return $(".globalize-languages").data("languages-description").one;
-      default:
-        return $(".globalize-languages").data("languages-description").other;
-      }
+      $(".js-languages-description").text(description);
     },
     initialize: function() {
       $(".js-add-language").on("change", function() {

--- a/app/assets/javascripts/globalize.js
+++ b/app/assets/javascripts/globalize.js
@@ -77,19 +77,18 @@
     update_description: function() {
       var count, description;
       count = App.Globalize.enabled_locales().length;
-      description = $(App.Globalize.language_description(count)).filter(".description").text();
+      description = App.Globalize.language_description(count);
 
-      $(".js-languages-description .description").text(description);
-      $(".js-languages-description .count").text(count);
+      $(".js-languages-description").text(description.replace("%{count}", count));
     },
     language_description: function(count) {
       switch (count) {
       case 0:
-        return $(".globalize-languages").data("zero-languages-description");
+        return $(".globalize-languages").data("languages-description").zero;
       case 1:
-        return $(".globalize-languages").data("one-languages-description");
+        return $(".globalize-languages").data("languages-description").one;
       default:
-        return $(".globalize-languages").data("other-languages-description");
+        return $(".globalize-languages").data("languages-description").other;
       }
     },
     initialize: function() {

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -1,6 +1,9 @@
 (function() {
   "use strict";
   App.I18n = {
+    set_pluralize: function(element, count) {
+      element.text(this.pluralize(element.data("texts"), count));
+    },
     pluralize: function(texts, count) {
       return this.raw_text(texts, count).replace("%{count}", count);
     },

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -1,0 +1,18 @@
+(function() {
+  "use strict";
+  App.I18n = {
+    pluralize: function(texts, count) {
+      return this.raw_text(texts, count).replace("%{count}", count);
+    },
+    raw_text: function(texts, count) {
+      switch (count) {
+      case 0:
+        return texts.zero;
+      case 1:
+        return texts.one;
+      default:
+        return texts.other;
+      }
+    }
+  };
+}).call(this);

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -72,13 +72,6 @@ class Admin::BudgetsController < Admin::BaseController
     end
   end
 
-  def assigned_users_translation
-    render json: { administrators: t("admin.budgets.edit.administrators", count: params[:administrators].to_i),
-                   valuators: t("admin.budgets.edit.valuators", count: params[:valuators].to_i),
-                   trackers: t("admin.budgets.edit.trackers", count: params[:trackers].to_i)
-    }
-  end
-
   private
 
     def budget_params

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -59,7 +59,7 @@ module Abilities
 
       can :manage, Dashboard::Action
 
-      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners, :assigned_users_translation], Budget
+      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget
       can [:read, :create, :update, :destroy], Budget::Group
       can [:read, :create, :update, :destroy], Budget::Heading
       can [:hide, :admin_update, :toggle_selection], Budget::Investment

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -2,8 +2,6 @@
 
 <%= translatable_form_for [:admin, @budget] do |f| %>
 
-  <div class="js-budget-id" id="<%= @budget.id %>"></div>
-
   <%= render "shared/errors", resource: @budget %>
 
   <div class="row">
@@ -29,7 +27,7 @@
         <%= link_to t("admin.budgets.edit.#{staff}", count: @budget.send(staff).count),
           "#",
           class: "button expanded hollow js-budget-show-#{staff}-list js-budget-show-users-list",
-          data: { toggle: "#{staff}_list" } %>
+          data: { toggle: "#{staff}_list", texts: t("admin.budgets.edit.#{staff}") } %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -24,18 +24,14 @@
   </div>
 
   <div class="margin-top">
-    <div class="small-12 medium-4 column end">
-      <a id="administrators_button" class="button expanded hollow js-budget-show-users-list js-budget-show-administrators-list" data-toggle="administrators_list"><%= t("admin.budgets.edit.administrators", count: @budget.administrators.count) %>
-      </a>
-    </div>
-    <div class="small-12 medium-4 column end">
-      <a id="valuators_button" class="button expanded hollow js-budget-show-users-list js-budget-show-valuators-list" data-toggle="valuators_list"><%= t("admin.budgets.edit.valuators", count: @budget.valuators.count) %>
-      </a>
-    </div>
-    <div class="small-12 medium-4 column end">
-      <a id="trackers_button" class="button expanded hollow js-budget-show-users-list js-budget-show-trackers-list" data-toggle="trackers_list"><%= t("admin.budgets.edit.trackers", count: @budget.trackers.count) %>
-      </a>
-    </div>
+    <% %w[administrators valuators trackers].each do |staff| %>
+      <div class="small-12 medium-4 column end">
+        <%= link_to t("admin.budgets.edit.#{staff}", count: @budget.send(staff).count),
+          "#",
+          class: "button expanded hollow js-budget-show-#{staff}-list js-budget-show-users-list",
+          data: { toggle: "#{staff}_list" } %>
+      </div>
+    <% end %>
   </div>
 
   <div class="margin-top">

--- a/app/views/shared/_common_globalize_locales.html.erb
+++ b/app/views/shared/_common_globalize_locales.html.erb
@@ -1,8 +1,10 @@
-<div class="row globalize-languages column padding-top <%= highlight_translation_html_class %>"
-     data-languages-description="<%= t("shared.translations.languages_in_use").to_json %>">
+<div class="row globalize-languages column padding-top <%= highlight_translation_html_class %>">
   <div class="small-6 large-3 column">
     <span class="small">
-      <strong class="js-languages-description"><%= selected_languages_description(resource) %></strong>
+      <strong class="js-languages-description"
+        data-texts="<%= t("shared.translations.languages_in_use").to_json %>">
+        <%= selected_languages_description(resource) %>
+      </strong>
     </span>
     <%= select_tag :select_language,
                    options_for_select_language(resource),

--- a/app/views/shared/_common_globalize_locales.html.erb
+++ b/app/views/shared/_common_globalize_locales.html.erb
@@ -1,7 +1,5 @@
 <div class="row globalize-languages column padding-top <%= highlight_translation_html_class %>"
-     data-zero-languages-description="<%= t("shared.translations.languages_in_use", count: 0) %>"
-     data-one-languages-description="<%= t("shared.translations.languages_in_use", count: 1) %>"
-     data-other-languages-description="<%= t("shared.translations.languages_in_use", count: 2) %>">
+     data-languages-description="<%= t("shared.translations.languages_in_use").to_json %>">
   <div class="small-6 large-3 column">
     <span class="small">
       <strong class="js-languages-description"><%= selected_languages_description(resource) %></strong>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -141,6 +141,7 @@ ignore_unused:
   - "admin.hidden_proposals.index.filter*"
   - "admin.proposal_notifications.index.filter*"
   - "admin.budgets.index.filter*"
+  - "admin.budgets.edit.(administrators|trackers|valuators).*"
   - "admin.budget_investments.index.filter*"
   - "admin.organizations.index.filter*"
   - "admin.hidden_users.index.filter*"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -788,9 +788,9 @@ en:
       remove_language: Remove language
       add_language: Add language
       languages_in_use:
-        zero: "<span class='count'>0</span> <span class='description'>languages in use</span>"
-        one: "<span class='count'>1</span> <span class='description'>language in use</span>"
-        other: "<span class='count'>%{count}</span> <span class='description'>languages in use</span>"
+        zero: "0 languages in use"
+        one: "1 language in use"
+        other: "%{count} languages in use"
   social:
     facebook: "%{org} Facebook"
     twitter: "%{org} Twitter"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -786,9 +786,9 @@ es:
       remove_language: Eliminar idioma
       add_language: Añadir idioma
       languages_in_use:
-        zero: "<span class='count'>0</span> <span class='description'>idiomas en uso</span>"
-        one: "<span class='count'>1</span> <span class='description'> idioma en uso</span>"
-        other: "<span class='count'>%{count}</span> <span class='description'>idiomas en uso</span>"
+        zero: "0 idiomas en uso"
+        one: "1 idioma en uso"
+        other: "%{count} idiomas en uso"
   social:
     facebook: "Facebook de %{org}"
     twitter: "Twitter de %{org}"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -54,7 +54,6 @@ namespace :admin do
   resources :budgets do
     member do
       put :calculate_winners
-      get :assigned_users_translation
     end
 
     resources :groups, except: [:show], controller: "budget_groups" do


### PR DESCRIPTION
## References

* Refactors code in pull request #3514

## Background

We were using two different systems to set translations in JavaScript: to set the text for languages, we were using data attributes, and to set the text for staff members, we were using AJAX calls.

## Objectives

Simplify and unify the way we pluralize translations in JavaScript.