### PR TITLE
Allow deleting polls with answers including videos

### DIFF
--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -9,7 +9,7 @@ class Poll::Question::Answer < ApplicationRecord
   accepts_nested_attributes_for :documents, allow_destroy: true
 
   belongs_to :question, class_name: "Poll::Question"
-  has_many :videos, class_name: "Poll::Question::Answer::Video"
+  has_many :videos, class_name: "Poll::Question::Answer::Video", dependent: :destroy
 
   validates_translation :title, presence: true
   validates :given_order, presence: true, uniqueness: { scope: :question_id }

--- a/spec/system/admin/poll/polls_spec.rb
+++ b/spec/system/admin/poll/polls_spec.rb
@@ -145,6 +145,19 @@ describe "Admin polls" do
       expect(Poll::Question::Answer.count).to eq(0)
     end
 
+    scenario "Can destroy polls with answers including videos", :js do
+      poll = create(:poll, name: "Do you support CONSUL?")
+      create(:poll_answer_video, poll: poll)
+
+      visit admin_polls_path
+
+      within(".poll", text: "Do you support CONSUL?") do
+        accept_confirm { click_link "Delete" }
+      end
+
+      expect(page).to have_content "Poll deleted successfully"
+    end
+
     scenario "Can't destroy poll with votes", :js do
       poll = create(:poll)
       create(:poll_question, poll: poll)


### PR DESCRIPTION
## Objectives

Avoid the following error when trying to delete a poll with answers that contain videos.
```
PG::ForeignKeyViolation: ERROR: update or delete on table "poll_question_answers" violates 
foreign key constraint "fk_rails_52941e957e" on table "poll_question_answer_videos" 
DETAIL: Key (id)=(1) is still referenced from table "poll_question_answer_videos". : 
DELETE FROM "poll_question_answers" WHERE "poll_question_answers"."id" = $1
```
Added the option `dependent: :destroy` to the `has_many` relation