### PR TITLE
Downgrade sassc from 2.4.0 to 2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (2.4.0)
+    sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)


### PR DESCRIPTION
## References

* We accidentally upgraded sassc when upgrading fontawesome-sass in pull request #4095
* The deprecation warning we're getting is discussed in foundation/foundation-sites#12080

## Background

Using sassc 2.4.0, we were getting several warnings when compiling Foundation's assets:

```
DEPRECATION WARNING (...) !global assignments won't be able to declare new variables in future versions.
```

## Objectives

* Make sure we don't get any warnings when compiling our assets

### Notes

Using sassc 2.3.0 my machine froze when trying to compile the assets in our current master branch, and that's why we're downgrading to version 2.2.1 instead.