### PR TITLE
Fixing styles for the related list component

### DIFF
--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -17,7 +17,6 @@
   }
 
   .goals {
-    @extend %sdg-goal-list-expanded;
 
     + label {
       @include element-invisible;
@@ -27,6 +26,10 @@
       font-weight: normal;
       font-style: italic;
     }
+  }
+
+  .goal-list {
+    @extend %sdg-goal-list-expanded;
 
     input {
       @include element-invisible;

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -4,9 +4,11 @@
   <div class="input-section">
     <fieldset class="goals">
       <legend><%= t("sdg.related_list_selector.goal_list", record: relatable_name) %></legend>
-      <%= f.collection_check_boxes(:sdg_goal_ids, goals, :id, :code) do |checkbox_form| %>
-        <%= goal_field(checkbox_form) %>
-      <% end %>
+      <div class="goal-list">
+        <%= f.collection_check_boxes(:sdg_goal_ids, goals, :id, :code) do |checkbox_form| %>
+          <%= goal_field(checkbox_form) %>
+        <% end %>
+      </div>
     </fieldset>
 
     <%= f.text_field :related_sdg_list,


### PR DESCRIPTION
## References
Related PR: #4325 

## Objectives
There is a bug in Chrome for versions prior to version 86, which affected our code by showing all goal selector icons vertically.
The aim of this PR is to modify the html and css of this section so that it displays correctly in these versions of the browser.

## Visual Changes
Before:
![Captura de pantalla 2021-03-08 a las 10 52 22](https://user-images.githubusercontent.com/16189/110305787-5b4a9500-7ffd-11eb-9b1e-27e03eb6e591.png)

After:
![Captura de pantalla 2021-03-08 a las 10 52 30](https://user-images.githubusercontent.com/16189/110305809-6271a300-7ffd-11eb-814f-cac26e0368c7.png)


## Notes
More information about the bug can be found here:
https://bugs.chromium.org/p/chromium/issues/detail?id=375693
