### PR TITLE
Fix admin permissions for finished budgets

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -31,6 +31,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
   end
 
   def edit
+    authorize! :admin_update, @investment
     load_staff
     load_valuator_groups
     load_tags
@@ -52,6 +53,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
   end
 
   def toggle_selection
+    authorize! :toggle_selection, @investment
     @investment.toggle :selected
     @investment.save!
     load_investments

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -64,7 +64,9 @@ module Abilities
       can [:read, :create, :update, :destroy], Budget::Heading
       can [:hide, :admin_update, :toggle_selection], Budget::Investment
       can [:valuate, :comment_valuation], Budget::Investment
-      cannot [:comment_valuation], Budget::Investment, budget: { phase: "finished" }
+      cannot [:admin_update, :toggle_selection, :valuate, :comment_valuation],
+        Budget::Investment, budget: { phase: "finished" }
+
       can :create, Budget::ValuatorAssignment
 
       can :read_admin_stats, Budget, &:balloting_or_later?

--- a/app/views/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/admin/budget_investments/_select_investment.html.erb
@@ -61,30 +61,34 @@
 
 <td id="selection" class="small text-center" data-field="selected">
   <% if investment.selected? %>
-      <%= link_to_unless investment.budget.finished?,
-                         t("admin.budget_investments.index.selected"),
-                         toggle_selection_admin_budget_budget_investment_path(@budget,
-                                                                              investment,
-                                                                              filter: params[:filter],
-                                                                              sort_by: params[:sort_by],
-                                                                              min_total_supports: params[:min_total_supports],
-                                                                              max_total_supports: params[:max_total_supports],
-                                                                              advanced_filters: params[:advanced_filters],
-                                                                              page: params[:page]),
-                         method: :patch,
-                         remote: true,
-                         class: "button small expanded" %>
+      <%= link_to_if can?(:toggle_selection, investment),
+                     t("admin.budget_investments.index.selected"),
+                     toggle_selection_admin_budget_budget_investment_path(
+                       @budget,
+                       investment,
+                       filter: params[:filter],
+                       sort_by: params[:sort_by],
+                       min_total_supports: params[:min_total_supports],
+                       max_total_supports: params[:max_total_supports],
+                       advanced_filters: params[:advanced_filters],
+                       page: params[:page]
+                     ),
+                     method: :patch,
+                     remote: true,
+                     class: "button small expanded" %>
   <% elsif investment.feasible? && investment.valuation_finished? %>
-    <% unless investment.budget.finished? %>
+    <% if can?(:toggle_selection, investment) %>
       <%= link_to t("admin.budget_investments.index.select"),
-                  toggle_selection_admin_budget_budget_investment_path(@budget,
-                                                                       investment,
-                                                                       filter: params[:filter],
-                                                                       sort_by: params[:sort_by],
-                                                                       min_total_supports: params[:min_total_supports],
-                                                                       max_total_supports: params[:max_total_supports],
-                                                                       advanced_filters: params[:advanced_filters],
-                                                                       page: params[:page]),
+                  toggle_selection_admin_budget_budget_investment_path(
+                    @budget,
+                    investment,
+                    filter: params[:filter],
+                    sort_by: params[:sort_by],
+                    min_total_supports: params[:min_total_supports],
+                    max_total_supports: params[:max_total_supports],
+                    advanced_filters: params[:advanced_filters],
+                    page: params[:page]
+                  ),
                   method: :patch,
                   remote: true,
                   class: "button small hollow expanded" %>

--- a/app/views/admin/budget_investments/show.html.erb
+++ b/app/views/admin/budget_investments/show.html.erb
@@ -6,15 +6,17 @@
 <%= render "written_by_author" %>
 
 <h2 class="inline-block"><%= t("admin.budget_investments.show.preview") %></h2>
-<div class="float-right">
-  <%= link_to t("admin.budget_investments.show.edit"),
-              edit_admin_budget_budget_investment_path(
-                @budget,
-                @investment,
-                Budget::Investment.filter_params(params).to_h
-              ),
-              class: "button hollow" unless @budget.finished? %>
-</div>
+<% if can?(:admin_update, @investment) %>
+  <div class="float-right">
+    <%= link_to t("admin.budget_investments.show.edit"),
+                edit_admin_budget_budget_investment_path(
+                  @budget,
+                  @investment,
+                  Budget::Investment.filter_params(params).to_h
+                ),
+                class: "button hollow" %>
+  </div>
+<% end %>
 
 <hr>
 <%= render "/budgets/investments/investment_detail", investment: @investment, preview: true %>
@@ -50,19 +52,26 @@
   <% end %>
 </p>
 
-<p>
-  <%= link_to t("admin.budget_investments.show.edit_classification"),
-                edit_admin_budget_budget_investment_path(@budget, @investment,
-                                                  { anchor: "classification" }.merge(Budget::Investment.filter_params(params).to_h)) unless @budget.finished? %>
-</p>
+<% if can?(:admin_update, @investment) %>
+  <p>
+    <%= link_to t("admin.budget_investments.show.edit_classification"),
+                edit_admin_budget_budget_investment_path(
+                  @budget,
+                  @investment,
+                  { anchor: "classification" }.merge(Budget::Investment.filter_params(params).to_h)
+                ) %>
+  </p>
+<% end %>
 
 <hr>
 
 <h2><%= t("admin.budget_investments.show.dossier") %></h2>
 <%= render "valuation/budget_investments/dossier" %>
-<p>
-  <%= link_to t("admin.budget_investments.show.edit_dossier"), edit_valuation_budget_budget_investment_path(@budget, @investment) unless @budget.finished? %>
-</p>
+<% if can?(:valuate, @investment) %>
+  <p>
+    <%= link_to t("admin.budget_investments.show.edit_dossier"), edit_valuation_budget_budget_investment_path(@budget, @investment) %>
+  </p>
+<% end %>
 
 <%= render "valuation/budget_investments/valuation_comments" %>
 

--- a/app/views/valuation/budget_investments/show.html.erb
+++ b/app/views/valuation/budget_investments/show.html.erb
@@ -3,15 +3,17 @@
 <br>
 
 <h2 class="inline-block"><%= t("admin.budget_investments.show.preview") %></h2>
-<div class="float-right">
-  <%= link_to t("admin.budget_investments.show.edit"),
-              edit_valuation_budget_budget_investment_path(
-                @budget,
-                @investment,
-                Budget::Investment.filter_params(params)
-              ),
-              class: "button hollow" unless @budget.finished? %>
-</div>
+<% if can?(:valuate, @investment) %>
+  <div class="float-right">
+    <%= link_to t("admin.budget_investments.show.edit"),
+                edit_valuation_budget_budget_investment_path(
+                  @budget,
+                  @investment,
+                  Budget::Investment.filter_params(params)
+                ),
+                class: "button hollow" %>
+  </div>
+<% end %>
 
 <hr>
 <%= render "/budgets/investments/investment_detail", investment: @investment, preview: true %>

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1017,7 +1017,7 @@ describe "Admin budget investments" do
       expect(page).to have_content("Ana (ana@admins.org)")
     end
 
-    scenario "Not show related content or hide links on preview" do
+    scenario "Does not show related content or hide links on preview" do
       budget_investment = create(:budget_investment,
                                   :unfeasible,
                                   price: 1234,

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -283,23 +283,6 @@ describe "Valuation budget investments" do
         visit valuation_budget_budget_investment_path(budget, investment)
       end.to raise_error "Not Found"
     end
-
-    scenario "preview is visible" do
-      logout
-      login_as create(:administrator).user
-
-      visit valuation_budget_budget_investment_path(budget, investment)
-
-      expect(page).to have_content("Investment preview")
-      expect(page).to have_content(investment.title)
-      expect(page).to have_content(investment.description)
-      expect(page).to have_content(investment.author.name)
-      expect(page).to have_content(investment.heading.name)
-      expect(page).to have_content("1234")
-      expect(page).to have_content("Unfeasible")
-      expect(page).to have_content("It is impossible")
-      expect(page).to have_content("Ana (ana@admins.org)")
-    end
   end
 
   describe "Valuate" do

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -15,6 +15,7 @@ describe Abilities::Administrator do
   let(:comment) { create(:comment) }
   let(:proposal) { create(:proposal, author: user) }
   let(:budget_investment) { create(:budget_investment) }
+  let(:finished_investment) { create(:budget_investment, budget: create(:budget, :finished)) }
   let(:legislation_question) { create(:legislation_question) }
   let(:poll_question) { create(:poll_question) }
 
@@ -77,7 +78,10 @@ describe Abilities::Administrator do
   it { should be_able_to(:hide, Budget::Investment) }
 
   it { should be_able_to(:valuate, create(:budget_investment, budget: create(:budget, :valuating))) }
-  it { should be_able_to(:valuate, create(:budget_investment, budget: create(:budget, :finished))) }
+  it { should_not be_able_to(:admin_update, finished_investment) }
+  it { should_not be_able_to(:valuate, finished_investment) }
+  it { should_not be_able_to(:comment_valuation, finished_investment) }
+  it { should_not be_able_to(:toggle_selection, finished_investment) }
 
   it { should be_able_to(:destroy, proposal_image) }
   it { should be_able_to(:destroy, proposal_document) }


### PR DESCRIPTION
## References

* Fixes issues related to pull request #2223
* Similar to pull request #3817

## Objectives

* Prevent admins from editing investments for finished budgets
* Fix typos related to investment previews

## Notes

Until now, we were not showing links to edit investments, but they could be edited by entering the URL to edit them.