### PR TITLE
Deactivate GraphQL API feature by default

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -99,7 +99,7 @@ class Setting < ApplicationRecord
         "feature.translation_interface": nil,
         "feature.remote_census": nil,
         "feature.valuation_comment_notification": true,
-        "feature.graphql_api": true,
+        "feature.graphql_api": false,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/spec/controllers/graphql_controller_spec.rb
+++ b/spec/controllers/graphql_controller_spec.rb
@@ -10,6 +10,7 @@ end
 
 describe GraphqlController, type: :request do
   let(:proposal) { create(:proposal) }
+  before { Setting["feature.graphql_api"] = true }
 
   describe "handles GET request" do
     specify "with query string inside query params" do


### PR DESCRIPTION
## References

* The option to enable/disable our GraphQL API was introduced in pull request #2151
* In pull request #4028 we stopped loading GraphQL definitions when the application starts

## Objectives

Disable the GraphQL API by default, since it's a feature which most Consul installations don't use.

## Notes

* TODO: update the documentation, and disable access to /graphiql when this feature is disabled

Existing installations will not be affected by this change.