### PR TITLE
Make the admin menu fill the screen vertically

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -22,6 +22,7 @@ $sidebar-hover:  #25597c;
 $sidebar-active: #f4fcd0;
 
 .admin {
+  @include admin-layout;
 
   h2 {
     font-weight: 100;

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -16,6 +16,10 @@
 // 01. Dashboard global
 // --------------------
 
+.proposal-dashboard {
+  @include admin-layout;
+}
+
 .proposal-title {
   display: inline-block;
 

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -134,6 +134,10 @@
   display: flex;
   flex-direction: column;
 
+  > header {
+    margin-bottom: 0;
+  }
+
   > .menu-and-content {
     flex: 1;
   }

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -3,6 +3,7 @@
 // 01. Logo
 // 02. Orbit bullets
 // 03. Direct uploads
+// 04. Admin layout
 // ------------------
 
 // 01. Logo
@@ -123,6 +124,18 @@
 
   .loading-bar.no-transition {
     transition: none;
+  }
+}
+
+// 04. Admin layout
+// ----------------
+
+@mixin admin-layout {
+  display: flex;
+  flex-direction: column;
+
+  > .menu-and-content {
+    flex: 1;
   }
 }
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -9,7 +9,7 @@
   <body class="admin">
     <%= render "layouts/admin_header" %>
 
-    <div class="menu-and-content no-margin-top">
+    <div class="menu-and-content">
       <%= check_box_tag :show_menu, nil, false, role: "switch" %>
 
       <nav id="side_menu" class="admin-sidebar">

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -27,7 +27,7 @@
 
     <%= render "layouts/header", with_subnavigation: false %>
 
-    <div class="menu-and-content no-margin-top">
+    <div class="menu-and-content">
       <%= check_box_tag :show_menu, nil, false, role: "switch" %>
 
       <nav id="side_menu" class="dashboard-sidebar">

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -45,7 +45,7 @@
       </div>
     </header>
 
-    <div class="menu-and-content no-margin-top">
+    <div class="menu-and-content">
       <%= check_box_tag :show_menu, nil, false, role: "switch" %>
 
       <nav class="admin-sidebar">


### PR DESCRIPTION
## References

* Pull request #3778 fixed some related issues
* Depends on pull request #4005

## Objectives

Make the admin menu fill the screen vertically so there's no empty space below it

## Visual Changes

Before these changes:

![There's a blank space below the admin menu](https://user-images.githubusercontent.com/35156/81455636-0b5a3200-9190-11ea-87be-4cd20956c023.png)

After these changes:

![The admin menu fills the screen vertically](https://user-images.githubusercontent.com/35156/81455659-1ad97b00-9190-11ea-8ebc-9bafe5f2ec98.png)