### PR TITLE
Fix a tiny CSS leak

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2770,8 +2770,11 @@ table {
     }
 
     a:hover {
-      box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.2);
       text-decoration: none;
+
+      &:not(.see-all) {
+        box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.2);
+      }
 
       img {
         transform: scale(1.1);


### PR DESCRIPTION
## References

- #2694

## Objectives

I just fixed a tiny CSS leak. The shadow effect of the cards was also applied to a link that didn't need it on hovering. The result was rather unpleasant aesthetically.

## Visual Changes

### Before
![Capture d’écran 2019-11-13 à 20 25 24](https://user-images.githubusercontent.com/7223028/68798101-18212180-0656-11ea-8761-8c43b36cb784.png)

### After

![Capture d’écran 2019-11-13 à 20 26 00](https://user-images.githubusercontent.com/7223028/68798180-371fb380-0656-11ea-8c68-ad45a6b9a5e5.png)


## Notes

- @decabeza would be the best reviewer if he has time. He was the one to introduce the CSS effect for the cards.