### PR TITLE
Update deprecated jQuery syntax

### DIFF
--- a/app/assets/javascripts/ckeditor/reinit.js
+++ b/app/assets/javascripts/ckeditor/reinit.js
@@ -1,4 +1,4 @@
-$(document).bind("page:change", function() {
+$(document).on("page:change", function() {
   if (typeof(CKEDITOR) != "undefined"){
     for(name in CKEDITOR.instances){
       try{CKEDITOR.replace(name);}catch(err){};

--- a/app/assets/javascripts/forms.js
+++ b/app/assets/javascripts/forms.js
@@ -9,13 +9,13 @@
       });
     },
     submitOnChange: function() {
-      $(".js-submit-on-change").unbind("change").on("change", function() {
+      $(".js-submit-on-change").off("change").on("change", function() {
         $(this).closest("form").submit();
         return false;
       });
     },
     toggleLink: function() {
-      $(".js-toggle-link").unbind("click").on("click", function() {
+      $(".js-toggle-link").off("click").on("click", function() {
         var toggle_txt;
         $($(this).data("toggle-selector")).toggle("down");
         if ($(this).data("toggle-text") !== undefined) {
@@ -54,7 +54,7 @@
           }
         }
       });
-      $("[name='progress_bar[kind]']").change();
+      $("[name='progress_bar[kind]']").trigger("change");
     },
     initialize: function() {
       App.Forms.disableEnter();

--- a/app/assets/javascripts/table_sortable.js
+++ b/app/assets/javascripts/table_sortable.js
@@ -17,7 +17,7 @@
       };
     },
     initialize: function() {
-      $("table.sortable th").click(function() {
+      $("table.sortable th").on("click", function() {
         var rows, table;
         table = $(this).parents("table").eq(0);
         rows = table.find("tbody tr").toArray().sort(App.TableSortable.comparer($(this).index()));

--- a/app/assets/javascripts/valuation_budget_investment_form.js
+++ b/app/assets/javascripts/valuation_budget_investment_form.js
@@ -23,7 +23,7 @@
       }
     },
     showFeasibilityFieldsOnChange: function() {
-      $("#valuation_budget_investment_edit_form input[type=radio][name='budget_investment[feasibility]']").change(function() {
+      $("#valuation_budget_investment_edit_form input[type=radio][name='budget_investment[feasibility]']").on("change", function() {
         App.ValuationBudgetInvestmentForm.showAllFields();
         App.ValuationBudgetInvestmentForm.showFeasibilityFields();
       });

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -319,11 +319,6 @@ def documentable_attach_new_file(path, success = true)
   page.execute_script("$('##{document_input[:id]}').css('display','block')")
   attach_file(document_input[:id], path, visible: true)
   page.execute_script("$('##{document_input[:id]}').css('display','none')")
-  # Poltergeist is not removing this attribute after file upload at
-  # https://github.com/teampoltergeist/poltergeist/blob/master/lib/capybara/poltergeist/client/browser.coffee#L187
-  # making https://github.com/teampoltergeist/poltergeist/blob/master/lib/capybara/poltergeist/client/browser.coffee#L186
-  # always choose the previous used input.
-  page.execute_script("$('##{document_input[:id]}').removeAttr('_poltergeist_selected')")
 
   within document do
     if success

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -316,9 +316,7 @@ def documentable_attach_new_file(path, success = true)
 
   document = all("#new_document").last
   document_input = document.find("input[type=file]", visible: false)
-  page.execute_script("$('##{document_input[:id]}').css('display','block')")
-  attach_file(document_input[:id], path, visible: true)
-  page.execute_script("$('##{document_input[:id]}').css('display','none')")
+  attach_file(document_input[:id], path, make_visible: true)
 
   within document do
     if success


### PR DESCRIPTION
## Objectives

* Make it easier to upgrade to jQuery 3 in the future

## Notes

We aren't upgraded to jQuery 3 yet because the annotator library and the cocoon gem use jQuery 1.x, and we have to test their compatibility with jQuery 3 carefully. Upgrading to jQuery 3 also causes our test for foundation's sticky on mobile phones to fail.