### PR TITLE
Fix advanced search filter button position

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1507,6 +1507,10 @@ form {
   select {
     height: $line-height * 2;
   }
+
+  .column.end.clear {
+    clear: both;
+  }
 }
 
 // 10. Officials levels


### PR DESCRIPTION
## References

* This bug was introduced when foundation changed some of its rules regarding when to clear floats, probably in pull request #3886

## Objectives

Fix the advanced search filter button position so it's where it was in version 1.0.

## Visual Changes

### Before these changes

![The filter button appears between two elements](https://user-images.githubusercontent.com/35156/103214692-6dc79480-4911-11eb-880c-35ce4957ba9c.png)

### After these changes

![The filter button appears at the end of the form](https://user-images.githubusercontent.com/35156/103214714-820b9180-4911-11eb-83d3-ef94f5de07dc.png)
