### PR TITLE
Remove blank space after footer

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2820,6 +2820,10 @@ table {
   .cards-container {
     display: flex;
     flex-wrap: wrap;
+
+    .card a {
+      height: 100%;
+    }
   }
 
   .card {
@@ -2828,8 +2832,6 @@ table {
     overflow: visible;
 
     a {
-      height: 100%;
-
       img {
         transition-duration: 0.3s;
         transition-property: transform;


### PR DESCRIPTION
## References

* This issue was introduced in commit a8537f7e1

## Background

We added a `height: 100%` rule on links inside cards, which is great for cards in the "Featured" section of the homepage. However, the card in the "Open processes" section of the homepage has as many links as open processes inside, causing its height to be 300% on some browsers (Firefox at the very least) if there are three open processes and so expanding below the footer.

## Objectives

Remove blank space after footer when there are open processes.

## Visual changes

### Before these changes

![There's a blank space below the footer](https://user-images.githubusercontent.com/35156/98439366-bde46080-20f1-11eb-9be6-5e0ac2d10737.png)

### After these changes
![There is no blank space below the footer](https://user-images.githubusercontent.com/35156/98439374-c8065f00-20f1-11eb-8441-cbcc0b5bbcaf.png)