### PR TITLE
Try to avoid exceptions after flaggable tests

### DIFF
--- a/spec/shared/system/flaggable.rb
+++ b/spec/shared/system/flaggable.rb
@@ -34,7 +34,12 @@ shared_examples "flaggable" do |factory_name, admin: false|
       expect(page).not_to have_link "Flag as inappropriate", visible: :all
     end
 
-    expect(Flag.flagged?(user, flaggable)).to be
+    visit path
+
+    within "##{dom_id(flaggable)} .flag-content" do
+      expect(page).to have_link "Unflag", visible: :hidden
+      expect(page).not_to have_link "Flag as inappropriate", visible: :all
+    end
   end
 
   scenario "Unflagging", :js do
@@ -54,7 +59,12 @@ shared_examples "flaggable" do |factory_name, admin: false|
       expect(page).not_to have_link "Unflag", visible: :all
     end
 
-    expect(Flag.flagged?(user, flaggable)).not_to be
+    visit path
+
+    within "##{dom_id(flaggable)} .flag-content" do
+      expect(page).to have_link "Flag as inappropriate", visible: :hidden
+      expect(page).not_to have_link "Unflag", visible: :all
+    end
   end
 
   scenario "Flagging and unflagging", :js do
@@ -66,7 +76,6 @@ shared_examples "flaggable" do |factory_name, admin: false|
       click_link "Flag as inappropriate"
 
       expect(page).to have_css ".flag-active"
-      expect(Flag.flagged?(user, flaggable)).to be
 
       find(".icon-flag").click
       click_link "Unflag"
@@ -74,7 +83,12 @@ shared_examples "flaggable" do |factory_name, admin: false|
       expect(page).not_to have_css ".flag-active"
     end
 
-    expect(Flag.flagged?(user, flaggable)).not_to be
+    visit path
+
+    within "##{dom_id(flaggable)} .flag-content" do
+      expect(page).to have_link "Flag as inappropriate", visible: :hidden
+      expect(page).not_to have_link "Unflag", visible: :all
+    end
   end
 
   scenario "Flagging a comment with a child does not update its children", :js do


### PR DESCRIPTION
## References

* Might be related to the failure in: https://github.com/consul/consul/runs/1856245992

## Failure:

```
  1) Commenting legislation questions Merged comment threads View
comments of annotations in an included range
     Failure/Error: count: annotation.comments.roots.count) %>

     ActionView::Template::Error:
       PG::ProtocolViolation: ERROR:  bind message supplies 0
parameters, but prepared statement "" requires 2
       : SELECT COUNT(*) FROM "comments" WHERE "comments"."hidden_at" IS
NULL AND "comments"."commentable_id" = $1 AND
"comments"."commentable_type" = $2 AND "comments"."ancestry" IS NULL
```

## Objectives

* Run expectations from the user's point of view in system tests
* Try to reduce the number of `PG::ProtocolViolation` we're getting on Github Actions

## Notes

Debugging shows the test which failed run right after the flaggable specs. There's a chance these exceptions take place because the test is accessing the database after the browser (chromedriver) process has already accessed the database.

This is just an attempt at fixing the issue; I don't know whether these changes will fix it since I've only seen this exception on Github Actions (never on my machine). Worst case scenario, we're encouraging good practices of system tests: test things from the user's point of view.