### PR TITLE
Add feature flag exception for the module polls

### DIFF
--- a/app/controllers/admin/poll/base_controller.rb
+++ b/app/controllers/admin/poll/base_controller.rb
@@ -1,4 +1,8 @@
 class Admin::Poll::BaseController < Admin::BaseController
+  include FeatureFlags
+
+  feature_flag :polls
+
   helper_method :namespace
 
   private

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,5 +1,8 @@
 class PollsController < ApplicationController
+  include FeatureFlags
   include PollsHelper
+
+  feature_flag :polls
 
   before_action :load_poll, except: [:index]
   before_action :load_active_poll, only: :index

--- a/spec/system/admin/poll/polls_spec.rb
+++ b/spec/system/admin/poll/polls_spec.rb
@@ -6,6 +6,11 @@ describe "Admin polls" do
     login_as(admin.user)
   end
 
+  scenario "Disabled with a feature flag" do
+    Setting["process.polls"] = nil
+    expect { visit admin_polls_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+  end
+
   scenario "Index empty", :js do
     visit admin_root_path
 

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -5,6 +5,11 @@ describe "Polls" do
     it_behaves_like "notifiable in-app", :poll
   end
 
+  scenario "Disabled with a feature flag" do
+    Setting["process.polls"] = nil
+    expect { visit polls_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+  end
+
   context "#index" do
     scenario "Shows description for open polls" do
       visit polls_path


### PR DESCRIPTION
## References

When a participatory process is disabled from the admin panel, an exception is raised when trying to access that module. But if you disable the **polls** module, you can still visit `/polls` or `/admin/polls`.

## Objectives

To have the same behavior for polls as for other modules.

