### PR TITLE
Fix flaky nested documentable / imageable specs

### DIFF
--- a/spec/shared/system/nested_documentable.rb
+++ b/spec/shared/system/nested_documentable.rb
@@ -80,6 +80,8 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
           Rails.root.join("spec/fixtures/files/empty.pdf"),
           make_visible: true
         )
+
+        expect(page).to have_css ".loading-bar.complete"
       end
 
       expect(page).to have_css ".file-name", text: "empty.pdf"
@@ -110,6 +112,8 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
           Rails.root.join("spec/fixtures/files/empty.pdf"),
           make_visible: true
         )
+
+        expect(page).to have_css ".loading-bar.complete"
       end
 
       expect_document_has_title(0, "My Title")

--- a/spec/shared/system/nested_imageable.rb
+++ b/spec/shared/system/nested_imageable.rb
@@ -182,6 +182,8 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
         Rails.root.join("spec/fixtures/files/clippy.jpg")
       )
 
+      expect(page).to have_selector ".loading-bar.complete"
+
       click_on submit_button
 
       expect(page).to have_content imageable_success_notice
@@ -196,6 +198,8 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
         imageable_factory_name,
         Rails.root.join("spec/fixtures/files/clippy.jpg")
       )
+
+      expect(page).to have_selector ".loading-bar.complete"
 
       click_on submit_button
       imageable_redirected_to_resource_show_or_navigate_to


### PR DESCRIPTION
## Background

We were checking `expect_document_has_title(0, "My Title")`, which was already true before the AJAX request generated by `attach_file` had finished.

That meant the AJAX request sometimes was handled after this test had finished, affecting the following test and causing it to fail because its cookie was overwritten and so `current_user` was set to `nil`.

In the test checking the filename is present, a similar scenario was taking place: we were updating the `.file-name` element in the `change` event of `fileupload` (using `App.Documentable.setFilename`); that is, when the AJAX request started. And so the test passed before the request was finished, causing the same issue.

Regarding images, we were submitting the form without checking the AJAX request to attach the image had finished, so sometimes two requests were executed at the same time. Sometimes this made InvisibleCaptcha to go crazy and report the form was submitted too quickly.

## Objectives

* Check the DOM after attaching file has succeeded in order to avoid residual requests causing other tests to fail
* Check the DOM after attaching an image in order to avoid simultaneous requests