### PR TITLE
 Clarify the meaning of max "votable" headings

### DIFF
--- a/app/views/admin/budget_groups/_form.html.erb
+++ b/app/views/admin/budget_groups/_form.html.erb
@@ -15,7 +15,9 @@
   <% if @group.persisted? %>
     <div class="row">
       <div class="small-12 medium-6 column">
-        <%= f.select :max_votable_headings, (1..@group.headings.count) %>
+        <%= f.select :max_votable_headings,
+                     (1..@group.headings.count),
+                     hint: t("admin.budget_groups.form.max_votable_headings_info") %>
       </div>
     </div>
   <% end %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -196,7 +196,7 @@ en:
         primary: "Primary"
         secondary: "Secondary"
       budget/group:
-        max_votable_headings: "Maximum number of headings in which a user can vote"
+        max_votable_headings: "Maximum number of headings in which a user can select projects"
       budget/group/translation:
         name: "Group name"
       budget/heading:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -133,6 +133,7 @@ en:
       form:
         create: "Create new group"
         edit: "Edit group"
+        max_votable_headings_info: "Only applies to the selecting projects phase. During the voting projects phase users can only vote in one heading per group."
         submit: "Save group"
       index:
         back: "Go back to budgets"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -198,7 +198,7 @@ es:
         primary: "Principal"
         secondary: "Secundaria"
       budget/group:
-        max_votable_headings: "Máximo número de partidas en que un usuario puede votar"
+        max_votable_headings: "Máximo número de partidas en que un usuario puede seleccionar proyectos"
       budget/group/translation:
         name: "Nombre del grupo"
       budget/heading:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -133,6 +133,7 @@ es:
       form:
         create: "Crear nuevo grupo"
         edit: "Editar grupo"
+        max_votable_headings_info: "Solo se aplica en la fase de apoyos. Durante la votación final un usuario solo puede votar en una partida por grupo."
         submit: "Guardar grupo"
       index:
         back: "Volver a presupuestos"

--- a/lib/consul_form_builder.rb
+++ b/lib/consul_form_builder.rb
@@ -35,6 +35,13 @@ class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
     super(attribute, tag_value, { label: default_label }.merge(options))
   end
 
+  def select(attribute, choices, options = {}, html_options = {})
+    label_with_hint(attribute, options.merge(label_options: label_options_for(options))) +
+      super(attribute, choices, options.merge(label: false, hint: nil), html_options.merge({
+        aria: { describedby: help_text_id(attribute, options) }
+      }))
+  end
+
   private
 
     def custom_label(attribute, text, options)

--- a/spec/lib/consul_form_builder_spec.rb
+++ b/spec/lib/consul_form_builder_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 describe ConsulFormBuilder do
   class DummyModel
     include ActiveModel::Model
-    attr_accessor :title
+    OPTIONS = %w[Good Bad Ugly].freeze
+    attr_accessor :title, :quality
   end
 
   let(:builder) { ConsulFormBuilder.new(:dummy, DummyModel.new, ActionView::Base.new, {}) }
@@ -27,6 +28,27 @@ describe ConsulFormBuilder do
       render builder.text_field(:title)
 
       expect(page).not_to have_css "input[hint]"
+    end
+  end
+
+  describe "#select" do
+    it "renders the label and the select with the given options" do
+      render builder.select(:quality, DummyModel::OPTIONS)
+
+      expect(page).to have_css "label", count: 1
+      expect(page).to have_css "label", text: "Quality"
+      expect(page).to have_css "select", count: 1
+      expect(page).to have_css "option", count: 3
+      expect(page).to have_css "option", text: "Good"
+      expect(page).to have_css "option", text: "Bad"
+      expect(page).to have_css "option", text: "Ugly"
+    end
+
+    it "accepts hints" do
+      render builder.select(:quality, DummyModel::OPTIONS, hint: "Ugly is neither good nor bad")
+
+      expect(page).to have_css ".help-text", text: "Ugly is neither good nor bad"
+      expect(page).to have_css "select[aria-describedby='dummy_quality-help-text']"
     end
   end
 

--- a/spec/system/admin/budget_groups_spec.rb
+++ b/spec/system/admin/budget_groups_spec.rb
@@ -160,7 +160,7 @@ describe "Admin budget groups" do
       within("#budget_group_#{group.id}") { click_link "Edit" }
 
       expect(page).to have_field "Group name", with: group.name
-      expect(page).to have_field "Maximum number of headings in which a user can vote", with: "2"
+      expect(page).to have_field "Maximum number of headings in which a user can select projects", with: "2"
     end
 
     scenario "Changing name for current locale will update the slug if budget is in draft phase", :js do
@@ -198,14 +198,14 @@ describe "Admin budget groups" do
       expect(page).to have_field "Group name", with: "All City"
 
       fill_in "Group name", with: "Districts"
-      select "2", from: "Maximum number of headings in which a user can vote"
+      select "2", from: "Maximum number of headings in which a user can select projects"
       click_button "Save group"
 
       expect(page).to have_content "Group updated successfully"
 
       visit edit_admin_budget_group_path(budget, group)
       expect(page).to have_field "Group name", with: "Districts"
-      expect(page).to have_field "Maximum number of headings in which a user can vote", with: "2"
+      expect(page).to have_field "Maximum number of headings in which a user can select projects", with: "2"
     end
 
     scenario "Group name is already used" do


### PR DESCRIPTION
## Background

We've got two different phases where citizens can participate during a budget: the selecting projects phase, where users support projects so they can enter the voting phase, and the mentioned voting phase. We were using a text saying it affects the number of headings where users can vote, but it only affected the selecting projects phase and not the voting phase.

## Objectives

Make it clear the maximum number of headings only applies to the selecting projects phase.

## Visual Changes

### Before these changes

!["Maximum number of headings in which a user can vote" is used as label](https://user-images.githubusercontent.com/35156/92586381-70d14300-f296-11ea-9324-26100400451d.png)

### After these changes

!["Maximum number of headings in which a user can vote" is used as label and there's a hint clarifying in only applies to the selecting projects phase](https://user-images.githubusercontent.com/35156/92586396-7595f700-f296-11ea-8544-25a95549e35a.png)