### PR TITLE
Add icons and cards to SDG homepage

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2790,11 +2790,8 @@ table {
     }
 
     a:hover {
+      box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.2);
       text-decoration: none;
-
-      &:not(.see-all) {
-        box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.2);
-      }
 
       img {
         transform: scale(1.1);
@@ -2863,18 +2860,6 @@ table {
     min-height: rem-calc(185);
   }
 
-  a {
-
-    h3,
-    .title {
-      color: #fff;
-    }
-
-    &:hover {
-      text-decoration: none;
-    }
-  }
-
   .gradient {
     background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.01) 1%, rgba(0, 0, 0, 1) 100%);
     height: 100%;
@@ -2899,8 +2884,7 @@ table {
     width: 100%;
     z-index: 3;
 
-    h3,
-    .title {
+    h3 {
       font-size: $base-font-size;
 
       @include breakpoint(medium) {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2840,21 +2840,6 @@ table {
     }
   }
 
-  .figure-card {
-
-    figcaption {
-      z-index: 3;
-    }
-
-    .gradient {
-      background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.01) 1%, rgba(0, 0, 0, 1) 100%);
-      height: 100%;
-      position: absolute;
-      width: 100%;
-      z-index: 2;
-    }
-  }
-
   figure img {
     height: 100%;
     width: 100%;
@@ -2906,6 +2891,14 @@ table {
     }
   }
 
+  .gradient {
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.01) 1%, rgba(0, 0, 0, 1) 100%);
+    height: 100%;
+    position: absolute;
+    width: 100%;
+    z-index: 2;
+  }
+
   img {
     height: 100%;
     width: 100%;
@@ -2920,6 +2913,7 @@ table {
     padding: $line-height / 4 $line-height / 2;
     position: absolute;
     width: 100%;
+    z-index: 3;
 
     h3,
     .title {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -73,15 +73,6 @@ a {
   &:active {
     color: $link-hover;
     text-decoration: underline;
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      color: $link-hover;
-    }
   }
 
   &:focus {
@@ -2767,13 +2758,6 @@ table {
         color: $text;
         word-wrap: break-word;
       }
-    }
-  }
-
-  a:hover {
-
-    h3 {
-      color: #fff;
     }
   }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2748,7 +2748,8 @@ table {
 
 .home-page,
 .custom-page,
-.sdg-goal-show {
+.sdg-goal-show,
+.sdg-goals-index {
 
   a {
 

--- a/app/assets/stylesheets/sdg/goals/index.scss
+++ b/app/assets/stylesheets/sdg/goals/index.scss
@@ -1,0 +1,25 @@
+.sdg-goals-index {
+
+  .sdg-goal-list {
+    @include grid-row;
+    @include grid-column-gutter;
+    list-style: none;
+    margin-bottom: 0;
+    max-width: 40rem;
+
+    li {
+      display: inline-block;
+      $spacing: 1vw;
+
+      line-height: 0;
+      margin-bottom: $spacing;
+      padding-left: $spacing / 2;
+      padding-right: $spacing / 2;
+      width: 1 * 100% / 6;
+
+      .sdg-goal-icon {
+        width: 100%;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/sdg/goals/index.scss
+++ b/app/assets/stylesheets/sdg/goals/index.scss
@@ -22,4 +22,13 @@
       }
     }
   }
+
+  .sdg-phase {
+    @include grid-row;
+    @include grid-column-gutter;
+
+    .cards-container {
+      @include grid-row-nest;
+    }
+  }
 }

--- a/app/components/sdg/goals/index_component.html.erb
+++ b/app/components/sdg/goals/index_component.html.erb
@@ -1,3 +1,13 @@
 <div class="sdg-goals-index">
   <%= link_list(*goal_links, class: "sdg-goal-list") %>
+
+  <% phases.each do |phase| %>
+    <section class="sdg-phase" id="sdg_phase_<%= phase.kind %>">
+      <header>
+        <h2 class="title"><%= phase.title %></h2>
+      </header>
+
+      <%= render "shared/cards", cards: phase.cards %>
+    </section>
+  <% end %>
 </div>

--- a/app/components/sdg/goals/index_component.html.erb
+++ b/app/components/sdg/goals/index_component.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title) { title } %>
+
 <div class="sdg-goals-index">
   <%= link_list(*goal_links, class: "sdg-goal-list") %>
 

--- a/app/components/sdg/goals/index_component.html.erb
+++ b/app/components/sdg/goals/index_component.html.erb
@@ -1,1 +1,3 @@
-<%= link_list(*goals.map { |goal| [goal.code_and_title, sdg_goal_path(goal.code)] }) %>
+<div class="sdg-goals-index">
+  <%= link_list(*goal_links, class: "sdg-goal-list") %>
+</div>

--- a/app/components/sdg/goals/index_component.rb
+++ b/app/components/sdg/goals/index_component.rb
@@ -1,9 +1,10 @@
 class SDG::Goals::IndexComponent < ApplicationComponent
-  attr_reader :goals
+  attr_reader :goals, :phases
   delegate :link_list, to: :helpers
 
-  def initialize(goals)
+  def initialize(goals, phases)
     @goals = goals
+    @phases = phases
   end
 
   private

--- a/app/components/sdg/goals/index_component.rb
+++ b/app/components/sdg/goals/index_component.rb
@@ -9,6 +9,10 @@ class SDG::Goals::IndexComponent < ApplicationComponent
 
   private
 
+    def title
+      t("sdg.goals.title")
+    end
+
     def goal_links
       goals.map { |goal| goal_link(goal) }
     end

--- a/app/components/sdg/goals/index_component.rb
+++ b/app/components/sdg/goals/index_component.rb
@@ -5,4 +5,18 @@ class SDG::Goals::IndexComponent < ApplicationComponent
   def initialize(goals)
     @goals = goals
   end
+
+  private
+
+    def goal_links
+      goals.map { |goal| goal_link(goal) }
+    end
+
+    def goal_link(goal)
+      [icon(goal), sdg_goal_path(goal.code)]
+    end
+
+    def icon(goal)
+      render SDG::Goals::IconComponent.new(goal)
+    end
 end

--- a/app/controllers/sdg/goals_controller.rb
+++ b/app/controllers/sdg/goals_controller.rb
@@ -5,6 +5,7 @@ class SDG::GoalsController < ApplicationController
 
   def index
     @goals = @goals.order(:code)
+    @phases = SDG::Phase.accessible_by(current_ability).order(:kind)
   end
 
   def show

--- a/app/views/pages/custom_page.html.erb
+++ b/app/views/pages/custom_page.html.erb
@@ -20,7 +20,7 @@
 
   <% if @cards.any? %>
     <div class="small-12 column">
-      <%= render "shared/cards" %>
+      <%= render "shared/cards", cards: @cards %>
     </div>
   <% end %>
 

--- a/app/views/sdg/goals/index.html.erb
+++ b/app/views/sdg/goals/index.html.erb
@@ -1,1 +1,1 @@
-<%= render SDG::Goals::IndexComponent.new(@goals) %>
+<%= render SDG::Goals::IndexComponent.new(@goals, @phases) %>

--- a/app/views/shared/_cards.html.erb
+++ b/app/views/shared/_cards.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="cards-container">
-    <% @cards.each do |card| %>
+    <% cards.each do |card| %>
       <%= render "shared/card", card: card %>
     <% end %>
   </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -21,7 +21,7 @@
       <div class="small-12 column <%= "large-8" if feed_processes_enabled? %>">
         <h2 class="title"><%= t("welcome.cards.title") %></h2>
 
-        <%= render "shared/cards" %>
+        <%= render "shared/cards", cards: @cards %>
       </div>
     <% end %>
 

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -424,6 +424,7 @@ en:
             title: "By 2020, enhance capacity-building support to developing countries, including for least developed countries and small island developing States, to increase significantly the availability of high-quality, timely and reliable data disaggregated by income, gender, age, race, ethnicity, migratory status, disability, geographic location and other characteristics relevant in national contexts."
           target_17_19:
             title: "By 2030, build on existing initiatives to develop measurements of progress on sustainable development that complement gross domestic product, and support statistical capacity-building in developing countries."
+      title: "Sustainable Development Goals"
       filter:
         heading: "Filters by SDG"
         link: "See all %{resources} related to goal %{code}"

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -424,6 +424,7 @@ es:
             title: "De aquí a 2020, mejorar el apoyo a la creación de capacidad prestado a los países en desarrollo, incluidos los países menos adelantados y los pequeños Estados insulares en desarrollo, para aumentar significativamente la disponibilidad de datos oportunos, fiables y de gran calidad desglosados por ingresos, sexo, edad, raza, origen étnico, estatus migratorio, discapacidad, ubicación geográfica y otras características pertinentes en los contextos nacionales."
           target_17_19:
             title: "De aquí a 2030, aprovechar las iniciativas existentes para elaborar indicadores que permitan medir los progresos en materia de desarrollo sostenible y complementen el producto interno bruto, y apoyar la creación de capacidad estadística en los países en desarrollo."
+      title: "Objetivos de Desarrollo Sostenible"
       filter:
         heading: "Filtros por ODS"
         link: "Ver %{resources} del objetivo %{code}"

--- a/spec/system/sdg/goals_spec.rb
+++ b/spec/system/sdg/goals_spec.rb
@@ -32,6 +32,17 @@ describe "SDG Goals", :js do
 
       expect(page).to have_current_path sdg_goal_path(7)
     end
+
+    scenario "has cards for phases" do
+      create(:widget_card, cardable: SDG::Phase["planning"], title: "Planning card")
+
+      visit sdg_goals_path
+
+      within "#sdg_phase_planning" do
+        expect(page).to have_css "header", exact_text: "Planning"
+        expect(page).to have_content "PLANNING CARD"
+      end
+    end
   end
 
   describe "Show" do


### PR DESCRIPTION
## References

* Depends on pull request #4311

## Objectives

* Add content to the SDG homepage

## Visual changes

![SDG homepage with the SDG icons and cards for each phase](https://user-images.githubusercontent.com/35156/104462607-1718b680-55b1-11eb-9903-a63310409949.png)

## Notes

We've still need to decide what to do about this page main header.
