### PR TITLE
Use complete keys on legislation translations

### DIFF
--- a/app/views/admin/legislation/draft_versions/index.html.erb
+++ b/app/views/admin/legislation/draft_versions/index.html.erb
@@ -38,7 +38,8 @@
             <td>
               <% if draft_version.status == "draft" %>
                 <%= Legislation::DraftVersion.human_attribute_name(:status_draft) %>
-                <%= link_to "(#{t(".preview")})", legislation_process_draft_version_path(@process, draft_version) %>
+                <%= link_to "(#{t("admin.legislation.draft_versions.index.preview")})",
+                            legislation_process_draft_version_path(@process, draft_version) %>
               <% else %>
                 <%= Legislation::DraftVersion.human_attribute_name(:status_published) %>
               <% end %>

--- a/app/views/legislation/annotations/_version_chooser.html.erb
+++ b/app/views/legislation/annotations/_version_chooser.html.erb
@@ -1,6 +1,6 @@
 <div class="row draft-chooser">
   <div class="small-12 medium-9 column">
-    <h3><%= t(".seeing_version") %></h3>
+    <h3><%= t("legislation.annotations.version_chooser.seeing_version") %></h3>
     <div class="select-box">
       <%= form_tag go_to_version_legislation_process_draft_versions_path(process), method: :get, id: "draft_version_go_to_version" do %>
         <%= select_tag "draft_version_id", options_from_collection_for_select(process.draft_versions.published, "id", "display_title", draft_version.id), "aria-label": t("legislation.draft_versions.show.select_draft_version") %>
@@ -11,8 +11,9 @@
     <span><%= t("legislation.draft_versions.show.updated_at", date: format_date(@draft_version.updated_at)) %></span>
   </div>
   <div class="small-12 medium-3 column">
-    <%= link_to legislation_process_draft_version_path(process, draft_version), title: t(".see_text"), class: "button" do %>
-      <%= t(".see_text") %>
+    <%= link_to legislation_process_draft_version_path(process, draft_version),
+                title: t("legislation.annotations.version_chooser.see_text"), class: "button" do %>
+      <%= t("legislation.annotations.version_chooser.see_text") %>
     <% end %>
   </div>
 </div>

--- a/app/views/legislation/annotations/index.html.erb
+++ b/app/views/legislation/annotations/index.html.erb
@@ -1,4 +1,6 @@
-<% provide :title do %><%= "#{t(".title")} - #{@draft_version.title} - #{@process.title}" %><% end %>
+<% provide :title do %>
+  <%= "#{t("legislation.annotations.index.title")} - #{@draft_version.title} - #{@process.title}" %>
+<% end %>
 
 <%= render "legislation/processes/header", process: @process, header: :small %>
 
@@ -15,17 +17,21 @@
 
     <% @annotations.each do |annotation| %>
       <div class="comment">
-        <strong><%= t(".comments_about") %></strong>
+        <strong><%= t("legislation.annotations.index.comments_about") %></strong>
         <span class="float-right">
           <%= link_to legislation_process_draft_version_path(@process, @draft_version, anchor: "annotation-id-#{annotation.id}") do %>
-            <span><%= t(".see_in_context") %></span> <span class="icon-expand" aria-hidden="true"></span>
+            <span><%= t("legislation.annotations.index.see_in_context") %></span>
+            <span class="icon-expand" aria-hidden="true"></span>
           <% end %>
         </span>
         <div class="comment-section">
           <%= sanitize(annotation.context).presence || annotation.quote %>
         </div>
         <%= link_to legislation_process_draft_version_annotation_path(@process, @draft_version, annotation) do %>
-          <span class="icon-comments" aria-hidden="true"></span> <span><%= t(".comments_count", count: annotation.comments_count) %></span></a>
+          <span class="icon-comments" aria-hidden="true"></span>
+          <span>
+            <%= t("legislation.annotations.index.comments_count", count: annotation.comments_count) %>
+          </span>
         <% end %>
       </div>
     <% end %>

--- a/app/views/legislation/annotations/show.html.erb
+++ b/app/views/legislation/annotations/show.html.erb
@@ -1,4 +1,6 @@
-<% provide :title do %><%= "#{t(".title")} - #{@draft_version.title} - #{@process.title}" %><% end %>
+<% provide :title do %>
+  <%= "#{t("legislation.annotations.show.title")} - #{@draft_version.title} - #{@process.title}" %>
+<% end %>
 
 <%= render "legislation/processes/header", process: @process, header: :small %>
 

--- a/app/views/legislation/draft_versions/changes.html.erb
+++ b/app/views/legislation/draft_versions/changes.html.erb
@@ -1,4 +1,6 @@
-<% provide :title do %><%= "#{@draft_version.title} - #{t(".title")} - #{@process.title}" %><% end %>
+<% provide :title do %>
+  <%= "#{@draft_version.title} - #{t("legislation.draft_versions.changes.title")} - #{@process.title}" %>
+<% end %>
 
 <%= render "legislation/processes/header", process: @process, header: :small %>
 
@@ -10,7 +12,7 @@
   <div class="draft-panels small-12 column row">
     <div class="row draft-chooser">
       <div class="small-12 medium-9 column">
-        <h3><%= t(".seeing_changelog_version") %></h3>
+        <h3><%= t("legislation.draft_versions.changes.seeing_changelog_version") %></h3>
         <div class="select-box">
           <%= form_tag go_to_version_legislation_process_draft_versions_path(@process), method: :get, id: "draft_version_go_to_version" do %>
             <%= select_tag "draft_version_id", options_from_collection_for_select(@draft_versions_list, "id", "display_title", @draft_version.id), "aria-label": t("legislation.draft_versions.show.select_draft_version") %>
@@ -21,8 +23,9 @@
         <span><%= t("legislation.draft_versions.show.updated_at", date: format_date(@draft_version.updated_at)) %></span>
       </div>
       <div class="small-12 medium-3 column">
-        <%= link_to legislation_process_draft_version_path(@process, @draft_version), title: t(".see_text"), class: "button" do %>
-          <strong><%= t(".see_text") %></strong>
+        <%= link_to legislation_process_draft_version_path(@process, @draft_version),
+                    title: t("legislation.draft_versions.changes.see_text"), class: "button" do %>
+          <strong><%= t("legislation.draft_versions.changes.see_text") %></strong>
         <% end %>
       </div>
     </div>

--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -10,23 +10,30 @@
   <div class="draft-panels small-12 column row">
     <div class="row draft-chooser">
       <div class="small-12 medium-9 column">
-        <h3><%= t(".seeing_version") %></h3>
+        <h3><%= t("legislation.draft_versions.show.seeing_version") %></h3>
         <div class="select-box">
           <%= form_tag go_to_version_legislation_process_draft_versions_path(@process), method: :get, id: "draft_version_go_to_version" do %>
-            <%= select_tag "draft_version_id", options_from_collection_for_select(@draft_versions_list, "id", "display_title", @draft_version.id), "aria-label": t(".select_draft_version") %>
-            <%= submit_tag t(".select_version_submit"), class: "button" %>
+            <%= select_tag "draft_version_id", options_from_collection_for_select(@draft_versions_list, "id", "display_title", @draft_version.id), "aria-label": t("legislation.draft_versions.show.select_draft_version") %>
+            <%= submit_tag t("legislation.draft_versions.show.select_version_submit"), class: "button" %>
           <% end %>
           <% if @draft_version.changelog.present? %>
-            <span><%= link_to t(".see_changes"), legislation_process_draft_version_changes_path(@process, @draft_version), class: "see-changes" %></span>
+            <span>
+              <%= link_to t("legislation.draft_versions.show.see_changes"),
+                          legislation_process_draft_version_changes_path(@process, @draft_version),
+                          class: "see-changes" %>
+            </span>
           <% end %>
         </div>
-        <span><%= t(".updated_at", date: format_date(@draft_version.updated_at)) %></span>
+        <span><%= t("legislation.draft_versions.show.updated_at",
+                     date: format_date(@draft_version.updated_at)) %></span>
       </div>
 
       <% unless @draft_version.final_version? %>
         <div class="small-12 medium-3 column">
-          <%= link_to legislation_process_draft_version_annotations_path(@process, @draft_version), title: t(".see_comments"), class: "button expanded" do %>
-            <strong><%= t(".see_comments") %></strong>
+          <%= link_to legislation_process_draft_version_annotations_path(@process, @draft_version),
+                      title: t("legislation.draft_versions.show.see_comments"),
+                      class: "button expanded" do %>
+            <strong><%= t("legislation.draft_versions.show.see_comments") %></strong>
           <% end %>
         </div>
       <% end %>
@@ -39,12 +46,13 @@
       <div class="small-12 calc-index column <%= "js-toggle-allegations" unless @draft_version.final_version? %>">
         <div class="draft-panel">
           <div>
-            <span class="icon-banner" aria-hidden="true"></span> <span class="panel-title"><%= t(".text_toc") %></span>
+            <span class="icon-banner" aria-hidden="true"></span>
+            <span class="panel-title"><%= t("legislation.draft_versions.show.text_toc") %></span>
           </div>
         </div>
 
         <div class="draft-index-rotated text-center">
-          <span class="panel-title"><%= t(".text_toc") %></span>
+          <span class="panel-title"><%= t("legislation.draft_versions.show.text_toc") %></span>
         </div>
 
         <div data-sticky-container>
@@ -55,7 +63,7 @@
       </div>
       <div class="small-12 calc-text column border-right border-left">
         <div class="draft-panel">
-          <div><span class="panel-title"><%= t(".text_body") %></span></div>
+          <div><span class="panel-title"><%= t("legislation.draft_versions.show.text_body") %></span></div>
         </div>
         <div id="sticky-panel" class="draft-text">
           <% if @draft_version.final_version? %>

--- a/app/views/legislation/processes/_process.html.erb
+++ b/app/views/legislation/processes/_process.html.erb
@@ -7,8 +7,10 @@
     </div>
 
     <div class="small-12 medium-4 column">
-      <%= link_to process, class: "button hollow big expanded", title:  t(".see_latest_comments_title") do %>
-        <span class="icon-comments"></span>&nbsp; <%= t(".see_latest_comments") %>
+      <%= link_to process, class: "button hollow big expanded",
+                           title:  t("legislation.processes.process.see_latest_comments_title") do %>
+        <span class="icon-comments"></span>&nbsp;
+        <%= t("legislation.processes.process.see_latest_comments") %>
       <% end %>
     </div>
 

--- a/app/views/legislation/processes/index.html.erb
+++ b/app/views/legislation/processes/index.html.erb
@@ -15,7 +15,7 @@
         <%= paginate @processes %>
       <% else %>
         <div class="callout primary margin-top">
-          <%= t(".no_#{@current_filter}_processes") %>
+          <%= t("legislation.processes.index.no_#{@current_filter}_processes") %>
         </div>
       <% end %>
 

--- a/app/views/legislation/processes/phase_empty.html.erb
+++ b/app/views/legislation/processes/phase_empty.html.erb
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="small-12 column">
       <div class="callout primary">
-        <p><%= t(".empty") %></p>
+        <p><%= t("legislation.processes.phase_empty.empty") %></p>
       </div>
     </div>
   </div>

--- a/app/views/legislation/processes/phase_not_open.html.erb
+++ b/app/views/legislation/processes/phase_not_open.html.erb
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="small-12 column">
       <div class="callout primary">
-        <p><%= t(".not_open") %></p>
+        <p><%= t("legislation.processes.phase_not_open.not_open") %></p>
       </div>
     </div>
   </div>

--- a/app/views/legislation/questions/_question.html.erb
+++ b/app/views/legislation/questions/_question.html.erb
@@ -1,11 +1,14 @@
 <div class="debate-block">
   <div class="debate-type">
-    <%= t(".debate") %> <span class="icon-debates" aria-hidden="true"></span>
+    <%= t("legislation.questions.question.debate") %> <span class="icon-debates" aria-hidden="true"></span>
   </div>
   <div class="debate-title">
     <h4><%= link_to question.title, legislation_process_question_path(question.process, question) %></h4>
   </div>
   <div class="debate-meta">
-    <span class="icon-comments" aria-hidden="true"></span> <span class="debate-comments"><%= link_to t(".comments", count: question.comments.count), legislation_process_question_path(question.process, question) %></span> · <span class="debate-date"><%= format_date question.created_at %></span>
+    <span class="icon-comments" aria-hidden="true"></span> <span class="debate-comments">
+      <%= link_to t("legislation.questions.question.comments", count: question.comments.count),
+                  legislation_process_question_path(question.process, question) %>
+    </span> · <span class="debate-date"><%= format_date question.created_at %></span>
   </div>
 </div>

--- a/app/views/legislation/questions/show.html.erb
+++ b/app/views/legislation/questions/show.html.erb
@@ -4,7 +4,7 @@
   <div class="quiz-header row small-collapse">
     <div class="small-12 medium-9 column">
       <div class="quiz-title">
-        <p class="quiz-header-title"><%= t(".title") %></p>
+        <p class="quiz-header-title"><%= t("legislation.questions.show.title") %></p>
         <h4><%= link_to @process.title, @process %></h4>
       </div>
     </div>
@@ -12,14 +12,14 @@
       <% if @question.next_question_id %>
         <%= link_to legislation_process_question_path(@process, @question.next_question_id), class: "quiz-next-link" do %>
           <div class="quiz-next">
-            <%= t(".next_question") %>
+            <%= t("legislation.questions.show.next_question") %>
             <span class="icon-angle-right" aria-hidden="true">
           </div>
         <% end %>
       <% elsif @question.first_question_id %>
         <%= link_to legislation_process_question_path(@process, @question.first_question_id), class: "quiz-next-link" do %>
           <div class="quiz-next">
-            <%= t(".first_question") %>
+            <%= t("legislation.questions.show.first_question") %>
             <span class="icon-angle-right" aria-hidden="true">
           </div>
         <% end %>
@@ -37,7 +37,7 @@
 
     <aside class="small-12 medium-3 column">
       <div id="social-share" class="sidebar-divider"></div>
-      <h3><%= t(".share") %></h3>
+      <h3><%= t("legislation.questions.show.share") %></h3>
       <%= render "/shared/social_share", title: @question.title, url: legislation_process_question_url(@question.process, @question) %>
     </aside>
   </div>

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -72,7 +72,7 @@ en:
       phase_not_open:
         not_open: This phase is not open yet
       phase_empty:
-          empty: Nothing published yet
+        empty: Nothing published yet
       process:
         see_latest_comments: See latest comments
         see_latest_comments_title: Comment on this process


### PR DESCRIPTION
## Objectives

To maintain consistency with the rest of the project this PR changes some i18n keys to use complete keys on legislation translations.

For example, instead of use: `<%= t(".debate") %>` use: `<%= t("legislation.questions.question.debate") %>`

This prevents missing keys errors when using legislation custom views.
