### PR TITLE
Run delayed job tasks in the staging environment

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,3 +1,3 @@
 set :branch, ENV["branch"] || :master
 
-server deploysecret(:server), user: deploysecret(:user), roles: %w[web app db importer cron]
+server deploysecret(:server), user: deploysecret(:user), roles: %w[web app db importer cron background]


### PR DESCRIPTION
## References

* We added the background role to the production and preproduction environments in commit d0b0782c4
* We officially support installing CONSUL on a staging server since consul/installer#138

## Objectives

Make sure background jobs are run properly after deploying with Capistrano to a staging server.