### PR TITLE
Fix checking for nil in page content

### DIFF
--- a/spec/features/admin/valuators_spec.rb
+++ b/spec/features/admin/valuators_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Admin valuators" do
   let(:admin) { create(:administrator) }
   let!(:user) { create(:user, username: "Jose Luis Balbin") }
-  let!(:valuator) { create(:valuator) }
+  let!(:valuator) { create(:valuator, description: "Very reliable") }
 
   before do
     login_as(admin.user)
@@ -14,7 +14,7 @@ describe "Admin valuators" do
     visit admin_valuator_path(valuator)
 
     expect(page).to have_content valuator.name
-    expect(page).to have_content valuator.description
+    expect(page).to have_content "Very reliable"
     expect(page).to have_content valuator.email
     expect(page).to have_content "Can comment, Can edit dossier"
   end

--- a/spec/features/admin/verifications_spec.rb
+++ b/spec/features/admin/verifications_spec.rb
@@ -37,12 +37,13 @@ describe "Incomplete verifications" do
 
   scenario "Residence unverified" do
     incompletely_verified_user = create(:user, :incomplete_verification)
+    failed_census_call = incompletely_verified_user.failed_census_calls.first
 
     visit admin_verifications_path
 
     within "#user_#{incompletely_verified_user.id}" do
       expect(page).to have_content "DNI"
-      expect(page).to have_content incompletely_verified_user.document_number
+      expect(page).to have_content failed_census_call.document_number
       expect(page).to have_content Date.new(1900, 1, 1)
       expect(page).to have_content "28000"
     end


### PR DESCRIPTION
## Background

When running our test suite, we were getting a warning: "Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead" because we were checking for values which were set to `nil` in the tests.

## Objectives

Check for actual content in specs where we were checking `nil` content is present.