### PR TITLE
Fix flaky spec: Admin Active polls Add

### DIFF
--- a/spec/features/admin/budget_phases_spec.rb
+++ b/spec/features/admin/budget_phases_spec.rb
@@ -14,8 +14,8 @@ describe "Admin budget phases" do
 
       fill_in "start_date", with: Date.current + 1.day
       fill_in "end_date", with: Date.current + 12.days
-      fill_in_translatable_ckeditor "summary", :en, with: "New summary of the phase."
-      fill_in_translatable_ckeditor "description", :en, with: "New description of the phase."
+      fill_in_ckeditor "Summary", with: "New summary of the phase."
+      fill_in_ckeditor "Description", with: "New description of the phase."
       uncheck "budget_phase_enabled"
       click_button "Save changes"
 

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -264,10 +264,7 @@ describe "Admin collaborative legislation" do
       expect(page).not_to have_link "Remove language"
       expect(page).not_to have_field "translation_locale"
 
-      within(".translatable-fields[data-locale='en']") do
-        fill_in_ckeditor find("textarea", visible: false)[:id],
-                         with: "There is still a long journey ahead of us"
-      end
+      fill_in_ckeditor "Summary", with: "There is still a long journey ahead of us"
 
       click_button "Update Process"
 

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -351,7 +351,7 @@ end
 
 def documentable_fill_new_valid_dashboard_action
   fill_in :dashboard_action_title, with: "Dashboard title"
-  fill_in_ckeditor :dashboard_action_description, with: "Dashboard description"
+  fill_in_ckeditor "Description", with: "Dashboard description"
 end
 
 def documentable_fill_new_valid_budget_investment

--- a/spec/support/common_actions/verifications.rb
+++ b/spec/support/common_actions/verifications.rb
@@ -44,12 +44,6 @@ module Verifications
     end
   end
 
-  def fill_in_translatable_ckeditor(field, locale, params = {})
-    selector = ".translatable-fields[data-locale='#{locale}'] textarea[id$='_#{field}']"
-    locator = find(selector, visible: false)[:id]
-    fill_in_ckeditor(locator, params)
-  end
-
   # @param [String] locator label text for the textarea or textarea id
   def fill_in_ckeditor(locator, params = {})
     # Find out ckeditor id at runtime using its label

--- a/spec/support/common_actions/verifications.rb
+++ b/spec/support/common_actions/verifications.rb
@@ -44,10 +44,9 @@ module Verifications
     end
   end
 
-  # @param [String] locator label text for the textarea or textarea id
-  def fill_in_ckeditor(locator, params = {})
-    # Find out ckeditor id at runtime using its label
-    locator = find("label", text: locator)[:for] if page.has_css?("label", text: locator)
+  def fill_in_ckeditor(text, params = {})
+    locator = find("label", text: text)[:for]
+
     # Fill the editor content
     page.execute_script <<-SCRIPT
         var ckeditor = CKEDITOR.instances.#{locator}
@@ -55,5 +54,7 @@ module Verifications
         ckeditor.focus()
         ckeditor.updateElement()
     SCRIPT
+
+    expect(page).to have_ckeditor text, with: params[:with]
   end
 end


### PR DESCRIPTION
## References

* Closes #3645

## Objectives

* Fix a flaky spec caused by CKEditor not converting text to HTML

## Notes

The test can be reproduced on my local machine after upgrading to Rails 5.1. However, failures in Travis are uncommon.