### PR TITLE
Rename admin proposal notifications controller

### DIFF
--- a/app/controllers/admin/hidden_proposal_notifications_controller.rb
+++ b/app/controllers/admin/hidden_proposal_notifications_controller.rb
@@ -1,4 +1,4 @@
-class Admin::ProposalNotificationsController < Admin::BaseController
+class Admin::HiddenProposalNotificationsController < Admin::BaseController
   has_filters %w[without_confirmed_hide all with_confirmed_hide], only: :index
 
   before_action :load_proposal, only: [:confirm_hide, :restore]

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -25,7 +25,7 @@ module AdminHelper
 
   def moderated_sections
     ["hidden_proposals", "hidden_debates", "hidden_comments", "hidden_users", "activity",
-     "hidden_budget_investments"]
+     "hidden_budget_investments", "hidden_proposal_notifications"]
   end
 
   def menu_budgets?

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -172,8 +172,8 @@
           <%= link_to t("admin.menu.hidden_comments"), admin_hidden_comments_path %>
         </li>
 
-        <li <%= "class=is-active" if controller_name == "proposal_notifications" %>>
-          <%= link_to t("admin.menu.hidden_proposal_notifications"), admin_proposal_notifications_path %>
+        <li <%= "class=is-active" if controller_name == "hidden_proposal_notifications" %>>
+          <%= link_to t("admin.menu.hidden_proposal_notifications"), admin_hidden_proposal_notifications_path %>
         </li>
 
         <li <%= "class=is-active" if controller_name == "hidden_users" %>>

--- a/app/views/admin/hidden_proposal_notifications/index.html.erb
+++ b/app/views/admin/hidden_proposal_notifications/index.html.erb
@@ -1,7 +1,7 @@
-<h2><%= t("admin.proposal_notifications.index.title") %></h2>
+<h2><%= t("admin.hidden_proposal_notifications.index.title") %></h2>
 <p><%= t("admin.shared.moderated_content") %></p>
 
-<%= render "shared/filter_subnav", i18n_namespace: "admin.proposal_notifications.index" %>
+<%= render "shared/filter_subnav", i18n_namespace: "admin.hidden_proposal_notifications.index" %>
 
 <% if @proposal_notifications.any? %>
   <h3 class="margin"><%= page_entries_info @proposal_notifications %></h3>
@@ -25,13 +25,13 @@
         </td>
         <td class="align-top">
           <%= link_to t("admin.actions.restore"),
-                restore_admin_proposal_notification_path(proposal_notification, request.query_parameters),
+                restore_admin_hidden_proposal_notification_path(proposal_notification, request.query_parameters),
                 method: :put,
                 data: { confirm: t("admin.actions.confirm") },
                 class: "button hollow warning" %>
           <% unless proposal_notification.confirmed_hide? %>
             <%= link_to t("admin.actions.confirm_hide"),
-                  confirm_hide_admin_proposal_notification_path(proposal_notification, request.query_parameters),
+                  confirm_hide_admin_hidden_proposal_notification_path(proposal_notification, request.query_parameters),
                   method: :put,
                   class: "button" %>
           <% end %>
@@ -44,6 +44,6 @@
   <%= paginate @proposal_notifications %>
 <% else %>
   <div class="callout primary margin">
-    <%= t("admin.proposal_notifications.index.no_hidden_proposals") %>
+    <%= t("admin.hidden_proposal_notifications.index.no_hidden_proposals") %>
   </div>
 <% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -137,7 +137,7 @@ ignore_unused:
   - "admin.banners.index.filters.*"
   - "admin.hidden_debates.index.filter*"
   - "admin.hidden_proposals.index.filter*"
-  - "admin.proposal_notifications.index.filter*"
+  - "admin.hidden_proposal_notifications.index.filter*"
   - "admin.budgets.index.filter*"
   - "admin.budgets.edit.(administrators|valuators).*"
   - "admin.budget_investments.index.filter*"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1218,7 +1218,7 @@ en:
           without_confirmed_hide: Pending
         title: Hidden proposals
         no_hidden_proposals: There are no hidden proposals.
-    proposal_notifications:
+    hidden_proposal_notifications:
       index:
         filter: Filter
         filters:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1217,7 +1217,7 @@ es:
           without_confirmed_hide: Pendientes
         title: Propuestas ocultas
         no_hidden_proposals: No hay propuestas ocultas.
-    proposal_notifications:
+    hidden_proposal_notifications:
       index:
         filter: Filtro
         filters:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -44,7 +44,7 @@ namespace :admin do
     end
   end
 
-  resources :proposal_notifications, only: :index do
+  resources :hidden_proposal_notifications, only: :index do
     member do
       put :restore
       put :confirm_hide

--- a/spec/system/admin/proposal_notifications_spec.rb
+++ b/spec/system/admin/proposal_notifications_spec.rb
@@ -8,7 +8,7 @@ describe "Admin proposal notifications" do
 
   scenario "List shows all relevant info" do
     proposal_notification = create(:proposal_notification, :hidden)
-    visit admin_proposal_notifications_path
+    visit admin_hidden_proposal_notifications_path
 
     expect(page).to have_content(proposal_notification.title)
     expect(page).to have_content(proposal_notification.body)
@@ -16,7 +16,7 @@ describe "Admin proposal notifications" do
 
   scenario "Restore" do
     proposal_notification = create(:proposal_notification, :hidden, created_at: Date.current - 5.days)
-    visit admin_proposal_notifications_path
+    visit admin_hidden_proposal_notifications_path
 
     click_link "Restore"
 
@@ -29,7 +29,7 @@ describe "Admin proposal notifications" do
 
   scenario "Confirm hide" do
     proposal_notification = create(:proposal_notification, :hidden, created_at: Date.current - 5.days)
-    visit admin_proposal_notifications_path
+    visit admin_hidden_proposal_notifications_path
 
     click_link "Confirm moderation"
 
@@ -41,22 +41,22 @@ describe "Admin proposal notifications" do
   end
 
   scenario "Current filter is properly highlighted" do
-    visit admin_proposal_notifications_path
+    visit admin_hidden_proposal_notifications_path
     expect(page).not_to have_link("Pending")
     expect(page).to have_link("All")
     expect(page).to have_link("Confirmed")
 
-    visit admin_proposal_notifications_path(filter: "Pending")
+    visit admin_hidden_proposal_notifications_path(filter: "Pending")
     expect(page).not_to have_link("Pending")
     expect(page).to have_link("All")
     expect(page).to have_link("Confirmed")
 
-    visit admin_proposal_notifications_path(filter: "all")
+    visit admin_hidden_proposal_notifications_path(filter: "all")
     expect(page).to have_link("Pending")
     expect(page).not_to have_link("All")
     expect(page).to have_link("Confirmed")
 
-    visit admin_proposal_notifications_path(filter: "with_confirmed_hide")
+    visit admin_hidden_proposal_notifications_path(filter: "with_confirmed_hide")
     expect(page).to have_link("All")
     expect(page).to have_link("Pending")
     expect(page).not_to have_link("Confirmed")
@@ -66,15 +66,15 @@ describe "Admin proposal notifications" do
     create(:proposal_notification, :hidden, title: "Unconfirmed notification")
     create(:proposal_notification, :hidden, :with_confirmed_hide, title: "Confirmed notification")
 
-    visit admin_proposal_notifications_path(filter: "pending")
+    visit admin_hidden_proposal_notifications_path(filter: "pending")
     expect(page).to have_content("Unconfirmed notification")
     expect(page).not_to have_content("Confirmed notification")
 
-    visit admin_proposal_notifications_path(filter: "all")
+    visit admin_hidden_proposal_notifications_path(filter: "all")
     expect(page).to have_content("Unconfirmed notification")
     expect(page).to have_content("Confirmed notification")
 
-    visit admin_proposal_notifications_path(filter: "with_confirmed_hide")
+    visit admin_hidden_proposal_notifications_path(filter: "with_confirmed_hide")
     expect(page).not_to have_content("Unconfirmed notification")
     expect(page).to have_content("Confirmed notification")
   end
@@ -83,7 +83,7 @@ describe "Admin proposal notifications" do
     allow(ProposalNotification).to receive(:default_per_page).and_return(2)
     4.times { create(:proposal_notification, :hidden, :with_confirmed_hide) }
 
-    visit admin_proposal_notifications_path(filter: "with_confirmed_hide", page: 2)
+    visit admin_hidden_proposal_notifications_path(filter: "with_confirmed_hide", page: 2)
 
     click_on("Restore", match: :first, exact: true)
 


### PR DESCRIPTION
## References

* A similar change was done in pull request #3376

## Objectives

Make all controllers dealing with hidden content use the word "hidden", so the code is consistent and easier to refactor.