### PR TITLE
Make sure Puma has restarted properly

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,6 +45,9 @@ set(:config_files, %w[
 set :whenever_roles, -> { :app }
 
 namespace :deploy do
+  Rake::Task["delayed_job:default"].clear_actions
+  Rake::Task["puma:smart_restart"].clear_actions
+
   after :updating, "rvm1:install:rvm"
   after :updating, "rvm1:install:ruby"
   after :updating, "install_bundler_gem"
@@ -54,8 +57,9 @@ namespace :deploy do
   after  :publishing, "setup_puma"
 
   after :published, "deploy:restart"
-  before "deploy:restart", "puma:smart_restart"
+  before "deploy:restart", "puma:restart"
   before "deploy:restart", "delayed_job:restart"
+  before "deploy:restart", "puma:start"
 
   after :finished, "refresh_sitemap"
 


### PR DESCRIPTION
## Background

We were getting an error when restarting Puma after upgrading Ruby. Even if the restart command was sent successfully, Puma silently crashed and the log had the following error:

```
/home/deploy/.rvm/rubies/ruby-2.4.9/lib/ruby/site_ruby/2.4.0/bundler/spec_set.rb:91:in
`block in materialize': Could not find rake-13.0.1 in any of the sources
(Bundler::GemNotFound)
```

So it looks like the crash happens because Puma was started when the application used Ruby 2.4 and now when it's restarted it still tries to use Ruby 2.4, even if the application now uses Ruby 2.5.

## Objectives

* Make sure Puma is started if it crashes after restarting it
* Avoid getting a 502 error after upgrading to version 1.2

## Notes

I haven't found a proper way to configure Puma so we can avoid this, so as a workaround I've added the `puma:start` task after restarting Puma. If Puma was successfully restarted, `puma:start` will do nothing; if Puma crashed, `puma:start` will start it.

To guarantee the tasks will be executed in the proper order, the tasks introduced by capistrano3-delayed_job and capistrano3-puma are cleared, and then we configure the order so first we restart Puma, then restart the Delayed Jobs processes (so there's enough time for Puma to crash if Ruby was upgraded) and then start Puma.