### PR TITLE
Use google icon in sign in page

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1538,8 +1538,7 @@ table {
 .button.button-twitter,
 .button.button-facebook,
 .button.button-google,
-.button.button-wordpress,
-.button.button-telegram {
+.button.button-wordpress {
   background: #fff;
   color: $text;
   font-weight: bold;
@@ -1648,16 +1647,6 @@ table {
   }
 }
 
-.button.button-telegram {
-  background: #ecf7fc;
-  border-left: 3px solid #08c;
-
-  &::before {
-    color: #08c;
-    content: "1";
-  }
-}
-
 .ssb-telegram {
   background: #08c;
 
@@ -1686,7 +1675,6 @@ table {
 
 @include breakpoint(medium) {
 
-  .button.button-telegram,
   .ssb-telegram,
   .ssb-whatsapp_app {
     display: none !important;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1541,29 +1541,19 @@ table {
 .button.button-wordpress {
   color: $text;
   font-weight: bold;
-  height: $line-height * 2;
-  line-height: $line-height * 2;
-  padding: 0;
-  position: relative;
 
   &::before {
-    font-family: "icons" !important;
     font-size: rem-calc(24);
-    left: 0;
-    line-height: $line-height * 2;
-    padding: 0 rem-calc(20);
-    position: absolute;
-    top: 0;
   }
 }
 
 .button.button-twitter {
+  @include has-fa-icon(twitter, brands);
   background: #ecf7fc;
   border-left: 3px solid #45b0e3;
 
   &::before {
     color: #45b0e3;
-    content: "f";
   }
 }
 
@@ -1604,12 +1594,12 @@ table {
 }
 
 .button.button-facebook {
+  @include has-fa-icon(facebook-f, brands);
   background: #ebeef4;
   border-left: 3px solid #3b5998;
 
   &::before {
     color: #3b5998;
-    content: "A";
   }
 }
 
@@ -1627,22 +1617,22 @@ table {
 }
 
 .button.button-google {
+  @include has-fa-icon(google, brands);
   background: #fcedea;
   border-left: 3px solid #de4c34;
 
   &::before {
     color: #de4c34;
-    content: "B";
   }
 }
 
 .button.button-wordpress {
+  @include has-fa-icon(wordpress, brands);
   background: #dcdde3;
   border-left: 3px solid #2f2f33;
 
   &::before {
     color: #2f2f33;
-    content: "J";
   }
 }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1561,17 +1561,13 @@ table {
   background-image: none;
   color: #fff;
   height: $icon-width;
-  position: relative;
+  line-height: $icon-width;
+  text-align: center;
   width: $icon-width;
 
   &::before {
-    font-family: "icons";
     font-size: $icon-width / 2;
-    left: 50%;
-    line-height: $icon-width;
-    margin-left: rem-calc(-11);
-    position: absolute;
-    top: 0;
+    margin-right: 0;
   }
 
   &:hover,
@@ -1581,11 +1577,8 @@ table {
 }
 
 .ssb-twitter {
+  @include has-fa-icon(twitter, brands);
   background: #45b0e3;
-
-  &::before {
-    content: "f";
-  }
 
   &:hover,
   &:focus {
@@ -1604,11 +1597,8 @@ table {
 }
 
 .ssb-facebook {
+  @include has-fa-icon(facebook-f, brands);
   background: #3b5998;
-
-  &::before {
-    content: "A";
-  }
 
   &:hover,
   &:focus {
@@ -1637,11 +1627,8 @@ table {
 }
 
 .ssb-telegram {
+  @include has-fa-icon(telegram-plane, brands);
   background: #08c;
-
-  &::before {
-    content: "1";
-  }
 
   &:hover,
   &:focus {
@@ -1650,11 +1637,8 @@ table {
 }
 
 .ssb-whatsapp_app {
+  @include has-fa-icon(whatsapp, brands);
   background: #43d854;
-
-  &::before {
-    content: "P";
-  }
 
   &:hover,
   &:focus {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1566,9 +1566,9 @@ table {
 
   &::before {
     font-family: "icons";
-    font-size: rem-calc(24);
+    font-size: $icon-width / 2;
     left: 50%;
-    line-height: $line-height * 2;
+    line-height: $icon-width;
     margin-left: rem-calc(-11);
     position: absolute;
     top: 0;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1539,7 +1539,6 @@ table {
 .button.button-facebook,
 .button.button-google,
 .button.button-wordpress {
-  background: #fff;
   color: $text;
   font-weight: bold;
   height: $line-height * 2;

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -169,10 +169,14 @@
   &::before {
     @extend %font-icon;
 
-    @if $style == "regular" {
-      font-weight: normal;
-    } @else {
+    @if $style == "solid" {
       font-weight: bold;
+    } @else {
+      font-weight: normal;
+    }
+
+    @if $style == "brands" {
+      font-family: "Font Awesome 5 Brands";
     }
   }
 


### PR DESCRIPTION
## Objectives

* Replace the google plus icon with the google icon in the link to sign in with google
* Avoid overlapping between text and icon, particularly in the "wordpress" icon

## Visual Changes

### Before these changes

![The google plus icon is used to sign in with google and the wordpress text overlaps with the icon](https://user-images.githubusercontent.com/35156/107407251-bde96780-6b09-11eb-9b70-6dc3d08c522c.png)
![On mobile phones, the icon is aligned to the left while the text is aligned in the center](https://user-images.githubusercontent.com/35156/107407255-be81fe00-6b09-11eb-853c-2cdef9944558.png)

### After these changes

![The google icon is used to sign in with google and there's no overlap between text and icons](https://user-images.githubusercontent.com/35156/107407291-c5107580-6b09-11eb-96e5-26db68674372.png)
![On mobile phones, both the icon and the text are aligned in the center](https://user-images.githubusercontent.com/35156/107407293-c641a280-6b09-11eb-8e66-f5ef0ca12fea.png)
