### PR TITLE
Restore all related content along when a user is restored

### DIFF
--- a/app/controllers/admin/hidden_users_controller.rb
+++ b/app/controllers/admin/hidden_users_controller.rb
@@ -19,7 +19,7 @@ class Admin::HiddenUsersController < Admin::BaseController
   end
 
   def restore
-    @user.restore
+    @user.full_restore
     Activity.log(current_user, :restore, @user)
     redirect_with_query_params_to(action: :index)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -250,7 +250,9 @@ class User < ApplicationRecord
       Comment.restore_all comments.where("hidden_at >= ?", hidden_at)
       Proposal.restore_all proposals.where("hidden_at >= ?", hidden_at)
       Budget::Investment.restore_all budget_investments.where("hidden_at >= ?", hidden_at)
-      ProposalNotification.restore_all ProposalNotification.where("hidden_at >= ?", hidden_at).where(author_id: id).unscope(:where)
+      ProposalNotification.restore_all(
+        ProposalNotification.where("hidden_at >= ?", hidden_at).where(author_id: id).unscope(:where)
+      )
 
       restore
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,19 +235,20 @@ class User < ApplicationRecord
   end
 
   def block
-    debates_ids = Debate.where(author_id: id).pluck(:id)
-    comments_ids = Comment.where(user_id: id).pluck(:id)
-    proposal_ids = Proposal.where(author_id: id).pluck(:id)
-    investment_ids = Budget::Investment.where(author_id: id).pluck(:id)
-    proposal_notification_ids = ProposalNotification.where(author_id: id).pluck(:id)
-
     hide
 
-    Debate.hide_all debates_ids
-    Comment.hide_all comments_ids
+    Debate.hide_all debate_ids
+    Comment.hide_all comment_ids
     Proposal.hide_all proposal_ids
-    Budget::Investment.hide_all investment_ids
-    ProposalNotification.hide_all proposal_notification_ids
+    Budget::Investment.hide_all budget_investment_ids
+    ProposalNotification.hide_all ProposalNotification.where(author_id: id).pluck(:id)
+  end
+
+  def after_restore
+    Debate.restore_all debate_ids
+    Comment.restore_all comment_ids
+    Proposal.restore_all proposal_ids
+    Budget::Investment.restore_all budget_investment_ids
   end
 
   def erase(erase_reason = nil)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -709,4 +709,21 @@ describe User do
       expect(User.find_by_manager_login("admin_user_#{user.id}")).to eq user
     end
   end
+
+  describe "#after_restore" do
+    it "restore all previous hidden user content" do
+      user                  = create(:user, :hidden)
+      debate                = create(:debate, :hidden, author: user)
+      comment               = create(:comment, :hidden, author: user)
+      proposal              = create(:proposal, :hidden, author: user)
+      budget_investment     = create(:budget_investment, :hidden, author: user)
+
+      user.restore
+
+      expect(debate.reload.hidden?).to be_falsey
+      expect(comment.reload.hidden?).to be_falsey
+      expect(proposal.reload.hidden?).to be_falsey
+      expect(budget_investment.reload.hidden?).to be_falsey
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -710,20 +710,25 @@ describe User do
     end
   end
 
-  describe "#after_restore" do
+  describe "#full_restore" do
     it "restore all previous hidden user content" do
       user = create(:user, :hidden)
       debate = create(:debate, :hidden, author: user)
+      old_hidden_debate = create(:debate, hidden_at: 3.days.ago, author: user)
       comment = create(:comment, :hidden, author: user)
       proposal = create(:proposal, :hidden, author: user)
       budget_investment = create(:budget_investment, :hidden, author: user)
+      proposal_notification = create(:proposal_notification, :hidden, author: user, proposal: proposal)
 
-      user.restore
+      user.full_restore
 
-      expect(debate.reload.hidden?).not_to be_hidden
-      expect(comment.reload.hidden?).not_to be_hidden
-      expect(proposal.reload.hidden?).not_to be_hidden
-      expect(budget_investment.reload.hidden?).not_to be_hidden
+      expect(old_hidden_debate.reload).to be_hidden
+
+      expect(debate.reload).not_to be_hidden
+      expect(comment.reload).not_to be_hidden
+      expect(proposal.reload).not_to be_hidden
+      expect(budget_investment.reload).not_to be_hidden
+      expect(proposal_notification.reload).not_to be_hidden
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -712,18 +712,18 @@ describe User do
 
   describe "#after_restore" do
     it "restore all previous hidden user content" do
-      user                  = create(:user, :hidden)
-      debate                = create(:debate, :hidden, author: user)
-      comment               = create(:comment, :hidden, author: user)
-      proposal              = create(:proposal, :hidden, author: user)
-      budget_investment     = create(:budget_investment, :hidden, author: user)
+      user = create(:user, :hidden)
+      debate = create(:debate, :hidden, author: user)
+      comment = create(:comment, :hidden, author: user)
+      proposal = create(:proposal, :hidden, author: user)
+      budget_investment = create(:budget_investment, :hidden, author: user)
 
       user.restore
 
-      expect(debate.reload.hidden?).to be_falsey
-      expect(comment.reload.hidden?).to be_falsey
-      expect(proposal.reload.hidden?).to be_falsey
-      expect(budget_investment.reload.hidden?).to be_falsey
+      expect(debate.reload.hidden?).not_to be_hidden
+      expect(comment.reload.hidden?).not_to be_hidden
+      expect(proposal.reload.hidden?).not_to be_hidden
+      expect(budget_investment.reload.hidden?).not_to be_hidden
     end
   end
 end


### PR DESCRIPTION
## References

https://github.com/consul/consul/issues/3551

## Objectives

Restore all related user content after restore user itself.

## Visual Changes

Nope

## Notes

As far as I understand is not needed to restore proposal notification, but nort 100% about this part.
