### PR TITLE
Add SDG goal/target selector

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,7 @@ extends: "eslint:recommended"
 globals:
   $: readonly
   App: readonly
+  AmsifySuggestags: readonly
   annotator: readonly
   c3: readonly
   CKEDITOR: readonly

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -62,6 +62,7 @@
 //= require moderator_legislation_proposals
 //= require gettext
 //= require annotator
+//= require jquery.amsify.suggestags
 //= require tags
 //= require users
 //= require votes
@@ -111,6 +112,7 @@
 //= require columns_selector
 //= require budget_edit_associations
 //= require datepicker
+//= require sdg/related_list_selector
 
 var initialize_modules = function() {
   "use strict";
@@ -163,6 +165,7 @@ var initialize_modules = function() {
   }
   App.BudgetEditAssociations.initialize();
   App.Datepicker.initialize();
+  App.SDGRelatedListSelector.initialize();
 };
 
 var destroy_non_idempotent_modules = function() {

--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -12,7 +12,7 @@
 
         amsify_suggestags.getTag = function(value) {
           if (this.getItem(value) !== undefined) {
-            return this.getItem(value).display_text;
+            return $("<div>" + this.getItem(value).display_text + "</div>").text();
           } else {
             return value;
           }

--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -4,6 +4,10 @@
     initialize: function() {
       if ($(".sdg-related-list-selector").length) {
         var amsify_suggestags = new AmsifySuggestags($(".sdg-related-list-selector .input"));
+
+        amsify_suggestags._settings({
+          suggestions: $(".sdg-related-list-selector .input").data("suggestions-list"),
+        });
         amsify_suggestags.classes.focus = ".sdg-related-list-focus";
         amsify_suggestags.classes.sTagsInput = ".sdg-related-list-selector-input";
         amsify_suggestags._init();

--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -8,13 +8,45 @@
         amsify_suggestags._settings({
           suggestions: $(".sdg-related-list-selector .input").data("suggestions-list"),
           whiteList: true,
+          afterRemove: function(value) {
+            var keep_goal = $(amsify_suggestags.selector).val().split(",").some(function(selected_value) {
+              return App.SDGRelatedListSelector.goal_code(value) === App.SDGRelatedListSelector.goal_code(selected_value);
+            });
+            App.SDGRelatedListSelector.goal_element(value).attr("aria-checked", keep_goal);
+          },
+          afterAdd: function(value) {
+            App.SDGRelatedListSelector.goal_element(value).attr("aria-checked", true);
+          },
           keepLastOnHoverTag: false,
           checkSimilar: false
         });
         amsify_suggestags.classes.focus = ".sdg-related-list-focus";
         amsify_suggestags.classes.sTagsInput = ".sdg-related-list-selector-input";
         amsify_suggestags._init();
+        App.SDGRelatedListSelector.manage_icons(amsify_suggestags);
       }
+    },
+    manage_icons: function(amsify_suggestags) {
+      $("[role='checkbox']").on("click keydown", function(event) {
+        var goal_id = this.dataset.code;
+
+        if (event.type === "click" || (event.type === "keydown" && [13, 32].indexOf(event.keyCode) >= 0)) {
+          if (amsify_suggestags.isPresent(goal_id)) {
+            amsify_suggestags.removeTag(goal_id, false);
+          } else {
+            amsify_suggestags.addTag(goal_id, false);
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      });
+    },
+    goal_element: function(value) {
+      return $("li[data-code=" + App.SDGRelatedListSelector.goal_code(value) + "]");
+    },
+    goal_code: function(value) {
+      return value.toString().split(".")[0];
     }
   };
 }).call(this);

--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -1,0 +1,13 @@
+(function() {
+  "use strict";
+  App.SDGRelatedListSelector = {
+    initialize: function() {
+      if ($(".sdg-related-list-selector").length) {
+        var amsify_suggestags = new AmsifySuggestags($(".sdg-related-list-selector .input"));
+        amsify_suggestags.classes.focus = ".sdg-related-list-focus";
+        amsify_suggestags.classes.sTagsInput = ".sdg-related-list-selector-input";
+        amsify_suggestags._init();
+      }
+    }
+  };
+}).call(this);

--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -18,6 +18,11 @@
           }
         };
 
+        amsify_suggestags.setIcon = function() {
+          var remove_tag_text = $(".sdg-related-list-selector .input").data("remove-tag-text");
+          return '<button aria-label="' + remove_tag_text + '" class="remove-tag ' + this.classes.removeTag.substring(1) + '">&#10006;</button>';
+        };
+
         amsify_suggestags._settings({
           suggestions: $(".sdg-related-list-selector .input").data("suggestions-list"),
           whiteList: true,

--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -5,6 +5,19 @@
       if ($(".sdg-related-list-selector").length) {
         var amsify_suggestags = new AmsifySuggestags($(".sdg-related-list-selector .input"));
 
+        amsify_suggestags.getItem = function(value) {
+          var item_key = this.getItemKey(value);
+          return this.settings.suggestions[item_key];
+        };
+
+        amsify_suggestags.getTag = function(value) {
+          if (this.getItem(value) !== undefined) {
+            return this.getItem(value).display_text;
+          } else {
+            return value;
+          }
+        };
+
         amsify_suggestags._settings({
           suggestions: $(".sdg-related-list-selector .input").data("suggestions-list"),
           whiteList: true,

--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -7,6 +7,9 @@
 
         amsify_suggestags._settings({
           suggestions: $(".sdg-related-list-selector .input").data("suggestions-list"),
+          whiteList: true,
+          keepLastOnHoverTag: false,
+          checkSimilar: false
         });
         amsify_suggestags.classes.focus = ".sdg-related-list-focus";
         amsify_suggestags.classes.sTagsInput = ".sdg-related-list-selector-input";

--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -44,6 +44,7 @@
         amsify_suggestags.classes.sTagsInput = ".sdg-related-list-selector-input";
         amsify_suggestags._init();
         App.SDGRelatedListSelector.manage_icons(amsify_suggestags);
+        App.SDGRelatedListSelector.fix_label(amsify_suggestags);
       }
     },
     manage_icons: function(amsify_suggestags) {
@@ -79,6 +80,14 @@
       if ($(amsify_suggestags.selector).val() === "") {
         $(".sdg-related-list-selector .help-section").addClass("hide");
       }
+    },
+    fix_label: function(amsify_suggestags) {
+      var original_input = amsify_suggestags.selector;
+      var suggestions_input = amsify_suggestags.selectors.sTagsInput;
+
+      suggestions_input[0].id = original_input[0].id + "_suggestions";
+
+      $("[for='" + original_input[0].id + "']").attr("for", suggestions_input[0].id);
     }
   };
 }).call(this);

--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -26,9 +26,11 @@
               return App.SDGRelatedListSelector.goal_code(value) === App.SDGRelatedListSelector.goal_code(selected_value);
             });
             App.SDGRelatedListSelector.goal_element(value).attr("aria-checked", keep_goal);
+            App.SDGRelatedListSelector.manage_remove_help(amsify_suggestags, value);
           },
           afterAdd: function(value) {
             App.SDGRelatedListSelector.goal_element(value).attr("aria-checked", true);
+            App.SDGRelatedListSelector.manage_add_help(amsify_suggestags, value);
           },
           keepLastOnHoverTag: false,
           checkSimilar: false
@@ -60,6 +62,18 @@
     },
     goal_code: function(value) {
       return value.toString().split(".")[0];
+    },
+    manage_add_help: function(amsify_suggestags, value) {
+      var title = amsify_suggestags.getItem(value).title;
+      var html = '<li data-id="' + value + '">' + "<strong>" + value + "</strong> " + title + "</li>";
+      $(".sdg-related-list-selector .help-section").removeClass("hide");
+      $(".sdg-related-list-selector .selected-info").append(html);
+    },
+    manage_remove_help: function(amsify_suggestags, value) {
+      $('[data-id="' + value + '"]').remove();
+      if ($(amsify_suggestags.selector).val() === "") {
+        $(".sdg-related-list-selector .help-section").addClass("hide");
+      }
     }
   };
 }).call(this);

--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -68,6 +68,8 @@ $color-alert:       #a94442;
 $pdf-primary:       #0300ff;
 $pdf-secondary:     #ff9e00;
 
+$outline-focus:     3px solid #ffbf47;
+
 // 2. Foundation settings overrides
 // ---------------------------------
 

--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -70,6 +70,8 @@ $pdf-secondary:     #ff9e00;
 
 $outline-focus:     3px solid #ffbf47;
 
+$input-height:      $line-height * 2;
+
 // 2. Foundation settings overrides
 // ---------------------------------
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@
 @import "custom";
 @import "c3";
 @import "annotator.min";
+@import "amsify.suggestags";
 @import "annotator_overrides";
 @import "jquery-ui/datepicker";
 @import "datepicker_overrides";

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1107,7 +1107,7 @@ form {
 
   [type]:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]):not(.close-button) {
     background: #f8f8f8;
-    height: $line-height * 2;
+    height: $input-height;
     margin-bottom: rem-calc(16);
 
     &.error {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -77,7 +77,7 @@ a {
 
   &:focus {
     color: $link-hover;
-    outline: 3px solid #ffbf47;
+    outline: $outline-focus;
   }
 }
 
@@ -1075,7 +1075,7 @@ footer {
     width: auto;
 
     &:focus {
-      outline: 3px solid #ffbf47;
+      outline: $outline-focus;
     }
   }
 }

--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -1,0 +1,12 @@
+.sdg-related-list-selector {
+
+  .amsify-suggestags-area .amsify-select-tag {
+    color: $white;
+
+    @each $code, $color in $sdg-colors {
+      &[data-val^="#{$code}"] {
+        background-color: $color;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -10,7 +10,7 @@
     }
   }
 
-  > ul {
+  label + ul {
     list-style: none;
     margin-bottom: 0;
     margin-left: 0;
@@ -25,11 +25,33 @@
       &:focus {
         outline: $outline-focus;
       }
+
+      &:hover {
+        cursor: pointer;
+      }
     }
   }
 
   .input-section {
-    margin-top: $line-height / 2;
+    margin-bottom: 2 * $line-height / 3;
+  }
+
+  .amsify-suggestags-area {
+    position: relative;
+
+    .amsify-suggestags-list {
+      top: $input-height;
+    }
+  }
+
+  .amsify-suggestags-input-area {
+    display: flex;
+    flex-wrap: wrap;
+
+    > input {
+      margin-bottom: $line-height / 4 !important;
+      order: -1;
+    }
   }
 
   .remove-tag {

--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -32,6 +32,14 @@
     margin-top: $line-height / 2;
   }
 
+  .remove-tag {
+    color: $white;
+
+    &:focus {
+      outline: $outline-focus;
+    }
+  }
+
   h3 {
     @include header-font-size(h4);
   }

--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -9,4 +9,26 @@
       }
     }
   }
+
+  > ul {
+    list-style: none;
+    margin-bottom: 0;
+    margin-left: 0;
+
+    li {
+      display: inline-block;
+
+      &[aria-checked=true] img {
+        opacity: 0.15;
+      }
+
+      &:focus {
+        outline: $outline-focus;
+      }
+    }
+  }
+
+  .input-section {
+    margin-top: $line-height / 2;
+  }
 }

--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -31,4 +31,8 @@
   .input-section {
     margin-top: $line-height / 2;
   }
+
+  h3 {
+    @include header-font-size(h4);
+  }
 }

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,4 +1,5 @@
 class ApplicationComponent < ViewComponent::Base
   include SettingsHelper
   delegate :back_link_to, to: :helpers
+  delegate :default_form_builder, to: :controller
 end

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -12,7 +12,8 @@
                       class: "input",
                       placeholder: t("sdg.related_list_selector.placeholder"),
                       hint: t("sdg.related_list_selector.hint"),
-                      data: { "suggestions-list": sdg_related_suggestions } %>
+                      data: { "suggestions-list": sdg_related_suggestions,
+                              "remove-tag-text": t("sdg.related_list_selector.remove_tag") } %>
   </div>
 
   <div class="help-section callout primary hide">

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -3,6 +3,7 @@
     <%= f.text_field :sdg_related_list,
                       class: "input",
                       placeholder: t("sdg.related_list_selector.placeholder"),
-                      hint: t("sdg.related_list_selector.hint") %>
+                      hint: t("sdg.related_list_selector.hint"),
+                      data: { "suggestions-list": sdg_related_suggestions } %>
   </div>
 </div>

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -1,15 +1,18 @@
 <div class="sdg-related-list-selector">
-  <ul aria-label="<%= t("sdg.related_list_selector.goal_list") %>">
-    <% goals.each do |goal| %>
-      <li data-code="<%= goal.code %>" role="checkbox" aria-checked="<%= checked?(goal.code) %>" tabindex="0">
-        <%= render SDG::Goals::IconComponent.new(goal) %>
-      </li>
-    <% end %>
-  </ul>
-
   <div class="input-section">
+    <%= f.label :sdg_related_list %>
+
+    <ul aria-label="<%= t("sdg.related_list_selector.goal_list") %>">
+      <% goals.each do |goal| %>
+        <li data-code="<%= goal.code %>" role="checkbox" aria-checked="<%= checked?(goal.code) %>" tabindex="0">
+          <%= render SDG::Goals::IconComponent.new(goal) %>
+        </li>
+      <% end %>
+    </ul>
+
     <%= f.text_field :sdg_related_list,
                       class: "input",
+                      label: false,
                       placeholder: t("sdg.related_list_selector.placeholder"),
                       hint: t("sdg.related_list_selector.hint"),
                       data: { "suggestions-list": sdg_related_suggestions,

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -1,0 +1,8 @@
+<div class="sdg-related-list-selector">
+  <div class="input-section">
+    <%= f.text_field :sdg_related_list,
+                      class: "input",
+                      placeholder: t("sdg.related_list_selector.placeholder"),
+                      hint: t("sdg.related_list_selector.hint") %>
+  </div>
+</div>

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -14,4 +14,9 @@
                       hint: t("sdg.related_list_selector.hint"),
                       data: { "suggestions-list": sdg_related_suggestions } %>
   </div>
+
+  <div class="help-section callout primary hide">
+    <h3><%= t("sdg.related_list_selector.help.title", record: f.object.model_name.human) %></h3>
+    <ul class="selected-info"></ul>
+  </div>
 </div>

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -1,4 +1,12 @@
 <div class="sdg-related-list-selector">
+  <ul aria-label="<%= t("sdg.related_list_selector.goal_list") %>">
+    <% goals.each do |goal| %>
+      <li data-code="<%= goal.code %>" role="checkbox" aria-checked="<%= checked?(goal.code) %>" tabindex="0">
+        <%= render SDG::Goals::IconComponent.new(goal) %>
+      </li>
+    <% end %>
+  </ul>
+
   <div class="input-section">
     <%= f.text_field :sdg_related_list,
                       class: "input",

--- a/app/components/sdg/related_list_selector_component.rb
+++ b/app/components/sdg/related_list_selector_component.rb
@@ -1,0 +1,7 @@
+class SDG::RelatedListSelectorComponent < ApplicationComponent
+  attr_reader :f
+
+  def initialize(form)
+    @f = form
+  end
+end

--- a/app/components/sdg/related_list_selector_component.rb
+++ b/app/components/sdg/related_list_selector_component.rb
@@ -5,6 +5,10 @@ class SDG::RelatedListSelectorComponent < ApplicationComponent
     @f = form
   end
 
+  def checked?(code)
+    f.object.sdg_goals.find_by(code: code).present?
+  end
+
   def sdg_related_suggestions
     goals_and_targets.map { |goal_or_target| suggestion_tag_for(goal_or_target) }
   end

--- a/app/components/sdg/related_list_selector_component.rb
+++ b/app/components/sdg/related_list_selector_component.rb
@@ -22,6 +22,7 @@ class SDG::RelatedListSelectorComponent < ApplicationComponent
   def suggestion_tag_for(goal_or_target)
     {
       tag: "#{goal_or_target.code}. #{goal_or_target.title.gsub(",", "")}",
+      display_text: text_for(goal_or_target),
       value: goal_or_target.code
     }
   end
@@ -30,5 +31,13 @@ class SDG::RelatedListSelectorComponent < ApplicationComponent
 
     def goals
       SDG::Goal.order(:code)
+    end
+
+    def text_for(goal_or_target)
+      if goal_or_target.class.name == "SDG::Goal"
+        t("sdg.related_list_selector.goal_identifier", code: goal_or_target.code)
+      else
+        goal_or_target.code
+      end
     end
 end

--- a/app/components/sdg/related_list_selector_component.rb
+++ b/app/components/sdg/related_list_selector_component.rb
@@ -23,6 +23,7 @@ class SDG::RelatedListSelectorComponent < ApplicationComponent
     {
       tag: "#{goal_or_target.code}. #{goal_or_target.title.gsub(",", "")}",
       display_text: text_for(goal_or_target),
+      title: goal_or_target.title,
       value: goal_or_target.code
     }
   end

--- a/app/components/sdg/related_list_selector_component.rb
+++ b/app/components/sdg/related_list_selector_component.rb
@@ -4,4 +4,27 @@ class SDG::RelatedListSelectorComponent < ApplicationComponent
   def initialize(form)
     @f = form
   end
+
+  def sdg_related_suggestions
+    goals_and_targets.map { |goal_or_target| suggestion_tag_for(goal_or_target) }
+  end
+
+  def goals_and_targets
+    goals.map do |goal|
+      [goal, *goal.targets.sort]
+    end.flatten
+  end
+
+  def suggestion_tag_for(goal_or_target)
+    {
+      tag: "#{goal_or_target.code}. #{goal_or_target.title.gsub(",", "")}",
+      value: goal_or_target.code
+    }
+  end
+
+  private
+
+    def goals
+      SDG::Goal.order(:code)
+    end
 end

--- a/app/components/sdg_management/relations/edit_component.html.erb
+++ b/app/components/sdg_management/relations/edit_component.html.erb
@@ -1,7 +1,7 @@
 <%= header %>
 
 <%= form_for record, url: update_path do |f| %>
-  <%= f.text_field :sdg_target_list %>
+  <%= f.text_field :sdg_related_list %>
 
   <%= f.submit %>
 <% end %>

--- a/app/components/sdg_management/relations/edit_component.html.erb
+++ b/app/components/sdg_management/relations/edit_component.html.erb
@@ -1,7 +1,7 @@
 <%= header %>
 
 <%= form_for record, url: update_path do |f| %>
-  <%= f.text_field :sdg_related_list %>
+  <%= render SDG::RelatedListSelectorComponent.new(f) %>
 
   <%= f.submit %>
 <% end %>

--- a/app/controllers/sdg_management/relations_controller.rb
+++ b/app/controllers/sdg_management/relations_controller.rb
@@ -21,7 +21,7 @@ class SDGManagement::RelationsController < SDGManagement::BaseController
   end
 
   def update
-    @record.sdg_target_list = params[@record.class.table_name.singularize][:sdg_target_list]
+    @record.sdg_related_list = params[@record.class.table_name.singularize][:sdg_related_list]
 
     redirect_to({ action: :index }, notice: update_notice)
   end

--- a/app/models/concerns/sdg/relatable.rb
+++ b/app/models/concerns/sdg/relatable.rb
@@ -50,12 +50,20 @@ module SDG::Relatable
     sdg_targets.sort.map(&:code).join(", ")
   end
 
-  def sdg_target_list=(codes)
-    targets = codes.tr(" ", "").split(",").map { |code| SDG::Target[code] }
+  def sdg_related_list
+    sdg_goals.order(:code).map do |goal|
+      [goal, sdg_targets.where(goal: goal).sort]
+    end.flatten.map(&:code).join(", ")
+  end
+
+  def sdg_related_list=(codes)
+    target_codes, goal_codes = codes.tr(" ", "").split(",").partition { |code| code.include?(".") }
+    targets = target_codes.map { |code| SDG::Target[code] }
+    goals = goal_codes.map { |code| SDG::Goal[code] }
 
     transaction do
       self.sdg_targets = targets
-      self.sdg_goals = targets.map(&:goal).uniq
+      self.sdg_goals = (targets.map(&:goal) + goals).uniq
     end
   end
 end

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -2,7 +2,7 @@ en:
   attributes:
     geozone_id: "Scope of operation"
     results_enabled: "Show results"
-    sdg_target_list: "Targets"
+    sdg_related_list: "Sustainable Development Goals and Targets"
     stats_enabled: "Show stats"
     advanced_stats_enabled: "Show advanced stats"
     name: Name

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -180,7 +180,7 @@ en:
           target_8_9:
             title: "By 2030, devise and implement policies to promote sustainable tourism that creates jobs and promotes local culture and products"
           target_8_10:
-            title: "8.10 Strengthen the capacity of domestic financial institutions to encourage and expand access to banking, insurance and financial services for all."
+            title: "Strengthen the capacity of domestic financial institutions to encourage and expand access to banking, insurance and financial services for all."
           target_8_A:
             title: "Increase Aid for Trade support for developing countries, in particular least developed countries, including through the Enhanced Integrated Framework for Trade-Related Technical Assistance to Least Developed Countries."
           target_8_B:

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -434,5 +434,7 @@ en:
     related_list_selector:
       goal_identifier: "SDG%{code}"
       goal_list: "Goal list"
+      help:
+        title: "Which SDGs and targets are aligned with my %{record}?"
       hint: "You can introduce the code of a specific goal/target or a text to find one"
       placeholder: "Write a goal or target code or description"

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -431,3 +431,6 @@ en:
         more:
           one: "One more goal"
           other: "%{count} more goals"
+    related_list_selector:
+      hint: "You can introduce the code of a specific goal/target or a text to find one"
+      placeholder: "Write a goal or target code or description"

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -432,5 +432,6 @@ en:
           one: "One more goal"
           other: "%{count} more goals"
     related_list_selector:
+      goal_list: "Goal list"
       hint: "You can introduce the code of a specific goal/target or a text to find one"
       placeholder: "Write a goal or target code or description"

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -438,3 +438,4 @@ en:
         title: "Which SDGs and targets are aligned with my %{record}?"
       hint: "You can introduce the code of a specific goal/target or a text to find one"
       placeholder: "Write a goal or target code or description"
+      remove_tag: "Remove"

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -432,6 +432,7 @@ en:
           one: "One more goal"
           other: "%{count} more goals"
     related_list_selector:
+      goal_identifier: "SDG%{code}"
       goal_list: "Goal list"
       hint: "You can introduce the code of a specific goal/target or a text to find one"
       placeholder: "Write a goal or target code or description"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -2,7 +2,7 @@ es:
   attributes:
     geozone_id: "Ámbito de actuación"
     results_enabled: "Mostrar resultados"
-    sdg_target_list: "Metas"
+    sdg_related_list: "Objetivos de Desarrollo Sostenible y Metas"
     stats_enabled: "Mostrar estadísticas"
     advanced_stats_enabled: "Mostrar estadísticas avanzadas"
     name: Nombre

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -180,7 +180,7 @@ es:
           target_8_9:
             title: "De aquí a 2030, elaborar y poner en práctica políticas encaminadas a promover un turismo sostenible que cree puestos de trabajo y promueva la cultura y los productos locales."
           target_8_10:
-            title: "8.10 Fortalecer la capacidad de las instituciones financieras nacionales para fomentar y ampliar el acceso a los servicios bancarios, financieros y de seguros para todos."
+            title: "Fortalecer la capacidad de las instituciones financieras nacionales para fomentar y ampliar el acceso a los servicios bancarios, financieros y de seguros para todos."
           target_8_A:
             title: "Aumentar el apoyo a la iniciativa de ayuda para el comercio en los países en desarrollo, en particular los países menos adelantados, incluso mediante el Marco Integrado Mejorado para la Asistencia Técnica a los Países Menos Adelantados en Materia de Comercio."
           target_8_B:

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -432,5 +432,6 @@ es:
           one: "Un objetivo más"
           other: "%{count} objetivos más"
     related_list_selector:
+      goal_list: "Listado de objetivos"
       hint: "Puedes introducir el código de un objetivo/meta específico o un texto para encontrar uno"
       placeholder: "Escribe las etiquetas que desees"

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -432,6 +432,7 @@ es:
           one: "Un objetivo más"
           other: "%{count} objetivos más"
     related_list_selector:
+      goal_identifier: "ODS%{code}"
       goal_list: "Listado de objetivos"
       hint: "Puedes introducir el código de un objetivo/meta específico o un texto para encontrar uno"
       placeholder: "Escribe las etiquetas que desees"

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -431,3 +431,6 @@ es:
         more:
           one: "Un objetivo más"
           other: "%{count} objetivos más"
+    related_list_selector:
+      hint: "Puedes introducir el código de un objetivo/meta específico o un texto para encontrar uno"
+      placeholder: "Escribe las etiquetas que desees"

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -434,5 +434,7 @@ es:
     related_list_selector:
       goal_identifier: "ODS%{code}"
       goal_list: "Listado de objetivos"
-      hint: "Puedes introducir el código de un objetivo/meta específico o un texto para encontrar uno"
+      help:
+        title: "¿Qué ODS y metas se alinean con mi %{record}?"
+      hint: "Puedes introducir el código de un objetivo/meta específico o un texto para encontrar uno"  
       placeholder: "Escribe las etiquetas que desees"

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -438,3 +438,4 @@ es:
         title: "¿Qué ODS y metas se alinean con mi %{record}?"
       hint: "Puedes introducir el código de un objetivo/meta específico o un texto para encontrar uno"  
       placeholder: "Escribe las etiquetas que desees"
+      remove_tag: "Eliminar"

--- a/spec/components/sdg/related_list_selector_component_spec.rb
+++ b/spec/components/sdg/related_list_selector_component_spec.rb
@@ -10,6 +10,7 @@ describe SDG::RelatedListSelectorComponent, type: :component do
 
     expect(page).to have_css ".sdg-related-list-selector .input"
     expect(page).to have_content "Sustainable Development Goals and Targets"
+    expect(page).to have_css ".help-section"
   end
 
   describe "#goals_and_targets" do
@@ -29,6 +30,7 @@ describe SDG::RelatedListSelectorComponent, type: :component do
       expect(suggestion).to eq({
         tag: "1. No Poverty",
         display_text: "SDG1",
+        title: "No Poverty",
         value: 1
       })
     end
@@ -39,6 +41,7 @@ describe SDG::RelatedListSelectorComponent, type: :component do
       expect(suggestion).to eq({
         tag: "1.1. By 2030 eradicate extreme poverty for all people everywhere currently measured as people living on less than $1.25 a day",
         display_text: "1.1",
+        title: "By 2030, eradicate extreme poverty for all people everywhere, currently measured as people living on less than $1.25 a day",
         value: "1.1"
       })
     end

--- a/spec/components/sdg/related_list_selector_component_spec.rb
+++ b/spec/components/sdg/related_list_selector_component_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe SDG::RelatedListSelectorComponent, type: :component do
+  let(:debate) { create(:debate) }
+  let(:form) { ConsulFormBuilder.new(:debate, debate, ActionView::Base.new, {}) }
+  let(:component) { SDG::RelatedListSelectorComponent.new(form) }
+
+  it "renders sdg_related_list field" do
+    render_inline component
+
+    expect(page).to have_css ".sdg-related-list-selector .input"
+    expect(page).to have_content "Sustainable Development Goals and Targets"
+  end
+end

--- a/spec/components/sdg/related_list_selector_component_spec.rb
+++ b/spec/components/sdg/related_list_selector_component_spec.rb
@@ -11,4 +11,34 @@ describe SDG::RelatedListSelectorComponent, type: :component do
     expect(page).to have_css ".sdg-related-list-selector .input"
     expect(page).to have_content "Sustainable Development Goals and Targets"
   end
+
+  describe "#goals_and_targets" do
+    it "return all goals and target with order" do
+      goals_and_targets = component.goals_and_targets
+
+      expect(goals_and_targets.first).to eq SDG::Goal[1]
+      expect(goals_and_targets.second).to eq SDG::Target[1.1]
+      expect(goals_and_targets.last).to eq SDG::Target[17.19]
+    end
+  end
+
+  describe "#suggestion_tag_for" do
+    it "return suggestion tag for goal" do
+      suggestion = component.suggestion_tag_for(SDG::Goal[1])
+
+      expect(suggestion).to eq({
+        tag: "1. No Poverty",
+        value: 1
+      })
+    end
+
+    it "return suggestion tag for target" do
+      suggestion = component.suggestion_tag_for(SDG::Target[1.1])
+
+      expect(suggestion).to eq({
+        tag: "1.1. By 2030 eradicate extreme poverty for all people everywhere currently measured as people living on less than $1.25 a day",
+        value: "1.1"
+      })
+    end
+  end
 end

--- a/spec/components/sdg/related_list_selector_component_spec.rb
+++ b/spec/components/sdg/related_list_selector_component_spec.rb
@@ -28,6 +28,7 @@ describe SDG::RelatedListSelectorComponent, type: :component do
 
       expect(suggestion).to eq({
         tag: "1. No Poverty",
+        display_text: "SDG1",
         value: 1
       })
     end
@@ -37,6 +38,7 @@ describe SDG::RelatedListSelectorComponent, type: :component do
 
       expect(suggestion).to eq({
         tag: "1.1. By 2030 eradicate extreme poverty for all people everywhere currently measured as people living on less than $1.25 a day",
+        display_text: "1.1",
         value: "1.1"
       })
     end

--- a/spec/models/sdg/relatable_spec.rb
+++ b/spec/models/sdg/relatable_spec.rb
@@ -80,6 +80,15 @@ describe SDG::Relatable do
     end
   end
 
+  describe "#sdg_related_list" do
+    it "orders related list by code" do
+      relatable.sdg_goals = [SDG::Goal[1], SDG::Goal[3], SDG::Goal[2]]
+      relatable.sdg_targets = [SDG::Target[2.2], SDG::Target[1.2], SDG::Target[2.1]]
+
+      expect(relatable.sdg_related_list).to eq "1, 1.2, 2, 2.1, 2.2, 3"
+    end
+  end
+
   describe "#related_sdgs" do
     it "returns all related goals and targets" do
       relatable.sdg_goals = [goal, another_goal]
@@ -91,29 +100,45 @@ describe SDG::Relatable do
     end
   end
 
-  describe "#sdg_target_list=" do
-    it "assigns a single target" do
-      relatable.sdg_target_list = "1.1"
+  describe "#sdg_related_list=" do
+    it "assigns a single goal" do
+      relatable.sdg_related_list = "1"
 
-      expect(relatable.reload.sdg_targets).to match_array [SDG::Target["1.1"]]
+      expect(relatable.reload.sdg_goals).to match_array [SDG::Goal[1]]
+    end
+
+    it "assigns a single target" do
+      relatable.sdg_related_list = "1.1"
+
+      expect(relatable.reload.sdg_goals).to match_array [SDG::Goal[1]]
+      expect(relatable.reload.sdg_targets).to match_array [SDG::Target[1.1]]
     end
 
     it "assigns multiple targets" do
-      relatable.sdg_target_list = "1.1,2.3"
+      relatable.sdg_related_list = "1.1,2.3"
 
-      expect(relatable.reload.sdg_targets).to match_array [SDG::Target["1.1"], SDG::Target["2.3"]]
+      expect(relatable.reload.sdg_goals).to match_array [SDG::Goal[1], SDG::Goal[2]]
+      expect(relatable.reload.sdg_targets).to match_array [SDG::Target[1.1], SDG::Target[2.3]]
+    end
+
+    it "assigns multiple goals" do
+      relatable.sdg_related_list = "3,2,1"
+
+      expect(relatable.reload.sdg_goals).to match_array [SDG::Goal[1], SDG::Goal[2], SDG::Goal[3]]
     end
 
     it "ignores trailing spaces and spaces between commas" do
-      relatable.sdg_target_list = " 1.1,  2.3 "
-
-      expect(relatable.reload.sdg_targets).to match_array [SDG::Target["1.1"], SDG::Target["2.3"]]
-    end
-
-    it "assigns goals" do
-      relatable.sdg_target_list = "1.1,1.2,2.3"
+      relatable.sdg_related_list = " 1.1,  2.3 "
 
       expect(relatable.reload.sdg_goals).to match_array [SDG::Goal[1], SDG::Goal[2]]
+      expect(relatable.reload.sdg_targets).to match_array [SDG::Target[1.1], SDG::Target[2.3]]
+    end
+
+    it "assigns goals and targets" do
+      relatable.sdg_related_list = "1.1,3,4,4.1"
+
+      expect(relatable.reload.sdg_goals).to match_array [SDG::Goal[1], SDG::Goal[3], SDG::Goal[4]]
+      expect(relatable.reload.sdg_targets).to match_array [SDG::Target[1.1], SDG::Target[4.1]]
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,5 +46,6 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 Capybara.exact = true
+Capybara.enable_aria_label = true
 
 OmniAuth.config.test_mode = true

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -263,7 +263,7 @@ describe "SDG Relations", :js do
       fill_in "Sustainable Development Goals and Targets", with: "3"
       within(".amsify-list") { find(:css, "[data-val='3']").click }
 
-      within(".amsify-suggestags-input-area") { expect(page).to have_content "3" }
+      within(".amsify-suggestags-input-area") { expect(page).to have_content "SDG3" }
 
       fill_in "Sustainable Development Goals and Targets", with: "1.1"
       within(".amsify-list") { find(:css, "[data-val='1.1']").click }

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -278,5 +278,14 @@ describe "SDG Relations", :js do
         expect(page).to have_css "td", exact_text: "1.1"
       end
     end
+
+    scenario "allows adding only white list suggestions" do
+      process = create(:legislation_process, title: "SDG process")
+
+      visit sdg_management_edit_legislation_process_path(process)
+
+      fill_in "Sustainable Development Goals and Targets", with: "tag nonexistent,"
+      within(".amsify-suggestags-input-area") { expect(page).not_to have_content "tag nonexistent" }
+    end
   end
 end

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -346,5 +346,31 @@ describe "SDG Relations", :js do
         expect(find("li[data-code='1']")["aria-checked"]).to eq "false"
       end
     end
+
+    describe "help section" do
+      scenario "when add new tag render title in help section" do
+        process = create(:legislation_process, title: "SDG process")
+
+        visit sdg_management_edit_legislation_process_path(process)
+        find("li[data-code='1']").click
+
+        within(".help-section") { expect(page).to have_content "No Poverty" }
+      end
+
+      scenario "when remove a tag remove his title in help section" do
+        process = create(:legislation_process, title: "SDG process")
+        process.sdg_goals = [SDG::Goal[1]]
+
+        visit sdg_management_edit_legislation_process_path(process)
+
+        within(".help-section") { expect(page).to have_content "No Poverty" }
+
+        within "span[data-val='1']" do
+          find(".amsify-remove-tag").click
+        end
+
+        expect(page).not_to have_content "No Poverty"
+      end
+    end
   end
 end

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -255,5 +255,28 @@ describe "SDG Relations", :js do
         expect(page).to have_css "td", exact_text: "1.2, 2.1"
       end
     end
+
+    scenario "allows adding the goals and targets with autocomplete" do
+      process = create(:legislation_process, title: "SDG process")
+      visit sdg_management_edit_legislation_process_path(process)
+
+      fill_in "Sustainable Development Goals and Targets", with: "3"
+      within(".amsify-list") { find(:css, "[data-val='3']").click }
+
+      within(".amsify-suggestags-input-area") { expect(page).to have_content "3" }
+
+      fill_in "Sustainable Development Goals and Targets", with: "1.1"
+      within(".amsify-list") { find(:css, "[data-val='1.1']").click }
+
+      within(".amsify-suggestags-input-area") { expect(page).to have_content "1.1" }
+
+      click_button "Update Process"
+      click_link "Marked as reviewed"
+
+      within("tr", text: "SDG process") do
+        expect(page).to have_css "td", exact_text: "1, 3"
+        expect(page).to have_css "td", exact_text: "1.1"
+      end
+    end
   end
 end

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -287,5 +287,54 @@ describe "SDG Relations", :js do
       fill_in "Sustainable Development Goals and Targets", with: "tag nonexistent,"
       within(".amsify-suggestags-input-area") { expect(page).not_to have_content "tag nonexistent" }
     end
+
+    describe "by clicking on a Goal icon" do
+      scenario "allows adding a Goal" do
+        process = create(:legislation_process, title: "SDG process")
+
+        visit sdg_management_edit_legislation_process_path(process)
+        find("li[data-code='1']").click
+        click_button "Update Process"
+        click_link "Marked as reviewed"
+
+        within("tr", text: "SDG process") do
+          expect(page).to have_css "td", exact_text: "1"
+        end
+      end
+
+      scenario "allows remove a Goal" do
+        skip("Pending to fix removing item twice")
+      end
+    end
+
+    describe "manage goals icon status" do
+      scenario "when add a tag related to Goal, the icon will be checked" do
+        process = create(:legislation_process, title: "SDG process")
+
+        visit sdg_management_edit_legislation_process_path(process)
+        find("li[data-code='1']").click
+
+        expect(find("li[data-code='1']")["aria-checked"]).to eq "true"
+      end
+
+      scenario "when remove a last tag related to a Goal, the icon will not be checked" do
+        process = create(:legislation_process, title: "SDG process")
+        process.sdg_goals = [SDG::Goal[1]]
+        process.sdg_targets = [SDG::Target[1.1]]
+
+        visit sdg_management_edit_legislation_process_path(process)
+        within "span[data-val='1']" do
+          find(".amsify-remove-tag").click
+        end
+
+        expect(find("li[data-code='1']")["aria-checked"]).to eq "true"
+
+        within "span[data-val='1.1']" do
+          find(".amsify-remove-tag").click
+        end
+
+        expect(find("li[data-code='1']")["aria-checked"]).to eq "false"
+      end
+    end
   end
 end

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -303,7 +303,17 @@ describe "SDG Relations", :js do
       end
 
       scenario "allows remove a Goal" do
-        skip("Pending to fix removing item twice")
+        process = create(:legislation_process, title: "SDG process")
+        process.sdg_goals = [SDG::Goal[1], SDG::Goal[2]]
+
+        visit sdg_management_edit_legislation_process_path(process)
+        find("li[data-code='1']").click
+        click_button "Update Process"
+        click_link "Marked as reviewed"
+
+        within("tr", text: "SDG process") do
+          expect(page).to have_css "td", exact_text: "2"
+        end
       end
     end
 

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -219,11 +219,11 @@ describe "SDG Relations", :js do
       visit sdg_management_edit_legislation_process_path(process)
 
       within "span[data-val='2']" do
-        find(".amsify-remove-tag").click
+        click_button "Remove"
       end
 
       within "span[data-val='3.3']" do
-        find(".amsify-remove-tag").click
+        click_button "Remove"
       end
 
       click_button "Update Process"
@@ -334,13 +334,13 @@ describe "SDG Relations", :js do
 
         visit sdg_management_edit_legislation_process_path(process)
         within "span[data-val='1']" do
-          find(".amsify-remove-tag").click
+          click_button "Remove"
         end
 
         expect(find("li[data-code='1']")["aria-checked"]).to eq "true"
 
         within "span[data-val='1.1']" do
-          find(".amsify-remove-tag").click
+          click_button "Remove"
         end
 
         expect(find("li[data-code='1']")["aria-checked"]).to eq "false"
@@ -366,7 +366,7 @@ describe "SDG Relations", :js do
         within(".help-section") { expect(page).to have_content "No Poverty" }
 
         within "span[data-val='1']" do
-          find(".amsify-remove-tag").click
+          click_button "Remove"
         end
 
         expect(page).not_to have_content "No Poverty"

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -190,12 +190,15 @@ describe "SDG Relations", :js do
   end
 
   describe "Edit" do
-    scenario "allows changing the targets and marks the resource as reviewed" do
+    scenario "allows adding the goals and targets and marks the resource as reviewed" do
       process = create(:legislation_process, title: "SDG process")
-      process.sdg_targets = [SDG::Target["3.3"]]
+      process.sdg_goals = [SDG::Goal[3]]
+      process.sdg_targets = [SDG::Target[3.3]]
 
       visit sdg_management_edit_legislation_process_path(process)
-      fill_in "Targets", with: "1.2, 2.1", fill_options: { clear: :backspace }
+
+      find(:css, ".sdg-related-list-selector-input").set("1.2, 2,")
+
       click_button "Update Process"
 
       expect(page).to have_content "Process updated successfully and marked as reviewed"
@@ -203,16 +206,44 @@ describe "SDG Relations", :js do
       click_link "Marked as reviewed"
 
       within("tr", text: "SDG process") do
-        expect(page).to have_css "td", exact_text: "1.2, 2.1"
+        expect(page).to have_css "td", exact_text: "1.2, 3.3"
+        expect(page).to have_css "td", exact_text: "1, 2, 3"
+      end
+    end
+
+    scenario "allows removing the goals and targets" do
+      process = create(:legislation_process, title: "SDG process")
+      process.sdg_goals = [SDG::Goal[2], SDG::Goal[3]]
+      process.sdg_targets = [SDG::Target[2.1], SDG::Target[3.3]]
+
+      visit sdg_management_edit_legislation_process_path(process)
+
+      within "span[data-val='2']" do
+        find(".amsify-remove-tag").click
+      end
+
+      within "span[data-val='3.3']" do
+        find(".amsify-remove-tag").click
+      end
+
+      click_button "Update Process"
+
+      expect(page).to have_content "Process updated successfully and marked as reviewed"
+
+      click_link "Marked as reviewed"
+
+      within("tr", text: "SDG process") do
+        expect(page).to have_css "td", exact_text: "2, 3"
+        expect(page).to have_css "td", exact_text: "2.1"
       end
     end
 
     scenario "does not show the review notice when resource was already reviewed" do
       debate = create(:sdg_review, relatable: create(:debate, title: "SDG debate")).relatable
-      debate.sdg_targets = [SDG::Target["3.3"]]
+      debate.sdg_targets = [SDG::Target[3.3]]
 
       visit sdg_management_edit_debate_path(debate, filter: "sdg_reviewed")
-      fill_in "Targets", with: "1.2, 2.1", fill_options: { clear: :backspace }
+      find(:css, ".sdg-related-list-selector-input").set("1.2, 2.1,")
       click_button "Update Debate"
 
       expect(page).not_to have_content "Debate updated successfully and marked as reviewed"

--- a/spec/system/xss_spec.rb
+++ b/spec/system/xss_spec.rb
@@ -76,6 +76,16 @@ describe "Cross-Site Scripting protection", :js do
     expect(page.text).not_to be_empty
   end
 
+  scenario "SDG identifier", :admin do
+    Setting["feature.sdg"] = true
+    Setting["sdg.process.proposals"] = true
+    I18nContent.create!(key: "sdg.related_list_selector.goal_identifier", value: attack_code)
+
+    visit sdg_management_edit_proposal_path(create(:proposal, sdg_goals: [SDG::Goal[1]]))
+
+    expect(page.text).not_to be_empty
+  end
+
   scenario "proposal actions in dashboard" do
     proposal = create(:proposal)
 

--- a/vendor/assets/javascripts/jquery.amsify.suggestags.js
+++ b/vendor/assets/javascripts/jquery.amsify.suggestags.js
@@ -626,7 +626,7 @@ var AmsifySuggestags;
 
 		removeTag: function(value, animate=true) {
 			var _self = this;
-			$findTags = $(this.selectors.sTagsArea).find('[data-val="'+value+'"]');
+			$findTags = $(this.selectors.inputArea).find('[data-val="'+value+'"]');
 			if($findTags.length) {
 				$findTags.each(function(){
 					_self.removeTagByItem(this, animate);

--- a/vendor/assets/javascripts/jquery.amsify.suggestags.js
+++ b/vendor/assets/javascripts/jquery.amsify.suggestags.js
@@ -1,0 +1,897 @@
+/**
+ * Amsify Suggestags
+ * https://github.com/amsify42/jquery.amsify.suggestags
+ */
+
+var AmsifySuggestags;
+
+(function(factory) {
+	if(typeof module === 'object' && typeof module.exports === 'object') {
+		factory(require('jquery'), window, document);
+	} else {
+		factory(jQuery, window, document);
+	}
+}
+(function($, window, document, undefined) {
+
+	AmsifySuggestags = function(selector) {
+		this.selector = selector;
+		this.settings = {
+			type              : 'bootstrap',
+			tagLimit          : -1,
+			suggestions       : [],
+			suggestMatch 	  : {},
+			suggestionsAction : {timeout: -1, minChars:2, minChange:-1, delay:100, type: 'GET'},
+			defaultTagClass   : '',
+			classes           : [],
+			backgrounds       : [],
+			colors            : [],
+			whiteList         : false,
+			afterAdd          : {},
+			afterRemove       : {},
+			//My changes
+			trimValue         : false,
+			dashspaces        : false,
+			lowercase         : false,
+			selectOnHover     : true,
+			triggerChange     : false,
+			noSuggestionMsg   : '',
+			showAllSuggestions: false,
+			keepLastOnHoverTag: true,
+			printValues 	  : true,
+			checkSimilar 	  : true,
+			delimiters 		  : [],
+			showPlusAfter 	  : 0
+		};
+		this.method        = undefined;
+		this.name          = null;
+		this.defaultLabel  = 'Type here';
+		this.classes       = {
+			sTagsArea     : '.amsify-suggestags-area',
+			inputArea     : '.amsify-suggestags-input-area',
+			inputAreaDef  : '.amsify-suggestags-input-area-default',
+			focus         : '.amsify-focus',
+			sTagsInput    : '.amsify-suggestags-input',
+			listArea      : '.amsify-suggestags-list',
+			list          : '.amsify-list',
+			listItem      : '.amsify-list-item',
+			itemPad       : '.amsify-item-pad',
+			inputType     : '.amsify-select-input',
+			tagItem       : '.amsify-select-tag',
+			plusItem 	  : '.amsify-plus-tag',
+			colBg         : '.col-bg',
+			removeTag     : '.amsify-remove-tag',
+			readyToRemove : '.ready-to-remove',
+			noSuggestion  : '.amsify-no-suggestion',
+			showPlusBg 	  : '.show-plus-bg'
+		};
+		this.selectors     = {
+			sTagsArea     : null,
+			inputArea     : null,
+			inputAreaDef  : null,
+			sTagsInput    : null,
+			listArea      : null,
+			list          : null,
+			listGroup     : null,
+			listItem      : null,
+			itemPad       : null,
+			inputType     : null,
+			plusTag 	  : null
+		};
+		this.isRequired = false;
+		this.ajaxActive = false;
+		this.tagNames   = [];
+		this.delayTimer = 0;
+		this.blurTgItems= null;
+	};
+	AmsifySuggestags.prototype = {
+	   /**
+		* Merging default settings with custom
+		* @type {object}
+		*/
+		_settings : function(settings) {
+			this.settings = $.extend(true, {}, this.settings, settings);
+		},
+
+		_setMethod : function(method) {
+			this.method = method;
+		},
+
+		_init : function() {
+			if(this.checkMethod()) {
+				this.name = ($(this.selector).attr('name'))? $(this.selector).attr('name')+'_amsify': 'amsify_suggestags';
+				this.createHTML();
+				this.setEvents();
+				$(this.selector).hide();
+				this.setDefault();
+			}
+		},
+
+		createHTML : function() {
+			var HTML                  = '<div class="'+this.classes.sTagsArea.substring(1)+'"></div>';
+			this.selectors.sTagsArea  = $(HTML).insertAfter(this.selector);
+			var labelHTML             = '<div class="'+this.classes.inputArea.substring(1)+'"></div>';
+			this.selectors.inputArea  = $(labelHTML).appendTo(this.selectors.sTagsArea);
+			this.defaultLabel         = ($(this.selector).attr('placeholder') !== undefined)? $(this.selector).attr('placeholder'): this.defaultLabel;
+			var sTagsInput            = '<input type="text" class="'+this.classes.sTagsInput.substring(1)+'" placeholder="'+this.defaultLabel+'">';
+			this.selectors.sTagsInput = $(sTagsInput).appendTo(this.selectors.inputArea).attr('autocomplete', 'off');
+			if($(this.selector).attr('required')) {
+				$(this.selector).removeAttr('required');
+				this.isRequired = true;
+				this.updateIsRequired();
+			}
+			var listArea              = '<div class="'+this.classes.listArea.substring(1)+'"></div>';
+			this.selectors.listArea   = $(listArea).appendTo(this.selectors.sTagsArea);
+			$(this.selectors.listArea).width($(this.selectors.sTagsArea).width()-3);
+			var list                  = '<ul class="'+this.classes.list.substring(1)+'"></ul>';
+			this.selectors.list       = $(list).appendTo(this.selectors.listArea);
+			this.updateSuggestionList();
+			this.fixCSS();
+		},
+
+		updateIsRequired : function() {
+			if(this.isRequired) {
+				if(this.tagNames.length){
+					$(this.selectors.sTagsInput).removeAttr('required');
+				} else {
+					$(this.selectors.sTagsInput).attr('required', 'required');
+				}
+			}
+		},
+
+		updateSuggestionList : function() {
+			$(this.selectors.list).html('');
+			$(this.createList()).appendTo(this.selectors.list);
+		},
+
+		setEvents : function() {
+			var _self = this;
+			$(this.selectors.inputArea).attr('style', $(this.selector).attr('style')).addClass($(this.selector).attr('class'));
+			this.setTagEvents();
+			if(window !== undefined) {
+				$(window).resize(function(){
+					$(_self.selectors.listArea).width($(_self.selectors.sTagsArea).width()-3);
+				});
+			}
+			this.setSuggestionsEvents();
+			this.setRemoveEvent();
+		},
+
+		setTagEvents : function() {
+			var _self = this;
+			$(this.selectors.sTagsInput).focus(function(){
+			   /**
+				* Show all suggestions if setting set to true
+				*/
+				if(_self.settings.showAllSuggestions) {
+					_self.suggestWhiteList('', 0, true);
+				}
+				$(this).closest(_self.classes.inputArea).addClass(_self.classes.focus.substring(1));
+				if(_self.settings.type == 'materialize') {
+					$(this).css({
+						'border-bottom': 'none',
+						'-webkit-box-shadow': 'none',
+						'box-shadow': 'none',
+					});
+				}
+				_self.checkPlusAfter();
+			});
+			$(this.selectors.sTagsInput).blur(function(){
+				$(this).closest(_self.classes.inputArea).removeClass(_self.classes.focus.substring(1));
+				if(!$(this).val()) {
+					$(_self.selectors.listArea).hide();
+				}
+				_self.checkPlusAfter(true);
+			});
+			$(this.selectors.sTagsInput).keyup(function(e){
+				var keycode = (e.keyCode ? e.keyCode : e.which);
+				var key 	= '';
+				if(e.key) {
+					key = e.key;
+				} else {
+					if(keycode == '13') {
+						key = 'Enter';
+					} else if(keycode == '188') {
+						key = ',';
+					}
+				}
+				var isDelimiter = ($.inArray(key, _self.settings.delimiters) !== -1)? true: false;
+				if(key == 'Enter' || key == ',' || isDelimiter) {
+					var value = $.trim($(this).val().replace(/,/g , ''));
+					if(isDelimiter) {
+						$.each(_self.settings.delimiters, function(dkey, delimiter) {
+							value = $.trim(value.replace(delimiter, ''));
+						});
+					}
+					$(this).val('');
+					_self.addTag(_self.getValue(value));
+					if(_self.settings.showAllSuggestions) {
+						_self.suggestWhiteList('', 0, true);
+					}
+				} else if(keycode == '8' && !$(this).val()) {
+					var removeClass = _self.classes.readyToRemove.substring(1);
+					if($(this).hasClass(removeClass)) {
+						$item = $(this).closest(_self.classes.inputArea).find(_self.classes.tagItem+':last');
+						_self.removeTagByItem($item, false);
+					} else {
+						$(this).addClass(removeClass);
+					}
+					$(_self.selectors.listArea).hide();
+					if(_self.settings.showAllSuggestions) {
+						_self.suggestWhiteList('', 0, true);
+					}
+				} else if((_self.settings.suggestions.length || _self.isSuggestAction()) && ($(this).val() || _self.settings.showAllSuggestions)) {
+					$(this).removeClass(_self.classes.readyToRemove.substring(1));
+					_self.processWhiteList(keycode, $(this).val());
+				}
+			});
+			$(this.selectors.sTagsInput).keypress(function(e){
+				var keycode = (e.keyCode ? e.keyCode : e.which);
+				if(keycode == 13) {
+					return false;
+				}
+			});
+			$(this.selectors.sTagsArea).click(function(){
+				$(_self.selectors.sTagsInput).focus();
+			});
+		},
+
+		setSuggestionsEvents : function() {
+			var _self = this;
+			if(this.settings.selectOnHover) {
+				$(this.selectors.listArea).find(this.classes.listItem).hover(function(){
+					$(_self.selectors.listArea).find(_self.classes.listItem).removeClass('active');
+					$(this).addClass('active');
+					$(_self.selectors.sTagsInput).val($(this).text());
+				}, function() {
+					$(this).removeClass('active');
+					if(!_self.settings.keepLastOnHoverTag) {
+						$(_self.selectors.sTagsInput).val('');
+					}
+				});
+			}
+			$(this.selectors.listArea).find(this.classes.listItem).click(function(){
+				_self.addTag($(this).data('val'));
+				$(_self.selectors.sTagsInput).val('').focus();
+			});
+		},
+
+		isSuggestAction : function() {
+			return (this.settings.suggestionsAction && this.settings.suggestionsAction.url);
+		},
+
+		getTag : function(value) {
+			if(this.settings.suggestions.length) {
+				var tag = value;
+				$.each(this.settings.suggestions, function(key, item){
+					if(typeof item === 'object' && item.value == value) {
+						tag = item.tag
+						return false;
+					}
+					else if(item == value) {
+						return false;
+					}
+				});
+				return tag;
+			}
+			return value;
+		},
+
+		getValue : function(tag) {
+			if(this.settings.suggestions.length) {
+				var value = tag;
+				var lower = tag.toString().toLowerCase();
+				$.each(this.settings.suggestions, function(key, item){
+					if(typeof item === 'object' && item.tag.toString().toLowerCase() == lower) {
+						value = item.value
+						return false;
+					}
+					else if(item.toString().toLowerCase() == lower) {
+						return false;
+					}
+				});
+				return value;
+			}
+			return tag;
+		},
+
+		processAjaxSuggestion : function(value, keycode) {
+			var _self           = this;
+			var actionURL    	= this.getActionURL(this.settings.suggestionsAction.url);
+			var params          = {existingTags: this.tagNames, existing: this.settings.suggestions, term: value};
+			var ajaxConfig      = (this.settings.suggestionsAction.callbacks)? this.settings.suggestionsAction.callbacks: {};
+			var ajaxFormParams  = {
+				url : actionURL,
+			};
+			if(this.settings.suggestionsAction.type == 'GET') {
+				ajaxFormParams.url = ajaxFormParams.url+'?'+$.param(params);
+			} else {
+				ajaxFormParams.type = this.settings.suggestionsAction.type;
+				ajaxFormParams.data = params;
+			}
+			if(this.settings.suggestionsAction.timeout !== -1) {
+				ajaxFormParams['timeout'] = this.settings.suggestionsAction.timeout*1000;
+			}
+			if(this.settings.suggestionsAction.beforeSend !== undefined && typeof this.settings.suggestionsAction.beforeSend == "function") {
+				ajaxFormParams['beforeSend'] = this.settings.suggestionsAction.beforeSend;
+			}
+			ajaxFormParams['success'] = function(data) {
+				if(data && data.suggestions) {
+					_self.settings.suggestions = $.merge(_self.settings.suggestions, data.suggestions);
+					_self.settings.suggestions = _self.unique(_self.settings.suggestions);
+					_self.updateSuggestionList();
+					_self.setSuggestionsEvents();
+					_self.suggestWhiteList(value, keycode);
+				}
+				if(_self.settings.suggestionsAction.success !== undefined && typeof _self.settings.suggestionsAction.success == "function") {
+					_self.settings.suggestionsAction.success(data);
+				}
+			};
+			if(this.settings.suggestionsAction.error !== undefined && typeof this.settings.suggestionsAction.error == "function") {
+				ajaxFormParams['error'] = this.settings.suggestionsAction.error;
+			}
+			ajaxFormParams['complete'] = function(data) {
+				if(_self.settings.suggestionsAction.complete !== undefined && typeof _self.settings.suggestionsAction.complete == "function") {
+					_self.settings.suggestionsAction.complete(data);
+				}
+				_self.ajaxActive = false;
+			};
+			$.ajax(ajaxFormParams);
+		},
+
+		processWhiteList : function(keycode, value) {
+			if(keycode == '40' || keycode == '38') {
+				var type = (keycode == '40')? 'down': 'up';
+				this.upDownSuggestion(value, type);
+			} else {
+				clearTimeout(this.delayTimer);
+				var _self       = this;
+				this.delayTimer = setTimeout(function() {
+					if(_self.isSuggestAction() && !_self.ajaxActive) {
+				      	var minChars  = _self.settings.suggestionsAction.minChars;
+						var minChange = _self.settings.suggestionsAction.minChange;
+						var lastSearch= _self.selectors.sTagsInput.attr('last-search');
+						if(value.length >= minChars && (minChange === -1 || !lastSearch || _self.similarity(lastSearch, value)*100 <= minChange)) {
+							_self.selectors.sTagsInput.attr('last-search', value);
+							_self.ajaxActive = true;
+							_self.processAjaxSuggestion(value, keycode);
+						}
+					} else {
+						_self.suggestWhiteList(value, keycode);
+					}
+			    }, this.settings.suggestionsAction.delay);
+			}
+		},
+
+		upDownSuggestion : function(value, type) {
+			var _self     = this;
+			var isActive  = false;
+			$(this.selectors.listArea).find(this.classes.listItem+':visible').each(function(){
+				if($(this).hasClass('active')) {
+					$(this).removeClass('active');
+					if(type == 'up') {
+						$item = $(this).prevAll(_self.classes.listItem+':visible:first');
+					} else {
+						$item = $(this).nextAll(_self.classes.listItem+':visible:first');
+					}
+					if($item.length) {
+						isActive = true;
+						$item.addClass('active');
+						$(_self.selectors.sTagsInput).val($item.text());
+					}
+					return false;
+				}
+			});
+			if(!isActive) {
+				var childItem = (type == 'down')? 'first': 'last';
+				$item = $(this.selectors.listArea).find(this.classes.listItem+':visible:'+childItem);
+				if($item.length) {
+					$item.addClass('active');
+					$(_self.selectors.sTagsInput).val($item.text());
+				}
+			}
+		},
+
+		suggestWhiteList : function(value, keycode, showAll) {
+			var _self = this;
+			var found = false;
+			var all   = (showAll)? true: false;
+			var lower = value.toString().toLowerCase();
+			$(this.selectors.listArea).find(_self.classes.noSuggestion).hide();
+			var $list = $(this.selectors.listArea).find(this.classes.list);
+			$list.find(this.classes.listItem).each(function(){
+				var dataVal = $(this).data('val');
+				if($.isNumeric(dataVal)) {
+					dataVal = (value.toString().indexOf('.') == -1)? parseInt(dataVal): parseFloat(dataVal);
+				}
+
+				/**
+				 * Suggest item matching result
+				 */
+				var suggestItemResult = 0;
+				if(_self.settings.suggestMatch && typeof _self.settings.suggestMatch == "function") {
+					suggestItemResult = _self.settings.suggestMatch($(this).text(), value);
+				} else {
+					suggestItemResult = ~$(this).text().toString().toLowerCase().indexOf(lower);
+				}
+
+				if((all || suggestItemResult) && $.inArray(dataVal, _self.tagNames) === -1) {
+					$(this).attr('data-show', 1);
+					found = true;
+				} else {
+					$(this).removeAttr('data-show');
+				}
+				$(this).hide();
+			});
+			if(found) {
+				/**
+				 * Sorting the suggestions
+				 */
+				$dataShow = $list.find(this.classes.listItem+'[data-show]');
+				if(lower) {
+					$dataShow.sort(function(a, b) {
+						return value.localeCompare($(a).text().toString());
+					}).appendTo($list);
+				} else {
+					$dataShow.sort(function(a, b) {
+						return $(a).text().toString().localeCompare($(b).text().toString());
+					}).appendTo($list);
+				}
+				$dataShow.each(function(){
+					$(this).show();
+				});
+
+			   /**
+				* If only one item left in whitelist suggestions
+				*/
+				$item = $(this.selectors.listArea).find(this.classes.listItem+':visible');
+				if($item.length == 1 && keycode != '8') {
+					if((this.settings.whiteList && this.isSimilarText(value.toLowerCase(), $item.text().toLowerCase(), 40)) || this.isSimilarText(value.toLowerCase(), $item.text().toLowerCase(), 60)) {
+						$item.addClass('active');
+						$(this.selectors.sTagsInput).val($item.text());
+					}
+				} else {
+					$item.removeClass('active');
+				}
+
+				$(this.selectors.listArea).show();
+
+			} else {
+				if(value && _self.settings.noSuggestionMsg) {
+					$(this.selectors.listArea).find(_self.classes.listItem).hide();
+					$(this.selectors.listArea).find(_self.classes.noSuggestion).show();
+				} else {
+					$(this.selectors.listArea).hide();
+				}
+			}
+		},
+
+		setDefault : function() {
+			var _self = this;
+			var items = $(this.selector).val().split(',');
+			if(items.length) {
+				$.each(items, function(index, item){
+					_self.addTag($.trim(item));
+				});
+			}
+		},
+
+		setRemoveEvent: function() {
+			var _self = this;
+			$(this.selectors.inputArea).find(this.classes.removeTag).click(function(e){
+				e.stopImmediatePropagation();
+				$tagItem = $(this).closest(_self.classes.tagItem);
+				_self.removeTagByItem($tagItem, false);
+			});
+		},
+
+		createList : function() {
+			var _self     = this;
+			var listHTML  = '';
+			$.each(this.settings.suggestions, function(index, item){
+				var value = '';
+				var tag   = '';
+				if(typeof item === 'object') {
+					value = item.value
+					tag   = item.tag
+				} else {
+					value = item;
+					tag   = item;
+				}
+				listHTML += '<li class="'+_self.classes.listItem.substring(1)+'" data-val="'+value+'">'+tag+'</li>';
+			});
+			if(_self.settings.noSuggestionMsg) {
+				listHTML += '<li class="'+_self.classes.noSuggestion.substring(1)+'">'+_self.settings.noSuggestionMsg+'</li>';
+			}
+			return listHTML;
+		},
+
+		addTag : function(value, animate=true) {
+			if(!value) {
+                return;
+			}
+			// Trim value
+			if (typeof value === "string" && this.settings.trimValue) {
+				value = $.trim(value);
+			}
+
+			// lowercase and dash
+			if (typeof value === "string" && this.settings.lowercase && this.settings.dashspaces) {
+				value = value.replace(/\s+/g, '-').toLowerCase();
+			}
+			else if (typeof value === "string" && this.settings.lowercase){
+				value = value.toLowerCase();
+			}
+			else if (typeof value === "string" && this.settings.dashspaces){
+				value = value.replace(/\s+/g, '-');
+			}
+
+			var html = '<span class="'+this.classes.tagItem.substring(1)+'" data-val="'+value+'">'+this.getTag(value)+' '+this.setIcon()+'</span>';
+			$item    = $(html).insertBefore($(this.selectors.sTagsInput));
+			if(this.settings.defaultTagClass) {
+				$item.addClass(this.settings.defaultTagClass);
+			}
+			if(this.settings.tagLimit != -1 && this.settings.tagLimit > 0 && this.tagNames.length >= this.settings.tagLimit) {
+				this.animateRemove($item, animate);
+				if(animate) {
+					this.flashItem(value);
+				}
+				return false;
+			}
+			var itemKey = this.getItemKey(value);
+			if(this.settings.whiteList && itemKey === -1) {
+				this.animateRemove($item, animate);
+				if(animate) {
+					this.flashItem(value);
+				}
+				return false;
+			}
+			if(this.isPresent(value)) {
+				this.animateRemove($item, animate);
+				if(animate) {
+					this.flashItem(value);
+				}
+			} else {
+				this.customStylings($item, itemKey);
+				var dataVal = value;
+				if($.isNumeric(dataVal)) {
+					dataVal = (value.toString().indexOf('.') == -1)? parseInt(dataVal): parseFloat(dataVal);
+				}
+				this.tagNames.push(dataVal);
+				this.setRemoveEvent();
+				this.setInputValue();
+				if(this.settings.afterAdd && typeof this.settings.afterAdd == "function") {
+					this.settings.afterAdd(value);
+				}
+			}
+			$(this.selector).trigger('suggestags.add', [value]);
+			$(this.selector).trigger('suggestags.change');
+			if(this.settings.triggerChange) {
+				$(this.selector).trigger('change');
+			}
+			$(this.selectors.listArea).find(this.classes.listItem).removeClass('active');
+			$(this.selectors.listArea).hide();
+			$(this.selectors.sTagsInput).removeClass(this.classes.readyToRemove.substring(1));
+			this.checkPlusAfter();
+		},
+
+		getItemKey : function(value) {
+			var itemKey = -1
+			if(this.settings.suggestions.length) {
+				var lower = value.toString().toLowerCase();
+				$.each(this.settings.suggestions, function(key, item){
+					if(typeof item === 'object') {
+						if(item.value.toString().toLowerCase() == lower) {
+							itemKey = key;
+							return false;
+						}
+					} else if(item.toString().toLowerCase() == lower) {
+						itemKey = key;
+						return false;
+					}
+				});
+			}
+			return itemKey;
+		},
+
+		isPresent : function(value) {
+			var present = false;
+			$.each(this.tagNames, function(index, tag){
+				if(value.toString().toLowerCase() == tag.toString().toLowerCase()) {
+					present = true;
+					return false;
+				}
+			});
+			return present;
+		},
+
+		customStylings : function(item, key) {
+			var isCutom = false;
+			if(this.settings.classes[key]) {
+				isCutom = true;
+				$(item).addClass(this.settings.classes[key]);
+			}
+			if(this.settings.backgrounds[key]) {
+				isCutom = true;
+				$(item).css('background', this.settings.backgrounds[key]);
+			}
+			if(this.settings.colors[key]) {
+				isCutom = true;
+				$(item).css('color', this.settings.colors[key]);
+			}
+			if(!isCutom) {
+                $(item).addClass(this.classes.colBg.substring(1));
+            }
+		},
+
+		removeTag: function(value, animate=true) {
+			var _self = this;
+			$findTags = $(this.selectors.sTagsArea).find('[data-val="'+value+'"]');
+			if($findTags.length) {
+				$findTags.each(function(){
+					_self.removeTagByItem(this, animate);
+				});
+			}
+		},
+
+		removeTagByItem : function(item, animate) {
+			this.tagNames.splice($(item).index(), 1);
+			this.animateRemove(item, animate);
+			this.setInputValue();
+			$(this.selector).trigger('suggestags.remove', [$(item).attr('data-val')]);
+			$(this.selector).trigger('suggestags.change');
+			if(this.settings.triggerChange) {
+				$(this.selector).trigger('change');
+			}
+			if(this.settings.afterRemove && typeof this.settings.afterRemove == "function") {
+				this.settings.afterRemove($(item).attr('data-val'));
+			}
+			$(this.selectors.sTagsInput).removeClass(this.classes.readyToRemove.substring(1));
+			this.checkPlusAfter();
+		},
+
+		animateRemove : function(item, animate) {
+			$(item).addClass('disabled');
+			if(animate) {
+				setTimeout(function(){
+					$(item).slideUp();
+					setTimeout(function(){
+						$(item).remove();
+					}, 500);
+				}, 500);
+			} else {
+				$(item).remove();
+			}
+		},
+
+		flashItem : function(value) {
+			$tagItem = '';
+			value 	 = value.toString().toLowerCase();
+			$(this.selectors.sTagsArea).find(this.classes.tagItem).each(function(){
+				var tagName = $.trim($(this).attr('data-val'));
+				if(value == tagName.toString().toLowerCase()) {
+					$tagItem = $(this);
+					return false;
+				}
+			});
+			if($tagItem) {
+				$tagItem.addClass('flash');
+				setTimeout(function(){
+					$tagItem.removeClass('flash');
+				}, 1500, $tagItem);
+			}
+		},
+
+		setIcon : function() {
+			var removeClass = this.classes.removeTag.substring(1);
+			if(this.settings.type == 'bootstrap') {
+				return '<span class="fa fa-times '+removeClass+'"></span>';
+			} else if(this.settings.type == 'materialize') {
+				return '<i class="material-icons right '+removeClass+'">clear</i>';
+			} else {
+				return '<b class="'+removeClass+'">&#10006;</b>';
+			}
+		},
+
+		setInputValue: function() {
+			this.updateIsRequired();
+			$(this.selector).val(this.tagNames.join(','));
+			if(this.settings.printValues) {
+				this.printValues();
+			}
+		},
+
+		fixCSS : function() {
+			if(this.settings.type == 'amsify') {
+				$(this.selectors.inputArea).addClass(this.classes.inputAreaDef.substring(1)).css({'padding': '5px 5px'});
+			} else if(this.settings.type == 'materialize') {
+				$(this.selectors.inputArea).addClass(this.classes.inputAreaDef.substring(1)).css({'height': 'auto', 'padding': '5px 5px'});
+				$(this.selectors.sTagsInput).css({'margin': '0', 'height': 'auto'});
+			}
+		},
+
+		printValues : function() {
+			console.info(this.tagNames, $(this.selector).val());
+		},
+
+		checkMethod : function() {
+			$findTags = $(this.selector).next(this.classes.sTagsArea);
+			if($findTags.length) {
+				$findTags.remove();
+			}
+			$(this.selector).show();
+			if(typeof this.method !== undefined && this.method == 'destroy') {
+				return false;
+			} else {
+				return true;
+			}
+		},
+
+		refresh : function() {
+			this._setMethod('refresh');
+			this._init();
+		},
+
+		destroy : function() {
+			this._setMethod('destroy');
+			this._init();
+		},
+
+		getActionURL : function(urlString) {
+			var URL = '';
+			if(window !== undefined) {
+				URL = window.location.protocol+'//'+window.location.host;
+			}
+			if(this.isAbsoluteURL(urlString)) {
+				URL = urlString;
+			} else {
+				URL += '/'+urlString.replace(/^\/|\/$/g, '');
+			}
+			return URL;
+		},
+
+		isAbsoluteURL : function(urlString) {
+			var regexURL = new RegExp('^(?:[a-z]+:)?//', 'i');
+			return (regexURL.test(urlString))? true: false;
+		},
+
+		unique: function(list) {
+			var result = [];
+			var _self  = this;
+			$.each(list, function(i, e) {
+				if(typeof e === 'object') {
+					if(!_self.objectInArray(e, result)) {
+						result.push(e);
+					}
+				} else {
+					if($.inArray(e, result) == -1) {
+						result.push(e);
+					}
+				}
+			});
+			return result;
+		},
+
+		objectInArray : function(element, result) {
+			if(result.length) {
+				var present = false;
+				$.each(result, function(i, e) {
+					if(typeof e === 'object') {
+						if(e.value == element.value) {
+							present = true;
+							return false;
+						}
+					} else {
+						if(e == element.value) {
+							present = true;
+							return false;
+						}
+					}
+				});
+				return present;
+			} else {
+				return false;
+			}
+		},
+
+		isSimilarText: function(str1, str2, perc) {
+			if(!this.settings.checkSimilar) {
+				return false;
+			}
+			var percent = this.similarity(str1, str2);
+			return (percent*100 >= perc)? true: false;
+		},
+
+		similarity: function(s1, s2) {
+			var longer = s1;
+			var shorter = s2;
+			if(s1.length < s2.length) {
+				longer = s2;
+				shorter = s1;
+			}
+			var longerLength = longer.length;
+			if(longerLength == 0) {
+				return 1.0;
+			}
+			return (longerLength - this.editDistance(longer, shorter))/parseFloat(longerLength);
+		},
+
+		editDistance: function(s1, s2) {
+			s1 = s1.toLowerCase();
+			s2 = s2.toLowerCase();
+			var costs = new Array();
+			for(var i = 0; i <= s1.length; i++) {
+				var lastValue = i;
+				for(var j = 0; j <= s2.length; j++) {
+					if(i == 0) {
+						costs[j] = j;
+					} else {
+						if(j > 0) {
+							var newValue = costs[j-1];
+							if(s1.charAt(i-1) != s2.charAt(j-1)) {
+								newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
+							}
+							costs[j-1] = lastValue;
+							lastValue  = newValue;
+						}
+					}
+				}
+				if(i > 0)
+					costs[s2.length] = lastValue;
+			}
+			return costs[s2.length];
+		},
+
+		checkPlusAfter : function(fromBlur) {
+			if(this.settings.showPlusAfter > 0) {
+				if(this.tagNames.length > this.settings.showPlusAfter) {
+					var _self 	   = this;
+					var plusNumber = this.tagNames.length - this.settings.showPlusAfter;
+					if(!this.selectors.plusTag) {
+						var html  = '<span class="'+this.classes.plusItem.substring(1)+'"></span>';
+						this.selectors.plusTag 	= $(html).appendTo(this.selectors.inputArea);
+						$(this.selectors.plusTag).addClass(this.classes.showPlusBg.substring(1));
+						/**
+						 * Show input after focus on input area
+						 */
+						$(this.selectors.inputArea).click(function(){
+							$(_self.selectors.sTagsInput).show();
+						});
+					}
+					$(this.selectors.plusTag).text('+ '+plusNumber);
+					$tagItems = $(this.selectors.inputArea).find(this.classes.tagItem);
+					$tagItems.show();
+					if($(this.selectors.inputArea).hasClass(this.classes.focus.substring(1))){
+						$(this.selectors.plusTag).hide();
+					} else {
+						if(fromBlur && !this.blurTgItems) {
+							this.blurTgItems = $tagItems;
+							setTimeout(function(){
+								if(_self.blurTgItems) {
+									_self.blurTgItems.slice(_self.settings.showPlusAfter).hide();
+								}
+							}, 200);
+						} else {
+							this.blurTgItems = null;
+							$tagItems.slice(this.settings.showPlusAfter).hide();
+						}
+						$(this.selectors.sTagsInput).hide();
+						$(this.selectors.plusTag).show();
+					}
+				} else if(this.selectors.plusTag) {
+					$(this.selectors.inputArea).find(this.classes.tagItem).show();
+					$(this.selectors.plusTag).hide();
+				}
+			}
+		}
+	};
+
+	$.fn.amsifySuggestags = function(options, method) {
+		return this.each(function() {
+			var amsifySuggestags = new AmsifySuggestags(this);
+			amsifySuggestags._settings(options);
+			amsifySuggestags._setMethod(method);
+			amsifySuggestags._init();
+		});
+	};
+}));

--- a/vendor/assets/stylesheets/amsify.suggestags.css
+++ b/vendor/assets/stylesheets/amsify.suggestags.css
@@ -1,0 +1,198 @@
+.amsify-suggestags-area
+.amsify-suggestags-input-area-default {
+	cursor: pointer;
+    border: 1px solid #cccccc;
+    min-height: 20px;
+    padding: 8px 5px;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-input-area {
+	text-align: left;
+	height: auto;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-input-area:hover {
+	cursor: text;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-input-area
+.amsify-suggestags-input {
+	max-width: 200px;
+	padding: 0px 4px;
+	border: 0;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-input-area
+.amsify-suggestags-input:focus {
+	outline: 0;
+}
+
+.amsify-focus {
+	border-color: #66afe9;
+	outline: 0;
+	-webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
+	box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
+}
+
+.amsify-focus-light {
+	border-color: #cacaca;
+	outline: 0;
+	-webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(189, 189, 189, 0.6);
+	box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(189, 189, 189, 0.6);
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-label {
+	cursor: pointer;
+	min-height: 20px;
+}
+
+.amsify-toggle-suggestags {
+	float: right;
+	cursor: pointer;
+}
+
+.amsify-suggestags-area .amsify-suggestags-list {
+	display: none;
+	position: absolute;
+	background: white;
+	border: 1px solid #dedede;
+	z-index: 1;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-list
+ul.amsify-list {
+	list-style: none;
+	padding: 3px 0px;
+	max-height: 150px;
+    overflow-y: auto;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-list
+ul.amsify-list
+li.amsify-list-item {
+	text-align: left;
+    cursor: pointer;
+    padding: 0px 10px;	
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-list
+ul.amsify-list
+li.amsify-list-item:active {
+	background: #717171;
+    color: white;
+    -moz-box-shadow:    inset 0 0 10px #000000;
+    -webkit-box-shadow: inset 0 0 10px #000000;
+    box-shadow:         inset 0 0 10px #000000;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-list
+ul.amsify-list
+li.amsify-list-group {
+	text-align: left;
+    padding: 0px 10px;
+    font-weight: bold;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-list
+ul.amsify-list
+li.amsify-item-pad {
+    padding-left: 30px;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-list
+ul.amsify-list
+li.amsify-item-noresult {
+    display: none;
+    color: #ff6060;
+    font-weight: bold;
+    text-align: center;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-list
+.amsify-select-input {
+	display: none;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-list
+ul.amsify-list
+li.active {
+	background: #d9d8d8;
+}
+
+.amsify-suggestags-area
+.amsify-suggestags-list
+ul.amsify-list
+li.amsify-item-pad.active {
+	font-weight: normal;
+}
+
+.amsify-suggestags-input-area
+.amsify-select-tag,
+.amsify-suggestags-input-area
+.amsify-plus-tag {
+    padding: 2px 7px;
+    margin: 0px 4px 1px 0px;
+    -webkit-border-radius: 2px;
+    -moz-border-radius: 2px;
+    border-radius: 2px;
+    display: inline-block;
+}
+
+.amsify-suggestags-input-area
+.amsify-select-tag.col-bg {
+	background: #d8d8d8;
+    color: black;
+}
+
+.amsify-suggestags-input-area
+.amsify-plus-tag.show-plus-bg {
+	background: #767676;
+    color: white;
+    -webkit-border-radius: 15px;
+    -moz-border-radius: 15px;
+    border-radius: 15px;
+}
+
+/*.amsify-suggestags-input-area
+.amsify-select-tag:hover {
+	background: #737373;
+    color: white;
+}*/
+
+.amsify-suggestags-input-area
+.disabled.amsify-select-tag {
+    background: #eaeaea;
+    color: #b9b9b9;
+    pointer-events: none;
+}
+
+.amsify-suggestags-input-area
+.flash.amsify-select-tag {
+    background-color: #f57f7f;
+    -webkit-transition: background-color 200ms linear;
+    -ms-transition: background-color 200ms linear;
+    transition: background-color 200ms linear;
+}
+
+.amsify-suggestags-input-area
+.amsify-remove-tag {
+	cursor: pointer;
+}
+
+.amsify-no-suggestion {
+	display: none;
+	opacity: 0.7;
+}


### PR DESCRIPTION
## References
Related PR: #4262 

## Objectives
- Adding a new component to be able to relate a resource to Goals and Targets with the same field.
- This component will also have a list of icons of all the Goals to be able to add or remove tags by clicking on them.
- This field has to be able to autocomplete both Goals and Targets.
- We will show tags with for each Goal and Target related to the following format:
  - Goals:  "SDG" prefix + Goal code. Example "SDG1", "SDG2", ...
  - Targets: Target code. Example "1.1", "2.A", ...
- Add a help section to display the title of the selected Goals and Targets/

## Visual Changes
![Captura de pantalla 2021-01-20 a las 13 59 28](https://user-images.githubusercontent.com/16189/105177997-c57ba900-5b27-11eb-825f-e74101f4a4bf.png)


## Notes
Add JQuery library for input tags: https://github.com/amsify42/jquery.amsify.suggestags

