### PR TITLE
Fix flaky annotation specs

### DIFF
--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -165,7 +165,7 @@ describe "Legislation Draft Versions" do
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
-      page.find(:css, ".legislation-annotatable").double_click
+      select_text_in(find(:css, ".legislation-annotatable"))
       page.find(:css, ".annotator-adder button").click
       expect(page).not_to have_css("#legislation_annotation_text")
       expect(page).to have_content "You must sign in or sign up to leave a comment."
@@ -174,7 +174,7 @@ describe "Legislation Draft Versions" do
     scenario "Create" do
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
 
-      page.find(:css, ".legislation-annotatable").double_click
+      select_text_in(find(:css, ".legislation-annotatable"))
       page.find(:css, ".annotator-adder button").click
       page.click_button "Publish Comment"
       expect(page).to have_content "Comment can't be blank"
@@ -231,7 +231,7 @@ describe "Legislation Draft Versions" do
       create(:legislation_annotation, draft_version: draft_version)
 
       visit legislation_process_draft_version_path(draft_version.process, draft_version)
-      find(:css, ".annotator-hl").double_click
+      select_text_in(find(:css, ".annotator-hl"))
       find(:css, ".annotator-adder button").click
       click_button "Publish Comment"
 
@@ -275,6 +275,10 @@ describe "Legislation Draft Versions" do
       click_button "Publish comment"
 
       expect(page).to have_content "My interesting comment"
+    end
+
+    def select_text_in(element)
+      element.double_click
     end
   end
 

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -278,7 +278,8 @@ describe "Legislation Draft Versions" do
     end
 
     def select_text_in(element)
-      element.double_click
+      element.click
+      3.times { page.driver.browser.action.click(element.native).perform }
     end
   end
 


### PR DESCRIPTION
## Background
We were selecting a word using a double click. However, the test failed sometimes when styles such as font family, font size or the element's width changed, since the double click takes place in the middle of the element and it's possible that the middle of the element contains a space between two words, meaning no word would be selected.

## Objectives

* Select text in specs a way that does not fail when certain styles are used

## Notes

Without these changes, the failure in the "Create" test can be reproduced by changing the `$base-font-size` variable to `2rem` or changing the default font family to Roboto.