### PR TITLE
Allow deploying a specific branch to production

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,4 @@
-set :branch, :master
+set :branch, ENV["branch"] || :master
 
 server deploysecret(:server1), user: deploysecret(:user), roles: %w[web app db importer cron background]
 #server deploysecret(:server2), user: deploysecret(:user), roles: %w(web app db importer cron background)


### PR DESCRIPTION
## Background

There are many ways to use CONSUL on production. A common one is to use a different branch without changing the source code.

## Objectives

Make it possible to deploy any branch to production.