### PR TITLE
Include link to unsubscribe in email notifications

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,6 +47,7 @@
 @import "sdg/**/*";
 @import "sdg_management/*";
 @import "sdg_management/**/*";
+@import "subscriptions";
 @import "widgets/**/*";
 
 @import "custom";

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -74,7 +74,8 @@ main {
   &.sdg-goals-index,
   &.sdg-goal-show,
   &.topic-edit,
-  &.topic-new {
+  &.topic-new,
+  &.subscriptions-edit {
     @include grid-column-gutter;
   }
 }

--- a/app/assets/stylesheets/subscriptions.scss
+++ b/app/assets/stylesheets/subscriptions.scss
@@ -1,0 +1,5 @@
+.subscriptions-edit {
+  form {
+    max-width: $global-width * 7 / 12;
+  }
+}

--- a/app/components/subscriptions/edit_component.html.erb
+++ b/app/components/subscriptions/edit_component.html.erb
@@ -1,0 +1,13 @@
+<main class="subscriptions-edit">
+  <%= form_for user, url: subscriptions_path(token: user.subscriptions_token) do |f| %>
+    <h2><%= t("account.show.notifications") %></h2>
+
+    <div><%= f.check_box :email_on_comment %></div>
+    <div><%= f.check_box :email_on_comment_reply %></div>
+    <div><%= f.check_box :newsletter %></div>
+    <div><%= f.check_box :email_digest %></div>
+    <div><%= f.check_box :email_on_direct_message %></div>
+
+    <%= f.submit t("account.show.save_changes_submit"), class: "button margin-top" %>
+  <% end %>
+</main>

--- a/app/components/subscriptions/edit_component.rb
+++ b/app/components/subscriptions/edit_component.rb
@@ -1,0 +1,7 @@
+class Subscriptions::EditComponent < ApplicationComponent
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,17 @@
+class SubscriptionsController < ApplicationController
+  before_action :set_user
+  skip_authorization_check
+
+  def edit
+  end
+
+  private
+
+    def set_user
+      @user = if params[:token].present?
+                User.find_by!(subscriptions_token: params[:token])
+              else
+                current_user || raise(CanCan::AccessDenied)
+              end
+    end
+end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,5 +1,5 @@
 class SubscriptionsController < ApplicationController
-  before_action :set_user
+  before_action :set_user, :set_user_locale
   skip_authorization_check
 
   def edit
@@ -27,5 +27,12 @@ class SubscriptionsController < ApplicationController
 
     def allowed_params
       [:email_on_comment, :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter]
+    end
+
+    def set_user_locale
+      if params[:locale].blank?
+        I18n.locale = I18n.available_locales.find { |locale| locale == @user.locale&.to_sym }
+        session[:locale] = I18n.locale
+      end
     end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -5,6 +5,12 @@ class SubscriptionsController < ApplicationController
   def edit
   end
 
+  def update
+    @user.update!(subscriptions_params)
+    redirect_to edit_subscriptions_path(token: @user.subscriptions_token),
+                notice: t("flash.actions.save_changes.notice")
+  end
+
   private
 
     def set_user
@@ -13,5 +19,13 @@ class SubscriptionsController < ApplicationController
               else
                 current_user || raise(CanCan::AccessDenied)
               end
+    end
+
+    def subscriptions_params
+      params.require(:user).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:email_on_comment, :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter]
     end
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -62,6 +62,7 @@ class Mailer < ApplicationMailer
   def proposal_notification_digest(user, notifications)
     @notifications = notifications
     @email_to = user.email
+    manage_subscriptions_token(user)
 
     with_user(user) do
       mail(to: @email_to, subject: t("mailers.proposal_notification_digest.title", org_name: Setting["org_name"]))

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -42,6 +42,7 @@ class Mailer < ApplicationMailer
     @direct_message = direct_message
     @receiver = @direct_message.receiver
     @email_to = @receiver.email
+    manage_subscriptions_token(@receiver)
 
     with_user(@receiver) do
       mail(to: @email_to, subject: t("mailers.direct_message_for_receiver.subject"))

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -120,6 +120,7 @@ class Mailer < ApplicationMailer
   def newsletter(newsletter, recipient_email)
     @newsletter = newsletter
     @email_to = recipient_email
+    manage_subscriptions_token(User.find_by(email: @email_to))
 
     mail(to: @email_to, from: @newsletter.from, subject: @newsletter.subject)
   end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -20,6 +20,7 @@ class Mailer < ApplicationMailer
   def reply(reply)
     @email = ReplyEmail.new(reply)
     @email_to = @email.to
+    manage_subscriptions_token(@email.recipient)
 
     with_user(@email.recipient) do
       mail(to: @email_to, subject: @email.subject) if @email.can_be_sent?

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -9,6 +9,7 @@ class Mailer < ApplicationMailer
     @comment = comment
     @commentable = comment.commentable
     @email_to = @commentable.author.email
+    manage_subscriptions_token(@commentable.author)
 
     with_user(@commentable.author) do
       subject = t("mailers.comment.subject", commentable: t("activerecord.models.#{@commentable.class.name.underscore}", count: 1).downcase)
@@ -149,5 +150,10 @@ class Mailer < ApplicationMailer
       if @email_to.blank?
         mail.perform_deliveries = false
       end
+    end
+
+    def manage_subscriptions_token(user)
+      user.add_subscriptions_token
+      @token = user.subscriptions_token
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -415,6 +415,10 @@ class User < ApplicationRecord
     devise_mailer.send(notification, self, *args).deliver_later
   end
 
+  def add_subscriptions_token
+    update!(subscriptions_token: SecureRandom.base58(32)) if subscriptions_token.blank?
+  end
+
   private
 
     def clean_document_number

--- a/app/views/mailer/comment.html.erb
+++ b/app/views/mailer/comment.html.erb
@@ -18,6 +18,13 @@
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 20px;">
-    <%= t("mailers.config.manage_email_subscriptions") %> <%= link_to t("account.show.title"), account_url, style: "color: #2895F1; text-decoration:none;" %>
+    <%= sanitize(t("mailers.config.unsubscribe_text",
+      notifications: link_to(
+        t("mailers.config.notifications_link"),
+        edit_subscriptions_url(token: @token),
+        style: "color: #2895F1; text-decoration: none;"
+      ),
+      notification: User.human_attribute_name(:email_on_comment)
+    )) %>
   </p>
 </td>

--- a/app/views/mailer/direct_message_for_receiver.html.erb
+++ b/app/views/mailer/direct_message_for_receiver.html.erb
@@ -26,9 +26,10 @@
       <tr>
         <td style="padding-left: 10px;">
           <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; margin: 0; font-style: italic; padding-bottom: 20px;">
-            <%= sanitize(t("mailers.direct_message_for_receiver.unsubscribe",
-                account: link_to(t("mailers.direct_message_for_receiver.unsubscribe_account"),
-                                account_url, style: "color: #2895F1; text-decoration: none;"))) %>
+            <%= sanitize(t("mailers.direct_message_for_receiver.unsubscribe_text",
+                notifications: link_to(t("mailers.config.notifications_link"),
+                                edit_subscriptions_url(token: @token),
+                                style: "color: #2895F1; text-decoration: none;"))) %>
           </p>
         </td>
       </tr>

--- a/app/views/mailer/newsletter.html.erb
+++ b/app/views/mailer/newsletter.html.erb
@@ -2,4 +2,15 @@
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;line-height: 24px;">
     <%= auto_link_already_sanitized_html wysiwyg(@newsletter.body) %>
   </p>
+
+  <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 20px;">
+    <%= sanitize(t("mailers.config.unsubscribe_text",
+      notifications: link_to(
+        t("mailers.config.notifications_link"),
+        edit_subscriptions_url(token: @token),
+        style: "color: #2895F1; text-decoration: none;"
+      ),
+      notification: User.human_attribute_name(:newsletter)
+    )) %>
+  </p>
 </td>

--- a/app/views/mailer/proposal_notification_digest.html.erb
+++ b/app/views/mailer/proposal_notification_digest.html.erb
@@ -70,9 +70,10 @@
       <tr>
         <td style="padding-left: 10px;">
           <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px; margin: 0; font-style: italic; padding-bottom: 20px;">
-            <%= sanitize(t("mailers.proposal_notification_digest.unsubscribe",
-                account: link_to(t("mailers.proposal_notification_digest.unsubscribe_account"),
-                                account_url, style: "color: #2895F1; text-decoration: none;"))) %>
+            <%= sanitize(t("mailers.proposal_notification_digest.unsubscribe_text",
+                notifications: link_to(t("mailers.config.notifications_link"),
+                                edit_subscriptions_url(token: @token),
+                                style: "color: #2895F1; text-decoration: none;"))) %>
           </p>
         </td>
       </tr>

--- a/app/views/mailer/reply.html.erb
+++ b/app/views/mailer/reply.html.erb
@@ -18,6 +18,13 @@
   </div>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 12px;font-weight: normal;line-height: 20px;">
-    <%= t("mailers.config.manage_email_subscriptions") %> <%= link_to t("account.show.title"), account_url, style: "color: #2895F1; text-decoration:none;" %>
+    <%= sanitize(t("mailers.config.unsubscribe_text",
+      notifications: link_to(
+        t("mailers.config.notifications_link"),
+        edit_subscriptions_url(token: @token),
+        style: "color: #2895F1; text-decoration: none;"
+      ),
+      notification: User.human_attribute_name(:email_on_comment_reply)
+    )) %>
   </p>
 </td>

--- a/app/views/subscriptions/edit.html.erb
+++ b/app/views/subscriptions/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render Subscriptions::EditComponent.new(@user) %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -272,7 +272,7 @@ en:
         password: "Password"
         current_password: "Current password"
         email_digest: "Receive a summary of proposal notifications"
-        email_on_comment: "Notify me by email when someone comments on my proposals or debates"
+        email_on_comment: "Notify me by email when someone comments on my contents"
         email_on_comment_reply: "Notify me by email when someone replies to my comments"
         email_on_direct_message: "Receive emails about direct messages"
         newsletter: "Receive by email website relevant information"

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -28,8 +28,7 @@ en:
       title: "Proposal notifications in %{org_name}"
       share: Share proposal
       comment: Comment proposal
-      unsubscribe: "If you don't want to receive any proposal notifications, visit %{account} and uncheck 'Receive a summary of proposal notifications'."
-      unsubscribe_account: My account
+      unsubscribe_text: "If you don't want to receive any proposal notifications, visit %{notifications} and uncheck 'Receive a summary of proposal notifications'."
       unfollow: "Visit this proposal and unfollow it to stop receiving notifications."
     direct_message_for_receiver:
       subject: "You have received a new private message"

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -9,6 +9,8 @@ en:
       title: New comment
     config:
       manage_email_subscriptions: To stop receiving these emails change your settings in
+      notifications_link: Notifications
+      unsubscribe_text: 'To unsubscribe from these emails, visit %{notifications} and uncheck "%{notification}".'
     email_verification:
       click_here_to_verify: this link
       instructions_2: This email will verify your account with <b>%{document_type} %{document_number}</b>. If these don't belong to you, please don't click on the previous link and ignore this email.

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -8,7 +8,6 @@ en:
       subject: Someone has commented on your %{commentable}
       title: New comment
     config:
-      manage_email_subscriptions: To stop receiving these emails change your settings in
       notifications_link: Notifications
       unsubscribe_text: 'To unsubscribe from these emails, visit %{notifications} and uncheck "%{notification}".'
     email_verification:

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -34,8 +34,7 @@ en:
     direct_message_for_receiver:
       subject: "You have received a new private message"
       reply: Reply to %{sender}
-      unsubscribe: "If you don't want to receive direct messages, visit %{account} and uncheck 'Receive emails about direct messages'."
-      unsubscribe_account: My account
+      unsubscribe_text: "If you don't want to receive direct messages, visit %{notifications} and uncheck 'Receive emails about direct messages'."
     direct_message_for_sender:
       subject: "You have sent a new private message"
       title: "You have sent a new private message to <strong>%{receiver}</strong> with the content:"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -272,7 +272,7 @@ es:
         password: "Contraseña"
         current_password: "Contraseña actual"
         email_digest: "Recibir resumen de notificaciones sobre propuestas"
-        email_on_comment: "Recibir un email cuando alguien comenta en mis propuestas o debates"
+        email_on_comment: "Recibir un email cuando alguien comenta en mis contenidos"
         email_on_comment_reply: "Recibir un email cuando alguien contesta a mis comentarios"
         email_on_direct_message: "Recibir emails con mensajes privados"
         newsletter: "Recibir emails con información interesante sobre la web"

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -28,8 +28,7 @@ es:
       title: "Notificaciones de propuestas en %{org_name}"
       share: Compartir propuesta
       comment: Comentar propuesta
-      unsubscribe: "Si no quieres recibir notificaciones de propuestas, puedes entrar en %{account} y desmarcar la opción 'Recibir resumen de notificaciones sobre propuestas'."
-      unsubscribe_account: Mi cuenta
+      unsubscribe_text: "Si no quieres recibir notificaciones de propuestas, puedes entrar en %{notifications} y desmarcar la opción 'Recibir resumen de notificaciones sobre propuestas'."
       unfollow: "Si no quieres recibir más notificaciones, visita esta propuesta y deja de seguirla."
     direct_message_for_receiver:
       subject: "Has recibido un nuevo mensaje privado"

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -9,6 +9,8 @@ es:
       title: Nuevo comentario
     config:
       manage_email_subscriptions: Puedes dejar de recibir estos emails cambiando tu configuración en
+      notifications_link: Notificaciones
+      unsubscribe_text: 'Para darse de baja de estos emails, puedes entrar en %{notifications} y desmarcar la opción "%{notification}".'
     email_verification:
       click_here_to_verify: en este enlace
       instructions_2: Este email es para verificar tu cuenta con <b>%{document_type} %{document_number}</b>. Si esos no son tus datos, por favor no pulses el enlace anterior e ignora este email.

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -8,7 +8,6 @@ es:
       subject: Alguien ha comentado en tu %{commentable}
       title: Nuevo comentario
     config:
-      manage_email_subscriptions: Puedes dejar de recibir estos emails cambiando tu configuración en
       notifications_link: Notificaciones
       unsubscribe_text: 'Para darse de baja de estos emails, puedes entrar en %{notifications} y desmarcar la opción "%{notification}".'
     email_verification:

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -34,8 +34,7 @@ es:
     direct_message_for_receiver:
       subject: "Has recibido un nuevo mensaje privado"
       reply: Responder a %{sender}
-      unsubscribe: "Si no quieres recibir mensajes privados, puedes entrar en %{account} y desmarcar la opción 'Recibir emails con mensajes privados'."
-      unsubscribe_account: Mi cuenta
+      unsubscribe_text: "Si no quieres recibir mensajes privados, puedes entrar en %{notifications} y desmarcar la opción 'Recibir emails con mensajes privados'."
     direct_message_for_sender:
       subject: "Has enviado un nuevo mensaje privado"
       title: "Has enviado un nuevo mensaje privado a <strong>%{receiver}</strong> con el siguiente contenido:"

--- a/config/routes/account.rb
+++ b/config/routes/account.rb
@@ -2,4 +2,4 @@ resource :account, controller: "account", only: [:show, :update, :delete] do
   get :erase, on: :collection
 end
 
-resource :subscriptions, only: [:edit]
+resource :subscriptions, only: [:edit, :update]

--- a/config/routes/account.rb
+++ b/config/routes/account.rb
@@ -1,3 +1,5 @@
 resource :account, controller: "account", only: [:show, :update, :delete] do
   get :erase, on: :collection
 end
+
+resource :subscriptions, only: [:edit]

--- a/db/migrate/20201218082830_add_subscriptions_token_to_users.rb
+++ b/db/migrate/20201218082830_add_subscriptions_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddSubscriptionsTokenToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :subscriptions_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1625,6 +1625,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_112944) do
     t.boolean "public_interests", default: false
     t.boolean "recommended_debates", default: true
     t.boolean "recommended_proposals", default: true
+    t.string "subscriptions_token"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["date_of_birth"], name: "index_users_on_date_of_birth"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/spec/components/subscriptions/edit_component_spec.rb
+++ b/spec/components/subscriptions/edit_component_spec.rb
@@ -8,8 +8,7 @@ describe Subscriptions::EditComponent do
     render_inline component
 
     expect(page).to have_content "Notifications"
-    expect(page).to have_field "Notify me by email when someone comments on my proposals or debates",
-                                type: :checkbox
+    expect(page).to have_field "Notify me by email when someone comments on my contents", type: :checkbox
     expect(page).to have_field "Notify me by email when someone replies to my comments", type: :checkbox
     expect(page).to have_field "Receive by email website relevant information", type: :checkbox
     expect(page).to have_field "Receive a summary of proposal notifications", type: :checkbox

--- a/spec/components/subscriptions/edit_component_spec.rb
+++ b/spec/components/subscriptions/edit_component_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Subscriptions::EditComponent do
+  let(:user) { create(:user, subscriptions_token: SecureRandom.base58(32)) }
+  let(:component) { Subscriptions::EditComponent.new(user) }
+
+  it "renders checkboxes to change the subscriptions preferences" do
+    render_inline component
+
+    expect(page).to have_content "Notifications"
+    expect(page).to have_field "Notify me by email when someone comments on my proposals or debates",
+                                type: :checkbox
+    expect(page).to have_field "Notify me by email when someone replies to my comments", type: :checkbox
+    expect(page).to have_field "Receive by email website relevant information", type: :checkbox
+    expect(page).to have_field "Receive a summary of proposal notifications", type: :checkbox
+    expect(page).to have_field "Receive emails about direct messages", type: :checkbox
+    expect(page).to have_button "Save changes"
+  end
+end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -12,5 +12,12 @@ describe SubscriptionsController do
       expect(response).to redirect_to "/"
       expect(flash[:alert]).to eq "You do not have permission to access this page."
     end
+
+    it "shows the 'not allowed' message in the current locale" do
+      get :edit, params: { token: "", locale: :es }
+
+      expect(response).to redirect_to "/"
+      expect(flash[:alert]).to eq "No tienes permiso para acceder a esta página."
+    end
   end
 end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe SubscriptionsController do
+  describe "GET edit" do
+    it "returns a 404 code with a wrong token" do
+      expect { get :edit, params: { token: "non_existent" } }.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it "doesn't allow access to anonymous users without a token" do
+      get :edit, params: { token: "" }
+
+      expect(response).to redirect_to "/"
+      expect(flash[:alert]).to eq "You do not have permission to access this page."
+    end
+  end
+end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -29,4 +29,26 @@ describe Mailer do
       expect(email.subject).to include("commented on your proposal")
     end
   end
+
+  describe "#manage_subscriptions_token" do
+    let(:user) { create(:user) }
+    let(:proposal) { create(:proposal, author: user) }
+    let(:comment) { create(:comment, commentable: proposal) }
+
+    it "generates a subscriptions token when the receiver doesn't have one" do
+      user.update!(subscriptions_token: nil)
+
+      Mailer.comment(comment).deliver_now
+
+      expect(user.reload.subscriptions_token).to be_present
+    end
+
+    it "uses the existing subscriptions token when the receivesr already has one" do
+      user.update!(subscriptions_token: "subscriptions_token_value")
+
+      Mailer.comment(comment).deliver_now
+
+      expect(user.subscriptions_token).to eq "subscriptions_token_value"
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -823,4 +823,22 @@ describe User do
       expect(other_user_legislation_proposal.reload).to be_hidden
     end
   end
+
+  describe "#add_subscriptions_token" do
+    let(:user) { build(:user, subscriptions_token: nil) }
+
+    it "generates a subscriptions token when the user doesn't have one" do
+      user.add_subscriptions_token
+
+      expect(user.subscriptions_token).to be_present
+    end
+
+    it "keeps the existing subscriptions token when the user already has one" do
+      user.update!(subscriptions_token: "already_set")
+
+      user.add_subscriptions_token
+
+      expect(user.subscriptions_token).to eq "already_set"
+    end
+  end
 end

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -176,6 +176,9 @@ describe "System Emails" do
       expect(page).to have_content reply.body
 
       expect(page).to have_link "Let's do...", href: comment_url(reply, host: app_host)
+      expect(page).to have_link("Notifications",
+                                href: edit_subscriptions_url(token: user.subscriptions_token,
+                                                             host: app_host))
     end
 
     scenario "#direct_message_for_receiver" do

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -155,6 +155,9 @@ describe "System Emails" do
       expect(page).to have_content comment.body
 
       expect(page).to have_link "Let's do...", href: debate_url(debate, host: app_host)
+      expect(page).to have_link("Notifications",
+                                href: edit_subscriptions_url(token: user.subscriptions_token,
+                                                             host: app_host))
     end
 
     scenario "#reply" do

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -92,6 +92,7 @@ describe "System Emails" do
                                 href: proposal_url(proposal_b, anchor: "tab-notifications", host: app_host))
       expect(page).to have_content("Proposal A Notification Body")
       expect(page).to have_content("Proposal B Notification Body")
+      expect(page).to have_link "Notifications"
     end
 
     scenario "#budget_investment_created" do

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -185,6 +185,9 @@ describe "System Emails" do
       expect(page).to have_content "This is a sample of message's content."
 
       expect(page).to have_link "Reply to #{admin.user.name}", href: user_url(admin.user, host: app_host)
+      expect(page).to have_link("Notifications",
+                                href: edit_subscriptions_url(token: admin.user.subscriptions_token,
+                                                             host: app_host))
     end
 
     scenario "#direct_message_for_sender" do

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -50,8 +50,10 @@ describe "Emails" do
       expect(email).to have_subject("Someone has commented on your citizen proposal")
       expect(email).to deliver_to(proposal.author)
       expect(email).to have_body_text(proposal_path(proposal))
-      expect(email).to have_body_text("To stop receiving these emails change your settings in")
-      expect(email).to have_body_text(account_path)
+      expect(email).to have_body_text("To unsubscribe from these emails, visit")
+      expect(email).to have_body_text(edit_subscriptions_path(token: proposal.author.subscriptions_token))
+      expect(email).to have_body_text(
+                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
     end
 
     scenario "Do not send email about own proposal comments" do
@@ -77,8 +79,10 @@ describe "Emails" do
       expect(email).to have_subject("Someone has commented on your debate")
       expect(email).to deliver_to(debate.author)
       expect(email).to have_body_text(debate_path(debate))
-      expect(email).to have_body_text("To stop receiving these emails change your settings in")
-      expect(email).to have_body_text(account_path)
+      expect(email).to have_body_text("To unsubscribe from these emails, visit")
+      expect(email).to have_body_text(edit_subscriptions_path(token: debate.author.subscriptions_token))
+      expect(email).to have_body_text(
+                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
     end
 
     scenario "Do not send email about own debate comments" do
@@ -104,8 +108,10 @@ describe "Emails" do
       expect(email).to have_subject("Someone has commented on your investment")
       expect(email).to deliver_to(investment.author)
       expect(email).to have_body_text(budget_investment_path(investment, budget_id: investment.budget_id))
-      expect(email).to have_body_text("To stop receiving these emails change your settings in")
-      expect(email).to have_body_text(account_path)
+      expect(email).to have_body_text("To unsubscribe from these emails, visit")
+      expect(email).to have_body_text(edit_subscriptions_path(token: investment.author.subscriptions_token))
+      expect(email).to have_body_text(
+                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
     end
 
     scenario "Do not send email about own budget investments comments" do
@@ -132,8 +138,10 @@ describe "Emails" do
       expect(email).to have_subject("Someone has commented on your topic")
       expect(email).to deliver_to(topic.author)
       expect(email).to have_body_text(community_topic_path(topic, community_id: topic.community_id))
-      expect(email).to have_body_text("To stop receiving these emails change your settings in")
-      expect(email).to have_body_text(account_path)
+      expect(email).to have_body_text("To unsubscribe from these emails, visit")
+      expect(email).to have_body_text(edit_subscriptions_path(token: topic.author.subscriptions_token))
+      expect(email).to have_body_text(
+                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
     end
 
     scenario "Do not send email about own topic comments" do
@@ -159,8 +167,10 @@ describe "Emails" do
       expect(email).to have_subject("Someone has commented on your poll")
       expect(email).to deliver_to(poll.author)
       expect(email).to have_body_text(poll_path(poll))
-      expect(email).to have_body_text("To stop receiving these emails change your settings in")
-      expect(email).to have_body_text(account_path)
+      expect(email).to have_body_text("To unsubscribe from these emails, visit")
+      expect(email).to have_body_text(edit_subscriptions_path(token: poll.author.subscriptions_token))
+      expect(email).to have_body_text(
+                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
     end
 
     scenario "Do not send email about own poll comments" do

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -198,8 +198,9 @@ describe "Emails" do
       expect(email).to deliver_to(user)
       expect(email).not_to have_body_text(debate_path(debate))
       expect(email).to have_body_text(comment_path(Comment.last))
-      expect(email).to have_body_text("To stop receiving these emails change your settings in")
-      expect(email).to have_body_text(account_path)
+      expect(email).to have_body_text("To unsubscribe from these emails, visit")
+      expect(email).to have_body_text(edit_subscriptions_path(token: user.subscriptions_token))
+      expect(email).to have_body_text('and uncheck "Notify me by email when someone replies to my comments"')
     end
 
     scenario "Do not send email about own replies to own comments" do
@@ -469,8 +470,9 @@ describe "Emails" do
       expect(email).to deliver_to(user1)
       expect(email).not_to have_body_text(poll_path(poll))
       expect(email).to have_body_text(comment_path(Comment.last))
-      expect(email).to have_body_text("To stop receiving these emails change your settings in")
-      expect(email).to have_body_text(account_path)
+      expect(email).to have_body_text("To unsubscribe from these emails, visit")
+      expect(email).to have_body_text(edit_subscriptions_path(token: user1.subscriptions_token))
+      expect(email).to have_body_text('and uncheck "Notify me by email when someone replies to my comments"')
     end
   end
 

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -243,6 +243,7 @@ describe "Emails" do
       expect(email).to have_body_text(direct_message.body)
       expect(email).to have_body_text(direct_message.sender.name)
       expect(email).to have_body_text(/#{user_path(direct_message.sender_id)}/)
+      expect(email).to have_body_text(edit_subscriptions_path(token: receiver.subscriptions_token))
     end
 
     scenario "Sender email" do

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -303,7 +303,7 @@ describe "Emails" do
       expect(email).to have_body_text(proposal2.author.name)
 
       expect(email).not_to have_body_text(proposal3.title)
-      expect(email).to have_body_text(/#{account_path}/)
+      expect(email).to have_body_text(edit_subscriptions_path(token: user.subscriptions_token))
       expect(email).to have_body_text("Visit this proposal and unfollow it to stop receiving notifications.")
 
       notification1.reload

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -502,6 +502,10 @@ describe "Emails" do
       expect(email).to have_subject("This is a different subject")
       expect(email).to deliver_from("no-reply@consul.dev")
       expect(email.body.encoded).to include("This is a different body")
+      expect(email).to have_body_text("To unsubscribe from these emails, visit")
+      expect(email).to have_body_text(
+                        edit_subscriptions_path(token: user_with_newsletter_in_segment_2.subscriptions_token))
+      expect(email).to have_body_text('and uncheck "Receive by email website relevant information"')
     end
   end
 

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -242,7 +242,7 @@ describe "Emails" do
       expect(email).to have_body_text(direct_message.title)
       expect(email).to have_body_text(direct_message.body)
       expect(email).to have_body_text(direct_message.sender.name)
-      expect(email).to have_body_text(/#{user_path(direct_message.sender_id)}/)
+      expect(email).to have_body_text(user_path(direct_message.sender_id))
       expect(email).to have_body_text(edit_subscriptions_path(token: receiver.subscriptions_token))
     end
 
@@ -290,16 +290,16 @@ describe "Emails" do
       expect(email).to have_body_text(notification1.notifiable.body)
       expect(email).to have_body_text(proposal1.author.name)
 
-      expect(email).to have_body_text(/#{proposal_path(proposal1, anchor: "tab-notifications")}/)
-      expect(email).to have_body_text(/#{proposal_path(proposal1, anchor: "comments")}/)
-      expect(email).to have_body_text(/#{proposal_path(proposal1, anchor: "social-share")}/)
+      expect(email).to have_body_text(proposal_path(proposal1, anchor: "tab-notifications"))
+      expect(email).to have_body_text(proposal_path(proposal1, anchor: "comments"))
+      expect(email).to have_body_text(proposal_path(proposal1, anchor: "social-share"))
 
       expect(email).to have_body_text(proposal2.title)
       expect(email).to have_body_text(notification2.notifiable.title)
       expect(email).to have_body_text(notification2.notifiable.body)
-      expect(email).to have_body_text(/#{proposal_path(proposal2, anchor: "tab-notifications")}/)
-      expect(email).to have_body_text(/#{proposal_path(proposal2, anchor: "comments")}/)
-      expect(email).to have_body_text(/#{proposal_path(proposal2, anchor: "social-share")}/)
+      expect(email).to have_body_text(proposal_path(proposal2, anchor: "tab-notifications"))
+      expect(email).to have_body_text(proposal_path(proposal2, anchor: "comments"))
+      expect(email).to have_body_text(proposal_path(proposal2, anchor: "social-share"))
       expect(email).to have_body_text(proposal2.author.name)
 
       expect(email).not_to have_body_text(proposal3.title)
@@ -347,7 +347,7 @@ describe "Emails" do
 
       email = open_last_email
       expect(email).to have_subject("Invitation to CONSUL")
-      expect(email).to have_body_text(/#{new_user_registration_path}/)
+      expect(email).to have_body_text(new_user_registration_path)
     end
   end
 

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -52,8 +52,7 @@ describe "Emails" do
       expect(email).to have_body_text(proposal_path(proposal))
       expect(email).to have_body_text("To unsubscribe from these emails, visit")
       expect(email).to have_body_text(edit_subscriptions_path(token: proposal.author.subscriptions_token))
-      expect(email).to have_body_text(
-                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
+      expect(email).to have_body_text('and uncheck "Notify me by email when someone comments on my contents"')
     end
 
     scenario "Do not send email about own proposal comments" do
@@ -81,8 +80,7 @@ describe "Emails" do
       expect(email).to have_body_text(debate_path(debate))
       expect(email).to have_body_text("To unsubscribe from these emails, visit")
       expect(email).to have_body_text(edit_subscriptions_path(token: debate.author.subscriptions_token))
-      expect(email).to have_body_text(
-                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
+      expect(email).to have_body_text('and uncheck "Notify me by email when someone comments on my contents"')
     end
 
     scenario "Do not send email about own debate comments" do
@@ -110,8 +108,7 @@ describe "Emails" do
       expect(email).to have_body_text(budget_investment_path(investment, budget_id: investment.budget_id))
       expect(email).to have_body_text("To unsubscribe from these emails, visit")
       expect(email).to have_body_text(edit_subscriptions_path(token: investment.author.subscriptions_token))
-      expect(email).to have_body_text(
-                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
+      expect(email).to have_body_text('and uncheck "Notify me by email when someone comments on my contents"')
     end
 
     scenario "Do not send email about own budget investments comments" do
@@ -140,8 +137,7 @@ describe "Emails" do
       expect(email).to have_body_text(community_topic_path(topic, community_id: topic.community_id))
       expect(email).to have_body_text("To unsubscribe from these emails, visit")
       expect(email).to have_body_text(edit_subscriptions_path(token: topic.author.subscriptions_token))
-      expect(email).to have_body_text(
-                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
+      expect(email).to have_body_text('and uncheck "Notify me by email when someone comments on my contents"')
     end
 
     scenario "Do not send email about own topic comments" do
@@ -169,8 +165,7 @@ describe "Emails" do
       expect(email).to have_body_text(poll_path(poll))
       expect(email).to have_body_text("To unsubscribe from these emails, visit")
       expect(email).to have_body_text(edit_subscriptions_path(token: poll.author.subscriptions_token))
-      expect(email).to have_body_text(
-                        'and uncheck "Notify me by email when someone comments on my proposals or debates"')
+      expect(email).to have_body_text('and uncheck "Notify me by email when someone comments on my contents"')
     end
 
     scenario "Do not send email about own poll comments" do

--- a/spec/system/subscriptions_spec.rb
+++ b/spec/system/subscriptions_spec.rb
@@ -3,6 +3,28 @@ require "rails_helper"
 describe "Subscriptions" do
   let(:user) { create(:user, subscriptions_token: SecureRandom.base58(32)) }
 
+  context "Edit page" do
+    scenario "Render content in the user's preferred locale" do
+      user.update!(locale: "es")
+      visit edit_subscriptions_path(token: user.subscriptions_token)
+
+      expect(page).to have_content "Notificaciones"
+      expect(page).to have_field "Recibir un email cuando alguien comenta en mis propuestas o debates",
+                                  type: :checkbox
+      expect(page).to have_field "Recibir un email cuando alguien contesta a mis comentarios", type: :checkbox
+      expect(page).to have_field "Recibir emails con información interesante sobre la web", type: :checkbox
+      expect(page).to have_field "Recibir resumen de notificaciones sobre propuestas", type: :checkbox
+      expect(page).to have_field "Recibir emails con mensajes privados", type: :checkbox
+      expect(page).to have_button "Guardar cambios"
+    end
+
+    scenario "Use the locale in the parameters when accessing anonymously" do
+      visit edit_subscriptions_path(token: user.subscriptions_token, locale: :es)
+
+      expect(page).to have_content "Notificaciones"
+    end
+  end
+
   context "Update" do
     scenario "Allow updating the status notification" do
       user.update!(email_on_comment: false,

--- a/spec/system/subscriptions_spec.rb
+++ b/spec/system/subscriptions_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe "Subscriptions" do
+  let(:user) { create(:user, subscriptions_token: SecureRandom.base58(32)) }
+
+  context "Update" do
+    scenario "Allow updating the status notification" do
+      user.update!(email_on_comment: false,
+                   email_on_comment_reply: true,
+                   newsletter: true,
+                   email_digest: false,
+                   email_on_direct_message: true)
+      visit edit_subscriptions_path(token: user.subscriptions_token)
+
+      check "Notify me by email when someone comments on my proposals or debates"
+      uncheck "Notify me by email when someone replies to my comments"
+      uncheck "Receive by email website relevant information"
+      check "Receive a summary of proposal notifications"
+      uncheck "Receive emails about direct messages"
+      click_button "Save changes"
+
+      expect(page).to have_content "Changes saved"
+      expect(page).to have_field "Notify me by email when someone comments on my contents", checked: true
+      expect(page).to have_field "Notify me by email when someone replies to my comments", checked: false
+      expect(page).to have_field "Receive by email website relevant information", checked: false
+      expect(page).to have_field "Receive a summary of proposal notifications", checked: true
+      expect(page).to have_field "Receive emails about direct messages", checked: false
+    end
+  end
+end

--- a/spec/system/subscriptions_spec.rb
+++ b/spec/system/subscriptions_spec.rb
@@ -9,8 +9,7 @@ describe "Subscriptions" do
       visit edit_subscriptions_path(token: user.subscriptions_token)
 
       expect(page).to have_content "Notificaciones"
-      expect(page).to have_field "Recibir un email cuando alguien comenta en mis propuestas o debates",
-                                  type: :checkbox
+      expect(page).to have_field "Recibir un email cuando alguien comenta en mis contenidos", type: :checkbox
       expect(page).to have_field "Recibir un email cuando alguien contesta a mis comentarios", type: :checkbox
       expect(page).to have_field "Recibir emails con información interesante sobre la web", type: :checkbox
       expect(page).to have_field "Recibir resumen de notificaciones sobre propuestas", type: :checkbox
@@ -34,7 +33,7 @@ describe "Subscriptions" do
                    email_on_direct_message: true)
       visit edit_subscriptions_path(token: user.subscriptions_token)
 
-      check "Notify me by email when someone comments on my proposals or debates"
+      check "Notify me by email when someone comments on my contents"
       uncheck "Notify me by email when someone replies to my comments"
       uncheck "Receive by email website relevant information"
       check "Receive a summary of proposal notifications"


### PR DESCRIPTION
## Objectives
Allow users to unsubscribe from email notifications through an "Unsubscribe" link in the footer of the email without the need to log in.
This link will take them to a unsubscribe page where they can manage the notifications they want to receive.

## Visual Changes
![Captura de pantalla 2021-02-02 a las 11 02 17](https://user-images.githubusercontent.com/16189/106584146-2488e700-6546-11eb-8283-112bbd503c92.png)
