### PR TITLE
Mitigate flaky specs for vote multiple times

### DIFF
--- a/spec/system/comments/budget_investments_spec.rb
+++ b/spec/system/comments/budget_investments_spec.rb
@@ -573,6 +573,11 @@ describe "Commenting Budget::Investments" do
 
       within("#comment_#{comment.id}_votes") do
         find(".in_favor a").click
+
+        within(".in_favor") do
+          expect(page).to have_content "1"
+        end
+
         find(".in_favor a").click
 
         within(".in_favor") do

--- a/spec/system/comments/polls_spec.rb
+++ b/spec/system/comments/polls_spec.rb
@@ -525,6 +525,11 @@ describe "Commenting polls" do
 
       within("#comment_#{comment.id}_votes") do
         find(".in_favor a").click
+
+        within(".in_favor") do
+          expect(page).to have_content "1"
+        end
+
         find(".in_favor a").click
 
         within(".in_favor") do

--- a/spec/system/comments/proposals_spec.rb
+++ b/spec/system/comments/proposals_spec.rb
@@ -505,6 +505,11 @@ describe "Commenting proposals" do
 
       within("#comment_#{comment.id}_votes") do
         find(".in_favor a").click
+
+        within(".in_favor") do
+          expect(page).to have_content "1"
+        end
+
         find(".in_favor a").click
 
         within(".in_favor") do

--- a/spec/system/comments/topics_spec.rb
+++ b/spec/system/comments/topics_spec.rb
@@ -555,6 +555,11 @@ describe "Commenting topics from proposals" do
 
       within("#comment_#{comment.id}_votes") do
         find(".in_favor a").click
+
+        within(".in_favor") do
+          expect(page).to have_content "1"
+        end
+
         find(".in_favor a").click
 
         within(".in_favor") do
@@ -1104,6 +1109,11 @@ describe "Commenting topics from budget investments" do
 
       within("#comment_#{comment.id}_votes") do
         find(".in_favor a").click
+
+        within(".in_favor") do
+          expect(page).to have_content "1"
+        end
+
         find(".in_favor a").click
 
         within(".in_favor") do


### PR DESCRIPTION
## References
[Fix flaky specs: Votes Debates and Voting comments Update #2734](https://github.com/consul/consul/pull/2734/)
[Fixes some random test failures #638](https://github.com/consul/consul/pull/638/)

## Objectives
Sometimes after running the specs related to "voting multiple times" unexpected errors occur. 
As we can't reproduce it in a "controlled" way we fix it based on the related PRs.

## Notes

Without these changes, on my machine running the tests in `system/comments` resulted in several failures most of the time. With these changes, they don't fail anymore.