### PR TITLE
Improve watch form changes feature

### DIFF
--- a/app/assets/javascripts/watch_form_changes.js
+++ b/app/assets/javascripts/watch_form_changes.js
@@ -85,5 +85,10 @@
     }
   };
 
-  $(document).on("turbolinks:before-visit", App.WatchFormChanges.checkChanges);
+  $(document).on("turbolinks:before-visit", function() {
+    // Ckeditor updates textarea input only on form submit. This patch will
+    // force the update of textarea input right before navigating to other pages
+    App.WatchFormChanges.update_editor_form_elements();
+    return App.WatchFormChanges.checkChanges();
+  });
 }).call(this);

--- a/app/assets/javascripts/watch_form_changes.js
+++ b/app/assets/javascripts/watch_form_changes.js
@@ -25,6 +25,10 @@
     },
     serialize: function(form) {
       var id = App.WatchFormChanges.trackInputId(form);
+      if ($("#" + id).length > 0) {
+        return;
+      }
+
       var input = $("<input>").attr({ id: id, type: "hidden", value: $(form).serialize() });
       $(input).insertBefore(form);
     },

--- a/app/assets/javascripts/watch_form_changes.js
+++ b/app/assets/javascripts/watch_form_changes.js
@@ -9,7 +9,8 @@
     },
     hasChanged: function() {
       return App.WatchFormChanges.forms().is(function() {
-        return $(this).serialize() !== $(this).data("watchChanges");
+        var id = "#" + App.WatchFormChanges.trackInputId(this);
+        return $(this).serialize() !== $(id).val();
       });
     },
     checkChanges: function() {
@@ -19,14 +20,30 @@
         return true;
       }
     },
+    trackInputId: function(form) {
+      return form.id + "_watch_form_changes";
+    },
+    serialize: function(form) {
+      var id = App.WatchFormChanges.trackInputId(form);
+      var input = $("<input>").attr({ id: id, type: "hidden", value: $(form).serialize() });
+      $(input).insertBefore(form);
+    },
     initialize: function() {
       if (App.WatchFormChanges.forms().length === 0 || App.WatchFormChanges.msg() === undefined) {
         return;
       }
-      $(document).off("turbolinks:before-visit").on("turbolinks:before-visit", App.WatchFormChanges.checkChanges);
-      App.WatchFormChanges.forms().each(function() {
-        $(this).data("watchChanges", $(this).serialize());
+
+      App.WatchFormChanges.forms().each(function(_, form) {
+        // Serialize form directly if there is not ckeditors within form
+        if ($(form).find(".html-area").length === 0) {
+          App.WatchFormChanges.serialize(form);
+          return;
+        }
+
+        App.WatchFormChanges.wait_for_html_editors(form);
       });
     }
   };
+
+  $(document).on("turbolinks:before-visit", App.WatchFormChanges.checkChanges);
 }).call(this);

--- a/spec/system/watch_form_changes_spec.rb
+++ b/spec/system/watch_form_changes_spec.rb
@@ -45,6 +45,33 @@ describe "Watch form changes", :js do
         expect(page).to have_text(:h2, "Proposals")
       end
     end
+
+    context "should not ask for confirmation before leaving the current page" do
+      scenario "when users restores original form data" do
+        visit path
+
+        expect(page).to have_ckeditor("Content", with: "This page is about...")
+
+        fill_in_ckeditor("Content", with: "New content for editor.")
+        accept_confirm(prompt) do
+          click_link "Proposals", match: :first
+        end
+
+        expect(page).to have_text(:h2, "Proposals")
+
+        go_back
+
+        expect(page).to have_ckeditor("Content", with: "New content for editor.")
+
+        fill_in_ckeditor("Content", with: "This page is about...")
+
+        expect(page).to have_ckeditor("Content", with: "This page is about...")
+
+        click_link "Proposals", match: :first
+
+        expect(page).to have_text(:h2, "Proposals")
+      end
+    end
   end
 
   describe "when form does not include html editor" do

--- a/spec/system/watch_form_changes_spec.rb
+++ b/spec/system/watch_form_changes_spec.rb
@@ -8,6 +8,45 @@ describe "Watch form changes", :js do
     login_as(admin.user)
   end
 
+  describe "when form includes html editor" do
+    let(:custom_page) { create(:site_customization_page, title: "Original title") }
+    let(:path) { edit_admin_site_customization_page_path(custom_page) }
+
+    context "should ask for confirmation before leaving the current page" do
+      scenario "when any form input was modified" do
+        visit path
+
+        fill_in "Title", with: "Unsaved title"
+        dismiss_confirm(prompt) do
+          click_link "Proposals", match: :first
+        end
+
+        expect(page).to have_current_path(path)
+      end
+
+      scenario "when any form input was modified and page was restored from browser history" do
+        visit path
+
+        fill_in "Title", with: "Unsaved title"
+        accept_confirm(prompt) do
+          click_link "Proposals", match: :first
+        end
+
+        expect(page).to have_text(:h2, "Proposals")
+
+        go_back
+
+        expect(page).to have_field("Title", with: "Unsaved title")
+
+        accept_confirm(prompt) do
+          click_link "Proposals", match: :first
+        end
+
+        expect(page).to have_text(:h2, "Proposals")
+      end
+    end
+  end
+
   describe "when form does not include html editor" do
     let(:legislation_process) { create(:legislation_process, title: "An example legislation process") }
     let(:legislation_draft_version) do

--- a/spec/system/watch_form_changes_spec.rb
+++ b/spec/system/watch_form_changes_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+describe "Watch form changes", :js do
+  let(:prompt) { "You have unsaved changes. Do you confirm to leave the page?" }
+
+  before do
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
+
+  describe "when form does not include html editor" do
+    let(:legislation_process) { create(:legislation_process, title: "An example legislation process") }
+    let(:legislation_draft_version) do
+      create(:legislation_draft_version, title: "Version 1", process: legislation_process)
+    end
+    let(:path) do
+      edit_admin_legislation_process_draft_version_path(legislation_process, legislation_draft_version)
+    end
+
+    context "should ask for confirmation before leaving the current page" do
+      scenario "when any form input was modified" do
+        visit path
+
+        fill_in "Changes", with: "Version 1b"
+        dismiss_confirm(prompt) do
+          click_link "Proposals", match: :first
+        end
+
+        expect(page).to have_current_path(path)
+      end
+
+      scenario "when any form input was modified and page was restored from browser history" do
+        visit path
+
+        fill_in "Changes", with: "Version 1b"
+        accept_confirm(prompt) do
+          click_link "Proposals", match: :first
+        end
+
+        expect(page).to have_text(:h2, "Proposals")
+
+        go_back
+
+        expect(page).to have_content legislation_process.title
+
+        accept_confirm(prompt) do
+          click_link "Proposals", match: :first
+        end
+
+        expect(page).to have_text(:h2, "Proposals")
+      end
+    end
+
+    context "should not ask for confirmation before leaving the current page" do
+      scenario "when users restores original form data" do
+        visit path
+
+        fill_in "Changes", with: "Version 1b"
+        accept_confirm(prompt) do
+          click_link "Proposals", match: :first
+        end
+
+        expect(page).to have_text(:h2, "Proposals")
+
+        go_back
+
+        expect(page).to have_content legislation_process.title
+
+        fill_in "Changes", with: legislation_draft_version.changelog
+
+        click_link "Proposals", match: :first
+
+        expect(page).to have_text(:h2, "Proposals")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## References
Related PR: #3699  (See Notes section)

## Objectives
1. Show "Unsaved changes" alert dialog when a user leaves a page with a "form to track changes" with unsaved data even when page is restored from browser history.

2. Do not show alert if users restores the original value (by hand) after modifying it.

## Solution
Data attributes dynamically added to the form to store form input values were lost when using browser history so when user navigates back to a page with a form with unsaved changes the form serialization is done again but this time with modified but unpersisted values so application thinks form wasn't changed, by using a hidden input to store form serialized data we can keep warning the user about unsaved changes from original version (persisted).

## Notes
None
