### PR TITLE
Remove ESLint rules incompatible with Pronto

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,6 @@
         "null": "ignore"
       }
     ],
-    "func-call-spacing": "error",
     "indent": [
       "error",
          2
@@ -42,7 +41,6 @@
     "key-spacing": "error",
     "keyword-spacing": "error",
     "linebreak-style": "error",
-    "lines-between-class-members": "error",
     "max-len": [
       "warn",
          {
@@ -61,7 +59,6 @@
     "no-param-reassign": "error",
     "no-shadow": "error",
     "no-spaced-func": "error",
-    "no-tabs": "error",
     "no-trailing-spaces": "error",
     "no-void": "error",
     "no-whitespace-before-property": "error",
@@ -109,7 +106,6 @@
       }
     ],
     "strict": "error",
-    "switch-colon-spacing": "error",
     "yoda": "error"
   }
 }

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,10 +13,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Setup NPM
-        uses: actions/setup-node@v1
-      - name: Install eslint
-        run: npm install --global eslint@6.0.1
       - name: Run Pronto
         run: |
           PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}


### PR DESCRIPTION
## References

* Pronto was introduced in pull request #4382
* These rules were marked as invalid in a [review by Pronto](https://github.com/consul/consul/pull/4374#pullrequestreview-605553213)

## Background

The pronto-eslint gem depends on the eslintrb gem, which uses a very old version of ESLint which doesn't support some of the rules we use.

The most useful rules here were no-tabs and func-call-spacing. It's a shame they were added to ESLint just one month after eslintrb stopped being maintained.

## Objectives

* Make sure we don't get any invalid rules warnings when running Pronto
* Remove unnecessary code installing ESLint in our github actions workflow