### PR TITLE
Don't include disabled processes in sitemap

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -14,28 +14,38 @@ SitemapGenerator::Sitemap.create do
   add how_to_use_path
   add faq_path
 
-  add debates_path, priority: 0.7, changefreq: "daily"
-  Debate.find_each do |debate|
-    add debate_path(debate), lastmod: debate.updated_at
+  if Setting["process.debates"]
+    add debates_path, priority: 0.7, changefreq: "daily"
+    Debate.find_each do |debate|
+      add debate_path(debate), lastmod: debate.updated_at
+    end
   end
 
-  add proposals_path, priority: 0.7, changefreq: "daily"
-  Proposal.find_each do |proposal|
-    add proposal_path(proposal), lastmod: proposal.updated_at
+  if Setting["process.proposals"]
+    add proposals_path, priority: 0.7, changefreq: "daily"
+    Proposal.find_each do |proposal|
+      add proposal_path(proposal), lastmod: proposal.updated_at
+    end
   end
 
-  add budgets_path, priority: 0.7, changefreq: "daily"
-  Budget.find_each do |budget|
-    add budget_path(budget), lastmod: budget.updated_at
+  if Setting["process.budgets"]
+    add budgets_path, priority: 0.7, changefreq: "daily"
+    Budget.find_each do |budget|
+      add budget_path(budget), lastmod: budget.updated_at
+    end
   end
 
-  add polls_path, priority: 0.7, changefreq: "daily"
-  Poll.find_each do |poll|
-    add poll_path(poll), lastmod: poll.starts_at
+  if Setting["process.polls"]
+    add polls_path, priority: 0.7, changefreq: "daily"
+    Poll.find_each do |poll|
+      add poll_path(poll), lastmod: poll.starts_at
+    end
   end
 
-  add legislation_processes_path, priority: 0.7, changefreq: "daily"
-  Legislation::Process.find_each do |process|
-    add legislation_process_path(process), lastmod: process.start_date
+  if Setting["process.legislation"]
+    add legislation_processes_path, priority: 0.7, changefreq: "daily"
+    Legislation::Process.find_each do |process|
+      add legislation_process_path(process), lastmod: process.start_date
+    end
   end
 end

--- a/spec/lib/tasks/sitemap_spec.rb
+++ b/spec/lib/tasks/sitemap_spec.rb
@@ -5,36 +5,78 @@ describe "rake sitemap:create", type: :feature do
 
   before do
     File.delete(file) if File.exist?(file)
-
     Rake::Task["sitemap:create"].reenable
-    Rake.application.invoke_task("sitemap:create")
   end
 
-  it "generates a sitemap" do
-    expect(file).to exist
+  describe "when processes are enabled" do
+    before { Rake.application.invoke_task("sitemap:create") }
+
+    it "generates a sitemap" do
+      expect(file).to exist
+    end
+
+    it "generates a valid sitemap" do
+      sitemap = Nokogiri::XML(File.open(file))
+      expect(sitemap.errors).to be_empty
+    end
+
+    it "generates a sitemap with expected and valid URLs" do
+      sitemap = File.read(file)
+
+      # Static pages
+      expect(sitemap).to include(faq_path)
+      expect(sitemap).to include(help_path)
+      expect(sitemap).to include(how_to_use_path)
+
+      # Dynamic URLs
+      expect(sitemap).to include(polls_path)
+      expect(sitemap).to include(budgets_path)
+      expect(sitemap).to include(debates_path)
+      expect(sitemap).to include(proposals_path)
+      expect(sitemap).to include(legislation_processes_path)
+
+      expect(sitemap).to have_content("0.7", count: 5)
+      expect(sitemap).to have_content("daily", count: 5)
+    end
   end
 
-  it "generates a valid sitemap" do
-    sitemap = Nokogiri::XML(File.open(file))
-    expect(sitemap.errors).to be_empty
-  end
+  describe "when processes are not enabled" do
+    before do
+      Setting["process.debates"] = nil
+      Setting["process.proposals"] = nil
+      Setting["process.budgets"] = nil
+      Setting["process.polls"] = nil
+      Setting["process.legislation"] = nil
 
-  it "generates a sitemap with expected and valid URLs" do
-    sitemap = File.read(file)
+      Rake.application.invoke_task("sitemap:create")
+    end
 
-    # Static pages
-    expect(sitemap).to include(faq_path)
-    expect(sitemap).to include(help_path)
-    expect(sitemap).to include(how_to_use_path)
+    it "generates a sitemap" do
+      expect(file).to exist
+    end
 
-    # Dynamic URLs
-    expect(sitemap).to include(polls_path)
-    expect(sitemap).to include(budgets_path)
-    expect(sitemap).to include(debates_path)
-    expect(sitemap).to include(proposals_path)
-    expect(sitemap).to include(legislation_processes_path)
+    it "generates a valid sitemap" do
+      sitemap = Nokogiri::XML(File.open(file))
+      expect(sitemap.errors).to be_empty
+    end
 
-    expect(sitemap).to have_content("0.7", count: 5)
-    expect(sitemap).to have_content("daily", count: 5)
+    it "generates a sitemap with expected and valid URLs" do
+      sitemap = File.read(file)
+
+      # Static pages
+      expect(sitemap).to include(faq_path)
+      expect(sitemap).to include(help_path)
+      expect(sitemap).to include(how_to_use_path)
+
+      # Dynamic URLs
+      expect(sitemap).not_to include(polls_path)
+      expect(sitemap).not_to include(budgets_path)
+      expect(sitemap).not_to include(debates_path)
+      expect(sitemap).not_to include(proposals_path)
+      expect(sitemap).not_to include(legislation_processes_path)
+
+      expect(sitemap).not_to have_content("0.7")
+      expect(sitemap).not_to have_content("daily")
+    end
   end
 end


### PR DESCRIPTION
## Objectives

Don't include URLs in the sitemap that are not accessible because the process has been disabled, even if they exist, to avoid robots try to access those URLs and raise exceptions on the Rails server.