### PR TITLE
Fix random title with trailing spaces

### DIFF
--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -132,7 +132,7 @@ FactoryBot.define do
   end
 
   factory :dashboard_action, class: "Dashboard::Action" do
-    title { Faker::Lorem.sentence[0..79] }
+    title { Faker::Lorem.sentence[0..79].strip }
     description { Faker::Lorem.sentence }
     link { nil }
     request_to_administrators { true }


### PR DESCRIPTION
## References

* Travis failure in [build 32206, job 3](https://travis-ci.org/consul/consul/jobs/609163986)

## Objectives

Fix a flaky spec in `spec/features/dashboard/dashboard_spec.rb:282`: Proposal's dashboard Request resource with admin request

## Notes

When the generated title for a dashboard action ended with a space, the action `click_link(feature.title)` failed because the link shown in the HTML ignores the trailing spaces.

Using `strip` solves the problem. Not the most elegant solution, though; ideally we'd generate a better title.