### PR TITLE
Add SDG stats page to admin section

### DIFF
--- a/app/components/admin/stats/sdg/goal_component.html.erb
+++ b/app/components/admin/stats/sdg/goal_component.html.erb
@@ -1,0 +1,14 @@
+<div class="sdg-goal-stats">
+
+  <h3><%= goal.code_and_title %></h3>
+
+  <div class="stats-numbers">
+    <% stats.each do |text, amount, options = {}| %>
+      <div class="small-12 medium-4 column">
+        <%= tag.p(options) do %>
+          <%= text %> <br><span class="number"><%= amount %></span>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/components/admin/stats/sdg/goal_component.rb
+++ b/app/components/admin/stats/sdg/goal_component.rb
@@ -1,0 +1,30 @@
+class Admin::Stats::SDG::GoalComponent < ApplicationComponent
+  with_collection_parameter :goal
+
+  attr_reader :goal
+
+  def initialize(goal:)
+    @goal = goal
+  end
+
+  private
+
+    def stats
+      [
+        [t("admin.stats.sdg.polls"), goal.polls.count],
+        [t("admin.stats.sdg.proposals"), goal.proposals.count],
+        [t("admin.stats.sdg.debates"), goal.debates.count],
+        [t("admin.stats.sdg.budget_investments.sent"), goal.budget_investments.count],
+        [t("admin.stats.sdg.budget_investments.winners"), goal.budget_investments.winners.count, featured],
+        [t("admin.stats.sdg.budget_investments.amount"), amount, featured]
+      ]
+    end
+
+    def amount
+      number_to_currency(goal.budget_investments.winners.sum(:price), precision: 0)
+    end
+
+    def featured
+      { class: "featured" }
+    end
+end

--- a/app/components/admin/stats/sdg_component.html.erb
+++ b/app/components/admin/stats/sdg_component.html.erb
@@ -1,0 +1,5 @@
+<%= back_link_to %>
+
+<%= header %>
+
+<%= render Admin::Stats::SDG::GoalComponent.with_collection(goals) %>

--- a/app/components/admin/stats/sdg_component.rb
+++ b/app/components/admin/stats/sdg_component.rb
@@ -1,0 +1,15 @@
+class Admin::Stats::SDGComponent < ApplicationComponent
+  include Header
+
+  attr_reader :goals
+
+  def initialize(goals)
+    @goals = goals
+  end
+
+  private
+
+    def title
+      t("admin.stats.sdg.title")
+    end
+end

--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -90,6 +90,10 @@ class Admin::StatsController < Admin::BaseController
     @participants = ::Poll::Voter.where(poll: @polls)
   end
 
+  def sdg
+    @goals = SDG::Goal.order(:code)
+  end
+
   private
 
     def voters_in_heading(heading)

--- a/app/views/admin/stats/sdg.html.erb
+++ b/app/views/admin/stats/sdg.html.erb
@@ -1,0 +1,1 @@
+<%= render Admin::Stats::SDGComponent.new(@goals) %>

--- a/app/views/admin/stats/show.html.erb
+++ b/app/views/admin/stats/show.html.erb
@@ -14,6 +14,8 @@
                     proposal_notifications_admin_stats_path, class: "button hollow" %>
         <%= link_to t("admin.stats.show.incomplete_verifications"),
                      admin_verifications_path, class: "button hollow" %>
+        <%= link_to t("admin.stats.show.sdg"),
+                     sdg_admin_stats_path, class: "button hollow" if feature?(:sdg) %>
       </div>
 
       <div class="clear"></div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1373,6 +1373,7 @@ en:
         proposal_notifications: Proposal notifications
         incomplete_verifications: Incomplete verifications
         polls: Polls
+        sdg: SDG
       graph:
         debate_created: Debates
         visit: Visits
@@ -1423,6 +1424,7 @@ en:
         debates: "Debates"
         polls: "Polls"
         proposals: "Proposals"
+        title: "Sustainable Development Goals - Stats"
     tags:
       create: Create topic
       destroy: Delete topic

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1415,6 +1415,14 @@ en:
           question_name: Question
           origin_web: Web participants
           origin_total: Total participants
+      sdg:
+        budget_investments:
+          amount: "Approved amount"
+          winners: "Winner investment projects"
+          sent: "Investment projects sent"
+        debates: "Debates"
+        polls: "Polls"
+        proposals: "Proposals"
     tags:
       create: Create topic
       destroy: Delete topic

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1372,6 +1372,7 @@ es:
         proposal_notifications: Notificaciones de propuestas
         incomplete_verifications: Verificaciones incompletas
         polls: Votaciones
+        sdg: ODS
       graph:
         debate_created: Debates
         visit: Visitas
@@ -1422,6 +1423,7 @@ es:
         debates: "Debates"
         polls: "Votaciones"
         proposals: "Propuestas"
+        title: "Objetivos de Desarrollo Sostenible - Estadísticas"
     tags:
       create: Crear tema
       destroy: Eliminar tema

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1414,6 +1414,14 @@ es:
           question_name: Pregunta
           origin_web: Participantes en Web
           origin_total: Participantes Totales
+      sdg:
+        budget_investments:
+          amount: "Presupuesto aprobado"
+          winners: "Proyectos de inversión ganadores"
+          sent: "Proyectos de inversión enviados"
+        debates: "Debates"
+        polls: "Votaciones"
+        proposals: "Propuestas"
     tags:
       create: Crear tema
       destroy: Eliminar tema

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -204,6 +204,7 @@ namespace :admin do
     get :proposal_notifications, on: :collection
     get :direct_messages, on: :collection
     get :polls, on: :collection
+    get :sdg, on: :collection
   end
 
   namespace :legislation do

--- a/spec/components/admin/stats/sdg/goal_component_spec.rb
+++ b/spec/components/admin/stats/sdg/goal_component_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Admin::Stats::SDG::GoalComponent, type: :component do
+  let(:component) { Admin::Stats::SDG::GoalComponent.new(goal: goal) }
+  let(:goal) { SDG::Goal.sample }
+
+  it "shows goal stats" do
+    create_list(:poll, 2, sdg_goals: [goal])
+    create_list(:proposal, 3, sdg_goals: [goal])
+    create_list(:debate, 1, sdg_goals: [goal])
+    create_list(:budget_investment, 2, :winner, sdg_goals: [goal], price: 1000)
+    create_list(:budget_investment, 2, sdg_goals: [goal], price: 1000)
+
+    render_inline component
+
+    expect(page).to have_text "Proposals 3"
+    expect(page).to have_text "Polls 2"
+    expect(page).to have_text "Debates 1"
+    expect(page).to have_text "Investment projects sent 4"
+    expect(page).to have_text "Winner investment projects 2"
+    expect(page).to have_text "Approved amount $2,000"
+  end
+end

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -395,4 +395,29 @@ describe "Stats", :admin do
       end
     end
   end
+
+  context "SDG", :js do
+    scenario "Shows SDG stats link when SDG feature is enabled" do
+      Setting["feature.sdg"] = true
+
+      visit admin_stats_path
+
+      expect(page).to have_link "SDG", href: sdg_admin_stats_path
+    end
+
+    scenario "Does not show SDG stats link when SDG feature is disbled" do
+      Setting["feature.sdg"] = false
+
+      visit admin_stats_path
+
+      expect(page).not_to have_link "SDG"
+    end
+
+    scenario "Renders all goals stats" do
+      visit sdg_admin_stats_path
+
+      expect(page).to have_css "h3", count: SDG::Goal.count
+      expect(page).to have_css ".sdg-goal-stats", count: SDG::Goal.count
+    end
+  end
 end


### PR DESCRIPTION
## Objectives

Add new page to admin stats to show each goal stats:

* Number of proposals
* Number of polls
* Number of debates
* Investment projects:
  * Number of submitted projects
  * Number of winner projects

## Visual Changes

**Desktop version**
<img width="1108" alt="Captura de pantalla 2021-01-21 a las 16 16 50" src="https://user-images.githubusercontent.com/15726/105371067-85d6bf00-5c04-11eb-8d01-8359649ccb70.png">
<img width="1109" alt="Captura de pantalla 2021-01-21 a las 16 17 01" src="https://user-images.githubusercontent.com/15726/105371072-8707ec00-5c04-11eb-8800-ff0832b52011.png">

**Mobile version**
<img width="444" alt="Captura de pantalla 2021-01-21 a las 16 21 26" src="https://user-images.githubusercontent.com/15726/105371333-cd5d4b00-5c04-11eb-8bd6-2371286e30cd.png">
