### PR TITLE
Fix Polls link in admin menu

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -33,12 +33,14 @@ module AdminHelper
   end
 
   def menu_polls?
-    %w[polls active_polls recounts results questions answers].include?(controller_name) ||
-    controller.class.parent == Admin::Poll::Questions::Answers
+    controller.class.parent == Admin::Poll::Questions::Answers ||
+      %w[polls active_polls recounts results questions answers].include?(controller_name) &&
+      action_name != "booth_assignments"
   end
 
   def menu_booths?
-    %w[officers booths shifts booth_assignments officer_assignments].include?(controller_name)
+    %w[officers booths shifts booth_assignments officer_assignments].include?(controller_name) ||
+      controller_name == "polls" && action_name == "booth_assignments"
   end
 
   def menu_profiles?

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -57,7 +57,7 @@
         <span class="icon-box"></span>
         <strong><%= t("admin.menu.title_booths") %></strong>
       </a>
-      <ul id="booths_menu" <%= "class=is-active" if menu_booths? || controller_name == "polls" && action_name == "booth_assignments" %>>
+      <ul id="booths_menu" <%= "class=is-active" if menu_booths? %>>
         <li <%= "class=is-active" if %w[officers officer_assignments].include?(controller_name) %>>
           <%= link_to t("admin.menu.poll_officers"), admin_officers_path %>
         </li>

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -29,6 +29,12 @@ describe "Admin booths assignments" do
       expect(page).to have_content(second_booth.name)
     end
 
+    scenario "Does not hide the Polls menu", :js do
+      visit booth_assignments_admin_polls_path
+
+      within("#admin_menu") { expect(page).to have_link "Polls" }
+    end
+
     scenario "Index do not show polls created by users from proposals dashboard" do
       create(:poll, name: "Poll created by admin")
       create(:poll, name: "Poll from user's proposal", related_type: "Proposal")


### PR DESCRIPTION
## Objectives

Fix a bug which made the link to "Polls" marked as active and hidden by foundation when we were in the "Booths Assignments" section.

## Visual Changes

Before these changes:

![The polls menu is not shown when we are manage booth assigments](https://user-images.githubusercontent.com/35156/73885082-716cab80-4867-11ea-929c-33d7dd3eeecb.png)

After these changes:

![The polls menu is shown when we are manage booth assigments](https://user-images.githubusercontent.com/35156/73885130-89442f80-4867-11ea-858c-d6fd3ec9d7d0.png)