### PR TITLE
Add smtp settings for staging environment on secrets

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -32,6 +32,15 @@ test:
 staging:
   secret_key_base: ""
   server_name: ""
+  # mailer_delivery_method: "smtp"
+  # smtp_settings:
+  #   address: "smtp.example.com"
+  #   port: 25
+  #   domain: "your_domain.com"
+  #   user_name: "<username>"
+  #   password: "<password>"
+  #   authentication: "plain"
+  #   enable_starttls_auto: true
   force_ssl: true
   delay_jobs: true
   rollbar_server_token: ""


### PR DESCRIPTION
## References
Related PR: [Installer: Add Staging configuration #138](https://github.com/consul/installer/pull/138)

## Objectives
Add smtp settings for staging environment

## Visual Changes
None