### PR TITLE
Fix filters for investments without admin/valuator

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -71,9 +71,9 @@ class Budget
     scope :sort_by_supports, -> { order("cached_votes_up DESC") }
 
     scope :valuation_open,              -> { where(valuation_finished: false) }
-    scope :without_admin,               -> { valuation_open.where(administrator_id: nil) }
+    scope :without_admin,               -> { where(administrator_id: nil) }
     scope :without_valuator_group,      -> { where(valuator_group_assignments_count: 0) }
-    scope :without_valuator,            -> { valuation_open.without_valuator_group.where(valuator_assignments_count: 0) }
+    scope :without_valuator,            -> { without_valuator_group.where(valuator_assignments_count: 0) }
     scope :under_valuation,             -> { valuation_open.valuating.where("administrator_id IS NOT ?", nil) }
     scope :managed,                     -> { valuation_open.where(valuator_assignments_count: 0).where("administrator_id IS NOT ?", nil) }
     scope :valuating,                   -> { valuation_open.where("valuator_assignments_count > 0 OR valuator_group_assignments_count > 0") }

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -459,19 +459,13 @@ describe Budget::Investment do
     end
 
     describe "without_admin" do
-      it "returns open investments without assigned admin" do
-        investment = create(:budget_investment, :open, administrator: nil)
+      it "returns investments without an admin" do
+        investment = create(:budget_investment, :finished, administrator: nil)
 
         expect(Budget::Investment.without_admin).to eq [investment]
       end
 
-      it "does not return investments with valuation finished" do
-        create(:budget_investment, :finished)
-
-        expect(Budget::Investment.without_admin).to be_empty
-      end
-
-      it "does not return investment with an admin" do
+      it "does not return investments with an admin" do
         create(:budget_investment, :with_administrator)
 
         expect(Budget::Investment.without_admin).to be_empty
@@ -1213,14 +1207,11 @@ describe Budget::Investment do
       let(:params) { { advanced_filters: ["without_admin"], budget_id: budget.id } }
       it "returns only investment without admin" do
         create(:budget_investment,
-          :finished,
-          budget: budget)
-        create(:budget_investment,
           :with_administrator,
           budget: budget)
-        investment3 = create(:budget_investment, budget: budget)
+        investment2 = create(:budget_investment, budget: budget)
 
-        expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment3])
+        expect(Budget::Investment.scoped_filter(params, "all")).to eq([investment2])
       end
     end
 
@@ -1228,7 +1219,7 @@ describe Budget::Investment do
       let(:params) { { advanced_filters: ["without_valuator"], budget_id: budget.id } }
       it "returns only investment without valuator" do
         create(:budget_investment,
-          :finished,
+          :with_valuator,
           budget: budget)
         investment2 = create(:budget_investment,
           :with_administrator,


### PR DESCRIPTION
## References

* The interface related to these filters was changer in pull reques #3351

## Background

Historically only one filter could be applied at a time, so these filters were only returning investments with valuation open.

## Objectives

Make the "without admin" and "without valuator" filters work as expected.