### PR TITLE
Don't add log info messages when running tests

### DIFF
--- a/lib/application_logger.rb
+++ b/lib/application_logger.rb
@@ -1,6 +1,6 @@
 class ApplicationLogger
   def info(message)
-    logger.info(message)
+    logger.info(message) unless Rails.env.test?
   end
 
   def logger


### PR DESCRIPTION
## Objectives

Reduce the number of messages we get when we run our test suite.