### PR TITLE
Apply Legislation Process default colors to dev seeds

### DIFF
--- a/app/helpers/legislation_helper.rb
+++ b/app/helpers/legislation_helper.rb
@@ -22,22 +22,6 @@ module LegislationHelper
     @process.background_color.present? && @process.font_color.present?
   end
 
-  def default_bg_color
-    "#e7f2fc"
-  end
-
-  def default_font_color
-    "#222222"
-  end
-
-  def bg_color_or_default
-    @process.background_color.presence || default_bg_color
-  end
-
-  def font_color_or_default
-    @process.font_color.presence || default_font_color
-  end
-
   def css_for_process_header
     if banner_color?
       "background: #{@process.background_color};color: #{@process.font_color};"

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -8,6 +8,9 @@ class Legislation::Process < ApplicationRecord
   acts_as_paranoid column: :hidden_at
   acts_as_taggable_on :customs
 
+  attribute :background_color, default: "#e7f2fc"
+  attribute :font_color, default: "#222222"
+
   translates :title,              touch: true
   translates :summary,            touch: true
   translates :description,        touch: true

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -134,8 +134,7 @@
       <p class="help-text"><%= t("admin.shared.color_help") %></p>
       <div class="row collapse">
         <div class="small-12 medium-6 column">
-          <%= f.text_field :background_color, label: false, type: :color,
-                                              value: bg_color_or_default %>
+          <%= f.text_field :background_color, label: false, type: :color %>
         </div>
         <div class="small-12 medium-6 column">
           <%= f.text_field :background_color, label: false, id: "background_color_input" %>
@@ -148,7 +147,7 @@
       <p class="help-text"><%= t("admin.shared.color_help") %></p>
       <div class="row collapse">
         <div class="small-12 medium-6 column">
-          <%= f.text_field :font_color, label: false, type: :color, value: font_color_or_default %>
+          <%= f.text_field :font_color, label: false, type: :color %>
         </div>
         <div class="small-12 medium-6 column">
           <%= f.text_field :font_color, label: false, id: "font_color_input" %>

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -10,6 +10,13 @@ describe Legislation::Process do
     expect(process).to be_valid
   end
 
+  it "assigns default values to new processes" do
+    process = Legislation::Process.new
+
+    expect(process.background_color).to be_present
+    expect(process.font_color).to be_present
+  end
+
   describe "dates validations" do
     it "is invalid if debate_start_date is present but debate_end_date is not" do
       process = build(:legislation_process, debate_start_date: Date.current, debate_end_date: "")


### PR DESCRIPTION
## References
Related commit: https://github.com/consul/consul/pull/4080/commits/0b83be6

## Objectives
- Apply Legislation Process default colors to dev seeds.
- Simplify code.

## Notes
Legislation Processes created through the admin form were getting the default color.
However, Legislation processes created by other means (like the `db:dev_seed` rake task) were not getting these default values.

This feature was originally implemented when we were using Rails 4. With Rails 5, we can provide default values to all new Legislation processes and simplify the code at the same time thanks to its `attribute` method.
