### PR TITLE
Check remote translations locales at runtime

### DIFF
--- a/app/models/remote_translation.rb
+++ b/app/models/remote_translation.rb
@@ -4,7 +4,7 @@ class RemoteTranslation < ApplicationRecord
   validates :remote_translatable_id, presence: true
   validates :remote_translatable_type, presence: true
   validates :locale, presence: true
-  validates :locale, inclusion: { in: RemoteTranslations::Microsoft::AvailableLocales.available_locales }
+  validates :locale, inclusion: { in: ->(_) { RemoteTranslations::Microsoft::AvailableLocales.available_locales }}
   validate :already_translated_resource
   after_create :enqueue_remote_translation
 

--- a/spec/controllers/remote_translation_controller_spec.rb
+++ b/spec/controllers/remote_translation_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe RemoteTranslationsController do
+describe RemoteTranslationsController, :remote_translations do
   describe "POST create", :delay_jobs do
     let(:debate) { create(:debate) }
 

--- a/spec/lib/remote_translations/caller_spec.rb
+++ b/spec/lib/remote_translations/caller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe RemoteTranslations::Caller do
+describe RemoteTranslations::Caller, :remote_translations do
   before do
     RemoteTranslation.skip_callback(:create, :after, :enqueue_remote_translation)
   end

--- a/spec/models/remote_translation_spec.rb
+++ b/spec/models/remote_translation_spec.rb
@@ -37,6 +37,18 @@ describe RemoteTranslation do
     expect(remote_translation).not_to be_valid
   end
 
+  it "checks available locales dynamically" do
+    allow(RemoteTranslations::Microsoft::AvailableLocales)
+      .to receive(:available_locales).and_return(["en"])
+
+    expect(remote_translation).not_to be_valid
+
+    allow(RemoteTranslations::Microsoft::AvailableLocales)
+      .to receive(:available_locales).and_return(["es"])
+
+    expect(remote_translation).to be_valid
+  end
+
   describe "#enqueue_remote_translation", :delay_jobs do
     it "after create enqueue Delayed Job" do
       expect { remote_translation.save }.to change { Delayed::Job.count }.by(1)

--- a/spec/models/remote_translation_spec.rb
+++ b/spec/models/remote_translation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe RemoteTranslation do
+describe RemoteTranslation, :remote_translations do
   let(:remote_translation) { build(:remote_translation, locale: :es) }
 
   it "is valid" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,11 @@ RSpec.configure do |config|
     Delayed::Worker.delay_jobs = false
   end
 
+  config.before(:each, :remote_translations) do
+    allow(RemoteTranslations::Microsoft::AvailableLocales)
+      .to receive(:available_locales).and_return(I18n.available_locales.map(&:to_s))
+  end
+
   config.before(:each, :with_frozen_time) do
     travel_to Time.current # TODO: use `freeze_time` after migrating to Rails 5.2.
   end


### PR DESCRIPTION
## References

* Remote translations were added in pull request #3359

## Objectives

* Avoid inconsistencies if remote translations available locales change while the application is running
* Make it possible to run tests for remote translations with no internet connection