### PR TITLE
Fix redirect with GET params of after POST requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,7 +107,7 @@ class ApplicationController < ActionController::Base
     end
 
     def set_return_url
-      if !devise_controller? && is_navigational_format?
+      if request.get? && !devise_controller? && is_navigational_format?
         store_location_for(:user, request.fullpath)
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,7 +107,7 @@ class ApplicationController < ActionController::Base
     end
 
     def set_return_url
-      if !devise_controller? && controller_name != "welcome" && is_navigational_format?
+      if !devise_controller? && is_navigational_format?
         store_location_for(:user, request.fullpath)
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,7 +108,7 @@ class ApplicationController < ActionController::Base
 
     def set_return_url
       if !devise_controller? && controller_name != "welcome" && is_navigational_format?
-        store_location_for(:user, request.path)
+        store_location_for(:user, request.fullpath)
       end
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,4 +1,9 @@
 class Users::SessionsController < Devise::SessionsController
+  def destroy
+    @stored_location = stored_location_for(:user)
+    super
+  end
+
   private
 
     def after_sign_in_path_for(resource)
@@ -10,7 +15,7 @@ class Users::SessionsController < Devise::SessionsController
     end
 
     def after_sign_out_path_for(resource)
-      request.referer.present? && !request.referer.match("management") ? request.referer : super
+      @stored_location.present? && !@stored_location.match("management") ? @stored_location : super
     end
 
     def verifying_via_email?

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -6,8 +6,10 @@ describe "Sessions" do
     debate = create(:debate)
 
     visit debate_path(debate)
-
-    login_through_form_as(user)
+    click_link "Sign in"
+    fill_in "user_login", with: user.email
+    fill_in "user_password", with: user.password
+    click_button "Enter"
 
     expect(page).to have_content("You have been signed in successfully")
     expect(page).to have_current_path(debate_path(debate))
@@ -29,5 +31,18 @@ describe "Sessions" do
     click_button "Enter"
 
     expect(page).to have_current_path budget_investments_path(heading.budget, heading_id: "outskirts")
+  end
+
+  scenario "Sign in redirects to the homepage if the user was there" do
+    user = create(:user, :level_two)
+
+    visit debates_path
+    visit "/"
+    click_link "Sign in"
+    fill_in "user_login", with: user.email
+    fill_in "user_password", with: user.password
+    click_button "Enter"
+
+    expect(page).to have_current_path "/"
   end
 end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -17,4 +17,17 @@ describe "Sessions" do
     expect(page).to have_content("You have been signed out successfully")
     expect(page).to have_current_path(debate_path(debate))
   end
+
+  scenario "Sign in redirects keeping GET parameters" do
+    create(:user, :level_two, email: "dev@consul.dev", password: "consuldev")
+    heading = create(:budget_heading, name: "outskirts")
+
+    visit budget_investments_path(heading.budget, heading_id: "outskirts")
+    click_link "Sign in"
+    fill_in "user_login",    with: "dev@consul.dev"
+    fill_in "user_password", with: "consuldev"
+    click_button "Enter"
+
+    expect(page).to have_current_path budget_investments_path(heading.budget, heading_id: "outskirts")
+  end
 end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -45,4 +45,19 @@ describe "Sessions" do
 
     expect(page).to have_current_path "/"
   end
+
+  scenario "Sign out does not redirect to POST requests URLs" do
+    login_as(create(:user))
+
+    visit account_path
+    click_link "Verify my account"
+    click_button "Verify residence"
+
+    expect(page).to have_content(/errors prevented the verification of your residence/)
+
+    click_link "Sign out"
+
+    expect(page).to have_content "You must sign in or register to continue."
+    expect(page).to have_current_path new_user_session_path
+  end
 end


### PR DESCRIPTION
## References

* Closes #4024
* Closes #4016

## Background

When signing in from a page containing GET params, like `/budgets/1/investments?heading_id=4`, we were redirected to a URL without those GET params; in this case, `/budgets/1/investments`.

Furthermore, when signing out we were redirecting to the URL of the request referer. Howewer, if that URL only existed for POST requests, we were getting a 404 error.

## Objectives

* Keep GET params in return URL after signing in, so users are redirected to the same page they came from
* Redirect to the last GET request instead of the last request
* Redirect to the homepage when signing in from the homepage