### PR TITLE
Remove duplicated local census records on deployment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,6 +43,7 @@ namespace :deploy do
   before :starting, "rvm1:install:rvm"
   before :starting, "rvm1:install:ruby"
   before :starting, "install_bundler_gem"
+  before "deploy:migrate", "remove_local_census_records_duplicates"
 
   after "deploy:migrate", "add_new_settings"
   after :publishing, "deploy:restart"
@@ -64,6 +65,16 @@ task :install_bundler_gem do
   on roles(:app) do
     within release_path do
       execute :rvm, fetch(:rvm1_ruby_version), "do", "gem install bundler"
+    end
+  end
+end
+
+task :remove_local_census_records_duplicates do
+  on roles(:db) do
+    within release_path do
+      with rails_env: fetch(:rails_env) do
+        execute :rake, "local_census_records:remove_duplicates"
+      end
     end
   end
 end

--- a/lib/tasks/local_census_records.rake
+++ b/lib/tasks/local_census_records.rake
@@ -1,0 +1,13 @@
+namespace :local_census_records do
+  desc "Remove duplicated records from database"
+  task remove_duplicates: :environment do
+    ids = LocalCensusRecord.group(:document_type, :document_number).pluck("MIN(id) as id")
+    duplicates = LocalCensusRecord.count - ids.size
+
+    if duplicates > 0
+      ApplicationLogger.new.info "Removing local census records duplicates"
+      LocalCensusRecord.where("id NOT IN (?)", ids).destroy_all
+      ApplicationLogger.new.info "Removed #{duplicates} records."
+    end
+  end
+end

--- a/spec/lib/tasks/local_census_records_spec.rb
+++ b/spec/lib/tasks/local_census_records_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require Rails.root.join("db", "migrate", "20190530082138_add_unique_index_to_local_census_records")
+
+describe "LocalCensusRecord tasks" do
+  let(:run_rake_task) do
+    Rake::Task["local_census_records:remove_duplicates"].reenable
+    Rake.application.invoke_task("local_census_records:remove_duplicates")
+  end
+
+  describe "#remove_duplicates" do
+    around do |example|
+      ActiveRecord::Migration.suppress_messages do
+        example.run
+      end
+    end
+
+    before { AddUniqueIndexToLocalCensusRecords.new.down }
+    after { AddUniqueIndexToLocalCensusRecords.new.up }
+
+    it "Remove all duplicates keeping older records" do
+      record1 = create(:local_census_record, document_type: "1", document_number: "#DOCUMENT_NUMBER")
+      record2 = create(:local_census_record, document_type: "2", document_number: "#DOCUMENT_NUMBER")
+      dup_record1 = build(:local_census_record, document_type: "1", document_number: "#DOCUMENT_NUMBER")
+      dup_record1.save!(validate: false)
+      dup_record2 = build(:local_census_record, document_type: "2", document_number: "#DOCUMENT_NUMBER")
+      dup_record2.save!(validate: false)
+      record3 = create(:local_census_record, document_type: "3", document_number: "#DOCUMENT_NUMBER")
+
+      expect(LocalCensusRecord.count).to eq(5)
+
+      run_rake_task
+
+      expect(LocalCensusRecord.all).to match_array([record1, record2, record3])
+    end
+  end
+end


### PR DESCRIPTION
## References

Related Pull Requests: #3646  

PR #3646 includes a migration that adds an unique database constraint to LocalCensusRecord model so we need to provide a way to remove duplicated records before to apply the new index to database.

## Objectives

Remove duplicated local census records automatically during capistrano deployment and before applying new aforementioned migration.

Also provide a rake task to remove duplicated records manually for those Consul installations that are not using caspistrano.

## Release notes

With this PR people using capistrano may not worry about deleting local census records dupicates manually from the database, but people using other deployment strategies that capistrano, for example Heroku, should manually run the rake task `local_census_records:remove_duplicates` before running `db:migrate`.

## Production server test results
**Deployment test steps**:
1. Prepare a production server with the Ansible installer and deploy the Consul 1.0.0 version.
2. Create dups in the LocalCensusRecord database table
2. Deploy with capistrano the code of this PR
3. Check during deployment and before the capistrano step deploy:migrate  those duplicated records were removed successfully

Below the deployment log that demonstrates this PR is working successfully.
```
01:02 remove_local_census_records_duplicates
      01 /home/deploy/consul/rvm1scripts/rvm-auto.sh . bundle exec rake local_census_records:remove_duplicates
      01 INFO Removing local census records duplicates
      01
      01 INFO Removed 6 records.
      01
    ✔ 01 deploy@ec2-63-32-46-29.eu-west-1.compute.amazonaws.com 4.907s
01:07 deploy:migrate
      [deploy:migrate] Run `rake db:migrate`
01:07 deploy:migrating
```

**This PR wil be in WIP status until all review issues are solved**