### PR TITLE
Do not require Pronto when running the application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,11 +102,11 @@ group :development do
   gem "erb_lint", "~> 0.0.35", require: false
   gem "github_changelog_generator", "~> 1.15.2"
   gem "mdl", "~> 0.11.0", require: false
-  gem "pronto", "~> 0.11.0"
-  gem "pronto-erb_lint", "~> 0.1.5"
-  gem "pronto-eslint", "~> 0.11.0"
-  gem "pronto-rubocop", "~> 0.11.0"
-  gem "pronto-scss", "~> 0.11.0"
+  gem "pronto", "~> 0.11.0", require: false
+  gem "pronto-erb_lint", "~> 0.1.5", require: false
+  gem "pronto-eslint", "~> 0.11.0", require: false
+  gem "pronto-rubocop", "~> 0.11.0", require: false
+  gem "pronto-scss", "~> 0.11.0", require: false
   gem "rubocop", "~> 0.91.0", require: false
   gem "rubocop-performance", "~> 1.7.1", require: false
   gem "rubocop-rails", "~> 2.6.0", require: false

--- a/config/initializers/better_html.rb
+++ b/config/initializers/better_html.rb
@@ -1,5 +1,0 @@
-if Rails.env.development?
-  BetterHtml.configure do |config|
-    config.template_exclusion_filter = proc { |filename| true }
-  end
-end


### PR DESCRIPTION
## References

* Pronto was added in pull request #4382

##  Background

Pronto is an external tool which is use to check code conventions and is not needed to run the application, just like rubocop or scss-lint.

Loading it caused a couple of issues. First, it loaded BetterHtml, and we had to disable it in order to avoid crashes in the development environment.

Second, it loaded ruby-progressbar, which loads the ProgressBar class, which conflicts with our own ProgressBar class. This made the application crash whenever the ProgressBar class was used.

## Objectives

* Avoid crashes in the development environment