### PR TITLE
Remove comments from `en/rails.yml` files

### DIFF
--- a/config/locales/en/rails.yml
+++ b/config/locales/en/rails.yml
@@ -1,23 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
 en:
   date:
     abbr_day_names:


### PR DESCRIPTION
## References

Related Pull Requests: https://github.com/consul/consul/pull/3883#discussion_r357154660

## Objectives

Remove outdated comments from `config/locales/en/rails.yml` because of two reasons:
1. Comments are outdated regarding current Consul locales configuration
2. By doing this Crowdin wont try to add those comments to other languages rails.yml files.

As Crowdin has no configuration option if we do not want those comments within all languages rails.yml files this is the only workaround we can apply now.