### PR TITLE
Refactor RemoteCensusApi spec to use a XML response

### DIFF
--- a/lib/census_caller.rb
+++ b/lib/census_caller.rb
@@ -1,5 +1,7 @@
 class CensusCaller
   def call(document_type, document_number, date_of_birth, postal_code)
+    return Response.new if document_number.blank? || document_type.blank?
+
     if Setting["feature.remote_census"].present?
       response = RemoteCensusApi.new.call(document_type, document_number, date_of_birth, postal_code)
     else
@@ -8,5 +10,11 @@ class CensusCaller
     response = LocalCensus.new.call(document_type, document_number) unless response.valid?
 
     response
+  end
+
+  class Response
+    def valid?
+      false
+    end
   end
 end

--- a/lib/document_parser.rb
+++ b/lib/document_parser.rb
@@ -1,5 +1,7 @@
 module DocumentParser
   def get_document_number_variants(document_type, document_number)
+    return [] if document_number.blank?
+
     # Delete all non-alphanumerics
     document_number = document_number.to_s.gsub(/[^0-9A-Za-z]/i, "")
     variants = []

--- a/lib/remote_census_api.rb
+++ b/lib/remote_census_api.rb
@@ -73,7 +73,7 @@ class RemoteCensusApi
   private
 
     def get_response_body(document_type, document_number, date_of_birth, postal_code)
-      if end_point_available?
+      if end_point_defined?
         request = request(document_type, document_number, date_of_birth, postal_code)
         client.call(Setting["remote_census.request.method_name"].to_sym, message: request).body
       else
@@ -118,8 +118,8 @@ class RemoteCensusApi
       to_set[final_key] = value
     end
 
-    def end_point_available?
-      !Rails.env.development?
+    def end_point_defined?
+      Setting["remote_census.general.endpoint"].present?
     end
 
     def stubbed_invalid_response

--- a/lib/remote_census_api.rb
+++ b/lib/remote_census_api.rb
@@ -77,7 +77,7 @@ class RemoteCensusApi
         request = request(document_type, document_number, date_of_birth, postal_code)
         client.call(Setting["remote_census.request.method_name"].to_sym, message: request).body
       else
-        stubbed_response(document_type, document_number)
+        stubbed_invalid_response
       end
     end
 
@@ -119,34 +119,10 @@ class RemoteCensusApi
     end
 
     def end_point_available?
-      Rails.env.staging? || Rails.env.preproduction? || Rails.env.production?
-    end
-
-    def stubbed_response(document_type, document_number)
-      if (document_number == "12345678Z" || document_number == "12345678Y") && document_type == "1"
-        stubbed_valid_response
-      else
-        stubbed_invalid_response
-      end
-    end
-
-    def stubbed_valid_response
-      {
-        response: {
-          data: {
-            date_of_birth: "31-12-1980",
-            document_number: "12345678Z",
-            gender: "Male",
-            name: "William",
-            surname: "Widmore",
-            postal_code: "28013",
-            district_code: "01"
-          }
-        }
-      }
+      !Rails.env.development?
     end
 
     def stubbed_invalid_response
-      { response: { data: {}}}
+      {}
     end
 end

--- a/lib/remote_census_api.rb
+++ b/lib/remote_census_api.rb
@@ -51,9 +51,9 @@ class RemoteCensusApi
       path_value = Setting["remote_census.response.gender"]
 
       case extract_value(path_value)
-      when "Varón"
+      when "Male", "Varón"
         "male"
-      when "Mujer"
+      when "Female", "Mujer"
         "female"
       end
     end
@@ -132,29 +132,21 @@ class RemoteCensusApi
 
     def stubbed_valid_response
       {
-        get_habita_datos_response: {
-          get_habita_datos_return: {
-            datos_habitante: {
-              item: {
-                fecha_nacimiento_string: "31-12-1980",
-                identificador_documento: "12345678Z",
-                descripcion_sexo: "Varón",
-                nombre: "José",
-                apellido1: "García"
-              }
-            },
-            datos_vivienda: {
-              item: {
-                codigo_postal: "28013",
-                codigo_distrito: "01"
-              }
-            }
+        response: {
+          data: {
+            date_of_birth: "31-12-1980",
+            document_number: "12345678Z",
+            gender: "Male",
+            name: "William",
+            surname: "Widmore",
+            postal_code: "28013",
+            district_code: "01"
           }
         }
       }
     end
 
     def stubbed_invalid_response
-      { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}, datos_vivienda: {}}}}
+      { response: { data: {}}}
     end
 end

--- a/spec/fixtures/files/remote_census_api/invalid.xml
+++ b/spec/fixtures/files/remote_census_api/invalid.xml
@@ -1,0 +1,8 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <s:Body>
+    <response>
+      <data>
+      </data>
+    </response>
+  </s:Body>
+</s:Envelope>

--- a/spec/fixtures/files/remote_census_api/valid.xml
+++ b/spec/fixtures/files/remote_census_api/valid.xml
@@ -1,0 +1,15 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <s:Body>
+    <response>
+      <data>
+        <date_of_birth>31/12/1980</date_of_birth>
+        <document_number>12345678Z</document_number>
+        <gender>Male</gender>
+        <name>William</name>
+        <surname>Widmore</surname>
+        <postal_code>28013</postal_code>
+        <district_code>01</district_code>
+      </data>
+    </response>
+  </s:Body>
+</s:Envelope>

--- a/spec/helpers/signature_sheets_helper_spec.rb
+++ b/spec/helpers/signature_sheets_helper_spec.rb
@@ -8,12 +8,11 @@ describe SignatureSheetsHelper do
     end
   end
 
-  describe "#required_fields_to_verify_text_help with remote_census active" do
-    before do
-      Setting["feature.remote_census"] = true
-    end
-
+  describe "#required_fields_to_verify_text_help with remote_census active", :remote_census do
     it "returns text help when date_of_birth and postal_code are not required" do
+      Setting["remote_census.request.date_of_birth"] = nil
+      Setting["remote_census.request.postal_code"] = nil
+
       text_help_1 = "To verify a user, your application needs: Document number"
       text_help_2 = "Required fields for each user must be separated by commas and each user must be separated by semicolons."
       text_example = "Example: 12345678Z; 87654321Y"
@@ -24,7 +23,7 @@ describe SignatureSheetsHelper do
     end
 
     it "returns text help when date_of_birth is required" do
-      Setting["remote_census.request.date_of_birth"] = "some.value"
+      Setting["remote_census.request.postal_code"] = nil
 
       text_help_1 = "To verify a user, your application needs: Document number, Day of birth (dd/mm/yyyy)"
       text_help_2 = "Required fields for each user must be separated by commas and each user must be separated by semicolons."
@@ -33,12 +32,10 @@ describe SignatureSheetsHelper do
       expect(required_fields_to_verify_text_help).to include(text_help_1)
       expect(required_fields_to_verify_text_help).to include(text_help_2)
       expect(example_text_help).to include(text_example)
-
-      Setting["remote_census.request.date_of_birth"] = nil
     end
 
     it "returns text help when postal_code is required" do
-      Setting["remote_census.request.postal_code"] = "some.value"
+      Setting["remote_census.request.date_of_birth"] = nil
 
       text_help_1 = "To verify a user, your application needs: Document number and Postal Code"
       text_help_2 = "Required fields for each user must be separated by commas and each user must be separated by semicolons."
@@ -47,14 +44,9 @@ describe SignatureSheetsHelper do
       expect(required_fields_to_verify_text_help).to include(text_help_1)
       expect(required_fields_to_verify_text_help).to include(text_help_2)
       expect(example_text_help).to include(text_example)
-
-      Setting["remote_census.request.postal_code"] = nil
     end
 
     it "returns text help when date_of_birth and postal_code are required" do
-      Setting["remote_census.request.date_of_birth"] = "some.value"
-      Setting["remote_census.request.postal_code"] = "some.value"
-
       text_help_1 = "To verify a user, your application needs: Document number, Day of birth (dd/mm/yyyy) and Postal Code"
       text_help_2 = "Required fields for each user must be separated by commas and each user must be separated by semicolons."
       text_example = "Example: 12345678Z, 01/01/1980, 28001; 87654321Y, 01/02/1990, 28002"
@@ -62,9 +54,6 @@ describe SignatureSheetsHelper do
       expect(required_fields_to_verify_text_help).to include(text_help_1)
       expect(required_fields_to_verify_text_help).to include(text_help_2)
       expect(example_text_help).to include(text_example)
-
-      Setting["remote_census.request.postal_code"] = nil
-      Setting["remote_census.request.postal_code"] = nil
     end
   end
 end

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -13,6 +13,16 @@ describe CensusCaller do
       { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}}}}
     end
 
+    it "returns invalid response when document_number or document_type are empty" do
+      response = api.call(1, "", nil, nil)
+
+      expect(response).not_to be_valid
+
+      response = api.call("", "12345678A", nil, nil)
+
+      expect(response).not_to be_valid
+    end
+
     it "returns local census response when census api response is invalid" do
       census_api_response = CensusApi::Response.new(invalid_body)
       allow_any_instance_of(CensusApi).to receive(:call).and_return(census_api_response)

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -45,6 +45,9 @@ describe CensusCaller do
     end
 
     describe "RemoteCensusApi", :remote_census do
+      let(:valid_body) { { response: { data: { document_number: "12345678" }}} }
+      let(:invalid_body) { { response: { data: {}}} }
+
       it "returns remote census api response when it's available and response is valid" do
         remote_census_api_response = RemoteCensusApi::Response.new(valid_body)
         allow_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -34,13 +34,7 @@ describe CensusCaller do
       end
     end
 
-    describe "RemoteCensusApi" do
-      before do
-        Setting["feature.remote_census"] = true
-        access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-        Setting["remote_census.response.valid"] = access_user_data
-      end
-
+    describe "RemoteCensusApi", :remote_census do
       it "returns remote census api response when it's available and response is valid" do
         remote_census_api_response = RemoteCensusApi::Response.new(valid_body)
         allow_any_instance_of(RemoteCensusApi).to receive(:call).and_return(remote_census_api_response)

--- a/spec/lib/document_parser_spec.rb
+++ b/spec/lib/document_parser_spec.rb
@@ -3,6 +3,10 @@ include DocumentParser
 
 describe DocumentParser do
   describe "#get_document_number_variants" do
+    it "returns no variants when document_number is not defined" do
+      expect(DocumentParser.get_document_number_variants("1", "")).to be_empty
+    end
+
     it "trims and cleans up entry" do
       expect(DocumentParser.get_document_number_variants(2, "  1 2@ 34")).to eq(["1234"])
     end

--- a/spec/lib/remote_census_api_spec.rb
+++ b/spec/lib/remote_census_api_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe RemoteCensusApi do
   let(:api) { RemoteCensusApi.new }
 
-  describe "#call" do
+  describe "#call", :remote_census do
     let(:invalid_body) { { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}}}} }
     let(:valid_body) do
       {
@@ -17,14 +17,6 @@ describe RemoteCensusApi do
           }
         }
       }
-    end
-
-    before do
-      access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-      access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-      Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-      Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-      Setting["remote_census.response.valid"] = access_user_data
     end
 
     it "returns the response for the first valid variant" do
@@ -184,20 +176,7 @@ describe RemoteCensusApi do
     end
   end
 
-  describe "RemoteCensusApi::Response" do
-    before do
-      Setting["feature.remote_census"] = true
-      access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-      access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-      Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-      Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-      Setting["remote_census.response.district"] = "#{access_residence_data}.codigo_distrito"
-      Setting["remote_census.response.gender"] = "#{access_user_data}.descripcion_sexo"
-      Setting["remote_census.response.name"] = "#{access_user_data}.nombre"
-      Setting["remote_census.response.surname"] = "#{access_user_data}.apellido1"
-      Setting["remote_census.response.valid"] = access_user_data
-    end
-
+  describe "RemoteCensusApi::Response", :remote_census do
     it "return expected response methods with default values" do
       document_type = "1"
       document_number = "12345678Z"

--- a/spec/lib/remote_census_api_spec.rb
+++ b/spec/lib/remote_census_api_spec.rb
@@ -90,5 +90,13 @@ describe RemoteCensusApi do
         api.call("1", "12345678Z", Date.parse("31/12/1980"), "28013")
       end
     end
+
+    it "returns an invalid response when endpoint is not defined" do
+      allow_any_instance_of(RemoteCensusApi).to receive(:end_point_defined?).and_return(false)
+
+      response = api.call("1", "12345678Z", Date.parse("01/01/1983"), "28013")
+
+      expect(response).not_to be_valid
+    end
   end
 end

--- a/spec/lib/remote_census_api_spec.rb
+++ b/spec/lib/remote_census_api_spec.rb
@@ -4,20 +4,12 @@ describe RemoteCensusApi do
   let(:api) { RemoteCensusApi.new }
 
   describe "#call", :remote_census do
-    let(:invalid_body) { { get_habita_datos_response: { get_habita_datos_return: { datos_habitante: {}}}} }
-    let(:valid_body) do
-      {
-        get_habita_datos_response: {
-          get_habita_datos_return: {
-            datos_habitante: {
-              item: {
-                fecha_nacimiento_string: "1-1-1980"
-              }
-            }
-          }
-        }
-      }
+    before do
+      Setting["remote_census.response.valid"] = "response.data.date_of_birth"
     end
+
+    let(:invalid_body) { { response: { data: {}}} }
+    let(:valid_body) { { response: { data: { date_of_birth: "1-1-1980" }}} }
 
     it "returns the response for the first valid variant" do
       date = Date.parse("01/01/1983")
@@ -153,23 +145,15 @@ describe RemoteCensusApi do
 
       response = RemoteCensusApi.new.send(:get_response_body, document_type, document_number, nil, nil)
 
-      expect(response).to eq({ get_habita_datos_response: {
-                                 get_habita_datos_return: {
-                                   datos_habitante: {
-                                     item: {
-                                       fecha_nacimiento_string: "31-12-1980",
-                                       identificador_documento: "12345678Z",
-                                       descripcion_sexo: "Varón",
-                                       nombre: "José",
-                                       apellido1: "García"
-                                     }
-                                   },
-                                   datos_vivienda: {
-                                     item: {
-                                       codigo_postal: "28013",
-                                       codigo_distrito: "01"
-                                     }
-                                   }
+      expect(response).to eq({ response: {
+                                 data: {
+                                   date_of_birth: "31-12-1980",
+                                   document_number: "12345678Z",
+                                   gender: "Male",
+                                   name: "William",
+                                   surname: "Widmore",
+                                   postal_code: "28013",
+                                   district_code: "01"
                                  }
                                }
                              })
@@ -187,9 +171,8 @@ describe RemoteCensusApi do
       expect(response.valid?).to eq true
       expect(response.date_of_birth).to eq Time.zone.local(1980, 12, 31).to_date
       expect(response.postal_code).to eq "28013"
-      expect(response.district_code).to eq "01"
       expect(response.gender).to eq "male"
-      expect(response.name).to eq "José García"
+      expect(response.name).to eq "William Widmore"
     end
   end
 end

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -34,23 +34,12 @@ describe Officing::Residence do
       expect(residence).to be_valid
     end
 
-    describe "custom validations" do
+    describe "custom validations", :remote_census do
       let(:custom_residence) do
         build(:officing_residence,
               document_number: "12345678Z",
               date_of_birth: "01/01/1980",
               postal_code: "28001")
-      end
-
-      before do
-        Setting["feature.remote_census"] = true
-        Setting["remote_census.request.date_of_birth"] = "some.value"
-        Setting["remote_census.request.postal_code"] = "some.value"
-        access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-        access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-        Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-        Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-        Setting["remote_census.response.valid"] = access_user_data
       end
 
       it "is valid" do

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -38,7 +38,7 @@ describe Officing::Residence do
       let(:custom_residence) do
         build(:officing_residence,
               document_number: "12345678Z",
-              date_of_birth: "01/01/1980",
+              date_of_birth: Date.parse("01/01/1980"),
               postal_code: "28001")
       end
 

--- a/spec/models/officing/residence_spec.rb
+++ b/spec/models/officing/residence_spec.rb
@@ -43,6 +43,8 @@ describe Officing::Residence do
       end
 
       it "is valid" do
+        mock_valid_remote_census_response
+
         expect(custom_residence).to be_valid
       end
 
@@ -59,11 +61,15 @@ describe Officing::Residence do
       it "is valid without a year of birth when date_of_birth is present" do
         custom_residence.year_of_birth = nil
 
+        mock_valid_remote_census_response
+
         expect(custom_residence).to be_valid
       end
 
       it "is not valid without a date of birth" do
         custom_residence.date_of_birth = nil
+
+        mock_valid_remote_census_response
 
         expect(custom_residence).not_to be_valid
       end
@@ -71,15 +77,18 @@ describe Officing::Residence do
       it "is not valid without a postal_code" do
         custom_residence.postal_code = nil
 
+        mock_valid_remote_census_response
+
         expect(custom_residence).not_to be_valid
       end
 
       describe "dates" do
-        it "is valid with a valid date of birth" do
+        it "is not valid but not because date of birth" do
           custom_residence = Officing::Residence.new("date_of_birth(3i)" => "1",
                                                  "date_of_birth(2i)" => "1",
                                                  "date_of_birth(1i)" => "1980")
 
+          expect(custom_residence).not_to be_valid
           expect(custom_residence.errors[:date_of_birth]).to be_empty
         end
 
@@ -99,6 +108,11 @@ describe Officing::Residence do
                           :invalid,
                           document_number: "12345678Z",
                           postal_code: "00001")
+
+        %w[12345678 12345678z 12345678Z].each do
+          mock_invalid_remote_census_response
+        end
+
         residence.save
 
         expect(FailedCensusCall.count).to eq(1)

--- a/spec/models/signature_sheet_spec.rb
+++ b/spec/models/signature_sheet_spec.rb
@@ -112,14 +112,15 @@ describe SignatureSheet do
       expect(signature_sheet.processed).to eq(true)
     end
 
-    context "with remote census active" do
-      before do
-        Setting["feature.remote_census"] = true
-      end
-
+    context "with remote census active", :remote_census do
       it "creates signatures for each group with document_number" do
+        Setting["remote_census.request.date_of_birth"] = nil
+        Setting["remote_census.request.postal_code"] = nil
+
         required_fields_to_verify = "123A; 456B"
         signature_sheet = create(:signature_sheet, required_fields_to_verify: required_fields_to_verify)
+
+        %w[123A 456B].each { mock_valid_remote_census_response }
         signature_sheet.verify_signatures
 
         expect(Signature.count).to eq(2)
@@ -132,10 +133,12 @@ describe SignatureSheet do
       end
 
       it "creates signatures for each group with document_number and date_of_birth" do
-        Setting["remote_census.request.date_of_birth"] = "some.value"
+        Setting["remote_census.request.postal_code"] = nil
 
         required_fields_to_verify = "123A, 01/01/1980; 456B, 01/02/1980"
         signature_sheet = create(:signature_sheet, required_fields_to_verify: required_fields_to_verify)
+
+        %w[123A 456B].each { mock_valid_remote_census_response }
         signature_sheet.verify_signatures
 
         expect(Signature.count).to eq(2)
@@ -145,15 +148,15 @@ describe SignatureSheet do
         expect(Signature.last.document_number).to eq("456B")
         expect(Signature.last.date_of_birth).to eq(Date.parse("01/02/1980"))
         expect(Signature.last.postal_code).to eq(nil)
-
-        Setting["remote_census.request.date_of_birth"] = nil
       end
 
       it "creates signatures for each group with document_number and postal_code" do
-        Setting["remote_census.request.postal_code"] = "some.value"
+        Setting["remote_census.request.date_of_birth"] = nil
 
         required_fields_to_verify = "123A, 28001; 456B, 28002"
         signature_sheet = create(:signature_sheet, required_fields_to_verify: required_fields_to_verify)
+
+        %w[123A 456B].each { mock_valid_remote_census_response }
         signature_sheet.verify_signatures
 
         expect(Signature.count).to eq(2)
@@ -163,16 +166,13 @@ describe SignatureSheet do
         expect(Signature.last.document_number).to eq("456B")
         expect(Signature.last.date_of_birth).to eq(nil)
         expect(Signature.last.postal_code).to eq("28002")
-
-        Setting["remote_census.request.postal_code"] = nil
       end
 
       it "creates signatures for each group with document_number, postal_code and date_of_birth" do
-        Setting["remote_census.request.date_of_birth"] = "some.value"
-        Setting["remote_census.request.postal_code"] = "some.value"
-
         required_fields_to_verify = "123A, 01/01/1980, 28001; 456B, 01/02/1980, 28002"
         signature_sheet = create(:signature_sheet, required_fields_to_verify: required_fields_to_verify)
+
+        %w[123A 456B].each { mock_valid_remote_census_response }
         signature_sheet.verify_signatures
 
         expect(Signature.count).to eq(2)
@@ -182,9 +182,6 @@ describe SignatureSheet do
         expect(Signature.last.document_number).to eq("456B")
         expect(Signature.last.date_of_birth).to eq(Date.parse("01/02/1980"))
         expect(Signature.last.postal_code).to eq("28002")
-
-        Setting["remote_census.request.date_of_birth"] = nil
-        Setting["remote_census.request.postal_code"] = nil
       end
     end
   end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -230,6 +230,8 @@ describe Signature do
                                        date_of_birth: "31/12/1980",
                                        postal_code: "28013")
 
+        mock_valid_remote_census_response
+
         expect_any_instance_of(Signature).to receive(:assign_vote_to_user).exactly(1).times
 
         signature.verify

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -225,18 +225,7 @@ describe Signature do
     end
 
     describe "document in census throught CustomCensusApi" do
-      before do
-        Setting["feature.remote_census"] = true
-        Setting["remote_census.request.date_of_birth"] = "some.value"
-        Setting["remote_census.request.postal_code"] = "some.value"
-        access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-        access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-        Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-        Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-        Setting["remote_census.response.valid"] = access_user_data
-      end
-
-      it "calls assign_vote_to_user" do
+      it "calls assign_vote_to_user", :remote_census do
         signature = create(:signature, document_number: "12345678Z",
                                        date_of_birth: "31/12/1980",
                                        postal_code: "28013")

--- a/spec/models/verification/management/document_spec.rb
+++ b/spec/models/verification/management/document_spec.rb
@@ -28,18 +28,7 @@ describe Verification::Management::Document do
       expect(verification_document).to be_valid
     end
 
-    describe "custom validations with RemoteCensus enabled" do
-      before do
-        Setting["feature.remote_census"] = true
-        Setting["remote_census.request.date_of_birth"] = "some.value"
-        Setting["remote_census.request.postal_code"] = "some.value"
-        access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-        access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-        Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-        Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-        Setting["remote_census.response.valid"] = access_user_data
-      end
-
+    describe "custom validations with RemoteCensus enabled", :remote_census do
       it "is valid" do
         expect(verification_document).to be_valid
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,6 +105,38 @@ RSpec.configure do |config|
     allow(Time).to receive(:zone).and_return(application_zone)
   end
 
+  config.before(:each, :remote_census) do |example|
+    Setting["remote_census.request.method_name"] = "get_habita_datos"
+    Setting["remote_census.request.document_type"] = "request.tipo_documento"
+    Setting["remote_census.request.document_number"] = "request.documento"
+    Setting["remote_census.request.date_of_birth"] = "request.fecha_nacimiento"
+    Setting["remote_census.request.postal_code"] = "request.codigo_postal"
+    Setting["remote_census.request.structure"] = '{ "request":
+      {
+        "codigo_institucion": 1,
+        "codigo_portal": 1,
+        "codigo_usuario": 1,
+        "documento": "nil",
+        "tipo_documento": "null",
+        "fecha_nacimiento": "null",
+        "codigo_postal": "nil",
+        "codigo_idioma": 102,
+        "nivel": 3
+      }
+    }'
+
+    access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
+    access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
+    Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
+    Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
+    Setting["remote_census.response.district"] = "#{access_residence_data}.codigo_distrito"
+    Setting["remote_census.response.gender"] = "#{access_user_data}.descripcion_sexo"
+    Setting["remote_census.response.name"] = "#{access_user_data}.nombre"
+    Setting["remote_census.response.surname"] = "#{access_user_data}.apellido1"
+    Setting["remote_census.response.valid"] = access_user_data
+    Setting["feature.remote_census"] = true
+  end
+
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options.
   config.example_status_persistence_file_path = "spec/examples.txt"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,35 +106,28 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :remote_census) do |example|
-    Setting["remote_census.request.method_name"] = "get_habita_datos"
-    Setting["remote_census.request.document_type"] = "request.tipo_documento"
-    Setting["remote_census.request.document_number"] = "request.documento"
-    Setting["remote_census.request.date_of_birth"] = "request.fecha_nacimiento"
-    Setting["remote_census.request.postal_code"] = "request.codigo_postal"
+    Setting["feature.remote_census"] = true
+    Setting["remote_census.request.method_name"] = "verify_residence"
     Setting["remote_census.request.structure"] = '{ "request":
       {
-        "codigo_institucion": 1,
-        "codigo_portal": 1,
-        "codigo_usuario": 1,
-        "documento": "nil",
-        "tipo_documento": "null",
-        "fecha_nacimiento": "null",
-        "codigo_postal": "nil",
-        "codigo_idioma": 102,
-        "nivel": 3
+        "document_type": "null",
+        "document_number": "nil",
+        "date_of_birth": "null",
+        "postal_code": "nil"
       }
     }'
 
-    access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-    access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-    Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-    Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-    Setting["remote_census.response.district"] = "#{access_residence_data}.codigo_distrito"
-    Setting["remote_census.response.gender"] = "#{access_user_data}.descripcion_sexo"
-    Setting["remote_census.response.name"] = "#{access_user_data}.nombre"
-    Setting["remote_census.response.surname"] = "#{access_user_data}.apellido1"
-    Setting["remote_census.response.valid"] = access_user_data
-    Setting["feature.remote_census"] = true
+    Setting["remote_census.request.document_type"] = "request.document_type"
+    Setting["remote_census.request.document_number"] = "request.document_number"
+    Setting["remote_census.request.date_of_birth"] = "request.date_of_birth"
+    Setting["remote_census.request.postal_code"] = "request.postal_code"
+    Setting["remote_census.response.date_of_birth"] = "response.data.date_of_birth"
+    Setting["remote_census.response.postal_code"] = "response.data.postal_code"
+    Setting["remote_census.response.district"] = "response.data.district_code"
+    Setting["remote_census.response.gender"] = "response.data.gender"
+    Setting["remote_census.response.name"] = "response.data.name"
+    Setting["remote_census.response.surname"] = "response.data.surname"
+    Setting["remote_census.response.valid"] = "response.data.document_number"
   end
 
   # Allows RSpec to persist some state between runs in order to support

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -128,6 +128,12 @@ RSpec.configure do |config|
     Setting["remote_census.response.name"] = "response.data.name"
     Setting["remote_census.response.surname"] = "response.data.surname"
     Setting["remote_census.response.valid"] = "response.data.document_number"
+
+    savon.mock!
+  end
+
+  config.after(:each, :remote_census) do
+    savon.unmock!
   end
 
   # Allows RSpec to persist some state between runs in order to support

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,6 +106,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :remote_census) do |example|
+    allow_any_instance_of(RemoteCensusApi).to receive(:end_point_defined?).and_return(true)
     Setting["feature.remote_census"] = true
     Setting["remote_census.request.method_name"] = "verify_residence"
     Setting["remote_census.request.structure"] = '{ "request":

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -8,6 +8,7 @@ module CommonActions
   include Notifications
   include Polls
   include Proposals
+  include RemoteCensusMock
   include Tags
   include Translations
   include Users

--- a/spec/support/common_actions/remote_census_mock.rb
+++ b/spec/support/common_actions/remote_census_mock.rb
@@ -1,0 +1,30 @@
+require "savon/mock/spec_helper"
+
+module RemoteCensusMock
+  include Savon::SpecHelper
+  include DocumentParser
+
+  def mock_valid_remote_census_response
+    mock_remote_census_response(File.read("spec/fixtures/files/remote_census_api/valid.xml"))
+  end
+
+  def mock_invalid_remote_census_response
+    mock_remote_census_response(File.read("spec/fixtures/files/remote_census_api/invalid.xml"))
+  end
+
+  def mock_invalid_signature_sheet_remote_census_response
+    xml = File.read("spec/fixtures/files/remote_census_api/invalid.xml")
+
+    Signature.new.document_types.each do |document_type|
+      get_document_number_variants(document_type, "12345678Z").each do
+        mock_remote_census_response(xml)
+      end
+    end
+  end
+
+  def mock_remote_census_response(xml)
+    savon.expects(Setting["remote_census.request.method_name"].to_sym)
+         .with(message: :any)
+         .returns(xml)
+  end
+end

--- a/spec/system/admin/signature_sheets_spec.rb
+++ b/spec/system/admin/signature_sheets_spec.rb
@@ -76,18 +76,7 @@ describe "Signature sheets" do
     end
   end
 
-  context "Create throught all required_fields_to_verify of custom census api" do
-    before do
-      Setting["feature.remote_census"] = true
-      Setting["remote_census.request.date_of_birth"] = "some.value"
-      Setting["remote_census.request.postal_code"] = "some.value"
-      access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-      access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-      Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-      Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-      Setting["remote_census.response.valid"] = access_user_data
-    end
-
+  context "Create throught all required_fields_to_verify of custom census api", :remote_census do
     scenario "Proposal" do
       proposal = create(:proposal)
       visit new_admin_signature_sheet_path

--- a/spec/system/admin/signature_sheets_spec.rb
+++ b/spec/system/admin/signature_sheets_spec.rb
@@ -77,6 +77,11 @@ describe "Signature sheets" do
   end
 
   context "Create throught all required_fields_to_verify of custom census api", :remote_census do
+    before do
+      mock_valid_remote_census_response
+      mock_invalid_signature_sheet_remote_census_response
+    end
+
     scenario "Proposal" do
       proposal = create(:proposal)
       visit new_admin_signature_sheet_path

--- a/spec/system/management/document_verifications_spec.rb
+++ b/spec/system/management/document_verifications_spec.rb
@@ -67,7 +67,10 @@ describe "DocumentVerifications" do
         expect(page).to have_content "This document is not registered"
       end
 
-      scenario "Verifying a user which does exists in the census but not in the db redirects allows sending an email" do
+      scenario "Verifying a user which does exists in the census but not in the db
+                redirects allows sending an email" do
+        mock_valid_remote_census_response
+
         visit management_document_verifications_path
         fill_in "document_verification_document_number", with: "12345678Z"
         select_date "31-December-1980", from: "document_verification_date_of_birth"

--- a/spec/system/management/document_verifications_spec.rb
+++ b/spec/system/management/document_verifications_spec.rb
@@ -53,18 +53,7 @@ describe "DocumentVerifications" do
       end
     end
 
-    context "Remote Census API" do
-      before do
-        Setting["feature.remote_census"] = true
-        Setting["remote_census.request.date_of_birth"] = "some.value"
-        Setting["remote_census.request.postal_code"] = "some.value"
-        access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-        access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-        Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-        Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-        Setting["remote_census.response.valid"] = access_user_data
-      end
-
+    context "Remote Census API", :remote_census do
       scenario "Verifying a user which does not exist and is not in the census shows an error" do
         expect_any_instance_of(Verification::Management::Document).to receive(:in_census?).
                                                                       and_return(false)

--- a/spec/system/officing/residence_spec.rb
+++ b/spec/system/officing/residence_spec.rb
@@ -111,11 +111,8 @@ describe "Residence", :with_frozen_time do
     expect(page).to have_content "Vote introduced!"
   end
 
-  context "With remote census configuration" do
+  context "With remote census configuration", :remote_census do
     before do
-      Setting["feature.remote_census"] = true
-      Setting["remote_census.request.date_of_birth"] = "some.value"
-      Setting["remote_census.request.postal_code"] = "some.value"
       create(:poll_officer_assignment, officer: officer)
       login_through_form_as_officer(officer.user)
       visit officing_root_path
@@ -137,9 +134,6 @@ describe "Residence", :with_frozen_time do
       end
 
       scenario "with all custom census not display year_of_birth" do
-        Setting["remote_census.request.date_of_birth"] = "some.value"
-        Setting["remote_census.request.postal_code"] = "some.value"
-
         within("#side_menu") do
           click_link "Validate document"
         end
@@ -153,11 +147,6 @@ describe "Residence", :with_frozen_time do
     end
 
     scenario "can verify voter with date_of_birth and postal_code fields" do
-      access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-      access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-      Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-      Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-      Setting["remote_census.response.valid"] = access_user_data
       within("#side_menu") do
         click_link "Validate document"
       end

--- a/spec/system/officing/residence_spec.rb
+++ b/spec/system/officing/residence_spec.rb
@@ -147,6 +147,8 @@ describe "Residence", :with_frozen_time do
     end
 
     scenario "can verify voter with date_of_birth and postal_code fields" do
+      mock_valid_remote_census_response
+
       within("#side_menu") do
         click_link "Validate document"
       end
@@ -154,7 +156,7 @@ describe "Residence", :with_frozen_time do
       select "DNI", from: "residence_document_type"
       fill_in "residence_document_number", with: "12345678Z"
       select_date "31-December-1980", from: "residence_date_of_birth"
-      fill_in "residence_postal_code", with: "28001"
+      fill_in "residence_postal_code", with: "28013"
 
       click_button "Validate document"
 

--- a/spec/system/verification/residence_spec.rb
+++ b/spec/system/verification/residence_spec.rb
@@ -20,14 +20,7 @@ describe "Residence" do
     expect(page).to have_content "Residence verified"
   end
 
-  scenario "Verify resident throught RemoteCensusApi" do
-    Setting["feature.remote_census"] = true
-
-    access_user_data = "get_habita_datos_response.get_habita_datos_return.datos_habitante.item"
-    access_residence_data = "get_habita_datos_response.get_habita_datos_return.datos_vivienda.item"
-    Setting["remote_census.response.date_of_birth"] = "#{access_user_data}.fecha_nacimiento_string"
-    Setting["remote_census.response.postal_code"] = "#{access_residence_data}.codigo_postal"
-    Setting["remote_census.response.valid"] = access_user_data
+  scenario "Verify resident throught RemoteCensusApi", :remote_census do
     user = create(:user)
     login_as(user)
 
@@ -42,7 +35,6 @@ describe "Residence" do
     click_button "Verify residence"
 
     expect(page).to have_content "Residence verified"
-    Setting["feature.remote_census"] = nil
   end
 
   scenario "Residence form use min age to participate" do

--- a/spec/system/verification/residence_spec.rb
+++ b/spec/system/verification/residence_spec.rb
@@ -23,6 +23,7 @@ describe "Residence" do
   scenario "Verify resident throught RemoteCensusApi", :remote_census do
     user = create(:user)
     login_as(user)
+    mock_valid_remote_census_response
 
     visit account_path
     click_link "Verify my account"


### PR DESCRIPTION
## References

Some contributors are getting confused with the format of the Web Service response as you can see in following issues:
* #4161 
* #3869 

## Objectives
To have a sample of a real XML response and RemoteCensusApi settings so main repository or fork contributors can see a working example of how the integration works.

The test keeps doing the same but now we use a mock of a valid XML response in place of using the stubbed response so other contributors can understand how this really behaves.

When any other contributor is confused about this integration we could link to this PR so they can see how the response should look like and how the Settings are configured.