### PR TITLE
Allow users to delete their own comments

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1940,6 +1940,20 @@ table {
     }
   }
 
+  .delete-comment {
+    @include has-fa-icon(trash-alt, regular);
+    color: $delete;
+
+    &:hover,
+    &:active {
+      color: $link-hover;
+    }
+
+    &::before {
+      transform: translateY(-1px);
+    }
+  }
+
   .comment-user {
     margin-top: $line-height / 4;
     padding: $line-height / 4 0;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  before_action :authenticate_user!, only: :create
+  before_action :authenticate_user!, only: [:create, :hide]
   before_action :load_commentable, only: :create
   before_action :verify_resident_for_commentable!, only: :create
   before_action :verify_comments_open!, only: [:create, :vote]
@@ -44,6 +44,11 @@ class CommentsController < ApplicationController
     set_comment_flags(@comment)
 
     render "shared/_refresh_flag_actions", locals: { flaggable: @comment, divider: true }
+  end
+
+  def hide
+    @comment.hide
+    set_comment_flags(@comment.subtree)
   end
 
   private

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -49,6 +49,8 @@ module Abilities
       can [:create, :created], Proposal
       can :create, Legislation::Proposal
 
+      can :hide, Comment, user_id: user.id
+
       can :suggest, Debate
       can :suggest, Proposal
       can :suggest, Legislation::Proposal

--- a/app/models/abilities/moderation.rb
+++ b/app/models/abilities/moderation.rb
@@ -12,7 +12,6 @@ module Abilities
       can :read, Comment
 
       can :hide, Comment, hidden_at: nil
-      cannot :hide, Comment, user_id: user.id
 
       can :ignore_flag, Comment, ignored_flag_at: nil, hidden_at: nil
       cannot :ignore_flag, Comment, user_id: user.id

--- a/app/views/comments/_actions.html.erb
+++ b/app/views/comments/_actions.html.erb
@@ -5,8 +5,15 @@
 <span class="js-moderation-actions">
   <% if can? :hide, comment %>
     <span class="divider">&nbsp;&bull;&nbsp;</span>
-    <%= link_to t("admin.actions.hide").capitalize, hide_moderation_comment_path(comment),
-                method: :put, remote: true, data: { confirm: t("admin.actions.confirm") } %>
+    <% if comment.author == current_user %>
+      <%= link_to t("comments.actions.delete"),
+                  hide_comment_path(comment),
+                  method: :put, remote: true, class: "delete-comment",
+                  data: { confirm: t("comments.actions.confirm_delete") } %>
+    <% else %>
+      <%= link_to t("admin.actions.hide").capitalize, hide_moderation_comment_path(comment),
+                  method: :put, remote: true, data: { confirm: t("admin.actions.confirm") } %>
+    <% end %>
   <% end %>
 
   <% if can? :hide, comment.user %>

--- a/app/views/comments/hide.js.erb
+++ b/app/views/comments/hide.js.erb
@@ -1,0 +1,1 @@
+$("#<%= dom_id(@comment) %>").replaceWith("<%= j render("comment", comment: @comment) %>");

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -29,6 +29,9 @@ en:
     close: Close
     menu: Menu
   comments:
+    actions:
+      confirm_delete: "Are you sure? This action will delete this comment. You can't undo this action."
+      delete: "Delete comment"
     comments_closed: Comments are closed
     verified_only: To participate %{verify_account}
     comment:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -29,6 +29,9 @@ es:
     close: Cerrar
     menu: Menú
   comments:
+    actions:
+      confirm_delete: "¿Estás seguro/a? Esta acción borrará este comentario. No puedes deshacer esta acción."
+      delete: "Borrar comentario"
     comments_closed: Los comentarios están cerrados
     verified_only: Para participar %{verify_account}
     comment:

--- a/config/routes/comment.rb
+++ b/config/routes/comment.rb
@@ -3,5 +3,6 @@ resources :comments, only: [:create, :show], shallow: true do
     post :vote
     put :flag
     put :unflag
+    put :hide
   end
 end

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -65,9 +65,6 @@ describe Abilities::Common do
   it { should be_able_to(:show, user) }
   it { should be_able_to(:edit, user) }
 
-  it { should be_able_to(:create, Comment) }
-  it { should be_able_to(:vote, Comment)   }
-
   it { should     be_able_to(:index, Proposal) }
   it { should     be_able_to(:show, proposal) }
   it { should_not be_able_to(:vote, Proposal) }
@@ -96,6 +93,14 @@ describe Abilities::Common do
   it { should_not be_able_to(:manage, Dashboard::Action) }
 
   it { should_not be_able_to(:manage, LocalCensusRecord) }
+
+  describe "Comment" do
+    it { should be_able_to(:create, Comment) }
+    it { should be_able_to(:vote, Comment) }
+
+    it { should be_able_to(:hide, own_comment) }
+    it { should_not be_able_to(:hide, comment) }
+  end
 
   describe "flagging content" do
     it { should be_able_to(:flag, debate)   }

--- a/spec/models/abilities/moderator_spec.rb
+++ b/spec/models/abilities/moderator_spec.rb
@@ -54,7 +54,7 @@ describe Abilities::Moderator do
     it { should be_able_to(:hide, comment) }
     it { should be_able_to(:hide_in_moderation_screen, comment) }
     it { should_not be_able_to(:hide, hidden_comment) }
-    it { should_not be_able_to(:hide, own_comment) }
+    it { should be_able_to(:hide, own_comment) }
 
     it { should be_able_to(:moderate, comment) }
     it { should_not be_able_to(:moderate, own_comment) }

--- a/spec/system/comments/debates_spec.rb
+++ b/spec/system/comments/debates_spec.rb
@@ -235,6 +235,58 @@ describe "Commenting debates" do
     expect(page).to have_content "Can't be blank"
   end
 
+  describe "Hide" do
+    scenario "Without replies" do
+      create(:comment, commentable: debate, user: user, body: "This was a mistake")
+
+      login_as(user)
+      visit debate_path(debate)
+
+      accept_confirm("Are you sure? This action will delete this comment. You can't undo this action.") do
+        within(".comment-body", text: "This was a mistake") { click_link "Delete comment" }
+      end
+
+      expect(page).not_to have_content "This was a mistake"
+      expect(page).not_to have_link "Delete comment"
+
+      visit debate_path(debate)
+
+      expect(page).not_to have_content "This was a mistake"
+      expect(page).not_to have_link "Delete comment"
+
+      logout
+      login_as(create(:administrator).user)
+
+      visit admin_hidden_comments_path
+
+      expect(page).to have_content "This was a mistake"
+    end
+
+    scenario "With replies" do
+      comment = create(:comment, commentable: debate, user: user, body: "Wrong comment")
+      create(:comment, commentable: debate, parent: comment, body: "Right reply")
+
+      login_as(user)
+      visit debate_path(debate)
+
+      accept_confirm("Are you sure? This action will delete this comment. You can't undo this action.") do
+        within(".comment-body", text: "Wrong comment") { click_link "Delete comment" }
+      end
+
+      within "#comments > .comment-list > li", text: "Right reply" do
+        expect(page).to have_content "This comment has been deleted"
+        expect(page).not_to have_content "Wrong comment"
+      end
+
+      visit debate_path(debate)
+
+      within "#comments > .comment-list > li", text: "Right reply" do
+        expect(page).to have_content "This comment has been deleted"
+        expect(page).not_to have_content "Wrong comment"
+      end
+    end
+  end
+
   scenario "Reply" do
     citizen = create(:user, username: "Ana")
     manuela = create(:user, username: "Manuela")


### PR DESCRIPTION
## Objectives

Sometimes a user makes a typo when writing a comment and cannot change it. Allow to edit is tricky because it could affect the context if the comment has some answers.

Other times users want to be able to delete the content they have created.

This PR allows users to delete their comments. A confirmation alert is displayed to avoid deleting content by mistake.

## Visual Changes
<img width="1206" alt="delete_comment_1" src="https://user-images.githubusercontent.com/631897/97557883-a9aab000-19db-11eb-8365-02cbeae4e87e.png">

<img width="458" alt="delete_comment_2" src="https://user-images.githubusercontent.com/631897/97557889-aadbdd00-19db-11eb-8617-0c4502cd8ec2.png">
