### PR TITLE
Fix legislation draft version TOC width

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -139,7 +139,6 @@ var initialize_modules = function() {
   App.MarkdownEditor.initialize();
   App.HTMLEditor.initialize();
   App.LegislationAdmin.initialize();
-  App.LegislationAllegations.initialize();
   App.Legislation.initialize();
   if ($(".legislation-annotatable").length) {
     App.LegislationAnnotatable.initialize();

--- a/app/assets/javascripts/legislation_allegations.js
+++ b/app/assets/javascripts/legislation_allegations.js
@@ -1,36 +1,10 @@
 (function() {
   "use strict";
   App.LegislationAllegations = {
-    toggle_comments: function() {
-      if (!App.LegislationAnnotatable.isMobile()) {
-        $(".draft-allegation").toggleClass("comments-on");
-        $("#comments-box").html("").hide();
-      }
-    },
     show_comments: function() {
       if (!App.LegislationAnnotatable.isMobile()) {
-        $(".draft-allegation").addClass("comments-on");
+        document.querySelector(".draft-allegation details.calc-comments").open = true;
       }
-    },
-    initialize: function() {
-      $(".js-toggle-allegations .draft-panel").on({
-        click: function(e) {
-          e.preventDefault();
-          e.stopPropagation();
-          if (!App.LegislationAnnotatable.isMobile()) {
-            App.LegislationAllegations.toggle_comments();
-          }
-        }
-      });
-      $(".js-toggle-allegations").on({
-        click: function() {
-          if (!App.LegislationAnnotatable.isMobile()) {
-            if ($(this).find(".draft-panel .panel-title:visible").length === 0) {
-              App.LegislationAllegations.toggle_comments();
-            }
-          }
-        }
-      });
     }
   };
 }).call(this);

--- a/app/assets/javascripts/legislation_annotatable.js
+++ b/app/assets/javascripts/legislation_annotatable.js
@@ -40,8 +40,10 @@
     },
     renderAnnotationComments: function(event) {
       if (event.offset) {
+        var default_top = $(".calc-comments").offset().top + $(".calc-comments .draft-panel").outerHeight();
+
         $("#comments-box").css({
-          top: event.offset - $(".calc-comments").offset().top
+          top: event.offset - default_top
         });
       }
       if (App.LegislationAnnotatable.isMobile()) {

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -326,6 +326,33 @@
   position: relative;
   padding: rem-calc(32) 0;
 
+  %calc-collapsed {
+    .draft-panel {
+      @include breakpoint(medium) {
+        line-height: 1;
+        display: block;
+        font-size: $small-font-size;
+        text-transform: uppercase;
+        font-weight: 700;
+        color: #696969;
+        padding: 0;
+        text-align: center;
+
+        .icon-banner::before,
+        .icon-comments::before {
+          display: block;
+          margin: rem-calc(24) auto rem-calc(36);
+        }
+
+        .panel-title {
+          display: block;
+          transform: rotate(-90deg);
+          filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+        }
+      }
+    }
+  }
+
   .draft-chooser {
 
     h3 {
@@ -388,10 +415,6 @@
       .draft-panel {
         cursor: pointer;
       }
-
-      .draft-index-rotated {
-        display: none;
-      }
     }
 
     @media screen and (min-width: 40em) {
@@ -445,7 +468,6 @@
         line-height: 0;
         color: $text-medium;
         vertical-align: sub;
-        margin-right: rem-calc(4);
       }
     }
 
@@ -536,57 +558,26 @@
       }
     }
 
-    .calc-comments {
+    &:not(.comments-on) .calc-comments {
+      @extend %calc-collapsed;
       position: relative;
 
       .comment-box {
         display: none;
-      }
-
-      .draft-comments-rotated {
-        @include breakpoint(medium) {
-          font-size: $small-font-size;
-          text-transform: uppercase;
-          font-weight: 700;
-          color: #696969;
-          margin-top: rem-calc(64);
-          transform: rotate(-90deg);
-          filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
-        }
       }
     }
   }
 
   .comments-on {
     .calc-index {
+      @extend %calc-collapsed;
+
       width: rem-calc(50);
       background: #f2f2f2;
       cursor: pointer;
 
-      .panel-title {
-        display: none;
-      }
-
       .draft-index {
         display: none;
-      }
-
-      .draft-index-rotated {
-        @include breakpoint(medium) {
-          line-height: 1;
-          display: block;
-          font-size: $small-font-size;
-          text-transform: uppercase;
-          font-weight: 700;
-          color: #696969;
-          margin-top: $line-height;
-          transform: rotate(-90deg);
-          filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
-
-          .panel-title {
-            display: block;
-          }
-        }
       }
     }
 
@@ -615,10 +606,6 @@
 
       .draft-panel {
         cursor: pointer;
-      }
-
-      .draft-comments-rotated {
-        display: none;
       }
 
       .comments-box-container {

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -326,33 +326,6 @@
   position: relative;
   padding: rem-calc(32) 0;
 
-  %calc-collapsed {
-    .draft-panel {
-      @include breakpoint(medium) {
-        line-height: 1;
-        display: block;
-        font-size: $small-font-size;
-        text-transform: uppercase;
-        font-weight: 700;
-        color: #696969;
-        padding: 0;
-        text-align: center;
-
-        .icon-banner::before,
-        .icon-comments::before {
-          display: block;
-          margin: rem-calc(24) auto rem-calc(36);
-        }
-
-        .panel-title {
-          display: block;
-          transform: rotate(-90deg);
-          filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
-        }
-      }
-    }
-  }
-
   .draft-chooser {
 
     h3 {
@@ -411,12 +384,6 @@
       padding-right: rem-calc(15);
     }
 
-    .calc-index {
-      .draft-panel {
-        cursor: pointer;
-      }
-    }
-
     @media screen and (min-width: 40em) {
       .calc-index {
         width: calc(35% - 25px);
@@ -424,19 +391,6 @@
 
       .calc-text {
         width: calc(65% - 25px);
-      }
-
-      .calc-comments {
-        cursor: pointer;
-        background: #f2f2f2;
-        width: rem-calc(50);
-
-        .draft-panel {
-
-          .panel-title {
-            display: none;
-          }
-        }
       }
     }
 
@@ -558,26 +512,51 @@
       }
     }
 
-    &:not(.comments-on) .calc-comments {
-      @extend %calc-collapsed;
+    .calc-comments {
       position: relative;
+    }
 
-      .comment-box {
+    summary {
+      cursor: pointer;
+      list-style: none;
+
+      &::-webkit-details-marker {
         display: none;
       }
     }
-  }
 
-  .comments-on {
-    .calc-index {
-      @extend %calc-collapsed;
-
-      width: rem-calc(50);
+    details:not([open]) {
       background: #f2f2f2;
-      cursor: pointer;
 
-      .draft-index {
-        display: none;
+      @include breakpoint(small only) {
+        border-bottom: 1px solid #d4d4d4;
+      }
+
+      @include breakpoint(medium) {
+        width: rem-calc(50);
+
+        .draft-panel {
+          line-height: 1;
+          display: block;
+          font-size: $small-font-size;
+          text-transform: uppercase;
+          font-weight: 700;
+          color: #696969;
+          padding: 0;
+          text-align: center;
+
+          .icon-banner::before,
+          .icon-comments::before {
+            display: block;
+            margin: rem-calc(24) auto rem-calc(36);
+          }
+
+          .panel-title {
+            display: block;
+            transform: rotate(-90deg);
+            filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+          }
+        }
       }
     }
 
@@ -604,8 +583,14 @@
       cursor: auto;
       width: calc(35% - 25px);
 
-      .draft-panel {
-        cursor: pointer;
+      @include breakpoint(small only) {
+        summary {
+          display: none;
+        }
+      }
+
+      &:not([open]) {
+        border-left: 1px solid #d4d4d4;
       }
 
       .comments-box-container {
@@ -788,15 +773,6 @@
               }
             }
           }
-        }
-      }
-
-      .draft-panel {
-        background: #e5e5e5;
-        border-left: 1px solid #d4d4d4;
-
-        .panel-title {
-          display: inline-block;
         }
       }
     }

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -384,6 +384,15 @@
       .calc-index {
         max-width: calc(35% - 25px);
 
+        .draft-index {
+          @supports (position: sticky) {
+            max-height: 100vh;
+            overflow-y: auto;
+            position: sticky;
+            top: $line-height;
+          }
+        }
+
         > * {
           padding-right: rem-calc(20);
         }

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -380,17 +380,26 @@
 
     @include breakpoint(medium) {
       display: flex;
-      padding-left: rem-calc(15);
-      padding-right: rem-calc(15);
-    }
 
-    @media screen and (min-width: 40em) {
       .calc-index {
-        width: calc(35% - 25px);
+        max-width: calc(35% - 25px);
+
+        > * {
+          padding-right: rem-calc(20);
+        }
       }
 
       .calc-text {
-        width: calc(65% - 25px);
+        flex: 1;
+      }
+
+      .calc-comments {
+        min-width: 15rem;
+        width: calc(35% - 25px);
+
+        > * {
+          padding-left: rem-calc(20);
+        }
       }
     }
 
@@ -467,6 +476,8 @@
       padding: rem-calc(16);
 
       @include breakpoint(medium) {
+        margin: 0 auto;
+        max-width: 3 * $grid-row-width / 4;
         padding: rem-calc(32) rem-calc(32) rem-calc(32) rem-calc(48);
       }
 
@@ -533,6 +544,7 @@
       }
 
       @include breakpoint(medium) {
+        min-width: auto;
         width: rem-calc(50);
 
         .draft-panel {
@@ -561,7 +573,6 @@
     }
 
     .calc-text {
-      width: calc(65% - 25px);
       border-right: 0;
 
       .show-comments {
@@ -581,7 +592,6 @@
     .calc-comments {
       background: #fff;
       cursor: auto;
-      width: calc(35% - 25px);
 
       @include breakpoint(small only) {
         summary {
@@ -594,12 +604,11 @@
       }
 
       .comments-box-container {
-        position: absolute;
-        top: rem-calc(230);
+        position: relative;
+        top: rem-calc(180);
       }
 
       .comment-box {
-        width: rem-calc(375);
         padding: rem-calc(4);
         background: #f9f9f9;
         border: 1px solid $border;

--- a/app/views/legislation/draft_versions/_comments_panel.html.erb
+++ b/app/views/legislation/draft_versions/_comments_panel.html.erb
@@ -1,4 +1,4 @@
-<details open=open class="small-12 calc-comments end column">
+<details open=open class="calc-comments">
   <summary class="draft-panel">
     <span class="icon-comments" aria-hidden="true"></span>
     <span class="panel-title"><%= t("legislation.draft_versions.show.text_comments") %></span>

--- a/app/views/legislation/draft_versions/_comments_panel.html.erb
+++ b/app/views/legislation/draft_versions/_comments_panel.html.erb
@@ -1,11 +1,6 @@
 <div class="small-12 calc-comments end column js-toggle-allegations">
   <div class="draft-panel">
-    <div>
-      <span class="icon-comments" aria-hidden="true"></span> <span class="panel-title"><%= t("legislation.draft_versions.show.text_comments") %></span>
-    </div>
-  </div>
-
-  <div class="draft-comments-rotated text-center">
+    <span class="icon-comments" aria-hidden="true"></span>
     <span class="panel-title"><%= t("legislation.draft_versions.show.text_comments") %></span>
   </div>
 

--- a/app/views/legislation/draft_versions/_comments_panel.html.erb
+++ b/app/views/legislation/draft_versions/_comments_panel.html.erb
@@ -1,8 +1,8 @@
-<div class="small-12 calc-comments end column js-toggle-allegations">
-  <div class="draft-panel">
+<details open=open class="small-12 calc-comments end column">
+  <summary class="draft-panel">
     <span class="icon-comments" aria-hidden="true"></span>
     <span class="panel-title"><%= t("legislation.draft_versions.show.text_comments") %></span>
-  </div>
+  </summary>
 
   <div id="comments-box" class="comments-box-container" style="display: none;">
     <div class="comment-box">
@@ -12,4 +12,4 @@
       </div>
     </div>
   </div>
-</div>
+</details>

--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -42,8 +42,8 @@
 
     <%= render "legislation/processes/help_gif" %>
 
-    <div class="row draft-allegation medium-collapse">
-      <details class="small-12 calc-index column">
+    <div class="draft-allegation">
+      <details class="calc-index">
         <summary class="draft-panel">
           <span class="icon-banner" aria-hidden="true"></span>
           <span class="panel-title"><%= t("legislation.draft_versions.show.text_toc") %></span>
@@ -53,7 +53,7 @@
           <%= AdminLegislationSanitizer.new.sanitize(@draft_version.toc_html) %>
         </div>
       </details>
-      <div class="small-12 calc-text column border-right border-left">
+      <div class="calc-text border-right border-left">
         <div class="draft-panel">
           <div><span class="panel-title"><%= t("legislation.draft_versions.show.text_body") %></span></div>
         </div>
@@ -72,7 +72,7 @@
       </div>
 
       <% if @draft_version.final_version? %>
-        <div class="small-12 calc-comments end column"></div>
+        <div class="calc-comments"></div>
       <% else %>
         <%= render "comments_panel", draft_version: @draft_version %>
       <% end %>

--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -42,19 +42,17 @@
 
     <%= render "legislation/processes/help_gif" %>
 
-    <div class="row draft-allegation medium-collapse comments-on">
-      <div class="small-12 calc-index column <%= "js-toggle-allegations" unless @draft_version.final_version? %>">
-        <div class="draft-panel">
+    <div class="row draft-allegation medium-collapse">
+      <details class="small-12 calc-index column">
+        <summary class="draft-panel">
           <span class="icon-banner" aria-hidden="true"></span>
           <span class="panel-title"><%= t("legislation.draft_versions.show.text_toc") %></span>
-        </div>
+        </summary>
 
-        <div data-sticky-container>
-          <div data-sticky data-anchor="sticky-panel" class="draft-index sticky" data-tree-navigator>
-            <%= AdminLegislationSanitizer.new.sanitize(@draft_version.toc_html) %>
-          </div>
+        <div class="draft-index" data-tree-navigator>
+          <%= AdminLegislationSanitizer.new.sanitize(@draft_version.toc_html) %>
         </div>
-      </div>
+      </details>
       <div class="small-12 calc-text column border-right border-left">
         <div class="draft-panel">
           <div><span class="panel-title"><%= t("legislation.draft_versions.show.text_body") %></span></div>

--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -45,13 +45,7 @@
     <div class="row draft-allegation medium-collapse comments-on">
       <div class="small-12 calc-index column <%= "js-toggle-allegations" unless @draft_version.final_version? %>">
         <div class="draft-panel">
-          <div>
-            <span class="icon-banner" aria-hidden="true"></span>
-            <span class="panel-title"><%= t("legislation.draft_versions.show.text_toc") %></span>
-          </div>
-        </div>
-
-        <div class="draft-index-rotated text-center">
+          <span class="icon-banner" aria-hidden="true"></span>
           <span class="panel-title"><%= t("legislation.draft_versions.show.text_toc") %></span>
         </div>
 


### PR DESCRIPTION
## References

* Closes #4231

## Objectives

* Fix legislation draft version TOC width right after opening it / closing it
* Make it possible to scroll through the TOC content when it's large enough to fill the whole window
* Improve the draft version layout on small and medium screens

## Visual Changes

### Before these changes

Table of contents:

![The table of contents is displayed so each line has only one word](https://user-images.githubusercontent.com/47716558/98003593-2def9f80-1def-11eb-8dce-d055108f77e5.png)

On medium screens:

![The width of the comment exceeds the width of the page](https://user-images.githubusercontent.com/35156/99294339-3c54a700-2844-11eb-9d3a-ce420a142230.png)

On small screens:

![The icon to show/hide the table of contents is shown even if it does not work](https://user-images.githubusercontent.com/35156/99294501-6b6b1880-2844-11eb-986b-bcb5ddce7d4a.png)

### After these changes

TODO