### PR TITLE
Avoid invalid random titles in dashboard specs

### DIFF
--- a/spec/features/admin/dashboard/actions_spec.rb
+++ b/spec/features/admin/dashboard/actions_spec.rb
@@ -69,7 +69,6 @@ describe "Admin dashboard actions" do
 
   context "when editing an action" do
     let!(:action) { create :dashboard_action }
-    let(:title) { Faker::Lorem.sentence }
 
     before do
       visit admin_dashboard_actions_path
@@ -79,10 +78,10 @@ describe "Admin dashboard actions" do
     end
 
     scenario "Updates the action" do
-      fill_in "dashboard_action_title", with: title
+      fill_in "dashboard_action_title", with: "Great action!"
       click_button "Save"
 
-      expect(page).to have_content(title)
+      expect(page).to have_content "Great action!"
     end
 
     scenario "Renders edit form in case data is invalid" do

--- a/spec/models/dashboard/action_spec.rb
+++ b/spec/models/dashboard/action_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Dashboard::Action do
   subject do
     build :dashboard_action,
-          title: title,
+          title: "Take action!",
           description: description,
           day_offset: day_offset,
           required_supports: required_supports,
@@ -11,7 +11,6 @@ describe Dashboard::Action do
           action_type: action_type
   end
 
-  let(:title) { Faker::Lorem.sentence }
   let(:description) { Faker::Lorem.sentence }
   let(:day_offset) { 0 }
   let(:required_supports) { 0 }


### PR DESCRIPTION
## References

* Pull request #3831 solved a similar issue

## Objectives

* Avoid unintended validation errors in specs

## Notes

The feature test failed once on my machine because the generated title was 81 characters long.