### PR TITLE
Fix redirect when toggling visible to valuators

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -39,16 +39,25 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
   def update
     authorize! :admin_update, @investment
-    if @investment.update(budget_investment_params)
-      redirect_to admin_budget_budget_investment_path(@budget,
-                                                      @investment,
-                                                      Budget::Investment.filter_params(params).to_h),
-                  notice: t("flash.actions.update.budget_investment")
-    else
-      load_staff
-      load_valuator_groups
-      load_tags
-      render :edit
+
+    respond_to do |format|
+      format.html do
+        if @investment.update(budget_investment_params)
+          redirect_to admin_budget_budget_investment_path(@budget,
+                                                          @investment,
+                                                          Budget::Investment.filter_params(params).to_h),
+                      notice: t("flash.actions.update.budget_investment")
+        else
+          load_staff
+          load_valuator_groups
+          load_tags
+          render :edit
+        end
+      end
+
+      format.json do
+        @investment.update!(budget_investment_params)
+      end
     end
   end
 

--- a/app/views/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/admin/budget_investments/_select_investment.html.erb
@@ -51,7 +51,7 @@
 </td>
 
 <td class="small text-center" data-field="visible_to_valuators">
-  <%= form_for [:admin, investment.budget, investment], remote: true do |f| %>
+  <%= form_for [:admin, investment.budget, investment], remote: true, format: :json do |f| %>
       <%= f.check_box :visible_to_valuators,
                       label: false,
                       class: "js-submit-on-change",

--- a/app/views/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/admin/budget_investments/_select_investment.html.erb
@@ -51,11 +51,15 @@
 </td>
 
 <td class="small text-center" data-field="visible_to_valuators">
-  <%= form_for [:admin, investment.budget, investment], remote: true, format: :json do |f| %>
-      <%= f.check_box :visible_to_valuators,
-                      label: false,
-                      class: "js-submit-on-change",
-                      id: "budget_investment_visible_to_valuators" %>
+  <% if can?(:admin_update, investment) %>
+    <%= form_for [:admin, investment.budget, investment], remote: true, format: :json do |f| %>
+        <%= f.check_box :visible_to_valuators,
+                        label: false,
+                        class: "js-submit-on-change",
+                        id: "budget_investment_visible_to_valuators" %>
+    <% end %>
+  <% else %>
+    <%= investment.visible_to_valuators? ? t("shared.yes") : t("shared.no") %>
   <% end %>
 </td>
 

--- a/spec/controllers/admin/budget_investments_controller_spec.rb
+++ b/spec/controllers/admin/budget_investments_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Admin::BudgetInvestmentsController do
+  describe "PATCH update" do
+    it "does not redirect on AJAX requests" do
+      investment = create(:budget_investment)
+      sign_in(create(:administrator).user)
+
+      patch :update, params: {
+        id: investment,
+        budget_id: investment.budget,
+        format: :json,
+        budget_investment: { visible_to_valuators: true }
+      }
+
+      expect(response).not_to be_redirect
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.include RequestSpecHelper, type: :request
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
   config.include FactoryBot::Syntax::Methods
   config.include(EmailSpec::Helpers)
   config.include(EmailSpec::Matchers)

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -1651,6 +1651,28 @@ describe "Admin budget investments" do
       end
     end
 
+    scenario "Cannot mark/unmark visible to valuators on finished budgets" do
+      budget.update!(phase: "finished")
+      create(:budget_investment, budget: budget, title: "Visible", visible_to_valuators: true)
+      create(:budget_investment, budget: budget, title: "Invisible", visible_to_valuators: false)
+
+      visit admin_budget_budget_investments_path(budget)
+
+      within "tr", text: "Visible" do
+        within "td[data-field=visible_to_valuators]" do
+          expect(page).to have_text "Yes"
+          expect(page).not_to have_field "budget_investment_visible_to_valuators"
+        end
+      end
+
+      within "tr", text: "Invisible" do
+        within "td[data-field=visible_to_valuators]" do
+          expect(page).to have_text "No"
+          expect(page).not_to have_field "budget_investment_visible_to_valuators"
+        end
+      end
+    end
+
     scenario "Showing the valuating checkbox" do
       investment1 = create(:budget_investment, :with_administrator, :with_valuator, :visible_to_valuators,
                            budget: budget)

--- a/spec/views/admin/budget_investments/select_investment_spec.rb
+++ b/spec/views/admin/budget_investments/select_investment_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe "investment row" do
+  it "uses a JSON request to update visible to valuators" do
+    investment = create(:budget_investment)
+    @budget = investment.budget
+    sign_in(create(:administrator).user)
+
+    render "admin/budget_investments/select_investment", investment: investment
+
+    expect(rendered).to have_css "form[action$='json'] input[name$='[visible_to_valuators]']"
+  end
+end


### PR DESCRIPTION
## References

* This bug was introduced after updating Turbolinks in pull request #3699
* [Travis build 35477, job 4](https://travis-ci.com/github/consul/consul/jobs/403746446) failed due to this bug
* We believe sometimes related tests get stuck, like [Travis build 35539, job 4](https://travis-ci.com/github/consul/consul/jobs/407572626) or [Travis build 35546, job 5](https://travis-ci.com/github/consul/consul/jobs/409896998), which timed out in the test "Admin budget investments Mark as visible to valuators Mark as visible to valuator"

## Objectives

* Fix a bug when marking/unmarking an investment as visible to valuators
* Don't show the option to mark/unmark an investment as visible to valuators when the investment cannot be edited