### PR TITLE
Allow links and images on legislation drafts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
       superscript:        true
     }
 
-    sanitize(Redcarpet::Markdown.new(renderer, extensions).render(text))
+    AdminLegislationSanitizer.new.sanitize(Redcarpet::Markdown.new(renderer, extensions).render(text))
   end
 
   def wysiwyg(text)

--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -57,7 +57,7 @@
 
         <div data-sticky-container>
           <div data-sticky data-anchor="sticky-panel" class="draft-index sticky" data-tree-navigator>
-            <%= sanitize(@draft_version.toc_html) %>
+            <%= AdminLegislationSanitizer.new.sanitize(@draft_version.toc_html) %>
           </div>
         </div>
       </div>
@@ -74,7 +74,7 @@
                    data-legislation-annotatable-base-url="<%= legislation_process_draft_version_path(@process, @draft_version) %>"
                    data-legislation-open-phase="<%= @process.allegations_phase.open? %>">
           <% end %>
-            <%= sanitize(@draft_version.body_html, { attributes: ["id"] }) %>
+            <%= AdminLegislationSanitizer.new.sanitize(@draft_version.body_html) %>
           </section>
         </div>
       </div>

--- a/lib/admin_legislation_sanitizer.rb
+++ b/lib/admin_legislation_sanitizer.rb
@@ -1,0 +1,9 @@
+class AdminLegislationSanitizer < WYSIWYGSanitizer
+  def allowed_tags
+    super + %w[img h1 h4 h5 h6]
+  end
+
+  def allowed_attributes
+    super + %w[alt src id]
+  end
+end

--- a/spec/system/xss_spec.rb
+++ b/spec/system/xss_spec.rb
@@ -164,12 +164,15 @@ describe "Cross-Site Scripting protection", :js do
     expect(page.text).not_to be_empty
   end
 
-  scenario "legislation version body filters script tags but not header IDs" do
-    version = create(:legislation_draft_version, :published, body: "# Title 1\n#{attack_code}")
+  scenario "legislation version body filters script tags but not header IDs nor tags like images" do
+    markdown = "# Title 1\n<a href='https://domain.com/url'>link</a><img src='/image.png'>"
+    version = create(:legislation_draft_version, :published, body: "#{markdown}#{attack_code}")
 
     visit legislation_process_draft_version_path(version.process, version)
 
     expect(page.text).not_to be_empty
     expect(page).to have_css "h1#title-1", text: "Title 1"
+    expect(page).to have_link "link", href: "https://domain.com/url"
+    expect(page).to have_css('img[src="/image.png"')
   end
 end


### PR DESCRIPTION
## References

* This bug was introduced in commit 9eee79f21

## Background

Some CONSUL users did have links and/or images on their legislation drafts. They claimed that after upgrading to version 1.1.0 the links and images are gone.

## Objectives

Allow links and images on legislation drafts.