### PR TITLE
Split investment projects statistics by participatory budget 

### DIFF
--- a/app/assets/stylesheets/admin/stats/sdg/goal.scss
+++ b/app/assets/stylesheets/admin/stats/sdg/goal.scss
@@ -1,0 +1,5 @@
+.sdg-goal-stats {
+  h4 {
+    @include grid-column-gutter;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,7 +30,7 @@
 @import "leaflet";
 @import "sticky_overrides";
 @import "tags";
-@import "admin/*";
+@import "admin/**/*";
 @import "sdg/**/*";
 @import "sdg_management/*";
 @import "sdg_management/**/*";

--- a/app/components/admin/stats/sdg/goal_component.html.erb
+++ b/app/components/admin/stats/sdg/goal_component.html.erb
@@ -6,5 +6,14 @@
     <% stats.each do |text, amount, options = {}| %>
       <%= render Admin::Stats::StatComponent.new(text: text, amount: amount, options: options) %>
     <% end %>
+
+    <% bugdets_stats.each do |budget_name, *budget_stats| %>
+      <div class="budget-stats">
+        <h4><%= budget_name %></h4>
+        <% budget_stats.each do |text, amount, options = {}| %>
+          <%= render Admin::Stats::StatComponent.new(text: text, amount: amount, options: options) %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/components/admin/stats/sdg/goal_component.html.erb
+++ b/app/components/admin/stats/sdg/goal_component.html.erb
@@ -4,11 +4,7 @@
 
   <div class="stats-numbers">
     <% stats.each do |text, amount, options = {}| %>
-      <div class="small-12 medium-4 column">
-        <%= tag.p(options) do %>
-          <%= text %> <br><span class="number"><%= amount %></span>
-        <% end %>
-      </div>
+      <%= render Admin::Stats::StatComponent.new(text: text, amount: amount, options: options) %>
     <% end %>
   </div>
 </div>

--- a/app/components/admin/stats/sdg/goal_component.rb
+++ b/app/components/admin/stats/sdg/goal_component.rb
@@ -13,15 +13,35 @@ class Admin::Stats::SDG::GoalComponent < ApplicationComponent
       [
         [t("admin.stats.sdg.polls"), goal.polls.count],
         [t("admin.stats.sdg.proposals"), goal.proposals.count],
-        [t("admin.stats.sdg.debates"), goal.debates.count],
-        [t("admin.stats.sdg.budget_investments.sent"), goal.budget_investments.count],
-        [t("admin.stats.sdg.budget_investments.winners"), goal.budget_investments.winners.count, featured],
-        [t("admin.stats.sdg.budget_investments.amount"), amount, featured]
+        [t("admin.stats.sdg.debates"), goal.debates.count]
       ]
     end
 
-    def amount
-      number_to_currency(goal.budget_investments.winners.sum(:price), precision: 0)
+    def bugdets_stats
+      Budget.order(created_at: :desc).map do |budget|
+        [
+          budget.name,
+          [t("admin.stats.sdg.budget_investments.sent"), sent(budget)],
+          [t("admin.stats.sdg.budget_investments.winners"), winners(budget), featured],
+          [t("admin.stats.sdg.budget_investments.amount"), amount(budget), featured]
+        ]
+      end
+    end
+
+    def sent(budget)
+      investments(budget).count
+    end
+
+    def winners(budget)
+      investments(budget).winners.count
+    end
+
+    def amount(budget)
+      number_to_currency(investments(budget).winners.sum(:price), precision: 0)
+    end
+
+    def investments(budget)
+      goal.budget_investments.by_budget(budget)
     end
 
     def featured

--- a/app/components/admin/stats/stat_component.html.erb
+++ b/app/components/admin/stats/stat_component.html.erb
@@ -1,0 +1,5 @@
+<div class="small-12 medium-4 column">
+  <%= tag.p(options) do %>
+    <%= text %> <br><span class="number"><%= amount %></span>
+  <% end %>
+</div>

--- a/app/components/admin/stats/stat_component.rb
+++ b/app/components/admin/stats/stat_component.rb
@@ -1,0 +1,9 @@
+class Admin::Stats::StatComponent < ApplicationComponent
+  attr_reader :text, :amount, :options
+
+  def initialize(text:, amount:, options: {})
+    @text = text
+    @amount = amount
+    @options = options
+  end
+end

--- a/spec/components/admin/stats/sdg/goal_component_spec.rb
+++ b/spec/components/admin/stats/sdg/goal_component_spec.rb
@@ -8,16 +8,22 @@ describe Admin::Stats::SDG::GoalComponent, type: :component do
     create_list(:poll, 2, sdg_goals: [goal])
     create_list(:proposal, 3, sdg_goals: [goal])
     create_list(:debate, 1, sdg_goals: [goal])
-    create_list(:budget_investment, 2, :winner, sdg_goals: [goal], price: 1000)
-    create_list(:budget_investment, 2, sdg_goals: [goal], price: 1000)
+    past = create(:budget, name: "Past year budget")
+    create_list(:budget_investment, 1, :winner, sdg_goals: [goal], price: 1000, budget: past)
+    current = create(:budget, name: "Current budget")
+    create_list(:budget_investment, 2, sdg_goals: [goal], price: 1000, budget: current)
 
     render_inline component
 
     expect(page).to have_text "Proposals 3"
     expect(page).to have_text "Polls 2"
     expect(page).to have_text "Debates 1"
-    expect(page).to have_text "Investment projects sent 4"
-    expect(page).to have_text "Winner investment projects 2"
-    expect(page).to have_text "Approved amount $2,000"
+    expect("Current budget").to appear_before("Past year budget")
+    expect(page).to have_text "Investment projects sent 2"
+    expect(page).to have_text "Winner investment projects 0"
+    expect(page).to have_text "Approved amount $0"
+    expect(page).to have_text "Investment projects sent 1"
+    expect(page).to have_text "Winner investment projects 1"
+    expect(page).to have_text "Approved amount $1,000"
   end
 end


### PR DESCRIPTION
## References

Related Pull Requests: #4323 

## Objectives

* Show investment projects stats for each participatory budget
* Newer budgets show first

## Visual Changes
**Before**
<img width="1124" alt="Captura de pantalla 2021-02-16 a las 15 36 57" src="https://user-images.githubusercontent.com/15726/108077470-d529d700-706c-11eb-9a04-c5e5d27fa476.png">

**After**
<img width="1123" alt="Captura de pantalla 2021-02-16 a las 15 36 32" src="https://user-images.githubusercontent.com/15726/108077476-d6f39a80-706c-11eb-80fa-f9cb070d1b59.png">