### PR TITLE
Update columns type of attachment file

### DIFF
--- a/db/migrate/20170322145702_create_site_customization_images.rb
+++ b/db/migrate/20170322145702_create_site_customization_images.rb
@@ -2,7 +2,10 @@ class CreateSiteCustomizationImages < ActiveRecord::Migration[4.2]
   def change
     create_table :site_customization_images do |t|
       t.string :name, null: false
-      t.attachment :image
+      t.string :image_file_name
+      t.string :image_content_type
+      t.integer :image_file_size
+      t.datetime :image_updated_at
       t.timestamps null: false
     end
 

--- a/db/migrate/20170627113331_create_images.rb
+++ b/db/migrate/20170627113331_create_images.rb
@@ -1,14 +1,13 @@
 class CreateImages < ActiveRecord::Migration[4.2]
-  def up
+  def change
     create_table :images do |t|
       t.references :imageable, polymorphic: true, index: true
       t.string :title, limit: 80
       t.timestamps null: false
+      t.string :attachment_file_name
+      t.string :attachment_content_type
+      t.integer :attachment_file_size
+      t.datetime :attachment_updated_at
     end
-    add_attachment :images, :attachment
-  end
-
-  def down
-    remove_attachment :images, :attachment
   end
 end

--- a/db/migrate/20170720092638_create_documents.rb
+++ b/db/migrate/20170720092638_create_documents.rb
@@ -2,7 +2,10 @@ class CreateDocuments < ActiveRecord::Migration[4.2]
   def change
     create_table :documents do |t|
       t.string :title
-      t.attachment :attachment
+      t.string :attachment_file_name
+      t.string :attachment_content_type
+      t.integer :attachment_file_size
+      t.datetime :attachment_updated_at
       t.references :user, index: true, foreign_key: true
       t.references :documentable, polymorphic: true, index: true
 

--- a/db/migrate/20200908084257_change_attachment_size_fields_to_bigint.rb
+++ b/db/migrate/20200908084257_change_attachment_size_fields_to_bigint.rb
@@ -1,0 +1,7 @@
+class ChangeAttachmentSizeFieldsToBigint < ActiveRecord::Migration[5.1]
+  def change
+    change_column :site_customization_images, :image_file_size, :bigint
+    change_column :images, :attachment_file_size, :bigint
+    change_column :documents, :attachment_file_size, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200519120717) do
+ActiveRecord::Schema.define(version: 20200908084257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -545,7 +545,7 @@ ActiveRecord::Schema.define(version: 20200519120717) do
     t.string "title"
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.integer "user_id"
     t.string "documentable_type"
@@ -641,7 +641,7 @@ ActiveRecord::Schema.define(version: 20200519120717) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.integer "user_id"
     t.index ["imageable_type", "imageable_id"], name: "index_images_on_imageable_type_and_imageable_id"
@@ -1347,7 +1347,7 @@ ActiveRecord::Schema.define(version: 20200519120717) do
     t.string "name", null: false
     t.string "image_file_name"
     t.string "image_content_type"
-    t.integer "image_file_size"
+    t.bigint "image_file_size"
     t.datetime "image_updated_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## References
Related PR: Bump paperclip from 5.2.1 to 6.1.0 #3905 

## Objectives
- Update old migrations to maintain consistency
- Add migration to change columns type of attachments from `integer` to `bigint`

## Notes
After merge "Bump paperclip from 5.2.1 to 6.1.0 #3905" as indicated in the [release_notes](https://github.com/thoughtbot/paperclip/releases/tag/v6.1.0) columns type for attachments are changed from integer to bigint.
> STABILITY: Change database column type of attachment file size from unsigned 4-byte integer to unsigned 8-byte bigint. The former type limits attachment size to just over 2GB, which can easily be exceeded by a large video file (Laurent Arnoud, Alen Zamanyan).

