### PR TITLE
Make puma restarts work with systemd

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -29,6 +29,9 @@ set :keep_releases, 5
 set :local_user, ENV["USER"]
 
 set :puma_restart_command, "bundle exec --keep-file-descriptors puma"
+set :puma_workers, 2
+set :puma_preload_app, true
+set :puma_init_active_record, true
 
 set :delayed_job_workers, 2
 set :delayed_job_roles, :background

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,6 +28,8 @@ set :keep_releases, 5
 
 set :local_user, ENV["USER"]
 
+set :puma_restart_command, "bundle exec --keep-file-descriptors puma"
+
 set :delayed_job_workers, 2
 set :delayed_job_roles, :background
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,47 +1,15 @@
+# ATTENTION: This file is only used to run puma on your development
+# machine. To configure puma on production environments, use the
+# `puma.rb` file in Capistrano's `shared` folder.
+
 # Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum, this matches the default thread size of Active Record.
-#
+# Default is set to 5 threads for minimum and maximum, matching the
+# default thread size of Active Record.
 threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
 threads threads_count, threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests, default is 3000.
-#
 port        ENV.fetch("PORT") { 3000 }
-
-# Specifies the `environment` that Puma will run in.
-#
 environment ENV.fetch("RAILS_ENV") { "development" }
-
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked webserver processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory. If you use this option
-# you need to make sure to reconnect any threads in the `on_worker_boot`
-# block.
-#
-# preload_app!
-
-# The code in the `on_worker_boot` will be called if you are using
-# clustered mode by specifying a number of `workers`. After each worker
-# process is booted this block will be run, if you are using `preload_app!`
-# option you will want to use this block to reconnect to any threads
-# or connections that may have been created at application boot, Ruby
-# cannot share connections between processes.
-#
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
## References

* [Puma socket activation](https://github.com/puma/puma/blob/master/docs/systemd.md#socket-activation)
* [Puma restarts](https://github.com/puma/puma/blob/master/docs/restart.md)

## Objectives

* Fix a bug restarting puma on systems with systemd
* Use as many puma workers as we used with unicorn