### PR TITLE
Fix invalid "hint" attribute in forms

### DIFF
--- a/lib/consul_form_builder.rb
+++ b/lib/consul_form_builder.rb
@@ -21,7 +21,7 @@ class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
 
   def check_box(attribute, options = {})
     if options[:label] != false
-      label = tag.span sanitize(label_text(object, attribute, options[:label])), class: "checkbox"
+      label = tag.span sanitize(label_text(attribute, options[:label])), class: "checkbox"
 
       super(attribute, options.merge(label: label, label_options: label_options_for(options)))
     else
@@ -41,7 +41,7 @@ class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
       if text == false
         super
       else
-        super(attribute, sanitize(label_text(object, attribute, text)), options)
+        super(attribute, sanitize(label_text(attribute, text)), options)
       end
     end
 
@@ -50,7 +50,7 @@ class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
         help_text(attribute, options)
     end
 
-    def label_text(object, attribute, text)
+    def label_text(attribute, text)
       if text.nil? || text == true
         default_label_text(object, attribute)
       else

--- a/lib/consul_form_builder.rb
+++ b/lib/consul_form_builder.rb
@@ -13,7 +13,7 @@ class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
     define_method field do |attribute, options = {}|
       label_with_hint(attribute, options.merge(label_options: label_options_for(options))) +
         super(attribute, options.merge(
-          label: false, hint: false,
+          label: false, hint: nil,
           aria: { describedby: help_text_id(attribute, options) }
         ))
     end

--- a/spec/lib/consul_form_builder_spec.rb
+++ b/spec/lib/consul_form_builder_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe ConsulFormBuilder do
+  class DummyModel
+    include ActiveModel::Model
+    attr_accessor :title
+  end
+
+  let(:builder) { ConsulFormBuilder.new(:dummy, DummyModel.new, ActionView::Base.new, {}) }
+
+  describe "hints" do
+    it "does not generate hints by default" do
+      render builder.text_field(:title)
+
+      expect(page).not_to have_css ".help-text"
+      expect(page).not_to have_css "input[aria-describedby]"
+    end
+
+    it "generates text with a hint if provided" do
+      render builder.text_field(:title, hint: "Make it quick")
+
+      expect(page).to have_css ".help-text", text: "Make it quick"
+      expect(page).to have_css "input[aria-describedby='dummy_title-help-text']"
+    end
+
+    it "does not generate a hint attribute" do
+      render builder.text_field(:title)
+
+      expect(page).not_to have_css "input[hint]"
+    end
+  end
+
+  attr_reader :content
+
+  def render(content)
+    @content = content
+  end
+
+  def page
+    Capybara::Node::Simple.new(content)
+  end
+end


### PR DESCRIPTION
## References

* This bug was introduced in pull request #3745

## Objectives

* Remove an invalid HTML attribute we were generating accidentally