### PR TITLE
Remove unused document section on polls

### DIFF
--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -43,13 +43,6 @@
         <h3><%= t("polls.show.more_info_title") %></h3>
         <%= auto_link_already_sanitized_html simple_format(@poll.description) %>
       </div>
-
-      <% if false %>
-        <aside class="small-12 medium-3 column">
-          <div class="sidebar-divider"></div>
-          <h2><%= t("polls.show.documents") %></h2>
-        </aside>
-      <% end %>
     </div>
   </div>
 


### PR DESCRIPTION
## Objectives

This section is not used because it's only possible to add documents to the poll's answers, not to the poll itself.

## Notes

The `<% if false %>` was [added 3 years ago](https://github.com/consul/consul/commit/70a35fbe58221bf6bd7a04683f9a5a432b9b39dd#diff-9d7534803a942c4e1527d539936492ecR46) so effectively this section is not being used.

The key `t("polls.show.documents")` is still used in another part of the view so it is not necessary to remove it.
