### PR TITLE
Simplify chromedriver installation with webdrivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ addons:
 cache: bundler
 bundler_args: --without development
 before_script:
-- wget -N https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip -P ~/
-- unzip ~/chromedriver_linux64.zip -d ~/
-- rm ~/chromedriver_linux64.zip
-- sudo mv -f ~/chromedriver /usr/local/share/
-- sudo chmod +x /usr/local/share/chromedriver
-- sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
 - for i in config/*.example; do cp "$i" "${i/.example}"; done
 - bundle exec rake db:setup
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,8 @@ RUN gem install bundler
 # Finish establishing our Ruby environment
 RUN bundle install --full-index
 
-# Install Chromium and ChromeDriver for E2E integration tests
+# Install Chromium for E2E integration tests
 RUN apt-get update -qq && apt-get install -y chromium
-RUN wget -N http://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
-RUN unzip chromedriver_linux64.zip
-RUN chmod +x chromedriver
-RUN mv -f chromedriver /usr/local/share/chromedriver
-RUN ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
-RUN ln -s /usr/local/share/chromedriver /usr/bin/chromedriver
 
 # Copy the Rails application into place
 COPY . .

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ group :test do
   gem "email_spec", "~> 2.2.0"
   gem "rspec-rails", "~> 3.8"
   gem "selenium-webdriver", "~> 3.141"
+  gem "webdrivers", "~> 4.3.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -588,6 +588,10 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
+    webdrivers (4.3.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -691,6 +695,7 @@ DEPENDENCIES
   turnout (~> 2.4.0)
   uglifier (~> 4.1.2)
   web-console (~> 3.3.0)
+  webdrivers (~> 4.3.0)
   whenever (~> 0.10.0)
   wicked_pdf (~> 1.1.0)
   wkhtmltopdf-binary (~> 0.12.4)

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Run the app locally:
 bin/rails s
 ```
 
-Prerequisites for testing: install ChromeDriver >= 2.33
-
 Run the tests with:
 
 ```bash

--- a/README_ES.md
+++ b/README_ES.md
@@ -56,8 +56,6 @@ Para ejecutar la aplicación en local:
 bin/rails s
 ```
 
-Prerequisitos para los tests: tener instalado ChromeDriver >= 2.33
-
 Para ejecutar los tests:
 
 ```

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,5 +53,6 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 Capybara.exact = true
+Webdrivers::Chromedriver.required_version = "2.38"
 
 OmniAuth.config.test_mode = true


### PR DESCRIPTION
## References

* [Issue #3361 in chromedriver](https://bugs.chromium.org/p/chromedriver/issues/detail?id=3361)
* teamcapybara/capybara#2318

## Objectives

* Make it easier to configure your development environment to run the test suite
* Simplify Travis configuration
* Fix an incompatibility between Chrome 2.36 (used in Travis until now) and Chrome 83
* Make it possible to execute our test suite using the latest stable version of Chrome