### PR TITLE
Show Wordpress login button if it's the only one enabled

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1548,6 +1548,16 @@ table {
   line-height: $line-height * 2;
   padding: 0;
   position: relative;
+
+  &::before {
+    font-family: "icons" !important;
+    font-size: rem-calc(24);
+    left: 0;
+    line-height: $line-height * 2;
+    padding: 0 rem-calc(20);
+    position: absolute;
+    top: 0;
+  }
 }
 
 .button.button-twitter {
@@ -1557,13 +1567,6 @@ table {
   &::before {
     color: #45b0e3;
     content: "f";
-    font-family: "icons" !important;
-    font-size: rem-calc(24);
-    left: 0;
-    line-height: $line-height * 2;
-    padding: 0 rem-calc(20);
-    position: absolute;
-    top: 0;
   }
 }
 
@@ -1600,13 +1603,6 @@ table {
   &::before {
     color: #3b5998;
     content: "A";
-    font-family: "icons" !important;
-    font-size: rem-calc(24);
-    left: 0;
-    line-height: $line-height * 2;
-    padding: 0 rem-calc(20);
-    position: absolute;
-    top: 0;
   }
 }
 
@@ -1643,13 +1639,6 @@ table {
   &::before {
     color: #de4c34;
     content: "B";
-    font-family: "icons" !important;
-    font-size: rem-calc(24);
-    left: 0;
-    line-height: $line-height * 2;
-    padding: 0 rem-calc(20);
-    position: absolute;
-    top: 0;
   }
 }
 
@@ -1660,13 +1649,6 @@ table {
   &::before {
     color: #2f2f33;
     content: "J";
-    font-family: "icons" !important;
-    font-size: rem-calc(24);
-    left: 0;
-    line-height: $line-height * 2;
-    padding: 0 rem-calc(20);
-    position: absolute;
-    top: 0;
   }
 }
 
@@ -1677,13 +1659,6 @@ table {
   &::before {
     color: #08c;
     content: "1";
-    font-family: "icons" !important;
-    font-size: rem-calc(24);
-    left: 0;
-    line-height: $line-height * 2;
-    padding: 0 rem-calc(20);
-    position: absolute;
-    top: 0;
   }
 }
 

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,4 +1,13 @@
 module SettingsHelper
+  def oauth_logins
+    [
+      (:twitter if feature?(:twitter_login)),
+      (:facebook if feature?(:facebook_login)),
+      (:google_oauth2 if feature?(:google_login)),
+      (:wordpress_oauth2 if feature?(:wordpress_login))
+    ].compact
+  end
+
   def feature?(name)
     setting["feature.#{name}"].presence || setting["process.#{name}"].presence
   end

--- a/app/views/devise/_omniauth_form.html.erb
+++ b/app/views/devise/_omniauth_form.html.erb
@@ -1,103 +1,49 @@
 <% if feature?(:twitter_login) || feature?(:facebook_login) || feature?(:google_login) %>
-
-  <% if current_page?(new_user_session_path) %>
-    <div class="row">
-      <div class="small-12 column">
-        <div class="margin-bottom">
-          <strong><%= t("omniauth.info_sign_in") %></strong>
-        </div>
-      </div>
-
-      <% if feature? :twitter_login %>
-        <div class="small-12 medium-6 large-4 column end">
-          <%= link_to t("omniauth.twitter.name"), user_twitter_omniauth_authorize_path,
-                      title: t("omniauth.twitter.sign_in"),
-                      class: "button-twitter button expanded",
-                      method: :post %>
-        </div>
-      <% end %>
-
-      <% if feature? :facebook_login %>
-        <div class="small-12 medium-6 large-4 column end">
-          <%= link_to t("omniauth.facebook.name"), user_facebook_omniauth_authorize_path,
-                      title: t("omniauth.facebook.sign_in"),
-                      class: "button-facebook button expanded",
-                      method: :post %>
-        </div>
-      <% end %>
-
-      <% if feature? :google_login %>
-        <div class="small-12 medium-6 large-4 column end">
-          <%= link_to t("omniauth.google_oauth2.name"), user_google_oauth2_omniauth_authorize_path,
-                      title: t("omniauth.google_oauth2.sign_in"),
-                      class: "button-google button expanded",
-                      method: :post %>
-        </div>
-      <% end %>
-
-      <% if feature? :wordpress_login %>
-        <div class="small-12 medium-6 large-4 column end">
-          <%= link_to t("omniauth.wordpress_oauth2.name"), user_wordpress_oauth2_omniauth_authorize_path,
-                      title: t("omniauth.wordpress_oauth2.sign_in"),
-                      class: "button-wordpress button expanded",
-                      method: :post %>
-        </div>
-      <% end %>
-
-      <div class="small-12 column auth-divider">
-        <span><%= t("omniauth.or_fill") %></span>
+  <div class="row">
+    <div class="small-12 column">
+      <div class="margin-bottom">
+        <strong><%= t("omniauth.info.#{action}") %></strong>
       </div>
     </div>
 
-  <% elsif current_page?(new_user_registration_path) %>
-    <div class="row">
-      <div class="small-12 column">
-        <div class="margin-bottom">
-          <strong><%= t("omniauth.info_sign_up") %></strong>
-        </div>
+    <% if feature? :twitter_login %>
+      <div class="small-12 medium-6 large-4 column end">
+        <%= link_to t("omniauth.twitter.name"), user_twitter_omniauth_authorize_path,
+                    title: t("omniauth.twitter.#{action}"),
+                    class: "button-twitter button expanded",
+                    method: :post %>
       </div>
+    <% end %>
 
-      <% if feature? :twitter_login %>
-        <div class="small-12 medium-6 large-4 column end">
-          <%= link_to t("omniauth.twitter.name"), user_twitter_omniauth_authorize_path,
-                      title: t("omniauth.twitter.sign_up"),
-                      class: "button-twitter button expanded",
-                      method: :post %>
-        </div>
-      <% end %>
-
-      <% if feature? :facebook_login %>
-        <div class="small-12 medium-6 large-4 column end">
-          <%= link_to t("omniauth.facebook.name"), user_facebook_omniauth_authorize_path,
-                      title: t("omniauth.facebook.sign_up"),
-                      class: "button-facebook button expanded",
-                      method: :post %>
-        </div>
-      <% end %>
-
-      <% if feature? :google_login %>
-        <div class="small-12 medium-6 large-4 column end">
-          <%= link_to t("omniauth.google_oauth2.name"), user_google_oauth2_omniauth_authorize_path,
-                      title: t("omniauth.google_oauth2.sign_up"),
-                      class: "button-google button expanded",
-                      method: :post %>
-
-        </div>
-      <% end %>
-
-      <% if feature? :wordpress_login %>
-        <div class="small-12 medium-6 large-4 column end">
-          <%= link_to t("omniauth.wordpress_oauth2.name"), user_wordpress_oauth2_omniauth_authorize_path,
-                      title: t("omniauth.wordpress_oauth2.sign_up"),
-                      class: "button-wordpress button expanded",
-                      method: :post %>
-        </div>
-      <% end %>
-
-      <div class="small-12 column auth-divider">
-        <span><%= t("omniauth.or_fill") %></span>
+    <% if feature? :facebook_login %>
+      <div class="small-12 medium-6 large-4 column end">
+        <%= link_to t("omniauth.facebook.name"), user_facebook_omniauth_authorize_path,
+                    title: t("omniauth.facebook.#{action}"),
+                    class: "button-facebook button expanded",
+                    method: :post %>
       </div>
+    <% end %>
+
+    <% if feature? :google_login %>
+      <div class="small-12 medium-6 large-4 column end">
+        <%= link_to t("omniauth.google_oauth2.name"), user_google_oauth2_omniauth_authorize_path,
+                    title: t("omniauth.google_oauth2.#{action}"),
+                    class: "button-google button expanded",
+                    method: :post %>
+      </div>
+    <% end %>
+
+    <% if feature? :wordpress_login %>
+      <div class="small-12 medium-6 large-4 column end">
+        <%= link_to t("omniauth.wordpress_oauth2.name"), user_wordpress_oauth2_omniauth_authorize_path,
+                    title: t("omniauth.wordpress_oauth2.#{action}"),
+                    class: "button-wordpress button expanded",
+                    method: :post %>
+      </div>
+    <% end %>
+
+    <div class="small-12 column auth-divider">
+      <span><%= t("omniauth.or_fill") %></span>
     </div>
-  <% end %>
-
+  </div>
 <% end %>

--- a/app/views/devise/_omniauth_form.html.erb
+++ b/app/views/devise/_omniauth_form.html.erb
@@ -6,38 +6,11 @@
       </div>
     </div>
 
-    <% if feature? :twitter_login %>
+    <% oauth_logins.each do |login| %>
       <div class="small-12 medium-6 large-4 column end">
-        <%= link_to t("omniauth.twitter.name"), user_twitter_omniauth_authorize_path,
-                    title: t("omniauth.twitter.#{action}"),
-                    class: "button-twitter button expanded",
-                    method: :post %>
-      </div>
-    <% end %>
-
-    <% if feature? :facebook_login %>
-      <div class="small-12 medium-6 large-4 column end">
-        <%= link_to t("omniauth.facebook.name"), user_facebook_omniauth_authorize_path,
-                    title: t("omniauth.facebook.#{action}"),
-                    class: "button-facebook button expanded",
-                    method: :post %>
-      </div>
-    <% end %>
-
-    <% if feature? :google_login %>
-      <div class="small-12 medium-6 large-4 column end">
-        <%= link_to t("omniauth.google_oauth2.name"), user_google_oauth2_omniauth_authorize_path,
-                    title: t("omniauth.google_oauth2.#{action}"),
-                    class: "button-google button expanded",
-                    method: :post %>
-      </div>
-    <% end %>
-
-    <% if feature? :wordpress_login %>
-      <div class="small-12 medium-6 large-4 column end">
-        <%= link_to t("omniauth.wordpress_oauth2.name"), user_wordpress_oauth2_omniauth_authorize_path,
-                    title: t("omniauth.wordpress_oauth2.#{action}"),
-                    class: "button-wordpress button expanded",
+        <%= link_to t("omniauth.#{login}.name"), send("user_#{login}_omniauth_authorize_path"),
+                    title: t("omniauth.#{login}.#{action}"),
+                    class: "button-#{login.to_s.delete_suffix("_oauth2")} button expanded",
                     method: :post %>
       </div>
     <% end %>

--- a/app/views/devise/_omniauth_form.html.erb
+++ b/app/views/devise/_omniauth_form.html.erb
@@ -1,4 +1,4 @@
-<% if feature?(:twitter_login) || feature?(:facebook_login) || feature?(:google_login) %>
+<% if oauth_logins.any? %>
   <div class="row">
     <div class="small-12 column">
       <div class="margin-bottom">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <% provide :title do %><%= t("devise_views.sessions.new.title") %><% end %>
 <h2><%= t("devise_views.sessions.new.title") %></h2>
 
-<%= render "devise/omniauth_form" %>
+<%= render "devise/omniauth_form", action: "sign_in" %>
 
 <p>
   <%= sanitize(t("devise_views.shared.links.signup",

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <% provide :title do %><%= t("devise_views.users.registrations.new.title") %><% end %>
 <h2><%= t("devise_views.users.registrations.new.title") %></h2>
 
-<%= render "devise/omniauth_form" %>
+<%= render "devise/omniauth_form", action: "sign_up" %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "shared/errors", resource: resource %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -299,8 +299,9 @@ en:
       sign_in: Sign in with Twitter
       sign_up: Sign up with Twitter
       name: Twitter
-    info_sign_in: "Sign in with:"
-    info_sign_up: "Sign up with:"
+    info:
+      sign_in: "Sign in with:"
+      sign_up: "Sign up with:"
     or_fill: "Or fill the following form:"
   proposals:
     create:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -299,8 +299,9 @@ es:
       sign_in: Entra con Twitter
       sign_up: Regístrate con Twitter
       name: Twitter
-    info_sign_in: "Entra con:"
-    info_sign_up: "Regístrate con:"
+    info:
+      sign_in: "Entra con:"
+      sign_up: "Regístrate con:"
     or_fill: "O rellena el siguiente formulario:"
   proposals:
     create:

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -100,6 +100,103 @@ describe "Users" do
   end
 
   context "OAuth authentication" do
+    context "Form buttons" do
+      before do
+        Setting["feature.facebook_login"] = false
+        Setting["feature.twitter_login"] = false
+        Setting["feature.google_login"] = false
+        Setting["feature.wordpress_login"] = false
+      end
+
+      scenario "No button will appear if all features are disabled" do
+        visit new_user_registration_path
+
+        expect(page).not_to have_link "Twitter"
+        expect(page).not_to have_link "Facebook"
+        expect(page).not_to have_link "Google"
+        expect(page).not_to have_link "Wordpress"
+
+        visit new_user_session_path
+
+        expect(page).not_to have_link "Twitter"
+        expect(page).not_to have_link "Facebook"
+        expect(page).not_to have_link "Google"
+        expect(page).not_to have_link "Wordpress"
+      end
+
+      scenario "Twitter login button will appear if feature is enabled" do
+        Setting["feature.twitter_login"] = true
+
+        visit new_user_registration_path
+
+        expect(page).to have_link "Twitter"
+        expect(page).not_to have_link "Facebook"
+        expect(page).not_to have_link "Google"
+        expect(page).not_to have_link "Wordpress"
+
+        visit new_user_session_path
+
+        expect(page).to have_link "Twitter"
+        expect(page).not_to have_link "Facebook"
+        expect(page).not_to have_link "Google"
+        expect(page).not_to have_link "Wordpress"
+      end
+
+      scenario "Facebook login button will appear if feature is enabled" do
+        Setting["feature.facebook_login"] = true
+
+        visit new_user_registration_path
+
+        expect(page).not_to have_link "Twitter"
+        expect(page).to have_link "Facebook"
+        expect(page).not_to have_link "Google"
+        expect(page).not_to have_link "Wordpress"
+
+        visit new_user_session_path
+
+        expect(page).not_to have_link "Twitter"
+        expect(page).to have_link "Facebook"
+        expect(page).not_to have_link "Google"
+        expect(page).not_to have_link "Wordpress"
+      end
+
+      scenario "Google login button will appear if feature is enabled" do
+        Setting["feature.google_login"] = true
+
+        visit new_user_registration_path
+
+        expect(page).not_to have_link "Twitter"
+        expect(page).not_to have_link "Facebook"
+        expect(page).to have_link "Google"
+        expect(page).not_to have_link "Wordpress"
+
+        visit new_user_session_path
+
+        expect(page).not_to have_link "Twitter"
+        expect(page).not_to have_link "Facebook"
+        expect(page).to have_link "Google"
+        expect(page).not_to have_link "Wordpress"
+      end
+
+      scenario "Wordpress login button will appear if feature is enabled" do
+        Setting["feature.wordpress_login"] = true
+
+        visit new_user_registration_path
+
+        expect(page).not_to have_link "Twitter"
+        expect(page).not_to have_link "Facebook"
+        expect(page).not_to have_link "Google"
+        expect(page).to have_link "Wordpress"
+
+        visit new_user_session_path
+
+        expect(page).not_to have_link "Twitter"
+        expect(page).not_to have_link "Facebook"
+        expect(page).not_to have_link "Google"
+        expect(page).to have_link "Wordpress"
+      end
+    end
+
     context "Twitter" do
       let(:twitter_hash) { { provider: "twitter", uid: "12345", info: { name: "manuela" }} }
       let(:twitter_hash_with_email) { { provider: "twitter", uid: "12345", info: { name: "manuela", email: "manuelacarmena@example.com" }} }


### PR DESCRIPTION
## References

Wordpress login was introduced in PR https://github.com/consul/consul/pull/3902 but a BUG was also introduced, the button will not appear if Wordpress login is the only one external authentication feature enabled.

## Objectives

- Fix the BUG and show the Wordpress login button if it's the only one enabled.

