### PR TITLE
Improve Dashboard emails

### DIFF
--- a/app/mailers/dashboard/mailer.rb
+++ b/app/mailers/dashboard/mailer.rb
@@ -1,6 +1,6 @@
 class Dashboard::Mailer < ApplicationMailer
   layout "mailer"
-  after_action :check_deliverability
+  after_action :check_deliverability, except: [:forward]
 
   def forward(proposal)
     @proposal = proposal

--- a/app/mailers/dashboard/mailer.rb
+++ b/app/mailers/dashboard/mailer.rb
@@ -41,6 +41,6 @@ class Dashboard::Mailer < ApplicationMailer
     end
 
     def check_deliverability
-      mail.perform_deliveries = false unless Setting["dashboard.emails"]
+      mail.perform_deliveries = false unless Setting["feature.dashboard.notification_emails"]
     end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -170,7 +170,7 @@ class Setting < ApplicationRecord
         "hot_score_period_in_days": 31,
         "related_content_score_threshold": -0.3,
         "featured_proposals_number": 3,
-        "dashboard.emails": nil,
+        "feature.dashboard.notification_emails": nil,
         "remote_census.general.endpoint": "",
         "remote_census.request.method_name": "",
         "remote_census.request.structure": "",

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -125,6 +125,9 @@ en:
       valuation_comment_notification: "Valuation comment notification"
       valuation_comment_notification_description: "Send an email to all associated users except valuation commenter to budget investment when a new valuation comment is created"
       graphql_api: "GraphQL API"
+      dashboard:
+        notification_emails: "Dashboard notification emails"
+        notification_emails_description: "Enable sending dashboard notification emails to proposal's authors"
     remote_census:
       general:
         endpoint: "Endpoint"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -125,6 +125,9 @@ es:
       valuation_comment_notification: "Notificar comentarios de evaluación"
       valuation_comment_notification_description: "Envía un email a todos los usuarios menos al que haya comentado asociados a un presupuesto participativo cuando se cree un nuevo comentario de evaluación"
       graphql_api: "API GraphQL"
+      dashboard:
+        notification_emails: "Emails del panel de progreso"
+        notification_emails_description: "Activar el envío de emails de notificaciones a los autores de las propuestas en la sección de panel de progreso"
     remote_census:
       general:
         endpoint: "Endpoint"

--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -1,6 +1,8 @@
 namespace :consul do
   desc "Runs tasks needed to upgrade to the latest version"
-  task execute_release_tasks: ["settings:add_new_settings", "execute_release_1.1.0_tasks"]
+  task execute_release_tasks: ["settings:rename_setting_keys",
+                               "settings:add_new_settings",
+                               "execute_release_1.1.0_tasks"]
 
   desc "Runs tasks needed to upgrade from 1.0.0 to 1.1.0"
   task "execute_release_1.1.0_tasks": [

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -4,4 +4,10 @@ namespace :settings do
     ApplicationLogger.new.info "Adding new settings"
     Setting.add_new_settings
   end
+
+  desc "Rename existing settings"
+  task rename_setting_keys: :environment do
+    ApplicationLogger.new.info "Renaming existing settings"
+    Setting.rename_key from: "dashboard.emails", to: "feature.dashboard.notification_emails"
+  end
 end

--- a/spec/lib/tasks/dashboards_spec.rb
+++ b/spec/lib/tasks/dashboards_spec.rb
@@ -6,7 +6,7 @@ describe "Dashboards Rake" do
     before do
       Rake.application.rake_require "tasks/dashboards"
       Rake::Task.define_task(:environment)
-      Setting["dashboard.emails"] = true
+      Setting["feature.dashboard.notification_emails"] = true
       ActionMailer::Base.deliveries.clear
     end
 

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -20,12 +20,12 @@ describe Dashboard::Mailer do
       ActionMailer::Base.deliveries.clear
     end
 
-    it "Disables email delivery using setting" do
+    it "Disables notification emails delivery using setting, does not affect the forward email" do
       Setting["feature.dashboard.notification_emails"] = nil
 
       Dashboard::Mailer.forward(proposal).deliver_now
 
-      expect(ActionMailer::Base.deliveries.count).to eq(0)
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
 
     it "sends forward email" do

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -10,7 +10,7 @@ describe Dashboard::Mailer do
   end
 
   before do
-    Setting["dashboard.emails"] = true
+    Setting["feature.dashboard.notification_emails"] = true
   end
 
   describe "#forward" do
@@ -21,7 +21,7 @@ describe Dashboard::Mailer do
     end
 
     it "Disables email delivery using setting" do
-      Setting["dashboard.emails"] = nil
+      Setting["feature.dashboard.notification_emails"] = nil
 
       Dashboard::Mailer.forward(proposal).deliver_now
 
@@ -57,8 +57,8 @@ describe Dashboard::Mailer do
     describe "#new_actions_notification_rake_created" do
       let!(:proposal) { create(:proposal, :draft) }
 
-      it "Disables email delivery using setting" do
-        Setting["dashboard.emails"] = nil
+      it "Disables notification email delivery using setting" do
+        Setting["feature.dashboard.notification_emails"] = nil
 
         action.update!(published_proposal: false)
         resource.update!(published_proposal: false)
@@ -102,8 +102,8 @@ describe Dashboard::Mailer do
     describe "#new_actions_notification_rake_published" do
       let!(:proposal) { create(:proposal) }
 
-      it "Disables email delivery using setting" do
-        Setting["dashboard.emails"] = nil
+      it "Disables notification email delivery using setting" do
+        Setting["feature.dashboard.notification_emails"] = nil
         ActionMailer::Base.deliveries.clear
 
         run_rake_task
@@ -154,8 +154,8 @@ describe Dashboard::Mailer do
 
     let!(:proposal) { build(:proposal, :draft) }
 
-    it "Disables email delivery using setting" do
-      Setting["dashboard.emails"] = nil
+    it "Disables notification email delivery using setting" do
+      Setting["feature.dashboard.notification_emails"] = nil
 
       action.update!(published_proposal: false)
       resource.update!(published_proposal: false)
@@ -220,8 +220,8 @@ describe Dashboard::Mailer do
 
     let!(:proposal) { build(:proposal, :draft) }
 
-    it "Disables email delivery using setting" do
-      Setting["dashboard.emails"] = nil
+    it "Disables notification email delivery using setting" do
+      Setting["feature.dashboard.notification_emails"] = nil
 
       proposal.save!
       proposal.publish

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -983,7 +983,7 @@ describe Proposal do
 
   describe "#send_new_actions_notification_on_create" do
     before do
-      Setting["dashboard.emails"] = true
+      Setting["feature.dashboard.notification_emails"] = true
       ActionMailer::Base.deliveries.clear
     end
 
@@ -1008,7 +1008,7 @@ describe Proposal do
 
   describe "#send_new_actions_notification_on_published" do
     before do
-      Setting["dashboard.emails"] = true
+      Setting["feature.dashboard.notification_emails"] = true
       ActionMailer::Base.deliveries.clear
     end
 


### PR DESCRIPTION
## References

* Closes #3852 

## Objectives
- Rename Setting["dashboard.emails"] to Setting["feature.dashboard.notification_emails"]. It currently appeared as Configuration Setting, without enable/disable button. Need that this setting appear as Feature Setting.
- To fix related issue #3852 we allow send the forward email always. 

## Notes
- In this commit [Disable dashboard email deliveries](https://github.com/consul/consul/commit/e1390570), we disabled all emails from Dashboard with a Setting. I think that the reason for this commit was to allow the enable/disable of the dashboard emails related to the notifications to the authors of the proposals, that is, the emails that are automatically sent through a Cron task with the resources/actions available to the dashboard users.
I have decided that it is best to continue allowing these emails to be enable/disable:
- new_actions_notification_rake_published
- new_actions_notification_rake_created
- new_actions_notification_on_create
- new_actions_notification_on_published
 
Except for the "forward" email, which I think should always be able to be sent, since it is a simple email that is sent to the author himself when he requests it from the dashboard. This "forward" email is only a description and a poster of your proposal, so that it can be shared and your proposal supported.