### PR TITLE
Remove deprecated columns

### DIFF
--- a/db/migrate/20200831112342_remove_deprecated_fields_from_budget_investments.rb
+++ b/db/migrate/20200831112342_remove_deprecated_fields_from_budget_investments.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedFieldsFromBudgetInvestments < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :budget_investments, :deprecated_title, :string
+    remove_column :budget_investments, :deprecated_description, :text
+  end
+end

--- a/db/migrate/20200831112559_remove_deprecated_field_from_comments.rb
+++ b/db/migrate/20200831112559_remove_deprecated_field_from_comments.rb
@@ -1,0 +1,5 @@
+class RemoveDeprecatedFieldFromComments < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :comments, :deprecated_body, :text
+  end
+end

--- a/db/migrate/20200831112936_remove_deprecated_fields_from_debates.rb
+++ b/db/migrate/20200831112936_remove_deprecated_fields_from_debates.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedFieldsFromDebates < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :debates, :deprecated_title, :string
+    remove_column :debates, :deprecated_description, :text
+  end
+end

--- a/db/migrate/20200831113416_remove_deprecated_fields_from_proposals.rb
+++ b/db/migrate/20200831113416_remove_deprecated_fields_from_proposals.rb
@@ -1,0 +1,8 @@
+class RemoveDeprecatedFieldsFromProposals < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :proposals, :deprecated_title, :string
+    remove_column :proposals, :deprecated_description, :text
+    remove_column :proposals, :deprecated_summary, :text
+    remove_column :proposals, :deprecated_retired_explanation, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -236,8 +236,6 @@ ActiveRecord::Schema.define(version: 20200908084257) do
   create_table "budget_investments", id: :serial, force: :cascade do |t|
     t.integer "author_id"
     t.integer "administrator_id"
-    t.string "deprecated_title"
-    t.text "deprecated_description"
     t.string "external_url"
     t.bigint "price"
     t.string "feasibility", limit: 15, default: "undecided"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1219,8 +1219,6 @@ ActiveRecord::Schema.define(version: 20200908084257) do
   end
 
   create_table "proposals", id: :serial, force: :cascade do |t|
-    t.string "deprecated_title", limit: 80
-    t.text "deprecated_description"
     t.integer "author_id"
     t.datetime "hidden_at"
     t.integer "flags_count", default: 0
@@ -1233,13 +1231,11 @@ ActiveRecord::Schema.define(version: 20200908084257) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "responsible_name", limit: 60
-    t.text "deprecated_summary"
     t.string "video_url"
     t.tsvector "tsv"
     t.integer "geozone_id"
     t.datetime "retired_at"
     t.string "retired_reason"
-    t.text "deprecated_retired_explanation"
     t.integer "community_id"
     t.datetime "published_at"
     t.boolean "selected", default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -397,7 +397,6 @@ ActiveRecord::Schema.define(version: 20200908084257) do
   create_table "comments", id: :serial, force: :cascade do |t|
     t.integer "commentable_id"
     t.string "commentable_type"
-    t.text "deprecated_body"
     t.string "subject"
     t.integer "user_id", null: false
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -480,8 +480,6 @@ ActiveRecord::Schema.define(version: 20200908084257) do
   end
 
   create_table "debates", id: :serial, force: :cascade do |t|
-    t.string "deprecated_title", limit: 80
-    t.text "deprecated_description"
     t.integer "author_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## References

Bring back removal of translatable columns #3828 

## Objectives

Remove deprecated columns starting with `deprecated_` that were added in version 1.1 or earlier and so their data has already been migrated on production environments.