### PR TITLE
Add processes feature info section in the help page

### DIFF
--- a/app/views/pages/help/_processes.html.erb
+++ b/app/views/pages/help/_processes.html.erb
@@ -10,7 +10,9 @@
     </p>
     <ul class="features">
       <li>
-        <% link = link_to(t("pages.help.processes.link"), legislation_processes_path) %>
+        <%= sanitize(t("pages.help.processes.feature",
+              link: link_to(t("pages.help.processes.feature_link", org_name: setting["org_name"]),
+                               new_user_registration_path))) %>
       </li>
     </ul>
   </div>

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -44,6 +44,8 @@ en:
         title: "Processes"
         description: "In the %{link} section, citizens participate in the drafting and modification of regulations affecting the city and can give their opinion on municipal policies in previous debates."
         link: "processes"
+        feature: "To participate in the processes you have to %{link} and verify your account."
+        feature_link: "register in %{org_name}"
       faq:
         title: "Technical problems?"
         description: "Read the FAQs and solve your questions."

--- a/config/locales/es/pages.yml
+++ b/config/locales/es/pages.yml
@@ -44,6 +44,8 @@ es:
         title: "Legislación colaborativa"
         description: "En la sección de %{link} la ciudadanía participa en la elaboración y modificación de normativa que afecta a la ciudad y puede dar su opinión sobre las políticas municipales en debates previos."
         link: "legislación colaborativa"
+        feature: "Para participar en la legislación colaborativa tienes que %{link} y verificar tu cuenta."
+        feature_link: "registrarte en %{org_name}"
       faq:
         title: "¿Problemas técnicos?"
         description: "Lee las preguntas frecuentes y resuelve tus dudas."


### PR DESCRIPTION
## Objectives

Add missing information for processes in the help section. `/help`

## Visual Changes

### BEFORE
![Captura de pantalla 2020-06-08 a las 11 23 09](https://user-images.githubusercontent.com/942995/83992762-925f1d80-a97b-11ea-8576-94dfadb0748d.png)


### AFTER
![Captura de pantalla 2020-06-08 a las 11 27 42](https://user-images.githubusercontent.com/942995/83992763-925f1d80-a97b-11ea-9e7d-ffec7e500cf9.png)
