### PR TITLE
Use symbols instead of strings for SMTP settings

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -32,15 +32,15 @@ test:
 staging:
   secret_key_base: ""
   server_name: ""
-  # mailer_delivery_method: "smtp"
+  # mailer_delivery_method: :smtp
   # smtp_settings:
-  #   address: "smtp.example.com"
-  #   port: 25
-  #   domain: "your_domain.com"
-  #   user_name: "<username>"
-  #   password: "<password>"
-  #   authentication: "plain"
-  #   enable_starttls_auto: true
+  #   :address: "smtp.example.com"
+  #   :port: 25
+  #   :domain: "your_domain.com"
+  #   :user_name: "<username>"
+  #   :password: "<password>"
+  #   :authentication: "plain"
+  #   :enable_starttls_auto: true
   force_ssl: true
   delay_jobs: true
   rollbar_server_token: ""
@@ -55,15 +55,15 @@ staging:
 preproduction:
   secret_key_base: ""
   server_name: ""
-  # mailer_delivery_method: "smtp"
+  # mailer_delivery_method: :smtp
   # smtp_settings:
-  #   address: "smtp.example.com"
-  #   port: 25
-  #   domain: "your_domain.com"
-  #   user_name: "<username>"
-  #   password: "<password>"
-  #   authentication: "plain"
-  #   enable_starttls_auto: true
+  #   :address: "smtp.example.com"
+  #   :port: 25
+  #   :domain: "your_domain.com"
+  #   :user_name: "<username>"
+  #   :password: "<password>"
+  #   :authentication: "plain"
+  #   :enable_starttls_auto: true
   force_ssl: true
   delay_jobs: true
   rollbar_server_token: ""
@@ -83,15 +83,15 @@ preproduction:
 production:
   secret_key_base: ""
   server_name: ""
-  # mailer_delivery_method: "smtp"
+  # mailer_delivery_method: :smtp
   # smtp_settings:
-  #   address: "smtp.example.com"
-  #   port: 25
-  #   domain: "your_domain.com"
-  #   user_name: "<username>"
-  #   password: "<password>"
-  #   authentication: "plain"
-  #   enable_starttls_auto: true
+  #   :address: "smtp.example.com"
+  #   :port: 25
+  #   :domain: "your_domain.com"
+  #   :user_name: "<username>"
+  #   :password: "<password>"
+  #   :authentication: "plain"
+  #   :enable_starttls_auto: true
   force_ssl: true
   delay_jobs: true
   rollbar_server_token: ""

--- a/lib/tasks/secrets.rake
+++ b/lib/tasks/secrets.rake
@@ -2,8 +2,8 @@ namespace :secrets do
   desc "Add SMTP, SSL and delay jobs settings to secrets.yml"
   task smtp_ssl_and_delay_jobs: :environment do
     current_settings = {
-      "mailer_delivery_method" => ActionMailer::Base.delivery_method.to_s,
-      "smtp_settings"          => ActionMailer::Base.smtp_settings.stringify_keys,
+      "mailer_delivery_method" => ActionMailer::Base.delivery_method,
+      "smtp_settings"          => ActionMailer::Base.smtp_settings,
       "force_ssl"              => Rails.application.config.force_ssl,
       "delay_jobs"             => Delayed::Worker.delay_jobs
     }


### PR DESCRIPTION
##  References

* Fixes a bug in pull request #3695

## Objectives

Use the right keys for action mailer settings.