### PR TITLE
Use icons in admin table actions

### DIFF
--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -122,3 +122,4 @@ $pagination-radius: $global-radius;
 
 $show-header-for-stacked: true;
 
+$tooltip-background-color: $brand;

--- a/app/assets/stylesheets/admin/table_actions.scss
+++ b/app/assets/stylesheets/admin/table_actions.scss
@@ -9,4 +9,17 @@
   > p {
     align-self: flex-start;
   }
+
+  a {
+    @include button($style: hollow);
+    border-color: $link !important;
+    color: $link !important;
+    font-size: $base-font-size;
+    margin-bottom: 0;
+
+    &.destroy-link {
+      border-color: $alert-color !important;
+      color: $alert-color !important;
+    }
+  }
 }

--- a/app/assets/stylesheets/admin/table_actions.scss
+++ b/app/assets/stylesheets/admin/table_actions.scss
@@ -1,25 +1,128 @@
 .admin .table-actions {
-  align-items: baseline;
   display: flex;
 
   > :not(:first-child) {
-    margin-left: $line-height / 2;
-  }
-
-  > p {
-    align-self: flex-start;
+    margin-left: rem-calc(10);
   }
 
   a {
-    @include button($style: hollow);
-    border-color: $link !important;
-    color: $link !important;
-    font-size: $base-font-size;
-    margin-bottom: 0;
+    position: relative;
 
-    &.destroy-link {
-      border-color: $alert-color !important;
-      color: $alert-color !important;
+    > :first-child {
+      @include bottom-tooltip;
+      left: -10000px;
+      opacity: 0;
+      transform: translateX(-50%);
+      transition: opacity 0.3s, left 0s 0.3s;
     }
+
+    &:hover,
+    &:focus {
+      color: $link-hover;
+
+      > :first-child {
+        left: 50%;
+        opacity: 1;
+        transition: opacity 0.4s 0.2s;
+      }
+    }
+
+    &:not(:focus) > :first-child:hover {
+      left: -10000px;
+    }
+
+    &::before {
+      font-size: rem-calc(18);
+    }
+  }
+
+  .edit-link {
+    @include has-fa-icon(edit, regular);
+  }
+
+  .destroy-link {
+    @include has-fa-icon(trash-alt, regular);
+    color: $alert-color;
+  }
+
+  .show-link,
+  .preview-link {
+    @include has-fa-icon(eye, regular);
+  }
+
+  .new-link,
+  .assign-booth-link {
+    @include has-fa-icon(plus-circle, solid);
+    color: $color-success;
+  }
+
+  .create-role-link,
+  .create-officer-link {
+    @include has-fa-icon(user-plus, solid);
+    color: $color-success;
+  }
+
+  .destroy-role-link,
+  .destroy-officer-link,
+  .reject-link {
+    @include has-fa-icon(user-times, solid);
+    color: $alert-color;
+  }
+
+  .restore-link {
+    @include has-fa-icon(undo, solid);
+    color: $warning-color;
+  }
+
+  .confirm-hide-link {
+    @include has-fa-icon(flag, regular);
+    color: $alert-color;
+  }
+
+  .verify-link {
+    @include has-fa-icon(user-check, solid);
+    color: $color-success;
+  }
+
+  .preview-pending-link {
+    @include has-fa-icon(search, solid);
+  }
+
+  .send-pending-link {
+    @include has-fa-icon(share-square, regular);
+    color: $color-success;
+  }
+
+  .configure-link,
+  .answers-link {
+    @include has-fa-icon(tools, solid);
+  }
+
+  .download-link {
+    @include has-fa-icon(download, solid);
+  }
+
+  .shifts-link {
+    @include has-fa-icon(clock, regular);
+  }
+
+  .investments-link {
+    @include has-fa-icon(coins, solid);
+    color: $warning-color;
+  }
+
+  .groups-link,
+  .headings-link {
+    @include has-fa-icon(chart-pie, solid);
+    color: $color-success;
+  }
+
+  .manage-link,
+  .ballots-link {
+    @include has-fa-icon(archive, solid);
+  }
+
+  .cards-link {
+    @include has-fa-icon(images, regular);
   }
 }

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -176,3 +176,17 @@
     }
   }
 }
+
+@mixin bottom-tooltip {
+  @include tooltip;
+  line-height: $global-lineheight;
+  margin-top: $line-height / 8;
+  white-space: nowrap;
+
+  &::before {
+    @include css-triangle($tooltip-pip-width, $tooltip-background-color, up);
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}

--- a/app/components/admin/budgets/table_actions_component.html.erb
+++ b/app/components/admin/budgets/table_actions_component.html.erb
@@ -1,10 +1,14 @@
 <%= render Admin::TableActionsComponent.new(budget, actions: [:edit], edit_text: t("admin.budgets.index.edit_budget")) do %>
   <%= link_to t("admin.budgets.index.budget_investments"),
                  admin_budget_budget_investments_path(budget_id: budget.id),
-                 class: "button hollow medium" %>
-  <%= link_to t("admin.budgets.index.edit_groups"), admin_budget_groups_path(budget) %>
+                 class: "investments-link" %>
+  <%= link_to t("admin.budgets.index.edit_groups"),
+                 admin_budget_groups_path(budget),
+                 class: "groups-link" %>
   <% if budget.poll.present? %>
-    <%= link_to t("admin.budgets.index.admin_ballots"), admin_poll_booth_assignments_path(budget.poll) %>
+    <%= link_to t("admin.budgets.index.admin_ballots"),
+                admin_poll_booth_assignments_path(budget.poll),
+                class: "ballots-link" %>
   <% else %>
     <%= link_to_create_budget_poll %>
   <% end %>

--- a/app/components/admin/budgets/table_actions_component.rb
+++ b/app/components/admin/budgets/table_actions_component.rb
@@ -1,4 +1,5 @@
 class Admin::Budgets::TableActionsComponent < ApplicationComponent
+  include TableActionLink
   attr_reader :budget
 
   def initialize(budget)

--- a/app/components/admin/budgets/table_actions_component.rb
+++ b/app/components/admin/budgets/table_actions_component.rb
@@ -13,10 +13,12 @@ class Admin::Budgets::TableActionsComponent < ApplicationComponent
 
       link_to t("admin.budgets.index.admin_ballots"),
         admin_polls_path(poll: {
-        name:      budget.name,
-        budget_id: budget.id,
-        starts_at: balloting_phase.starts_at,
-        ends_at:   balloting_phase.ends_at }),
+          name:      budget.name,
+          budget_id: budget.id,
+          starts_at: balloting_phase.starts_at,
+          ends_at:   balloting_phase.ends_at
+        }),
+        class: "ballots-link",
         method: :post
     end
 end

--- a/app/components/admin/hidden_table_actions_component.html.erb
+++ b/app/components/admin/hidden_table_actions_component.html.erb
@@ -2,11 +2,11 @@
   <%= link_to restore_text, restore_path,
     method: :put,
     data: { confirm: t("admin.actions.confirm") },
-    class: "button hollow warning" %>
+    class: "restore-link" %>
 
   <% unless record.confirmed_hide? %>
     <%= link_to confirm_hide_text, confirm_hide_path,
       method: :put,
-      class: "button" %>
+      class: "confirm-hide-link" %>
   <% end %>
 <% end %>

--- a/app/components/admin/hidden_table_actions_component.rb
+++ b/app/components/admin/hidden_table_actions_component.rb
@@ -1,4 +1,5 @@
 class Admin::HiddenTableActionsComponent < ApplicationComponent
+  include TableActionLink
   attr_reader :record
 
   def initialize(record)

--- a/app/components/admin/organizations/table_actions_component.html.erb
+++ b/app/components/admin/organizations/table_actions_component.html.erb
@@ -2,12 +2,12 @@
   <% if can_verify? %>
     <%= link_to t("admin.organizations.index.verify"),
       verify_admin_organization_path(organization, request.query_parameters),
-      method: :put, class: "button success small-5" %>
+      method: :put, class: "verify-link" %>
   <% end %>
 
   <% if can_reject? %>
     <%= link_to t("admin.organizations.index.reject"),
       reject_admin_organization_path(organization, request.query_parameters),
-      method: :put, class: "button hollow alert small-5" %>
+      method: :put, class: "reject-link" %>
   <% end %>
 <% end %>

--- a/app/components/admin/organizations/table_actions_component.rb
+++ b/app/components/admin/organizations/table_actions_component.rb
@@ -1,4 +1,5 @@
 class Admin::Organizations::TableActionsComponent < ApplicationComponent
+  include TableActionLink
   delegate :can?, to: :controller
   attr_reader :organization
 

--- a/app/components/admin/poll/officers/officers_component.html.erb
+++ b/app/components/admin/poll/officers/officers_component.html.erb
@@ -3,7 +3,7 @@
     <tr>
       <th><%= t("admin.poll_officers.officer.name") %></th>
       <th><%= t("admin.poll_officers.officer.email") %></th>
-      <th class="small-3"><%= t("admin.actions.actions") %></th>
+      <th><%= t("admin.actions.actions") %></th>
     </tr>
   </thead>
   <tbody>
@@ -19,14 +19,15 @@
           <% if officer.persisted? %>
             <%= render Admin::TableActionsComponent.new(officer,
               actions: [:destroy],
-              destroy_text: t("admin.poll_officers.officer.delete")
+              destroy_text: t("admin.poll_officers.officer.delete"),
+              destroy_options: { class: "destroy-officer-link" }
             ) %>
           <% else %>
             <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
               <%= actions.link_to t("admin.poll_officers.officer.add"),
                                   add_user_path(officer),
                                   method: :post,
-                                  class: "button success expanded" %>
+                                  class: "create-officer-link" %>
             <% end %>
           <% end %>
         </td>

--- a/app/components/admin/roles/table_actions_component.html.erb
+++ b/app/components/admin/roles/table_actions_component.html.erb
@@ -1,7 +1,10 @@
 <% if already_has_role? %>
-  <%= render Admin::TableActionsComponent.new(record, actions: actions) %>
+  <%= render Admin::TableActionsComponent.new(record,
+    actions: actions,
+    destroy_options: { class: "destroy-role-link" }
+  ) %>
 <% else %>
   <%= render Admin::TableActionsComponent.new(actions: []) do %>
-    <%= link_to add_user_text, add_user_path, method: :post, class: "button success expanded" %>
+    <%= link_to add_user_text, add_user_path, method: :post, class: "create-role-link" %>
   <% end %>
 <% end %>

--- a/app/components/admin/roles/table_actions_component.rb
+++ b/app/components/admin/roles/table_actions_component.rb
@@ -1,4 +1,5 @@
 class Admin::Roles::TableActionsComponent < ApplicationComponent
+  include TableActionLink
   attr_reader :record, :actions
 
   def initialize(record, actions: [:destroy])

--- a/app/components/admin/table_actions_component.rb
+++ b/app/components/admin/table_actions_component.rb
@@ -1,4 +1,5 @@
 class Admin::TableActionsComponent < ApplicationComponent
+  include TableActionLink
   attr_reader :record, :options
 
   def initialize(record = nil, **options)

--- a/app/components/admin/table_actions_component.rb
+++ b/app/components/admin/table_actions_component.rb
@@ -22,7 +22,7 @@ class Admin::TableActionsComponent < ApplicationComponent
     end
 
     def edit_options
-      { class: "button hollow" }.merge(options[:edit_options] || {})
+      { class: "edit-link" }.merge(options[:edit_options] || {})
     end
 
     def destroy_text
@@ -36,7 +36,7 @@ class Admin::TableActionsComponent < ApplicationComponent
     def destroy_options
       {
         method: :delete,
-        class: "button hollow alert",
+        class: "destroy-link",
         data: { confirm: destroy_confirmation }
       }.merge(options[:destroy_options] || {})
     end

--- a/app/components/concerns/table_action_link.rb
+++ b/app/components/concerns/table_action_link.rb
@@ -1,0 +1,7 @@
+module TableActionLink
+  extend ActiveSupport::Concern
+
+  def link_to(text, url, **options)
+    super(text, url, options)
+  end
+end

--- a/app/components/concerns/table_action_link.rb
+++ b/app/components/concerns/table_action_link.rb
@@ -2,6 +2,6 @@ module TableActionLink
   extend ActiveSupport::Concern
 
   def link_to(text, url, **options)
-    super(text, url, options)
+    super(tag.span(text), url, options)
   end
 end

--- a/app/views/admin/admin_notifications/index.html.erb
+++ b/app/views/admin/admin_notifications/index.html.erb
@@ -9,7 +9,7 @@
         <th><%= t("admin.admin_notifications.index.title") %></th>
         <th><%= t("admin.admin_notifications.index.segment_recipient") %></th>
         <th><%= t("admin.admin_notifications.index.sent") %></th>
-        <th class="small-5"><%= t("admin.admin_notifications.index.actions") %></th>
+        <th><%= t("admin.admin_notifications.index.actions") %></th>
       </tr>
     </thead>
     <tbody>
@@ -33,13 +33,13 @@
             <%= render Admin::TableActionsComponent.new(admin_notification) do |actions| %>
               <%= actions.link_to t("admin.admin_notifications.index.preview"),
                                   admin_admin_notification_path(admin_notification),
-                                  class: "button" %>
+                                  class: "preview-link" %>
             <% end %>
           <% else %>
             <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
               <%= actions.link_to t("admin.admin_notifications.index.view"),
                                   admin_admin_notification_path(admin_notification),
-                                  class: "button" %>
+                                  class: "show-link" %>
             <% end %>
           <% end %>
         </td>

--- a/app/views/admin/administrators/search.html.erb
+++ b/app/views/admin/administrators/search.html.erb
@@ -10,7 +10,7 @@
       <thead>
         <th scope="col"><%= t("admin.administrators.index.name") %></th>
         <th scope="col"><%= t("admin.administrators.index.email") %></th>
-        <th scope="col" class="small-3"><%= t("admin.shared.actions") %></th>
+        <th scope="col"><%= t("admin.shared.actions") %></th>
       </thead>
       <tbody>
         <% @users.each do |user| %>

--- a/app/views/admin/audits/_audits.html.erb
+++ b/app/views/admin/audits/_audits.html.erb
@@ -37,7 +37,7 @@
               <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
                 <%= actions.link_to t("shared.show"),
                   admin_polymorphic_path(audit),
-                  class: "button hollow primary" %>
+                  class: "show-link" %>
               <% end %>
             </td>
           </tr>

--- a/app/views/admin/banners/index.html.erb
+++ b/app/views/admin/banners/index.html.erb
@@ -13,7 +13,7 @@
       <tr id="<%= dom_id(banner) %>">
         <th scope="col"><%= Banner.human_attribute_name(:post_started_at) %></th>
         <th scope="col"><%= Banner.human_attribute_name(:post_ended_at) %></th>
-        <th scope="col" class="small-4"><%= t("admin.actions.actions") %></th>
+        <th scope="col"><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/admin/budget_groups/index.html.erb
+++ b/app/views/admin/budget_groups/index.html.erb
@@ -28,7 +28,8 @@
           <td>
             <%= render Admin::TableActionsComponent.new(group) do |actions| %>
               <%= actions.link_to t("admin.budget_groups.headings_manage"),
-                                  admin_budget_group_headings_path(@budget, group) %>
+                                  admin_budget_group_headings_path(@budget, group),
+                                  class: "headings-link" %>
             <% end %>
           </td>
         </tr>

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -76,9 +76,10 @@
                 <span class="budget-phase-enabled <%= phase.enabled? ? "enabled" : "disabled" %>"></span>
               </td>
               <td>
-                <%= link_to t("admin.budgets.edit.edit_phase"),
-                            edit_admin_budget_budget_phase_path(@budget, phase),
-                            class: "button hollow expanded" %>
+                <%= render Admin::TableActionsComponent.new(phase,
+                  actions: [:edit],
+                  edit_text: t("admin.budgets.edit.edit_phase")
+                ) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/admin/dashboard/actions/index.html.erb
+++ b/app/views/admin/dashboard/actions/index.html.erb
@@ -17,7 +17,7 @@
       <th class="text-center"><%= t("admin.dashboard.actions.index.day_offset") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.required_supports") %></th>
       <th class="text-center"><%= t("admin.dashboard.actions.index.order") %></th>
-      <th class="small-3"><%= t("admin.actions.actions") %></th>
+      <th><%= t("admin.actions.actions") %></th>
     </tr>
   </thead>
 

--- a/app/views/admin/geozones/index.html.erb
+++ b/app/views/admin/geozones/index.html.erb
@@ -10,7 +10,7 @@
       <th><%= t("admin.geozones.geozone.external_code") %></th>
       <th><%= t("admin.geozones.geozone.census_code") %></th>
       <th><%= t("admin.geozones.geozone.coordinates") %></th>
-      <th class="small-3"><%= t("admin.actions.actions") %></th>
+      <th><%= t("admin.actions.actions") %></th>
     </tr>
   </thead>
 

--- a/app/views/admin/legislation/processes/index.html.erb
+++ b/app/views/admin/legislation/processes/index.html.erb
@@ -27,16 +27,12 @@
     <tbody>
       <% @processes.each do |process| %>
         <tr id="<%= dom_id(process) %>">
-          <td class="small-12 medium-6 large-4">
-            <%= link_to process.title, edit_admin_legislation_process_path(process) %>
-          </td>
+          <td class="small-12 medium-6 large-4"><%= process.title %></td>
           <td><%= t("admin.legislation.processes.process.status_#{process.status}") %></td>
           <td class="text-center"><%= I18n.l process.start_date %></td>
           <td class="text-center"><%= I18n.l process.end_date %></td>
           <td class="text-center"><%= process.total_comments %></td>
-          <td>
-            <%= render Admin::TableActionsComponent.new(process, actions: [:destroy]) %>
-          </td>
+          <td><%= render Admin::TableActionsComponent.new(process) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/managers/search.html.erb
+++ b/app/views/admin/managers/search.html.erb
@@ -10,7 +10,7 @@
       <thead>
         <th scope="col"><%= t("admin.managers.index.name") %></th>
         <th scope="col"><%= t("admin.managers.index.email") %></th>
-        <th scope="col" class="small-3"><%= t("admin.shared.actions") %></th>
+        <th scope="col"><%= t("admin.shared.actions") %></th>
       </thead>
       <tbody>
       <% @users.each do |user| %>

--- a/app/views/admin/milestones/_milestones.html.erb
+++ b/app/views/admin/milestones/_milestones.html.erb
@@ -30,9 +30,7 @@
       <% milestoneable.milestones.order_by_publication_date.each do |milestone| %>
         <tr id="<%= dom_id(milestone) %>" class="milestone">
           <td class="text-center"><%= milestone.id %></td>
-          <td>
-            <%= link_to milestone.title, admin_polymorphic_path(milestone, action: :edit) %>
-          </td>
+          <td><%= milestone.title %></td>
           <td class="small small-5"><%= milestone.description %></td>
           <td class="small">
             <%= l(milestone.publication_date.to_date) if milestone.publication_date.present? %>
@@ -57,7 +55,6 @@
           </td>
           <td class="small-2">
             <%= render Admin::TableActionsComponent.new(milestone,
-              actions: [:destroy],
               destroy_text: t("admin.milestones.index.delete")
             ) %>
           </td>

--- a/app/views/admin/milestones/_milestones.html.erb
+++ b/app/views/admin/milestones/_milestones.html.erb
@@ -53,7 +53,7 @@
               <% end %>
             <% end %>
           </td>
-          <td class="small-2">
+          <td>
             <%= render Admin::TableActionsComponent.new(milestone,
               destroy_text: t("admin.milestones.index.delete")
             ) %>

--- a/app/views/admin/moderators/search.html.erb
+++ b/app/views/admin/moderators/search.html.erb
@@ -10,7 +10,7 @@
       <thead>
         <th scope="col"><%= t("admin.moderators.index.name") %></th>
         <th scope="col" class="small-6"><%= t("admin.moderators.index.email") %></th>
-        <th scope="col" class="small-3"><%= t("admin.shared.actions") %></th>
+        <th scope="col"><%= t("admin.shared.actions") %></th>
       </thead>
       <tbody>
       <% @users.each do |user| %>

--- a/app/views/admin/newsletters/index.html.erb
+++ b/app/views/admin/newsletters/index.html.erb
@@ -9,7 +9,7 @@
         <th class="small-2"><%= t("admin.newsletters.index.subject") %></th>
         <th><%= t("admin.newsletters.index.segment_recipient") %></th>
         <th><%= t("admin.newsletters.index.sent") %></th>
-        <th class="small-5"><%= t("admin.newsletters.index.actions") %></th>
+        <th><%= t("admin.newsletters.index.actions") %></th>
       </tr>
     </thead>
     <tbody>
@@ -32,7 +32,7 @@
           <%= render Admin::TableActionsComponent.new(newsletter) do |actions| %>
             <%= actions.link_to t("admin.newsletters.index.preview"),
                                 admin_newsletter_path(newsletter),
-                                class: "button" %>
+                                class: "preview-link" %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -31,8 +31,7 @@
                             admin_poll_booth_assignments_path(@poll, booth_id: booth.id),
                             method: :post,
                             remote: true,
-                            title: t("admin.booth_assignments.manage.actions.assign"),
-                            class: "button hollow expanded" %>
+                            class: "assign-booth-link" %>
       <% end %>
     <% end %>
   </td>

--- a/app/views/admin/poll/booths/_booth.html.erb
+++ b/app/views/admin/poll/booths/_booth.html.erb
@@ -10,7 +10,7 @@
       <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
         <%= actions.link_to t("admin.booths.booth.shifts"),
                             new_admin_booth_shift_path(booth),
-                            class: "button hollow" %>
+                            class: "shifts-link" %>
       <% end %>
     <% else %>
       <%= render Admin::TableActionsComponent.new(booth,

--- a/app/views/admin/poll/polls/_poll.html.erb
+++ b/app/views/admin/poll/polls/_poll.html.erb
@@ -14,7 +14,7 @@
     ) do |actions| %>
       <%= actions.link_to t("admin.actions.configure"),
                           admin_poll_path(poll),
-                          class: "button hollow " %>
+                          class: "configure-link" %>
     <% end %>
   </td>
 </tr>

--- a/app/views/admin/poll/polls/_questions.html.erb
+++ b/app/views/admin/poll/polls/_questions.html.erb
@@ -8,11 +8,11 @@
     <%= t("admin.polls.show.no_questions") %>
   </div>
 <% else %>
-  <table class="fixed margin">
+  <table class="margin">
     <thead>
       <tr>
         <th><%= t("admin.polls.show.table_title") %></th>
-        <th class="small-6"><%= t("admin.actions.actions") %></th>
+        <th><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
     <% @poll.questions.each do |question| %>
@@ -30,7 +30,7 @@
         <td>
           <%= render Admin::TableActionsComponent.new(question) do |actions| %>
             <%= actions.link_to t("admin.polls.show.edit_answers"), admin_question_path(question),
-                                                                    class: "button hollow" %>
+                                                                    class: "answers-link" %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/poll/polls/booth_assignments.html.erb
+++ b/app/views/admin/poll/polls/booth_assignments.html.erb
@@ -18,7 +18,7 @@
             <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
               <%= actions.link_to t("admin.booth_assignments.manage_assignments"),
                                   manage_admin_poll_booth_assignments_path(poll),
-                                  class: "button hollow" %>
+                                  class: "manage-link" %>
             <% end %>
           </td>
         </tr>

--- a/app/views/admin/poll/questions/_questions.html.erb
+++ b/app/views/admin/poll/questions/_questions.html.erb
@@ -18,7 +18,7 @@
     <tbody>
       <% @questions.each do |question| %>
         <tr id="<%= dom_id(question) %>">
-          <td><%= link_to question.title, admin_question_path(question) %></td>
+          <td><%= question.title %></td>
           <td>
             <% if question.poll.present? %>
               <%= question.poll.name %>
@@ -27,7 +27,10 @@
             <% end %>
           </td>
           <td>
-            <%= render Admin::TableActionsComponent.new(question) %>
+            <%= render Admin::TableActionsComponent.new(question) do |actions| %>
+              <%= actions.link_to t("admin.polls.show.edit_answers"), admin_question_path(question),
+                                                                      class: "button hollow" %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/poll/questions/_questions.html.erb
+++ b/app/views/admin/poll/questions/_questions.html.erb
@@ -7,12 +7,12 @@
     <%= t("admin.questions.index.no_questions") %>
   </div>
 <% else %>
-  <table class="fixed">
+  <table>
     <thead>
       <tr>
         <th><%= t("admin.questions.index.table_question") %></th>
         <th><%= t("admin.questions.index.table_poll") %></th>
-        <th class="small-4"><%= t("admin.actions.actions") %></th>
+        <th><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
     <tbody>
@@ -29,7 +29,7 @@
           <td>
             <%= render Admin::TableActionsComponent.new(question) do |actions| %>
               <%= actions.link_to t("admin.polls.show.edit_answers"), admin_question_path(question),
-                                                                      class: "button hollow" %>
+                                                                      class: "answers-link" %>
             <% end %>
           </td>
         </tr>

--- a/app/views/admin/poll/questions/_successful_proposals.html.erb
+++ b/app/views/admin/poll/questions/_successful_proposals.html.erb
@@ -9,13 +9,14 @@
     <% @proposals.each do |proposal| %>
       <tr id="<%= dom_id(proposal) %>">
         <td>
-          <%= link_to proposal.title, proposal_path(proposal) %>
+          <%= proposal.title %>
           <p>
             <%= proposal.summary %><br>
           </p>
         </td>
         <td>
           <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
+            <%= actions.link_to t("admin.shared.view"), proposal_path(proposal), class: "button hollow" %>
             <%= actions.link_to t("admin.questions.index.create_question"),
                   new_admin_question_path(proposal_id: proposal.id),
                   class: "button hollow" %>

--- a/app/views/admin/poll/questions/_successful_proposals.html.erb
+++ b/app/views/admin/poll/questions/_successful_proposals.html.erb
@@ -1,4 +1,4 @@
-<table class="fixed">
+<table>
   <thead>
     <tr>
       <th class="small-9"><%= t("admin.questions.index.table_proposal") %></th>
@@ -16,10 +16,10 @@
         </td>
         <td>
           <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
-            <%= actions.link_to t("admin.shared.view"), proposal_path(proposal), class: "button hollow" %>
+            <%= actions.link_to t("admin.shared.view"), proposal_path(proposal), class: "show-link" %>
             <%= actions.link_to t("admin.questions.index.create_question"),
                   new_admin_question_path(proposal_id: proposal.id),
-                  class: "button hollow" %>
+                  class: "new-link" %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/poll/questions/answers/documents.html.erb
+++ b/app/views/admin/poll/questions/answers/documents.html.erb
@@ -44,7 +44,7 @@
                                   document.attachment.url,
                                   target: "_blank",
                                   rel: "nofollow",
-                                  class: "button hollow" %>
+                                  class: "download-link" %>
 
             <% end %>
           </td>

--- a/app/views/admin/poll/shifts/_shifts.html.erb
+++ b/app/views/admin/poll/shifts/_shifts.html.erb
@@ -1,5 +1,5 @@
 <h3><%= t("admin.poll_shifts.new.shifts") %></h3>
-<table class="fixed">
+<table>
   <thead>
     <tr>
       <th><%= t("admin.poll_shifts.new.date") %></th>

--- a/app/views/admin/site_customization/pages/index.html.erb
+++ b/app/views/admin/site_customization/pages/index.html.erb
@@ -13,7 +13,6 @@
       <tr>
         <th><%= t("admin.site_customization.pages.page.title") %></th>
         <th><%= t("admin.site_customization.pages.page.slug") %></th>
-        <th><%= t("admin.site_customization.pages.page.cards_title") %></th>
         <th><%= t("admin.site_customization.pages.page.created_at") %></th>
         <th><%= t("admin.site_customization.pages.page.updated_at") %></th>
         <th><%= t("admin.site_customization.pages.page.status") %></th>
@@ -23,22 +22,17 @@
     <tbody>
     <% @pages.each do |page| %>
       <tr id="<%= dom_id(page) %>">
-        <td>
-          <%= link_to page.title, edit_admin_site_customization_page_path(page) %>
-        </td>
+        <td><%= page.title %></td>
         <td><%= page.slug %></td>
-        <td>
-          <%= link_to t("admin.site_customization.pages.page.see_cards"), admin_site_customization_page_cards_path(page),
-                                      class: "button hollow expanded" %>
-        </td>
         <td><%= I18n.l page.created_at, format: :short %></td>
         <td><%= I18n.l page.created_at, format: :short %></td>
         <td><%= t("admin.site_customization.pages.page.status_#{page.status}") %></td>
         <td>
-          <%= render Admin::TableActionsComponent.new(page,
-            actions: [:destroy],
-            destroy_text: t("admin.site_customization.pages.index.delete")
-          ) do |actions| %>
+          <%= render Admin::TableActionsComponent.new(page) do |actions| %>
+            <%= actions.link_to t("admin.site_customization.pages.page.see_cards"),
+                                admin_site_customization_page_cards_path(page),
+                                class: "button hollow expanded" %>
+
             <% if page.status == "published" %>
               <%= actions.link_to t("admin.site_customization.pages.index.see_page"),
                                   page.url,

--- a/app/views/admin/site_customization/pages/index.html.erb
+++ b/app/views/admin/site_customization/pages/index.html.erb
@@ -16,7 +16,7 @@
         <th><%= t("admin.site_customization.pages.page.created_at") %></th>
         <th><%= t("admin.site_customization.pages.page.updated_at") %></th>
         <th><%= t("admin.site_customization.pages.page.status") %></th>
-        <th class="small-4"><%= t("admin.actions.actions") %></th>
+        <th><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
     <tbody>
@@ -31,13 +31,13 @@
           <%= render Admin::TableActionsComponent.new(page) do |actions| %>
             <%= actions.link_to t("admin.site_customization.pages.page.see_cards"),
                                 admin_site_customization_page_cards_path(page),
-                                class: "button hollow expanded" %>
+                                class: "cards-link" %>
 
             <% if page.status == "published" %>
               <%= actions.link_to t("admin.site_customization.pages.index.see_page"),
                                   page.url,
                                   target: "_blank",
-                                  class: "button hollow" %>
+                                  class: "show-link" %>
             <% end %>
           <% end %>
         </td>

--- a/app/views/admin/system_emails/index.html.erb
+++ b/app/views/admin/system_emails/index.html.erb
@@ -22,16 +22,16 @@
           <% if system_email_actions.include?("view") %>
             <%= actions.link_to t("admin.shared.view"),
                                 admin_system_email_view_path(system_email_title),
-                                class: "button hollow" %>
+                                class: "show-link" %>
           <% end %>
 
           <% if system_email_actions.include?("preview_pending") %>
             <%= actions.link_to t("admin.system_emails.preview_pending.action"),
                                 admin_system_email_preview_pending_path(system_email_title),
-                                class: "button" %>
+                                class: "preview-pending-link" %>
             <%= actions.link_to t("admin.system_emails.preview_pending.send_pending"),
                                 admin_system_email_send_pending_path(system_email_title),
-                                class: "button success",
+                                class: "send-pending-link",
                                 method: :put %>
           <% end %>
 

--- a/app/views/admin/valuators/_valuator_row.html.erb
+++ b/app/views/admin/valuators/_valuator_row.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to valuator.name, admin_valuator_path(valuator) %></td>
+  <td><%= valuator.name %></td>
   <td><%= valuator.email %></td>
   <td>
     <% if valuator.description.present? %>
@@ -19,6 +19,10 @@
     <%= valuator_abilities(valuator) %>
   </td>
   <td>
-    <%= render Admin::TableActionsComponent.new(valuator) %>
+    <%= render Admin::TableActionsComponent.new(valuator) do |actions| %>
+      <%= actions.link_to t("admin.shared.view"),
+        admin_valuator_path(valuator),
+        class: "button hollow" %>
+    <% end %>
   </td>
 </tr>

--- a/app/views/admin/valuators/_valuator_row.html.erb
+++ b/app/views/admin/valuators/_valuator_row.html.erb
@@ -22,7 +22,7 @@
     <%= render Admin::TableActionsComponent.new(valuator) do |actions| %>
       <%= actions.link_to t("admin.shared.view"),
         admin_valuator_path(valuator),
-        class: "button hollow" %>
+        class: "show-link" %>
     <% end %>
   </td>
 </tr>

--- a/app/views/admin/valuators/_valuators.html.erb
+++ b/app/views/admin/valuators/_valuators.html.erb
@@ -5,7 +5,7 @@
     <th scope="col"><%= t("admin.valuators.index.description") %></th>
     <th scope="col"><%= t("admin.valuators.index.group") %></th>
     <th scope="col"><%= t("admin.valuators.index.abilities") %></th>
-    <th scope="col" class="small-3"><%= t("admin.actions.actions") %></th>
+    <th scope="col"><%= t("admin.actions.actions") %></th>
   </thead>
   <tbody>
     <% valuators.each do |valuator| %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1512,7 +1512,6 @@ en:
           updated_at: Updated at
           title: Title
           slug: Slug
-          cards_title: Cards
           see_cards: See Cards
         cards:
           cards_title: cards

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1511,7 +1511,6 @@ es:
           updated_at: Última actualización
           title: Título
           slug: Slug
-          cards_title: Tarjetas
           see_cards: Ver tarjetas
         cards:
           cards_title: tarjetas

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -274,6 +274,10 @@ resolve "Budget::Heading" do |heading, options|
   [heading.budget, :group, :heading, options.merge(group_id: heading.group, id: heading)]
 end
 
+resolve "Budget::Phase" do |phase, options|
+  [phase.budget, :phase, options.merge(id: phase)]
+end
+
 resolve "Poll::Booth" do |booth, options|
   [:booth, options.merge(id: booth)]
 end

--- a/spec/shared/system/admin_milestoneable.rb
+++ b/spec/shared/system/admin_milestoneable.rb
@@ -90,7 +90,7 @@ shared_examples "admin_milestoneable" do |factory_name, path_name|
         visit path
         expect(page).to have_link document.title
 
-        click_link milestone.title
+        within("tr", text: milestone.title) { click_link "Edit" }
 
         expect(page).to have_css("img[alt='#{milestone.image.title}']")
 

--- a/spec/system/admin/legislation/draft_versions_spec.rb
+++ b/spec/system/admin/legislation/draft_versions_spec.rb
@@ -21,7 +21,7 @@ describe "Admin legislation draft versions" do
 
       visit admin_legislation_processes_path(filter: "all")
 
-      click_link "An example legislation process"
+      within("tr", text: "An example legislation process") { click_link "Edit" }
       click_link "Drafting"
       click_link "Version 1"
 
@@ -41,10 +41,7 @@ describe "Admin legislation draft versions" do
       end
 
       click_link "All"
-
-      expect(page).to have_content "An example legislation process"
-
-      click_link "An example legislation process"
+      within("tr", text: "An example legislation process") { click_link "Edit" }
       click_link "Drafting"
 
       click_link "Create version"
@@ -77,7 +74,7 @@ describe "Admin legislation draft versions" do
 
       expect(page).not_to have_link "All"
 
-      click_link "An example legislation process"
+      within("tr", text: "An example legislation process") { click_link "Edit" }
       click_link "Drafting"
 
       click_link "Version 1"

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -201,7 +201,7 @@ describe "Admin collaborative legislation" do
         click_link "Collaborative Legislation"
       end
 
-      click_link "An example legislation process"
+      within("tr", text: "An example legislation process") { click_link "Edit" }
 
       expect(page).to have_selector("h2", text: "An example legislation process")
       expect(find("#legislation_process_debate_phase_enabled")).to be_checked
@@ -224,7 +224,7 @@ describe "Admin collaborative legislation" do
         click_link "Collaborative Legislation"
       end
 
-      click_link "An example legislation process"
+      within("tr", text: "An example legislation process") { click_link "Edit" }
 
       expect(find("#legislation_process_draft_publication_enabled")).to be_checked
 

--- a/spec/system/admin/legislation/questions_spec.rb
+++ b/spec/system/admin/legislation/questions_spec.rb
@@ -25,7 +25,7 @@ describe "Admin legislation questions" do
 
       visit admin_legislation_processes_path(filter: "all")
 
-      click_link "An example legislation process"
+      within("tr", text: "An example legislation process") { click_link "Edit" }
       click_link "Debate"
 
       expect(page).to have_content("Question 1")
@@ -43,9 +43,7 @@ describe "Admin legislation questions" do
 
       click_link "All"
 
-      expect(page).to have_content "An example legislation process"
-
-      click_link "An example legislation process"
+      within("tr", text: "An example legislation process") { click_link "Edit" }
       click_link "Debate"
 
       click_link "Create question"
@@ -71,9 +69,8 @@ describe "Admin legislation questions" do
 
       expect(page).not_to have_link "All"
 
-      click_link "An example legislation process"
+      within("tr", text: "An example legislation process") { click_link "Edit" }
       click_link "Debate"
-
       click_link "Question 2"
 
       fill_in "Question", with: "Question 2b"

--- a/spec/system/admin/site_customization/pages_spec.rb
+++ b/spec/system/admin/site_customization/pages_spec.rb
@@ -70,7 +70,7 @@ describe "Admin custom pages" do
         click_link "Custom pages"
       end
 
-      click_link "An example custom page"
+      within("tr", text: "An example custom page") { click_link "Edit" }
 
       expect(page).to have_selector("h2", text: "An example custom page")
       expect(page).to have_selector("input[value='custom-example-page']")


### PR DESCRIPTION
## References

* Depends on pull request #4206
* Motivated by the budgets changes in pull request #4198

## Objectives

* Replace button-shaped links in admin tables with icons

## Visual Changes

### Before

Custom pages index:

![The custom pages table displays links and buttons in some colums](https://user-images.githubusercontent.com/35156/97211439-578d4300-17bf-11eb-8f46-cc40e1aec4f3.png)

Budgets index:

![The participatory budgets table displays links and buttons in the actions column](https://user-images.githubusercontent.com/35156/97211444-59570680-17bf-11eb-8b8e-a87039a801e6.png)

Polls index:

![The polls table displays buttons to edit and delete a poll](https://user-images.githubusercontent.com/35156/97211446-59ef9d00-17bf-11eb-9025-4bada6bb9b35.png)

### After

Cutom pages index:

![The custom pages table displays icons in the actions column with a tooltip on the currently focused item](https://user-images.githubusercontent.com/35156/97211934-0cbffb00-17c0-11eb-9df3-2cb258177397.png)

Budgets index:

![The participatory budgets table displays icons in the actions column](https://user-images.githubusercontent.com/35156/97991535-de56a700-1de1-11eb-8965-3c97b4145e2a.png)

Polls index:

![The polls table displays icons to edit and delete a poll](https://user-images.githubusercontent.com/35156/97211537-7a1f5c00-17bf-11eb-9e7f-7eedcc76111c.png)