### PR TITLE
Remove redundant calls to load resources

### DIFF
--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -2,7 +2,7 @@ module Budgets
   class ExecutionsController < ApplicationController
     before_action :load_budget
 
-    load_and_authorize_resource :budget
+    authorize_resource :budget
 
     def show
       authorize! :read_executions, @budget

--- a/app/controllers/budgets/groups_controller.rb
+++ b/app/controllers/budgets/groups_controller.rb
@@ -2,8 +2,8 @@ module Budgets
   class GroupsController < ApplicationController
     before_action :load_budget
     before_action :load_group
-    load_and_authorize_resource :budget
-    load_and_authorize_resource :group, class: "Budget::Group"
+    authorize_resource :budget
+    authorize_resource :group, class: "Budget::Group"
 
     before_action :set_default_budget_filter, only: :show
     has_filters %w[not_unfeasible feasible unfeasible unselected selected winners], only: [:show]

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -12,7 +12,7 @@ module Budgets
     before_action :authenticate_user!, except: [:index, :show, :json_data]
     before_action :load_budget, except: :json_data
 
-    load_and_authorize_resource :budget, except: :json_data
+    authorize_resource :budget, except: :json_data
     load_and_authorize_resource :investment, through: :budget, class: "Budget::Investment",
                                 except: :json_data
 

--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -3,7 +3,7 @@ module Budgets
     before_action :load_budget
     before_action :load_heading
 
-    load_and_authorize_resource :budget
+    authorize_resource :budget
 
     def show
       authorize! :read_results, @budget

--- a/app/controllers/budgets/stats_controller.rb
+++ b/app/controllers/budgets/stats_controller.rb
@@ -1,7 +1,7 @@
 module Budgets
   class StatsController < ApplicationController
     before_action :load_budget
-    load_and_authorize_resource :budget
+    authorize_resource :budget
 
     def show
       authorize! :read_stats, @budget


### PR DESCRIPTION
## References
I've seen this [commit](https://github.com/consul/consul/pull/4062/commits/aff213b0ef5f8725925a49572e7c6d9e662eaffe) from @javierm and I found it interesting to apply it to some controllers.

## Objectives
We already load resources in `before_action` calls, so we don't have to load them again.