### PR TITLE
Add global SDG feature setting

### DIFF
--- a/app/controllers/sdg_management/base_controller.rb
+++ b/app/controllers/sdg_management/base_controller.rb
@@ -1,4 +1,7 @@
 class SDGManagement::BaseController < ApplicationController
+  include FeatureFlags
+  feature_flag :sdg
+
   layout "admin"
 
   before_action :authenticate_user!

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -100,6 +100,7 @@ class Setting < ApplicationRecord
         "feature.remote_census": nil,
         "feature.valuation_comment_notification": true,
         "feature.graphql_api": true,
+        "feature.sdg": false,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/app/views/admin/settings/_sdg_configuration_tab.html.erb
+++ b/app/views/admin/settings/_sdg_configuration_tab.html.erb
@@ -1,3 +1,9 @@
-<h2><%= t("admin.settings.index.sdg.title") %></h2>
+<% if feature?(:sdg) %>
+  <h2><%= t("admin.settings.index.sdg.title") %></h2>
 
-<%= render "featured_settings_table", features: @sdg_settings, tab: "#tab-sdg-configuration" %>
+  <%= render "featured_settings_table", features: @sdg_settings, tab: "#tab-sdg-configuration" %>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.settings.index.sdg.how_to_enable") %>
+  </div>
+<% end %>

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -33,7 +33,7 @@
         </li>
       <% end %>
 
-      <% if current_user.administrator? %>
+      <% if feature?(:sdg) && current_user.administrator? %>
         <li>
           <%= link_to t("sdg_management.header.title"), sdg_management_root_path %>
         </li>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1242,6 +1242,7 @@ en:
           how_to_enable: 'To configure remote census (SOAP) you must enable "Configure connection to remote census (SOAP)" on "Features" tab.'
         sdg:
           title: SDG configuration
+          how_to_enable: 'To show the configuration options from Sustainable Development Goals you must enable "SDG" on "Features" tab.'
       remote_census_general_name: General Information
       remote_census_request_name: Request Data
       remote_census_response_name: Response Data

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -130,6 +130,8 @@ en:
       dashboard:
         notification_emails: "Dashboard notification emails"
         notification_emails_description: "Enable sending dashboard notification emails to proposal's authors"
+      sdg: SDG
+      sdg_description: Enable Sustainable Development Goals sections in the administration menu and in the Global Settings.
     remote_census:
       general:
         endpoint: "Endpoint"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1241,6 +1241,7 @@ es:
           how_to_enable: 'Para configurar la conexión con el Censo Remoto (SOAP) se debe activar "Configurar la conexión al censo remoto (SOAP)" en la pestaña "Funcionalidades".'
         sdg:
           title: Configuración ODS
+          how_to_enable: 'Para mostrar las opciones de configuración de los Objetivos de Desarrollo Sostenible se debe activar "ODS" en la pestaña "Funcionalidades".'
       remote_census_general_name: Datos Generales
       remote_census_request_name: Datos Petición
       remote_census_response_name: Datos Respuesta

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -130,6 +130,8 @@ es:
       dashboard:
         notification_emails: "Emails del panel de progreso"
         notification_emails_description: "Activar el envío de emails de notificaciones a los autores de las propuestas en la sección de panel de progreso"
+      sdg: ODS
+      sdg_description: Habilitar secciones relacionadas con Objetivos de Desarrollo Sostenible en el menú de administración y en la sección de Configuración Global.
     remote_census:
       general:
         endpoint: "Endpoint"

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -5,6 +5,7 @@ section "Creating Settings" do
     "facebook_handle": "CONSUL",
     "feature.featured_proposals": "true",
     "feature.map": "true",
+    "feature.sdg": "true",
     "instagram_handle": "CONSUL",
     "mailer_from_address": "noreply@consul.dev",
     "mailer_from_name": "CONSUL",

--- a/spec/system/admin/settings_spec.rb
+++ b/spec/system/admin/settings_spec.rb
@@ -267,6 +267,7 @@ describe "Admin settings", :admin do
     end
 
     scenario "On #tab-sdg-configuration", :js do
+      Setting["feature.sdg"] = true
       Setting.create!(key: "sdg.whatever")
       login_as(create(:administrator).user)
 
@@ -311,6 +312,30 @@ describe "Admin settings", :admin do
       expect(page).to have_content "Value updated"
 
       Setting["feature.user.skip_verification"] = nil
+    end
+  end
+
+  describe "SDG configuration tab", :js do
+    scenario "is enabled when the sdg feature is enabled" do
+      Setting["feature.sdg"] = true
+      login_as(create(:administrator).user)
+
+      visit admin_settings_path
+      click_link "SDG configuration"
+
+      expect(page).to have_css "h2", exact_text: "SDG configuration"
+    end
+
+    scenario "is disabled when the sdg feature is disabled" do
+      Setting["feature.sdg"] = false
+      login_as(create(:administrator).user)
+
+      visit admin_settings_path
+      click_link "SDG configuration"
+
+      expect(page).to have_content "To show the configuration options from " \
+                                   "Sustainable Development Goals you must " \
+                                   'enable "SDG" on "Features" tab.'
     end
   end
 end

--- a/spec/system/sdg_management/goals_spec.rb
+++ b/spec/system/sdg_management/goals_spec.rb
@@ -5,6 +5,8 @@ describe "Goals", :js do
 
   describe "Index" do
     scenario "Visit the index" do
+      Setting["feature.sdg"] = true
+
       visit sdg_management_root_path
 
       within("#side_menu") do

--- a/spec/system/sdg_management/sdg_spec.rb
+++ b/spec/system/sdg_management/sdg_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "SDG Management" do
+  before { login_as(create(:administrator).user) }
+
+  context "SDG feature flag is enabled", :js do
+    before { Setting["feature.sdg"] = true }
+
+    scenario "shows the SDG content link" do
+      visit root_path
+      click_link "Menu"
+
+      expect(page).to have_link "SDG content"
+    end
+  end
+
+  context "SDG feature is disabled" do
+    before { Setting["feature.sdg"] = false }
+
+    scenario "does not show the SDG Content link", :js do
+      visit root_path
+      click_link "Menu"
+
+      expect(page).not_to have_link "SDG content"
+    end
+
+    scenario "does not allow visits to the SDG content" do
+      expect { visit sdg_management_root_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    end
+  end
+end


### PR DESCRIPTION
## References
Related PR's: #4247 #4252

## Objectives
Add new global sdg feature setting to Show/Hide:
  - SDG Configuration tab on Global Settings section
  - SDG content section on sidebar

## Visual Changes
![Captura de pantalla 2020-11-12 a las 9 21 15](https://user-images.githubusercontent.com/16189/98914027-73cff600-24c8-11eb-9fcd-69db66ae932a.png)

## Notes
This PR has rebased:
  - Add SDG settings #4247 
  - Add SDG admin index #4248