### PR TITLE
Align select admins and valuators with the rest of the form

### DIFF
--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -21,7 +21,7 @@
     </div>
   </div>
 
-  <div class="margin-top">
+  <div class="row margin-top">
     <% %w[administrators valuators].each do |staff| %>
       <div class="small-12 medium-4 column end">
         <%= link_to t("admin.budgets.edit.#{staff}", count: @budget.send(staff).count),
@@ -32,7 +32,7 @@
     <% end %>
   </div>
 
-  <div class="margin-top">
+  <div class="row margin-top">
     <%= render "/admin/budgets/association", assignable_type: "administrators", assignables: @admins, form: f %>
     <%= render "/admin/budgets/association", assignable_type: "valuators", assignables: @valuators, form: f %>
   </div>


### PR DESCRIPTION
## Objectives

Align the selection of administrators and valuators with the rest of the form when creating or editing a Participatory Budget.

## Visual Changes
### BEFORE
![before](https://user-images.githubusercontent.com/942995/74415495-0c701180-4e76-11ea-8b35-17a2474cb0e5.png)

### AFTER
![after](https://user-images.githubusercontent.com/942995/74415506-1265f280-4e76-11ea-9308-c9da1a03887a.png)
