### PR TITLE
Refactor editing budget investments

### DIFF
--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -49,4 +49,8 @@ module BudgetInvestmentsHelper
   def investments_secondary_view
     investments_current_view == "default" ? "minimal" : "default"
   end
+
+  def show_author_actions?(investment)
+    can?(:edit, investment) || can_destroy_image?(investment)
+  end
 end

--- a/app/views/budgets/investments/_author_actions.html.erb
+++ b/app/views/budgets/investments/_author_actions.html.erb
@@ -1,12 +1,18 @@
-<% if can_destroy_image?(investment) %>
+<% if show_author_actions?(investment) %>
   <div class="sidebar-divider"></div>
   <h2><%= t("budgets.investments.show.author") %></h2>
   <div class="show-actions-menu">
-    <%= link_to image_path(investment.image),
-                method: :delete,
-                class: "button hollow alert expanded" do %>
-        <span class="icon-image"></span>
-        <%= t("images.remove_image") %>
+    <% if can?(:edit, investment) %>
+      <%= link_to t("shared.edit"),
+                  edit_budget_investment_path(investment.budget, investment),
+                  method: :get, class: "button hollow expanded" %>
+    <% else %>
+        <%= link_to image_path(investment.image),
+                    method: :delete,
+                    class: "button hollow alert expanded" do %>
+          <span class="icon-image"></span>
+          <%= t("images.remove_image") %>
+        <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/budgets/investments/_author_actions.html.erb
+++ b/app/views/budgets/investments/_author_actions.html.erb
@@ -1,0 +1,12 @@
+<% if can_destroy_image?(investment) %>
+  <div class="sidebar-divider"></div>
+  <h2><%= t("budgets.investments.show.author") %></h2>
+  <div class="show-actions-menu">
+    <%= link_to image_path(investment.image),
+                method: :delete,
+                class: "button hollow alert expanded" do %>
+        <span class="icon-image"></span>
+        <%= t("images.remove_image") %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -22,18 +22,7 @@
       </div>
 
       <aside class="small-12 medium-3 column">
-        <% if can_destroy_image?(investment) %>
-          <div class="sidebar-divider"></div>
-          <h2><%= t("budgets.investments.show.author") %></h2>
-          <div class="show-actions-menu">
-            <%= link_to image_path(investment.image),
-                        method: :delete,
-                        class: "button hollow alert expanded" do %>
-                <span class="icon-image"></span>
-                <%= t("images.remove_image") %>
-            <% end %>
-          </div>
-        <% end %>
+        <%= render "/budgets/investments/author_actions", investment: investment %>
 
         <% if investment.should_show_aside? %>
           <% if investment.should_show_votes? %>

--- a/app/views/users/_budget_investment.html.erb
+++ b/app/views/users/_budget_investment.html.erb
@@ -3,14 +3,14 @@
     <%= link_to budget_investment.title, budget_investment_path(budget_investment.budget, budget_investment) %>
   </td>
   <td>
-    <% if can? :destroy, budget_investment %>
-      <%= link_to t("shared.delete"), budget_investment_path(budget_investment.budget, budget_investment),
-                  method: :delete, class: "button hollow alert expanded",
-                  data: { confirm: "#{t("users.show.delete_alert")}" } %>
-    <% end %>
     <% if can? :update, budget_investment %>
       <%= link_to t("shared.edit"), edit_budget_investment_path(budget_investment.budget, budget_investment),
-                  class: "button hollow expanded" %>
+                  class: "button hollow" %>
+    <% end %>
+    <% if can? :destroy, budget_investment %>
+      <%= link_to t("shared.delete"), budget_investment_path(budget_investment.budget, budget_investment),
+                  method: :delete, class: "button hollow alert",
+                  data: { confirm: "#{t("users.show.delete_alert")}" } %>
     <% end %>
   </td>
 </tr>

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1957,5 +1957,48 @@ describe "Budget Investments" do
         expect(page).to have_css(".map-icon", count: 3, visible: false)
       end
     end
+
+    context "Author actions section" do
+      scenario "Is not shown if investment is not editable or does not have an image" do
+        budget.update!(phase: "reviewing")
+        investment = create(:budget_investment, heading: heading, author: author)
+
+        login_as(author)
+        visit budget_investment_path(budget, investment)
+
+        within("aside") do
+          expect(page).not_to have_content "Author"
+          expect(page).not_to have_link "Edit"
+          expect(page).not_to have_link "Remove image"
+        end
+      end
+
+      scenario "Contains edit button in the accepting phase" do
+        investment = create(:budget_investment, heading: heading, author: author)
+
+        login_as(author)
+        visit budget_investment_path(budget, investment)
+
+        within("aside") do
+          expect(page).to have_content "Author"
+          expect(page).to have_link "Edit"
+          expect(page).not_to have_link "Remove image"
+        end
+      end
+
+      scenario "Contains remove image button in phases different from accepting" do
+        budget.update!(phase: "reviewing")
+        investment = create(:budget_investment, :with_image, heading: heading, author: author)
+
+        login_as(author)
+        visit budget_investment_path(budget, investment)
+
+        within("aside") do
+          expect(page).to have_content "Author"
+          expect(page).not_to have_link "Edit"
+          expect(page).to have_link "Remove image"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## References

PR https://github.com/consul/consul/pull/3716

## Objectives

- Since now it's possible to edit the budget investment during the accepting phase, it does not really make sense to show the button to just remove the image when the investment project can be fully edited, and the image can be removed from the editing form.

- In most of the rest of the application, the buttons are shown in this way, we do this little adjustment to improve the consistency with the rest of the application

## Visual Changes
### INVESTMENT SHOW (BEFORE)
![Captura de pantalla 2020-02-04 a las 12 58 09](https://user-images.githubusercontent.com/942995/73718828-2d3ab780-4750-11ea-84c9-fb5df3fc3d4b.png)

### INVESTMENT SHOW (AFTER)
![Captura de pantalla 2020-02-04 a las 12 57 20](https://user-images.githubusercontent.com/942995/73718836-3461c580-4750-11ea-81a0-ef8de8532043.png)

### USER ACTIVITY (BEFORE)
![Captura de pantalla 2020-02-04 a las 12 30 34](https://user-images.githubusercontent.com/942995/73718849-3b88d380-4750-11ea-89ac-a90d4cc8f4c2.png)

### USER ACTIVITY (AFTER)
![Captura de pantalla 2020-02-04 a las 13 02 27](https://user-images.githubusercontent.com/942995/73718860-43e10e80-4750-11ea-968f-3b0190ed513b.png)
