### PR TITLE
Fix build status badge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Test suite
+name: tests
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ on:
       - i18n_master
 
 jobs:
-  test:
+  tests:
     runs-on: ubuntu-18.04
     services:
       postgres:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Citizen Participation and Open Government Application
 
-![Build status](https://github.com/consul/consul/workflows/.github/workflows/tests.yml/badge.svg)
+![Build status](https://github.com/consul/consul/workflows/tests/badge.svg)
 [![Code Climate](https://codeclimate.com/github/consul/consul/badges/gpa.svg)](https://codeclimate.com/github/consul/consul)
 [![Coverage Status](https://coveralls.io/repos/github/consul/consul/badge.svg)](https://coveralls.io/github/consul/consul?branch=master)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/consul/localized.svg)](https://crowdin.com/project/consul)

--- a/README_ES.md
+++ b/README_ES.md
@@ -10,7 +10,7 @@
 
 Aplicación de Participación Ciudadana y Gobierno Abierto
 
-![Estado de los tests](https://github.com/consul/consul/workflows/.github/workflows/tests.yml/badge.svg)
+![Estado de los tests](https://github.com/consul/consul/workflows/tests/badge.svg)
 [![Code Climate](https://codeclimate.com/github/consul/consul/badges/gpa.svg)](https://codeclimate.com/github/consul/consul)
 [![Coverage Status](https://coveralls.io/repos/github/consul/consul/badge.svg?branch=master)](https://coveralls.io/github/consul/consul?branch=master)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/consul/localized.svg)](https://crowdin.com/project/consul)


### PR DESCRIPTION
## References

* Fixes an issue in pull request #4265
* As mentioned in the [GitHub Actions documentation](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/adding-a-workflow-status-badge): "Note: Referencing the workflow file using the file path does not work if the workflow has a name."