### PR TITLE
Skip CI for Crowdin commits

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,6 +4,7 @@ files:
     ignore:
       - /config/locales/**/rails_date_order.yml
     update_option: update_without_changes
+    commit_message: "[ci skip]"
     languages_mapping:
       locale:
         ar: ar


### PR DESCRIPTION
Disable continuous integration temporarily for Crowdin commits.

## References
Pull request: #3877 

## Objectives
Regenerate `i18n_master` branch with new commits because some of the current ones are obsolete. After deleting this branch from the repo Crowdin will create new commits with most of the translations from #3877  but ommiting some unneeded commits with errors 🤞 .

@crowdin support service suggested us this way to avoid to clean by hand obsolete code from PR #3877.

## Visual Changes
None

## Notes
This is a temporary patch. Once new Pull Request is generated this PR will be reverted to enable CI again.
