### PR TITLE
Fix rubocop offenses in XLSX files

### DIFF
--- a/app/views/legislation/processes/summary.xlsx.axlsx
+++ b/app/views/legislation/processes/summary.xlsx.axlsx
@@ -1,8 +1,7 @@
 xlsx_package.workbook.add_worksheet(name: "Summary") do |sheet|
-
-styles = xlsx_package.workbook.styles
-title = styles.add_style(b:true)
-link = styles.add_style(fg_color: "0000FF", u: true)
+  styles = xlsx_package.workbook.styles
+  title = styles.add_style(b: true)
+  link = styles.add_style(fg_color: "0000FF", u: true)
 
   if @process.debate_phase.enabled? && @process.questions.any?
     sheet.add_row [t("legislation.summary.debate_phase"), t("legislation.summary.debates", count: @process.questions.count)], style: title

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -54,7 +54,7 @@ namespace :deploy do
 
   after "deploy:migrate", "add_new_settings"
 
-  after  :publishing, "setup_puma"
+  after :publishing, "setup_puma"
 
   after :published, "deploy:restart"
   before "deploy:restart", "puma:restart"


### PR DESCRIPTION
## References

* These offenses were introduced in pull request #4065

## Objectives

Make sure we follow conventions and so the command `bundle exec rubocop --fail-level convention --display-only-fail-level-offenses` does not return any offenses