### PR TITLE
Fix poll answer images not being displayed

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1769,6 +1769,7 @@
 
 .orbit-slide {
   max-height: none !important;
+  position: relative;
 }
 
 .orbit-caption {

--- a/app/views/polls/_gallery.html.erb
+++ b/app/views/polls/_gallery.html.erb
@@ -1,4 +1,4 @@
-<div class="orbit margin-bottom" role="region" aria-label="<%= answer.title %>" data-orbit data-auto-play="false">
+<div class="orbit margin-bottom" role="region" aria-label="<%= answer.title %>" data-orbit data-auto-play="false" data-use-m-u-i="false">
   <a data-toggle="answer_<%= answer.id %> zoom_<%= answer.id %>" class="zoom-link hide-for-small-only">
     <span id="zoom_<%= answer.id %>" class="icon-search-plus" data-toggler="icon-search-plus icon-search-minus"></span>
     <span class="show-for-sr"><%= t("polls.show.zoom_plus") %></span>

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -190,6 +190,33 @@ describe "Polls" do
       end
     end
 
+    scenario "Answer images are shown", :js do
+      question = create(:poll_question, :yes_no, poll: poll)
+      create(:image, imageable: question.question_answers.first, title: "The yes movement")
+
+      visit poll_path(poll)
+
+      expect(page).to have_css "img[alt='The yes movement']"
+    end
+
+    scenario "Buttons to slide through images work back and forth", :js do
+      question = create(:poll_question, :yes_no, poll: poll)
+      create(:image, imageable: question.question_answers.last, title: "The no movement")
+      create(:image, imageable: question.question_answers.last, title: "No movement planning")
+
+      visit poll_path(poll)
+
+      within(".orbit-bullets") do
+        find("[data-slide='1']").click
+
+        expect(page).to have_css ".is-active[data-slide='1']"
+
+        find("[data-slide='0']").click
+
+        expect(page).to have_css ".is-active[data-slide='0']"
+      end
+    end
+
     scenario "Non-logged in users" do
       create(:poll_question, :yes_no, poll: poll)
 


### PR DESCRIPTION
## References

* Closes #3961
* The bug was introduced when updating foundation-rails in pull request #3886

## Objectives

Fix a bug which caused poll question answer images not to be displayed.

## Notes

In the past, we used to have an animation effect when switching from one image to a different one. However, we've had to disable it because after the mentioned foundation-rails update with our current styles the animation effect looks really bad :relieved:.