### PR TITLE
Fix pagination problem on mobile

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -409,6 +409,10 @@ a {
   background: $brand;
 }
 
+.pagination li {
+  display: inline-block;
+}
+
 .truncate-horizontal-text {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Objectives

- Fixes a bug in which the pagination buttons wouldn't be displayed correctly if there are more than two pages.
- Backports the fix from [AyuntamientoMadrid/consul](https://github.com/AyuntamientoMadrid/consul/pull/248)

## Visual Changes

### Before:
![Capture d’écran 2019-11-08 à 16 34 15](https://user-images.githubusercontent.com/7223028/68488741-0569af80-0246-11ea-9e7f-3536bc0720e6.png)
### After:
![Capture d’écran 2019-11-08 à 16 34 56](https://user-images.githubusercontent.com/7223028/68488737-00a4fb80-0246-11ea-8084-7986928764cc.png)

## Notes

- Fixed thanks to @javierm 