### PR TITLE
Use labels for web_section_ids checkboxes texts

### DIFF
--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -37,7 +37,9 @@
     <div class="small-12 column">
       <%= f.label :sections, t("admin.banners.banner.sections_label") %>
       <%= f.collection_check_boxes(:web_section_ids, @banner_sections, :id, :name) do |b| %>
-        <%= b.check_box %> <%= t("admin.banners.banner.sections.#{b.text}") %><br>
+        <%= b.label do %>
+          <%= b.check_box + t("admin.banners.banner.sections.#{b.text}") %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -34,14 +34,14 @@
   </div>
 
   <div class="row">
-    <div class="small-12 column">
-      <%= f.label :sections, t("admin.banners.banner.sections_label") %>
+    <fieldset class="small-12 column">
+      <legend><%= t("admin.banners.banner.sections_label") %></legend>
       <%= f.collection_check_boxes(:web_section_ids, @banner_sections, :id, :name) do |b| %>
         <%= b.label do %>
           <%= b.check_box + t("admin.banners.banner.sections.#{b.text}") %>
         <% end %>
       <% end %>
-    </div>
+    </fieldset>
   </div>
 
   <div class="row">

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -73,7 +73,7 @@ describe "Admin banners magement" do
   end
 
   scenario "Publish a banner" do
-    section = create(:web_section, name: "proposals")
+    section = WebSection.find_by(name: "proposals")
 
     visit admin_root_path
 
@@ -92,7 +92,7 @@ describe "Admin banners magement" do
     fill_in "post_ended_at", with: next_week.strftime("%d/%m/%Y")
     fill_in "banner_background_color", with: "#850000"
     fill_in "banner_font_color", with: "#ffb2b2"
-    check "banner_web_section_ids_#{section.id}"
+    check section.name.titleize
 
     click_button "Save changes"
 


### PR DESCRIPTION
# Objectives
Use labels for banners `web_section_ids` checkboxes intead of plain text so when a user clicks on the checkbox label the checkbox is checked/unchecked. 

Use fieldset to group the checkboxes collection and replace label with a legend.

# Screenshots

**Before**

<img width="526" alt="Captura de pantalla 2020-10-28 a las 11 25 12" src="https://user-images.githubusercontent.com/15726/97428631-8bc74780-1916-11eb-94ec-29980c95c5d5.png">

**After**
<img width="530" alt="Captura de pantalla 2020-10-28 a las 11 20 04" src="https://user-images.githubusercontent.com/15726/97428645-9386ec00-1916-11eb-816a-c35a5214b291.png">

