### PR TITLE
Fix typos in columns selector

### DIFF
--- a/app/assets/javascripts/columns_selector.js
+++ b/app/assets/javascripts/columns_selector.js
@@ -16,7 +16,7 @@
       });
     },
     initChecks: function() {
-      $(".column-selecteable th[data-field]").each(function() {
+      $(".column-selectable th[data-field]").each(function() {
         var field, input, item, label, text;
         field = $(this).data("field");
         text = $(this).text().trim();
@@ -82,7 +82,7 @@
           App.ColumnsSelector.toggleColumn(event);
         }
       });
-      $(".column-selecteable").on("inserted", function() {
+      $(".column-selectable").on("inserted", function() {
         App.ColumnsSelector.initColumns();
       });
     }

--- a/app/assets/javascripts/cookies.js
+++ b/app/assets/javascripts/cookies.js
@@ -3,7 +3,6 @@
   App.Cookies = {
     saveCookie: function(name, value, days) {
       var date, expires;
-      expires = undefined;
       if (days) {
         date = new Date;
         date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1289,7 +1289,7 @@ table {
   }
 }
 
-.column-selecteable {
+.column-selectable {
 
   .hidden {
     display: none;

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -24,7 +24,7 @@
 
   <%= render "filters_description", i18n_namespace: "admin.budget_investments.index" %>
 
-  <table class="table-for-mobile column-selecteable">
+  <table class="table-for-mobile column-selectable">
     <thead>
       <tr>
         <th><%= link_to_investments_sorted_by :id %></th>

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1738,7 +1738,7 @@ describe "Admin budget investments" do
     scenario "Display default columns", :js do
       visit admin_budget_budget_investments_path(budget)
 
-      within("table.column-selecteable") do
+      within("table.column-selectable") do
         default_columns.each do |default_column|
           columns_header = I18n.t("admin.budget_investments.index.list.#{default_column}")
           expect(page).to have_content(columns_header)
@@ -1751,7 +1751,7 @@ describe "Admin budget investments" do
     scenario "Display incompatible column as default if selected filter was set", :js do
       visit admin_budget_budget_investments_path(budget, advanced_filters: ["selected"])
 
-      within("table.column-selecteable") do
+      within("table.column-selectable") do
         expect(page).to have_content("Incompatible")
       end
 
@@ -1790,7 +1790,7 @@ describe "Admin budget investments" do
         check "Author"
       end
 
-      within("table.column-selecteable") do
+      within("table.column-selectable") do
         expect(page).not_to have_content("Title")
         expect(page).not_to have_content("Price")
         expect(page).to have_content("Author")


### PR DESCRIPTION
## Objectives

* Use `selectable` instead of `selecteable`
* Remove an unnecessary variable declaration generated by CoffeeScript