### PR TITLE
Fix "go back" link in newsletters

### DIFF
--- a/app/views/admin/newsletters/edit.html.erb
+++ b/app/views/admin/newsletters/edit.html.erb
@@ -1,4 +1,5 @@
-<%= back_link_to %>
+<%= back_link_to admin_newsletters_path %>
+
 <h2><%= t("admin.newsletters.edit.title") %></h2>
 
 <%= render "form" %>

--- a/app/views/admin/newsletters/new.html.erb
+++ b/app/views/admin/newsletters/new.html.erb
@@ -1,4 +1,5 @@
-<%= back_link_to %>
+<%= back_link_to admin_newsletters_path %>
+
 <h2><%= t("admin.newsletters.new.title") %></h2>
 <p>
   <%= sanitize(t("admin.newsletters.new.header_footer_help_text",

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -1,4 +1,4 @@
-<%= back_link_to %>
+<%= back_link_to admin_newsletters_path %>
 
 <h2><%= t("admin.newsletters.show.title") %></h2>
 

--- a/spec/features/admin/emails/newsletters_spec.rb
+++ b/spec/features/admin/emails/newsletters_spec.rb
@@ -15,6 +15,7 @@ describe "Admin newsletter emails" do
 
       visit admin_newsletter_path(newsletter)
 
+      expect(page).to have_link "Go back", href: admin_newsletters_path
       expect(page).to have_content "This is a subject"
       expect(page).to have_content I18n.t("admin.segment_recipient.#{newsletter.segment_recipient}")
       expect(page).to have_content "no-reply@consul.dev"
@@ -62,6 +63,8 @@ describe "Admin newsletter emails" do
     visit admin_newsletters_path
     click_link "New newsletter"
 
+    expect(page).to have_link "Go back", href: admin_newsletters_path
+
     fill_in_newsletter_form(subject: "This is a subject",
                             segment_recipient: "Proposal authors",
                             body: "This is a body")
@@ -81,6 +84,8 @@ describe "Admin newsletter emails" do
     within("#newsletter_#{newsletter.id}") do
       click_link "Edit"
     end
+
+    expect(page).to have_link "Go back", href: admin_newsletters_path
 
     fill_in_newsletter_form(subject: "This is a subject",
                             segment_recipient: "Investment authors in the current budget",


### PR DESCRIPTION
## References

* Closes #2483

## Objectives

* Make the "go back" link in newsletters consistent with the rest of the "go back" links in the admin section