### PR TITLE
Fix race condition with ballot lines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ end
 group :development, :test do
   gem "bullet", "~> 5.9.0"
   gem "byebug", "~> 11.1.1"
+  gem "database_cleaner", "~> 1.7.0"
   gem "factory_bot_rails", "~> 4.8.2"
   gem "faker", "~> 1.8.7"
   gem "i18n-tasks", "~> 0.9.29"
@@ -94,7 +95,6 @@ group :development do
   gem "capistrano-rails", "~> 1.4.0", require: false
   gem "capistrano3-delayed-job", "~> 1.7.3"
   gem "capistrano3-puma", "~> 4.0.0"
-  gem "database_cleaner", "~> 1.7.0"
   gem "erb_lint", require: false
   gem "github_changelog_generator", "~> 1.15.0"
   gem "mdl", "~> 0.5.0", require: false

--- a/app/models/budget/ballot/line.rb
+++ b/app/models/budget/ballot/line.rb
@@ -19,6 +19,7 @@ class Budget
       after_save :store_user_heading
 
       def check_sufficient_funds
+        ballot.lock!
         errors.add(:money, "insufficient funds") if ballot.amount_available(investment.heading) < investment.price.to_i
       end
 

--- a/spec/models/budget/stats_spec.rb
+++ b/spec/models/budget/stats_spec.rb
@@ -10,11 +10,13 @@ describe Budget::Stats do
     let!(:author_and_voter) { create(:user, :hidden, votables: [investment]) }
     let!(:voter) { create(:user, votables: [investment]) }
     let!(:voter_and_balloter) { create(:user, votables: [investment], ballot_lines: [investment]) }
-    let!(:balloter) { create(:user, :hidden, ballot_lines: [investment]) }
+    let!(:balloter) { create(:user, ballot_lines: [investment]) }
     let!(:poll_balloter) { create(:user, :level_two) }
     let!(:non_participant) { create(:user, :level_two) }
 
     before do
+      balloter.hide
+
       create(:budget_investment, :selected, budget: budget, author: author_and_voter)
 
       create(:poll_voter, :from_booth, user: poll_balloter, budget: budget)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,15 @@ RSpec.configure do |config|
     Setting["feature.user.skip_verification"] = nil
   end
 
+  config.around(:each, :race_condition) do |example|
+    self.use_transactional_tests = false
+    example.run
+    self.use_transactional_tests = true
+
+    DatabaseCleaner.clean_with(:truncation)
+    Rails.application.load_seed
+  end
+
   config.before(:each, type: :system) do
     Capybara::Webmock.start
   end


### PR DESCRIPTION
## Backgroud

With two concurrent requests, it's possible to create two ballot lines when only one of them should be created.

The reason is the code validating the line is not thread safe:

```
errors.add(:money, "insufficient funds") if ballot.amount_available(investment.heading) < investment.price.to_i
```

If the second request executes this code after the first request has executed it but before the first request has saved the record to the database, both records will pass this validation and both will be saved to the database.

## Objectives

Introduce a lock in the database, so when the second request tries to lock the ballot, it finds it's already locked by the first request and waits for the transaction of the first request to finish before checking whether there are sufficient funds.