### PR TITLE
Add filter to display all budgets in admin section

### DIFF
--- a/app/assets/stylesheets/admin/budgets/index.scss
+++ b/app/assets/stylesheets/admin/budgets/index.scss
@@ -1,0 +1,24 @@
+.admin .budgets-table {
+
+  .budget-completed {
+    @include has-fa-icon(lock, solid);
+    padding-left: calc(1em + #{rem-calc(10)});
+    position: relative;
+
+    &::before {
+      color: $admin-border-color;
+      left: rem-calc(4);
+      position: absolute;
+      transform: translateY(50%);
+    }
+
+    span {
+      color: $admin-text;
+      display: block;
+      font-size: $tiny-font-size;
+      font-weight: bold;
+      line-height: rem-calc(12);
+      text-transform: uppercase;
+    }
+  }
+}

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -4,7 +4,7 @@ class Admin::BudgetsController < Admin::BaseController
   include FeatureFlags
   feature_flag :budgets
 
-  has_filters %w[open finished], only: :index
+  has_filters %w[all open finished], only: :index
 
   before_action :load_budget, except: [:index, :new, :create]
   before_action :load_staff, only: [:new, :create, :edit, :update, :show]

--- a/app/views/admin/budgets/index.html.erb
+++ b/app/views/admin/budgets/index.html.erb
@@ -9,7 +9,7 @@
 <% if @budgets.any? %>
   <h3><%= page_entries_info @budgets %></h3>
 
-  <table>
+  <table class="budgets-table">
     <thead>
       <tr>
         <th><%= t("admin.budgets.index.table_name") %></th>
@@ -20,8 +20,13 @@
     <tbody>
       <% @budgets.each do |budget| %>
         <tr id="<%= dom_id(budget) %>" class="budget">
-          <td>
-            <%= budget.name %>
+          <td class="<%= "budget-completed" if budget.finished? %>">
+            <% if budget.finished? %>
+              <span>
+                <%= t("admin.budgets.index.table_completed") %>
+              </span>
+            <% end %>
+            <strong><%= budget.name %></strong>
           </td>
           <td class="small">
             <%= t("budgets.phase.#{budget.phase}") %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -75,6 +75,7 @@ en:
           finished: Finished
         help: "Participatory budgets allow citizens to propose and decide directly how to spend part of the budget, with monitoring and rigorous evaluation of proposals by the institution."
         budget_investments: Manage projects
+        table_completed: Completed
         table_name: Name
         table_phase: Phase
         edit_groups: Edit headings groups

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -70,6 +70,7 @@ en:
         new_link: Create new budget
         filter: Filter
         filters:
+          all: All
           open: Open
           finished: Finished
         help: "Participatory budgets allow citizens to propose and decide directly how to spend part of the budget, with monitoring and rigorous evaluation of proposals by the institution."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -70,6 +70,7 @@ es:
         new_link: Crear nuevo presupuesto
         filter: Filtro
         filters:
+          all: Todos
           open: Abiertos
           finished: Terminados
         help: "Los presupuestos participativos permiten que los ciudadanos propongan y decidan de manera directa cómo gastar parte del presupuesto, con un seguimiento y evaluación riguroso de las propuestas por parte de la institución."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -75,6 +75,7 @@ es:
           finished: Terminados
         help: "Los presupuestos participativos permiten que los ciudadanos propongan y decidan de manera directa cómo gastar parte del presupuesto, con un seguimiento y evaluación riguroso de las propuestas por parte de la institución."
         budget_investments: Gestionar proyectos de gasto
+        table_completed: Completado
         table_name: Nombre
         table_phase: Fase
         edit_groups: Editar grupos de partidas

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -77,15 +77,15 @@ describe "Admin budgets", :admin do
       expect(page).not_to have_content(finished_budget.name)
     end
 
-    scenario "Open filter is properly highlighted" do
-      filters_links = { "current" => "Open", "finished" => "Finished" }
+    scenario "Filters are properly highlighted" do
+      filters_links = { "all" => "All", "open" => "Open", "finished" => "Finished" }
 
       visit admin_budgets_path
 
       expect(page).not_to have_link(filters_links.values.first)
       filters_links.keys.drop(1).each { |filter| expect(page).to have_link(filters_links[filter]) }
 
-      filters_links.each_pair do |current_filter, link|
+      filters_links.each do |current_filter, link|
         visit admin_budgets_path(filter: current_filter)
 
         expect(page).not_to have_link(link)

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -60,7 +60,11 @@ describe "Admin budgets", :admin do
       expect(page).to have_content(accepting_budget.name)
       expect(page).to have_content(selecting_budget.name)
       expect(page).to have_content(balloting_budget.name)
-      expect(page).not_to have_content(finished_budget.name)
+      expect(page).to have_content(finished_budget.name)
+
+      within "#budget_#{finished_budget.id}" do
+        expect(page).to have_content("Completed")
+      end
 
       click_link "Finished"
       expect(page).not_to have_content(drafting_budget.name)


### PR DESCRIPTION
## References

* These changes are part of pull request #4198

## Visual Changes

### Before these changes

![Users can choose between displaying open budgets or finished budgets](https://user-images.githubusercontent.com/35156/108612617-9ee0b480-73ea-11eb-9304-daeabc7f653b.png)

### After these changes

![Users can choose between displaying all budgets, open budgets or finished budgets; finished budgets add the word "completed" so they can easily be recognized](https://user-images.githubusercontent.com/35156/108612619-a1430e80-73ea-11eb-8395-06b87354db30.png)