### PR TITLE
Remove obsolete report columns from polls

### DIFF
--- a/db/migrate/20191107193003_remove_old_stats_and_results_enabled_columns.rb
+++ b/db/migrate/20191107193003_remove_old_stats_and_results_enabled_columns.rb
@@ -1,0 +1,6 @@
+class RemoveOldStatsAndResultsEnabledColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :polls, :results_enabled, :boolean, default: false
+    remove_column :polls, :stats_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191105184023) do
+ActiveRecord::Schema.define(version: 20191107193003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1222,8 +1222,6 @@ ActiveRecord::Schema.define(version: 20191105184023) do
     t.integer  "author_id"
     t.datetime "hidden_at"
     t.string   "slug"
-    t.boolean  "results_enabled",    default: false
-    t.boolean  "stats_enabled",      default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "budget_id"


### PR DESCRIPTION
## References

* Pull request #3520 made these columns obsolete, but we had to wait for version 1.0 to delete them

## Objectives

Remove obsolete columns whose content was already migrated.