### PR TITLE
Categories are still shown when properties of the legislation process are changed

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -24,8 +24,6 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
 
   def update
     if @process.update(process_params)
-      set_tag_list
-
       link = legislation_process_path(@process)
       redirect_back(fallback_location: (request.referer || root_path),
                     notice: t("admin.legislation.processes.update.notice", link: link))
@@ -75,11 +73,6 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
         image_attributes: image_attributes
       ]
-    end
-
-    def set_tag_list
-      @process.set_tag_list_on(:customs, process_params[:custom_list])
-      @process.save!
     end
 
     def resource

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -249,6 +249,13 @@ describe "Admin collaborative legislation" do
 
       visit admin_legislation_process_proposals_path(process)
       expect(page).to have_field("Categories", with: "bicycles, recycling")
+
+      within(".admin-content") { click_link "Information" }
+      fill_in "Summary", with: "Summarizing the process"
+      click_button "Save changes"
+
+      visit admin_legislation_process_proposals_path(process)
+      expect(page).to have_field("Categories", with: "bicycles, recycling")
     end
 
     scenario "Edit milestones summary", :js do


### PR DESCRIPTION
## References

Closes #3558 : "Keep categories being shown when change proposal phase date on colaborative legislation processes"

## Notes

In the issue, it is mentioned that date changes to the legislation process cause the categories of the process to be deleted. I discovered that this bug occurs when any change whatsoever is made to the process from the administrator view, not just date. That was because in the update action it calls set_tag_list even when there are no tags in the parameters, and this causes the tag list to be set to empty. The fix for this is to make the set_tag_list call to be conditional on the presence of tags in the parameters. I have also added to one of the existing specs to have confidence to know if this bug reoccurs. This spec fails now without my change, and passes with it. Hope it's ok!
