### PR TITLE
Avoid seasonal clock changes issues in specs

### DIFF
--- a/spec/system/proposal_notifications_spec.rb
+++ b/spec/system/proposal_notifications_spec.rb
@@ -405,7 +405,7 @@ describe "Proposal Notifications" do
 
       expect(page).to have_content "Your message has been sent correctly."
 
-      travel(3.days + 1.second) do
+      travel_to(3.days.from_now + 1.second) do
         visit new_proposal_notification_path(proposal_id: proposal.id)
         fill_in "Title", with: "Thank you again for supporting my proposal"
         fill_in "Message", with: "Please share it again with others so we can make it happen!"


### PR DESCRIPTION
## References

* This issue happened last year as well and we mitigated it a bit in pull request #3797

## Background

Using `travel` we go to `Time.now + interval`. If the application's time zone changes due to seasonal clock changes during that interval, we might travel to a time which is not the time we intended to travel to.

Example:

On a system using the UTC time zone, it's 9AM on October 25 (Friday). Since by default CONSUL uses the Madrid time zone, it means the application's time is 11AM.

We use `travel` to advance three days. That means we go to 9AM UTC on October 28 (Monday). The application's time will be 10AM due to the seasonal clock change, so we haven't fully traveled three days in application's time.

To reproduce locally, run:

```bash
TZ=UTC rspec spec/system/proposal_notifications_spec.rb:410
```

## Objectives

Using `travel_to` with `3.days.from_now`, which uses the application's time zone and so it will travel to October 28 at 11AM, solves the problem.