### PR TITLE
Improve retired proposal page when translation interface is enabled.

### DIFF
--- a/app/views/proposals/retire_form.html.erb
+++ b/app/views/proposals/retire_form.html.erb
@@ -14,14 +14,14 @@
 
     <%= translatable_form_for(@proposal, url: retire_proposal_path(@proposal)) do |f| %>
       <%= render "shared/errors", resource: @proposal %>
-      <div class="row">
+      <div class="row column">
         <div class="small-12 medium-6 large-4 column">
           <%= f.select :retired_reason, retire_proposals_options,
             include_blank: t("proposals.retire_form.retired_reason_blank") %>
         </div>
       </div>
 
-      <div class="row">
+      <div class="row column">
         <%= f.translatable_fields do |translations_form| %>
           <div class="small-12 medium-9 column float-left">
             <%= translations_form.text_area :retired_explanation,
@@ -31,7 +31,7 @@
         <% end %>
       </div>
 
-      <div class="row">
+      <div class="row column">
         <div class="actions small-12 medium-3 column">
           <%= f.submit(class: "button expanded", value: t("proposals.retire_form.submit_button")) %>
         </div>


### PR DESCRIPTION
## References
Related PR: Responsive translation interface #3579

## Objectives
Adding styles to give consistency with other pages when the translation interface is displayed.

## Visual Changes
- Before PR:
  - with translations interface
![Captura de pantalla 2020-02-03 a las 17 56 33](https://user-images.githubusercontent.com/16189/73829820-e4dcd180-4803-11ea-9dd9-238a91d260a9.png)
  - without translations interface
![Captura de pantalla 2020-02-03 a las 17 54 48](https://user-images.githubusercontent.com/16189/73829982-2bcac700-4804-11ea-827c-d642fdc0f338.png)

- After PR:
    - with translations interface
![Captura de pantalla 2020-02-03 a las 17 57 01](https://user-images.githubusercontent.com/16189/73829842-ec03df80-4803-11ea-88e1-c219e8bf264d.png)
  - without translations interface (same as the proposal page)
![Captura de pantalla 2020-02-03 a las 17 55 39](https://user-images.githubusercontent.com/16189/73830007-31281180-4804-11ea-9872-c8ac2a9aaf9f.png)



