### PR TITLE
Enable Wordpress Oauth login and registration

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1539,6 +1539,7 @@ table {
 .button.button-twitter,
 .button.button-facebook,
 .button.button-google,
+.button.button-wordpress,
 .button.button-telegram {
   background: #fff;
   color: $text;
@@ -1675,6 +1676,23 @@ table {
   &:focus {
     background: #fff;
     color: #ce3e26;
+  }
+}
+
+.button.button-wordpress {
+  background: #dcdde3;
+  border-left: 3px solid #2f2f33;
+
+  &::before {
+    color: #2f2f33;
+    content: "J";
+    font-family: "icons" !important;
+    font-size: rem-calc(24);
+    left: 0;
+    line-height: $line-height * 2;
+    padding: 0 rem-calc(20);
+    position: absolute;
+    top: 0;
   }
 }
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,6 +11,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     sign_in_with :google_login, :google_oauth2
   end
 
+  def wordpress_oauth2
+    sign_in_with :wordpress_login, :wordpress_oauth2
+  end
+
   def after_sign_in_path_for(resource)
     if resource.registering_with_oauth
       finish_signup_path

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -84,6 +84,7 @@ class Setting < ApplicationRecord
         "feature.facebook_login": true,
         "feature.google_login": true,
         "feature.twitter_login": true,
+        "feature.wordpress_login": false,
         "feature.public_stats": true,
         "feature.signature_sheets": true,
         "feature.user.recommendations": true,

--- a/app/views/devise/_omniauth_form.html.erb
+++ b/app/views/devise/_omniauth_form.html.erb
@@ -35,6 +35,15 @@
         </div>
       <% end %>
 
+      <% if feature? :wordpress_login %>
+        <div class="small-12 medium-6 large-4 column end">
+          <%= link_to t("omniauth.wordpress_oauth2.name"), user_wordpress_oauth2_omniauth_authorize_path,
+                      title: t("omniauth.wordpress_oauth2.sign_in"),
+                      class: "button-wordpress button expanded",
+                      method: :post %>
+        </div>
+      <% end %>
+
       <div class="small-12 column auth-divider">
         <span><%= t("omniauth.or_fill") %></span>
       </div>
@@ -71,6 +80,16 @@
           <%= link_to t("omniauth.google_oauth2.name"), user_google_oauth2_omniauth_authorize_path,
                       title: t("omniauth.google_oauth2.sign_up"),
                       class: "button-google button expanded",
+                      method: :post %>
+
+        </div>
+      <% end %>
+
+      <% if feature? :wordpress_login %>
+        <div class="small-12 medium-6 large-4 column end">
+          <%= link_to t("omniauth.wordpress_oauth2.name"), user_wordpress_oauth2_omniauth_authorize_path,
+                      title: t("omniauth.wordpress_oauth2.sign_up"),
+                      class: "button-wordpress button expanded",
                       method: :post %>
         </div>
       <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,3 +1,5 @@
+require Rails.root.join("lib", "omniauth_wordpress")
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -242,6 +244,11 @@ Devise.setup do |config|
   config.omniauth :twitter, Rails.application.secrets.twitter_key, Rails.application.secrets.twitter_secret
   config.omniauth :facebook, Rails.application.secrets.facebook_key, Rails.application.secrets.facebook_secret, scope: "email", info_fields: "email,name,verified"
   config.omniauth :google_oauth2, Rails.application.secrets.google_oauth2_key, Rails.application.secrets.google_oauth2_secret
+  config.omniauth :wordpress_oauth2,
+                  Rails.application.secrets.wordpress_oauth2_key,
+                  Rails.application.secrets.wordpress_oauth2_secret,
+                  strategy_class: OmniAuth::Strategies::Wordpress,
+                  client_options: { site: Rails.application.secrets.wordpress_oauth2_site }
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -294,6 +294,10 @@ en:
       sign_in: Sign in with Google
       sign_up: Sign up with Google
       name: Google
+    wordpress_oauth2:
+      sign_in: Sign in with Wordpress
+      sign_up: Sign up with Wordpress
+      name: Wordpress
     twitter:
       sign_in: Sign in with Twitter
       sign_up: Sign up with Twitter

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -89,6 +89,8 @@ en:
       facebook_login_description: "Allow users to sign up with their Facebook account"
       google_login: "Google login"
       google_login_description: "Allow users to sign up with their Google Account"
+      wordpress_login: "Wordpress login"
+      wordpress_login_description: "Allow users to sign up with their Wordpress Account"
       featured_proposals: "Featured proposals"
       featured_proposals_description: "Shows featured proposals on index proposals page"
       signature_sheets: "Signature sheets"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -294,6 +294,10 @@ es:
       sign_in: Entra con Google
       sign_up: Regístrate con Google
       name: Google
+    wordpress_oauth2:
+      sign_in: Entra con Wordpress
+      sign_up: Regístrate con Wordpress
+      name: Wordpress
     twitter:
       sign_in: Entra con Twitter
       sign_up: Regístrate con Twitter

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -89,6 +89,8 @@ es:
       facebook_login_description: "Permitir que los usuarios se registren con su cuenta de Facebook"
       google_login: "Registro con Google"
       google_login_description: "Permitir que los usuarios se registren con su cuenta de Google"
+      wordpress_login: "Registro con Wordpress"
+      wordpress_login_description: "Permitir que los usuarios se registren con su cuenta de Wordpress"
       featured_proposals: "Propuestas destacadas"
       featured_proposals_description: "Muestra propuestas destacadas en la página principal de propuestas"
       signature_sheets: "Hojas de firmas"

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -105,5 +105,8 @@ production:
   facebook_secret: ""
   google_oauth2_key: ""
   google_oauth2_secret: ""
+  wordpress_oauth2_key: ""
+  wordpress_oauth2_secret: ""
+  wordpress_oauth2_site: ""
   <<: *maps
   <<: *apis

--- a/lib/omniauth_wordpress.rb
+++ b/lib/omniauth_wordpress.rb
@@ -1,0 +1,40 @@
+# This code is based on this gem https://github.com/jwickard/omniauth-wordpress-oauth2-plugin
+
+require "omniauth-oauth2"
+
+module OmniAuth
+  module Strategies
+    class Wordpress < OmniAuth::Strategies::OAuth2
+      option :name, "wordpress_oauth2"
+
+      option :client_options, {}
+
+      uid { raw_info["ID"] }
+
+      info do
+        {
+            name: raw_info["display_name"],
+            email: raw_info["user_email"],
+            nickname: raw_info["user_nicename"],
+            urls: { "Website" => raw_info["user_url"] }
+        }
+      end
+
+      extra do
+        { raw_info: raw_info }
+      end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
+      def raw_info
+        @raw_info ||= obtain_raw_info
+      end
+
+      def obtain_raw_info
+        access_token.get("/oauth/me", params: { "Authorization" => "Bearer #{access_token.token}" }).parsed
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Objectives

Make it possible to register and login using a Wordpress Oauth server.

The feature will be disabled by default. To enable it:

- Go to the admin panel -> Settings -> Features Tab [Image 1]
- Configure your Wordpress Oauth credentials in your `config/secrets.yml` and reload your Rails server.
```
production:
  wordpress_oauth2_key: ""
  wordpress_oauth2_secret: ""
  wordpress_oauth2_site: "https://your.wordpress.server.domain"
```

- Use the Wordpress button from the Registration or Login page [Image 2]

## Visual Changes
### Image 1
![Image_1](https://user-images.githubusercontent.com/942995/72663426-43910580-3a25-11ea-814b-693da77b12db.png)
### Image 2
![Image_2](https://user-images.githubusercontent.com/942995/72663437-5b688980-3a25-11ea-965b-4bfba86cfcfe.png)