### PR TITLE
Simplify banner form dates

### DIFF
--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -5,17 +5,11 @@
   <%= render "shared/errors", resource: @banner %>
 
   <div class="row">
-    <% date_started_at = @banner.post_started_at.present? ? I18n.localize(@banner.post_started_at) : "" %>
     <div class="small-12 medium-3 column">
-      <%= f.date_field :post_started_at,
-                        value: date_started_at,
-                        id: "post_started_at" %>
+      <%= f.date_field :post_started_at, id: "post_started_at" %>
     </div>
-    <% date_ended_at = @banner.post_ended_at.present? ? I18n.localize(@banner.post_ended_at) : "" %>
     <div class="small-12 medium-3 column end">
-      <%= f.date_field  :post_ended_at,
-                        value: date_ended_at,
-                        id: "post_ended_at" %>
+      <%= f.date_field :post_ended_at, id: "post_ended_at" %>
     </div>
   </div>
 


### PR DESCRIPTION
## References

* This change should have been part of pull request #4111, but I thought I had pushed it when I hadn't

## Objectives

* Simplify the code to render date fields in the banners form