### PR TITLE
Update Ruby after `deploy:updating`

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,9 +47,9 @@ set :whenever_roles, -> { :app }
 namespace :deploy do
   Rake::Task["puma:check"].clear_actions
 
-  before :starting, "rvm1:install:rvm"
-  before :starting, "rvm1:install:ruby"
-  before :starting, "install_bundler_gem"
+  after :updating, "rvm1:install:rvm"
+  after :updating, "rvm1:install:ruby"
+  after :updating, "install_bundler_gem"
   before "deploy:migrate", "remove_local_census_records_duplicates"
 
   after "deploy:migrate", "add_new_settings"


### PR DESCRIPTION
## References

* Pull request #1271 configured installing Ruby on deployment
* Pull request #3627 configured Capistrano to install Ruby based on the `.ruby-version` file

## Background

We were invoking the task to install Ruby before updating the application. However, the `rvm1-capistrano` gem makes sure this task is executed after updating the application, in case it needs to read the Ruby version present in the `.ruby-version` file. So the `deploy:updating` task was invoked twice, the first time before tasks which were supposed to be executed after it, generating a warning:

```
Capistrano tasks may only be invoked once. Since task `deploy:updating' was previously invoked, invoke("deploy:updating") will be skipped.
If you really meant to run this task again, use invoke!("deploy:updating")
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO.
```

## Objectives

* Avoid invoking the `deploy:updating` task twice, which might lead to bugs during deployment