### PR TITLE
Fix card description overflow

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2769,6 +2769,7 @@ table {
 
       &.description {
         color: $text;
+        word-wrap: break-word;
       }
     }
   }


### PR DESCRIPTION
## References

> Related Issues/Pull Requests/Travis Builds/Rollbar errors/etc...

https://demo.consulproject.org/

## Objectives

> What are the objectives of these changes?

This PR fixes a bug that was caused when a card had a big description.

## Visual Changes
Before: 
![Screenshot from 2020-02-18 09-28-15](https://user-images.githubusercontent.com/49662698/74736620-ed84cd00-5231-11ea-9904-f07909bd1fb9.png)

After:
![Screenshot from 2020-02-18 09-28-37](https://user-images.githubusercontent.com/49662698/74736636-f4abdb00-5231-11ea-9dc3-784b53f1c19e.png)

