### PR TITLE
Do not run all javascript after every ajax call

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -173,5 +173,4 @@ $(function() {
 
   $(document).ready(initialize_modules);
   $(document).on("page:load", initialize_modules);
-  $(document).on("ajax:complete", initialize_modules);
 });

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -43,23 +43,18 @@
       $("span#" + id + "_arrow").toggleClass("fa-minus-square").toggleClass("fa-plus-square");
     },
     initialize: function() {
-      $("body .js-add-comment-link").each(function() {
-        if ($(this).data("initialized") !== "yes") {
-          $(this).on("click", function() {
-            App.Comments.toggle_form($(this).data().id);
-            return false;
-          }).data("initialized", "yes");
-        }
+      $("body").on("click", ".js-add-comment-link", function() {
+        App.Comments.toggle_form($(this).data().id);
+        return false;
       });
-      $("body .js-toggle-children").each(function() {
-        $(this).on("click", function() {
-          var children_container_id;
-          children_container_id = ($(this).data().id) + "_children";
-          $("#" + children_container_id).toggle("slow");
-          App.Comments.toggle_arrow(children_container_id);
-          $(this).children(".js-child-toggle").toggle();
-          return false;
-        });
+
+      $("body").on("click", ".js-toggle-children", function() {
+        var children_container_id;
+        children_container_id = ($(this).data().id) + "_children";
+        $("#" + children_container_id).toggle("slow");
+        App.Comments.toggle_arrow(children_container_id);
+        $(this).children(".js-child-toggle").toggle();
+        return false;
       });
     }
   };

--- a/app/assets/javascripts/legislation_annotatable.js
+++ b/app/assets/javascripts/legislation_annotatable.js
@@ -31,6 +31,13 @@
         return $(this).contents();
       });
     },
+    loadAnnotationComments: function(annotation_url, annotation_id) {
+      $.ajax({
+        method: "GET",
+        url: annotation_url + "/annotations/" + annotation_id + "/comments",
+        dataType: "script"
+      });
+    },
     renderAnnotationComments: function(event) {
       if (event.offset) {
         $("#comments-box").css({
@@ -40,11 +47,7 @@
       if (App.LegislationAnnotatable.isMobile()) {
         return;
       }
-      $.ajax({
-        method: "GET",
-        url: event.annotation_url + "/annotations/" + event.annotation_id + "/comments",
-        dataType: "script"
-      });
+      App.LegislationAnnotatable.loadAnnotationComments(event.annotation_url, event.annotation_id);
     },
     onClick: function(event) {
       var annotation_id, annotation_url, parents, parents_ids, target;
@@ -112,11 +115,7 @@
               App.LegislationAnnotatable.remove_highlight();
               App.LegislationAnnotatable.app.annotations.runHook("annotationCreated", [data.responseJSON]);
               $("#comments-box").html("").hide();
-              $.ajax({
-                method: "GET",
-                url: annotation_url + "/annotations/" + data.responseJSON.id + "/comments",
-                dataType: "script"
-              });
+              App.LegislationAnnotatable.loadAnnotationComments(annotation_url, data.responseJSON.id);
             } else {
               $(e.target).find("label").addClass("error");
               $("<small class='error'>" + data.responseJSON[0] + "</small>").insertAfter($(e.target).find("textarea"));

--- a/app/assets/javascripts/legislation_annotatable.js
+++ b/app/assets/javascripts/legislation_annotatable.js
@@ -108,9 +108,9 @@
           App.LegislationAnnotatable.highlight("#7fff9a");
           $("#comments-box textarea").focus();
           $("#new_legislation_annotation").on("ajax:complete", function(e, data) {
-            App.LegislationAnnotatable.app.destroy();
             if (data.status === 200) {
               App.LegislationAnnotatable.remove_highlight();
+              App.LegislationAnnotatable.app.annotations.runHook("annotationCreated", [data.responseJSON]);
               $("#comments-box").html("").hide();
               $.ajax({
                 method: "GET",


### PR DESCRIPTION
## References

* Closes #1736 

## Objectives
Run application javascript initialization once and update affected javascript modules to work with this new pattern.

Now that we are not initializing all the DOM after every ajax call we must ensure that new elements added through AJAX (only those that need javascript to work) are initialized as expected by using  "Delegated Event Handlers" [1] when possible or by doing it manually at `js.erb` file.

[1] https://api.jquery.com/on/#direct-and-delegated-events

## Visual Changes
None

## Notes
Successfully tested on production environment!

As this kind of change feels dangerous we had to review all places where using ajax calls to ensure elements added to the DOM were being initialized as we expect.
