### PR TITLE
Get map center longitude from correct place

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -49,7 +49,7 @@
         markerLatitude = dataCoordinates.lat;
         markerLongitude = dataCoordinates.long;
         mapCenterLatitude = dataCoordinates.lat;
-        mapCenterLongitude = dataCoordinates.lat;
+        mapCenterLongitude = dataCoordinates.long;
       } else {
         mapCenterLatitude = $(element).data("map-center-latitude");
         mapCenterLongitude = $(element).data("map-center-longitude");

--- a/spec/shared/system/mappable.rb
+++ b/spec/shared/system/mappable.rb
@@ -283,12 +283,14 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       do_login_for(user) if management
     end
 
-    scenario "Should display map on #{mappable_factory_name} show page", :js do
+    scenario "Should display map and marker on #{mappable_factory_name} show page", :js do
       arguments[:id] = mappable.id
 
       visit send(mappable_show_path, arguments)
 
-      expect(page).to have_css(".map_location")
+      within ".map_location" do
+        expect(page).to have_css(".map-icon")
+      end
     end
 
     scenario "Should not display map on #{mappable_factory_name} show when marker is not defined", :js do


### PR DESCRIPTION
## References

Related Pull Request: #3699

This error was introduced at commit b9ce68bc821bc2dba1cb8270d875f2e14a21d81b.

## Objectives
We were loading map center longitude from wrong map data attribute.