### PR TITLE
Avoid jumping CKEditor

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1076,6 +1076,15 @@ form {
     margin-bottom: $line-height;
   }
 
+  .html-area {
+    height: 272px;
+    margin-bottom: $line-height;
+
+    &.admin {
+      height: 572px;
+    }
+  }
+
   .checkbox,
   .radio {
     display: inline-block;


### PR DESCRIPTION
## References

* This bug was introduced in pull request #3802

## Objectives

* Make sure elements on the page don't move around when CKEditor loads

## Notes

This is a hack: we're making the textarea have the same size as CKEditor so when it's replaced the page won't jump.

A very similar hack was removed in commit e844b0b2. Back then I thought this was a small issue we could live with, but the user experience turns out to be a bit annoying, and it makes tests fail sometimes because Capybara is trying to click something when the page jumps, and so it
misses the click.