### PR TITLE
Use more generic names for validation rules

### DIFF
--- a/app/models/custom/verification/residence.rb
+++ b/app/models/custom/verification/residence.rb
@@ -1,18 +1,18 @@
 require_dependency Rails.root.join("app", "models", "verification", "residence").to_s
 
 class Verification::Residence
-  validate :postal_code_in_madrid
-  validate :residence_in_madrid
+  validate :local_postal_code
+  validate :local_residence
 
-  def postal_code_in_madrid
+  def local_postal_code
     errors.add(:postal_code, I18n.t("verification.residence.new.error_not_allowed_postal_code")) unless valid_postal_code?
   end
 
-  def residence_in_madrid
+  def local_residence
     return if errors.any?
 
     unless residency_valid?
-      errors.add(:residence_in_madrid, false)
+      errors.add(:local_residence, false)
       store_failed_attempt
       Lock.increase_tries(user)
     end

--- a/app/models/officing/residence.rb
+++ b/app/models/officing/residence.rb
@@ -15,7 +15,7 @@ class Officing::Residence
   validates :year_of_birth, presence: true, unless: -> { Setting.force_presence_date_of_birth? }
 
   validate :allowed_age
-  validate :residence_in_madrid
+  validate :local_residence
 
   def initialize(attrs = {})
     self.date_of_birth = parse_date("date_of_birth", attrs)
@@ -72,12 +72,12 @@ class Officing::Residence
     User.find_by(document_number: document_number, document_type: document_type)
   end
 
-  def residence_in_madrid
+  def local_residence
     return if errors.any?
 
     unless residency_valid?
       store_failed_census_call
-      errors.add(:residence_in_madrid, false)
+      errors.add(:local_residence, false)
     end
   end
 

--- a/app/views/officing/residence/_errors.html.erb
+++ b/app/views/officing/residence/_errors.html.erb
@@ -1,4 +1,4 @@
-<% if @residence.errors[:residence_in_madrid].present? %>
+<% if @residence.errors[:local_residence].present? %>
 
   <div id="error_explanation" data-alert class="callout alert" data-closable>
     <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>

--- a/app/views/verification/residence/_errors.html.erb
+++ b/app/views/verification/residence/_errors.html.erb
@@ -1,4 +1,4 @@
-<% if @residence.errors[:residence_in_madrid].present? %>
+<% if @residence.errors[:local_residence].present? %>
 
   <div id="error_explanation" data-alert class="callout alert" data-closable>
     <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>


### PR DESCRIPTION
## References
Backport from https://github.com/AyuntamientoLorca/consul/pull/3

## Objectives
It's weird for developers to have validation rules with the word "Madrid". The new names are more generic and will not get developers confused.
