### PR TITLE
Fix uploading images through CKEditor's upload tab

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -15,6 +15,7 @@ CKEDITOR.editorConfig = function( config )
   config.filebrowserImageBrowseUrl = "/ckeditor/pictures";
   config.filebrowserImageUploadUrl = "/ckeditor/pictures";
   config.filebrowserUploadUrl = "/ckeditor/attachment_files";
+  config.filebrowserUploadMethod = "form";
 
   config.allowedContent = true;
   config.format_tags = "p;h2;h3";

--- a/spec/features/ckeditor_spec.rb
+++ b/spec/features/ckeditor_spec.rb
@@ -14,4 +14,20 @@ describe "CKEditor" do
 
     expect(page).to have_css ".translatable-fields[data-locale='en'] .cke_wysiwyg_frame"
   end
+
+  scenario "uploading an image through the upload tab", :js do
+    login_as(create(:administrator).user)
+
+    visit new_admin_site_customization_page_path
+    find(".cke_button__image").click
+    click_link "Upload"
+
+    within_frame(1) do
+      attach_file "Send it to the Server", Rails.root.join("spec/fixtures/files/clippy.jpg")
+    end
+
+    click_link "Send it to the Server"
+
+    expect(page).to have_css "img[src$='clippy.jpg']"
+  end
 end


### PR DESCRIPTION
## References

* The bug was introduced when we upgraded the ckeditor gem in  pull request #3804
* The fix applied was suggested in galetahub/ckeditor#847

## Objectives

Fix a bug which prevented us from uploading images with CKEditor using the "upload" tab (uploading through the "browse server" button worked fine).

## Visual Changes

Before these changes, instead of uploading the image, the browser displayed this error:

![Popup with the text undefined](https://user-images.githubusercontent.com/35156/72639158-47f5e980-3965-11ea-8fc7-43f2fc9b9b6d.png)