### PR TITLE
Fix deleting searched managers/moderators/admins

### DIFF
--- a/app/views/admin/administrators/index.html.erb
+++ b/app/views/admin/administrators/index.html.erb
@@ -29,21 +29,13 @@
             <%= administrator.description %>
           </td>
           <td>
-            <% if administrator.persisted? %>
-              <%= link_to t("admin.actions.edit"),
-                          edit_admin_administrator_path(administrator),
-                          class: "button hollow" %>
-              <%= link_to t("admin.administrators.administrator.delete"),
-                          admin_administrator_path(administrator),
-                          method: :delete,
-                          class: "button hollow alert" %>
-            <% else %>
-              <%= link_to t("admin.administrators.administrator.add"),
-                          { controller: "admin/administrators", action: :create,
-                            user_id: administrator.user_id },
-                            method: :post,
-                            class: "button success expanded" %>
-            <% end %>
+            <%= link_to t("admin.actions.edit"),
+                        edit_admin_administrator_path(administrator),
+                        class: "button hollow" %>
+            <%= link_to t("admin.administrators.administrator.delete"),
+                        admin_administrator_path(administrator),
+                        method: :delete,
+                        class: "button hollow alert" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/administrators/search.html.erb
+++ b/app/views/admin/administrators/search.html.erb
@@ -20,7 +20,7 @@
             <td class="text-right">
               <% if user.administrator? && user.administrator.persisted? %>
                 <%= link_to t("admin.administrators.administrator.delete"),
-                            admin_administrator_path(user),
+                            admin_administrator_path(user.administrator),
                             method: :delete,
                             class: "button hollow alert expanded" %>
               <% else %>

--- a/app/views/admin/managers/index.html.erb
+++ b/app/views/admin/managers/index.html.erb
@@ -22,20 +22,10 @@
               <%= manager.email %>
             </td>
             <td>
-              <% if manager.persisted? %>
-                <%= link_to t("admin.managers.manager.delete"),
-                  admin_manager_path(manager),
-                  method: :delete,
-                  class: "button hollow alert expanded"
-                %>
-              <% else %>
-                <%= link_to t("admin.managers.manager.add"),
-                             { controller: "admin/managers",
-                               action: :create,
-                               user_id: manager.user_id },
-                               method: :post,
-                               class: "button success expanded" %>
-              <% end %>
+              <%= link_to t("admin.managers.manager.delete"),
+                admin_manager_path(manager),
+                method: :delete,
+                class: "button hollow alert expanded" %>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/managers/search.html.erb
+++ b/app/views/admin/managers/search.html.erb
@@ -20,7 +20,7 @@
           <td>
             <% if user.manager? && user.manager.persisted? %>
               <%= link_to t("admin.managers.manager.delete"),
-                          admin_manager_path(user),
+                          admin_manager_path(user.manager),
                           method: :delete,
                           class: "button hollow alert expanded" %>
             <% else %>

--- a/app/views/admin/moderators/index.html.erb
+++ b/app/views/admin/moderators/index.html.erb
@@ -24,19 +24,10 @@
               <%= moderator.email %>
             </td>
             <td>
-              <% if moderator.persisted? %>
-                <%= link_to t("admin.moderators.moderator.delete"),
-                            admin_moderator_path(moderator),
-                            method: :delete,
-                            class: "button hollow alert expanded"
-                %>
-              <% else %>
-                <%= link_to t("admin.moderators.moderator.add"),
-                            { controller: "admin/moderators", action: :create,
-                              user_id: moderator.user_id },
-                              method: :post,
-                              class: "button success expanded" %>
-              <% end %>
+              <%= link_to t("admin.moderators.moderator.delete"),
+                          admin_moderator_path(moderator),
+                          method: :delete,
+                          class: "button hollow alert expanded" %>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/moderators/search.html.erb
+++ b/app/views/admin/moderators/search.html.erb
@@ -20,7 +20,7 @@
           <td>
             <% if user.moderator? && user.moderator.persisted? %>
               <%= link_to t("admin.moderators.moderator.delete"),
-                          admin_moderator_path(user),
+                          admin_moderator_path(user.moderator),
                           method: :delete,
                           class: "button hollow alert expanded" %>
             <% else %>

--- a/app/views/admin/officials/index.html.erb
+++ b/app/views/admin/officials/index.html.erb
@@ -28,7 +28,7 @@
             <%= t("admin.officials.level_#{official.official_level}") %>
           </td>
           <td>
-            <%= link_to official.official? ? t("admin.officials.search.edit_official") : t("admin.officials.search.make_official"),
+            <%= link_to t("admin.officials.search.edit_official"),
                         edit_admin_official_path(official), class: "button hollow expanded" %>
           </td>
         </tr>

--- a/spec/system/admin/administrators_spec.rb
+++ b/spec/system/admin/administrators_spec.rb
@@ -98,6 +98,16 @@ describe "Admin administrators" do
       expect(page).to have_content(administrator2.email)
       expect(page).not_to have_content(administrator1.email)
     end
+
+    scenario "Delete after searching" do
+      fill_in "Search user by name or email", with: administrator2.email
+      click_button "Search"
+
+      click_link "Delete"
+
+      expect(page).to have_content(administrator1.email)
+      expect(page).not_to have_content(administrator2.email)
+    end
   end
 
   context "Edit" do

--- a/spec/system/admin/managers_spec.rb
+++ b/spec/system/admin/managers_spec.rb
@@ -80,5 +80,15 @@ describe "Admin managers" do
       expect(page).to have_content(manager2.email)
       expect(page).not_to have_content(manager1.email)
     end
+
+    scenario "Delete after searching" do
+      fill_in "Search user by name or email", with: manager2.email
+      click_button "Search"
+
+      click_link "Delete"
+
+      expect(page).to have_content(manager1.email)
+      expect(page).not_to have_content(manager2.email)
+    end
   end
 end

--- a/spec/system/admin/moderators_spec.rb
+++ b/spec/system/admin/moderators_spec.rb
@@ -80,5 +80,15 @@ describe "Admin moderators" do
       expect(page).to have_content(moderator2.email)
       expect(page).not_to have_content(moderator1.email)
     end
+
+    scenario "Delete after searching" do
+      fill_in "Search user by name or email", with: moderator2.email
+      click_button "Search"
+
+      click_link "Delete"
+
+      expect(page).to have_content(moderator1.email)
+      expect(page).not_to have_content(moderator2.email)
+    end
   end
 end


### PR DESCRIPTION
## Background

While displaying search results, we were offering the option to delete managers, moderators and administrators based on their user ID, instead of their manager/moderator/administrator ID.

## Objectives

* Delete the proper manager/moderator/administrator when clicking the "delete" button after searching for a certain manager/moderator/administrator
* Remove unnecessary code checking whether a manager/moderator/administrator is indeed a manager/moderator/administrator