### PR TITLE
Sanitize values before sending them to remote translation client

### DIFF
--- a/lib/remote_translations/caller.rb
+++ b/lib/remote_translations/caller.rb
@@ -40,7 +40,7 @@ class RemoteTranslations::Caller
 
     def fields_values
       resource.translated_attribute_names.map do |field|
-        resource.send(field)
+        WYSIWYGSanitizer.new.sanitize(resource.send(field))
       end
     end
 


### PR DESCRIPTION
## References

* Closes #3872 
* Related PR's: #3749

## Objectives
Sanitize resource fields values from ddbb before send to remote translate client.

## Visual Changes
None

## Notes
Before we saved the sanitized values in database
In #3749  was removed sanitize before saving in database and is only managed in the views.
The remote translation feature has been affected by this change, as we send the database value directly to the remote translation client. The solution is to sanitize the values of the fields before sending them to the remote translation client.
