### PR TITLE
Disable ckeditor unused plugins

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -14,6 +14,8 @@ CKEDITOR.editorConfig = function( config )
   config.allowedContent = true;
   config.format_tags = "p;h2;h3";
 
+  config.removePlugins = "balloonpanel,balloontoolbar,copyformatting,scayt,wsc";
+
   // Rails CSRF token
   config.filebrowserParams = function(){
     var csrf_token, csrf_param, meta,

--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -8,7 +8,7 @@ Ckeditor.setup do |config|
   config.authorize_with :cancan
 
   config.assets_languages = Rails.application.config.i18n.available_locales.map { |l| l.to_s.downcase }
-  config.assets_plugins = %w[balloonpanel balloontoolbar copyformatting image
-                             link magicline pastefromword scayt table tableselection wsc]
+  config.assets_plugins = %w[image link magicline pastefromword
+                             table tableselection]
   config.assets.reject! { |asset| asset =~ /\Ackeditor\/samples\// }
 end


### PR DESCRIPTION
## References
This enhancement was discovered working on #3979.

## Objectives
Disable unused plugins so we can reduce the ckeditor assets precompilation time during deployment and do not load uneeded JS code into users browsers.

We detected a few plugins that were being loaded but never used:

1. **balloonpanel**: Plugin to create custom panels (dialogs). Not needed.

   https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_balloonPanel.html

2. **balloontoolbar**: Plugin to create custom toolbars for content elements that is not used    anywhere.

   https://ckeditor.com/docs/ckeditor4/latest/features/balloontoolbar.html

3. **copyformatting**: Plugin to allow to copy the format of selected elements and to apply to other elements.

    This tool is never shown at ckeditor UI, so its never used.

4. **scayt**: Plugin to do spell and grammar checking "As you type" against an external service https://webspellchecker.com/wsc-scayt-ckeditor4/.

    This tool is never shown at ckeditor UI, so its never used.

   https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#spell-check-as-you-type-scayt

5. **wsc**: Plugin to open spell check window. 

   This tool is never shown at ckeditor UI, so its never used.

   https://ckeditor.com/docs/ckeditor4/latest/features/spellcheck.html#spell-checking-in-a-dialog-window   

## Visual Changes
None

## Notes
This PR was successfully tested on a production environment.
