### PR TITLE
Specify which bundler version to install

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -71,7 +71,7 @@ end
 task :install_bundler_gem do
   on roles(:app) do
     within release_path do
-      execute :rvm, fetch(:rvm1_ruby_version), "do", "gem install bundler"
+      execute :rvm, fetch(:rvm1_ruby_version), "do", "gem install bundler --version 1.17.1"
     end
   end
 end


### PR DESCRIPTION
## Background

Using the latest bundler we got a deprecation warning, which might turn into an error in the future:

```
[DEPRECATED] The `--deployment` flag is deprecated because it relies on
being remembered across bundler invocations, which bundler will no
longer do in future versions.
```

## Objectives

Use the same version of Bundler we used to generate our Gemfile.lock.

## Notes

We could also upgrade to bundler 2.x, but since we're using Ruby 2.4, and Ruby 2.6 comes with bundler 1.17, we've decided to keep this version.