### PR TITLE
Remove unused deployment configuration variables

### DIFF
--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -2,27 +2,18 @@ staging:
   deploy_to: "/var/www/consul"
   ssh_port: "21"
   server: "staging.consul.es"
-  db_server: "postgre.consul.es"
   user: "xxxxx"
-  server_name: "staging.consul.es"
-  full_app_name: "consul"
 
 preproduction:
   deploy_to: "/var/www/consul"
   ssh_port: "2222"
   server1: xxx.xxx.xxx.xxx
   server2: xxx.xxx.xxx.xxx
-  db_server: xxx.xxx.xxx.xxx
   user: xxxxx
-  server_name: pre.consul.es
-  full_app_name: "consul"
 
 production:
   deploy_to: "/var/www/consul"
   ssh_port: "22"
   server1: xxx.xxx.xxx.xxx
   server2: xxx.xxx.xxx.xxx
-  db_server: xxx.xxx.xxx.xxx
   user: "deploy"
-  server_name: "consul.es"
-  full_app_name: "consul"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,10 +10,7 @@ set :rails_env, fetch(:stage)
 set :rvm1_map_bins, -> { fetch(:rvm_map_bins).to_a.concat(%w[rake gem bundle ruby]).uniq }
 
 set :application, "consul"
-set :full_app_name, deploysecret(:full_app_name)
 set :deploy_to, deploysecret(:deploy_to)
-set :server_name, deploysecret(:server_name)
-set :db_server, deploysecret(:db_server)
 set :ssh_options, port: deploysecret(:ssh_port)
 
 set :repo_url, "https://github.com/consul/consul.git"
@@ -35,12 +32,6 @@ set :puma_conf, "#{release_path}/config/puma/#{fetch(:rails_env)}.rb"
 
 set :delayed_job_workers, 2
 set :delayed_job_roles, :background
-
-set(:config_files, %w[
-  log_rotation
-  database.yml
-  secrets.yml
-])
 
 set :whenever_roles, -> { :app }
 


### PR DESCRIPTION
## References

* These variables aren't used since commits 012d5297e and 94a7e13dc

## Objectives

* Remove obsolete deployment configuration variables which are no longer used