### PR TITLE
Send informative email for already confirmed users

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,4 +1,17 @@
 class Users::ConfirmationsController < Devise::ConfirmationsController
+  # POST /resource/confirmation
+  def create
+    self.resource = resource_class.send_confirmation_instructions(resource_params)
+    yield resource if block_given?
+
+    if successfully_sent?(resource)
+      Mailer.already_confirmed(resource).deliver_later unless resource.confirmation_required?
+      respond_with({}, location: after_resending_confirmation_instructions_path_for(resource_name))
+    else
+      respond_with(resource)
+    end
+  end
+
   # new action, PATCH does not exist in the default Devise::ConfirmationsController
   # PATCH /resource/confirmation
   def update

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -144,6 +144,15 @@ class Mailer < ApplicationMailer
     mail(to: @email_to, subject: t("mailers.machine_learning_success.subject"))
   end
 
+  def already_confirmed(user)
+    @email_to = user.email
+    @user = user
+
+    with_user(@user) do
+      mail(to: @email_to, subject: t("mailers.already_confirmed.subject"))
+    end
+  end
+
   private
 
     def with_user(user, &block)

--- a/app/views/mailer/already_confirmed.html.erb
+++ b/app/views/mailer/already_confirmed.html.erb
@@ -1,0 +1,17 @@
+<td style="padding-bottom: 20px; padding-left: 10px;">
+
+  <h1 style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;">
+    <%= t("mailers.already_confirmed.subject") %>
+  </h1>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;line-height: 24px;">
+    <%= t("mailers.already_confirmed.info") %>
+  </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;line-height: 24px;">
+    <%= t("mailers.already_confirmed.new_password") %>
+  </p>
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
+    <%= link_to t("devise_views.shared.links.new_password"), new_password_url(@user), style: "color: #2895F1; text-decoration:none;" %>
+  </p>
+</td>

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -9,8 +9,8 @@ en:
       updated: "Password successfully updated"
     confirmations:
       confirmed: "Your account has been confirmed."
-      send_instructions: "In a few minutes you will receive an email containing instructions on how to reset your password."
-      send_paranoid_instructions: "If your email address is in our database, in a few minutes you will receive an email containing instructions on how to reset your password."
+      send_instructions: "In a few minutes you will receive an email containing instructions on how to confirm your email address."
+      send_paranoid_instructions: "If your email address exists in our database, in a few minutes you will receive an email with instructions on how to confirm your email address."
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account has not yet been activated."

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -2,6 +2,10 @@ en:
   mailers:
     title: "Open Government"
     no_reply: "This message was sent from an email address that does not accept replies."
+    already_confirmed:
+      info: "We've received a request to send you instructions to confirm your account. However, your account is already confirmed, so there's no need to do so again."
+      new_password: "If you've forgotten your password, you can reset it at the following link:"
+      subject: Your account is already confirmed
     comment:
       hi: Hi
       new_comment_by: There is a new comment from <strong>%{commenter}</strong>

--- a/config/locales/es/devise.yml
+++ b/config/locales/es/devise.yml
@@ -9,8 +9,8 @@ es:
       updated: "Contraseña actualizada con éxito"
     confirmations:
       confirmed: "Tu cuenta ha sido confirmada. Por favor autentifícate con tu red social o tu usuario y contraseña"
-      send_instructions: "Recibirás un correo electrónico en unos minutos con instrucciones sobre cómo restablecer tu contraseña."
-      send_paranoid_instructions: "Si tu correo electrónico existe en nuestra base de datos recibirás un correo electrónico en unos minutos con instrucciones sobre cómo restablecer tu contraseña."
+      send_instructions: "Recibirás un correo electrónico en unos minutos con instrucciones sobre cómo confirmar tu cuenta."
+      send_paranoid_instructions: "Si tu correo electrónico existe en nuestra base de datos recibirás un correo electrónico en unos minutos con instrucciones sobre cómo confirmar tu cuenta."
     failure:
       already_authenticated: "Ya has iniciado sesión."
       inactive: "Tu cuenta aún no ha sido activada."

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -2,6 +2,10 @@ es:
   mailers:
     title: "Gobierno abierto"
     no_reply: "Este mensaje se ha enviado desde una dirección de correo electrónico que no admite respuestas."
+    already_confirmed:
+      info: "Hemos recibido una solicitud para enviarte instrucciones para confirmar tu cuenta. Sin embargo, tu cuenta ya está confirmada, por lo que no es necesario volver a hacerlo."
+      new_password: "Si has olvidado tu contraseña, puedes restablecerla en el siguiente enlace:"
+      subject: Tu cuenta ya está confirmada
     comment:
       hi: Hola
       new_comment_by: Hay un nuevo comentario de <strong>%{commenter}</strong> en

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -585,7 +585,8 @@ describe "Users" do
   end
 
   scenario "Re-send confirmation instructions" do
-    create(:user, email: "manuela@consul.dev")
+    create(:user, email: "manuela@consul.dev", confirmed_at: nil)
+    ActionMailer::Base.deliveries.clear
 
     visit "/"
     click_link "Sign in"
@@ -596,9 +597,13 @@ describe "Users" do
 
     expect(page).to have_content "If your email address exists in our database, in a few minutes you will "\
                                  "receive an email with instructions on how to confirm your email address."
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.first.to).to eq(["manuela@consul.dev"])
+    expect(ActionMailer::Base.deliveries.first.subject).to eq("Confirmation instructions")
   end
 
   scenario "Re-send confirmation instructions with unexisting email" do
+    ActionMailer::Base.deliveries.clear
     visit "/"
     click_link "Sign in"
     click_link "Haven't received instructions to activate your account?"
@@ -608,6 +613,25 @@ describe "Users" do
 
     expect(page).to have_content "If your email address exists in our database, in a few minutes you will "\
                                  "receive an email with instructions on how to confirm your email address."
+    expect(ActionMailer::Base.deliveries.count).to eq(0)
+  end
+
+  scenario "Re-send confirmation instructions with already verified email" do
+    ActionMailer::Base.deliveries.clear
+
+    create(:user, email: "manuela@consul.dev")
+
+    visit new_user_session_path
+    click_link "Haven't received instructions to activate your account?"
+
+    fill_in "user_email", with: "manuela@consul.dev"
+    click_button "Re-send instructions"
+
+    expect(page).to have_content "If your email address exists in our database, in a few minutes you will "\
+                                 "receive an email with instructions on how to confirm your email address."
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.first.to).to eq(["manuela@consul.dev"])
+    expect(ActionMailer::Base.deliveries.first.subject).to eq("Your account is already confirmed")
   end
 
   scenario "Sign in, admin with password expired" do

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -594,9 +594,8 @@ describe "Users" do
     fill_in "Email", with: "manuela@consul.dev"
     click_button "Re-send instructions"
 
-    expect(page).to have_content "If your email address is in our database, in a few minutes you "\
-                                 "will receive an email containing instructions on how to reset "\
-                                 "your password."
+    expect(page).to have_content "If your email address exists in our database, in a few minutes you will "\
+                                 "receive an email with instructions on how to confirm your email address."
   end
 
   scenario "Re-send confirmation instructions with unexisting email" do
@@ -607,9 +606,8 @@ describe "Users" do
     fill_in "Email", with: "fake@mail.dev"
     click_button "Re-send instructions"
 
-    expect(page).to have_content "If your email address is in our database, in a few minutes you "\
-                                 "will receive an email containing instructions on how to reset "\
-                                 "your password."
+    expect(page).to have_content "If your email address exists in our database, in a few minutes you will "\
+                                 "receive an email with instructions on how to confirm your email address."
   end
 
   scenario "Sign in, admin with password expired" do


### PR DESCRIPTION
## Objectives

When a user requests the confirmation email, a message appears indicating that they will receive an email. The same message appears if their account is already confirmed, but CONSUL doesn't send any email.

This PR maintains the behavior to don't resend confirmation instructions email for already confirmed users.
But, we will send an email to the user informing them that their account is now registered.

This way no one can know if someone else's account is confirmed and we don't have to worry about GDPR either.

## Notes
One of the problems with adding this text could be that it provides information that the account already exists to a potential "hacker". But the application already gives this information when registering a new user if you enter an existing email "has already been taken".

Perhaps the more correct text would be:
"If your email address exists in our database **and you have not received a confirmation email in the past,** you will receive an email with instructions for how to confirm your email address in a few minutes." The problem with this text is that it is too long and not concise for a notification. 

Conclusion: between the fact that the information disclosed with the proposed PR message ("You have already confirmed your email account.") is already available from the registration page, and that the more correct text in my opinion is too long and not concise, I think we can include this change.

Edit: 
As the two previously proposed solutions had some drawbacks, a new commit has been added which directly sends an email to the user informing him that his account is now validated and a link to reset his password. This way we avoid a notice with too much information and unclear or a notice that could somehow breach the GDPR.