### PR TITLE
fix ActionViewer Sanitizer allow target blank

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -42,7 +42,8 @@
                  terms: link_to(t("devise_views.users.registrations.new.terms_link"), "/conditions",
                                 title: t("shared.target_blank"),
                                 target: "_blank")
-                ) %>
+                ) 
+      %>
 
       <div class="small-12 medium-6 small-centered">
         <%= f.submit t("devise_views.users.registrations.new.submit"), class: "button expanded" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,10 @@ Bundler.require(*Rails.groups)
 module Consul
   class Application < Rails::Application
     config.load_defaults 5.2
-
+  
+    config.action_view.sanitized_allowed_tags = ['strong', 'em', 'a']
+    config.action_view.sanitized_allowed_attributes = ['href', 'title', 'target']
+    
     # Keep belongs_to fields optional by default, because that's the way
     # Rails 4 models worked
     config.active_record.belongs_to_required_by_default = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,8 +21,7 @@ module Consul
   class Application < Rails::Application
     config.load_defaults 5.2
   
-    config.action_view.sanitized_allowed_tags = ['strong', 'em', 'a']
-    config.action_view.sanitized_allowed_attributes = ['href', 'title', 'target']
+    config.action_view.sanitized_allowed_attributes = ['href', 'title', 'target', 'style']
     
     # Keep belongs_to fields optional by default, because that's the way
     # Rails 4 models worked


### PR DESCRIPTION
## References
#4355 

## Objectives

Fix the issue bug to allow when clicking in links with `target="_blank"` the new page opens in new window.

## Visual Changes
No.

## Notes

Added the HTML tag "target" to the `application.rb` file to allow the use across the application. The problem is the ActionView Sanitizer removing the target tag.
