### PR TITLE
Update comment responses count when adding replies

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -173,5 +173,4 @@ $(function() {
 
   $(document).ready(initialize_modules);
   $(document).on("page:load", initialize_modules);
-  $(document).on("ajax:complete", initialize_modules);
 });

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -43,23 +43,18 @@
       $("span#" + id + "_arrow").toggleClass("fa-minus-square").toggleClass("fa-plus-square");
     },
     initialize: function() {
-      $("body .js-add-comment-link").each(function() {
-        if ($(this).data("initialized") !== "yes") {
-          $(this).on("click", function() {
-            App.Comments.toggle_form($(this).data().id);
-            return false;
-          }).data("initialized", "yes");
-        }
+      $("body").on("click", ".js-add-comment-link", function() {
+        App.Comments.toggle_form($(this).data().id);
+        return false;
       });
-      $("body .js-toggle-children").each(function() {
-        $(this).on("click", function() {
-          var children_container_id;
-          children_container_id = ($(this).data().id) + "_children";
-          $("#" + children_container_id).toggle("slow");
-          App.Comments.toggle_arrow(children_container_id);
-          $(this).children(".js-child-toggle").toggle();
-          return false;
-        });
+
+      $("body").on("click", ".js-toggle-children", function() {
+        var children_container_id;
+        children_container_id = ($(this).data().id) + "_children";
+        $("#" + children_container_id).toggle("slow");
+        App.Comments.toggle_arrow(children_container_id);
+        $(this).children(".js-child-toggle").toggle();
+        return false;
       });
     }
   };

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -7,6 +7,7 @@
     },
     replace_comment: function(comment_id, response_html) {
       $("#" + comment_id).replaceWith(response_html);
+      App.Users.initializeAvatar();
       this.update_comments_count();
     },
     update_comments_count: function() {

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -5,11 +5,8 @@
       $(response_html).insertAfter($("#js-comment-form-" + parent_id));
       this.update_comments_count();
     },
-    add_reply: function(parent_id, response_html) {
-      if ($("#" + parent_id + " .comment-children").length === 0) {
-        $("#" + parent_id).append("<li><ul id='" + parent_id + "_children' class='no-bullet comment-children'></ul></li>");
-      }
-      $("#" + parent_id + " .comment-children:first").prepend($(response_html));
+    replace_comment: function(comment_id, response_html) {
+      $("#" + comment_id).replaceWith(response_html);
       this.update_comments_count();
     },
     update_comments_count: function() {

--- a/app/assets/javascripts/legislation_annotatable.js
+++ b/app/assets/javascripts/legislation_annotatable.js
@@ -31,6 +31,13 @@
         return $(this).contents();
       });
     },
+    loadAnnotationComments: function(annotation_url, annotation_id) {
+      $.ajax({
+        method: "GET",
+        url: annotation_url + "/annotations/" + annotation_id + "/comments",
+        dataType: "script"
+      });
+    },
     renderAnnotationComments: function(event) {
       if (event.offset) {
         $("#comments-box").css({
@@ -40,11 +47,7 @@
       if (App.LegislationAnnotatable.isMobile()) {
         return;
       }
-      $.ajax({
-        method: "GET",
-        url: event.annotation_url + "/annotations/" + event.annotation_id + "/comments",
-        dataType: "script"
-      });
+      App.LegislationAnnotatable.loadAnnotationComments(event.annotation_url, event.annotation_id);
     },
     onClick: function(event) {
       var annotation_id, annotation_url, parents, parents_ids, target;
@@ -112,11 +115,7 @@
               App.LegislationAnnotatable.remove_highlight();
               App.LegislationAnnotatable.app.annotations.runHook("annotationCreated", [data.responseJSON]);
               $("#comments-box").html("").hide();
-              $.ajax({
-                method: "GET",
-                url: annotation_url + "/annotations/" + data.responseJSON.id + "/comments",
-                dataType: "script"
-              });
+              App.LegislationAnnotatable.loadAnnotationComments(annotation_url, data.responseJSON.id);
             } else {
               $(e.target).find("label").addClass("error");
               $("<small class='error'>" + data.responseJSON[0] + "</small>").insertAfter($(e.target).find("textarea"));

--- a/app/assets/javascripts/legislation_annotatable.js
+++ b/app/assets/javascripts/legislation_annotatable.js
@@ -108,9 +108,9 @@
           App.LegislationAnnotatable.highlight("#7fff9a");
           $("#comments-box textarea").focus();
           $("#new_legislation_annotation").on("ajax:complete", function(e, data) {
-            App.LegislationAnnotatable.app.destroy();
             if (data.status === 200) {
               App.LegislationAnnotatable.remove_highlight();
+              App.LegislationAnnotatable.app.annotations.runHook("annotationCreated", [data.responseJSON]);
               $("#comments-box").html("").hide();
               $.ajax({
                 method: "GET",

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,8 +1,11 @@
 (function() {
   "use strict";
   App.Users = {
-    initialize: function() {
+    initializeAvatar: function() {
       $(".initialjs-avatar").initial();
+    },
+    initialize: function() {
+      this.initializeAvatar();
     }
   };
 }).call(this);

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,6 +13,7 @@ class CommentsController < ApplicationController
       CommentNotifier.new(comment: @comment).process
       add_notification @comment
       EvaluationCommentNotifier.new(comment: @comment).process if send_evaluation_notification?
+      set_comment_flags(@comment.root.subtree) unless @comment.root?
     else
       render :new
     end

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,11 +1,11 @@
-var comment_html = "<%= j(render @comment) %>"
-
 <% if @comment.root? -%>
+  var comment_html = "<%= j(render @comment) %>"
   var commentable_id = "<%= dom_id(@commentable) %>";
   App.Comments.reset_form(commentable_id);
   App.Comments.add_comment(commentable_id, comment_html);
 <% else -%>
+  var parent_comment_html = "<%= j(render @comment.parent) %>"
   var parent_id = "<%= "comment_#{@comment.parent_id}" %>";
   App.Comments.reset_and_hide_form(parent_id);
-  App.Comments.add_reply(parent_id, comment_html);
+  App.Comments.replace_comment(parent_id, parent_comment_html);
 <% end -%>

--- a/spec/system/comments/budget_investments_spec.rb
+++ b/spec/system/comments/budget_investments_spec.rb
@@ -236,6 +236,25 @@ describe "Commenting Budget::Investments" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
+  scenario "Reply update parent comment responses count", :js do
+    citizen = create(:user, username: "Ana")
+    manuela = create(:user, username: "Manuela")
+    comment = create(:comment, commentable: investment, user: citizen)
+
+    login_as(manuela)
+    visit budget_investment_path(investment.budget, investment)
+
+    within ".comment", text: comment.body do
+      expect(page).to have_content("No responses")
+
+      click_link "Reply"
+      fill_in "comment-body-comment_#{comment.id}", with: "It will be done next week."
+      click_button "Publish reply"
+
+      expect(page).to have_content("1 response (collapse)")
+    end
+  end
+
   scenario "Errors on reply", :js do
     comment = create(:comment, commentable: investment, user: user)
 

--- a/spec/system/comments/budget_investments_valuation_spec.rb
+++ b/spec/system/comments/budget_investments_valuation_spec.rb
@@ -210,6 +210,23 @@ describe "Internal valuation comments on Budget::Investments" do
       expect(page).not_to have_content("It will be done next week.")
     end
 
+    scenario "Reply update parent comment responses count", :js do
+      comment = create(:comment, :valuation, author: admin_user, commentable: investment)
+
+      login_as(valuator_user)
+      visit valuation_budget_budget_investment_path(budget, investment)
+
+      within ".comment", text: comment.body do
+        expect(page).to have_content("No responses")
+
+        click_link "Reply"
+        fill_in "comment-body-comment_#{comment.id}", with: "It will be done next week."
+        click_button "Publish reply"
+
+        expect(page).to have_content("1 response (collapse)")
+      end
+    end
+
     scenario "Errors on reply without comment text", :js do
       comment = create(:comment, :valuation, author: admin_user, commentable: investment)
 

--- a/spec/system/comments/debates_spec.rb
+++ b/spec/system/comments/debates_spec.rb
@@ -275,6 +275,25 @@ describe "Commenting debates" do
     end
   end
 
+  scenario "Reply update parent comment responses count", :js do
+    citizen = create(:user, username: "Ana")
+    manuela = create(:user, username: "Manuela")
+    comment = create(:comment, commentable: debate, user: citizen)
+
+    login_as(manuela)
+    visit debate_path(debate)
+
+    within ".comment", text: comment.body do
+      expect(page).to have_content("No responses")
+
+      click_link "Reply"
+      fill_in "comment-body-comment_#{comment.id}", with: "It will be done next week."
+      click_button "Publish reply"
+
+      expect(page).to have_content("1 response (collapse)")
+    end
+  end
+
   scenario "Errors on reply", :js do
     comment = create(:comment, commentable: debate, user: user)
 

--- a/spec/system/comments/legislation_annotations_spec.rb
+++ b/spec/system/comments/legislation_annotations_spec.rb
@@ -272,6 +272,28 @@ describe "Commenting legislation questions" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
+  scenario "Reply update parent comment responses count", :js do
+    citizen = create(:user, username: "Ana")
+    manuela = create(:user, :level_two, username: "Manuela")
+    legislation_annotation = create(:legislation_annotation, author: citizen)
+    comment = legislation_annotation.comments.first
+
+    login_as(manuela)
+    visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
+                                                            legislation_annotation.draft_version,
+                                                            legislation_annotation)
+
+    within ".comment", text: comment.body do
+      expect(page).to have_content("No responses")
+
+      click_link "Reply"
+      fill_in "comment-body-comment_#{comment.id}", with: "It will be done next week."
+      click_button "Publish reply"
+
+      expect(page).to have_content("1 response (collapse)")
+    end
+  end
+
   scenario "Errors on reply", :js do
     comment = legislation_annotation.comments.first
 

--- a/spec/system/comments/legislation_questions_spec.rb
+++ b/spec/system/comments/legislation_questions_spec.rb
@@ -254,6 +254,25 @@ describe "Commenting legislation questions" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
+  scenario "Reply update parent comment responses count", :js do
+    citizen = create(:user, username: "Ana")
+    manuela = create(:user, :level_two, username: "Manuela")
+    comment = create(:comment, commentable: legislation_question, user: citizen)
+
+    login_as(manuela)
+    visit legislation_process_question_path(legislation_question.process, legislation_question)
+
+    within ".comment", text: comment.body do
+      expect(page).to have_content("No responses")
+
+      click_link "Reply"
+      fill_in "comment-body-comment_#{comment.id}", with: "It will be done next week."
+      click_button "Publish reply"
+
+      expect(page).to have_content("1 response (collapse)")
+    end
+  end
+
   scenario "Errors on reply", :js do
     comment = create(:comment, commentable: legislation_question, user: user)
 

--- a/spec/system/comments/polls_spec.rb
+++ b/spec/system/comments/polls_spec.rb
@@ -234,6 +234,25 @@ describe "Commenting polls" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
+  scenario "Reply update parent comment responses count", :js do
+    citizen = create(:user, username: "Ana")
+    manuela = create(:user, username: "Manuela")
+    comment = create(:comment, commentable: poll, user: citizen)
+
+    login_as(manuela)
+    visit poll_path(poll)
+
+    within ".comment", text: comment.body do
+      expect(page).to have_content("No responses")
+
+      click_link "Reply"
+      fill_in "comment-body-comment_#{comment.id}", with: "It will be done next week."
+      click_button "Publish reply"
+
+      expect(page).to have_content("1 response (collapse)")
+    end
+  end
+
   scenario "Errors on reply", :js do
     comment = create(:comment, commentable: poll, user: user)
 

--- a/spec/system/comments/proposals_spec.rb
+++ b/spec/system/comments/proposals_spec.rb
@@ -232,6 +232,25 @@ describe "Commenting proposals" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
+  scenario "Reply update parent comment responses count", :js do
+    citizen = create(:user, username: "Ana")
+    manuela = create(:user, username: "Manuela")
+    comment = create(:comment, commentable: proposal, user: citizen)
+
+    login_as(manuela)
+    visit proposal_path(proposal)
+
+    within ".comment", text: comment.body do
+      expect(page).to have_content("No responses")
+
+      click_link "Reply"
+      fill_in "comment-body-comment_#{comment.id}", with: "It will be done next week."
+      click_button "Publish reply"
+
+      expect(page).to have_content("1 response (collapse)")
+    end
+  end
+
   scenario "Errors on reply", :js do
     comment = create(:comment, commentable: proposal, user: user)
 

--- a/spec/system/comments/topics_spec.rb
+++ b/spec/system/comments/topics_spec.rb
@@ -258,6 +258,27 @@ describe "Commenting topics from proposals" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}", visible: true)
   end
 
+  scenario "Reply update parent comment responses count", :js do
+    community = proposal.community
+    topic = create(:topic, community: community)
+    citizen = create(:user, username: "Ana")
+    manuela = create(:user, username: "Manuela")
+    comment = create(:comment, commentable: topic, user: citizen)
+
+    login_as(manuela)
+    visit community_topic_path(community, topic)
+
+    within ".comment", text: comment.body do
+      expect(page).to have_content("No responses")
+
+      click_link "Reply"
+      fill_in "comment-body-comment_#{comment.id}", with: "It will be done next week."
+      click_button "Publish reply"
+
+      expect(page).to have_content("1 response (collapse)")
+    end
+  end
+
   scenario "Errors on reply", :js do
     community = proposal.community
     topic = create(:topic, community: community)


### PR DESCRIPTION
## References

This PR needs #3997 commits to work. Will rebase when #3997 is merged.

## Objectives
Update the parent comment "responses count" when a new reply is added.

Replace parent comment of a reply when a reply for a comment is added, this will replace parent comment which will include the reply also.

Changes introduced at 7105f21 (the comments part) are needed to initialize automatically comments added or replaced through ajax calls.

## Steps to reproduce
1. Go to any debate (or any other commentable resource)
2. Add a reply to a comment

At this point you can see your reply but parent comment responses count is not updated!

## Visual Changes

**Before**
![ResponsesCountUpdateError](https://user-images.githubusercontent.com/15726/81383995-51bc7c00-9111-11ea-90bb-9f83d25345d6.gif)

**After**
![ResponsesCountUpdateFix](https://user-images.githubusercontent.com/15726/81384009-5719c680-9111-11ea-95a7-52282412a43f.gif)

## Notes
None
