### PR TITLE
Setup mailer default settings on tests

### DIFF
--- a/spec/lib/tasks/dashboards_spec.rb
+++ b/spec/lib/tasks/dashboards_spec.rb
@@ -45,6 +45,10 @@ describe "Dashboards Rake" do
     end
 
     describe "Send notifications to proposal author" do
+      before do
+        Setting["mailer_from_name"] = "CONSUL"
+        Setting["mailer_from_address"] = "noreply@consul.dev"
+      end
       let!(:action)   { create(:dashboard_action, :proposed_action, :active, day_offset: 0) }
       let!(:resource) { create(:dashboard_action, :resource, :active, day_offset: 0) }
 


### PR DESCRIPTION
So when a fork changes the default mailer settings, the affected specs keep passing.

## References

* Similar to pull request #4281
* Backport from https://github.com/AyuntamientoLorca/consul/pull/9

## Objectives

Allow forks to customize the default mailer settings without changing the specs.

Before this change when a fork overrides the default mailer settings some specs crash.