### PR TITLE
Allow to paste formatted content into ckeditors

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -6,8 +6,6 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 CKEDITOR.editorConfig = function( config )
 {
 
-  config.forcePasteAsPlainText = true;
-
   config.filebrowserImageBrowseLinkUrl = "/ckeditor/pictures";
   config.filebrowserImageBrowseUrl = "/ckeditor/pictures";
   config.filebrowserImageUploadUrl = "/ckeditor/pictures";

--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -9,6 +9,6 @@ Ckeditor.setup do |config|
 
   config.assets_languages = Rails.application.config.i18n.available_locales.map { |l| l.to_s.downcase }
   config.assets_plugins = %w[balloonpanel balloontoolbar copyformatting image
-                             link magicline scayt table tableselection wsc]
+                             link magicline pastefromword scayt table tableselection wsc]
   config.assets.reject! { |asset| asset =~ /\Ackeditor\/samples\// }
 end


### PR DESCRIPTION
## References
None, we realized about this behavior working on #3659.

This feature was deactivated in commit 762c4fae, but not sure why 🤔. 

## Objectives
Enable copy/paste ckeditor feature keeping formatted content when possible.

Before this PR all Consul ckeditors were only allowing pasting content as plain text, so when a users pastes formatted content from external editor into any Consul ckeditor, or pasting from another ckeditor the format of content was completely lost and user had to re-format all of it by hand.

This PR also adds a built-in ckeditor plugin to enable copy/pasting formatted content from MS Word and MS Excel. 

## Visual Changes
None. 

## Notes
No new specs were added. Its difficult to emulate user behavior in a feature spec and if we finally achieve it might be in a very hacky way. Probably we can rely on CKEditor tests and feel confident about this change. 🤔 

This change was tested in a production server, and also done a lot of manual testing copy/pasting formatted contents from .odt, .doc, .docx files and from a Google Docs document.

There are more plugins related to copy/paste like `pastefromgoogledocs` and `pastefromlibreoffice` but were ignored because tests done only with `pastefromword` plugin enabled were successful also for Google Docs and LibreOffice documents. As we do not see any improvement by adding them lets keep the deactivated.

Tests were done using sample documents provider by ckeditor 4 docs on a production environment test server:
1. MS Word: https://ckeditor.com/docs/ckeditor4/latest/examples/pastefromword.html
2. Google Docs: https://ckeditor.com/docs/ckeditor4/latest/examples/pastefromgoogledocs.html
3. LibreOffice: https://ckeditor.com/docs/ckeditor4/latest/examples/pastefromlibreoffice.html