### PR TITLE
Add Security/Open rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -446,6 +446,9 @@ Security/Eval:
 Security/JSONLoad:
   Enabled: true
 
+Security/Open:
+  Enabled: true
+
 Security/YAMLLoad:
   Enabled: true
 

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -37,7 +37,7 @@ module Attachable
     if filesystem_storage?
       File.open(cached_attachment) { |file| self.attachment = file }
     else
-      self.attachment = URI.open(cached_attachment)
+      self.attachment = URI.parse(cached_attachment).open
     end
   end
 

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -26,7 +26,7 @@ module Attachable
   end
 
   def set_cached_attachment_from_attachment
-    self.cached_attachment = if Paperclip::Attachment.default_options[:storage] == :filesystem
+    self.cached_attachment = if filesystem_storage?
                                attachment.path
                              else
                                attachment.url
@@ -34,7 +34,7 @@ module Attachable
   end
 
   def set_attachment_from_cached_attachment
-    if Paperclip::Attachment.default_options[:storage] == :filesystem
+    if filesystem_storage?
       File.open(cached_attachment) { |file| self.attachment = file }
     else
       self.attachment = URI.open(cached_attachment)
@@ -50,6 +50,10 @@ module Attachable
   end
 
   private
+
+    def filesystem_storage?
+      Paperclip::Attachment.default_options[:storage] == :filesystem
+    end
 
     def validate_attachment_size
       if association_class && attachment_file_size > max_file_size.megabytes

--- a/lib/sms_api.rb
+++ b/lib/sms_api.rb
@@ -9,7 +9,7 @@ class SMSApi
   def url
     return "" unless end_point_available?
 
-    open(Rails.application.secrets.sms_end_point).base_uri.to_s
+    URI.parse(Rails.application.secrets.sms_end_point).to_s
   end
 
   def authorization

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -88,7 +88,7 @@ namespace :active_storage do
       source_file = if paperclip_storage == :filesystem
                       paperclip_attachment.path
                     else
-                      URI.open(paperclip_attachment.url, &:read)
+                      URI.parse(paperclip_attachment.url).open.read
                     end
 
       logger.info "Copying #{paperclip_attachment.url} to active storage"

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -8,4 +8,38 @@ describe ProposalsController do
       expect { get :index }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
   end
+
+  describe "PUT update" do
+    let(:file) { Rails.root.join("spec/hacked") }
+
+    before do
+      File.delete(file) if File.exist?(file)
+      InvisibleCaptcha.timestamp_enabled = false
+    end
+
+    after { InvisibleCaptcha.timestamp_enabled = true }
+
+    it "ignores malicious cached attachments with remote storages" do
+      allow_any_instance_of(Image).to receive(:filesystem_storage?).and_return(false)
+      user = create(:user)
+      proposal = create(:proposal, author: user)
+      sign_in user
+
+      begin
+        put :update, params: {
+          id: proposal,
+          proposal: {
+            image_attributes: {
+              title: "Hacked!",
+              user_id: user.id,
+              cached_attachment: "| touch #{file}"
+            }
+          }
+        }
+      rescue StandardError
+      ensure
+        expect(file).not_to exist
+      end
+    end
+  end
 end


### PR DESCRIPTION
## References

* Closes #2571
* We changed the way to handle Paperclip attachments with remote storages in commit 5a4921a1a from pull request #4598

## Objectives

* Make sure we get a warning if we use `Kernel#open` in the future, since it might be dangerous if done with user input
* Make sure we parse cached attachment URLs when using remote storages with Paperclip

## Notes

We had a false positive for a "dangerous" usage which wasn't actually dangerous because it used a value extracted from the `secrets.yml` file; that is, the argument was under our control.