### PR TITLE
Add Serbian (Cyrillic) new language mapping

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -17,5 +17,6 @@ files:
         nl: nl
         pt-PT: pt
         ru: ru
+        sr: sr
         sr-CS: sr-CS
         val-ES: val


### PR DESCRIPTION
## References

Update translations from Crowdin #4121 

## Objectives
Update language mappings so each Serbian language use a different locale code.

We want to use:

* **sr**       for Serbian (Cyrillic)
* **sr-CS** for Serbian (Latin)

Now translations for both languages are done by the Crowdin Github integration using the same locale code `sr` so translations would be mixed.

This language_mapping was requested by Crowdin support team to make Crowdin integration understand that we want Serbian (Latin) with locale code `sr-CS` and Serbian (Cyrillic) with locale code `sr`, we were asked to add the same mappings to [Crowdin project settings](https://crowdin.com/project/consul/settings#general) at [1]

[1] `Project Settings -> General -> Export -> Language mapping`

<img width="504" alt="Captura de pantalla 2020-09-16 a las 16 34 30" src="https://user-images.githubusercontent.com/15726/93351908-8ddbb800-f83a-11ea-9373-6675807f0117.png">

