### PR TITLE
Avoid conflict between SDG::Manager classes 

### DIFF
--- a/app/models/abilities/sdg/manager.rb
+++ b/app/models/abilities/sdg/manager.rb
@@ -1,12 +1,10 @@
-module Abilities
-  class SDG::Manager
-    include CanCan::Ability
+class Abilities::SDG::Manager
+  include CanCan::Ability
 
-    def initialize(user)
-      merge Abilities::Common.new(user)
+  def initialize(user)
+    merge Abilities::Common.new(user)
 
-      can :read, ::SDG::Goal
-      can :read, ::SDG::Target
-    end
+    can :read, ::SDG::Goal
+    can :read, ::SDG::Target
   end
 end


### PR DESCRIPTION
## References
Related PR: #4272 

## Objectives
Avoiding abilities conflict between Manager and SDG::Manager when deploy on production environment.
```
01 TypeError: superclass mismatch for class Manager
```

## Notes
We can reproduce this error by running the following command:
`rails s -e production`