### PR TITLE
Fix flaky spec when unselecting an investment

### DIFF
--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1525,6 +1525,8 @@ describe "Admin budget investments" do
 
       within("#budget_investment_#{selected_bi.id}") do
         click_link("Selected")
+
+        expect(page).to have_link("Select")
       end
 
       click_button("Filter")


### PR DESCRIPTION
## References

* [Travis build 32487, job 4](https://travis-ci.org/consul/consul/jobs/648339684)
* [Travis build 32498, job 4](https://travis-ci.org/consul/consul/jobs/651957658)

## Objectives

* Fix a flaky spec which tests unselecting an investment

## Notes

The tests failed sometimes because we performed a synchronous request before checking the previous AJAX request had already finished.