### PR TITLE
Add related list selector component to forms

### DIFF
--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -1,4 +1,6 @@
 .sdg-related-list-selector {
+  @include grid-column-gutter;
+  clear: both;
 
   .amsify-suggestags-area .amsify-select-tag {
     color: $white;

--- a/app/assets/stylesheets/sdg_management/relations/edit.scss
+++ b/app/assets/stylesheets/sdg_management/relations/edit.scss
@@ -1,0 +1,6 @@
+.sdg-relations-edit {
+
+  .sdg-related-list-selector {
+    padding: 0;
+  }
+}

--- a/app/components/sdg/related_list_selector_component.rb
+++ b/app/components/sdg/related_list_selector_component.rb
@@ -28,6 +28,10 @@ class SDG::RelatedListSelectorComponent < ApplicationComponent
     }
   end
 
+  def render?
+    SDG::ProcessEnabled.new(f.object).enabled?
+  end
+
   private
 
     def goals

--- a/app/components/sdg_management/relations/edit_component.html.erb
+++ b/app/components/sdg_management/relations/edit_component.html.erb
@@ -1,6 +1,6 @@
 <%= header %>
 
-<%= form_for record, url: update_path do |f| %>
+<%= form_for record, url: update_path, html: { class: "sdg-relations-edit" } do |f| %>
   <%= render SDG::RelatedListSelectorComponent.new(f) %>
 
   <%= f.submit %>

--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -69,6 +69,7 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         :custom_list,
         :background_color,
         :font_color,
+        :sdg_related_list,
         translation_params(::Legislation::Process),
         documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
         image_attributes: image_attributes

--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -76,7 +76,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
     end
 
     def poll_params
-      attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :budget_id,
+      attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :budget_id, :sdg_related_list,
                     geozone_ids: [], image_attributes: image_attributes]
 
       params.require(:poll).permit(*attributes, *report_attributes, translation_params(Poll))

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -132,8 +132,8 @@ module Budgets
       end
 
       def investment_params
-        attributes = [:heading_id, :tag_list,
-                      :organization_name, :location, :terms_of_service, :skip_map,
+        attributes = [:heading_id, :tag_list, :organization_name, :location,
+                      :terms_of_service, :skip_map, :sdg_related_list,
                       image_attributes: image_attributes,
                       documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                       map_location_attributes: [:latitude, :longitude, :zoom]]

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -55,7 +55,7 @@ class DebatesController < ApplicationController
   private
 
     def debate_params
-      attributes = [:tag_list, :terms_of_service]
+      attributes = [:tag_list, :terms_of_service, :sdg_related_list]
       params.require(:debate).permit(attributes, translation_params(Debate))
     end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -98,8 +98,8 @@ class ProposalsController < ApplicationController
   private
 
     def proposal_params
-      attributes = [:video_url, :responsible_name, :tag_list,
-                    :terms_of_service, :geozone_id, :skip_map,
+      attributes = [:video_url, :responsible_name, :tag_list, :terms_of_service,
+                    :geozone_id, :skip_map, :sdg_related_list,
                     image_attributes: image_attributes,
                     documents_attributes: [:id, :title, :attachment, :cached_attachment,
                                            :user_id, :_destroy],

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -191,6 +191,10 @@
   </div>
 
   <div class="row">
+    <%= render SDG::RelatedListSelectorComponent.new(f) %>
+  </div>
+
+  <div class="row">
     <div class="small-12 medium-3 column clear end">
       <%= f.submit(class: "button success expanded", value: t("admin.legislation.processes.#{admin_submit_action(@process)}.submit_button")) %>
     </div>

--- a/app/views/admin/legislation/processes/index.html.erb
+++ b/app/views/admin/legislation/processes/index.html.erb
@@ -20,6 +20,8 @@
         <th class="text-center"><%= t("admin.legislation.processes.process.start_date") %></th>
         <th class="text-center"><%= t("admin.legislation.processes.process.end_date") %></th>
         <th class="text-center"><%= t("admin.legislation.processes.process.comments") %></th>
+        <th class="text-center"><%= SDG::Goal.model_name.human(count: :other).upcase_first %></th>
+        <th class="text-center"><%= SDG::Target.model_name.human(count: :other).upcase_first %></th>
         <th><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
@@ -32,6 +34,8 @@
           <td class="text-center"><%= I18n.l process.start_date %></td>
           <td class="text-center"><%= I18n.l process.end_date %></td>
           <td class="text-center"><%= process.total_comments %></td>
+          <td class="text-center"><%= process.sdg_goal_list %></td>
+          <td class="text-center"><%= process.sdg_target_list %></td>
           <td><%= render Admin::TableActionsComponent.new(process) %></td>
         </tr>
       <% end %>

--- a/app/views/admin/poll/polls/_form.html.erb
+++ b/app/views/admin/poll/polls/_form.html.erb
@@ -56,6 +56,10 @@
   </div>
 
   <div class="row">
+    <%= render SDG::RelatedListSelectorComponent.new(f) %>
+  </div>
+
+  <div class="row">
     <div class="clear">
       <div class="small-12 medium-4 large-2 column">
         <%= f.submit t("admin.polls.#{admin_submit_action(@poll)}.submit_button"),

--- a/app/views/admin/poll/polls/_poll.html.erb
+++ b/app/views/admin/poll/polls/_poll.html.erb
@@ -1,13 +1,9 @@
 <tr id="<%= dom_id(poll) %>" class="poll">
-  <td>
-    <strong><%= poll.name %></strong>
-  </td>
-  <td class="text-center">
-    <%= l poll.starts_at.to_date %>
-  </td>
-  <td class="text-center">
-    <%= l poll.ends_at.to_date %>
-  </td>
+  <td><strong><%= poll.name %></strong></td>
+  <td class="text-center"><%= l poll.starts_at.to_date %></td>
+  <td class="text-center"><%= l poll.ends_at.to_date %></td>
+  <td class="text-center"><%= poll.sdg_goal_list %></td>
+  <td class="text-center"><%= poll.sdg_target_list %></td>
   <td>
     <%= render Admin::TableActionsComponent.new(poll,
       destroy_confirmation: t("admin.polls.destroy.alert")

--- a/app/views/admin/poll/polls/index.html.erb
+++ b/app/views/admin/poll/polls/index.html.erb
@@ -14,6 +14,8 @@
       <th class="small-5"><%= t("admin.polls.index.name") %></th>
       <th class="text-center"><%= t("admin.polls.index.start_date") %></th>
       <th class="text-center"><%= t("admin.polls.index.closing_date") %></th>
+      <th class="text-center"><%= SDG::Goal.model_name.human(count: :other).upcase_first %></th>
+      <th class="text-center"><%= SDG::Target.model_name.human(count: :other).upcase_first %></th>
       <th><%= t("admin.actions.actions") %></th>
     </thead>
     <tbody>

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -86,6 +86,8 @@
                         data: { js_url: suggest_tags_path } %>
     </div>
 
+    <%= render SDG::RelatedListSelectorComponent.new(f) %>
+
     <% unless current_user.manager? %>
 
       <div class="small-12 column">

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -32,6 +32,9 @@
                         data: { js_url: suggest_tags_path },
                         class: "tag-autocomplete" %>
     </div>
+
+    <%= render SDG::RelatedListSelectorComponent.new(f) %>
+
     <div class="small-12 column">
       <% if @debate.new_record? %>
         <%= f.check_box :terms_of_service,

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -93,6 +93,8 @@
       </div>
     <% end %>
 
+    <%= render SDG::RelatedListSelectorComponent.new(f) %>
+
     <div class="small-12 column">
       <% if @proposal.new_record? %>
         <%= f.check_box :terms_of_service,

--- a/spec/components/sdg/related_list_selector_component_spec.rb
+++ b/spec/components/sdg/related_list_selector_component_spec.rb
@@ -5,6 +5,27 @@ describe SDG::RelatedListSelectorComponent, type: :component do
   let(:form) { ConsulFormBuilder.new(:debate, debate, ActionView::Base.new, {}) }
   let(:component) { SDG::RelatedListSelectorComponent.new(form) }
 
+  before do
+    Setting["feature.sdg"] = true
+    Setting["sdg.process.debates"] = true
+  end
+
+  it "does not render when the feature is disabled" do
+    Setting["feature.sdg"] = false
+
+    render_inline component
+
+    expect(page).not_to have_css ".sdg-related-list-selector"
+  end
+
+  it "does not render when the SDG process feature is disabled" do
+    Setting["sdg.process.debates"] = false
+
+    render_inline component
+
+    expect(page).not_to have_css ".sdg-related-list-selector"
+  end
+
   it "renders sdg_related_list field" do
     render_inline component
 

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -43,4 +43,14 @@ module CommonActions
     allow_any_instance_of(Officing::BaseController).
     to receive(:current_booth).and_return(booth)
   end
+
+  def click_sdg_goal(code)
+    find("li[data-code='#{code}']").click
+  end
+
+  def remove_sdg_goal_or_target_tag(code)
+    within "span[data-val='#{code}']" do
+      click_button "Remove"
+    end
+  end
 end

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -330,4 +330,42 @@ describe "Admin collaborative legislation", :admin do
       expect(page).not_to have_link "Remove language"
     end
   end
+
+  context "SDG related list" do
+    before do
+      Setting["feature.sdg"] = true
+      Setting["sdg.process.legislation"] = true
+    end
+
+    scenario "create Collaborative Legislation with sdg related list", :js do
+      visit new_admin_legislation_process_path
+      fill_in "Process Title", with: "Legislation process with SDG related content"
+      within_fieldset "Process" do
+        fill_in "Start", with: 2.days.ago
+        fill_in "End", with: 1.day.from_now
+      end
+
+      click_sdg_goal(17)
+      click_button "Create process"
+      visit admin_legislation_processes_path
+
+      within("tr", text: "Legislation process with SDG related content") do
+        expect(page).to have_css "td", exact_text: "17"
+      end
+    end
+
+    scenario "edit Collaborative Legislation with sdg related list", :js do
+      process = create(:legislation_process, title: "Legislation process with SDG related content")
+      process.sdg_goals = [SDG::Goal[1], SDG::Goal[17]]
+      visit edit_admin_legislation_process_path(process)
+
+      remove_sdg_goal_or_target_tag(1)
+      click_button "Save changes"
+      visit admin_legislation_processes_path
+
+      within("tr", text: "Legislation process with SDG related content") do
+        expect(page).to have_css "td", exact_text: "17"
+      end
+    end
+  end
 end

--- a/spec/system/admin/poll/polls_spec.rb
+++ b/spec/system/admin/poll/polls_spec.rb
@@ -521,4 +521,42 @@ describe "Admin polls", :admin do
       end
     end
   end
+
+  context "SDG related list" do
+    before do
+      Setting["feature.sdg"] = true
+      Setting["sdg.process.polls"] = true
+    end
+
+    scenario "create poll with sdg related list", :js do
+      visit new_admin_poll_path
+      fill_in "Name", with: "Upcoming poll with SDG related content"
+      fill_in "Start Date", with: 1.week.from_now
+      fill_in "Closing Date", with: 2.weeks.from_now
+      fill_in "Summary", with: "Upcoming poll's summary. This poll..."
+      fill_in "Description", with: "Upcomming poll's description. This poll..."
+
+      click_sdg_goal(17)
+      click_button "Create poll"
+      visit admin_polls_path
+
+      within("tr", text: "Upcoming poll with SDG related content") do
+        expect(page).to have_css "td", exact_text: "17"
+      end
+    end
+
+    scenario "edit poll with sdg related list", :js do
+      poll = create(:poll, name: "Upcoming poll with SDG related content")
+      poll.sdg_goals = [SDG::Goal[1], SDG::Goal[17]]
+      visit edit_admin_poll_path(poll)
+
+      remove_sdg_goal_or_target_tag(1)
+      click_button "Update poll"
+      visit admin_polls_path
+
+      within("tr", text: "Upcoming poll with SDG related content") do
+        expect(page).to have_css "td", exact_text: "17"
+      end
+    end
+  end
 end

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1933,4 +1933,41 @@ describe "Budget Investments" do
       end
     end
   end
+
+  describe "SDG related list" do
+    before do
+      Setting["feature.sdg"] = true
+      Setting["sdg.process.budgets"] = true
+      budget.update!(phase: "accepting")
+    end
+
+    scenario "create budget investment with sdg related list", :js do
+      login_as(author)
+      visit new_budget_investment_path(budget)
+      select heading.name, from: "Heading"
+      fill_in "Title", with: "A title for a budget investment related with SDG related content"
+      fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
+      click_sdg_goal(1)
+      check "budget_investment_terms_of_service"
+
+      click_button "Create Investment"
+
+      within(".sdg-goal-tag-list") { expect(page).to have_link "1. No Poverty" }
+    end
+
+    scenario "edit budget investment with sdg related list", :js do
+      investment = create(:budget_investment, heading: heading, author: author)
+      investment.sdg_goals = [SDG::Goal[1], SDG::Goal[2]]
+      login_as(author)
+      visit edit_budget_investment_path(budget, investment)
+
+      remove_sdg_goal_or_target_tag(1)
+      click_button "Update Investment"
+
+      within(".sdg-goal-tag-list") do
+        expect(page).not_to have_link "1. No Poverty"
+        expect(page).to have_link "2. Zero Hunger"
+      end
+    end
+  end
 end

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -1115,4 +1115,41 @@ describe "Debates" do
       expect(page).not_to have_content("Featured")
     end
   end
+
+  describe "SDG related list" do
+    let(:user) { create(:user) }
+
+    before do
+      Setting["feature.sdg"] = true
+      Setting["sdg.process.debates"] = true
+    end
+
+    scenario "create debate with sdg related list", :js do
+      login_as(user)
+      visit new_debate_path
+      fill_in "Debate title", with: "A title for a debate related with SDG related content"
+      fill_in_ckeditor "Initial debate text", with: "This is very important because..."
+      click_sdg_goal(1)
+      check "debate_terms_of_service"
+
+      click_button "Start a debate"
+
+      within(".sdg-goal-tag-list") { expect(page).to have_link "1. No Poverty" }
+    end
+
+    scenario "edit debate with sdg related list", :js do
+      debate = create(:debate, author: user)
+      debate.sdg_goals = [SDG::Goal[1], SDG::Goal[2]]
+      login_as(user)
+      visit edit_debate_path(debate)
+
+      remove_sdg_goal_or_target_tag(1)
+      click_button "Save changes"
+
+      within(".sdg-goal-tag-list") do
+        expect(page).not_to have_link "1. No Poverty"
+        expect(page).to have_link "2. Zero Hunger"
+      end
+    end
+  end
 end

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -1907,4 +1907,42 @@ describe "Successful proposals" do
       expect(page).to have_content "Proposal created successfully."
     end
   end
+
+  describe "SDG related list" do
+    let(:user) { create(:user) }
+
+    before do
+      Setting["feature.sdg"] = true
+      Setting["sdg.process.proposals"] = true
+    end
+
+    scenario "create proposal with sdg related list", :js do
+      login_as(user)
+      visit new_proposal_path
+      fill_in "Proposal title", with: "A title for a proposal related with SDG related content"
+      fill_in "Proposal summary", with: "In summary, what we want is..."
+      fill_in "proposal_responsible_name", with: "Isabel Garcia"
+      click_sdg_goal(1)
+      check "proposal_terms_of_service"
+
+      click_button "Create proposal"
+
+      within(".sdg-goal-tag-list") { expect(page).to have_link "1. No Poverty" }
+    end
+
+    scenario "edit proposal with sdg related list", :js do
+      proposal = create(:proposal, author: user)
+      proposal.sdg_goals = [SDG::Goal[1], SDG::Goal[2]]
+      login_as(user)
+      visit edit_proposal_path(proposal)
+
+      remove_sdg_goal_or_target_tag(1)
+      click_button "Save changes"
+
+      within(".sdg-goal-tag-list") do
+        expect(page).not_to have_link "1. No Poverty"
+        expect(page).to have_link "2. Zero Hunger"
+      end
+    end
+  end
 end

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -218,13 +218,8 @@ describe "SDG Relations", :js do
 
       visit sdg_management_edit_legislation_process_path(process)
 
-      within "span[data-val='2']" do
-        click_button "Remove"
-      end
-
-      within "span[data-val='3.3']" do
-        click_button "Remove"
-      end
+      remove_sdg_goal_or_target_tag(2)
+      remove_sdg_goal_or_target_tag(3.3)
 
       click_button "Update Process"
 
@@ -293,7 +288,7 @@ describe "SDG Relations", :js do
         process = create(:legislation_process, title: "SDG process")
 
         visit sdg_management_edit_legislation_process_path(process)
-        find("li[data-code='1']").click
+        click_sdg_goal(1)
         click_button "Update Process"
         click_link "Marked as reviewed"
 
@@ -307,7 +302,7 @@ describe "SDG Relations", :js do
         process.sdg_goals = [SDG::Goal[1], SDG::Goal[2]]
 
         visit sdg_management_edit_legislation_process_path(process)
-        find("li[data-code='1']").click
+        click_sdg_goal(1)
         click_button "Update Process"
         click_link "Marked as reviewed"
 
@@ -322,7 +317,7 @@ describe "SDG Relations", :js do
         process = create(:legislation_process, title: "SDG process")
 
         visit sdg_management_edit_legislation_process_path(process)
-        find("li[data-code='1']").click
+        click_sdg_goal(1)
 
         expect(find("li[data-code='1']")["aria-checked"]).to eq "true"
       end
@@ -333,15 +328,11 @@ describe "SDG Relations", :js do
         process.sdg_targets = [SDG::Target[1.1]]
 
         visit sdg_management_edit_legislation_process_path(process)
-        within "span[data-val='1']" do
-          click_button "Remove"
-        end
+        remove_sdg_goal_or_target_tag(1)
 
         expect(find("li[data-code='1']")["aria-checked"]).to eq "true"
 
-        within "span[data-val='1.1']" do
-          click_button "Remove"
-        end
+        remove_sdg_goal_or_target_tag(1.1)
 
         expect(find("li[data-code='1']")["aria-checked"]).to eq "false"
       end
@@ -352,7 +343,7 @@ describe "SDG Relations", :js do
         process = create(:legislation_process, title: "SDG process")
 
         visit sdg_management_edit_legislation_process_path(process)
-        find("li[data-code='1']").click
+        click_sdg_goal(1)
 
         within(".help-section") { expect(page).to have_content "No Poverty" }
       end
@@ -365,9 +356,7 @@ describe "SDG Relations", :js do
 
         within(".help-section") { expect(page).to have_content "No Poverty" }
 
-        within "span[data-val='1']" do
-          click_button "Remove"
-        end
+        remove_sdg_goal_or_target_tag(1)
 
         expect(page).not_to have_content "No Poverty"
       end


### PR DESCRIPTION
## References
Related PRs: #4305 #4315 

## Objectives
Add SDG::RelatedListSelectorComponent to allow related SDGs and Targets to:
  - public forms: Proposals, Debates, Investments
  - admin forms: Polls, Legislation Processes

## Visual Changes
![Captura de pantalla 2021-01-22 a las 10 58 56](https://user-images.githubusercontent.com/16189/105476385-dbf94000-5ca0-11eb-8cb9-6bb79a517f46.png)

## Notes
Pending create a new PR to render all icons from RelatedListSelectorComponent in one line on frontend forms.
