### PR TITLE
Add link to top feature

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -112,6 +112,7 @@
 //= require columns_selector
 //= require budget_edit_associations
 //= require datepicker
+//= require link_to_top
 //= require_tree ./admin
 //= require_tree ./sdg
 //= require_tree ./sdg_management
@@ -169,6 +170,7 @@ var initialize_modules = function() {
   App.AdminMachineLearningScripts.initialize();
   App.BudgetEditAssociations.initialize();
   App.Datepicker.initialize();
+  App.LinkToTop.initialize();
   App.SDGRelatedListSelector.initialize();
   App.SDGManagementRelationSearch.initialize();
 };

--- a/app/assets/javascripts/link_to_top.js
+++ b/app/assets/javascripts/link_to_top.js
@@ -1,0 +1,16 @@
+(function() {
+  "use strict";
+  App.LinkToTop = {
+    initialize: function() {
+      $(document).scroll(function() {
+        var y = $(this).scrollTop();
+        var link_to_top_scroll = $(window).height() * 20 / 100;
+        if (y > link_to_top_scroll) {
+          $(".link-to-top").fadeIn();
+        } else {
+          $(".link-to-top").fadeOut();
+        }
+      });
+    }
+  };
+}).call(this);

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -512,6 +512,28 @@ button,
   }
 }
 
+.link-to-top {
+  background: rgba(226, 226, 226, 0.5);
+  border-radius: rem-calc(6);
+  bottom: 12px;
+  display: table;
+  height: rem-calc(48);
+  position: fixed;
+  right: 24px;
+  width: rem-calc(48);
+
+  a {
+    @include has-fa-icon(arrow-up, solid);
+    color: $text;
+    display: table-cell;
+    font-size: rem-calc(24);
+    text-align: center;
+    text-decoration: none;
+    vertical-align: middle;
+    width: 100%;
+  }
+}
+
 // 02. Header
 // ----------
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -103,6 +103,7 @@ class Setting < ApplicationRecord
         "feature.sdg": true,
         "feature.machine_learning": false,
         "feature.remove_investments_supports": false,
+        "feature.link_to_top": false,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/app/views/layouts/_link_to_top.html.erb
+++ b/app/views/layouts/_link_to_top.html.erb
@@ -1,0 +1,5 @@
+<div class="link-to-top" style="display: none;" data-smooth-scroll>
+  <a href="#body" title="<%= t("layouts.link_to_top.title") %>">
+    <span class="show-for-sr"><%= t("layouts.link_to_top.title") %></span>
+  </a>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -6,7 +6,7 @@
     <%= content_for :head %>
   </head>
 
-  <body class="admin">
+  <body id="body" class="admin">
     <%= render "layouts/admin_header" %>
 
     <div class="menu-and-content">
@@ -29,6 +29,10 @@
         <%= render "layouts/flash" %>
         <%= render "layouts/officing_booth" if controller.class.parent == Officing && session[:booth_id].present? %>
         <%= yield %>
+
+        <% if feature?(:link_to_top) %>
+          <%= render "layouts/link_to_top" %>
+        <% end %>
       </div>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 
     <%= raw setting["html.per_page_code_head"] %>
   </head>
-  <body class="<%= yield(:body_class) %> public">
+  <body id="body" class="<%= yield(:body_class) %> public">
     <%= raw setting["html.per_page_code_body"] %>
 
     <div class="wrapper <%= yield(:wrapper_class) %>">
@@ -42,6 +42,10 @@
       <%= render "layouts/flash" %>
 
       <%= yield %>
+
+      <% if feature?(:link_to_top) %>
+        <%= render "layouts/link_to_top" %>
+      <% end %>
     </div>
     <div class="footer">
       <%= render "layouts/footer" %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -208,6 +208,8 @@ en:
           zero: No supports
           one: 1 Support
           other: "Supports"
+    link_to_top:
+      title: "Go back to the top of the page"
     footer:
       accessibility: Accessibility
       conditions: Terms and conditions of use

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -120,6 +120,8 @@ en:
       public_stats_description: "Display public stats in the Administration panel"
       help_page: "Help page"
       help_page_description: 'Displays a Help menu that contains a page with an info section about each enabled feature. Also custom pages and menus can be created in the "Custom pages" and  "Custom content blocks" sections'
+      link_to_top: "Link to top"
+      link_to_top_description: "Show a link to return to the top of the page after scrolling"
       remote_translations: "Remote translation"
       remote_translations_description: "Displays a button that allows users to request a translation when there are not contents in their language."
       translation_interface: "Translation interface"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -208,6 +208,8 @@ es:
           zero: Sin apoyos
           one: 1 Apoyo
           other: "Apoyos"
+    link_to_top:
+      title: "Volver a la parte superior de la página"
     footer:
       accessibility: Accesibilidad
       conditions: Condiciones de uso

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -120,6 +120,8 @@ es:
       public_stats_description: "Muestra las estadísticas públicas en el panel de Administración"
       help_page: "Página de ayuda"
       help_page_description: 'Muestra un menú Ayuda que contiene una página con una sección de información sobre cada funcionalidad habilitada. También se pueden crear páginas y menús personalizados en las secciones "Personalizar páginas" y "Personalizar bloques"'
+      link_to_top: "Enlace al inicio"
+      link_to_top_description: "Muestra una enlace para volver a la parte superior de la página después de desplazarse"
       remote_translations: "Traducciones remotas"
       remote_translations_description: "Muestra un botón que permite a los usuarios solicitar una traducción de una página no traducida en su idioma."
       translation_interface: "Interfaz de traducción"

--- a/spec/system/link_to_top_spec.rb
+++ b/spec/system/link_to_top_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe "Link to top" do
+  scenario "is displayed if the feature is enabled" do
+    Setting["feature.link_to_top"] = true
+
+    window_height = page.evaluate_script("window.innerHeight;")
+    scroll = (window_height * 20 / 100) + 1
+
+    visit root_path
+    expect(page).to have_link("Go back to the top of the page", visible: :hidden)
+
+    execute_script "window.scrollTo(0, #{scroll})"
+    expect(page.evaluate_script("window.scrollY;")).not_to eq(0)
+    expect(page).to have_link("Go back to the top of the page", visible: :visible)
+
+    click_link "Go back to the top of the page"
+    expect(page.evaluate_script("window.scrollY;")).to eq(0)
+
+    login_as(create(:administrator).user)
+
+    visit admin_root_path
+    expect(page).to have_link("Go back to the top of the page", visible: :hidden)
+
+    execute_script "window.scrollTo(0, #{scroll})"
+    expect(page).to have_link("Go back to the top of the page", visible: :visible)
+    expect(page.evaluate_script("window.scrollY;")).not_to eq(0)
+
+    click_link "Go back to the top of the page"
+    expect(page.evaluate_script("window.scrollY;")).to eq(0)
+  end
+
+  scenario "is not displayed if the feature is disabled" do
+    Setting["feature.link_to_top"] = false
+
+    visit root_path
+
+    expect(page).not_to have_link "Go back to the top of the page", visible: :all
+
+    login_as(create(:administrator).user)
+    visit admin_root_path
+
+    expect(page).not_to have_link "Go back to the top of the page", visible: :all
+  end
+end


### PR DESCRIPTION
## Objectives

Add link to top feature, if this feature is enabled show a link to return to the top of the page after scrolling.

## Visual Changes

### Admin feature
![link_to_top](https://user-images.githubusercontent.com/631897/76806818-c8f52400-67e2-11ea-9219-09d8e01057ca.png)

### Link to top working
![link_to_top](https://user-images.githubusercontent.com/631897/76806819-ca265100-67e2-11ea-8756-bc9114faa2f6.gif)

## Notes

It's necessary to run `rake settings:add_new_settings` to include the new setting if you don't use Capistrano to deploy. 😌 