### PR TITLE
Use "resolve" for polymorphic hierarchy paths

### DIFF
--- a/app/controllers/admin/milestones_controller.rb
+++ b/app/controllers/admin/milestones_controller.rb
@@ -67,6 +67,6 @@ class Admin::MilestonesController < Admin::BaseController
     end
 
     def milestoneable_path
-      polymorphic_path([:admin, *resource_hierarchy_for(@milestone.milestoneable)])
+      admin_polymorphic_path(@milestone.milestoneable)
     end
 end

--- a/app/controllers/admin/progress_bars_controller.rb
+++ b/app/controllers/admin/progress_bars_controller.rb
@@ -64,6 +64,6 @@ class Admin::ProgressBarsController < Admin::BaseController
     end
 
     def progress_bars_index
-      polymorphic_path([:admin, *resource_hierarchy_for(@progressable), ProgressBar.new])
+      admin_polymorphic_path(@progressable.progress_bars.new)
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -102,7 +102,7 @@ class CommentsController < ApplicationController
       return if current_user.administrator? || current_user.moderator?
 
       if @commentable.respond_to?(:comments_closed?) && @commentable.comments_closed?
-        redirect_to polymorphic_hierarchy_path(@commentable), alert: t("comments.comments_closed")
+        redirect_to polymorphic_path(@commentable), alert: t("comments.comments_closed")
       end
     end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -39,7 +39,7 @@ class NotificationsController < ApplicationController
       if notification.linkable_resource.is_a?(AdminNotification)
         notification.linkable_resource.link || notifications_path
       else
-        polymorphic_hierarchy_path(notification.linkable_resource)
+        polymorphic_path(notification.linkable_resource)
       end
     end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -40,7 +40,7 @@ module CommentsHelper
   end
 
   def commentable_path(comment)
-    polymorphic_hierarchy_path(comment.commentable)
+    polymorphic_path(comment.commentable)
   end
 
   def user_level_class(comment)

--- a/app/views/admin/audits/_audits.html.erb
+++ b/app/views/admin/audits/_audits.html.erb
@@ -35,7 +35,7 @@
             </td>
             <td>
               <%= link_to t("shared.show"),
-                polymorphic_path([:admin, *resource_hierarchy_for(audit)]),
+                admin_polymorphic_path(audit),
                 class: "button hollow primary" %>
             </td>
           </tr>

--- a/app/views/admin/audits/show.html.erb
+++ b/app/views/admin/audits/show.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title) do %>
   <%= t("admin.audits.title") %>
 <% end %>
-<%= back_link_to polymorphic_path([:admin, *resource_hierarchy_for(@audit.associated || @audit.auditable)]) %>
+<%= back_link_to admin_polymorphic_path(@audit.associated || @audit.auditable) %>
 
 <h2><%= t("admin.audits.title") %></h2>
 

--- a/app/views/admin/milestones/_form.html.erb
+++ b/app/views/admin/milestones/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/globalize_locales", resource: @milestone %>
 
-<%= translatable_form_for [:admin, *resource_hierarchy_for(@milestone)] do |f| %>
+<%= translatable_form_for @milestone, url: admin_polymorphic_path(@milestone) do |f| %>
 
   <div class="row">
     <div class="small-12 medium-6 margin-bottom column">

--- a/app/views/admin/milestones/_milestones.html.erb
+++ b/app/views/admin/milestones/_milestones.html.erb
@@ -1,7 +1,7 @@
 <h2 class="inline-block"><%= t("admin.milestones.index.milestone") %></h2>
 
 <%= link_to t("admin.progress_bars.manage"),
-            polymorphic_path([:admin, *resource_hierarchy_for(milestoneable.progress_bars.new)]),
+            admin_polymorphic_path(milestoneable.progress_bars.new),
             class: "button hollow float-right" %>
 
 <% if milestoneable.milestone_tag_list.any? %>
@@ -31,9 +31,7 @@
         <tr id="<%= dom_id(milestone) %>" class="milestone">
           <td class="text-center"><%= milestone.id %></td>
           <td>
-            <%= link_to milestone.title,
-                        polymorphic_path([:admin, *resource_hierarchy_for(milestone)],
-                                         action: :edit) %>
+            <%= link_to milestone.title, admin_polymorphic_path(milestone, action: :edit) %>
           </td>
           <td class="small small-5"><%= milestone.description %></td>
           <td class="small">
@@ -59,7 +57,7 @@
           </td>
           <td class="small-2">
             <%= link_to t("admin.milestones.index.delete"),
-                        polymorphic_path([:admin, *resource_hierarchy_for(milestone)]),
+                        admin_polymorphic_path(milestone),
                         method: :delete,
                         class: "button hollow alert expanded" %>
           </td>
@@ -73,7 +71,6 @@
 
 <p>
   <%= link_to t("admin.milestones.index.new_milestone"),
-              polymorphic_path([:admin, *resource_hierarchy_for(milestoneable.milestones.new)],
-                               action: :new),
+              admin_polymorphic_path(milestoneable.milestones.new, action: :new),
               class: "button hollow" %>
 </p>

--- a/app/views/admin/progress_bars/_form.html.erb
+++ b/app/views/admin/progress_bars/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/globalize_locales", resource: @progress_bar %>
 
-<%= translatable_form_for [:admin, *resource_hierarchy_for(@progress_bar)] do |f| %>
+<%= translatable_form_for @progress_bar, url: admin_polymorphic_path(@progress_bar) do |f| %>
 
   <div class="row">
     <div class="small-12 medium-6 column">

--- a/app/views/admin/progress_bars/_progress_bars.html.erb
+++ b/app/views/admin/progress_bars/_progress_bars.html.erb
@@ -1,8 +1,8 @@
 <h2 class="inline-block"><%= t("admin.progress_bars.index.title") %></h2>
 
 <%= link_to t("admin.progress_bars.index.new_progress_bar"),
-            polymorphic_path(
-              [:admin, *resource_hierarchy_for(ProgressBar.new(progressable: progressable))],
+            admin_polymorphic_path(
+              ProgressBar.new(progressable: progressable),
               action: :new
             ),
             class: "button float-right" %>
@@ -37,12 +37,11 @@
           </td>
           <td>
             <%= link_to t("admin.actions.edit"),
-                        polymorphic_path([:admin, *resource_hierarchy_for(progress_bar)],
-                                         action: :edit),
+                        admin_polymorphic_path(progress_bar, action: :edit),
                         class: "button hollow" %>
 
             <%= link_to t("admin.actions.delete"),
-                        polymorphic_path([:admin, *resource_hierarchy_for(progress_bar)]),
+                        admin_polymorphic_path(progress_bar),
                         method: :delete,
                         class: "button hollow alert" %>
           </td>

--- a/app/views/admin/progress_bars/index.html.erb
+++ b/app/views/admin/progress_bars/index.html.erb
@@ -2,7 +2,7 @@
   <%= "#{t("admin.header.title")} - #{t("admin.progress_bars.index.title")}" %>
 <% end %>
 
-<%= back_link_to polymorphic_path([:admin, *resource_hierarchy_for(@progressable)]) %>
+<%= back_link_to admin_polymorphic_path(@progressable) %>
 
 <div class="clear"></div>
 

--- a/config/initializers/routes_hierarchy.rb
+++ b/config/initializers/routes_hierarchy.rb
@@ -63,4 +63,8 @@ module ActionDispatch::Routing::UrlFor
       polymorphic_path(resources)
     end
   end
+
+  def admin_polymorphic_path(resource, options = {})
+    polymorphic_path([:admin, *resource_hierarchy_for(resource)], options)
+  end
 end

--- a/config/initializers/routes_hierarchy.rb
+++ b/config/initializers/routes_hierarchy.rb
@@ -2,9 +2,9 @@
 # routes with nested resources in the admin namespace
 module ActionDispatch::Routing::UrlFor
   def resource_hierarchy_for(resource)
-    if polymorphic_mapping(resource)
-      resolve = polymorphic_mapping(resource).send(:eval_block, self, resource, {})
+    resolve = resolve_for(resource)
 
+    if resolve
       if resolve.last.is_a?(Hash)
         [resolve.first, *resolve.last.values]
       else
@@ -16,6 +16,20 @@ module ActionDispatch::Routing::UrlFor
   end
 
   def admin_polymorphic_path(resource, options = {})
-    polymorphic_path([:admin, *resource_hierarchy_for(resource)], options)
+    if %w[Budget::Group Budget::Heading Poll::Booth Poll::Officer
+          Poll::Question Poll::Question::Answer::Video].include?(resource.class.name)
+      resolve = resolve_for(resource)
+      resolve_options = resolve.pop
+
+      polymorphic_path([:admin, *resolve], options.merge(resolve_options))
+    else
+      polymorphic_path([:admin, *resource_hierarchy_for(resource)], options)
+    end
   end
+
+  private
+
+    def resolve_for(resource)
+      polymorphic_mapping(resource)&.send(:eval_block, self, resource, {})
+    end
 end

--- a/config/initializers/routes_hierarchy.rb
+++ b/config/initializers/routes_hierarchy.rb
@@ -1,66 +1,17 @@
 # This module is expanded in order to make it easier to use polymorphic
-# routes with nested resources.
-# HACK: is there a way to avoid monkey-patching here? Using helpers is
-# a similar use of a global namespace too...
+# routes with nested resources in the admin namespace
 module ActionDispatch::Routing::UrlFor
   def resource_hierarchy_for(resource)
-    case resource.class.name
-    when "Budget::Investment", "Budget::Phase", "Budget::Group"
-      [resource.budget, resource]
-    when "Budget::Heading"
-      [resource.group.budget, resource.group, resource]
-    when "Milestone"
-      [*resource_hierarchy_for(resource.milestoneable), resource]
-    when "ProgressBar"
-      [*resource_hierarchy_for(resource.progressable), resource]
-    when "Audit"
-      [*resource_hierarchy_for(resource.associated || resource.auditable), resource]
-    when "Legislation::Annotation"
-      [resource.draft_version.process, resource.draft_version, resource]
-    when "Legislation::Proposal", "Legislation::Question", "Legislation::DraftVersion"
-      [resource.process, resource]
-    when "Topic"
-      [resource.community, resource]
+    if polymorphic_mapping(resource)
+      resolve = polymorphic_mapping(resource).send(:eval_block, self, resource, {})
+
+      if resolve.last.is_a?(Hash)
+        [resolve.first, *resolve.last.values]
+      else
+        resolve
+      end
     else
       resource
-    end
-  end
-
-  def polymorphic_hierarchy_path(resource)
-    # Unfortunately, we can't use polymorphic routes because there
-    # are cases where polymorphic_path doesn't get the named routes properly.
-    # Example:
-    #
-    # polymorphic_path([legislation_proposal.process, legislation_proposal])
-    #
-    # That line tries to find legislation_process_legislation_proposal_path
-    # while the correct route would be legislation_process_proposal_path
-    #
-    # We probably need to define routes differently in order to be able to use
-    # polymorphic_path which might be possible with Rails 5.1 `direct` and
-    # `resolve` methods.
-
-    resources = resource_hierarchy_for(resource)
-
-    case resource.class.name
-    when "Budget::Investment"
-      # polymorphic_path would return budget_budget_investment_path
-      budget_investment_path(*resources)
-    when "Legislation::Annotation"
-      # polymorphic_path would return:
-      # "legislation_process_legislation_draft_version_legislation_annotation_path"
-      legislation_process_draft_version_annotation_path(*resources)
-    when "Legislation::Proposal"
-      # polymorphic_path would return legislation_process_legislation_proposal_path
-      legislation_process_proposal_path(*resources)
-    when "Legislation::Question"
-      # polymorphic_path would return legislation_process_legislation_question_path
-      legislation_process_question_path(*resources)
-    when "Poll::Question"
-      # polymorphic_path would return poll_question_path
-      question_path(*resources)
-    else
-      polymorphic_path(resources)
     end
   end
 

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -253,3 +253,15 @@ namespace :admin do
     resources :imports, only: [:new, :create, :show]
   end
 end
+
+resolve "Milestone" do |milestone|
+  [*resource_hierarchy_for(milestone.milestoneable), milestone]
+end
+
+resolve "ProgressBar" do |progress_bar|
+  [*resource_hierarchy_for(progress_bar.progressable), progress_bar]
+end
+
+resolve "Audit" do |audit|
+  [*resource_hierarchy_for(audit.associated || audit.auditable), audit]
+end

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -265,3 +265,23 @@ end
 resolve "Audit" do |audit|
   [*resource_hierarchy_for(audit.associated || audit.auditable), audit]
 end
+
+resolve "Budget::Group" do |group, options|
+  [group.budget, :group, options.merge(id: group)]
+end
+
+resolve "Budget::Heading" do |heading, options|
+  [heading.budget, :group, :heading, options.merge(group_id: heading.group, id: heading)]
+end
+
+resolve "Poll::Booth" do |booth, options|
+  [:booth, options.merge(id: booth)]
+end
+
+resolve "Poll::Officer" do |officer, options|
+  [:officer, options.merge(id: officer)]
+end
+
+resolve "Poll::Question::Answer::Video" do |video, options|
+  [:video, options.merge(id: video)]
+end

--- a/config/routes/budget.rb
+++ b/config/routes/budget.rb
@@ -19,5 +19,9 @@ resources :budgets, only: [:show, :index] do
   resource :executions, only: :show, controller: "budgets/executions"
 end
 
+resolve "Budget::Investment" do |investment, options|
+  [investment.budget, :investment, options.merge(id: investment)]
+end
+
 get "investments/:id/json_data", action: :json_data, controller: "budgets/investments"
 get "/budgets/:budget_id/investments/:id/json_data", action: :json_data, controller: "budgets/investments"

--- a/config/routes/community.rb
+++ b/config/routes/community.rb
@@ -1,3 +1,5 @@
 resources :communities, only: [:show] do
   resources :topics
 end
+
+resolve("Topic") { |topic, options| [topic.community, topic, options] }

--- a/config/routes/legislation.rb
+++ b/config/routes/legislation.rb
@@ -36,3 +36,16 @@ namespace :legislation do
     end
   end
 end
+
+resolve "Legislation::Proposal" do |proposal, options|
+  [proposal.process, :proposal, options.merge(id: proposal)]
+end
+
+resolve "Legislation::Question" do |question, options|
+  [question.process, :question, options.merge(id: question)]
+end
+
+resolve "Legislation::Annotation" do |annotation, options|
+  [annotation.draft_version.process, :draft_version, :annotation,
+   options.merge(draft_version_id: annotation.draft_version, id: annotation)]
+end

--- a/config/routes/poll.rb
+++ b/config/routes/poll.rb
@@ -8,3 +8,7 @@ resources :polls, only: [:show, :index] do
     post :answer, on: :member
   end
 end
+
+resolve "Poll::Question" do |question, options|
+  [:question, options.merge(id: question)]
+end

--- a/spec/routing/polymorphic_routes_spec.rb
+++ b/spec/routing/polymorphic_routes_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+describe "Polymorphic routes" do
+  describe "polymorphic_path" do
+    it "routes investments" do
+      budget = create(:budget)
+      investment = create(:budget_investment, budget: budget)
+
+      expect(polymorphic_path(investment)).to eq budget_investment_path(budget, investment)
+    end
+
+    it "routes legislation proposals" do
+      process = create(:legislation_process)
+      proposal = create(:legislation_proposal, process: process)
+
+      expect(polymorphic_path(proposal)).to eq legislation_process_proposal_path(process, proposal)
+    end
+
+    it "routes legislation questions" do
+      process = create(:legislation_process)
+      question = create(:legislation_question, process: process)
+
+      expect(polymorphic_path(question)).to eq legislation_process_question_path(process, question)
+    end
+
+    it "routes legislation annotations" do
+      process = create(:legislation_process)
+      draft_version = create(:legislation_draft_version, process: process)
+      annotation = create(:legislation_annotation, draft_version: draft_version)
+
+      expect(polymorphic_path(annotation)).to eq(
+        legislation_process_draft_version_annotation_path(process, draft_version, annotation)
+      )
+    end
+
+    it "routes poll questions" do
+      question = create(:poll_question)
+
+      expect(polymorphic_path(question)).to eq question_path(question)
+    end
+
+    it "routes topics" do
+      community = create(:proposal).community
+      topic = create(:topic, community: community)
+
+      expect(polymorphic_path(topic)).to eq community_topic_path(community, topic)
+    end
+  end
+
+  describe "admin_polymorphic_path" do
+    include ActionDispatch::Routing::UrlFor
+
+    it "routes milestones for resources with no hierarchy" do
+      proposal = create(:proposal)
+      milestone = create(:milestone, milestoneable: proposal)
+
+      expect(admin_polymorphic_path(milestone)).to eq(
+        admin_proposal_milestone_path(proposal, milestone)
+      )
+    end
+
+    it "routes milestones for resources with hierarchy" do
+      budget = create(:budget)
+      investment = create(:budget_investment, budget: budget)
+      milestone = create(:milestone, milestoneable: investment)
+
+      expect(admin_polymorphic_path(milestone)).to eq(
+        admin_budget_budget_investment_milestone_path(budget, investment, milestone)
+      )
+    end
+
+    it "routes progress bars for resources with no hierarchy" do
+      proposal = create(:proposal)
+      progress_bar = create(:progress_bar, progressable: proposal)
+
+      expect(admin_polymorphic_path(progress_bar)).to eq(
+        admin_proposal_progress_bar_path(proposal, progress_bar)
+      )
+    end
+
+    it "routes progress_bars for resources with hierarchy" do
+      budget = create(:budget)
+      investment = create(:budget_investment, budget: budget)
+      progress_bar = create(:progress_bar, progressable: investment)
+
+      expect(admin_polymorphic_path(progress_bar)).to eq(
+        admin_budget_budget_investment_progress_bar_path(budget, investment, progress_bar)
+      )
+    end
+
+    it "routes audits" do
+      budget = create(:budget)
+      investment = create(:budget_investment, budget: budget)
+      audit = investment.audits.create!
+
+      expect(admin_polymorphic_path(audit)).to eq(
+        admin_budget_budget_investment_audit_path(budget, investment, audit)
+      )
+    end
+
+    it "supports routes for actions like edit" do
+      proposal = create(:proposal)
+      milestone = create(:milestone, milestoneable: proposal)
+
+      expect(admin_polymorphic_path(milestone, action: :edit)).to eq(
+        edit_admin_proposal_milestone_path(proposal, milestone)
+      )
+    end
+  end
+end
+
+def polymorphic_path(record, options = {})
+  super(record, options.merge(only_path: true))
+end

--- a/spec/routing/polymorphic_routes_spec.rb
+++ b/spec/routing/polymorphic_routes_spec.rb
@@ -50,6 +50,56 @@ describe "Polymorphic routes" do
   describe "admin_polymorphic_path" do
     include ActionDispatch::Routing::UrlFor
 
+    it "routes budget investments" do
+      budget = create(:budget)
+      investment = create(:budget_investment, budget: budget)
+
+      expect(admin_polymorphic_path(investment)).to eq(
+        admin_budget_budget_investment_path(budget, investment)
+      )
+    end
+
+    it "routes budget groups" do
+      budget = create(:budget)
+      group = create(:budget_group, budget: budget)
+
+      expect(admin_polymorphic_path(group)).to eq(admin_budget_group_path(budget, group))
+    end
+
+    it "routes budget headings" do
+      budget = create(:budget)
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+
+      expect(admin_polymorphic_path(heading)).to eq(
+        admin_budget_group_heading_path(budget, group, heading)
+      )
+    end
+
+    it "routes poll booths" do
+      booth = create(:poll_booth)
+
+      expect(admin_polymorphic_path(booth)).to eq(admin_booth_path(booth))
+    end
+
+    it "routes poll officers" do
+      officer = create(:poll_officer)
+
+      expect(admin_polymorphic_path(officer)).to eq admin_officer_path(officer)
+    end
+
+    it "routes poll questions" do
+      question = create(:poll_question)
+
+      expect(admin_polymorphic_path(question)).to eq(admin_question_path(question))
+    end
+
+    it "routes poll answer videos" do
+      video = create(:poll_answer_video)
+
+      expect(admin_polymorphic_path(video)).to eq admin_video_path(video)
+    end
+
     it "routes milestones for resources with no hierarchy" do
       proposal = create(:proposal)
       milestone = create(:milestone, milestoneable: proposal)

--- a/spec/shared/system/admin_milestoneable.rb
+++ b/spec/shared/system/admin_milestoneable.rb
@@ -3,7 +3,7 @@ shared_examples "admin_milestoneable" do |factory_name, path_name|
 
   describe "Admin milestones" do
     let!(:milestoneable) { create(factory_name) }
-    let(:path) { send(path_name, *resource_hierarchy_for(milestoneable)) }
+    let(:path) { send(path_name, milestoneable) }
 
     context "Index" do
       scenario "Displaying milestones" do

--- a/spec/shared/system/admin_progressable.rb
+++ b/spec/shared/system/admin_progressable.rb
@@ -2,7 +2,7 @@ shared_examples "admin_progressable" do |factory_name, path_name|
   let!(:progressable) { create(factory_name) }
 
   describe "Manage progress bars" do
-    let(:progressable_path) { send(path_name, *resource_hierarchy_for(progressable)) }
+    let(:progressable_path) { send(path_name, progressable) }
 
     let(:path) do
       admin_polymorphic_path(progressable.progress_bars.new)

--- a/spec/shared/system/admin_progressable.rb
+++ b/spec/shared/system/admin_progressable.rb
@@ -5,7 +5,7 @@ shared_examples "admin_progressable" do |factory_name, path_name|
     let(:progressable_path) { send(path_name, *resource_hierarchy_for(progressable)) }
 
     let(:path) do
-      polymorphic_path([:admin, *resource_hierarchy_for(progressable.progress_bars.new)])
+      admin_polymorphic_path(progressable.progress_bars.new)
     end
 
     context "Index" do

--- a/spec/shared/system/milestoneable.rb
+++ b/spec/shared/system/milestoneable.rb
@@ -1,10 +1,10 @@
-shared_examples "milestoneable" do |factory_name, path_name|
-  it_behaves_like "progressable", factory_name, path_name
+shared_examples "milestoneable" do |factory_name|
+  it_behaves_like "progressable", factory_name
 
   let!(:milestoneable) { create(factory_name) }
 
   describe "Show milestones" do
-    let(:path) { send(path_name, *resource_hierarchy_for(milestoneable)) }
+    let(:path) { polymorphic_path(milestoneable) }
 
     scenario "Show milestones", :js do
       create(:milestone, milestoneable: milestoneable,

--- a/spec/shared/system/progressable.rb
+++ b/spec/shared/system/progressable.rb
@@ -1,7 +1,7 @@
-shared_examples "progressable" do |factory_name, path_name|
+shared_examples "progressable" do |factory_name|
   describe "Progress bars", :js do
     let!(:progressable) { create(factory_name) }
-    let(:path) { send(path_name, *resource_hierarchy_for(progressable)) }
+    let(:path) { polymorphic_path(progressable) }
 
     scenario "With main progress bar" do
       create(:progress_bar, progressable: progressable)

--- a/spec/support/common_actions/notifications.rb
+++ b/spec/support/common_actions/notifications.rb
@@ -50,7 +50,7 @@ module Notifications
   end
 
   def path_for(resource)
-    polymorphic_hierarchy_path(resource)
+    polymorphic_path(resource)
   end
 
   def error_message(resource_model = nil)

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -8,7 +8,7 @@ describe "Admin budget investments" do
 
   it_behaves_like "admin_milestoneable",
                   :budget_investment,
-                  "admin_budget_budget_investment_path"
+                  "admin_polymorphic_path"
 
   before do
     login_as(create(:administrator).user)

--- a/spec/system/admin/proposals_spec.rb
+++ b/spec/system/admin/proposals_spec.rb
@@ -7,7 +7,7 @@ describe "Admin proposals" do
 
   it_behaves_like "admin_milestoneable",
                   :proposal,
-                  "admin_proposal_path"
+                  "admin_polymorphic_path"
 
   context "Index" do
     scenario "Search" do

--- a/spec/system/admin/translatable_spec.rb
+++ b/spec/system/admin/translatable_spec.rb
@@ -17,7 +17,7 @@ describe "Admin edit translatable records" do
   context "Add a translation", :js do
     context "Input fields" do
       let(:translatable) { create(:budget_heading) }
-      let(:path) { edit_admin_budget_group_heading_path(*resource_hierarchy_for(translatable)) }
+      let(:path) { edit_admin_budget_group_heading_path(translatable.budget, translatable.group, translatable) }
 
       scenario "Maintains existing translations" do
         visit path
@@ -356,7 +356,7 @@ describe "Admin edit translatable records" do
     let(:translatable) { create(:milestone) }
 
     scenario "Shows an error message" do
-      visit edit_admin_budget_budget_investment_milestone_path(*resource_hierarchy_for(translatable))
+      visit admin_polymorphic_path(translatable, action: :edit)
 
       click_link "Remove language"
       click_link "Remove language"

--- a/spec/system/admin/translatable_spec.rb
+++ b/spec/system/admin/translatable_spec.rb
@@ -17,7 +17,7 @@ describe "Admin edit translatable records" do
   context "Add a translation", :js do
     context "Input fields" do
       let(:translatable) { create(:budget_heading) }
-      let(:path) { edit_admin_budget_group_heading_path(translatable.budget, translatable.group, translatable) }
+      let(:path) { admin_polymorphic_path(translatable, action: :edit) }
 
       scenario "Maintains existing translations" do
         visit path

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -8,9 +8,7 @@ describe "Budget Investments" do
   let(:group) { create(:budget_group, name: "Health", budget: budget) }
   let!(:heading) { create(:budget_heading, name: "More hospitals", price: 666666, group: group) }
 
-  it_behaves_like "milestoneable",
-                  :budget_investment,
-                  "budget_investment_path"
+  it_behaves_like "milestoneable", :budget_investment
 
   context "Concerns" do
     it_behaves_like "notifiable in-app", :budget_investment

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 describe "Proposals" do
-  it_behaves_like "milestoneable",
-                  :proposal,
-                  "proposal_path"
+  it_behaves_like "milestoneable", :proposal
 
   scenario "Disabled with a feature flag" do
     Setting["process.proposals"] = nil

--- a/spec/system/xss_spec.rb
+++ b/spec/system/xss_spec.rb
@@ -116,7 +116,7 @@ describe "Cross-Site Scripting protection", :js do
     annotation = create(:legislation_annotation)
     annotation.update_column(:context, attack_code)
 
-    visit polymorphic_hierarchy_path(annotation)
+    visit polymorphic_path(annotation)
 
     expect(page.text).not_to be_empty
   end


### PR DESCRIPTION
## References

* Simplifies the code in pull request #2903
* It will make it possible to simplify the code in pull request #3948

## Background

In Rails 5.0, we couldn't share code using `polymorphic_path` in many places of our code because we're using nested routes.

Furthermore, the way we define our routes (for instance, using `resources :investments` for `Budget::Investment` records) caused `polymorphic_path` to generate the wrong path, even if we passed it the right arguments.

So we created the `polymorphic_hierarchy_path` method, which took nested routes into account.
However, it only handled the `show` action, and we had to use the `resource_hierarchy_path` method for other actions, making the code harder to read.

With Rails 5.1, we can handle nested routes with `polymorphic_path` using the `resolve` method.

## Objectives

* Simplify the code using polymorphic paths and nested routes
* Make it possible to use polymorphic paths for any controller action