### PR TITLE
Add SDG tags to most active feeds

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2770,7 +2770,7 @@ table {
     overflow: visible;
 
     a {
-      img {
+      .figure-card img {
         transition-duration: 0.3s;
         transition-property: transform;
       }
@@ -2780,7 +2780,7 @@ table {
       box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.2);
       text-decoration: none;
 
-      img {
+      .figure-card img {
         transform: scale(1.1);
       }
     }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2785,7 +2785,8 @@ table {
       }
     }
 
-    p {
+    p,
+    .sdg-tag-list {
       padding: 0 $line-height / 4;
     }
   }

--- a/app/assets/stylesheets/widgets/feeds/participation.scss
+++ b/app/assets/stylesheets/widgets/feeds/participation.scss
@@ -22,6 +22,10 @@
     }
   }
 
+  .sdg-tag-list {
+    margin-top: $line-height / 2;
+  }
+
   .feed-debates,
   .feed-proposals {
     @include grid-col;

--- a/app/components/widget/feeds/debate_component.html.erb
+++ b/app/components/widget/feeds/debate_component.html.erb
@@ -1,3 +1,4 @@
 <div class="debate">
   <strong><%= link_to debate.title, url_for(debate) %></strong>
+  <%= render SDG::TagListComponent.new(debate, limit: 5) %>
 </div>

--- a/app/components/widget/feeds/process_component.html.erb
+++ b/app/components/widget/feeds/process_component.html.erb
@@ -8,6 +8,7 @@
       </figcaption>
     </figure>
     <p class="description small"><%= process.summary %></p>
+    <%= render SDG::TagListComponent.new(process, linkable: false) %>
     <p class="small"><%= t("welcome.feed.see_process") %></p>
   <% end %>
 </div>

--- a/app/components/widget/feeds/proposal_component.html.erb
+++ b/app/components/widget/feeds/proposal_component.html.erb
@@ -3,6 +3,7 @@
              <%= "medium-6 large-9" if proposal.image.present? %>">
     <strong><%= link_to proposal.title, url_for(proposal) %></strong><br>
     <p><%= proposal.summary %></p>
+    <%= render SDG::TagListComponent.new(proposal, limit: 5) %>
   </div>
 
   <% if proposal.image.present? %>

--- a/spec/components/widget/feeds/debate_component_spec.rb
+++ b/spec/components/widget/feeds/debate_component_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe Widget::Feeds::DebateComponent, type: :component do
+  let(:debate) { create(:debate, sdg_goals: [SDG::Goal[1]]) }
+  let(:component) { Widget::Feeds::DebateComponent.new(debate) }
+
+  before do
+    Setting["feature.sdg"] = true
+    Setting["sdg.process.debates"] = true
+  end
+
+  it "renders a title with link" do
+    render_inline component
+
+    expect(page).to have_link debate.title, href: "/debates/#{debate.to_param}"
+  end
+
+  it "renders a tag list" do
+    render_inline component
+
+    expect(page).to have_link "1. No Poverty",
+                              title: "See all Debates related to goal 1",
+                              href: "/debates?advanced_search#{CGI.escape("[goal]")}=1"
+  end
+end

--- a/spec/components/widget/feeds/process_component_spec.rb
+++ b/spec/components/widget/feeds/process_component_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Widget::Feeds::ProcessComponent, type: :component do
+  let(:process) { create(:legislation_process, sdg_goals: [SDG::Goal[1]]) }
+  let(:component) { Widget::Feeds::ProcessComponent.new(process) }
+
+  before do
+    Setting["feature.sdg"] = true
+    Setting["sdg.process.legislation"] = true
+  end
+
+  it "renders a card with link" do
+    render_inline component
+
+    expect(page).to have_link href: "/legislation/processes/#{process.to_param}"
+  end
+
+  it "renders a plain tag list" do
+    render_inline component
+
+    expect(page).to have_css("img[alt='1. No Poverty']")
+  end
+end

--- a/spec/components/widget/feeds/proposal_component_spec.rb
+++ b/spec/components/widget/feeds/proposal_component_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe Widget::Feeds::ProposalComponent, type: :component do
+  let(:proposal) { create(:proposal, sdg_goals: [SDG::Goal[1]]) }
+  let(:component) { Widget::Feeds::ProposalComponent.new(proposal) }
+
+  before do
+    Setting["feature.sdg"] = true
+    Setting["sdg.process.proposals"] = true
+  end
+
+  it "renders a title with link" do
+    render_inline component
+
+    expect(page).to have_link proposal.title, href: "/proposals/#{proposal.to_param}"
+  end
+
+  it "renders a tag list" do
+    render_inline component
+
+    expect(page).to have_link "1. No Poverty",
+                              title: "See all Citizen proposals related to goal 1",
+                              href: "/proposals?advanced_search#{CGI.escape("[goal]")}=1"
+  end
+end


### PR DESCRIPTION
## References
Related PR: #4329 

## Objectives
Display tag list on widget feeds:
 - Welcome page
 - Goals index

## Visual Changes
![Captura de pantalla 2021-01-30 a las 19 36 00](https://user-images.githubusercontent.com/16189/106364923-6b9e8e80-6332-11eb-9fe4-93747f9b7a9d.png)

## Notes
For the review just look at the last 3 commits:
- Add tag list component to debate feed
- Add tag list component to proposal feed
- Add tag list component to process feed 
