### PR TITLE
Simplify generating lists of links 

### DIFF
--- a/app/assets/stylesheets/admin/menu.scss
+++ b/app/assets/stylesheets/admin/menu.scss
@@ -117,7 +117,8 @@
       padding-left: $line-height / 2;
     }
 
-    &.is-active a {
+    &.is-active a,
+    &[aria-current] a {
       background: $sidebar-hover;
       border-left: 2px solid $sidebar-active;
       font-weight: bold;

--- a/app/components/admin/menu_component.html.erb
+++ b/app/components/admin/menu_component.html.erb
@@ -1,6 +1,6 @@
 <ul id="admin_menu" data-accordion-menu data-multi-open="true">
   <% if feature?(:proposals) %>
-    <li>
+    <li class="<%= "is-active" if controller_name == "proposals" %>">
       <%= link_to t("admin.menu.proposals"), admin_proposals_path, class: "proposals-link" %>
     </li>
   <% end %>

--- a/app/components/admin/menu_component.html.erb
+++ b/app/components/admin/menu_component.html.erb
@@ -36,26 +36,10 @@
   <li>
     <a href="#" class="booths-link"><%= t("admin.menu.title_booths") %></a>
     <%= link_list(
-      [
-        t("admin.menu.poll_officers"),
-        admin_officers_path,
-        %w[officers officer_assignments].include?(controller_name)
-      ],
-      [
-        t("admin.menu.poll_booths"),
-        admin_booths_path,
-        controller_name == "booths" && action_name != "available"
-      ],
-      [
-        t("admin.menu.poll_booth_assignments"),
-        booth_assignments_admin_polls_path,
-        controller_name == "polls" && action_name == "booth_assignments" || controller_name == "booth_assignments" && action_name == "manage"
-      ],
-      [
-        t("admin.menu.poll_shifts"),
-        available_admin_booths_path,
-        %w[shifts booths].include?(controller_name) && %w[available new].include?(action_name)
-      ],
+      officers_link,
+      booths_link,
+      booth_assignments_link,
+      shifts_link,
       id: "booths_menu", class: ("is-active" if booths?)
     ) %>
   </li>
@@ -69,26 +53,10 @@
   <li>
     <a href="#" class="messages-link"><%= t("admin.menu.messaging_users") %></a>
     <%= link_list(
-      [
-        t("admin.menu.newsletters"),
-        admin_newsletters_path,
-        controller_name == "newsletters"
-      ],
-      [
-        t("admin.menu.admin_notifications"),
-        admin_admin_notifications_path,
-        controller_name == "admin_notifications"
-      ],
-      [
-        t("admin.menu.system_emails"),
-        admin_system_emails_path,
-        controller_name == "system_emails"
-      ],
-      [
-        t("admin.menu.emails_download"),
-        admin_emails_download_index_path,
-        controller_name == "emails_download"
-      ],
+      newsletters_link,
+      admin_notifications_link,
+      system_emails_link,
+      emails_download_link,
       id: "messaging_users_menu", class: ("is-active" if messages_menu_active?)
     ) %>
   </li>
@@ -96,31 +64,11 @@
   <li>
     <a href="#" class="site-customization-link"><%= t("admin.menu.title_site_customization") %></a>
     <%= link_list(
-      [
-        t("admin.menu.site_customization.homepage"),
-        admin_homepage_path,
-        homepage?
-      ],
-      [
-        t("admin.menu.site_customization.pages"),
-        admin_site_customization_pages_path,
-        pages? || controller_name == "pages"
-      ],
-      [
-        t("admin.menu.banner"),
-        admin_banners_path,
-        controller_name == "banners"
-      ],
-      [
-        t("admin.menu.site_customization.information_texts"),
-        admin_site_customization_information_texts_path,
-        controller_name == "information_texts"
-      ],
-      [
-        t("admin.menu.site_customization.documents"),
-        admin_site_customization_documents_path,
-        controller_name == "documents"
-      ],
+      homepage_link,
+      pages_link,
+      banners_link,
+      information_texts_link,
+      documents_link,
       class: ("is-active" if customization? && controller.class.parent != Admin::Poll::Questions::Answers)
     ) %>
   </li>
@@ -128,47 +76,13 @@
   <li>
     <a href="#" class="moderated-content-link"><%= t("admin.menu.title_moderated_content") %></a>
     <%= link_list(
-      (
-        [
-          t("admin.menu.hidden_proposals"),
-          admin_hidden_proposals_path,
-          controller_name == "hidden_proposals"
-        ] if feature?(:proposals)
-      ),
-      (
-        [
-          t("admin.menu.hidden_debates"),
-          admin_hidden_debates_path,
-          controller_name == "hidden_debates"
-        ] if feature?(:debates)
-      ),
-      (
-        [
-          t("admin.menu.hidden_budget_investments"),
-          admin_hidden_budget_investments_path,
-          controller_name == "hidden_budget_investments"
-        ] if feature?(:budgets)
-      ),
-      [
-        t("admin.menu.hidden_comments"),
-        admin_hidden_comments_path,
-        controller_name == "hidden_comments"
-      ],
-      [
-        t("admin.menu.hidden_proposal_notifications"),
-        admin_hidden_proposal_notifications_path,
-        controller_name == "hidden_proposal_notifications"
-      ],
-      [
-        t("admin.menu.hidden_users"),
-        admin_hidden_users_path,
-        controller_name == "hidden_users"
-      ],
-      [
-        t("admin.menu.activity"),
-        admin_activity_path,
-        controller_name == "activity"
-      ],
+      (hidden_proposals_link if feature?(:proposals)),
+      (hidden_debates_link if feature?(:debates)),
+      (hidden_budget_investments_link if feature?(:budgets)),
+      hidden_comments_link,
+      hidden_proposal_notifications_link,
+      hidden_users_link,
+      activity_link,
       class: ("is-active" if moderated_content?)
     ) %>
   </li>
@@ -176,41 +90,13 @@
   <li>
     <a href="#" class="profiles-link"><%= t("admin.menu.title_profiles") %></a>
     <%= link_list(
-      [
-        t("admin.menu.administrators"),
-        admin_administrators_path,
-        controller_name == "administrators"
-      ],
-      [
-        t("admin.menu.organizations"),
-        admin_organizations_path,
-        controller_name == "organizations"
-      ],
-      [
-        t("admin.menu.officials"),
-        admin_officials_path,
-        controller_name == "officials"
-      ],
-      [
-        t("admin.menu.moderators"),
-        admin_moderators_path,
-        controller_name == "moderators"
-      ],
-      [
-        t("admin.menu.valuators"),
-        admin_valuators_path,
-        controller_name == "valuators"
-      ],
-      [
-        t("admin.menu.managers"),
-        admin_managers_path,
-        controller_name == "managers"
-      ],
-      [
-        t("admin.menu.users"),
-        admin_users_path,
-        controller_name == "users"
-      ],
+      administrators_link,
+      organizations_link,
+      officials_link,
+      moderators_link,
+      valuators_link,
+      managers_link,
+      users_link,
       class: ("is-active" if profiles?)
     ) %>
   </li>
@@ -222,52 +108,20 @@
   <li>
     <a href="#" class="settings-link"><%= t("admin.menu.title_settings") %></a>
     <%= link_list(
-      [
-        t("admin.menu.settings"),
-        admin_settings_path,
-        controller_name == "settings"
-      ],
-      [
-        t("admin.menu.proposals_topics"),
-        admin_tags_path,
-        controller_name == "tags"
-      ],
-      [
-        t("admin.menu.geozones"),
-        admin_geozones_path,
-        controller_name == "geozones"
-      ],
-      [
-        t("admin.menu.site_customization.images"),
-        admin_site_customization_images_path,
-        controller_name == "images" && controller.class.parent != Admin::Poll::Questions::Answers
-      ],
-      [
-        t("admin.menu.site_customization.content_blocks"),
-        admin_site_customization_content_blocks_path,
-        controller_name == "content_blocks"
-      ],
-      [
-        t("admin.menu.local_census_records"),
-        admin_local_census_records_path,
-        local_census_records?
-      ],
+      settings_link,
+      tags_link,
+      geozones_link,
+      images_link,
+      content_blocks_link,
+      local_census_records_link,
       class: ("is-active" if settings?)
     ) %>
   </li>
   <li>
     <a href="#" class="dashboard-link"><%= t("admin.menu.dashboard") %></a>
     <%= link_list(
-      [
-        t("admin.menu.dashboard_actions"),
-        admin_dashboard_actions_path,
-        controller_name == "actions"
-      ],
-      [
-        t("admin.menu.administrator_tasks"),
-        admin_dashboard_administrator_tasks_path,
-        controller_name == "administrator_tasks"
-      ],
+      dashboard_actions_link,
+      administrator_tasks_link,
       class: ("is-active" if dashboard?)
     ) %>
   </li>

--- a/app/components/admin/menu_component.html.erb
+++ b/app/components/admin/menu_component.html.erb
@@ -35,28 +35,29 @@
 
   <li>
     <a href="#" class="booths-link"><%= t("admin.menu.title_booths") %></a>
-    <ul id="booths_menu" <%= "class=is-active" if booths? %>>
-      <li <%= "class=is-active" if %w[officers officer_assignments].include?(controller_name) %>>
-        <%= link_to t("admin.menu.poll_officers"), admin_officers_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "booths" &&
-                                action_name != "available" %>>
-        <%= link_to t("admin.menu.poll_booths"), admin_booths_path %>
-      </li>
-
-      <li <%= "class=is-active" if (controller_name == "polls" &&
-                                    action_name == "booth_assignments") ||
-                                    controller_name == "booth_assignments" &&
-                                    action_name == "manage" %>>
-        <%= link_to t("admin.menu.poll_booth_assignments"), booth_assignments_admin_polls_path %>
-      </li>
-
-      <li <%= "class=is-active" if %w[shifts booths].include?(controller_name) &&
-                                %w[available new].include?(action_name) %>>
-        <%= link_to t("admin.menu.poll_shifts"), available_admin_booths_path %>
-      </li>
-    </ul>
+    <%= link_list(
+      [
+        t("admin.menu.poll_officers"),
+        admin_officers_path,
+        %w[officers officer_assignments].include?(controller_name)
+      ],
+      [
+        t("admin.menu.poll_booths"),
+        admin_booths_path,
+        controller_name == "booths" && action_name != "available"
+      ],
+      [
+        t("admin.menu.poll_booth_assignments"),
+        booth_assignments_admin_polls_path,
+        controller_name == "polls" && action_name == "booth_assignments" || controller_name == "booth_assignments" && action_name == "manage"
+      ],
+      [
+        t("admin.menu.poll_shifts"),
+        available_admin_booths_path,
+        %w[shifts booths].include?(controller_name) && %w[available new].include?(action_name)
+      ],
+      id: "booths_menu", class: ("is-active" if booths?)
+    ) %>
   </li>
 
   <% if feature?(:signature_sheets) %>
@@ -67,120 +68,151 @@
 
   <li>
     <a href="#" class="messages-link"><%= t("admin.menu.messaging_users") %></a>
-    <ul id="messaging_users_menu" <%= "class=is-active" if messages_menu_active? %>>
-      <li <%= "class=is-active" if controller_name == "newsletters" %>>
-        <%= link_to t("admin.menu.newsletters"), admin_newsletters_path %>
-      </li>
-      <li <%= "class=is-active" if controller_name == "admin_notifications" %>>
-        <%= link_to t("admin.menu.admin_notifications"), admin_admin_notifications_path %>
-      </li>
-      <li <%= "class=is-active" if controller_name == "system_emails" %>>
-        <%= link_to t("admin.menu.system_emails"), admin_system_emails_path %>
-      </li>
-      <li <%= "class=is-active" if controller_name == "emails_download" %>>
-        <%= link_to t("admin.menu.emails_download"), admin_emails_download_index_path %>
-      </li>
-    </ul>
+    <%= link_list(
+      [
+        t("admin.menu.newsletters"),
+        admin_newsletters_path,
+        controller_name == "newsletters"
+      ],
+      [
+        t("admin.menu.admin_notifications"),
+        admin_admin_notifications_path,
+        controller_name == "admin_notifications"
+      ],
+      [
+        t("admin.menu.system_emails"),
+        admin_system_emails_path,
+        controller_name == "system_emails"
+      ],
+      [
+        t("admin.menu.emails_download"),
+        admin_emails_download_index_path,
+        controller_name == "emails_download"
+      ],
+      id: "messaging_users_menu", class: ("is-active" if messages_menu_active?)
+    ) %>
   </li>
 
   <li>
     <a href="#" class="site-customization-link"><%= t("admin.menu.title_site_customization") %></a>
-    <ul <%= "class=is-active" if customization? &&
-                                 controller.class.parent != Admin::Poll::Questions::Answers %>>
-
-      <li <%= "class=is-active" if homepage? %>>
-        <%= link_to t("admin.menu.site_customization.homepage"), admin_homepage_path %>
-      </li>
-
-      <li <%= "class=is-active" if pages? || controller_name == "pages" %>>
-        <%= link_to t("admin.menu.site_customization.pages"), admin_site_customization_pages_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "banners" %>>
-        <%= link_to t("admin.menu.banner"), admin_banners_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "information_texts" %>>
-        <%= link_to t("admin.menu.site_customization.information_texts"), admin_site_customization_information_texts_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "documents" %>>
-        <%= link_to t("admin.menu.site_customization.documents"),
-                    admin_site_customization_documents_path %>
-      </li>
-    </ul>
+    <%= link_list(
+      [
+        t("admin.menu.site_customization.homepage"),
+        admin_homepage_path,
+        homepage?
+      ],
+      [
+        t("admin.menu.site_customization.pages"),
+        admin_site_customization_pages_path,
+        pages? || controller_name == "pages"
+      ],
+      [
+        t("admin.menu.banner"),
+        admin_banners_path,
+        controller_name == "banners"
+      ],
+      [
+        t("admin.menu.site_customization.information_texts"),
+        admin_site_customization_information_texts_path,
+        controller_name == "information_texts"
+      ],
+      [
+        t("admin.menu.site_customization.documents"),
+        admin_site_customization_documents_path,
+        controller_name == "documents"
+      ],
+      class: ("is-active" if customization? && controller.class.parent != Admin::Poll::Questions::Answers)
+    ) %>
   </li>
 
   <li>
     <a href="#" class="moderated-content-link"><%= t("admin.menu.title_moderated_content") %></a>
-    <ul <%= "class=is-active" if moderated_content? %>>
-      <% if feature?(:proposals) %>
-        <li <%= "class=is-active" if controller_name == "hidden_proposals" %>>
-          <%= link_to t("admin.menu.hidden_proposals"), admin_hidden_proposals_path %>
-        </li>
-      <% end %>
-
-      <% if feature?(:debates) %>
-        <li <%= "class=is-active" if controller_name == "hidden_debates" %>>
-          <%= link_to t("admin.menu.hidden_debates"), admin_hidden_debates_path %>
-        </li>
-      <% end %>
-
-      <% if feature?(:budgets) %>
-        <li <%= "class=is-active" if controller_name == "hidden_budget_investments" %>>
-          <%= link_to t("admin.menu.hidden_budget_investments"), admin_hidden_budget_investments_path %>
-        </li>
-      <% end %>
-
-      <li <%= "class=is-active" if controller_name == "hidden_comments" %>>
-        <%= link_to t("admin.menu.hidden_comments"), admin_hidden_comments_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "hidden_proposal_notifications" %>>
-        <%= link_to t("admin.menu.hidden_proposal_notifications"), admin_hidden_proposal_notifications_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "hidden_users" %>>
-        <%= link_to t("admin.menu.hidden_users"), admin_hidden_users_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "activity" %>>
-        <%= link_to t("admin.menu.activity"), admin_activity_path %>
-      </li>
-    </ul>
+    <%= link_list(
+      (
+        [
+          t("admin.menu.hidden_proposals"),
+          admin_hidden_proposals_path,
+          controller_name == "hidden_proposals"
+        ] if feature?(:proposals)
+      ),
+      (
+        [
+          t("admin.menu.hidden_debates"),
+          admin_hidden_debates_path,
+          controller_name == "hidden_debates"
+        ] if feature?(:debates)
+      ),
+      (
+        [
+          t("admin.menu.hidden_budget_investments"),
+          admin_hidden_budget_investments_path,
+          controller_name == "hidden_budget_investments"
+        ] if feature?(:budgets)
+      ),
+      [
+        t("admin.menu.hidden_comments"),
+        admin_hidden_comments_path,
+        controller_name == "hidden_comments"
+      ],
+      [
+        t("admin.menu.hidden_proposal_notifications"),
+        admin_hidden_proposal_notifications_path,
+        controller_name == "hidden_proposal_notifications"
+      ],
+      [
+        t("admin.menu.hidden_users"),
+        admin_hidden_users_path,
+        controller_name == "hidden_users"
+      ],
+      [
+        t("admin.menu.activity"),
+        admin_activity_path,
+        controller_name == "activity"
+      ],
+      class: ("is-active" if moderated_content?)
+    ) %>
   </li>
 
   <li>
     <a href="#" class="profiles-link"><%= t("admin.menu.title_profiles") %></a>
-    <ul <%= "class=is-active" if profiles? %>>
-      <li <%= "class=is-active" if controller_name == "administrators" %>>
-        <%= link_to t("admin.menu.administrators"), admin_administrators_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "organizations" %>>
-        <%= link_to t("admin.menu.organizations"), admin_organizations_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "officials" %>>
-        <%= link_to t("admin.menu.officials"), admin_officials_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "moderators" %>>
-        <%= link_to t("admin.menu.moderators"), admin_moderators_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "valuators" %>>
-        <%= link_to t("admin.menu.valuators"), admin_valuators_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "managers" %>>
-        <%= link_to t("admin.menu.managers"), admin_managers_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "users" %>>
-        <%= link_to t("admin.menu.users"), admin_users_path %>
-      </li>
-    </ul>
+    <%= link_list(
+      [
+        t("admin.menu.administrators"),
+        admin_administrators_path,
+        controller_name == "administrators"
+      ],
+      [
+        t("admin.menu.organizations"),
+        admin_organizations_path,
+        controller_name == "organizations"
+      ],
+      [
+        t("admin.menu.officials"),
+        admin_officials_path,
+        controller_name == "officials"
+      ],
+      [
+        t("admin.menu.moderators"),
+        admin_moderators_path,
+        controller_name == "moderators"
+      ],
+      [
+        t("admin.menu.valuators"),
+        admin_valuators_path,
+        controller_name == "valuators"
+      ],
+      [
+        t("admin.menu.managers"),
+        admin_managers_path,
+        controller_name == "managers"
+      ],
+      [
+        t("admin.menu.users"),
+        admin_users_path,
+        controller_name == "users"
+      ],
+      class: ("is-active" if profiles?)
+    ) %>
   </li>
 
   <li class="<%= "is-active" if controller_name == "stats" %>">
@@ -189,45 +221,54 @@
 
   <li>
     <a href="#" class="settings-link"><%= t("admin.menu.title_settings") %></a>
-    <ul <%= "class=is-active" if settings? %>>
-      <li <%= "class=is-active" if controller_name == "settings" %>>
-        <%= link_to t("admin.menu.settings"), admin_settings_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "tags" %>>
-        <%= link_to t("admin.menu.proposals_topics"), admin_tags_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "geozones" %>>
-        <%= link_to t("admin.menu.geozones"), admin_geozones_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "images" &&
-                                controller.class.parent != Admin::Poll::Questions::Answers %>>
-        <%= link_to t("admin.menu.site_customization.images"), admin_site_customization_images_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "content_blocks" %>>
-        <%= link_to t("admin.menu.site_customization.content_blocks"), admin_site_customization_content_blocks_path %>
-      </li>
-
-      <li <%= "class=is-active" if local_census_records? %>>
-        <%= link_to t("admin.menu.local_census_records"), admin_local_census_records_path %>
-      </li>
-    </ul>
+    <%= link_list(
+      [
+        t("admin.menu.settings"),
+        admin_settings_path,
+        controller_name == "settings"
+      ],
+      [
+        t("admin.menu.proposals_topics"),
+        admin_tags_path,
+        controller_name == "tags"
+      ],
+      [
+        t("admin.menu.geozones"),
+        admin_geozones_path,
+        controller_name == "geozones"
+      ],
+      [
+        t("admin.menu.site_customization.images"),
+        admin_site_customization_images_path,
+        controller_name == "images" && controller.class.parent != Admin::Poll::Questions::Answers
+      ],
+      [
+        t("admin.menu.site_customization.content_blocks"),
+        admin_site_customization_content_blocks_path,
+        controller_name == "content_blocks"
+      ],
+      [
+        t("admin.menu.local_census_records"),
+        admin_local_census_records_path,
+        local_census_records?
+      ],
+      class: ("is-active" if settings?)
+    ) %>
   </li>
   <li>
     <a href="#" class="dashboard-link"><%= t("admin.menu.dashboard") %></a>
-    <ul <%= "class=is-active" if dashboard? %>>
-      <li <%= "class=is-active" if controller_name == "actions" %>>
-        <%= link_to t("admin.menu.dashboard_actions"), admin_dashboard_actions_path %>
-      </li>
-
-      <li <%= "class=is-active" if controller_name == "administrator_tasks" %>>
-        <%= link_to admin_dashboard_administrator_tasks_path do %>
-          <%= t("admin.menu.administrator_tasks") %>
-        <% end %>
-      </li>
-    </ul>
+    <%= link_list(
+      [
+        t("admin.menu.dashboard_actions"),
+        admin_dashboard_actions_path,
+        controller_name == "actions"
+      ],
+      [
+        t("admin.menu.administrator_tasks"),
+        admin_dashboard_administrator_tasks_path,
+        controller_name == "administrator_tasks"
+      ],
+      class: ("is-active" if dashboard?)
+    ) %>
   </li>
 </ul>

--- a/app/components/admin/menu_component.rb
+++ b/app/components/admin/menu_component.rb
@@ -1,4 +1,6 @@
 class Admin::MenuComponent < ApplicationComponent
+  include LinkListHelper
+
   private
 
     def moderated_content?

--- a/app/components/admin/menu_component.rb
+++ b/app/components/admin/menu_component.rb
@@ -67,4 +67,284 @@ class Admin::MenuComponent < ApplicationComponent
     def messages_sections
       %w[newsletters emails_download admin_notifications system_emails]
     end
+
+    def officers_link
+      [
+        t("admin.menu.poll_officers"),
+        admin_officers_path,
+        %w[officers officer_assignments].include?(controller_name)
+      ]
+    end
+
+    def booths_link
+      [
+        t("admin.menu.poll_booths"),
+        admin_booths_path,
+        controller_name == "booths" && action_name != "available"
+      ]
+    end
+
+    def booth_assignments_link
+      [
+        t("admin.menu.poll_booth_assignments"),
+        booth_assignments_admin_polls_path,
+        controller_name == "polls" && action_name == "booth_assignments" || controller_name == "booth_assignments" && action_name == "manage"
+      ]
+    end
+
+    def shifts_link
+      [
+        t("admin.menu.poll_shifts"),
+        available_admin_booths_path,
+        %w[shifts booths].include?(controller_name) && %w[available new].include?(action_name)
+      ]
+    end
+
+    def newsletters_link
+      [
+        t("admin.menu.newsletters"),
+        admin_newsletters_path,
+        controller_name == "newsletters"
+      ]
+    end
+
+    def admin_notifications_link
+      [
+        t("admin.menu.admin_notifications"),
+        admin_admin_notifications_path,
+        controller_name == "admin_notifications"
+      ]
+    end
+
+    def system_emails_link
+      [
+        t("admin.menu.system_emails"),
+        admin_system_emails_path,
+        controller_name == "system_emails"
+      ]
+    end
+
+    def emails_download_link
+      [
+        t("admin.menu.emails_download"),
+        admin_emails_download_index_path,
+        controller_name == "emails_download"
+      ]
+    end
+
+    def homepage_link
+      [
+        t("admin.menu.site_customization.homepage"),
+        admin_homepage_path,
+        homepage?
+      ]
+    end
+
+    def pages_link
+      [
+        t("admin.menu.site_customization.pages"),
+        admin_site_customization_pages_path,
+        pages? || controller_name == "pages"
+      ]
+    end
+
+    def banners_link
+      [
+        t("admin.menu.banner"),
+        admin_banners_path,
+        controller_name == "banners"
+      ]
+    end
+
+    def information_texts_link
+      [
+        t("admin.menu.site_customization.information_texts"),
+        admin_site_customization_information_texts_path,
+        controller_name == "information_texts"
+      ]
+    end
+
+    def documents_link
+      [
+        t("admin.menu.site_customization.documents"),
+        admin_site_customization_documents_path,
+        controller_name == "documents"
+      ]
+    end
+
+    def hidden_proposals_link
+      [
+        t("admin.menu.hidden_proposals"),
+        admin_hidden_proposals_path,
+        controller_name == "hidden_proposals"
+      ]
+    end
+
+    def hidden_debates_link
+      [
+        t("admin.menu.hidden_debates"),
+        admin_hidden_debates_path,
+        controller_name == "hidden_debates"
+      ]
+    end
+
+    def hidden_budget_investments_link
+      [
+        t("admin.menu.hidden_budget_investments"),
+        admin_hidden_budget_investments_path,
+        controller_name == "hidden_budget_investments"
+      ]
+    end
+
+    def hidden_comments_link
+      [
+        t("admin.menu.hidden_comments"),
+        admin_hidden_comments_path,
+        controller_name == "hidden_comments"
+      ]
+    end
+
+    def hidden_proposal_notifications_link
+      [
+        t("admin.menu.hidden_proposal_notifications"),
+        admin_hidden_proposal_notifications_path,
+        controller_name == "hidden_proposal_notifications"
+      ]
+    end
+
+    def hidden_users_link
+      [
+        t("admin.menu.hidden_users"),
+        admin_hidden_users_path,
+        controller_name == "hidden_users"
+      ]
+    end
+
+    def activity_link
+      [
+        t("admin.menu.activity"),
+        admin_activity_path,
+        controller_name == "activity"
+      ]
+    end
+
+    def administrators_link
+      [
+        t("admin.menu.administrators"),
+        admin_administrators_path,
+        controller_name == "administrators"
+      ]
+    end
+
+    def organizations_link
+      [
+        t("admin.menu.organizations"),
+        admin_organizations_path,
+        controller_name == "organizations"
+      ]
+    end
+
+    def officials_link
+      [
+        t("admin.menu.officials"),
+        admin_officials_path,
+        controller_name == "officials"
+      ]
+    end
+
+    def moderators_link
+      [
+        t("admin.menu.moderators"),
+        admin_moderators_path,
+        controller_name == "moderators"
+      ]
+    end
+
+    def valuators_link
+      [
+        t("admin.menu.valuators"),
+        admin_valuators_path,
+        controller_name == "valuators"
+      ]
+    end
+
+    def managers_link
+      [
+        t("admin.menu.managers"),
+        admin_managers_path,
+        controller_name == "managers"
+      ]
+    end
+
+    def users_link
+      [
+        t("admin.menu.users"),
+        admin_users_path,
+        controller_name == "users"
+      ]
+    end
+
+    def settings_link
+      [
+        t("admin.menu.settings"),
+        admin_settings_path,
+        controller_name == "settings"
+      ]
+    end
+
+    def tags_link
+      [
+        t("admin.menu.proposals_topics"),
+        admin_tags_path,
+        controller_name == "tags"
+      ]
+    end
+
+    def geozones_link
+      [
+        t("admin.menu.geozones"),
+        admin_geozones_path,
+        controller_name == "geozones"
+      ]
+    end
+
+    def images_link
+      [
+        t("admin.menu.site_customization.images"),
+        admin_site_customization_images_path,
+        controller_name == "images" && controller.class.parent != Admin::Poll::Questions::Answers
+      ]
+    end
+
+    def content_blocks_link
+      [
+        t("admin.menu.site_customization.content_blocks"),
+        admin_site_customization_content_blocks_path,
+        controller_name == "content_blocks"
+      ]
+    end
+
+    def local_census_records_link
+      [
+        t("admin.menu.local_census_records"),
+        admin_local_census_records_path,
+        local_census_records?
+      ]
+    end
+
+    def administrator_tasks_link
+      [
+        t("admin.menu.administrator_tasks"),
+        admin_dashboard_administrator_tasks_path,
+        controller_name == "administrator_tasks"
+      ]
+    end
+
+    def dashboard_actions_link
+      [
+        t("admin.menu.dashboard_actions"),
+        admin_dashboard_actions_path,
+        controller_name == "actions"
+      ]
+    end
 end

--- a/app/components/sdg_management/menu_component.html.erb
+++ b/app/components/sdg_management/menu_component.html.erb
@@ -1,5 +1,9 @@
-<ul class="sdg-content-menu">
-  <li class="<%= "is-active" if sdg? %>">
-    <%= link_to t("sdg_management.menu.sdg_content"), sdg_management_goals_path, class: "goals-link" %>
-  </li>
-</ul>
+<%= link_list(
+  [
+    t("sdg_management.menu.sdg_content"),
+    sdg_management_goals_path,
+    sdg?,
+    class: "goals-link"
+  ],
+  class: "sdg-content-menu"
+) %>

--- a/app/components/sdg_management/menu_component.rb
+++ b/app/components/sdg_management/menu_component.rb
@@ -1,4 +1,6 @@
 class SDGManagement::MenuComponent < ApplicationComponent
+  include LinkListHelper
+
   private
 
     def sdg?

--- a/app/helpers/link_list_helper.rb
+++ b/app/helpers/link_list_helper.rb
@@ -3,8 +3,8 @@ module LinkListHelper
     return "" if links.compact.empty?
 
     tag.ul(options) do
-      safe_join(links.compact.map do |text, url, is_active = false, **link_options|
-        tag.li(class: ("is-active" if is_active)) do
+      safe_join(links.compact.map do |text, url, current = false, **link_options|
+        tag.li(({ "aria-current": true } if current)) do
           link_to text, url, link_options
         end
       end)

--- a/app/helpers/link_list_helper.rb
+++ b/app/helpers/link_list_helper.rb
@@ -1,0 +1,13 @@
+module LinkListHelper
+  def link_list(*links, **options)
+    return "" if links.compact.empty?
+
+    tag.ul(options) do
+      safe_join(links.compact.map do |text, url, **link_options|
+        tag.li do
+          link_to text, url, link_options
+        end
+      end)
+    end
+  end
+end

--- a/app/helpers/link_list_helper.rb
+++ b/app/helpers/link_list_helper.rb
@@ -3,8 +3,8 @@ module LinkListHelper
     return "" if links.compact.empty?
 
     tag.ul(options) do
-      safe_join(links.compact.map do |text, url, **link_options|
-        tag.li do
+      safe_join(links.compact.map do |text, url, is_active = false, **link_options|
+        tag.li(class: ("is-active" if is_active)) do
           link_to text, url, link_options
         end
       end)

--- a/app/views/admin/poll/_menu.html.erb
+++ b/app/views/admin/poll/_menu.html.erb
@@ -1,1 +1,0 @@
-<%= render "admin/menu" %>

--- a/app/views/admin/widget/_menu.html.erb
+++ b/app/views/admin/widget/_menu.html.erb
@@ -1,1 +1,0 @@
-<%= render "admin/menu" %>

--- a/app/views/management/_menu.html.erb
+++ b/app/views/management/_menu.html.erb
@@ -1,41 +1,50 @@
 <ul id="admin_menu" data-accordion-menu>
   <li class="section-title">
     <a href="#" class="users-link"><%= t("management.menu.users") %></a>
-    <ul class="is-active">
-
-      <li <%= "class=is-active" if menu_users? %>>
-        <%= link_to t("management.menu.select_user"), management_document_verifications_path %>
-      </li>
-
-      <% if managed_user.email %>
-        <li <%= "class=is-active" if menu_edit_password_email? %>>
-          <%= link_to t("management.account.menu.reset_password_email"), edit_password_email_management_account_path %>
-        </li>
-      <% end %>
-
-      <li <%= "class=is-active" if menu_edit_password_manually? %>>
-        <%= link_to t("management.account.menu.reset_password_manually"), edit_password_manually_management_account_path %>
-      </li>
-
-      <li <%= "class=is-active" if menu_create_proposal? %>>
-        <%= link_to t("management.menu.create_proposal"), new_management_proposal_path %>
-      </li>
-
-      <li <%= "class=is-active" if menu_support_proposal? %>>
-        <%= link_to t("management.menu.support_proposals"), management_proposals_path %>
-      </li>
-
-      <% if Setting["process.budgets"] %>
-        <li <%= "class=is-active" if menu_create_investments? %>>
-          <%= link_to t("management.menu.create_budget_investment"), create_investments_management_budgets_path %>
-        </li>
-
-        <li <%= "class=is-active" if menu_support_investments? %>>
-          <%= link_to t("management.menu.support_budget_investments"), support_investments_management_budgets_path %>
-        </li>
-      <% end %>
-    </li>
-    </ul>
+    <%= link_list(
+      [
+        t("management.menu.select_user"),
+        management_document_verifications_path,
+        menu_users?
+      ],
+      (
+        [
+          t("management.account.menu.reset_password_email"),
+          edit_password_email_management_account_path,
+          menu_edit_password_email?
+        ] if managed_user.email
+      ),
+      [
+        t("management.account.menu.reset_password_manually"),
+        edit_password_manually_management_account_path,
+        menu_edit_password_manually?
+      ],
+      [
+        t("management.menu.create_proposal"),
+        new_management_proposal_path,
+        menu_create_proposal?
+      ],
+      [
+        t("management.menu.support_proposals"),
+        management_proposals_path,
+        menu_support_proposal?
+      ],
+      (
+        [
+          t("management.menu.create_budget_investment"),
+          create_investments_management_budgets_path,
+          menu_create_investments?
+        ] if Setting["process.budgets"]
+      ),
+      (
+        [
+          t("management.menu.support_budget_investments"),
+          support_investments_management_budgets_path,
+          menu_support_investments?
+        ] if Setting["process.budgets"]
+      ),
+      class: "is-active"
+    ) %>
   </li>
 
   <% if Setting["process.budgets"] %>

--- a/app/views/moderation/_menu.html.erb
+++ b/app/views/moderation/_menu.html.erb
@@ -1,35 +1,48 @@
-<ul id="moderation_menu">
-  <li>
-    <%= link_to t("moderation.dashboard.index.title"), moderation_root_path %>
-  </li>
-
-  <% if feature?(:proposals) %>
-    <li <%= "class=is-active" if controller_name == "proposals" %>>
-      <%= link_to t("moderation.menu.proposals"), moderation_proposals_path, class: "proposals-link" %>
-    </li>
-
-    <li <%= "class=is-active" if controller_name == "proposal_notifications" %>>
-      <%= link_to t("moderation.menu.proposal_notifications"), moderation_proposal_notifications_path, class: "proposal-notifications-link" %>
-    </li>
-  <% end %>
-
-  <% if feature?(:debates) %>
-    <li <%= "class=is-active" if controller_name == "debates" %>>
-      <%= link_to t("moderation.menu.flagged_debates"), moderation_debates_path, class: "debates-link" %>
-    </li>
-  <% end %>
-
-  <% if feature?(:budgets) %>
-    <li <%= "class=is-active" if controller_name == "investments" %>>
-      <%= link_to t("moderation.menu.flagged_investments"), moderation_budget_investments_path, class: "investments-link" %>
-    </li>
-  <% end %>
-
-  <li <%= "class=is-active" if controller_name == "comments" %>>
-    <%= link_to t("moderation.menu.flagged_comments"), moderation_comments_path, class: "comments-link" %>
-  </li>
-
-  <li <%= "class=is-active" if controller_name == "users" %>>
-    <%= link_to t("moderation.menu.users"), moderation_users_path, class: "users-link" %>
-  </li>
-</ul>
+<%= link_list(
+  [t("moderation.dashboard.index.title"), moderation_root_path],
+  (
+    [
+      t("moderation.menu.proposals"),
+      moderation_proposals_path,
+      controller_name == "proposals",
+      class: "proposals-link"
+    ] if feature?(:proposals)
+  ),
+  (
+    [
+      t("moderation.menu.proposal_notifications"),
+      moderation_proposal_notifications_path,
+      controller_name == "proposal_notifications",
+      class: "proposal-notifications-link"
+    ] if feature?(:proposals)
+  ),
+  (
+    [
+      t("moderation.menu.flagged_debates"),
+      moderation_debates_path,
+      controller_name == "debates",
+      class: "debates-link"
+    ] if feature?(:debates)
+  ),
+  (
+    [
+      t("moderation.menu.flagged_investments"),
+      moderation_budget_investments_path,
+      controller_name == "investments",
+      class: "investments-link"
+    ] if feature?(:budgets)
+  ),
+  [
+    t("moderation.menu.flagged_comments"),
+    moderation_comments_path,
+    controller_name == "comments",
+    class: "comments-link"
+  ],
+  [
+    t("moderation.menu.users"),
+    moderation_users_path,
+    controller_name == "users",
+    class: "users-link"
+  ],
+  id: "moderation_menu"
+) %>

--- a/app/views/pages/help/_menu.html.erb
+++ b/app/views/pages/help/_menu.html.erb
@@ -1,34 +1,47 @@
 <div class="row">
   <div class="small-12 column">
-    <ul class="menu-pages" data-magellan>
-      <% if feature?(:debates) %>
-      <li>
-        <%= link_to t("pages.help.menu.debates"), "#debates", class: "button hollow expanded" %>
-      </li>
-      <% end %>
-      <% if feature?(:proposals) %>
-        <li>
-          <%= link_to t("pages.help.menu.proposals"), "#proposals", class: "button hollow expanded" %>
-        </li>
-      <% end %>
-      <% if feature?(:budgets) %>
-      <li>
-        <%= link_to t("pages.help.menu.budgets"), "#budgets", class: "button hollow expanded" %>
-      </li>
-      <% end %>
-      <% if feature?(:polls) %>
-      <li>
-        <%= link_to t("pages.help.menu.polls"), "#polls", class: "button hollow expanded" %>
-      </li>
-      <% end %>
-      <% if feature?(:legislation) %>
-      <li>
-        <%= link_to t("pages.help.menu.processes"), "#processes", class: "button hollow expanded" %>
-      </li>
-      <% end %>
-      <li>
-        <%= link_to t("pages.help.menu.other"), "#other", class: "button hollow expanded" %>
-      </li>
-    </ul>
+    <%= link_list(
+      (
+        [
+          t("pages.help.menu.debates"),
+          "#debates",
+          class: "button hollow expanded"
+        ] if feature?(:debates)
+      ),
+      (
+        [
+          t("pages.help.menu.proposals"),
+          "#proposals",
+          class: "button hollow expanded"
+        ] if feature?(:proposals)
+      ),
+      (
+        [
+          t("pages.help.menu.budgets"),
+          "#budgets",
+          class: "button hollow expanded"
+        ] if feature?(:budgets)
+      ),
+      (
+        [
+          t("pages.help.menu.polls"),
+          "#polls",
+          class: "button hollow expanded"
+        ] if feature?(:polls)
+      ),
+      (
+        [
+          t("pages.help.menu.processes"),
+          "#processes",
+          class: "button hollow expanded"
+        ]
+      ),
+      [
+        t("pages.help.menu.other"),
+        "#other",
+        class: "button hollow expanded"
+      ],
+      class: "menu-pages", "data-magellan": true
+    ) %>
   </div>
 </div>

--- a/app/views/valuation/_menu.html.erb
+++ b/app/views/valuation/_menu.html.erb
@@ -1,11 +1,5 @@
-<ul id="valuation_menu">
-  <li>
-    <%= link_to t("valuation.menu.title"), valuation_root_path %>
-  </li>
-
-  <% if feature?(:budgets) %>
-    <li <%= "class=is-active" if controller_name == "budget_investments" %>>
-      <%= link_to t("valuation.menu.budgets"), valuation_budgets_path, class: "budgets-link" %>
-    </li>
-  <% end %>
-</ul>
+<%= link_list(
+  [t("valuation.menu.title"), valuation_root_path],
+  [t("valuation.menu.budgets"), valuation_budgets_path, controller_name == "budget_investments", class: "budgets-link"],
+  id: "valuation_menu"
+) %>

--- a/app/views/valuation/_menu.html.erb
+++ b/app/views/valuation/_menu.html.erb
@@ -1,13 +1,11 @@
-<nav class="admin-sidebar">
-  <ul id="valuation_menu">
-    <li>
-      <%= link_to t("valuation.menu.title"), valuation_root_path %>
-    </li>
+<ul id="valuation_menu">
+  <li>
+    <%= link_to t("valuation.menu.title"), valuation_root_path %>
+  </li>
 
-    <% if feature?(:budgets) %>
-      <li <%= "class=is-active" if controller_name == "budget_investments" %>>
-        <%= link_to t("valuation.menu.budgets"), valuation_budgets_path, class: "budgets-link" %>
-      </li>
-    <% end %>
-  </ul>
-</nav>
+  <% if feature?(:budgets) %>
+    <li <%= "class=is-active" if controller_name == "budget_investments" %>>
+      <%= link_to t("valuation.menu.budgets"), valuation_budgets_path, class: "budgets-link" %>
+    </li>
+  <% end %>
+</ul>

--- a/spec/helpers/link_list_helper_spec.rb
+++ b/spec/helpers/link_list_helper_spec.rb
@@ -41,7 +41,7 @@ describe LinkListHelper do
       )
 
       expect(page).to have_css "li", count: 3
-      expect(page).to have_css "li.is-active", count: 1, exact_text: "Info"
+      expect(page).to have_css "li[aria-current='true']", count: 1, exact_text: "Info"
     end
 
     it "allows passing both the active condition and link options" do
@@ -52,7 +52,7 @@ describe LinkListHelper do
       )
 
       expect(page).to have_css "li", count: 3
-      expect(page).to have_css "li.is-active", count: 1, exact_text: "Info"
+      expect(page).to have_css "li[aria-current='true']", count: 1, exact_text: "Info"
 
       expect(page).to have_css "a.root", count: 1, exact_text: "Home"
       expect(page).to have_css "a#info", count: 1, exact_text: "Info"

--- a/spec/helpers/link_list_helper_spec.rb
+++ b/spec/helpers/link_list_helper_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe LinkListHelper do
+  describe "#link_list" do
+    it "returns an empty string with an empty list" do
+      expect(helper.link_list).to eq ""
+    end
+
+    it "returns nothing with a list of nil elements" do
+      expect(helper.link_list(nil, nil)).to eq ""
+    end
+
+    it "generates a list of links" do
+      list = helper.link_list(["Home", "/"], ["Info", "/info"], class: "menu")
+
+      expect(list).to eq '<ul class="menu"><li><a href="/">Home</a></li><li><a href="/info">Info</a></li></ul>'
+      expect(list).to be_html_safe
+    end
+
+    it "accepts options for links" do
+      render helper.link_list(["Home", "/", class: "root"], ["Info", "/info", id: "info"])
+
+      expect(page).to have_css "a", count: 2
+      expect(page).to have_css "a.root", count: 1, exact_text: "Home"
+      expect(page).to have_css "a#info", count: 1, exact_text: "Info"
+    end
+
+    it "ignores nil entries" do
+      render helper.link_list(["Home", "/", class: "root"], nil, ["Info", "/info", id: "info"])
+
+      expect(page).to have_css "a", count: 2
+      expect(page).to have_css "a.root", count: 1, exact_text: "Home"
+      expect(page).to have_css "a#info", count: 1, exact_text: "Info"
+    end
+  end
+
+  attr_reader :content
+
+  def render(content)
+    @content = content
+  end
+
+  def page
+    Capybara::Node::Simple.new(content)
+  end
+end

--- a/spec/helpers/link_list_helper_spec.rb
+++ b/spec/helpers/link_list_helper_spec.rb
@@ -32,6 +32,32 @@ describe LinkListHelper do
       expect(page).to have_css "a.root", count: 1, exact_text: "Home"
       expect(page).to have_css "a#info", count: 1, exact_text: "Info"
     end
+
+    it "accepts an optional condition to check the active element" do
+      render helper.link_list(
+        ["Home", "/", false],
+        ["Info", "/info", true],
+        ["Help", "/help"]
+      )
+
+      expect(page).to have_css "li", count: 3
+      expect(page).to have_css "li.is-active", count: 1, exact_text: "Info"
+    end
+
+    it "allows passing both the active condition and link options" do
+      render helper.link_list(
+        ["Home", "/", false, class: "root"],
+        ["Info", "/info", true, id: "info"],
+        ["Help", "/help", rel: "help"]
+      )
+
+      expect(page).to have_css "li", count: 3
+      expect(page).to have_css "li.is-active", count: 1, exact_text: "Info"
+
+      expect(page).to have_css "a.root", count: 1, exact_text: "Home"
+      expect(page).to have_css "a#info", count: 1, exact_text: "Info"
+      expect(page).to have_css "a[rel='help']", count: 1, exact_text: "Help"
+    end
   end
 
   attr_reader :content


### PR DESCRIPTION
## References

* Continues pull request #4274

## Objectives

* Make it easier to generate lists of navigation links
* Increase screen reader capability to recognize the current item in admin menus
* Fix proposals admin menu entry when we're in the proposals section
* Remove unused views
* Fix double `<nav>` tag in valuation menu