### PR TITLE
Make tests independent of the organization name

### DIFF
--- a/spec/lib/email_digests_spec.rb
+++ b/spec/lib/email_digests_spec.rb
@@ -56,6 +56,7 @@ describe EmailDigest do
     let(:user) { create(:user) }
 
     it "delivers email if notifications pending" do
+      Setting["org_name"] = "CONSUL"
       create(:notification, :for_proposal_notification, user: user)
 
       reset_mailer

--- a/spec/lib/tasks/dashboards_spec.rb
+++ b/spec/lib/tasks/dashboards_spec.rb
@@ -48,6 +48,11 @@ describe "Dashboards Rake" do
       let!(:action)   { create(:dashboard_action, :proposed_action, :active, day_offset: 0) }
       let!(:resource) { create(:dashboard_action, :resource, :active, day_offset: 0) }
 
+      before do
+        Setting["mailer_from_name"] = "CONSUL"
+        Setting["mailer_from_address"] = "noreply@consul.dev"
+      end
+
       it " when there are news actions actived for published proposals" do
         proposal = create(:proposal)
         action.update!(published_proposal: true)

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -11,6 +11,8 @@ describe Dashboard::Mailer do
 
   before do
     Setting["feature.dashboard.notification_emails"] = true
+    Setting["mailer_from_name"] = "CONSUL"
+    Setting["mailer_from_address"] = "noreply@consul.dev"
   end
 
   describe "#forward" do

--- a/spec/mailers/dashboard/mailer_spec.rb
+++ b/spec/mailers/dashboard/mailer_spec.rb
@@ -165,6 +165,7 @@ describe Dashboard::Mailer do
     end
 
     it "sends emails if new actions detected when creating a proposal" do
+      Setting["org_name"] = "CONSUL"
       action.update!(published_proposal: false)
       resource.update!(published_proposal: false)
       proposal.save!

--- a/spec/shared/system/mappable.rb
+++ b/spec/shared/system/mappable.rb
@@ -80,6 +80,8 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     end
 
     describe "When restoring the page from browser history" do
+      before { Setting["org_name"] = "CONSUL" }
+
       scenario "map should not be duplicated", :js do
         do_login_for user
         visit send(mappable_new_path, arguments)

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -201,6 +201,7 @@ describe "System Emails" do
     end
 
     scenario "#user_invite" do
+      Setting["org_name"] = "CONSUL"
       visit admin_system_email_view_path("user_invite")
 
       expect(page).to have_content "Invitation to CONSUL"

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -250,6 +250,7 @@ describe "Emails" do
 
   context "Proposal notification digest" do
     scenario "notifications for proposals that I'm following" do
+      Setting["org_name"] = "CONSUL"
       user = create(:user, email_digest: true)
 
       proposal1 = create(:proposal, followers: [user])
@@ -317,6 +318,7 @@ describe "Emails" do
 
   context "User invites" do
     scenario "Send an invitation" do
+      Setting["org_name"] = "CONSUL"
       login_as_manager
       visit new_management_user_invite_path
 

--- a/spec/system/help_page_spec.rb
+++ b/spec/system/help_page_spec.rb
@@ -4,6 +4,7 @@ describe "Help page" do
   context "Index" do
     scenario "Help menu and page is visible if feature is enabled" do
       Setting["feature.help_page"] = true
+      Setting["org_name"] = "CONSUL"
 
       visit root_path
 

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -239,6 +239,7 @@ describe "Legislation Draft Versions" do
     end
 
     scenario "When page is restored from browser cache do not duplicate annotation handlers" do
+      Setting["org_name"] = "CONSUL"
       create(:legislation_annotation, draft_version: draft_version, text: "my annotation")
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
@@ -256,6 +257,7 @@ describe "Legislation Draft Versions" do
     end
 
     scenario "When page is restored from browser cache publish comment button keeps working" do
+      Setting["org_name"] = "CONSUL"
       create(:legislation_annotation, draft_version: draft_version, text: "my annotation")
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -193,6 +193,7 @@ describe "Notifications" do
     end
 
     it "sends pending proposal notifications" do
+      Setting["org_name"] = "CONSUL"
       Delayed::Worker.delay_jobs = false
       Notification.send_pending
 

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -200,6 +200,7 @@ describe "Proposals" do
     end
 
     scenario "After using the browser's back button, social buttons will have one screen reader", :js do
+      Setting["org_name"] = "CONSUL"
       proposal = create(:proposal)
       visit proposal_path(proposal)
       click_link "Help"


### PR DESCRIPTION
## References

* Based on concello-santiago-de-compostela#16

## Objectives

* Improve test readability
* Make sure tests will pass when institutations change the organization name (which everyone will do)