### PR TITLE
Replaces icons of expand/collapse comments

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -40,13 +40,7 @@
       $("#js-comment-form-" + id).toggle();
     },
     toggle_arrow: function(id) {
-      var arrow;
-      arrow = "span#" + id + "_arrow";
-      if ($(arrow).hasClass("icon-arrow-right")) {
-        $(arrow).removeClass("icon-arrow-right").addClass("icon-arrow-down");
-      } else {
-        $(arrow).removeClass("icon-arrow-down").addClass("icon-arrow-right");
-      }
+      $("span#" + id + "_arrow").toggleClass("fa-minus-square").toggleClass("fa-plus-square");
     },
     initialize: function() {
       $("body .js-add-comment-link").each(function() {

--- a/app/assets/stylesheets/icons.scss
+++ b/app/assets/stylesheets/icons.scss
@@ -203,10 +203,6 @@
   content: "\f00b";
 }
 
-.icon-arrow-down::before {
-  content: "\f0dd";
-}
-
 .icon-arrow-left::before {
   content: "\f0d9";
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2116,17 +2116,16 @@ table {
     padding: $line-height / 4;
     position: relative;
 
-    .relative,
-    [class^="icon-arrow"] {
-      padding-left: $line-height / 2;
+    .relative {
+      padding-left: rem-calc(18);
     }
 
-    [class^="icon-arrow"] {
-      font-size: $base-font-size;
-      left: -20px;
+    .far {
+      font-size: $small-font-size;
+      left: 0;
       position: absolute;
       text-decoration: none;
-      top: -1px;
+      top: 2px;
     }
 
     .divider {

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -94,7 +94,7 @@
             <%= link_to "", class: "js-toggle-children relative", data: { "id": "#{dom_id(comment)}" } do %>
               <span class="show-for-sr js-child-toggle" style="display: none;"><%= t("shared.show") %></span>
               <span class="show-for-sr js-child-toggle"><%= t("shared.hide") %></span>
-              <span id="<%= dom_id(comment) %>_children_arrow" class="icon-arrow-down"></span>
+              <span id="<%= dom_id(comment) %>_children_arrow" class="far fa-minus-square"></span>
               <span class="js-child-toggle" style="display: none;"><%= t("comments.comment.responses_show", count: comment.children.size) %></span>
               <span class="js-child-toggle"><%= t("comments.comment.responses_collapse", count: comment.children.size) %></span>
             <% end %>


### PR DESCRIPTION
## References

This PR close https://github.com/consul/consul/issues/2605.

## Objectives

Replaces icons of expand/collapse comments.

## Visual Changes

### Before
![before](https://user-images.githubusercontent.com/631897/79219390-76933b80-7e52-11ea-866d-9adf63d3bf5c.gif)

### After
![after](https://user-images.githubusercontent.com/631897/79219378-7430e180-7e52-11ea-8ce8-6277a36b31e6.gif)
