### PR TITLE
Fix minor design details in admin front

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -435,11 +435,11 @@ code {
     [class^="icon-"] {
       color: #fff;
       display: inline-block;
-      font-size: rem-calc(24);
+      font-size: rem-calc(20);
       line-height: $line-height;
-      padding: $line-height / 2 $line-height / 4;
-      padding-left: 0;
+      text-align: center;
       vertical-align: middle;
+      width: $line-height * 1.5;
     }
   }
 
@@ -458,13 +458,20 @@ code {
       border-left: 2px solid $sidebar-active;
       font-weight: bold;
     }
+
+    &[aria-expanded="true"] {
+
+      > a::after {
+        transform: rotate(180deg);
+      }
+    }
   }
 
   li a {
     color: #fff;
     display: block;
-    line-height: rem-calc(48);
-    padding-left: rem-calc(12);
+    line-height: $line-height * 2;
+    padding-left: $line-height / 4;
     vertical-align: top;
 
     &:hover {
@@ -478,12 +485,13 @@ code {
 
     > a::after {
       border: 0;
-      content: "\61" !important;
-      font-family: "icons" !important;
+      content: "\f078";
+      font-family: "Font Awesome 5 Free";
+      font-weight: bold;
       height: auto;
-      position: absolute !important;
-      right: 30px;
-      top: 6px !important;
+      position: absolute;
+      right: 24px;
+      transition: 0.25s;
     }
   }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -63,10 +63,6 @@ $sidebar-active: #f4fcd0;
     color: #000;
     height: auto;
 
-    @include breakpoint(medium) {
-      box-shadow: 0 2px 2px #eee;
-    }
-
     @include breakpoint(small only) {
 
       .top-bar-left ul {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -364,26 +364,25 @@ $sidebar-active: #f4fcd0;
 }
 
 .icon-sortable {
-  font-family: "icons";
+  font-family: "Font Awesome 5 Free";
   font-size: $small-font-size;
-  padding-right: $line-height / 2;
   position: relative;
 
   &::before,
   &::after {
     left: 6px;
-    opacity: 0.25;
+    opacity: 0.5;
     position: absolute;
   }
 
   &::before {
-    content: "\57";
-    top: -2px;
+    content: "\f0d8";
+    bottom: 0;
   }
 
   &::after {
-    content: "\52";
-    bottom: -10px;
+    content: "\f0d7";
+    top: 0;
   }
 
   &.asc {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -446,18 +446,18 @@ a {
 }
 
 .menu-and-content {
-  $side-menu-min-width: 250px;
+  $side-menu-min-width: rem-calc(240);
 
   @include breakpoint(medium) {
     display: flex;
 
     > nav {
-      flex: 25%;
+      flex: 20%;
       min-width: $side-menu-min-width;
 
       + * {
-        flex: 75%;
-        padding: $line-height !important;
+        flex: 80%;
+        padding: $line-height;
       }
     }
 
@@ -478,7 +478,7 @@ a {
       z-index: 12;
 
       + * {
-        padding: $line-height !important;
+        padding: $line-height;
       }
     }
 


### PR DESCRIPTION
## Objectives

This PR:

- Fix bottom blank space in the admin section sidebar.
- Make a little a refactor in scss to avoid using a mixin for side menu and content styles.
- Improve styles for the admin sidebar aligning the icons correctly and adding a little CSS animation on the arrow icon when the menu opens.
- Remove admin header box-shadow.
- Fix icon sortable styles in the admin budget investment list.

## Visual Changes

![admin](https://user-images.githubusercontent.com/631897/77912057-2d5bbd00-7292-11ea-90e5-ca312d201a61.png)

![animation](https://user-images.githubusercontent.com/631897/77912069-32207100-7292-11ea-8594-bbc45ca7fe80.gif)

![icons](https://user-images.githubusercontent.com/631897/77912065-2fbe1700-7292-11ea-9e1e-d885f59ee1e5.png)
