### PR TITLE
Order legislation process tags alphabetically

### DIFF
--- a/app/views/admin/legislation/proposals/_form.html.erb
+++ b/app/views/admin/legislation/proposals/_form.html.erb
@@ -3,7 +3,7 @@
   <%= render "shared/errors", resource: @process %>
 
   <div class="small-12 medium-8 column">
-    <%= f.text_field :custom_list, value: @process.tag_list_on(:customs).to_s,
+    <%= f.text_field :custom_list, value: @process.tag_list_on(:customs).sort.join(", "),
                       label: t("admin.legislation.proposals.form.custom_categories"),
                       hint: t("admin.legislation.proposals.form.custom_categories_description"),
                       placeholder: t("admin.legislation.proposals.form.custom_categories_placeholder"),

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -244,18 +244,20 @@ describe "Admin collaborative legislation" do
       visit edit_admin_legislation_process_path(process)
       within(".admin-content") { click_link "Proposals" }
 
-      fill_in "Categories", with: "recycling,bicycles"
+      fill_in "Categories", with: "recycling,bicycles,pollution"
       click_button "Save changes"
 
       visit admin_legislation_process_proposals_path(process)
-      expect(page).to have_field("Categories", with: "bicycles, recycling")
+
+      expect(page).to have_field("Categories", with: "bicycles, pollution, recycling")
 
       within(".admin-content") { click_link "Information" }
       fill_in "Summary", with: "Summarizing the process"
       click_button "Save changes"
 
       visit admin_legislation_process_proposals_path(process)
-      expect(page).to have_field("Categories", with: "bicycles, recycling")
+
+      expect(page).to have_field("Categories", with: "bicycles, pollution, recycling")
     end
 
     scenario "Edit milestones summary", :js do


### PR DESCRIPTION
## References

* [Travis build 33100, job2](https://travis-ci.org/github/consul/consul/jobs/664600616) (Rails 5.1 branch) and [Travis build 33270, job 5](https://travis-ci.org/github/consul/consul/jobs/673439300) (master with Rails 5.0) failed due to this issue

## Background

The method `tag_list_on` doesn't add an `ORDER_BY` clause to the SQL query it generates, and so results may come in any order.

However, in the tests we were assuming the tags were ordered by ID in descending order. Since that isn't always the case, the tests were failing sometimes. The user experience was also not that great since tags could be ordered differently after reloading the page.

## Objectives

Make sure legislation process tags are always ordered the same way.

## Notes

One test failed with this message:

```
Failures:
  1) Admin collaborative legislation Update Change proposal categories
     Failure/Error: expect(page).to have_field("Categories", with: "bicycles, recycling")
       expected to find visible field "Categories" that is not disabled with value "bicycles, recycling" but there were no matches. Also found "", which matched the selector but not all filters. Expected value to be "bicycles, recycling" but was "recycling, bicycles"
     # ./spec/features/admin/legislation/processes_spec.rb:251:in `block (3 levels) in <top (required)>'
```


We could also use the same order admins used when adding the tags:

```ruby
@process.customs.order("taggings.created_at").pluck(:name).join(", ")
```

However, I'm not sure it improves the user experience, and it makes the code more complicated.
benefit to administratos.