### PR TITLE
Use a memory cache store in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,7 +60,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.cache_store = :dalli_store
   config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
 
   config.after_initialize do


### PR DESCRIPTION
## References

* This change makes it easier to debug some of the changes in pull request #4008

## Background

In commit 574133a5 we configured the development to use Dalli to cache pages. However, cache is usually disabled in the development environment.

When we upgraded to Rails 5 in commit eb36b7e2, we configured the development environment to enable caching (using a memory store) when a certain file is present, and to disable it when it's not. This configuration makes more sense IMHO, and it was being overwritten by the one previously mentioned.

## Objectives

* Allow caching in the development environment without memcached
* Get rid of the `DalliError: No server available` error message 