### PR TITLE
Remove unused tag filter

### DIFF
--- a/app/controllers/concerns/commentable_actions.rb
+++ b/app/controllers/concerns/commentable_actions.rb
@@ -10,7 +10,6 @@ module CommentableActions
     @resources = @current_order == "recommendations" && current_user.present? ? @resources.recommendations(current_user) : @resources.for_render
     @resources = @resources.search(@search_terms) if @search_terms.present?
     @resources = @advanced_search_terms.present? ? @resources.filter(@advanced_search_terms) : @resources
-    @resources = @resources.tagged_with(@tag_filter) if @tag_filter
 
     @resources = @resources.page(params[:page]).send("sort_by_#{@current_order}")
 
@@ -101,12 +100,6 @@ module CommentableActions
 
     def load_categories
       @categories = Tag.category.order(:name)
-    end
-
-    def parse_tag_filter
-      if params[:tag].present?
-        @tag_filter = params[:tag] if Tag.named(params[:tag]).exists?
-      end
     end
 
     def set_resource_votes(instance)

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -4,7 +4,6 @@ class DebatesController < ApplicationController
   include FlagActions
   include Translatable
 
-  before_action :parse_tag_filter, only: :index
   before_action :authenticate_user!, except: [:index, :show, :map]
   before_action :set_view, only: :index
   before_action :debates_recommendations, only: :index, if: :current_user

--- a/app/controllers/legislation/proposals_controller.rb
+++ b/app/controllers/legislation/proposals_controller.rb
@@ -3,7 +3,6 @@ class Legislation::ProposalsController < Legislation::BaseController
   include FlagActions
   include ImageAttributes
 
-  before_action :parse_tag_filter, only: :index
   before_action :load_categories, only: [:index, :new, :create, :edit, :map, :summary]
   before_action :load_geozones, only: [:edit, :map, :summary]
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -5,7 +5,6 @@ class ProposalsController < ApplicationController
   include ImageAttributes
   include Translatable
 
-  before_action :parse_tag_filter, only: :index
   before_action :load_categories, only: [:index, :new, :create, :edit, :map, :summary]
   before_action :load_geozones, only: [:edit, :map, :summary]
   before_action :authenticate_user!, except: [:index, :show, :map, :summary]
@@ -152,7 +151,7 @@ class ProposalsController < ApplicationController
     end
 
     def load_featured
-      return unless !@advanced_search_terms && @search_terms.blank? && @tag_filter.blank? && params[:retired].blank? && @current_order != "recommendations"
+      return unless !@advanced_search_terms && @search_terms.blank? && params[:retired].blank? && @current_order != "recommendations"
 
       if Setting["feature.featured_proposals"]
         @featured_proposals = Proposal.not_archived.unsuccessful

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <main>
-  <% if @search_terms || @advanced_search_terms || @tag_filter %>
+  <% if @search_terms || @advanced_search_terms %>
     <div class="highlight no-margin-top padding margin-bottom">
       <div class="row">
         <div class="small-12 column">
@@ -22,12 +22,6 @@
                   t("debates.index.search_results", count: @debates.size, search_term: @search_terms)
                 ) %>
               <% end %>
-            </p>
-          <% elsif @tag_filter %>
-            <h2><%= t("shared.search_results") %></h2>
-            <p>
-              <%= page_entries_info @debates %>
-              <%= t("debates.index.filter_topic", count: @debates.size, topic: @tag_filter) %>
             </p>
           <% end %>
         </div>
@@ -50,7 +44,7 @@
         <%= render "shared/banner" %>
       <% end %>
 
-      <% unless @tag_filter || @search_terms || !has_featured? %>
+      <% unless @search_terms || !has_featured? %>
         <%= render "featured_debates" %>
       <% end %>
 
@@ -81,7 +75,7 @@
       <% end %>
       <%= paginate @debates %>
 
-      <% unless @search_terms || @advanced_search_terms || @tag_filter %>
+      <% unless @search_terms || @advanced_search_terms %>
         <div id="section_help" class="margin" data-magellan-target="section_help">
           <p class="lead">
             <strong><%= t("debates.index.section_footer.title") %></strong>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -12,7 +12,6 @@
   <% if [
           @search_terms,
           @advanced_search_terms,
-          @tag_filter,
           params[:retired].present?,
           params[:selected].present?
         ].any? %>
@@ -29,12 +28,6 @@
                 ) %>
               <% end %>
             <p>
-          <% elsif @tag_filter %>
-            <h2><%= t("shared.search_results") %></h2>
-            <p>
-              <%= page_entries_info @proposals %>
-              <%= t("proposals.index.filter_topic", count: @proposals.size, topic: @tag_filter) %>
-            </p>
           <% elsif params[:retired].present? %>
             <h2><%= t("proposals.index.retired_proposals") %></h2>
           <% elsif params[:selected].present? %>
@@ -112,7 +105,7 @@
         <% end %>
         <%= paginate @proposals %>
 
-        <% unless @search_terms || @advanced_search_terms || @tag_filter %>
+        <% unless @search_terms || @advanced_search_terms %>
           <div id="section_help" class="margin" data-magellan-target="section_help">
             <p class="lead">
               <strong><%= t("proposals.index.section_footer.title") %></strong>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -95,9 +95,6 @@ en:
       tags_placeholder: "Enter the tags you would like to use, separated by commas (',')"
     index:
       featured_debates: Featured
-      filter_topic:
-        one: " with topic '%{topic}'"
-        other: " with topic '%{topic}'"
       orders:
         confidence_score: highest rated
         created_at: newest
@@ -351,9 +348,6 @@ en:
       map_skip_checkbox: "This proposal doesn't have a concrete location or I'm not aware of it."
     index:
       featured_proposals: Featured
-      filter_topic:
-        one: " with topic '%{topic}'"
-        other: " with topic '%{topic}'"
       orders:
         confidence_score: highest rated
         created_at: newest

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -95,9 +95,6 @@ es:
       tags_placeholder: "Escribe las etiquetas que desees separadas por coma (',')"
     index:
       featured_debates: Destacar
-      filter_topic:
-        one: " con el tema '%{topic}'"
-        other: " con el tema '%{topic}'"
       orders:
         confidence_score: Mejor valorados
         created_at: Nuevos
@@ -351,9 +348,6 @@ es:
       map_skip_checkbox: "Esta propuesta no tiene una ubicación concreta o no la conozco."
     index:
       featured_proposals: Destacadas
-      filter_topic:
-        one: " con el tema '%{topic}'"
-        other: " con el tema '%{topic}'"
       orders:
         confidence_score: Más apoyadas
         created_at: Nuevas


### PR DESCRIPTION
## References

* The filter was added in pull request #275 and partially removed in pull request #339
* Most of the code from the original commit has disappeared without a trace (maybe due to a merge conflict?).

## Objectives

* Remove unused code

## Notes

This filter could actually be useful if we started using it when users click on a tag. Since we don't, I'm removing it. We might add it back if we decide to actually use it.