### PR TITLE
Bump knapsack_pro from 1.1.0 to 1.15.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :development, :test do
   gem "factory_bot_rails", "~> 4.8.2"
   gem "faker", "~> 1.8.7"
   gem "i18n-tasks", "~> 0.9.29"
-  gem "knapsack_pro", "~> 1.1.0"
+  gem "knapsack_pro", "~> 1.15.0"
   gem "launchy", "~> 2.4.3"
   gem "letter_opener_web", "~> 1.3.4"
   gem "spring", "~> 2.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
-    knapsack_pro (1.1.0)
+    knapsack_pro (1.15.0)
       rake
     kramdown (1.17.0)
     launchy (2.4.3)
@@ -641,7 +641,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3.3)
   jquery-ui-rails (~> 6.0.1)
   kaminari (~> 1.1.1)
-  knapsack_pro (~> 1.1.0)
+  knapsack_pro (~> 1.15.0)
   launchy (~> 2.4.3)
   letter_opener_web (~> 1.3.4)
   mdl (~> 0.5.0)


### PR DESCRIPTION
## Changelog

Extracted from [Knapsack Pro's changelog](https://github.com/KnapsackPro/knapsack_pro-ruby/blob/master/CHANGELOG.md)

### 1.15.0

* Add support for Codefresh.io CI provider https://github.com/KnapsackPro/knapsack_pro-ruby/pull/92


### 1.14.0

* Add support for GitHub Actions https://github.com/KnapsackPro/knapsack_pro-ruby/pull/90


### 1.13.0

* Add support for job index and job count for parallelism in Semaphore 2.0 https://github.com/KnapsackPro/knapsack_pro-ruby/pull/89


### 1.12.1

* Use `CI_PIPELINE_ID` as build ID for GitLab CI because it is unique across parallel jobs
* Load GitLab CI first to avoid edge case with order of loading envs for `CI_NODE_INDEX` https://github.com/KnapsackPro/knapsack_pro-ruby/pull/88


### 1.12.0

* Add Queue Mode for Cucumber https://github.com/KnapsackPro/knapsack_pro-ruby/pull/87


### 1.11.0

* Add support for `KNAPSACK_PRO_TEST_FILE_LIST` environment variable to run explicitly listed tests https://github.com/KnapsackPro/knapsack_pro-ruby/pull/86


### 1.10.1

* Fix log info when measured time of tests was lost https://github.com/KnapsackPro/knapsack_pro-ruby/pull/85

### 1.10.0

* Logs error on lost info about recorded timing for test files due to missing json files in Queue Mode https://github.com/KnapsackPro/knapsack_pro-ruby/pull/83

* Fix bug: default test file time should not be added to measured time https://github.com/KnapsackPro/knapsack_pro-ruby/pull/84


### 1.9.0

* Reduce data transfer and speed up usage of Knapsack Pro API for Queue Mode https://github.com/KnapsackPro/knapsack_pro-ruby/pull/81


### 1.8.0

* Run Fallback Mode when `OpenSSL::SSL::SSLError` certificate verify failed for API https://github.com/KnapsackPro/knapsack_pro-ruby/pull/80


### 1.7.0

* Add `KNAPSACK_PRO_LOG_DIR` to set directory where to write logs https://github.com/KnapsackPro/knapsack_pro-ruby/pull/79


### 1.6.0

* Retry request 3 times when API returns 5xx HTTP status https://github.com/KnapsackPro/knapsack_pro-ruby/pull/78


### 1.5.0

* Add support for Semaphore CI 2.0 https://github.com/KnapsackPro/knapsack_pro-ruby/pull/77

### 1.4.0

* Use .test domain for development mode https://github.com/KnapsackPro/knapsack_pro-ruby/pull/76

### 1.3.0

* Add metadata to the gemspec

### 1.2.1

* Run Fallback Mode for exception `Errno::EPIPE` https://github.com/KnapsackPro/knapsack_pro-ruby/pull/75


### 1.2.0

* Add support for GitLab CI env vars CI_NODE_TOTAL and CI_NODE_INDEX. https://github.com/KnapsackPro/knapsack_pro-ruby/pull/73