### PR TITLE
Fix flaky budget polls voting spec

### DIFF
--- a/spec/system/budget_polls/voter_spec.rb
+++ b/spec/system/budget_polls/voter_spec.rb
@@ -54,6 +54,8 @@ describe "BudgetPolls", :with_frozen_time do
 
       within("#poll_#{poll.id}") do
         click_button("Confirm vote")
+
+        expect(page).to have_content "Vote introduced"
       end
 
       visit new_officing_residence_path


### PR DESCRIPTION
## References

* This test failed in https://github.com/consul/consul/runs/1855207922

## Failure

```
1) BudgetPolls Offline A citizen cannot vote offline again
     Failure/Error:
       Rails.cache.fetch(translation_class.where(locale: locale)) do
         all.map do |content|
           [content.key, translation_class.find_by(i18n_content_id: content, locale: locale)&.value]
         end.to_h
       end

     ActionView::Template::Error:
       PG::ProtocolViolation: ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 1
       : SELECT COUNT(*) AS "size", MAX("i18n_content_translations"."updated_at") AS timestamp FROM "i18n_content_translations" WHERE "i18n_content_translations"."locale" = $1

     # ./app/models/i18n_content.rb:99:in `translations_hash'
     # ./config/initializers/i18n_translation.rb:13:in `t'
     # ./app/views/officing/voters/_voted.html.erb:2:in `_app_views_officing_voters__voted_html_erb___770453900510770847_69845250837360'
     # ./app/views/officing/voters/create.js.erb:1:in `_app_views_officing_voters_create_js_erb__523806974899496352_69845250796300'
     # ./config/initializers/wicked_pdf.rb:10:in `render'
     # ------------------
     # --- Caused by: ---
     # PG::ProtocolViolation:
     #   ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 1
     #   ./app/models/i18n_content.rb:99:in `translations_hash'
```

## Objectives

* Make the test pass 100% of the time

## Notes

A possible cause could be an HTTP request taking place at the same time as an AJAX request, with both trying to access the database at the same time. We've had several similar issues in the past which have been fixed by checking the AJAX request has finished before requesting another page, so we're applying the same principle here.