### PR TITLE
Fix hidden active elements in admin menu

### DIFF
--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="admin-sidebar">
-  <ul id="admin_menu" data-accordion-menu data-multi-open="false">
+  <ul id="admin_menu" data-accordion-menu data-multi-open="true">
     <% if feature?(:proposals) %>
       <li class="section-title">
         <%= link_to admin_proposals_path do %>

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -84,4 +84,17 @@ describe "Admin" do
     expect(page).not_to have_css("#moderation_menu")
     expect(page).not_to have_css("#valuation_menu")
   end
+
+  scenario "Admin menu does not hide active elements", :js do
+    login_as(administrator)
+    visit admin_budgets_path
+
+    within("#admin_menu") do
+      expect(page).to have_link "Participatory budgets"
+
+      click_link "Site content"
+
+      expect(page).to have_link "Participatory budgets"
+    end
+  end
 end


### PR DESCRIPTION
## Background

In the admin menu, some links take you to a section, and some links open a submenu with more links.

When we disable the "multi-open" property of the menu and the active element is a link which takes you to a section, Foundation will hide it whenever we click a link which opens a submenu.

## Objectives

Make sure active menu items aren't hidden when navigating through the menus.

## Visual Changes

Before these changes:

![The current element is hidden when opening a submenu](https://user-images.githubusercontent.com/35156/74962585-7eb19a80-5410-11ea-9864-98ee56e76649.png)  

After these changes:

![The current element is present when opening a submenu](https://user-images.githubusercontent.com/35156/74962592-83764e80-5410-11ea-969e-0ee4d0d258d3.png)