### PR TITLE
Enable Lint/SafeNavigationChain rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -167,6 +167,9 @@ Lint/LiteralAsCondition:
 Lint/ParenthesesAsGroupedExpression:
   Enabled: true
 
+Lint/SafeNavigationChain:
+  Enabled: true
+
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 


### PR DESCRIPTION
## References

* Continues pull request #3735 

## Notes

We didn't add this rule before because we weren't following it in the code related to votation types, but we removed that code in pull request #3806.