### PR TITLE
Fix banner overlapping with other content

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2287,6 +2287,13 @@ table {
 // 18. Banners
 // -----------
 
+.banner {
+
+  + .budget.expanded,
+  + .jumbo {
+    margin-top: 0;
+  }
+}
 
 // 19. Recommendations
 // -------------------

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2292,6 +2292,10 @@ table {
   a > * {
     @include grid-row;
     padding: 0 rem-calc(16);
+
+    &:empty {
+      display: none;
+    }
   }
 
   + .budget.expanded,

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2289,6 +2289,11 @@ table {
 
 .banner {
 
+  a > * {
+    @include grid-row;
+    padding: 0 rem-calc(16);
+  }
+
   + .budget.expanded,
   + .jumbo {
     margin-top: 0;

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -909,6 +909,8 @@
 .help-header {
   background: #fafafa;
   border-bottom: 1px solid #eee;
+  margin-top: -$line-height;
+  margin-bottom: $line-height;
   padding-bottom: $line-height / 2;
   padding-top: $line-height;
 
@@ -1142,6 +1144,7 @@
 
   &.budget {
     background: $budget;
+    margin-top: -$line-height;
 
     h1,
     h2,

--- a/app/helpers/banners_helper.rb
+++ b/app/helpers/banners_helper.rb
@@ -3,22 +3,6 @@ module BannersHelper
     @banners.present? && @banners.count > 0
   end
 
-  def banner_default_bg_color
-    "#e7f2fc"
-  end
-
-  def banner_default_font_color
-    "#222222"
-  end
-
-  def banner_bg_color_or_default
-    @banner.background_color.presence || banner_default_bg_color
-  end
-
-  def banner_font_color_or_default
-    @banner.font_color.presence || banner_default_font_color
-  end
-
   def banner_target_link(banner)
     link_to banner.target_url do
       tag.h2(banner.title, style: "color:#{banner.font_color}") +

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -2,6 +2,9 @@ class Banner < ApplicationRecord
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
+  attribute :background_color, default: "#e7f2fc"
+  attribute :font_color, default: "#222222"
+
   translates :title,       touch: true
   translates :description, touch: true
   include Globalizable

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -56,8 +56,7 @@
       <p class="help-text"><%= t("admin.shared.color_help") %></p>
       <div class="row collapse">
         <div class="small-12 medium-6 column">
-          <%= f.text_field :background_color, label: false, type: :color,
-                                              value: banner_bg_color_or_default %>
+          <%= f.text_field :background_color, label: false, type: :color %>
         </div>
         <div class="small-12 medium-6 column">
           <%= f.text_field :background_color, label: false, id: "background_color_input" %>
@@ -70,8 +69,7 @@
       <p class="help-text"><%= t("admin.shared.color_help") %></p>
       <div class="row collapse">
         <div class="small-12 medium-6 column">
-          <%= f.text_field :font_color, label: false, type: :color,
-                                        value: banner_font_color_or_default %>
+          <%= f.text_field :font_color, label: false, type: :color %>
         </div>
         <div class="small-12 medium-6 column">
           <%= f.text_field :font_color, label: false, id: "font_color_input" %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% if current_budget.present? %>
-  <div id="budget_heading" class="expanded budget no-margin-top">
+  <div id="budget_heading" class="expanded budget">
     <div class="row" data-equalizer data-equalizer-on="medium">
       <div class="small-12 medium-9 column padding" data-equalizer-watch>
 

--- a/app/views/shared/_section_header.html.erb
+++ b/app/views/shared/_section_header.html.erb
@@ -1,4 +1,4 @@
-<div class="help-header no-margin-top margin-bottom">
+<div class="help-header">
   <div class="row">
     <div class="small-12 column" data-magellan>
       <%= image_tag "help/help_icon_#{image}.png", alt: t("#{i18n_namespace}.icon_alt"), class: "align-top" %>

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -11,4 +11,11 @@ describe Banner do
   it "is valid" do
     expect(banner).to be_valid
   end
+
+  it "assigns default values to new banners" do
+    banner = Banner.new
+
+    expect(banner.background_color).to be_present
+    expect(banner.font_color).to be_present
+  end
 end


### PR DESCRIPTION
## References

* Closes #3639

## Objectives

* Fix banner content overlapping with other content
* Align banner text like other elements on the page
* Add default colors to banners created with our `db:dev_seed` task

## Visual Changes

### Before these changes:

![The banner text is not aligned in the homepage](https://user-images.githubusercontent.com/35156/89799494-d7473200-db2d-11ea-865d-acadb6516051.png)
![The banner contents overlap with the budget heading](https://user-images.githubusercontent.com/35156/89799500-d910f580-db2d-11ea-8e25-b120e8d45759.png)
![The banner contents overlap with the help page heading](https://user-images.githubusercontent.com/35156/89799502-d910f580-db2d-11ea-8cc7-ee52d07f4c59.png)

### After these changes:

![The banner text is aligned in the homepage](https://user-images.githubusercontent.com/35156/89799836-458bf480-db2e-11ea-9c1e-b8fc238a104e.png)
![The banner contents does not overlap with the budget heading](https://user-images.githubusercontent.com/35156/89799842-46bd2180-db2e-11ea-838c-c379038a3aa2.png)
![The banner contents does not overlap with the help page heading](https://user-images.githubusercontent.com/35156/89799846-4755b800-db2e-11ea-8da5-a6c8db585a4c.png)
