### PR TITLE
Support creates follow

### DIFF
--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -37,6 +37,7 @@ class Management::ProposalsController < Management::BaseController
   end
 
   def vote
+    @follow = Follow.create(user: current_user, followable: @proposal)
     @proposal.register_vote(managed_user, "yes")
     set_proposal_votes(@proposal)
   end

--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -37,7 +37,7 @@ class Management::ProposalsController < Management::BaseController
   end
 
   def vote
-    @follow = Follow.create(user: current_user, followable: @proposal)
+    @follow = Follow.find_or_create_by!(user: current_user, followable: @proposal)
     @proposal.register_vote(managed_user, "yes")
     set_proposal_votes(@proposal)
   end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -57,7 +57,7 @@ class ProposalsController < ApplicationController
   end
 
   def vote
-    @follow = Follow.create(user: current_user, followable: @proposal)
+    @follow = Follow.find_or_create_by!(user: current_user, followable: @proposal)
     @proposal.register_vote(current_user, "yes")
     set_proposal_votes(@proposal)
   end
@@ -74,7 +74,7 @@ class ProposalsController < ApplicationController
   end
 
   def vote_featured
-    @follow = Follow.create(user: current_user, followable: @proposal)
+    @follow = Follow.find_or_create_by!(user: current_user, followable: @proposal)
     @proposal.register_vote(current_user, "yes")
     set_featured_proposal_votes(@proposal)
   end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -57,6 +57,7 @@ class ProposalsController < ApplicationController
   end
 
   def vote
+    @follow = Follow.create(user: current_user, followable: @proposal)
     @proposal.register_vote(current_user, "yes")
     set_proposal_votes(@proposal)
   end
@@ -73,6 +74,7 @@ class ProposalsController < ApplicationController
   end
 
   def vote_featured
+    @follow = Follow.create(user: current_user, followable: @proposal)
     @proposal.register_vote(current_user, "yes")
     set_featured_proposal_votes(@proposal)
   end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -232,7 +232,7 @@ class Proposal < ApplicationRecord
   end
 
   def users_to_notify
-    followers.uniq - [author]
+    followers - [author]
   end
 
   def self.proposals_orders(user)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -232,7 +232,7 @@ class Proposal < ApplicationRecord
   end
 
   def users_to_notify
-    (voters + followers).uniq - [author]
+    followers.uniq - [author]
   end
 
   def self.proposals_orders(user)

--- a/app/views/mailer/proposal_notification_digest.html.erb
+++ b/app/views/mailer/proposal_notification_digest.html.erb
@@ -48,6 +48,15 @@
                     <% end %>
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; margin: 0; padding-bottom: 20px;">
+                      <%= sanitize(link_to(t("mailers.proposal_notification_digest.unfollow"),
+                          proposal_url(notification.notifiable.proposal),
+                          style: "color: #2895F1; text-decoration: none;")) %>
+                    </p>
+                  </td>
+                </tr>
               </tbody>
             </table>
           </td>

--- a/app/views/proposals/vote.js.erb
+++ b/app/views/proposals/vote.js.erb
@@ -1,1 +1,6 @@
 $("#<%= dom_id(@proposal) %>_votes").html("<%= j render("proposals/votes", proposal: @proposal) %>");
+<% if @follow %>
+  App.Followable.update("<%= dom_id(@follow.followable) %>",
+                        "<%= j render("follows/follow_button", follow: @follow) %>",
+                        "<%= j render("layouts/flash") %>")
+<% end %>

--- a/app/views/proposals/vote.js.erb
+++ b/app/views/proposals/vote.js.erb
@@ -1,6 +1,4 @@
 $("#<%= dom_id(@proposal) %>_votes").html("<%= j render("proposals/votes", proposal: @proposal) %>");
-<% if @follow %>
-  App.Followable.update("<%= dom_id(@follow.followable) %>",
-                        "<%= j render("follows/follow_button", follow: @follow) %>",
-                        "<%= j render("layouts/flash") %>")
-<% end %>
+App.Followable.update("<%= dom_id(@follow.followable) %>",
+                      "<%= j render("follows/follow_button", follow: @follow) %>",
+                      "<%= j render("layouts/flash") %>")

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -539,7 +539,7 @@ en:
       comments: Comments
       latest_comments: Latest messages
     messages:
-      send_notification: Send message to proposal supporters
+      send_notification: Send message to proposal followers
       previous_notifications: See previous notifications
     polls:
       index:

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -28,7 +28,7 @@ en:
       comment: Comment proposal
       unsubscribe: "If you don't want to receive any proposal notifications, visit %{account} and uncheck 'Receive a summary of proposal notifications'."
       unsubscribe_account: My account
-      unfollow: "Unfollow to stop receiving notifications for this proposal."
+      unfollow: "Visit this proposal and unfollow it to stop receiving notifications."
     direct_message_for_receiver:
       subject: "You have received a new private message"
       reply: Reply to %{sender}

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -26,12 +26,13 @@ en:
       title: "Proposal notifications in %{org_name}"
       share: Share proposal
       comment: Comment proposal
-      unsubscribe: "If you don't want receive proposal's notification, visit %{account} and uncheck 'Receive a summary of proposal notifications'."
+      unsubscribe: "If you don't want to receive any proposal notifications, visit %{account} and uncheck 'Receive a summary of proposal notifications'."
       unsubscribe_account: My account
+      unfollow: "Unfollow to stop receiving notifications for this proposal."
     direct_message_for_receiver:
       subject: "You have received a new private message"
       reply: Reply to %{sender}
-      unsubscribe: "If you don't want receive direct messages, visit %{account} and uncheck 'Receive emails about direct messages'."
+      unsubscribe: "If you don't want to receive direct messages, visit %{account} and uncheck 'Receive emails about direct messages'."
       unsubscribe_account: My account
     direct_message_for_sender:
       subject: "You have sent a new private message"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -79,7 +79,7 @@ en:
       poster_description_description: Detailed description of the poster feature
     analytics_url: "Analytics URL"
     proposal_notification_minimum_interval_in_days: "Minimum interval (in days) for authors of proposals to send new proposal notifications"
-    proposal_notification_minimum_interval_in_days_description: "The number of days user can send a notification for all supporters of their proposal"
+    proposal_notification_minimum_interval_in_days_description: "The number of days user can send a notification for all followers of their proposal"
     direct_message_max_per_day: "Direct Message max number per day"
     direct_message_max_per_day_description: "Number max of direct messages one user can send per day"
     feature:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -539,7 +539,7 @@ es:
       comments: Comentarios
       latest_comments: Últimos mensajes
     messages:
-      send_notification: Enviar mensaje a los que han apoyado la propuesta
+      send_notification: Enviar mensaje a los que siguen la propuesta
       previous_notifications: Ver notificaciones anteriores
     polls:
       index:

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -28,6 +28,7 @@ es:
       comment: Comentar propuesta
       unsubscribe: "Si no quieres recibir notificaciones de propuestas, puedes entrar en %{account} y desmarcar la opción 'Recibir resumen de notificaciones sobre propuestas'."
       unsubscribe_account: Mi cuenta
+      unfollow: "Si no quieres recibir más notificaciones, visita esta propuesta y deja de seguirla."
     direct_message_for_receiver:
       subject: "Has recibido un nuevo mensaje privado"
       reply: Responder a %{sender}

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -79,7 +79,7 @@ es:
       poster_description_description: Descripción detallada de la funcionalidad de póster
     analytics_url: "URL de estadísticas externas"
     proposal_notification_minimum_interval_in_days: "Intervalo mínimo (en días) para que los autores de propuestas puedan enviar nuevas notificaciones de propuesta"
-    proposal_notification_minimum_interval_in_days_description: "El número de días en los que un usuario puede enviar una notificación a todos los que apoyan su propuesta"
+    proposal_notification_minimum_interval_in_days_description: "El número de días en los que un usuario puede enviar una notificación a todos los que siguen su propuesta"
     direct_message_max_per_day: "Mensajes directos máximos por día"
     direct_message_max_per_day_description: "Número de mensajes directos máximos que un usuario puede enviar por día"
     feature:

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -365,13 +365,13 @@ describe "Proposal's dashboard" do
       click_link "Message to users"
     end
 
-    expect(page).to have_link("Send message to proposal supporters")
+    expect(page).to have_link("Send message to proposal followers")
     expect(page).to have_link("See previous notifications")
   end
 
   scenario "Dashboard has a link to send message to proposal supporters" do
     visit messages_proposal_dashboard_path(proposal)
-    click_link("Send message to proposal supporters")
+    click_link("Send message to proposal followers")
 
     fill_in "Title", with: "Thank you for supporting my proposal"
     fill_in "Message", with: "Please share it with others!"

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -252,8 +252,8 @@ describe "Emails" do
     scenario "notifications for proposals that I have supported" do
       user = create(:user, email_digest: true)
 
-      proposal1 = create(:proposal, voters: [user])
-      proposal2 = create(:proposal, voters: [user])
+      proposal1 = create(:proposal, voters: [user], followers: [user])
+      proposal2 = create(:proposal, voters: [user], followers: [user])
       proposal3 = create(:proposal)
 
       reset_mailer
@@ -288,6 +288,7 @@ describe "Emails" do
 
       expect(email).not_to have_body_text(proposal3.title)
       expect(email).to have_body_text(/#{account_path}/)
+      expect(email).to have_body_text("Unfollow to stop receiving notifications for this proposal.")
 
       notification1.reload
       notification2.reload

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -249,11 +249,11 @@ describe "Emails" do
   end
 
   context "Proposal notification digest" do
-    scenario "notifications for proposals that I have supported" do
+    scenario "notifications for proposals that I'm following" do
       user = create(:user, email_digest: true)
 
-      proposal1 = create(:proposal, voters: [user], followers: [user])
-      proposal2 = create(:proposal, voters: [user], followers: [user])
+      proposal1 = create(:proposal, followers: [user])
+      proposal2 = create(:proposal, followers: [user])
       proposal3 = create(:proposal)
 
       reset_mailer
@@ -288,7 +288,7 @@ describe "Emails" do
 
       expect(email).not_to have_body_text(proposal3.title)
       expect(email).to have_body_text(/#{account_path}/)
-      expect(email).to have_body_text("Unfollow to stop receiving notifications for this proposal.")
+      expect(email).to have_body_text("Visit this proposal and unfollow it to stop receiving notifications.")
 
       notification1.reload
       notification2.reload

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -157,6 +157,7 @@ describe "Proposals" do
 
       expect(page).to have_content "1 support"
       expect(page).to have_content "You have already supported this proposal. Share it!"
+      expect(page).to have_content "Following"
       expect(page).to have_current_path(management_proposal_path(proposal))
     end
 

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -29,7 +29,7 @@ describe "Proposal Notifications" do
   scenario "Send a notification (Active voter)" do
     proposal = create(:proposal)
 
-    create(:user, :level_two, votables: [proposal])
+    create(:user, :level_two, votables: [proposal], followables: [proposal])
     create_proposal_notification(proposal)
 
     expect(Notification.count).to eq(1)
@@ -98,6 +98,7 @@ describe "Proposal Notifications" do
     proposal = create(:proposal, author: author)
 
     7.times { create(:vote, votable: proposal, vote_flag: true) }
+    7.times { create(:follow, followable: proposal) }
 
     login_as(author)
     visit new_proposal_notification_path(proposal_id: proposal.id)
@@ -133,7 +134,7 @@ describe "Proposal Notifications" do
     login_as(author)
     visit new_proposal_notification_path(proposal_id: proposal.id)
 
-    expect(page).to have_content "This message will be sent to 14 people and it will "\
+    expect(page).to have_content "This message will be sent to 7 people and it will "\
                                  "be visible in the proposal's page"
     expect(page).to have_link("the proposal's page", href: proposal_path(proposal,
                                                      anchor: "comments"))
@@ -189,12 +190,12 @@ describe "Proposal Notifications" do
   end
 
   context "In-app notifications from the proposal's author" do
-    scenario "Voters should receive a notification", :js do
+    scenario "Voters who are followed should receive a notification", :js do
       author = create(:user)
       proposal = create(:proposal, author: author)
 
-      user1 = create(:user, votables: [proposal])
-      user2 = create(:user, votables: [proposal])
+      user1 = create(:user, votables: [proposal], followables: [proposal])
+      user2 = create(:user, votables: [proposal], followables: [proposal])
       user3 = create(:user)
 
       login_as(author)
@@ -297,7 +298,7 @@ describe "Proposal Notifications" do
     scenario "Proposal hidden", :js do
       author = create(:user)
       user = create(:user)
-      proposal = create(:proposal, author: author, voters: [user])
+      proposal = create(:proposal, author: author, voters: [user], followers: [user])
 
       login_as(author)
       visit root_path

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -14,7 +14,7 @@ describe "Proposal Notifications" do
       click_link "Message to users"
     end
 
-    click_link "Send message to proposal supporters"
+    click_link "Send message to proposal followers"
 
     fill_in "proposal_notification_title", with: "Thank you for supporting my proposal"
     fill_in "proposal_notification_body", with: "Please share it with "\
@@ -93,22 +93,6 @@ describe "Proposal Notifications" do
     expect(page).to have_content "We are almost there please share with your peoples!"
   end
 
-  scenario "Message about receivers (Voters)" do
-    author = create(:user)
-    proposal = create(:proposal, author: author)
-
-    7.times { create(:vote, votable: proposal, vote_flag: true) }
-    7.times { create(:follow, followable: proposal) }
-
-    login_as(author)
-    visit new_proposal_notification_path(proposal_id: proposal.id)
-
-    expect(page).to have_content "This message will be sent to 7 people and it will "\
-                                 "be visible in the proposal's page"
-    expect(page).to have_link("the proposal's page", href: proposal_path(proposal,
-                                                     anchor: "comments"))
-  end
-
   scenario "Message about receivers (Followers)" do
     author = create(:user)
     proposal = create(:proposal, author: author)
@@ -173,7 +157,7 @@ describe "Proposal Notifications" do
         click_link "Message to users"
       end
 
-      expect(page).to have_link "Send message to proposal supporters"
+      expect(page).to have_link "Send message to proposal followers"
     end
 
     scenario "Accessing form directly" do
@@ -196,7 +180,7 @@ describe "Proposal Notifications" do
 
       user1 = create(:user, votables: [proposal], followables: [proposal])
       user2 = create(:user, votables: [proposal], followables: [proposal])
-      user3 = create(:user)
+      user3 = create(:user, votables: [proposal])
 
       login_as(author)
       visit root_path

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -889,22 +889,14 @@ describe Proposal do
   end
 
   describe "#user_to_notify" do
-    it "returns voters and followers" do
+    it "returns followers" do
       proposal = create(:proposal)
-      voter = create(:user, :level_two, votables: [proposal])
       follower = create(:user, :level_two, followables: [proposal])
 
-      expect(proposal.users_to_notify).to eq([voter, follower])
+      expect(proposal.users_to_notify).to eq([follower])
     end
 
-    it "returns voters and followers discarding duplicates" do
-      proposal = create(:proposal)
-      voter_and_follower = create(:user, :level_two, votables: [proposal], followables: [proposal])
-
-      expect(proposal.users_to_notify).to eq([voter_and_follower])
-    end
-
-    it "returns voters and followers except the proposal author" do
+    it "returns followers except the proposal author" do
       author = create(:user, :level_two)
       voter_and_follower = create(:user, :level_two)
       proposal = create(:proposal, author: author,

--- a/spec/support/common_actions/notifications.rb
+++ b/spec/support/common_actions/notifications.rb
@@ -27,7 +27,7 @@ module Notifications
       click_link "Message to users"
     end
 
-    click_link "Send message to proposal supporters"
+    click_link "Send message to proposal followers"
 
     fill_in "proposal_notification_title", with: "Thanks for supporting proposal: #{proposal.title}"
     fill_in "proposal_notification_body", with: "Please share it with others! #{proposal.summary}"


### PR DESCRIPTION
## References

* Closes #3550 

## Objectives

When a user supports a proposal, it should automatically activate also the "Follow citizen proposal" option. The proposal notifications will be sent not to all users supporting the proposal but to the users who have activated the "Follow citizen proposal" option. In the notification digest, under each notification it will appear also the link to unfollow that particular proposal.

## Visual Changes

For the most part, there are no visual changes. There are only behavioural changes (Supporting a proposal causes the follow button to also be toggled active). However, there is now a link in the proposal notification digest email which leads to a page where user can unfollow the proposal. It looks like this:

![proposal notifications](https://user-images.githubusercontent.com/40895962/71502540-e04c0180-28c4-11ea-8a33-8836f42f14c0.png)

## Summary of code changes

### Change to proposals controller and associated views

Calls to the vote action now also cause a Follow to be created. When this triggers the vote partial to be rendered, if there is a follow object that has been passed, it triggers a rerender of the follow button partial also. This means that both buttons are rerendered simultaneously when the vote button is pressed.

### Change to Proposal model

users_to_notify only returns users who have followed the proposal, not users who have supported it.

### Change to mailer

Proposals notification mailer view includes a small link which invites the user to unfollow the proposal, as shown in the screenshot above. This necessitated adding a line in mailer.yml. Possibly you will want translations in other languages? If you provide me with a Spanish translation I would be happy to add this to the PR. I have also corrected some minor errors I noticed in the English.

### Spec changes

My changes caused some specs to break. This was the case when there were tests that assumed that users who supported a proposal would be sent notifications about them. This is no longer the case, because they have to be _followed_ to that proposal and not merely support it. Secondly, I updated the specs for users_to_notify for this same reason. I removed the test for deduplication because duplication should only occur if there are users who exist in both supporters and followers list and now there is only the followers list which is looked at in the method. Finally, I added to the test to check for the unfollow link in the notifications digest and to make sure that clicking support also creates a follow.

Please let me know how I can improve this PR or any of my changes! Also I tend to commit often, so can rebase this history if required. Thanks!