### PR TITLE
Fix style of banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,4 @@
 @import "autocomplete_overrides";
 @import "jquery-ui/sortable";
 @import "leaflet";
+@import "banner";

--- a/app/assets/stylesheets/banner.scss
+++ b/app/assets/stylesheets/banner.scss
@@ -1,0 +1,11 @@
+.banner {
+  margin-bottom: 2rem;
+
+  &__container {
+    max-width: 75rem;
+    height: auto;
+    width: 100%;
+    display: block;
+    margin: 0 auto;
+  }
+}

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <% if current_budget.present? %>
-  <div id="budget_heading" class="expanded budget no-margin-top">
+  <div id="budget_heading" class="expanded budget">
     <div class="row" data-equalizer data-equalizer-on="medium">
       <div class="small-12 medium-9 column padding" data-equalizer-watch>
 

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -1,4 +1,6 @@
 <% banner ||= @banners.sample %>
 <div class="banner" style="background-color:<%= banner.background_color %>;">
-  <%= sanitize banner_target_link(banner), attributes: %w[href style] %>
+  <div class="banner__container">
+    <%= sanitize banner_target_link(banner), attributes: %w[href style] %>
+  </div>
 </div>


### PR DESCRIPTION
## References

* Closes #3639 

## Objectives

This PR fixes banner style in all pages. You can see all broken styles in #3639 

## Visual Changes

Before of the changes, in home page, the banner was outside of site container and now:
![Screenshot from 2020-02-17 15-09-22](https://user-images.githubusercontent.com/49662698/74677868-39833380-5198-11ea-82db-879321024637.png)

Before of the changes, in help page, the banner wasn't bottom margin, and this caused an impression that banner was together with default banner of help page, and now:
![Screenshot from 2020-02-12 10-44-11](https://user-images.githubusercontent.com/49662698/74678035-9aab0700-5198-11ea-9b62-c5b72d5ebbfd.png)

Before of the changes, in budgets page, banner was broken, and now:
![Screenshot from 2020-02-17 15-09-41](https://user-images.githubusercontent.com/49662698/74678049-a39bd880-5198-11ea-94ac-f7c3de316321.png)