### PR TITLE
Do not update form location fields when marker is not defined

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -96,7 +96,11 @@
       }
       if (editable) {
         $(removeMarkerSelector).on("click", removeMarker);
-        map.on("zoomend", updateFormfields);
+        map.on("zoomend", function() {
+          if (marker) {
+            updateFormfields();
+          }
+        });
         map.on("click", moveOrPlaceMarker);
       }
       if (addMarkerInvestments) {


### PR DESCRIPTION
## References
Discovered while playing with other things.

## Objectives
Avoid the javascript error thrown when zoom map changes and map marker is not definet yet.

The error was:
```
TypeError: marker is null (Firefox)
TypeError: Cannot read property 'getLatLng' of null (Chrome)
```

## Visual Changes
None

## Steps to reproduce
1. Go to new proposal page and scroll to the map
2. Zoom in or zoom out and check browser console (Remember to not to add marker before zooming 😉 )

## Notes
Successfully tested on production environment.

No new specs were added because it's very difficult to emulate zoom in/out so does not worth it.