### PR TITLE
Replace old Spanish text with org name

### DIFF
--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>
-    <%= render "layouts/common_head", default_title: "Gobierno abierto" %>
+    <%= render "layouts/common_head", default_title: setting["org_name"] %>
     <%= render "layouts/meta_tags" %>
     <%= raw setting["html.per_page_code_head"] %>
   </head>

--- a/app/views/users/registrations/success.html.erb
+++ b/app/views/users/registrations/success.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title) { t("devise_views.users.registrations.success.title") } %>
 <h2><%= t("devise_views.users.registrations.success.title") %></h2>
 <p><%= sanitize(t("devise_views.users.registrations.success.thank_you")) %></p>
 <p><%= sanitize(t("devise_views.users.registrations.success.instructions_1")) %></p>

--- a/spec/features/registration_form_spec.rb
+++ b/spec/features/registration_form_spec.rb
@@ -35,6 +35,7 @@ describe "Registration form" do
 
     click_button "Register"
 
+    expect(page).to have_title "Confirm your email address"
     expect(page).to have_content "Thank you for registering"
 
     new_user = User.last


### PR DESCRIPTION
## Objectives

It's a tiny PR, it just removes an old Spanish text that would show as title of the page displayed after creating an account: Gobierno abierto.

Right now, I'm using the org name as title, that's open for improvements. It could also say something like "Account created" or "Check your e-mails".

## Visual Changes

### Before
![Capture d’écran 2019-11-09 à 13 40 41](https://user-images.githubusercontent.com/7223028/68528725-dd865480-02f6-11ea-9bea-1366bbe04941.png)

### After
![Capture d’écran 2019-11-09 à 13 43 37](https://user-images.githubusercontent.com/7223028/68528732-f858c900-02f6-11ea-88ec-77e7eaf089b6.png)