### PR TITLE
Fix tags styles in forms

### DIFF
--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -1,6 +1,3 @@
-ul {
-
-  &.tags {
-    @extend %tags;
-  }
+.tags {
+  @extend %tags;
 }


### PR DESCRIPTION
## References

* This bug was introduced in pull request #4324

## Objectives

* Fix a bug causing tag styles to be missing in forms

## Visual Changes

### Before these changes

![The tags are not styled and have no space between them](https://user-images.githubusercontent.com/35156/107884818-46e01480-6ef7-11eb-975c-97adf980d15c.png)

### After these changes

![The tags feature a rounded gray background and there's space between them](https://user-images.githubusercontent.com/35156/107884822-49426e80-6ef7-11eb-89a2-ad9cc7daa723.png)
