### PR TITLE
Fix table icon tooltips with long texts

### DIFF
--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -181,7 +181,7 @@
   @include tooltip;
   line-height: $global-lineheight;
   margin-top: $line-height / 8;
-  white-space: nowrap;
+  width: max-content;
 
   &::before {
     @include css-triangle($tooltip-pip-width, $tooltip-background-color, up);


### PR DESCRIPTION
## References

* This bug was introduced in pull request #4218

## Visual Changes

### Before

![Captura de pantalla 2020-11-17 a las 19 41 05](https://user-images.githubusercontent.com/16189/99432835-00d1df80-290d-11eb-9c05-1aac4603c487.png)


### After

![Captura de pantalla 2020-11-17 a las 19 41 50](https://user-images.githubusercontent.com/16189/99432890-16470980-290d-11eb-85a3-d307b0a9890b.png)
