### PR TITLE
Do not delete users when deleting legislation answers

### DIFF
--- a/app/models/legislation/answer.rb
+++ b/app/models/legislation/answer.rb
@@ -5,7 +5,7 @@ class Legislation::Answer < ApplicationRecord
   belongs_to :question, foreign_key: "legislation_question_id", inverse_of: :answers, counter_cache: true
   belongs_to :question_option, foreign_key: "legislation_question_option_id",
                                inverse_of: :answers, counter_cache: true
-  belongs_to :user, dependent: :destroy, inverse_of: :legislation_answers
+  belongs_to :user, inverse_of: :legislation_answers
 
   validates :question, presence: true, uniqueness: { scope: :user_id }
   validates :question_option, presence: true

--- a/spec/models/legislation/answer_spec.rb
+++ b/spec/models/legislation/answer_spec.rb
@@ -36,4 +36,12 @@ RSpec.describe Legislation::Answer, type: :model do
     expect(option_2.answers_count).to eq 1
     expect(option_1.answers_count).to eq 0
   end
+
+  it "does not delete users that created the answer" do
+    user = legislation_answer.user
+
+    legislation_answer.destroy!
+
+    expect(user).not_to be_hidden
+  end
 end


### PR DESCRIPTION
## Objectives

When a legislation process is deleted, everything related will be deleted, including the answers. This `dependent: :destroy` was causing that users accounts were being accidentally deleted.