### PR TITLE
Add SDG help page

### DIFF
--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -244,10 +244,12 @@
   width: calc(100% + #{$spacing});
   width: calc(100% + #{$max-spacing});
 
-  > * {
+  > *,
+  > .tabs-title {
     margin-bottom: 0;
     margin-left: $spacing;
     margin-left: $max-spacing;
+    margin-right: 0;
     margin-top: $spacing;
     margin-top: $max-spacing;
   }
@@ -259,6 +261,33 @@
 
 %sdg-goal-list {
   @include sdg-goal-list;
+}
+
+%sdg-goal-list-expanded {
+  $spacing: 0.5%;
+  @include sdg-goal-list($spacing);
+
+  label,
+  li {
+    min-width: $sdg-icon-min-width;
+    width: calc(100% / 17 - #{$spacing});
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    .sdg-goal-icon {
+      width: 100%;
+    }
+
+    a:focus {
+      outline: none;
+
+      img {
+        outline: $outline-focus;
+      }
+    }
+  }
 }
 
 %tags {

--- a/app/assets/stylesheets/sdg/goals/targets.scss
+++ b/app/assets/stylesheets/sdg/goals/targets.scss
@@ -1,4 +1,4 @@
-.sdg-goal-show .targets {
+.sdg-goal-targets {
   dt,
   dd {
     display: inline;

--- a/app/assets/stylesheets/sdg/help.scss
+++ b/app/assets/stylesheets/sdg/help.scss
@@ -1,0 +1,14 @@
+.sdg-help-content {
+  @include grid-column-gutter;
+
+  > .tabs {
+    @extend %sdg-goal-list-expanded;
+
+    li {
+
+      &:focus {
+        outline: $outline-focus;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -19,6 +19,10 @@
   .goals {
     @extend %sdg-goal-list-expanded;
 
+    + label {
+      @include element-invisible;
+    }
+
     legend {
       font-weight: normal;
       font-style: italic;
@@ -37,9 +41,10 @@
     }
   }
 
-  label {
+  .help-text {
     font-weight: normal;
     font-style: italic;
+    font-size: $base-font-size;
   }
 
   .input-section {

--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -17,25 +17,11 @@
   }
 
   .goals {
-    $spacing: 0.5%;
-    @include sdg-goal-list($spacing);
+    @extend %sdg-goal-list-expanded;
 
     legend {
       font-weight: normal;
       font-style: italic;
-    }
-
-    label {
-      min-width: $sdg-icon-min-width;
-      width: calc(100% / 17 - #{$spacing});
-
-      &:hover {
-        cursor: pointer;
-      }
-
-      .sdg-goal-icon {
-        width: 100%;
-      }
     }
 
     input {

--- a/app/components/sdg/goals/help_page_component.html.erb
+++ b/app/components/sdg/goals/help_page_component.html.erb
@@ -1,0 +1,25 @@
+<% provide(:title) { t("sdg.goals.help.title") } %>
+
+<section class="row sdg-help-content">
+  <h1><%= t("sdg.goals.help.title") %></h1>
+  <p><%= t("sdg.goals.help.description") %></p>
+  <ul class="tabs" id="help_tabs" data-deep-link="true" data-tabs>
+    <% @goals.each do |goal| %>
+      <li class="tabs-title <%= is_active?(goal) %>">
+        <%= link_to "#goal_#{goal.code}_tab" do %>
+          <% render SDG::Goals::IconComponent.new(goal) %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+
+  <div class="tabs-content" data-tabs-content="help_tabs">
+    <% @goals.each do |goal| %>
+      <div id="goal_<%= goal.code %>_tab" class="tabs-panel <%= is_active?(goal) %>">
+        <h2><%= goal.code_and_title %></h2>
+        <p><%= sanitize t("sdg.goals.goal_#{goal.code}.description") %></p>
+        <%= render SDG::Goals::TargetsComponent.new(goal) %>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/components/sdg/goals/help_page_component.html.erb
+++ b/app/components/sdg/goals/help_page_component.html.erb
@@ -1,5 +1,9 @@
 <% provide(:title) { t("sdg.goals.help.title") } %>
 
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: sdg_help_url %>
+<% end %>
+
 <section class="row sdg-help-content">
   <h1><%= t("sdg.goals.help.title") %></h1>
   <p><%= t("sdg.goals.help.description") %></p>

--- a/app/components/sdg/goals/help_page_component.rb
+++ b/app/components/sdg/goals/help_page_component.rb
@@ -1,0 +1,17 @@
+class SDG::Goals::HelpPageComponent < ApplicationComponent
+  attr_reader :goals
+
+  def initialize(goals)
+    @goals = goals
+  end
+
+  def render?
+    feature?("sdg")
+  end
+
+  private
+
+    def is_active?(goal)
+      "is-active" if goal.code == 1
+    end
+end

--- a/app/components/sdg/goals/targets_component.html.erb
+++ b/app/components/sdg/goals/targets_component.html.erb
@@ -1,15 +1,15 @@
-<section class="targets">
-  <ul class="tabs" id="target_tabs" data-deep-link="true" data-tabs>
+<section class="sdg-goal-targets">
+  <ul class="tabs" id="goal_<%= goal.code %>_targets" data-deep-link="true" data-tabs>
     <% [global_targets, local_targets].each do |targets| %>
       <li class="tabs-title <%= active(targets) %>">
-        <%= link_to title(targets), "#tab_#{type(targets)}_targets" %>
+        <%= link_to title(targets), "#goal_#{@goal.code}_tab_#{type(targets)}_targets" %>
       </li>
     <% end %>
   </ul>
 
-  <div class="tabs-content" data-tabs-content="target_tabs">
+  <div class="tabs-content" data-tabs-content="goal_<%= goal.code %>_targets">
     <% [global_targets, local_targets].each do |targets| %>
-      <div class="tabs-panel <%= active(targets) %>" id="tab_<%= type(targets) %>_targets">
+      <div class="tabs-panel <%= active(targets) %>" id="goal_<%= goal.code %>_tab_<%= type(targets) %>_targets">
         <% if targets.blank? %>
           <div class="callout primary">
             <%= t("sdg.goals.show.targets.no_local_targets") %>

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -12,7 +12,11 @@
     <%= f.text_field :related_sdg_list,
                       class: "input",
                       placeholder: t("sdg.related_list_selector.placeholder"),
-                      label: t("sdg.related_list_selector.hint"),
+                      hint: sanitize(t("sdg.related_list_selector.hint",
+                                      link: link_to(t("sdg.related_list_selector.help.text"),
+                                                      sdg_help_path,
+                                                      title: t("shared.target_blank"),
+                                                      target: "_blank"))),
                       data: { "suggestions-list": sdg_related_suggestions,
                               "remove-tag-text": t("sdg.related_list_selector.remove_tag") } %>
   </div>

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -16,7 +16,8 @@
                                       link: link_to(t("sdg.related_list_selector.help.text"),
                                                       sdg_help_path,
                                                       title: t("shared.target_blank"),
-                                                      target: "_blank"))),
+                                                      target: "_blank")),
+                                     attributes: %w[href title target]),
                       data: { "suggestions-list": sdg_related_suggestions,
                               "remove-tag-text": t("sdg.related_list_selector.remove_tag") } %>
   </div>

--- a/app/controllers/sdg/goals_controller.rb
+++ b/app/controllers/sdg/goals_controller.rb
@@ -11,4 +11,8 @@ class SDG::GoalsController < ApplicationController
 
   def show
   end
+
+  def help
+    @goals = @goals.order(:code)
+  end
 end

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -28,7 +28,7 @@ module Abilities
       can [:read, :map, :share], Legislation::Proposal
       can [:search, :comments, :read, :create, :new_comment], Legislation::Annotation
 
-      can :read, ::SDG::Goal
+      can [:read, :help], ::SDG::Goal
       can :read, ::SDG::Phase
     end
   end

--- a/app/views/pages/help/_other.html.erb
+++ b/app/views/pages/help/_other.html.erb
@@ -3,6 +3,10 @@
 <ul class="features">
   <li><%= link_to t("pages.help.other.how_to_use", org_name: setting["org_name"]), how_to_use_path %></li>
 
+  <% if feature?(:sdg) %>
+    <li><%= link_to t("pages.help.other.sdg"), sdg_help_path %></li>
+  <% end %>
+
   <% SiteCustomization::Page.with_more_info_flag.with_same_locale.each do |custom_page| %>
     <li><%= link_to custom_page.title, page_path(custom_page.slug) %></li>
   <% end %>

--- a/app/views/sdg/goals/help.html.erb
+++ b/app/views/sdg/goals/help.html.erb
@@ -1,0 +1,1 @@
+<%= render SDG::Goals::HelpPageComponent.new(@goals) %>

--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -46,7 +46,7 @@
       <li>
         <%= layout_menu_link_to t("layouts.header.sdg"),
                                 sdg_goals_path,
-                                controller_path.split("/").first == "sdg",
+                                controller_path == "sdg/goals" && action_name != "help",
                                 accesskey: "6" %>
       </li>
     <% end %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -7,6 +7,7 @@ en:
     name: Name
     email: Email
     description: Description
+    related_sdg_list: Goals and Targets
   activerecord:
     models:
       activity:

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -56,6 +56,7 @@ en:
       other:
         title: "Other information of interest"
         how_to_use: "Use %{org_name} in your city"
+        sdg: "Sustainable Development Goals help"
       how_to_use:
         text: |-
           Use it in your local government or help us to improve it, it is free software.

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -24,7 +24,7 @@ en:
       goal_2:
         title: "Zero Hunger"
         title_in_two_lines: "Zero\nHunger"
-        description: "Zero Hunger"
+        description: "Zero Hunger."
         long_description: '<p>After decades of steady decline, the number of people who suffer from hunger – as measured by the prevalence of undernourishment – began to slowly increase again in 2015. Current estimates show that <a href="http://www.fao.org/publications/sofi/2020/en/">nearly 690 million people are hungry, or 8.9 percent of the world population</a> – up by 10 million people in one year and by nearly 60 million in five years.</p> <p>The world is not on track to achieve Zero Hunger by 2030. If recent trends continue, the number of people affected by hunger would surpass 840 million by 2030.</p> <p>According to the World Food Programme, <a href="https://www.wfp.org/publications/2020-global-report-food-crises">135 million suffer from acute hunger</a> largely due to man-made conflicts, climate change and economic downturns. The COVID-19 pandemic could now double that number, putting an additional 130 million people at risk of suffering acute hunger by the end of 2020.</p> <p>With more than <a href="https://insight.wfp.org/covid-19-will-almost-double-people-in-acute-hunger-by-end-of-2020-59df0c4a8072">a quarter of a billion people potentially at the brink of starvation</a>, swift action needs to be taken to provide food and humanitarian relief to the most at-risk regions.</p> <p>At the same time,&nbsp;a profound change of the global food and agriculture system is needed if we are to nourish the more than 690 million people who are hungry today – and the&nbsp;<a href="https://www.un.org/development/desa/en/news/population/world-population-prospects-2019.html">additional 2 billion people</a>&nbsp;the world will have by 2050. Increasing agricultural productivity and sustainable food production are crucial to help alleviate the perils of hunger.</p>'
         targets:
           target_2_1:
@@ -441,6 +441,9 @@ en:
             title: "By 2020, enhance capacity-building support to developing countries, including for least developed countries and small island developing States, to increase significantly the availability of high-quality, timely and reliable data disaggregated by income, gender, age, race, ethnicity, migratory status, disability, geographic location and other characteristics relevant in national contexts."
           target_17_19:
             title: "By 2030, build on existing initiatives to develop measurements of progress on sustainable development that complement gross domestic product, and support statistical capacity-building in developing countries."
+      help:
+        title: "Sustainable Development Goals help"
+        description: "You can align your contributions to the community (debates, citizen proposals and investment projects) with the Sustaniable Development Goals 2030 Agenda, this will allow us to have an overview of our contribution to each of the Sustainable Development Goals. Below you can find out about all the goals, their targets and localized targets."
       show:
         read_more: "Read more about %{goal}"
         read_less: "Read less about %{goal}"

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -461,7 +461,8 @@ en:
       goal_list: "You can choose one or several SDGs aligned with your %{record}"
       help:
         title: "Which SDGs and targets are aligned with my %{record}?"
-      hint: "You can introduce the code of a specific goal/target or a text to find one"
+        text: "SDG help page"
+      hint: You can introduce the code of a specific goal/target or a text to find one. For more information visit the %{link}.
       placeholder: "Write a goal or target code or description"
       remove_tag: "Remove"
       title: "Sustainable Development Goals and Targets"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -7,6 +7,7 @@ es:
     name: Nombre
     email: Email
     description: Descripción
+    related_sdg_list: Objetivos y Metas
   activerecord:
     models:
       activity:

--- a/config/locales/es/pages.yml
+++ b/config/locales/es/pages.yml
@@ -56,6 +56,7 @@ es:
       other:
         title: "Otra información de interés"
         how_to_use: "Utiliza %{org_name} en tu municipio"
+        sdg: "Ayuda Objetivos de Desarrollo Sostenible"
       how_to_use:
         text: |-
           Utilízalo en tu municipio libremente o ayúdanos a mejorarlo, es software libre.

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -441,6 +441,9 @@ es:
             title: "De aquí a 2020, mejorar el apoyo a la creación de capacidad prestado a los países en desarrollo, incluidos los países menos adelantados y los pequeños Estados insulares en desarrollo, para aumentar significativamente la disponibilidad de datos oportunos, fiables y de gran calidad desglosados por ingresos, sexo, edad, raza, origen étnico, estatus migratorio, discapacidad, ubicación geográfica y otras características pertinentes en los contextos nacionales."
           target_17_19:
             title: "De aquí a 2030, aprovechar las iniciativas existentes para elaborar indicadores que permitan medir los progresos en materia de desarrollo sostenible y complementen el producto interno bruto, y apoyar la creación de capacidad estadística en los países en desarrollo."
+      help:
+        title: "Ayuda Objetivos de Desarrollo Sostenible"
+        description: "Puedes alinear tus aportaciones a la comunidad (debates, propuestas ciudadanas y proyectos de inversión) con los Objetivos de Desarrollo Sostenible de la Agenda 2030, esto nos permitirá tener una visión general de nuestra aportación en cada uno de los objetivos de desarrollo sostenible. A continuación puedes informarte de todos los objetivos, sus metas y las metas localizadas."
       show:
         read_more: "Leer más sobre %{goal}"
         read_less: "Leer menos sobre %{goal}"

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -461,7 +461,8 @@ es:
       goal_list: "Puedes seleccionar uno o varios ODS con los que se alinea tu %{record}"
       help:
         title: "¿Qué ODS y metas se alinean con mi %{record}?"
-      hint: "Puedes introducir el código de un objetivo/meta específico o un texto para encontrar uno"
+        text: "página de ayuda de ODS"
+      hint: Puedes introducir el código de un objetivo/meta específico o un texto para encontrar uno. Para más información visita la %{link}.
       placeholder: "Escribe las etiquetas que desees"
       remove_tag: "Eliminar"
       title: "Objetivos de Desarrollo Sostenible y Metas"

--- a/config/routes/sdg.rb
+++ b/config/routes/sdg.rb
@@ -1,3 +1,4 @@
 namespace :sdg do
   resources :goals, param: :code, only: [:index, :show]
+  get :help, controller: "goals"
 end

--- a/spec/components/sdg/goals/help_page_component_spec.rb
+++ b/spec/components/sdg/goals/help_page_component_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe SDG::Goals::HelpPageComponent, type: :component do
+  let(:goals) { SDG::Goal.all }
+  let(:component) { SDG::Goals::HelpPageComponent.new(goals) }
+
+  before do
+    Setting["feature.sdg"] = true
+  end
+
+  it "does not render when the feature is disabled" do
+    Setting["feature.sdg"] = false
+
+    render_inline component
+
+    expect(page).not_to have_css ".sdg-help-content"
+  end
+
+  it "renders content when the feature is enabled" do
+    render_inline component
+
+    expect(page).to have_css ".sdg-help-content"
+    expect(page).to have_content SDG::Goal[1].title
+    expect(page).to have_content SDG::Goal[1].description
+    expect(page).to have_css "#help_tabs"
+    expect(page).to have_css "#goal_1_tab"
+  end
+end

--- a/spec/components/sdg/goals/targets_component_spec.rb
+++ b/spec/components/sdg/goals/targets_component_spec.rb
@@ -21,13 +21,13 @@ describe SDG::Goals::TargetsComponent, type: :component do
   it "renders tabs panel" do
     render_inline component
 
-    expect(page).to have_css ".targets"
-    expect(page).to have_css "#target_tabs"
+    expect(page).to have_css ".sdg-goal-targets"
+    expect(page).to have_css "#goal_1_targets"
     expect(page).to have_css "li", count: 2
     expect(page).to have_content "Targets"
     expect(page).to have_content "Local targets"
     expect(page).to have_css ".tabs-content"
-    expect(page).to have_css "#tab_global_targets"
+    expect(page).to have_css "#goal_1_tab_global_targets"
   end
 
   it "renders code and title for each target" do

--- a/spec/system/help_page_spec.rb
+++ b/spec/system/help_page_spec.rb
@@ -25,4 +25,27 @@ describe "Help page" do
       expect(page).not_to have_link "Help"
     end
   end
+
+  scenario "renders the SDG help page link when the feature is enabled" do
+    Setting["feature.help_page"] = true
+    Setting["feature.sdg"] = true
+
+    visit root_path
+    within("#navigation_bar") do
+      click_link "Help"
+    end
+
+    expect(page).to have_link "Sustainable Development Goals help", href: sdg_help_path
+  end
+
+  scenario "does not render the SDG help page link when the feature is disabled" do
+    Setting["feature.sdg"] = nil
+
+    visit root_path
+    within("#navigation_bar") do
+      click_link "Help"
+    end
+
+    expect(page).not_to have_link "Sustainable Development Goals help"
+  end
 end

--- a/spec/system/sdg/goals_spec.rb
+++ b/spec/system/sdg/goals_spec.rb
@@ -122,7 +122,7 @@ describe "SDG Goals", :js do
       create(:sdg_local_target, code: "15.1.1", title: "SDG local target sample text")
       visit sdg_goal_path(15)
 
-      within "#target_tabs" do
+      within ".sdg-goal-targets" do
         expect(page).to have_content "Targets"
         expect(page).to have_content "Local targets"
       end

--- a/spec/system/sdg/goals_spec.rb
+++ b/spec/system/sdg/goals_spec.rb
@@ -140,4 +140,34 @@ describe "SDG Goals", :js do
       end
     end
   end
+
+  describe "Help" do
+    scenario "shows all SDGs targets" do
+      create(:sdg_local_target, code: "15.1.1", title: "SDG local target sample text")
+      visit sdg_help_path
+
+      expect(page).to have_content "You can align your contributions to the community"
+      expect(page).to have_css "h2", exact_text: "1. No Poverty"
+      expect(page).to have_content "End poverty in all its forms, everywhere."
+      expect(page).to have_content "1.1 By 2030, eradicate extreme poverty for all people everywhere"
+
+      click_link "7. Affordable and Clean Energy"
+
+      expect(page).not_to have_css "h2", exact_text: "1. No Poverty"
+      expect(page).to have_css "h2", exact_text: "7. Affordable and Clean Energy"
+      expect(page).to have_content "Ensure access to affordable, reliable, sustainable and modern energy."
+      expect(page).to have_content "7.1 By 2030, ensure universal access to affordable"
+
+      click_link "15. Life on Land"
+
+      expect(page).to have_css "h2", exact_text: "15. Life on Land"
+      expect(page).to have_content "Sustainably manage forests, combat desertification, halt and reverse"
+      expect(page).to have_content "15.1 By 2020, ensure the conservation, restoration and sustainable use"
+
+      click_link "Local targets"
+
+      expect(page).not_to have_content "15.1 By 2020, ensure the conservation, restoration and sustainable use"
+      expect(page).to have_content "SDG local target sample text"
+    end
+  end
 end

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -305,17 +305,17 @@ describe "SDG Relations", :js do
       create(:sdg_local_target, code: "1.1.1")
       visit sdg_management_edit_legislation_process_path(process)
 
-      fill_in "You can introduce the code of a specific goal/target or a text to find one", with: "3"
+      fill_in "Goals and Targets", with: "3"
       within(".amsify-list") { find(:css, "[data-val='3']").click }
 
       within(".amsify-suggestags-input-area") { expect(page).to have_content "SDG3" }
 
-      fill_in "You can introduce the code of a specific goal/target or a text to find one", with: "1.1"
+      fill_in "Goals and Targets", with: "1.1"
       within(".amsify-list") { find(:css, "[data-val='1.1']").click }
 
       within(".amsify-suggestags-input-area") { expect(page).to have_content "1.1" }
 
-      fill_in "You can introduce the code of a specific goal/target or a text to find one", with: "1.1.1"
+      fill_in "Goals and Targets", with: "1.1.1"
       within(".amsify-list") { find(:css, "[data-val='1.1.1']").click }
 
       within(".amsify-suggestags-input-area") { expect(page).to have_content "1.1.1" }
@@ -333,7 +333,7 @@ describe "SDG Relations", :js do
       process = create(:legislation_process, title: "SDG process")
 
       visit sdg_management_edit_legislation_process_path(process)
-      fill_in "You can introduce the code of a specific goal/target or a text to find one", with: "tag nonexistent,"
+      fill_in "Goals and Targets", with: "tag nonexistent,"
 
       within(".amsify-suggestags-input-area") { expect(page).not_to have_content "tag nonexistent" }
     end

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -413,6 +413,16 @@ describe "SDG Relations", :js do
           expect(find("input[data-code='1']")).to be_checked
         end
       end
+
+      scenario "Help page link opens in new window" do
+        process = create(:legislation_process, title: "SDG process")
+
+        visit sdg_management_edit_legislation_process_path(process)
+
+        within_window(window_opened_by { click_link "SDG help page" }) do
+          expect(page).to have_content "Sustainable Development Goals help"
+        end
+      end
     end
 
     describe "help section" do


### PR DESCRIPTION
## References
Related PR: #4325 

## Objectives
Create new SDG help page to render all targets and local targets related by goal.

## Visual Changes
- New help page
![Captura de pantalla 2021-02-22 a las 12 32 35](https://user-images.githubusercontent.com/16189/108702859-1ce7ad00-750a-11eb-9aec-57cb8567d108.png)


- Add link to related list selector component
![Captura de pantalla 2021-02-22 a las 13 07 41](https://user-images.githubusercontent.com/16189/108706490-faa45e00-750e-11eb-8dfb-0f02d5887b82.png)

