### PR TITLE
Add e-mail validation when creating user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem "translator-text", "~> 0.1.0"
 gem "turbolinks", "~> 2.5.3"
 gem "turnout", "~> 2.4.0"
 gem "uglifier", "~> 4.1.2"
+gem "valid_email2", "~> 3.1.0"
 gem "whenever", "~> 0.10.0", require: false
 gem "wicked_pdf", "~> 1.1.0"
 gem "wkhtmltopdf-binary", "~> 0.12.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,6 +557,9 @@ GEM
     uniform_notifier (1.11.0)
     user_agent_parser (2.4.1)
     uuidtools (2.1.5)
+    valid_email2 (3.1.0)
+      activemodel (>= 3.2)
+      mail (~> 2.5)
     warden (1.2.8)
       rack (>= 2.0.6)
     wasabi (3.5.0)
@@ -666,10 +669,10 @@ DEPENDENCIES
   turbolinks (~> 2.5.3)
   turnout (~> 2.4.0)
   uglifier (~> 4.1.2)
+  valid_email2 (~> 3.1.0)
   web-console (~> 3.3.0)
   whenever (~> 0.10.0)
   wicked_pdf (~> 1.1.0)
   wkhtmltopdf-binary (~> 0.12.4)
 
 BUNDLED WITH
-   1.17.1

--- a/app/assets/javascripts/registration_form.js
+++ b/app/assets/javascripts/registration_form.js
@@ -27,6 +27,31 @@
           validateUsername(username);
         }
       });
+      var clearEmailMessage, showEmailMessage, emailInput, validateEmail;
+      emailInput = $("form#new_user[action=\"/users\"] input#user_email");
+      clearEmailMessage = function() {
+        $("small").remove();
+      };
+      showEmailMessage = function(response) {
+        var klass;
+        klass = response.available ? "no-error" : "error";
+        emailInput.after($("<small class=\"" + klass + "\" style=\"margin-top: -16px;\">" + response.message + "</small>"));
+      };
+      validateEmail = function(email) {
+        var request;
+        request = $.get("/user/registrations/check_email?email=" + email);
+        request.done(function(response) {
+          showEmailMessage(response);
+        });
+      };
+      emailInput.on("focusout", function() {
+        var email;
+        clearEmailMessage();
+        email = emailInput.val();
+        if (email !== "") {
+          validateEmail(email);
+        }
+      });
     }
   };
 }).call(this);

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -58,7 +58,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def check_email
     address = ValidEmail2::Address.new(params[:email])
-    if address.valid? && address.valid_mx?
+    if params[:email].end_with?("@consul.dev") || (address.valid? && address.valid_mx?)
       render json: { available: true, message: t("devise_views.users.registrations.new.email_is_valid") }
     else
       render json: { available: false, message: t("devise_views.users.registrations.new.email_is_invalid") }

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -56,6 +56,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  def check_email
+    address = ValidEmail2::Address.new(params[:email])
+    if address.valid? && address.valid_mx?
+      render json: { available: true, message: t("devise_views.users.registrations.new.email_is_valid") }
+    else
+      render json: { available: false, message: t("devise_views.users.registrations.new.email_is_invalid") }
+    end
+  end
+
   private
 
     def sign_up_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,6 +78,8 @@ class User < ApplicationRecord
 
   validates :username, presence: true, if: :username_required?
   validates :username, uniqueness: { scope: :registering_with_oauth }, if: :username_required?
+  validates :email, presence: true, 'valid_email_2/email': true, allow_blank: true
+  validates :email, 'valid_email_2/email': { mx: true }
   validates :document_number, uniqueness: { scope: :document_type }, allow_nil: true
 
   validate :validate_username_length

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,8 +78,8 @@ class User < ApplicationRecord
 
   validates :username, presence: true, if: :username_required?
   validates :username, uniqueness: { scope: :registering_with_oauth }, if: :username_required?
-  validates :email, presence: true, 'valid_email_2/email': true, allow_blank: true
-  validates :email, 'valid_email_2/email': { mx: true }
+  validates :email, 'valid_email_2/email': true, allow_blank: true, if: :not_email_consul_dev?
+  validates :email, 'valid_email_2/email': { mx: true }, if: :not_email_consul_dev?
   validates :document_number, uniqueness: { scope: :document_type }, allow_nil: true
 
   validate :validate_username_length
@@ -415,5 +415,9 @@ class User < ApplicationRecord
         attributes: :username,
         maximum: User.username_max_length)
       validator.validate(self)
+    end
+
+    def not_email_consul_dev?
+      ->(user) { user.email.end_with?("@consul.dev") }
     end
 end

--- a/config/locales/en/devise_views.yml
+++ b/config/locales/en/devise_views.yml
@@ -106,6 +106,8 @@ en:
           waiting_for: "Awaiting confirmation of:"
         new:
           cancel: Cancel login
+          email_is_valid: This e-mail address seems to be valid
+          email_is_invalid: This e-mail address does not seem to be valid
           email_label: Email
           organization_signup: Do you represent an organisation or collective? %{signup_link}
           organization_signup_link: Sign up here

--- a/config/routes/devise.rb
+++ b/config/routes/devise.rb
@@ -8,6 +8,7 @@ devise_for :users, controllers: {
 devise_scope :user do
   patch "/user/confirmation", to: "users/confirmations#update", as: :update_user_confirmation
   get "/user/registrations/check_username", to: "users/registrations#check_username"
+  get "/user/registrations/check_email", to: "users/registrations#check_email"
   get "users/sign_up/success", to: "users/registrations#success"
   get "users/registrations/delete_form", to: "users/registrations#delete_form"
   delete "users/registrations", to: "users/registrations#delete"

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -27,4 +27,30 @@ describe Users::RegistrationsController do
       end
     end
   end
+
+  describe "POST check_email" do
+    before do
+      request.env["devise.mapping"] = Devise.mappings[:user]
+    end
+
+    context "when email is valid" do
+      it "returns true with no error message" do
+        get :check_email, params: { email: "test@test.com" }
+
+        data = JSON.parse response.body, symbolize_names: true
+        expect(data[:available]).to be true
+        expect(data[:message]).to eq I18n.t("devise_views.users.registrations.new.email_is_valid")
+      end
+    end
+
+    context "when email is invalid" do
+      it "returns false with an error message" do
+        get :check_email, params: { email: "test@test" }
+
+        data = JSON.parse response.body, symbolize_names: true
+        expect(data[:available]).to be false
+        expect(data[:message]).to eq I18n.t("devise_views.users.registrations.new.email_is_invalid")
+      end
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -65,7 +65,7 @@ FactoryBot.define do
     end
 
     trait :skip_validate do
-      to_create {|instance| instance.save(validate: false) }
+      to_create { |instance| instance.save(validate: false) }
     end
 
     transient do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -64,6 +64,10 @@ FactoryBot.define do
       after(:create) { |user| create(:comment, author: user) }
     end
 
+    trait :skip_validate do
+      to_create {|instance| instance.save(validate: false) }
+    end
+
     transient do
       votables { [] }
       followables { [] }

--- a/spec/features/registration_form_spec.rb
+++ b/spec/features/registration_form_spec.rb
@@ -23,6 +23,26 @@ describe "Registration form" do
     expect(page).to have_content I18n.t("devise_views.users.registrations.new.username_is_available")
   end
 
+  scenario "email is invalid", :js do
+    visit new_user_registration_path
+    expect(page).not_to have_content I18n.t("devise_views.users.registrations.new.email_is_invalid")
+
+    fill_in "user_email", with: "test@test"
+    check "user_terms_of_service"
+
+    expect(page).to have_content I18n.t("devise_views.users.registrations.new.email_is_invalid")
+  end
+
+  scenario "email is valid", :js do
+    visit new_user_registration_path
+    expect(page).not_to have_content I18n.t("devise_views.users.registrations.new.email_is_valid")
+
+    fill_in "user_email", with: "test@test.com"
+    check "user_terms_of_service"
+
+    expect(page).to have_content I18n.t("devise_views.users.registrations.new.email_is_valid")
+  end
+
   scenario "do not save blank redeemable codes" do
     visit new_user_registration_path(use_redeemable_code: "true")
 

--- a/spec/lib/email_digests_spec.rb
+++ b/spec/lib/email_digests_spec.rb
@@ -125,7 +125,7 @@ describe EmailDigest do
     end
 
     it "returns nil if email is invalid" do
-      user = create(:user, email: "invalid_email@email..com")
+      user = create(:user, :skip_validate, email: "invalid_email@email..com")
 
       email_digest = EmailDigest.new(user)
       expect(email_digest.valid_email?).to be(nil)

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -129,7 +129,7 @@ describe Newsletter do
     it "skips invalid emails" do
       Proposal.destroy_all
       create(:user, :with_proposal, email: "valid@consul.dev")
-      create(:user, :with_proposal, email: "invalid@consul..dev")
+      create(:user, :skip_validate, :with_proposal, email: "invalid@consul..dev")
 
       newsletter.deliver
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -709,4 +709,12 @@ describe User do
       expect(User.find_by_manager_login("admin_user_#{user.id}")).to eq user
     end
   end
+
+  describe "valid_email_required" do
+    it "doesn't create users with invalid emails" do
+      expect{ create(:user, email: "user@consul") }.to raise_error(ActiveRecord::RecordInvalid)
+      expect{ create(:user, email: "user@consul..dev") }.to raise_error(ActiveRecord::RecordInvalid)
+      expect{ create(:user, email: "user@@consul.dev") }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -712,9 +712,9 @@ describe User do
 
   describe "valid_email_required" do
     it "doesn't create users with invalid emails" do
-      expect{ create(:user, email: "user@consul") }.to raise_error(ActiveRecord::RecordInvalid)
-      expect{ create(:user, email: "user@consul..dev") }.to raise_error(ActiveRecord::RecordInvalid)
-      expect{ create(:user, email: "user@@consul.dev") }.to raise_error(ActiveRecord::RecordInvalid)
+      expect { create(:user, email: "user@consul") }.to raise_error(ActiveRecord::RecordInvalid)
+      expect { create(:user, email: "user@consul..dev") }.to raise_error(ActiveRecord::RecordInvalid)
+      expect { create(:user, email: "userconsul.dev") }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -160,6 +160,10 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.expect_with(:rspec) { |c| c.syntax = :expect }
+
+  config.before(:each) do
+    allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?).and_return(true)
+  end
 end
 
 # Parallel build helper configuration for travis


### PR DESCRIPTION
## References

- #3837

## Objectives

This PR adds email validation both at the model level (when saving to the DB) and in real-time on the form.

## Notes

- I had to skip validation when creating users with invalid email on some old specs. I didn't remove them as I assumed that existing installations will have invalid e-mails in their DB and need a filter when sending newsletters and notifications. But ideally, we could remove them as the filter is now applied when creating the user.
- I added a validation of MX records for the domain. It works surprisingly fast and catches a few more invalid emails (like `test@gnail.com`).
- I added an exception for `@consul.dev` e-mail addresses as that's what we're using for the seeds.