### PR TITLE
SDG translation interface by default

### DIFF
--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -10,7 +10,7 @@ module TranslatableFormHelper
   end
 
   def backend_translations_enabled?
-    (controller.class.parents & [Admin, Management, Valuation]).any?
+    (controller.class.parents & [Admin, Management, Valuation, SDGManagement]).any?
   end
 
   def highlight_translation_html_class

--- a/spec/system/sdg_management/local_targets_spec.rb
+++ b/spec/system/sdg_management/local_targets_spec.rb
@@ -97,4 +97,22 @@ describe "Local Targets", :js do
       expect(page).not_to have_content("1.1.1")
     end
   end
+
+  describe "When translation interface feature setting" do
+    scenario "Is enabled translation interface should be rendered" do
+      Setting["feature.translation_interface"] = true
+
+      visit new_sdg_management_local_target_path
+
+      expect(page).to have_css ".globalize-languages"
+    end
+
+    scenario "Is disabled translation interface should be rendered" do
+      Setting["feature.translation_interface"] = nil
+
+      visit new_sdg_management_local_target_path
+
+      expect(page).to have_css ".globalize-languages"
+    end
+  end
 end


### PR DESCRIPTION
## References
Related PR: #4271 

## Objectives
Render interface translation by default on SDGManagement

## Visual Changes
- Before
![Captura de pantalla 2020-12-18 a las 18 16 08](https://user-images.githubusercontent.com/16189/102641905-25fc7c80-415d-11eb-960a-7894eb4ed5b6.png)

- After
![Captura de pantalla 2020-12-18 a las 18 15 48](https://user-images.githubusercontent.com/16189/102641921-2f85e480-415d-11eb-8315-a8009ff22411.png)

