### PR TITLE
Increase severity of DynamicFindBy rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -209,7 +209,10 @@ Rails/Date:
 
 Rails/DynamicFindBy:
   Enabled: true
-  Severity: refactor
+  Whitelist:
+    - find_by_slug_or_id
+    - find_by_slug_or_id!
+    - find_by_manager_login
 
 Rails/EnumUniqueness:
   Enabled: true


### PR DESCRIPTION

Thanks taitus for the tip.

## References

* This rule was added in pull request #3792

## Background

Back in commint 49e55b4d we lowered its severity because there were a few false positives. Back then, I didn't realize we could just whitelist the methods causing false positives.

## Objectives

Filter false positives instead of lowering the severity of a rule we apply all the time.

## Notes

Thanks @taitus for the tip :wink: :pray: :tada:.