### PR TITLE
Fix attaching images in CKEditor via drag and drop

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -10,7 +10,7 @@ CKEDITOR.editorConfig = function( config )
 
   config.filebrowserImageBrowseLinkUrl = "/ckeditor/pictures";
   config.filebrowserImageBrowseUrl = "/ckeditor/pictures";
-  config.filebrowserImageUploadUrl = "/ckeditor/pictures";
+  config.filebrowserImageUploadUrl = "/ckeditor/pictures?";
   config.filebrowserUploadMethod = "form";
 
   config.allowedContent = true;


### PR DESCRIPTION
## References

* The bug and its solution are described in galetahub/ckeditor#763 and galetahub/ckeditor#836

## Objectives

Fix a 404 error when trying to upload an image into CKEditor using drag & drop

## Notes

I haven't added a test for this case since simulating dropping a file in the browser with Selenium/Capybara seems to be quite tricky and I haven't found a solution guaranteed to correctly emulate what users do.