### PR TITLE
Fix crash in management with successful proposals

### DIFF
--- a/app/views/proposals/_support_status.html.erb
+++ b/app/views/proposals/_support_status.html.erb
@@ -22,7 +22,7 @@
             </div>
           <% elsif proposal.successful? %>
             <div class="supports text-center">
-              <%= render "supports", proposal: proposal %>
+              <%= render "proposals/supports", proposal: proposal %>
             </div>
           <% elsif proposal.archived? %>
             <div class="padding text-center">

--- a/spec/system/management/proposals_spec.rb
+++ b/spec/system/management/proposals_spec.rb
@@ -75,6 +75,15 @@ describe "Proposals" do
       expect(page).not_to have_current_path(old_path)
       expect(page).to have_current_path(right_path)
     end
+
+    scenario "Successful proposal", :js do
+      proposal = create(:proposal, :successful, title: "Success!")
+
+      login_managed_user(create(:user, :level_two))
+      visit management_proposal_path(proposal)
+
+      expect(page).to have_content("Success!")
+    end
   end
 
   scenario "Searching" do


### PR DESCRIPTION
 ## References

* Closes #4137

## Background

The page was crashing because it was looking for the `supports` partial under `management/proposals`, when the right path was `proposals/`.

## Objectives

Fix a bug causing the page to crash when accessing a successful proposal from the management section.