### PR TITLE
Expire investment cache when its image changes

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -9,6 +9,7 @@
 
 <% cache [locale_and_user_status(investment),
           investment,
+          investment.image,
           investment.author,
           Flag.flagged?(current_user, investment),
           @investment_votes] do %>


### PR DESCRIPTION
## Background

We've added the option to remove an image from an investment. However,
removing the image did not expire the cache, so the rendered HTML still
included an `<image>` tag (which wouldn't show an image, since it had
been deleded) and a link to remove an image.

## Objectives

Fix a bug resulting in an empty image being shown after removing it.

## Visual Changes

Before these changes:

![The alternative text is shown and there is a link to delete the image](https://user-images.githubusercontent.com/35156/73750947-667a2400-475e-11ea-87fa-baf63614da4d.png)