### PR TITLE
Deactivate ckeditor file attachments feature

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -8,13 +8,9 @@ CKEDITOR.editorConfig = function( config )
 
   config.forcePasteAsPlainText = true;
 
-  config.filebrowserBrowseUrl = "/ckeditor/attachment_files";
-  config.filebrowserFlashBrowseUrl = "/ckeditor/attachment_files";
-  config.filebrowserFlashUploadUrl = "/ckeditor/attachment_files";
   config.filebrowserImageBrowseLinkUrl = "/ckeditor/pictures";
   config.filebrowserImageBrowseUrl = "/ckeditor/pictures";
   config.filebrowserImageUploadUrl = "/ckeditor/pictures";
-  config.filebrowserUploadUrl = "/ckeditor/attachment_files";
   config.filebrowserUploadMethod = "form";
 
   config.allowedContent = true;

--- a/spec/features/ckeditor_spec.rb
+++ b/spec/features/ckeditor_spec.rb
@@ -30,4 +30,15 @@ describe "CKEditor" do
 
     expect(page).to have_css "img[src$='clippy.jpg']"
   end
+
+  scenario "cannot upload attachments through link tab", :js do
+    login_as(create(:administrator).user)
+    visit new_admin_site_customization_page_path
+
+    find(".cke_button__link").click
+
+    expect(page).to have_css(".cke_dialog")
+    expect(page).not_to have_link "Upload"
+    expect(page).not_to have_link "Browse Server"
+  end
 end


### PR DESCRIPTION
## References
By working on #3659 i realized about this error.

## Objectives
This feature was not working because it was not fully configured and tested so its better to disable it completely.

## Visual Changes
**Before**
<img width="477" alt="Captura de pantalla 2020-04-17 a las 20 17 45" src="https://user-images.githubusercontent.com/15726/79601112-917edd80-80e8-11ea-9b42-1e823e529307.png">


**After**
Now ckeditor buttons related to file uploads are not shown anymore.
<img width="568" alt="Captura de pantalla 2020-04-17 a las 19 55 48" src="https://user-images.githubusercontent.com/15726/79600497-87101400-80e7-11ea-8e8a-e62b0c4a54d4.png">

## Notes
-