### PR TITLE
Fix custom translations with options

### DIFF
--- a/config/initializers/i18n_translation.rb
+++ b/config/initializers/i18n_translation.rb
@@ -12,7 +12,11 @@ module ActionView
         i18_content = I18nContent.find_by(key: key)
         translation = I18nContentTranslation.find_by(i18n_content_id: i18_content&.id,
                                                      locale: current_locale)&.value
-        translation.presence || translate(key, options)
+        if translation.present?
+          translation % options
+        else
+          translate(key, options)
+        end
       end
     end
   end

--- a/spec/features/site_customization/information_texts_spec.rb
+++ b/spec/features/site_customization/information_texts_spec.rb
@@ -30,4 +30,26 @@ describe "Custom information texts" do
       expect(page).not_to have_content "Help about proposals"
     end
   end
+
+  scenario "Show custom text with options", :js do
+    admin = create(:administrator)
+    user = create(:user, username: "Rachel")
+    create(:budget_investment, author_id: user.id)
+
+    intro_key = "mailers.budget_investment_created.intro"
+    create(:i18n_content, key: intro_key, value_en: "Hi %{author}")
+
+    login_as(admin.user)
+    visit admin_site_customization_information_texts_path(tab: "mailers")
+
+    expect(page).to have_content "Hi %{author}"
+
+    fill_in "contents[content_#{intro_key}]values[value_en]", with: "Custom hi to %{author}"
+    click_button "Save"
+
+    visit admin_system_email_view_path("budget_investment_created")
+
+    expect(page).to have_content "Custom hi to Rachel"
+    expect(page).not_to have_content "%{author}"
+  end
 end


### PR DESCRIPTION
## References

This PR resolves https://github.com/consul/consul/issues/3676.

## Objectives

There was a **bug** when an admin user tries to change a text on the "Custom information text" section `/admin/site_customization/information_texts` with the keys that include some `%{variable}` in the text.

### Screenshot
#### BEFORE
![interpolation](https://user-images.githubusercontent.com/631897/77913301-4e251200-7294-11ea-8c58-3cfb45640d65.png)

#### AFTER
![after](https://user-images.githubusercontent.com/631897/78009674-a9610e00-7341-11ea-926c-9345b22f8ce3.png)