### PR TITLE
Filter investments only by assigned staff

### DIFF
--- a/app/helpers/admin_budget_investments_helper.rb
+++ b/app/helpers/admin_budget_investments_helper.rb
@@ -13,16 +13,16 @@ module AdminBudgetInvestmentsHelper
     params[:advanced_filters] = [] unless params[:advanced_filters]
   end
 
-  def admin_select_options
-    Administrator.with_user.map { |v| [v.description_or_name, v.id] }.sort_by { |a| a[0] }
+  def admin_select_options(budget)
+    budget.administrators.with_user.map { |v| [v.description_or_name, v.id] }.sort_by { |a| a[0] }
   end
 
-  def valuator_or_group_select_options
-    valuator_group_select_options + valuator_select_options
+  def valuator_or_group_select_options(budget)
+    valuator_group_select_options + valuator_select_options(budget)
   end
 
-  def valuator_select_options
-    Valuator.order("description ASC").order("users.email ASC").includes(:user).
+  def valuator_select_options(budget)
+    budget.valuators.order("description ASC").order("users.email ASC").includes(:user).
       map { |v| [v.description_or_email, "valuator_#{v.id}"] }
   end
 

--- a/app/helpers/admin_budget_investments_helper.rb
+++ b/app/helpers/admin_budget_investments_helper.rb
@@ -12,4 +12,25 @@ module AdminBudgetInvestmentsHelper
   def init_advanced_menu
     params[:advanced_filters] = [] unless params[:advanced_filters]
   end
+
+  def admin_select_options
+    Administrator.with_user.map { |v| [v.description_or_name, v.id] }.sort_by { |a| a[0] }
+  end
+
+  def valuator_or_group_select_options
+    valuator_group_select_options + valuator_select_options
+  end
+
+  def valuator_select_options
+    Valuator.order("description ASC").order("users.email ASC").includes(:user).
+      map { |v| [v.description_or_email, "valuator_#{v.id}"] }
+  end
+
+  def valuator_group_select_options
+    ValuatorGroup.order("name ASC").map { |g| [g.name, "group_#{g.id}"] }
+  end
+
+  def investment_tags_select_options(budget, context)
+    budget.investments.tags_on(context).order(:name).pluck(:name)
+  end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -84,10 +84,6 @@ module AdminHelper
     options
   end
 
-  def admin_select_options
-    Administrator.with_user.map { |v| [v.description_or_name, v.id] }.sort_by { |a| a[0] }
-  end
-
   def admin_submit_action(resource)
     resource.persisted? ? "edit" : "new"
   end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -59,10 +59,6 @@ module BudgetsHelper
     Budget::Ballot.find_by(user: current_user, budget: @budget)
   end
 
-  def investment_tags_select_options(budget, context)
-    budget.investments.tags_on(context).order(:name).pluck(:name)
-  end
-
   def unfeasible_or_unselected_filter
     ["unselected", "unfeasible"].include?(@current_filter)
   end

--- a/app/helpers/valuation_helper.rb
+++ b/app/helpers/valuation_helper.rb
@@ -1,17 +1,4 @@
 module ValuationHelper
-  def valuator_or_group_select_options
-    valuator_group_select_options + valuator_select_options
-  end
-
-  def valuator_select_options
-    Valuator.order("description ASC").order("users.email ASC").includes(:user).
-             map { |v| [v.description_or_email, "valuator_#{v.id}"] }
-  end
-
-  def valuator_group_select_options
-    ValuatorGroup.order("name ASC").map { |g| [g.name, "group_#{g.id}"] }
-  end
-
   def explanation_field(field)
     simple_format_no_tags_no_sanitize(sanitize_and_auto_link(field)) if field.present?
   end

--- a/app/views/admin/budget_investments/_search_form.html.erb
+++ b/app/views/admin/budget_investments/_search_form.html.erb
@@ -34,12 +34,12 @@
 
   <div class="small-12 medium-3 column">
     <%= select_tag :administrator_id,
-                   options_for_select(admin_select_options, params[:administrator_id]),
+                   options_for_select(admin_select_options(@budget), params[:administrator_id]),
                    { prompt: t("admin.budget_investments.index.administrator_filter_all") } %>
   </div>
   <div class="small-12 medium-3 column">
     <%= select_tag :valuator_or_group_id,
-                   options_for_select(valuator_or_group_select_options, params[:valuator_or_group_id]),
+                   options_for_select(valuator_or_group_select_options(@budget), params[:valuator_or_group_id]),
                    { prompt: t("admin.budget_investments.index.valuator_filter_all") } %>
   </div>
   <div class="small-12 medium-3 column">

--- a/spec/helpers/admin_budget_investments_helper_spec.rb
+++ b/spec/helpers/admin_budget_investments_helper_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe AdminBudgetInvestmentsHelper do
+  describe "#admin_select_options" do
+    it "includes administrators assigned to the budget" do
+      admin = create(:administrator, user: create(:user, username: "Winston"))
+      budget = create(:budget, administrators: [admin])
+
+      expect(admin_select_options(budget)).to eq([["Winston", admin.id]])
+    end
+
+    it "does not include other administrators" do
+      create(:administrator, user: create(:user, username: "Winston"))
+      budget = create(:budget, administrators: [])
+
+      expect(admin_select_options(budget)).to be_empty
+    end
+  end
+
+  describe "#valuator_select_options" do
+    it "includes valuators assigned to the budget" do
+      valuator = create(:valuator, description: "Kodogo")
+      budget = create(:budget, valuators: [valuator])
+
+      expect(valuator_select_options(budget)).to eq([["Kodogo", "valuator_#{valuator.id}"]])
+    end
+
+    it "does not include other valuators" do
+      create(:valuator, description: "Kodogo")
+      budget = create(:budget, valuators: [])
+
+      expect(valuator_select_options(budget)).to be_empty
+    end
+  end
+end

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -160,7 +160,8 @@ describe "Admin budget investments" do
       user = create(:user, username: "Admin 1")
       user2 = create(:user, username: "Admin 2")
       administrator = create(:administrator, user: user)
-      create(:administrator, user: user2, description: "Alias")
+      administrator2 = create(:administrator, user: user2, description: "Alias")
+      budget.administrators = [administrator, administrator2]
       create(:budget_investment, title: "Realocate visitors", budget: budget,
                                                               administrator: administrator)
       create(:budget_investment, title: "Destroy the city", budget: budget)
@@ -201,6 +202,7 @@ describe "Admin budget investments" do
     scenario "Filtering by valuator", :js do
       user = create(:user)
       valuator = create(:valuator, user: user, description: "Valuator 1")
+      budget.valuators = [valuator]
 
       create(:budget_investment, title: "Realocate visitors", budget: budget, valuators: [valuator])
       create(:budget_investment, title: "Destroy the city", budget: budget)
@@ -645,6 +647,7 @@ describe "Admin budget investments" do
     scenario "Combination of checkbox with text search", :js do
       user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
+      budget.administrators = [administrator]
 
       create(:budget_investment, budget: budget, title: "Educate the children",
                                  administrator: administrator)
@@ -716,6 +719,7 @@ describe "Admin budget investments" do
     scenario "Combination of checkbox with text search and checkbox", :js do
       user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
+      budget.administrators = [administrator]
 
       create(:budget_investment, :feasible, :finished, budget: budget, title: "Educate the children",
                                  administrator: administrator)


### PR DESCRIPTION
## References

* The possibility to assign administrators and valuators to a budget was introduced in pull requests #3514 and #3807

## Objectives

* Make the form to filter investments in the admin section more usable