### PR TITLE
Force dateFormat on datepicker

### DIFF
--- a/app/assets/javascripts/advanced_search.js
+++ b/app/assets/javascripts/advanced_search.js
@@ -25,6 +25,7 @@
       });
       $(".js-calendar-full").datepicker();
       $.datepicker.setDefaults($.datepicker.regional[locale]);
+      $.datepicker.setDefaults({ dateFormat: "dd/mm/yy" });
     },
     initialize: function() {
       App.AdvancedSearch.init_calendar();

--- a/spec/features/admin/banners_spec.rb
+++ b/spec/features/admin/banners_spec.rb
@@ -179,6 +179,17 @@ describe "Admin banners magement" do
     expect(page).not_to have_content "Wrong text"
   end
 
+  scenario "when change date field on edit banner page display expected format", :js do
+    banner = create(:banner)
+    visit edit_admin_banner_path(banner)
+
+    fill_in "Post started at", with: "20/02/2002"
+    find_field("Post started at").click
+    within(".ui-datepicker") { click_link "22" }
+
+    expect(page).to have_field "Post started at", with: "22/02/2002"
+  end
+
   scenario "Delete a banner" do
     create(:banner, title: "Ugly banner",
                     description: "Bad text",


### PR DESCRIPTION
## Objectives
After this change: 1f059d44cfd960b58cca9fc376b238be8378b394
When locale is :en, after select a date in datepicker the format rendered is "mm/dd/yyyy". The problem is that format is Date invalid. To fix this behaviour, we force dateFormat to the same format that is used to filter on advanced search in the frontend and that format is a valid format "dd/mm/yyyy"

## Visual Changes
- Before PR:
![Captura de pantalla 2020-01-28 a las 17 32 57](https://user-images.githubusercontent.com/16189/73284058-48f40a00-41f4-11ea-9a13-3fe250a60372.png)

- After PR:
![Captura de pantalla 2020-01-29 a las 12 34 17](https://user-images.githubusercontent.com/16189/73353471-b0ad6200-4293-11ea-9357-a5d49ab20647.png)

## Notes
Pending improve manage Dates on admin section. Unify the format from datepicker render with the form date fields format and with advanced search.
This is a temporary solution that we should analyze in depth to allow different date formats depending on the language in the filters.

