### PR TITLE
Filter erased users and show erase reason in admin

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,8 +1,11 @@
 class Admin::UsersController < Admin::BaseController
   load_and_authorize_resource
 
+  has_filters %w[active erased], only: :index
+
   def index
-    @users = User.by_username_email_or_document_number(params[:search]) if params[:search]
+    @users = @users.send(@current_filter)
+    @users = @users.by_username_email_or_document_number(params[:search]) if params[:search]
     @users = @users.page(params[:page])
     respond_to do |format|
       format.html

--- a/app/views/admin/users/_users.html.erb
+++ b/app/views/admin/users/_users.html.erb
@@ -1,24 +1,36 @@
+<%= render "shared/filter_subnav", i18n_namespace: "admin.users.index" %>
+
 <% if @users.any? %>
   <h3 class="margin"><%= page_entries_info @users %></h3>
 
   <table>
     <thead>
       <tr>
-        <th scope="col"><%= t("admin.users.columns.name") %></th>
-        <th scope="col"><%= t("admin.users.columns.email") %></th>
-        <th scope="col"><%= t("admin.users.columns.document_number") %></th>
-        <th scope="col"><%= t("admin.users.columns.roles") %></th>
-        <th scope="col"><%= t("admin.users.columns.verification_level") %></th>
+        <% if @current_filter == "erased" %>
+          <th scope="col"><%= t("admin.users.columns.id") %></th>
+          <th scope="col"><%= t("admin.users.columns.erase_reason") %></th>
+        <% else %>
+          <th scope="col"><%= t("admin.users.columns.name") %></th>
+          <th scope="col"><%= t("admin.users.columns.email") %></th>
+          <th scope="col"><%= t("admin.users.columns.document_number") %></th>
+          <th scope="col"><%= t("admin.users.columns.roles") %></th>
+          <th scope="col"><%= t("admin.users.columns.verification_level") %></th>
+        <% end %>
       </tr>
     </thead>
     <tbody>
       <% @users.each do |user| %>
         <tr>
-          <td><%= link_to user.name, user_path(user), target: "_blank" %></td>
-          <td><%= user.email %></td>
-          <td><%= user.document_number %></td>
-          <td><%= display_user_roles(user) %></td>
-          <td><%= user.user_type %></td>
+          <% if @current_filter == "erased" %>
+            <td><%= link_to user.id, user_path(user), target: "_blank" %></td>
+            <td><%= user.erase_reason %></td>
+          <% else %>
+            <td><%= link_to user.name, user_path(user), target: "_blank" %></td>
+            <td><%= user.email %></td>
+            <td><%= user.document_number %></td>
+            <td><%= display_user_roles(user) %></td>
+            <td><%= user.user_type %></td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -159,6 +159,7 @@ ignore_unused:
   - "admin.homepage.*"
   - "admin.dashboard.administrator_tasks.index.filter*"
   - "admin.dashboard.actions.index.default.*"
+  - "admin.users.index.filter*"
   - "moderation.comments.index.filter*"
   - "moderation.comments.index.order*"
   - "moderation.debates.index.filter*"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1439,6 +1439,8 @@ en:
         help: "When a user creates a proposal, the following topics are suggested as default tags."
     users:
       columns:
+        id: ID
+        erase_reason: Erase reason
         name: Name
         email: Email
         document_number: Document number
@@ -1447,6 +1449,10 @@ en:
       index:
         title: User
         no_users: There are no users.
+        filter: Filter
+        filters:
+          active: Active
+          erased: Erased
       search:
         placeholder: Search user by email, name or document number
         search: Search

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1438,6 +1438,8 @@ es:
         help: "Cuando un usuario crea una propuesta se le sugieren como etiquetas por defecto los siguientes temas."
     users:
       columns:
+        id: ID
+        erase_reason: Razón de la baja
         name: Nombre
         email: Email
         document_number: Número de documento
@@ -1446,6 +1448,10 @@ es:
       index:
         title: Usuarios
         no_users: No hay usuarios.
+        filter: Filtro
+        filters:
+          active: Activos
+          erased: Borrados
       search:
         placeholder: Buscar usuario por email, nombre o DNI
         search: Buscar

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -22,6 +22,28 @@ describe "Admin users" do
     expect(page).to have_current_path(user_path(user))
   end
 
+  scenario "Show active or erased users using filters" do
+    erased_user = create(:user, username: "Erased")
+    erased_user.erase("I don't like this site.")
+
+    visit admin_users_path
+
+    expect(page).not_to have_link("#{erased_user.id}", href: user_path(erased_user))
+    expect(page).to have_link("Erased")
+
+    click_link "Erased"
+
+    expect(page).to have_link("Active")
+    expect(page).to have_link("#{erased_user.id}", href: user_path(erased_user))
+    expect(page).to have_content "I don't like this site."
+    expect(page).to have_content("Erased")
+
+    fill_in :search, with: "Erased"
+    click_button "Search"
+
+    expect(page).to have_content "There are no users."
+  end
+
   scenario "Search" do
     fill_in :search, with: "Luis"
     click_button "Search"


### PR DESCRIPTION
## Objectives

When a user removes their account all fields are removed from the database and in `admin/users` appears a link with the user id without any other information.

This PR adds new filters to show "**Active**" or "**Erased**" users showing the erase reason, so the admin can view the reason why the users are removing their accounts.

## Visual Changes

### Before
![before](https://user-images.githubusercontent.com/631897/80685861-1b0ab400-8ac8-11ea-87c0-63d7f0dc1b87.png)

### After
![after](https://user-images.githubusercontent.com/631897/80685869-1e05a480-8ac8-11ea-869a-014ea58773fd.png)
