### PR TITLE
Bring back removal of translatable columns

### DIFF
--- a/db/migrate/20190213150434_rename_old_translatable_attibutes_in_debates.rb
+++ b/db/migrate/20190213150434_rename_old_translatable_attibutes_in_debates.rb
@@ -1,0 +1,8 @@
+class RenameOldTranslatableAttibutesInDebates < ActiveRecord::Migration[4.2]
+  def change
+    remove_index :debates, :title
+
+    rename_column :debates, :title, :deprecated_title
+    rename_column :debates, :description, :deprecated_description
+  end
+end

--- a/db/migrate/20190215152236_rename_old_translatable_attibutes_in_proposals.rb
+++ b/db/migrate/20190215152236_rename_old_translatable_attibutes_in_proposals.rb
@@ -1,0 +1,11 @@
+class RenameOldTranslatableAttibutesInProposals < ActiveRecord::Migration[4.2]
+  def change
+    remove_index :proposals, :title
+    remove_index :proposals, :summary
+
+    rename_column :proposals, :title, :deprecated_title
+    rename_column :proposals, :description, :deprecated_description
+    rename_column :proposals, :summary, :deprecated_summary
+    rename_column :proposals, :retired_explanation, :deprecated_retired_explanation
+  end
+end

--- a/db/migrate/20190218122530_rename_old_translatable_attibutes_in_comments.rb
+++ b/db/migrate/20190218122530_rename_old_translatable_attibutes_in_comments.rb
@@ -1,0 +1,5 @@
+class RenameOldTranslatableAttibutesInComments < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :comments, :body, :deprecated_body
+  end
+end

--- a/db/migrate/20190218162141_rename_old_translatable_attibutes_in_budget_investments.rb
+++ b/db/migrate/20190218162141_rename_old_translatable_attibutes_in_budget_investments.rb
@@ -1,0 +1,6 @@
+class RenameOldTranslatableAttibutesInBudgetInvestments < ActiveRecord::Migration[4.2]
+  def change
+    rename_column :budget_investments, :title, :deprecated_title
+    rename_column :budget_investments, :description, :deprecated_description
+  end
+end

--- a/db/migrate/20190221154819_remove_deprecated_translatable_fields_from_banners.rb
+++ b/db/migrate/20190221154819_remove_deprecated_translatable_fields_from_banners.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromBanners < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :banners, :title, :string
+    remove_column :banners, :description, :string
+  end
+end

--- a/db/migrate/20190221162450_remove_deprecated_translatable_fields_from_polls.rb
+++ b/db/migrate/20190221162450_remove_deprecated_translatable_fields_from_polls.rb
@@ -1,0 +1,7 @@
+class RemoveDeprecatedTranslatableFieldsFromPolls < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :polls, :name, :string
+    remove_column :polls, :summary, :text
+    remove_column :polls, :description, :text
+  end
+end

--- a/db/migrate/20190221162858_remove_deprecated_translatable_fields_from_poll_questions.rb
+++ b/db/migrate/20190221162858_remove_deprecated_translatable_fields_from_poll_questions.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromPollQuestions < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :poll_questions, :title, :string
+  end
+end

--- a/db/migrate/20190221163117_remove_deprecated_translatable_fields_from_poll_question_answers.rb
+++ b/db/migrate/20190221163117_remove_deprecated_translatable_fields_from_poll_question_answers.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromPollQuestionAnswers < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :poll_question_answers, :title, :string
+    remove_column :poll_question_answers, :description, :text
+  end
+end

--- a/db/migrate/20190221163818_remove_deprecated_translatable_fields_from_admin_notifications.rb
+++ b/db/migrate/20190221163818_remove_deprecated_translatable_fields_from_admin_notifications.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromAdminNotifications < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :admin_notifications, :title, :string
+    remove_column :admin_notifications, :body, :text
+  end
+end

--- a/db/migrate/20190221164056_remove_deprecated_translatable_fields_from_milestones.rb
+++ b/db/migrate/20190221164056_remove_deprecated_translatable_fields_from_milestones.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromMilestones < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :milestones, :title, :string
+    remove_column :milestones, :description, :text
+  end
+end

--- a/db/migrate/20190221164559_remove_deprecated_translatable_fields_from_legislation_draft_versions.rb
+++ b/db/migrate/20190221164559_remove_deprecated_translatable_fields_from_legislation_draft_versions.rb
@@ -1,0 +1,7 @@
+class RemoveDeprecatedTranslatableFieldsFromLegislationDraftVersions < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :legislation_draft_versions, :title, :string
+    remove_column :legislation_draft_versions, :changelog, :text
+    remove_column :legislation_draft_versions, :body, :text
+  end
+end

--- a/db/migrate/20190221164928_remove_deprecated_translatable_fields_from_legislation_processes.rb
+++ b/db/migrate/20190221164928_remove_deprecated_translatable_fields_from_legislation_processes.rb
@@ -1,0 +1,8 @@
+class RemoveDeprecatedTranslatableFieldsFromLegislationProcesses < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :legislation_processes, :title, :string
+    remove_column :legislation_processes, :summary, :text
+    remove_column :legislation_processes, :description, :text
+    remove_column :legislation_processes, :additional_info, :text
+  end
+end

--- a/db/migrate/20190221165347_remove_deprecated_translatable_fields_from_legislation_questions.rb
+++ b/db/migrate/20190221165347_remove_deprecated_translatable_fields_from_legislation_questions.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromLegislationQuestions < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :legislation_questions, :title, :text
+  end
+end

--- a/db/migrate/20190221171155_remove_deprecated_translatable_fields_from_legislation_question_options.rb
+++ b/db/migrate/20190221171155_remove_deprecated_translatable_fields_from_legislation_question_options.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromLegislationQuestionOptions < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :legislation_question_options, :value, :string
+  end
+end

--- a/db/migrate/20190221171859_remove_deprecated_translatable_fields_from_site_customization_pages.rb
+++ b/db/migrate/20190221171859_remove_deprecated_translatable_fields_from_site_customization_pages.rb
@@ -1,0 +1,7 @@
+class RemoveDeprecatedTranslatableFieldsFromSiteCustomizationPages < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :site_customization_pages, :title, :string
+    remove_column :site_customization_pages, :subtitle, :string
+    remove_column :site_customization_pages, :content, :text
+  end
+end

--- a/db/migrate/20190221172209_remove_deprecated_translatable_fields_from_widget_cards.rb
+++ b/db/migrate/20190221172209_remove_deprecated_translatable_fields_from_widget_cards.rb
@@ -1,0 +1,8 @@
+class RemoveDeprecatedTranslatableFieldsFromWidgetCards < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :widget_cards, :label, :string
+    remove_column :widget_cards, :title, :string
+    remove_column :widget_cards, :description, :text
+    remove_column :widget_cards, :link_text, :string
+  end
+end

--- a/db/migrate/20190325184500_remove_deprecated_translatable_fields_from_budgets.rb
+++ b/db/migrate/20190325184500_remove_deprecated_translatable_fields_from_budgets.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromBudgets < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :budgets, :name, :string
+  end
+end

--- a/db/migrate/20190325185046_remove_deprecated_translatable_fields_from_budget_groups.rb
+++ b/db/migrate/20190325185046_remove_deprecated_translatable_fields_from_budget_groups.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromBudgetGroups < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :budget_groups, :name, :string
+  end
+end

--- a/db/migrate/20190325185405_remove_deprecated_translatable_fields_from_budget_headings.rb
+++ b/db/migrate/20190325185405_remove_deprecated_translatable_fields_from_budget_headings.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedTranslatableFieldsFromBudgetHeadings < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :budget_headings, :name, :string
+  end
+end

--- a/db/migrate/20190325185550_remove_deprecated_translatable_fields_from_budget_phases.rb
+++ b/db/migrate/20190325185550_remove_deprecated_translatable_fields_from_budget_phases.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromBudgetPhases < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :budget_phases, :summary, :text
+    remove_column :budget_phases, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,8 +55,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   end
 
   create_table "admin_notifications", force: :cascade do |t|
-    t.string   "title"
-    t.text     "body"
     t.string   "link"
     t.string   "segment_recipient"
     t.integer  "recipients_count"
@@ -127,14 +125,12 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   end
 
   create_table "banners", force: :cascade do |t|
-    t.string   "title",            limit: 80
-    t.string   "description"
     t.string   "target_url"
     t.date     "post_started_at"
     t.date     "post_ended_at"
     t.datetime "hidden_at"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
     t.text     "background_color"
     t.text     "font_color"
     t.index ["hidden_at"], name: "index_banners_on_hidden_at", using: :btree
@@ -193,9 +189,8 @@ ActiveRecord::Schema.define(version: 20191107193003) do
 
   create_table "budget_groups", force: :cascade do |t|
     t.integer  "budget_id"
-    t.string   "name",                 limit: 50
     t.string   "slug"
-    t.integer  "max_votable_headings",            default: 1
+    t.integer  "max_votable_headings", default: 1
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["budget_id"], name: "index_budget_groups_on_budget_id", using: :btree
@@ -213,11 +208,10 @@ ActiveRecord::Schema.define(version: 20191107193003) do
 
   create_table "budget_headings", force: :cascade do |t|
     t.integer  "group_id"
-    t.string   "name",                 limit: 50
     t.bigint   "price"
     t.integer  "population"
     t.string   "slug"
-    t.boolean  "allow_custom_content",            default: false
+    t.boolean  "allow_custom_content", default: false
     t.text     "latitude"
     t.text     "longitude"
     t.datetime "created_at"
@@ -272,8 +266,8 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   create_table "budget_investments", force: :cascade do |t|
     t.integer  "author_id"
     t.integer  "administrator_id"
-    t.string   "title"
-    t.text     "description"
+    t.string   "deprecated_title"
+    t.text     "deprecated_description"
     t.string   "external_url"
     t.bigint   "price"
     t.string   "feasibility",                      limit: 15, default: "undecided"
@@ -332,8 +326,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
     t.integer  "budget_id"
     t.integer  "next_phase_id"
     t.string   "kind",                         null: false
-    t.text     "summary"
-    t.text     "description"
     t.datetime "starts_at"
     t.datetime "ends_at"
     t.boolean  "enabled",       default: true
@@ -384,7 +376,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   end
 
   create_table "budgets", force: :cascade do |t|
-    t.string   "name",                          limit: 80
     t.string   "currency_symbol",               limit: 10
     t.string   "phase",                         limit: 40, default: "accepting"
     t.datetime "created_at",                                                     null: false
@@ -437,7 +428,7 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   create_table "comments", force: :cascade do |t|
     t.integer  "commentable_id"
     t.string   "commentable_type"
-    t.text     "body"
+    t.text     "deprecated_body"
     t.string   "subject"
     t.integer  "user_id",                            null: false
     t.datetime "created_at"
@@ -521,8 +512,8 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   end
 
   create_table "debates", force: :cascade do |t|
-    t.string   "title",                        limit: 80
-    t.text     "description"
+    t.string   "deprecated_title",             limit: 80
+    t.text     "deprecated_description"
     t.integer  "author_id"
     t.datetime "created_at",                                          null: false
     t.datetime "updated_at",                                          null: false
@@ -552,7 +543,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
     t.index ["geozone_id"], name: "index_debates_on_geozone_id", using: :btree
     t.index ["hidden_at"], name: "index_debates_on_hidden_at", using: :btree
     t.index ["hot_score"], name: "index_debates_on_hot_score", using: :btree
-    t.index ["title"], name: "index_debates_on_title", using: :btree
     t.index ["tsv"], name: "index_debates_on_tsv", using: :gin
   end
 
@@ -737,11 +727,8 @@ ActiveRecord::Schema.define(version: 20191107193003) do
 
   create_table "legislation_draft_versions", force: :cascade do |t|
     t.integer  "legislation_process_id"
-    t.string   "title"
-    t.text     "changelog"
     t.string   "status",                 default: "draft"
     t.boolean  "final_version",          default: false
-    t.text     "body"
     t.datetime "hidden_at"
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
@@ -768,9 +755,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   end
 
   create_table "legislation_processes", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.text     "additional_info"
     t.date     "start_date"
     t.date     "end_date"
     t.date     "debate_start_date"
@@ -782,7 +766,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
     t.datetime "hidden_at"
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
-    t.text     "summary"
     t.boolean  "debate_phase_enabled",       default: false
     t.boolean  "allegations_phase_enabled",  default: false
     t.boolean  "draft_publication_enabled",  default: false
@@ -857,7 +840,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
 
   create_table "legislation_question_options", force: :cascade do |t|
     t.integer  "legislation_question_id"
-    t.string   "value"
     t.integer  "answers_count",           default: 0
     t.datetime "hidden_at"
     t.datetime "created_at",                          null: false
@@ -880,7 +862,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
 
   create_table "legislation_questions", force: :cascade do |t|
     t.integer  "legislation_process_id"
-    t.text     "title"
     t.integer  "answers_count",          default: 0
     t.datetime "hidden_at"
     t.datetime "created_at",                         null: false
@@ -959,12 +940,10 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   create_table "milestones", force: :cascade do |t|
     t.string   "milestoneable_type"
     t.integer  "milestoneable_id"
-    t.string   "title",              limit: 80
-    t.text     "description"
     t.datetime "publication_date"
     t.integer  "status_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
     t.index ["status_id"], name: "index_milestones_on_status_id", using: :btree
   end
 
@@ -1102,8 +1081,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   end
 
   create_table "poll_question_answers", force: :cascade do |t|
-    t.string  "title"
-    t.text    "description"
     t.integer "question_id"
     t.integer "given_order", default: 1
     t.boolean "most_voted",  default: false
@@ -1127,7 +1104,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
     t.integer  "poll_id"
     t.integer  "author_id"
     t.string   "author_visible_name"
-    t.string   "title"
     t.integer  "comments_count"
     t.datetime "hidden_at"
     t.datetime "created_at"
@@ -1211,13 +1187,10 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   end
 
   create_table "polls", force: :cascade do |t|
-    t.string   "name"
     t.datetime "starts_at"
     t.datetime "ends_at"
     t.boolean  "published",          default: false
     t.boolean  "geozone_restricted", default: false
-    t.text     "summary"
-    t.text     "description"
     t.integer  "comments_count",     default: 0
     t.integer  "author_id"
     t.datetime "hidden_at"
@@ -1280,30 +1253,30 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   end
 
   create_table "proposals", force: :cascade do |t|
-    t.string   "title",               limit: 80
-    t.text     "description"
+    t.string   "deprecated_title",               limit: 80
+    t.text     "deprecated_description"
     t.integer  "author_id"
     t.datetime "hidden_at"
-    t.integer  "flags_count",                    default: 0
+    t.integer  "flags_count",                               default: 0
     t.datetime "ignored_flag_at"
-    t.integer  "cached_votes_up",                default: 0
-    t.integer  "comments_count",                 default: 0
+    t.integer  "cached_votes_up",                           default: 0
+    t.integer  "comments_count",                            default: 0
     t.datetime "confirmed_hide_at"
-    t.bigint   "hot_score",                      default: 0
-    t.integer  "confidence_score",               default: 0
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
-    t.string   "responsible_name",    limit: 60
-    t.text     "summary"
+    t.bigint   "hot_score",                                 default: 0
+    t.integer  "confidence_score",                          default: 0
+    t.datetime "created_at",                                                null: false
+    t.datetime "updated_at",                                                null: false
+    t.string   "responsible_name",               limit: 60
+    t.text     "deprecated_summary"
     t.string   "video_url"
     t.tsvector "tsv"
     t.integer  "geozone_id"
     t.datetime "retired_at"
     t.string   "retired_reason"
-    t.text     "retired_explanation"
+    t.text     "deprecated_retired_explanation"
     t.integer  "community_id"
     t.datetime "published_at"
-    t.boolean  "selected",                       default: false
+    t.boolean  "selected",                                  default: false
     t.index ["author_id", "hidden_at"], name: "index_proposals_on_author_id_and_hidden_at", using: :btree
     t.index ["author_id"], name: "index_proposals_on_author_id", using: :btree
     t.index ["cached_votes_up"], name: "index_proposals_on_cached_votes_up", using: :btree
@@ -1312,8 +1285,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
     t.index ["geozone_id"], name: "index_proposals_on_geozone_id", using: :btree
     t.index ["hidden_at"], name: "index_proposals_on_hidden_at", using: :btree
     t.index ["hot_score"], name: "index_proposals_on_hot_score", using: :btree
-    t.index ["summary"], name: "index_proposals_on_summary", using: :btree
-    t.index ["title"], name: "index_proposals_on_title", using: :btree
     t.index ["tsv"], name: "index_proposals_on_tsv", using: :gin
   end
 
@@ -1425,9 +1396,6 @@ ActiveRecord::Schema.define(version: 20191107193003) do
 
   create_table "site_customization_pages", force: :cascade do |t|
     t.string   "slug",                                 null: false
-    t.string   "title"
-    t.string   "subtitle"
-    t.text     "content"
     t.boolean  "more_info_flag"
     t.boolean  "print_content_flag"
     t.string   "status",             default: "draft"
@@ -1648,11 +1616,7 @@ ActiveRecord::Schema.define(version: 20191107193003) do
   end
 
   create_table "widget_cards", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.string   "link_text"
     t.string   "link_url"
-    t.string   "label"
     t.boolean  "header",                     default: false
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false


### PR DESCRIPTION
## References

* Reverts commit 251326ea.

## Objectives

* Remove unused columns

## Notes

Globalize does not support having translatable columns with the same name in the original table and the translations table. We were planning to migrate to Mobility, but we aren't doing so before releasing version 1.1.

We've also found a gotcha regarding having both columns: if we use the `update_column` method, which we use in rake tasks to speed up the process and in tests where we want to skip validations and callbacks, we update the column in the original table and no exception is raised. If we remove the column in the original table, when we use `update_column` we get an exception, which is what we want since our intention is to update the column in the translations table.

There are also fields we've added to translation tables but not the original tables, like `milestones_summary` and `homepage` in `legislation_process_translations` or `description` in `active_polls`. Having some fields in both tables and some fields only in translation tables is not very consistent.

With this change we're following the advice given by the Mobility lead developer: ["If you don't need the columns, I think it would make sense to just remove them to avoid any edge case issues."](https://gitter.im/mobility-ruby/mobility?at=5d226a7451d87058befce542)