### PR TITLE
Use Harmony mode in uglifier for ES2015+ support

### DIFF
--- a/config/environments/preproduction.rb
+++ b/config/environments/preproduction.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
## References

* This bug was introduced in pull request #3288
* This problem is mentioned in rmosolgo/graphiql-rails#44 and rmosolgo/graphiql-rails#70
* How to enable this mode is described in the [Uglifier README](https://github.com/lautis/uglifier/tree/v4.2.0#es6--es2015--harmony-mode)

## Objectives

Make it possible to compile the assets included in `graphql-rails` with Uglifier on production environments.