### PR TITLE
Fix style for validation errors in HTML areas

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1076,7 +1076,7 @@ form {
     margin-bottom: $line-height;
   }
 
-  .html-area {
+  .html-area:not(.form-error) {
     height: 272px;
     margin-bottom: $line-height;
 


### PR DESCRIPTION
## References

* This issue was introduced in pull request #3824

## Objectives

Fix a bug which caused extra blank space to appear after validation erros related to CKEditor fields.

## Visual Changes

Before these changes:

![Ther's blank space after the validation error](https://user-images.githubusercontent.com/35156/72619424-85468100-393d-11ea-9918-69e1ce1a7e09.png)

After these changes:

![There's no blank space after the validation error](https://user-images.githubusercontent.com/35156/72619427-8aa3cb80-393d-11ea-9318-2d68a206eb86.png)
