### PR TITLE
Fix duplicate records in investments by tag

### DIFF
--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -5,7 +5,7 @@ module BudgetExecutionsHelper
 
   def options_for_milestone_tags
     @budget.investments_milestone_tags.map do |tag|
-      ["#{tag} (#{@budget.investments.winners.tagged_with(tag).count})", tag]
+      ["#{tag} (#{@budget.investments.winners.by_tag(tag).count})", tag]
     end
   end
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -98,7 +98,7 @@ class Budget
     scope :by_group,          ->(group_id)    { where(group_id: group_id) }
     scope :by_heading,        ->(heading_id)  { where(heading_id: heading_id) }
     scope :by_admin,          ->(admin_id)    { where(administrator_id: admin_id) }
-    scope :by_tag,            ->(tag_name)    { tagged_with(tag_name) }
+    scope :by_tag,            ->(tag_name)    { tagged_with(tag_name).distinct }
 
     scope :for_render, -> { includes(:heading) }
 

--- a/spec/helpers/budget_executions_helper_spec.rb
+++ b/spec/helpers/budget_executions_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe BudgetExecutionsHelper do
+  describe "#options_for_milestone_tags" do
+    let(:budget) { create(:budget) }
+
+    it "does not return duplicate records for tags in different contexts" do
+      create(:budget_investment, :winner, budget: budget, milestone_tag_list: ["Multiple"])
+      create(:budget_investment, :winner, budget: budget, milestone_tag_list: ["Multiple"])
+      create(:budget_investment, :winner, budget: budget, milestone_tag_list: ["Dup"], tag_list: ["Dup"])
+
+      @budget = budget
+
+      expect(options_for_milestone_tags).to eq [["Dup (1)", "Dup"], ["Multiple (2)", "Multiple"]]
+    end
+  end
+end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -796,6 +796,14 @@ describe Budget::Investment do
 
         expect(investment.valuation_tag_list).to match_array(%w[Code Test Refactor])
       end
+
+      describe ".by_tag" do
+        it "does not return duplicate records for tags in different contexts" do
+          investment = create(:budget_investment, tag_list: ["Same"], valuation_tag_list: ["Same"])
+
+          expect(Budget::Investment.by_tag("Same")).to eq [investment]
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## References

* Closes #3682
* See also https://github.com/mbleigh/acts-as-taggable-on/issues/402

## Background

When an investment had been assigned a user tag and a valuation tag with the same name, it appeared twice when filtering by tag.

This is because by design, in order to provide compatibility with scopes using "select" or "distinct", the method `tagged_with` doesn't select unique records.

## Objectives

Don't return duplicate records when filtering by tag.