### PR TITLE
Fix tags and SDG "tags" on legislation proposals

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,0 +1,10 @@
+module TagsHelper
+  def taggables_path(taggable, tag_name)
+    case taggable.class.name
+    when "Legislation::Proposal"
+      legislation_process_proposals_path(taggable.process, search: tag_name)
+    else
+      polymorphic_path(taggable.class, search: tag_name)
+    end
+  end
+end

--- a/app/models/sdg/process_enabled.rb
+++ b/app/models/sdg/process_enabled.rb
@@ -7,7 +7,7 @@ class SDG::ProcessEnabled
   end
 
   def enabled?
-    feature?("sdg") && feature?(process_name) && setting["sdg.process.#{process_name}"]
+    feature?("sdg") && feature?(process_name) && setting["sdg.process.#{process_name}"] && relatable?
   end
 
   def name
@@ -38,5 +38,11 @@ class SDG::ProcessEnabled
 
     def module_name
       name.split("::").first
+    end
+
+    def relatable?
+      return true if controller_path_name?
+
+      (SDG::Related::RELATABLE_TYPES & [record_or_name.class.name, record_or_name]).any?
     end
 end

--- a/app/views/shared/_tags.html.erb
+++ b/app/views/shared/_tags.html.erb
@@ -7,7 +7,7 @@
     <% taggable.tag_list_with_limit(limit).each do |tag| %>
       <li>
         <%= link_to sanitize(tag.name),
-                    polymorphic_path(taggable.class, search: tag.name) %></li>
+                    taggables_path(taggable, tag.name) %></li>
     <% end %>
 
     <% if taggable.tags_count_out_of_limit(limit) > 0 %>

--- a/spec/models/sdg/process_enabled_spec.rb
+++ b/spec/models/sdg/process_enabled_spec.rb
@@ -31,6 +31,12 @@ describe SDG::ProcessEnabled do
 
         expect(process).to be_enabled
       end
+
+      it "returns false when record or name are not a relatable type" do
+        expect(SDG::ProcessEnabled.new(build(:legislation_proposal))).not_to be_enabled
+        expect(SDG::ProcessEnabled.new("Legislation::Proposal")).not_to be_enabled
+        expect(SDG::ProcessEnabled.new("officing/booth")).not_to be_enabled
+      end
     end
 
     context "SDG feature is disabled" do

--- a/spec/models/sdg/process_enabled_spec.rb
+++ b/spec/models/sdg/process_enabled_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe SDG::ProcessEnabled do
+  describe "#enabled?" do
+    context "SDG feature and namespace are enabled" do
+      before do
+        Setting["feature.sdg"] = true
+        %w[debates proposals polls budgets legislation].each do |process_name|
+          Setting["sdg.process.#{process_name}"] = true
+        end
+      end
+
+      it "returns true with relatable records" do
+        SDG::Related::RELATABLE_TYPES.each do |relatable_type|
+          process = SDG::ProcessEnabled.new(relatable_type.constantize.new)
+
+          expect(process).to be_enabled
+        end
+      end
+
+      it "returns true with relatable class names" do
+        SDG::Related::RELATABLE_TYPES.each do |relatable_type|
+          process = SDG::ProcessEnabled.new(relatable_type)
+
+          expect(process).to be_enabled
+        end
+      end
+
+      it "returns true with relatable controller paths" do
+        process = SDG::ProcessEnabled.new("budgets/investments")
+
+        expect(process).to be_enabled
+      end
+    end
+
+    context "SDG feature is disabled" do
+      before do
+        Setting["feature.sdg"] = false
+        Setting["sdg.process.debates"] = true
+      end
+
+      it "returns false" do
+        expect(SDG::ProcessEnabled.new(build(:debate))).not_to be_enabled
+        expect(SDG::ProcessEnabled.new("Debate")).not_to be_enabled
+        expect(SDG::ProcessEnabled.new("debates")).not_to be_enabled
+      end
+    end
+
+    context "Some SDG processes are disabled" do
+      before do
+        Setting["feature.sdg"] = true
+        Setting["sdg.process.debates"] = true
+        Setting["sdg.process.proposals"] = false
+      end
+
+      it "returns false for disabled processes" do
+        expect(SDG::ProcessEnabled.new(build(:proposal))).not_to be_enabled
+        expect(SDG::ProcessEnabled.new("Proposal")).not_to be_enabled
+        expect(SDG::ProcessEnabled.new("proposals")).not_to be_enabled
+      end
+
+      it "returns true for enabled processes" do
+        expect(SDG::ProcessEnabled.new(build(:debate))).to be_enabled
+        expect(SDG::ProcessEnabled.new("Debate")).to be_enabled
+        expect(SDG::ProcessEnabled.new("debates")).to be_enabled
+      end
+    end
+  end
+end

--- a/spec/system/legislation/proposals_spec.rb
+++ b/spec/system/legislation/proposals_spec.rb
@@ -226,7 +226,10 @@ describe "Legislation Proposals" do
     expect(page).to have_content "Open concert"
   end
 
-  scenario "Show proposal tags on show", :js do
+  scenario "Show proposal tags on show when SDG is enabled", :js do
+    Setting["feature.sdg"] = true
+    Setting["sdg.process.legislation"] = true
+
     proposal = create(:legislation_proposal, process: process, tag_list: "Culture")
 
     visit legislation_process_proposal_path(proposal.process, proposal)

--- a/spec/system/legislation/proposals_spec.rb
+++ b/spec/system/legislation/proposals_spec.rb
@@ -210,4 +210,27 @@ describe "Legislation Proposals" do
       expect(page).to have_link(process.title)
     end
   end
+
+  scenario "Shows proposal tags as proposals filter", :js do
+    create(:legislation_proposal, process: process, tag_list: "Culture", title: "Open concert")
+    create(:legislation_proposal, process: process, tag_list: "Sports", title: "Baseball field")
+
+    visit legislation_process_proposals_path(process)
+
+    expect(page).to have_content "Open concert"
+    expect(page).to have_content "Baseball field"
+
+    click_link "Culture"
+
+    expect(page).not_to have_content "Baseball field"
+    expect(page).to have_content "Open concert"
+  end
+
+  scenario "Show proposal tags on show", :js do
+    proposal = create(:legislation_proposal, process: process, tag_list: "Culture")
+
+    visit legislation_process_proposal_path(proposal.process, proposal)
+
+    expect(page).to have_link("Culture")
+  end
 end


### PR DESCRIPTION
## References

* These bugs were introduced in pull request #4305

## Objectives

* Fix a bug when displaying tags related to a legislation proposal
* Fix a bug displaying legislation proposals when the SDG feature is enabled