### PR TITLE
Add ckeditor tabletools plugin

### DIFF
--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -8,7 +8,7 @@ Ckeditor.setup do |config|
   config.authorize_with :cancan
 
   config.assets_languages = Rails.application.config.i18n.available_locales.map { |l| l.to_s.downcase }
-  config.assets_plugins = %w[image link magicline pastefromword
-                             table tableselection]
+  config.assets_plugins = %w[image link magicline pastefromword table tableselection
+                             tabletools]
   config.assets.reject! { |asset| asset =~ /\Ackeditor\/samples\// }
 end


### PR DESCRIPTION
## References
Bug discovered working on #3979.

## Objectives
Fix error detected during manual testing of ckeditor table plugin: When a user clicks on table "Cell properties" feature from contextual menu browser throws a javascript error when running in production environment.

**Tabletools** plugin provides the dialog window to allow users to edit **"Cell properties"**.

Documentation: https://ckeditor.com/cke4/addon/tabletools

## How to reproduce
Create a table within any application ckeditor, right click on any cell and the click on "Cell properties" from contextual menu. You will see a javascript error within browser console.

This is happening with all browsers.

Error location:
<img width="1139" alt="Captura de pantalla 2020-04-23 a las 18 33 46" src="https://user-images.githubusercontent.com/15726/80124755-06db2a00-8591-11ea-80dd-38f39c997a10.png">

## Visual Changes
None

## Notes
This change was successfully tested on production environment!
