### PR TITLE
Don't audit Globalize data migrations

### DIFF
--- a/db/migrate/20181214094002_add_budget_investment_translations.rb
+++ b/db/migrate/20181214094002_add_budget_investment_translations.rb
@@ -1,12 +1,14 @@
 class AddBudgetInvestmentTranslations < ActiveRecord::Migration[4.2]
   def self.up
-    Budget::Investment.create_translation_table!(
-      {
-        title:               :string,
-        description:         :text
-      },
-      { migrate_data: true }
-    )
+    Budget::Investment::Translation.without_auditing do
+      Budget::Investment.create_translation_table!(
+        {
+          title:               :string,
+          description:         :text
+        },
+        { migrate_data: true }
+      )
+    end
   end
 
   def self.down


### PR DESCRIPTION
## References

* Audit was added in pull request #3811

## Background

There's a conflict between the data migrations Globalize uses and the audited configuration. Since Globalize uses the model to run the migrations, it might try to run code that wasn't available when the migration was created.

In this case, when migrating data it tries to audit the translations table for budget investments. However, the migration creating the table for audits hasn't been run at this point, since it was added after the migration to add translations to investments was.

On the other hand, this data migration isn't really a change in the model attibutes, so it shouldn't be audited anyway.

## Objectives

Disable auditing during the migration which adds translations to budget investments.