### PR TITLE
Fix sticky element on medium/large screens

### DIFF
--- a/app/assets/javascripts/foundation_extras.js
+++ b/app/assets/javascripts/foundation_extras.js
@@ -3,6 +3,13 @@
   App.FoundationExtras = {
     initialize: function() {
       $(document).foundation();
+    },
+    destroy: function() {
+      if ($(".sticky").length > 0) {
+        $(".sticky").foundation("_destroy");
+      }
     }
   };
+
+  $(document).on("turbolinks:before-visit", App.FoundationExtras.destroy);
 }).call(this);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,4 @@
 @import "autocomplete_overrides";
 @import "jquery-ui/sortable";
 @import "leaflet";
+@import "sticky_overrides";

--- a/app/assets/stylesheets/sticky_overrides.scss
+++ b/app/assets/stylesheets/sticky_overrides.scss
@@ -1,0 +1,9 @@
+// Overrides styles of foundation-sticky
+
+// Patch authored by shashabeep
+// Check https://github.com/foundation/foundation-sites/issues/11098#issuecomment-528363771
+.proposal-show {
+  .sticky.is-anchored {
+    top: 0 !important;
+  }
+}

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -212,6 +212,19 @@ describe "Proposals" do
     end
   end
 
+  describe "Sticky support button on medium and up screens", :js do
+    scenario "is shown anchored to top" do
+      proposal = create(:proposal)
+      visit proposals_path
+
+      click_link proposal.title
+
+      within("#proposal_sticky") do
+        expect(find(".is-anchored")).to match_style(top: "0px")
+      end
+    end
+  end
+
   describe "Show sticky support button on mobile screens", :js do
     let!(:window_size) { Capybara.current_window.size }
 


### PR DESCRIPTION
# Objectives
Resolve the following issues with Foundation Sticky:

1º Remove scroll listener from window object by destroying sticky elements before leaving the page
2º Fix proposal support box positioning when sticky element is-anchored

## Visual Changes
**Before**
![Captura de pantalla 2020-08-21 a las 15 18 39](https://user-images.githubusercontent.com/15726/90895365-59531880-e3c2-11ea-950c-1787e31a12d5.png)

**After**
![Captura de pantalla 2020-08-21 a las 15 19 28](https://user-images.githubusercontent.com/15726/90895373-5bb57280-e3c2-11ea-827e-e17f38267c7f.png)

**Javascript errors if Sticky window listener is not removed**

![StickyWindowScrollListener](https://user-images.githubusercontent.com/15726/90898164-8acde300-e3c6-11ea-88ef-5004a1b1156c.gif)

