### PR TITLE
Fix chromedriver hanging with CKEditor

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,5 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 Capybara.exact = true
-Webdrivers::Chromedriver.required_version = "2.38"
 
 OmniAuth.config.test_mode = true

--- a/spec/support/common_actions/verifications.rb
+++ b/spec/support/common_actions/verifications.rb
@@ -51,14 +51,8 @@ module Verifications
       sleep 0.01
     end
 
-    # Fill the editor content
-    page.execute_script <<-SCRIPT
-        var ckeditor = CKEDITOR.instances.#{locator}
-        ckeditor.setData("#{with}")
-        ckeditor.focus()
-        ckeditor.updateElement()
-    SCRIPT
-
-    expect(page).to have_ckeditor label, with: with
+    within("#cke_#{locator}") do
+      within_frame(0) { find("body").set(with) }
+    end
   end
 end

--- a/spec/support/matchers/have_ckeditor.rb
+++ b/spec/support/matchers/have_ckeditor.rb
@@ -14,6 +14,10 @@ RSpec::Matchers.define :have_ckeditor do |label, with:|
   match do
     return false unless has_ckeditor?
 
+    until page.execute_script("return CKEDITOR.instances.#{textarea_id}.status === 'ready';") do
+      sleep 0.01
+    end
+
     page.within(ckeditor_id) do
       within_frame(0) { has_content?(with, exact: true) }
     end

--- a/spec/support/matchers/have_ckeditor.rb
+++ b/spec/support/matchers/have_ckeditor.rb
@@ -15,7 +15,7 @@ RSpec::Matchers.define :have_ckeditor do |label, with:|
     return false unless has_ckeditor?
 
     page.within(ckeditor_id) do
-      within_frame(0) { has_content?(with) }
+      within_frame(0) { has_content?(with, exact: true) }
     end
   end
 


### PR DESCRIPTION
## References

* Related to pull request #4012
* [Issue #3337 in chromedriver](https://bugs.chromium.org/p/chromedriver/issues/detail?id=3337) 
* [Issue #3361 in chromedriver](https://bugs.chromium.org/p/chromedriver/issues/detail?id=3361)
* teamcapybara/capybara#2318

## Objectives

* Make the test suite work with the latest chromedriver

## Notes

There were two reasons why chromedriver was freezing: using `ckeditor.setData` and loading the same page twice. The third commit in this pull request (probably) solves both problems, while the second one only solves one of them.

I've decided to keep both commits because IMHO the second commit improves the existing code and because it will help us remember there are two different problems causing this issue.

The exact cause why chromedriver freezing with CKEditor when visiting the same page twice is unknown. It could be a coincidence just because the second time the page loads faster.

My best (wild) guess is at a certain point chromdriver executes `DOM.setChildNodes` and `DevTools WebSocket Event: DOM.attributeModified (...) "name": "cd_frame_id_"`. If at that point we're already inside `within_frame`, chromedriver can no longer navigate through that frame.
