### PR TITLE
Feature close support comments

### DIFF
--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -121,11 +121,11 @@ module Abilities
       can :disable_recommendations, [Debate, Proposal]
 
       cannot [:vote, :create_comment], Legislation::Process do |process|
-        not process.draft_phase.open?
+        !process.draft_phase.open?
       end
 
       cannot [:vote, :create_comment], Legislation::Process do |process|
-        not process.debate_phase.open?
+        !process.debate_phase.open?
       end
     end
   end

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -119,6 +119,10 @@ module Abilities
       can [:update, :destroy], Topic, author_id: user.id
 
       can :disable_recommendations, [Debate, Proposal]
+
+      cannot [:vote, :create_comment], Legislation::Process do |process|
+        not process.draft_phase.open?
+      end
     end
   end
 end

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -123,6 +123,10 @@ module Abilities
       cannot [:vote, :create_comment], Legislation::Process do |process|
         not process.draft_phase.open?
       end
+
+      cannot [:vote, :create_comment], Legislation::Process do |process|
+        not process.debate_phase.open?
+      end
     end
   end
 end

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -58,7 +58,7 @@ describe Abilities::Common do
   let(:own_budget_investment_image) { build(:image, imageable: own_investment_in_accepting_budget) }
   let(:budget_investment_image)     { build(:image, imageable: investment_in_accepting_budget) }
 
-  let(:process) { create(:legislation_process, :past)}
+  let(:process) { create(:legislation_process, :past) }
 
   it { should be_able_to(:index, Debate) }
   it { should be_able_to(:show, debate)  }

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -58,6 +58,8 @@ describe Abilities::Common do
   let(:own_budget_investment_image) { build(:image, imageable: own_investment_in_accepting_budget) }
   let(:budget_investment_image)     { build(:image, imageable: investment_in_accepting_budget) }
 
+  let(:process) { create(:legislation_process, :past)}
+
   it { should be_able_to(:index, Debate) }
   it { should be_able_to(:show, debate)  }
   it { should be_able_to(:vote, debate)  }
@@ -303,5 +305,17 @@ describe Abilities::Common do
   describe "#disable_recommendations" do
     it { should be_able_to(:disable_recommendations, Debate) }
     it { should be_able_to(:disable_recommendations, Proposal) }
+  end
+
+  describe "colaborative legislation process" do
+    context "when debate phase have finished" do
+      it { should_not be_able_to(:vote, process) }
+      it { should_not be_able_to(:create_comment, process) }
+    end
+
+    context "when draft phase have finished" do
+      it { should_not be_able_to(:vote, process) }
+      it { should_not be_able_to(:create_comment, process) }
+    end
   end
 end


### PR DESCRIPTION
## References

* Closes #3553 

## Objectives

Close the votes and comments when a draft or debate phase of the collaborative process is done
