### PR TITLE
Improve test checking order by relevance

### DIFF
--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -503,7 +503,8 @@ describe Debate do
     end
 
     context "stemming" do
-      it "searches word stems in Spanish", :spanish_search do
+      it "searches word stems in Spanish" do
+        allow(SearchDictionarySelector).to receive(:call).and_return("spanish")
         debate = create(:debate, title: "limpiar")
 
         results = Debate.search("limpiará")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,10 +99,6 @@ RSpec.configure do |config|
     allow(Time).to receive(:zone).and_return(application_zone)
   end
 
-  config.before(:each, :spanish_search) do |example|
-    allow(SearchDictionarySelector).to receive(:call).and_return("spanish")
-  end
-
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options.
   config.example_status_persistence_file_path = "spec/examples.txt"

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -1409,21 +1409,21 @@ describe "Proposals" do
       end
     end
 
-    scenario "Order by relevance by default", :spanish_search, :js do
-      create(:proposal, title: "Show you got",      cached_votes_up: 10)
-      create(:proposal, title: "Show what you got", cached_votes_up: 1)
-      create(:proposal, title: "Show you got",      cached_votes_up: 100)
+    scenario "Order by relevance by default", :js do
+      create(:proposal, title: "In summary", summary: "Title content too", cached_votes_up: 10)
+      create(:proposal, title: "Title content", summary: "Summary", cached_votes_up: 1)
+      create(:proposal, title: "Title here", summary: "Content here", cached_votes_up: 100)
 
       visit proposals_path
-      fill_in "search", with: "Show what you got"
+      fill_in "search", with: "Title content"
       click_button "Search"
 
       expect(page).to have_selector("a.is-active", text: "relevance")
 
       within("#proposals") do
-        expect(all(".proposal")[0].text).to match "Show what you got"
-        expect(all(".proposal")[1].text).to match "Show you got"
-        expect(all(".proposal")[2].text).to match "Show you got"
+        expect(all(".proposal")[0].text).to match "Title content"
+        expect(all(".proposal")[1].text).to match "Title here"
+        expect(all(".proposal")[2].text).to match "In summary"
       end
     end
 


### PR DESCRIPTION
## References

* Fixes an issue we found while working on pull request #3856

## Objectives

Properly test results are ordered by relevance, using the right dictionary.

## Notes

The test wasn't working when postgres used the English dictionary because in English the word "what" was ignored (or, at least, not given enough relevance) while searching. When we wrote the test, it passed because back then we always used the Spanish dictionary. However, when
we switched to a dictionary based on the default locale (in commit d99875cd), we had to force this test to keep using the Spanish dictionary.

Using the Spanish dictionary in a test where all texts are in English is strange to say the least :wink:. So here we're making the test a bit easier to understand.