### PR TITLE
Allow SDG managers to manage SDG local targets records

### DIFF
--- a/app/controllers/sdg_management/local_targets_controller.rb
+++ b/app/controllers/sdg_management/local_targets_controller.rb
@@ -1,19 +1,16 @@
 class SDGManagement::LocalTargetsController < SDGManagement::BaseController
   include Translatable
 
-  LocalTarget = ::SDG::LocalTarget
+  load_and_authorize_resource class: "SDG::LocalTarget"
 
   def index
-    @local_targets = LocalTarget.all.sort
+    @local_targets = @local_targets.sort
   end
 
   def new
-    @local_target = LocalTarget.new
   end
 
   def create
-    @local_target = LocalTarget.new(local_target_params)
-
     if @local_target.save
       redirect_to sdg_management_local_targets_path, notice: t("sdg_management.local_targets.create.notice")
     else
@@ -22,12 +19,9 @@ class SDGManagement::LocalTargetsController < SDGManagement::BaseController
   end
 
   def edit
-    @local_target = LocalTarget.find(params[:id])
   end
 
   def update
-    @local_target = LocalTarget.find(params[:id])
-
     if @local_target.update(local_target_params)
       redirect_to sdg_management_local_targets_path, notice: t("sdg_management.local_targets.update.notice")
     else
@@ -36,7 +30,6 @@ class SDGManagement::LocalTargetsController < SDGManagement::BaseController
   end
 
   def destroy
-    @local_target = LocalTarget.find(params[:id])
     @local_target.destroy!
     redirect_to sdg_management_local_targets_path, notice: t("sdg_management.local_targets.destroy.notice")
   end
@@ -44,7 +37,7 @@ class SDGManagement::LocalTargetsController < SDGManagement::BaseController
   private
 
     def local_target_params
-      translations_attributes = translation_params(LocalTarget)
+      translations_attributes = translation_params(::SDG::LocalTarget)
       params.require(:sdg_local_target).permit(:code, :target_id, translations_attributes)
     end
 end

--- a/app/models/abilities/sdg/manager.rb
+++ b/app/models/abilities/sdg/manager.rb
@@ -6,5 +6,6 @@ class Abilities::SDG::Manager
 
     can :read, ::SDG::Goal
     can :read, ::SDG::Target
+    can :manage, ::SDG::LocalTarget
   end
 end

--- a/spec/models/abilities/sdg/manager.rb
+++ b/spec/models/abilities/sdg/manager.rb
@@ -9,6 +9,7 @@ describe "Abilities::SDG::Manager" do
 
   it { should be_able_to(:read, SDG::Goal) }
   it { should be_able_to(:read, SDG::Target) }
+  it { should be_able_to(:manage, SDG::LocalTarget) }
 
   it { should_not be_able_to(:read, SDG::Manager) }
   it { should_not be_able_to(:create, SDG::Manager) }


### PR DESCRIPTION
## References

This PR extends #4271 

## Objectives

Allow SDG managers to manage local target records.

Load local target records by using cancancan `load_and_authorize_resource` method.
