### PR TITLE
Apply rubocop Rails/FindBy rule everywhere

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -228,6 +228,8 @@ Rails/EnvironmentComparison:
 
 Rails/FindBy:
   Enabled: true
+  Include:
+    - "**/*.rb"
 
 Rails/FindEach:
   Enabled: true

--- a/app/controllers/admin/homepage_controller.rb
+++ b/app/controllers/admin/homepage_controller.rb
@@ -13,7 +13,7 @@ class Admin::HomepageController < Admin::BaseController
     end
 
     def load_recommendations
-      @recommendations = Setting.where(key: "feature.user.recommendations").first
+      @recommendations = Setting.find_by(key: "feature.user.recommendations")
     end
 
     def load_cards

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -98,7 +98,7 @@ class ApplicationController < ActionController::Base
 
     def track_email_campaign
       if params[:track_id]
-        campaign = Campaign.where(track_id: params[:track_id]).first
+        campaign = Campaign.find_by(track_id: params[:track_id])
         ahoy.track campaign.name if campaign.present?
       end
     end

--- a/app/controllers/dashboard/actions_controller.rb
+++ b/app/controllers/dashboard/actions_controller.rb
@@ -38,7 +38,7 @@ class Dashboard::ActionsController < Dashboard::BaseController
   def unexecute
     authorize! :dashboard, proposal
 
-    Dashboard::ExecutedAction.where(proposal: proposal, action: dashboard_action).first.destroy!
+    Dashboard::ExecutedAction.find_by(proposal: proposal, action: dashboard_action).destroy!
 
     redirect_to request.referer
   end

--- a/app/controllers/legislation/annotations_controller.rb
+++ b/app/controllers/legislation/annotations_controller.rb
@@ -33,9 +33,12 @@ class Legislation::AnnotationsController < Legislation::BaseController
       render(json: {}, status: :not_found) && return
     end
 
-    existing_annotation = @draft_version.annotations.where(
-      range_start: annotation_params[:ranges].first[:start], range_start_offset: annotation_params[:ranges].first[:startOffset].to_i,
-      range_end: annotation_params[:ranges].first[:end], range_end_offset: annotation_params[:ranges].first[:endOffset].to_i).first
+    existing_annotation = @draft_version.annotations.find_by(
+      range_start: annotation_params[:ranges].first[:start],
+      range_start_offset: annotation_params[:ranges].first[:startOffset].to_i,
+      range_end: annotation_params[:ranges].first[:end],
+      range_end_offset: annotation_params[:ranges].first[:endOffset].to_i
+    )
 
     @annotation = existing_annotation
     if @annotation.present?

--- a/app/controllers/officing/base_controller.rb
+++ b/app/controllers/officing/base_controller.rb
@@ -44,6 +44,6 @@ class Officing::BaseController < ApplicationController
     end
 
     def current_booth
-      Poll::Booth.where(id: session[:booth_id]).first
+      Poll::Booth.find_by(id: session[:booth_id])
     end
 end

--- a/app/controllers/officing/results_controller.rb
+++ b/app/controllers/officing/results_controller.rb
@@ -43,7 +43,7 @@ class Officing::ResultsController < Officing::BaseController
         results.each_pair do |answer_index, count|
           next if count.blank?
 
-          answer = question.question_answers.where(given_order: answer_index.to_i + 1).first.title
+          answer = question.question_answers.find_by(given_order: answer_index.to_i + 1).title
           go_back_to_new if question.blank?
 
           partial_result = ::Poll::PartialResult.find_or_initialize_by(booth_assignment_id: @officer_assignment.booth_assignment_id,

--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -19,7 +19,7 @@ class Officing::VotersController < Officing::BaseController
                              poll: @poll,
                              origin: "booth",
                              officer: current_user.poll_officer,
-                             booth_assignment: Poll::BoothAssignment.where(poll: @poll, booth: current_booth).first,
+                             booth_assignment: Poll::BoothAssignment.find_by(poll: @poll, booth: current_booth),
                              officer_assignment: officer_assignment(@poll))
     @voter.save!
   end
@@ -35,7 +35,6 @@ class Officing::VotersController < Officing::BaseController
                              .by_poll(poll)
                              .by_booth(current_booth)
                              .by_date(Date.current)
-                             .where(final: false)
-                             .first
+                             .find_by(final: false)
     end
 end

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -43,7 +43,7 @@ class PollsController < ApplicationController
   private
 
     def load_poll
-      @poll = Poll.where(slug: params[:id]).first || Poll.where(id: params[:id]).first
+      @poll = Poll.find_by(slug: params[:id]) || Poll.find_by(id: params[:id])
     end
 
     def load_active_poll

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -43,7 +43,7 @@ class PollsController < ApplicationController
   private
 
     def load_poll
-      @poll = Poll.find_by(slug: params[:id]) || Poll.find_by(id: params[:id])
+      @poll = Poll.find_by_slug_or_id!(params[:id])
     end
 
     def load_active_poll

--- a/app/controllers/verification/email_controller.rb
+++ b/app/controllers/verification/email_controller.rb
@@ -31,7 +31,7 @@ class Verification::EmailController < ApplicationController
   private
 
     def set_verified_user
-      @verified_user = VerifiedUser.by_user(current_user).where(id: verified_user_params[:id]).first
+      @verified_user = VerifiedUser.by_user(current_user).find_by(id: verified_user_params[:id])
     end
 
     def verified_user_params

--- a/app/controllers/verification/sms_controller.rb
+++ b/app/controllers/verification/sms_controller.rb
@@ -58,7 +58,7 @@ class Verification::SmsController < ApplicationController
     def verified_user
       return false unless params[:verified_user]
 
-      @verified_user = VerifiedUser.by_user(current_user).where(id: params[:verified_user][:id]).first
+      @verified_user = VerifiedUser.by_user(current_user).find_by(id: params[:verified_user][:id])
     end
 
     def redirect_to_next_path

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -50,7 +50,7 @@ module BudgetsHelper
   end
 
   def current_ballot
-    Budget::Ballot.where(user: current_user, budget: @budget).first
+    Budget::Ballot.find_by(user: current_user, budget: @budget)
   end
 
   def investment_tags_select_options(budget, context)
@@ -96,7 +96,7 @@ module BudgetsHelper
   end
 
   def link_to_create_budget_poll(budget)
-    balloting_phase = budget.phases.where(kind: "balloting").first
+    balloting_phase = budget.phases.find_by(kind: "balloting")
 
     link_to t("admin.budgets.index.admin_ballots"),
             admin_polls_path(poll: {

--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -41,7 +41,7 @@ module PollsHelper
   end
 
   def poll_voter_token(poll, user)
-    Poll::Voter.where(poll: poll, user: user, origin: "web").first&.token || ""
+    Poll::Voter.find_by(poll: poll, user: user, origin: "web")&.token || ""
   end
 
   def voted_before_sign_in(question)

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -9,10 +9,10 @@ module SiteCustomizationHelper
 
   def translation_for_locale(content, locale)
     if content.present?
-      I18nContentTranslation.where(
+      I18nContentTranslation.find_by(
         i18n_content_id: content.id,
         locale: locale
-      ).first&.value
+      )&.value
     else
       false
     end

--- a/config/initializers/i18n_translation.rb
+++ b/config/initializers/i18n_translation.rb
@@ -10,8 +10,8 @@ module ActionView
         current_locale = options[:locale].presence || I18n.locale
 
         i18_content = I18nContent.find_by(key: key)
-        translation = I18nContentTranslation.where(i18n_content_id: i18_content&.id,
-                                                   locale: current_locale).first&.value
+        translation = I18nContentTranslation.find_by(i18n_content_id: i18_content&.id,
+                                                     locale: current_locale)&.value
         translation.presence || translate(key, options)
       end
     end

--- a/spec/features/admin/homepage/homepage_spec.rb
+++ b/spec/features/admin/homepage/homepage_spec.rb
@@ -15,7 +15,7 @@ describe "Homepage" do
   let!(:debates_feed)      { create(:widget_feed, kind: "debates") }
   let!(:processes_feed)    { create(:widget_feed, kind: "processes") }
 
-  let(:user_recommendations) { Setting.where(key: "feature.user.recommendations").first }
+  let(:user_recommendations) { Setting.find_by(key: "feature.user.recommendations") }
   let(:user)                 { create(:user) }
 
   context "Header" do

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -273,7 +273,7 @@ describe "Admin settings" do
   describe "Skip verification" do
     scenario "deactivate skip verification", :js do
       Setting["feature.user.skip_verification"] = "true"
-      setting = Setting.where(key: "feature.user.skip_verification").first
+      setting = Setting.find_by(key: "feature.user.skip_verification")
 
       visit admin_settings_path
       find("#features-tab").click
@@ -287,7 +287,7 @@ describe "Admin settings" do
 
     scenario "activate skip verification", :js do
       Setting["feature.user.skip_verification"] = nil
-      setting = Setting.where(key: "feature.user.skip_verification").first
+      setting = Setting.find_by(key: "feature.user.skip_verification")
 
       visit admin_settings_path
       find("#features-tab").click

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -233,7 +233,7 @@ describe "Stats" do
 
       expect(page).to have_content "#{campaign.name} (1)"
       within("#graph") do
-        event_created_at = Ahoy::Event.where(name: campaign.name).first.time
+        event_created_at = Ahoy::Event.find_by(name: campaign.name).time
         expect(page).to have_content event_created_at.strftime("%Y-%m-%d")
       end
     end

--- a/spec/features/budget_polls/budgets_spec.rb
+++ b/spec/features/budget_polls/budgets_spec.rb
@@ -14,7 +14,7 @@ describe "Admin Budgets" do
 
       click_link "Admin ballots"
 
-      balloting_phase = budget.phases.where(kind: "balloting").first
+      balloting_phase = budget.phases.find_by(kind: "balloting")
 
       expect(page).to have_current_path(/admin\/polls\/\d+/)
       expect(page).to have_content(budget.name)

--- a/spec/features/budget_polls/voter_spec.rb
+++ b/spec/features/budget_polls/voter_spec.rb
@@ -41,7 +41,7 @@ describe "BudgetPolls", :with_frozen_time do
         expect(page).to have_content "1"
       end
 
-      within("#poll_booth_assignment_#{Poll::BoothAssignment.where(poll: poll, booth: booth).first.id}_recounts") do
+      within("#poll_booth_assignment_#{Poll::BoothAssignment.find_by(poll: poll, booth: booth).id}_recounts") do
         expect(page).to have_content "1"
       end
     end

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -193,7 +193,7 @@ describe "Legislation" do
 
       scenario "Shows another translation when the default locale isn't available" do
         process = create(:legislation_process, title_fr: "Français")
-        process.translations.where(locale: :en).first.destroy!
+        process.translations.find_by(locale: :en).destroy!
 
         visit legislation_process_path(process)
         expect(page).to have_content("Français")

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Organizations" do
   scenario "Organizations can be created" do
-    user = User.organizations.where(email: "green@peace.com").first
+    user = User.organizations.find_by(email: "green@peace.com")
     expect(user).not_to be
 
     visit new_organization_registration_path
@@ -16,7 +16,7 @@ describe "Organizations" do
 
     click_button "Register"
 
-    user = User.organizations.where(email: "green@peace.com").first
+    user = User.organizations.find_by(email: "green@peace.com")
     expect(user).to be
     expect(user).to be_organization
     expect(user.organization).not_to be_verified

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -72,7 +72,7 @@ describe "Voter" do
         expect(page).to have_content "1"
       end
 
-      within("#poll_booth_assignment_#{Poll::BoothAssignment.where(poll: poll, booth: booth).first.id}_recounts") do
+      within("#poll_booth_assignment_#{Poll::BoothAssignment.find_by(poll: poll, booth: booth).id}_recounts") do
         expect(page).to have_content "1"
       end
     end
@@ -159,7 +159,7 @@ describe "Voter" do
           expect(page).to have_content "1"
         end
 
-        within("#poll_booth_assignment_#{Poll::BoothAssignment.where(poll: poll, booth: booth).first.id}_recounts") do
+        within("#poll_booth_assignment_#{Poll::BoothAssignment.find_by(poll: poll, booth: booth).id}_recounts") do
           expect(page).to have_content "1"
         end
       end
@@ -224,7 +224,7 @@ describe "Voter" do
         expect(page).to have_content "1"
       end
 
-      within("#poll_booth_assignment_#{Poll::BoothAssignment.where(poll: poll, booth: booth).first.id}_recounts") do
+      within("#poll_booth_assignment_#{Poll::BoothAssignment.find_by(poll: poll, booth: booth).id}_recounts") do
         expect(page).to have_content "1"
       end
     end

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -216,7 +216,7 @@ describe "Proposal Notifications" do
 
       find(".icon-notification").click
 
-      notification_for_user1 = Notification.where(user: user1).first
+      notification_for_user1 = Notification.find_by(user: user1)
       expect(page).to have_css ".notification", count: 1
       expect(page).to have_content "There is one new notification on #{proposal.title}"
       expect(page).to have_xpath "//a[@href='#{notification_path(notification_for_user1)}']"
@@ -228,7 +228,7 @@ describe "Proposal Notifications" do
 
       find(".icon-notification").click
 
-      notification_for_user2 = Notification.where(user: user2).first
+      notification_for_user2 = Notification.find_by(user: user2)
       expect(page).to have_css ".notification", count: 1
       expect(page).to have_content "There is one new notification on #{proposal.title}"
       expect(page).to have_xpath "//a[@href='#{notification_path(notification_for_user2)}']"
@@ -269,7 +269,7 @@ describe "Proposal Notifications" do
 
       find(".icon-notification").click
 
-      notification_for_user1 = Notification.where(user: user1).first
+      notification_for_user1 = Notification.find_by(user: user1)
       expect(page).to have_css ".notification", count: 1
       expect(page).to have_content "There is one new notification on #{proposal.title}"
       expect(page).to have_xpath "//a[@href='#{notification_path(notification_for_user1)}']"
@@ -280,7 +280,7 @@ describe "Proposal Notifications" do
 
       find(".icon-notification").click
 
-      notification_for_user2 = Notification.where(user: user2).first
+      notification_for_user2 = Notification.find_by(user: user2)
       expect(page).to have_css ".notification", count: 1
       expect(page).to have_content "There is one new notification on #{proposal.title}"
       expect(page).to have_xpath "//a[@href='#{notification_path(notification_for_user2)}']"
@@ -320,7 +320,7 @@ describe "Proposal Notifications" do
 
       find(".icon-notification").click
 
-      notification_for_user = Notification.where(user: user).first
+      notification_for_user = Notification.find_by(user: user)
       expect(page).to have_css ".notification", count: 1
       expect(page).to have_content "This resource is not available anymore"
       expect(page).not_to have_xpath "//a[@href='#{notification_path(notification_for_user)}']"

--- a/spec/mailers/previews/dashboard_mailer_preview.rb
+++ b/spec/mailers/previews/dashboard_mailer_preview.rb
@@ -6,14 +6,14 @@ class DashboardMailerPreview < ActionMailer::Preview
 
   # http://localhost:3000/rails/mailers/dashboard_mailer/new_actions_notification_rake_published
   def new_actions_notification_rake_published
-    proposal = Proposal.where(published: true).first
+    proposal = Proposal.find_by(published: true)
     new_actions_ids = Dashboard::Action.limit(1).id
     Dashboard::Mailer.new_actions_notification(proposal, [new_actions_ids])
   end
 
   # http://localhost:3000/rails/mailers/dashboard_mailer/new_actions_notification_rake_created
   def new_actions_notification_rake_created
-    proposal = Proposal.where(published: false).first
+    proposal = Proposal.find_by(published: false)
     new_actions_ids = Dashboard::Action.limit(1).id
     Dashboard::Mailer.new_actions_notification(proposal, [new_actions_ids])
   end

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -399,7 +399,7 @@ describe Debate do
   describe "custom tag counters when hiding/restoring" do
     it "decreases the tag counter when hiden, and increases it when restored" do
       debate = create(:debate, tag_list: "foo")
-      tag = Tag.where(name: "foo").first
+      tag = Tag.find_by(name: "foo")
       expect(tag.debates_count).to eq(1)
 
       debate.hide

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -117,8 +117,8 @@ describe Newsletter do
       expect(Activity.count).to eq(3)
 
       recipients.each do |email|
-        user = User.where(email: email).first
-        activity = Activity.where(user: user).first
+        user = User.find_by(email: email)
+        activity = Activity.find_by(user: user)
 
         expect(activity.user_id).to eq(user.id)
         expect(activity.action).to eq("email")

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -341,7 +341,7 @@ describe Proposal do
   describe "custom tag counters when hiding/restoring" do
     it "decreases the tag counter when hiden, and increases it when restored" do
       proposal = create(:proposal, tag_list: "foo")
-      tag = Tag.where(name: "foo").first
+      tag = Tag.find_by(name: "foo")
       expect(tag.proposals_count).to eq(1)
 
       proposal.hide


### PR DESCRIPTION
## References

* Continues pull request #3792

## Objectives

* Make the code more consistent

## Notes

We should probably replace some `find_by` usages with `find_by!`, but that's an issue for a different pull request.