### PR TITLE
Fix Airbrake crash with no project key

### DIFF
--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -5,7 +5,10 @@ Airbrake.configure do |config|
 
   config.environment = Rails.env
   config.ignore_environments = %w[development test]
-  config.ignore_environments += [Rails.env] if Rails.application.secrets.errbit_project_id.blank?
+
+  if config.host.blank? || config.project_id.blank? || config.project_key.blank?
+    config.ignore_environments += [Rails.env]
+  end
 end
 
 Airbrake.add_filter do |notice|


### PR DESCRIPTION
## References

* Errbit/Airbrake support was introduced in pull request #3624

## Background

We were checking the project_id but not the project_key. However, in our example secrets file we actually include a project_id but not a project_key, and so new CONSUL installations would crash in production environments.

## Objectives

Ignore Errbit settings when no project key is provided.