### PR TITLE
Add Knapsack Pro badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Citizen Participation and Open Government Application
 [![Join the chat at https://gitter.im/consul/consul](https://badges.gitter.im/consul/consul.svg)](https://gitter.im/consul/consul?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/consul/consul/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted")
 
-[![Knapsack Pro Parallel CI builds for RSpec tests](https://img.shields.io/badge/Knapsack%20Pro-Parallel%20/%20RSpec%20tests-%230074ff)](https://knapsackpro.com/dashboard/organizations/176/projects/202/test_suites/318/builds)
+[![Knapsack Pro Parallel CI builds for RSpec tests](https://img.shields.io/badge/Knapsack%20Pro-Parallel%20/%20RSpec%20tests-%230074ff)](https://knapsackpro.com/dashboard/organizations/176/projects/202/test_suites/318/builds?utm_campaign=organization-id-176&utm_content=test-suite-id-318&utm_medium=readme&utm_source=knapsack-pro-badge&utm_term=project-id-202)
 
 This is the opensource code repository of the eParticipation website CONSUL, originally developed for the Madrid City government eParticipation website
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Citizen Participation and Open Government Application
 [![Join the chat at https://gitter.im/consul/consul](https://badges.gitter.im/consul/consul.svg)](https://gitter.im/consul/consul?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/consul/consul/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted")
 
+[![Knapsack Pro Parallel CI builds for RSpec tests](https://img.shields.io/badge/Knapsack%20Pro-Parallel%20/%20RSpec%20tests-%230074ff)](https://knapsackpro.com/dashboard/organizations/176/projects/202/test_suites/318/builds)
+
 This is the opensource code repository of the eParticipation website CONSUL, originally developed for the Madrid City government eParticipation website
 
 ## Documentation


### PR DESCRIPTION
I talked with Javi Martín about making a public dashboard with recorded parallel CI builds with Knapsack Pro. 

In this PR I added Knapsack Pro badge to README. You can click on it to see public data recorded in Knapsack Pro for Consul project (I already made your test suite in Knapsack Pro user dashboard settings to be public).