### PR TITLE
Unify budget landing pages

### DIFF
--- a/app/assets/stylesheets/budgets/groups_and_headings.scss
+++ b/app/assets/stylesheets/budgets/groups_and_headings.scss
@@ -1,10 +1,27 @@
 .groups-and-headings {
+  $spacing: rem-calc(4);
+
+  .headings-list {
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+    margin-left: -$spacing;
+  }
 
   .heading {
     border: 1px solid $border;
     border-radius: rem-calc(3);
-    display: inline-block;
     margin-bottom: $line-height / 2;
+    margin-left: $spacing;
+    width: 100%;
+
+    @include breakpoint(medium) {
+      width: calc(100% / 3 - #{$spacing});
+    }
+
+    @include breakpoint(large) {
+      width: calc(100% / 6 - #{$spacing});
+    }
 
     a {
       display: block;

--- a/app/assets/stylesheets/budgets/groups_and_headings.scss
+++ b/app/assets/stylesheets/budgets/groups_and_headings.scss
@@ -13,6 +13,8 @@
     border-radius: rem-calc(3);
     margin-bottom: $line-height / 2;
     margin-left: $spacing;
+    padding: $line-height / 2;
+    position: relative;
     width: 100%;
 
     @include breakpoint(medium) {
@@ -23,22 +25,37 @@
       width: calc(100% / 6 - #{$spacing});
     }
 
-    a {
-      display: block;
-      padding: $line-height / 2;
+    &:focus-within {
+      outline: $outline-focus;
 
-      &:hover {
-        background: $highlight;
-        text-decoration: none;
+      a:focus {
+        outline: none;
       }
     }
 
-    .heading-name {
-      padding: $line-height / 2;
+    a {
+
+      &::after,
+      &::before {
+        bottom: 0;
+        content: "";
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+
+      &:hover {
+        text-decoration: none;
+      }
+
+      &:hover::before {
+        background: $highlight;
+        z-index: -1;
+      }
     }
 
     span {
-      color: $text;
       display: block;
       font-size: $small-font-size;
     }

--- a/app/assets/stylesheets/budgets/groups_and_headings.scss
+++ b/app/assets/stylesheets/budgets/groups_and_headings.scss
@@ -1,0 +1,29 @@
+.groups-and-headings {
+
+  .heading {
+    border: 1px solid $border;
+    border-radius: rem-calc(3);
+    display: inline-block;
+    margin-bottom: $line-height / 2;
+
+    a {
+      display: block;
+      padding: $line-height / 2;
+
+      &:hover {
+        background: $highlight;
+        text-decoration: none;
+      }
+    }
+
+    .heading-name {
+      padding: $line-height / 2;
+    }
+
+    span {
+      color: $text;
+      display: block;
+      font-size: $small-font-size;
+    }
+  }
+}

--- a/app/assets/stylesheets/budgets/groups_and_headings.scss
+++ b/app/assets/stylesheets/budgets/groups_and_headings.scss
@@ -1,5 +1,5 @@
 .groups-and-headings {
-  $spacing: rem-calc(4);
+  $spacing: $line-height / 2;
 
   .headings-list {
     display: flex;
@@ -9,10 +9,12 @@
   }
 
   .heading {
-    border: 1px solid $border;
-    border-radius: rem-calc(3);
+    border: 2px solid $border;
+    border-radius: rem-calc(6);
+    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
     margin-bottom: $line-height / 2;
     margin-left: $spacing;
+    margin-top: $line-height / 4;
     padding: $line-height / 2;
     position: relative;
     width: 100%;
@@ -34,6 +36,7 @@
     }
 
     a {
+      font-weight: bold;
 
       &::after,
       &::before {
@@ -58,6 +61,7 @@
     span {
       display: block;
       font-size: $small-font-size;
+      padding-top: $line-height / 2;
     }
   }
 }

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1222,36 +1222,6 @@
   color: $brand;
 }
 
-.groups-and-headings {
-
-  .heading {
-    border: 1px solid $border;
-    border-radius: rem-calc(3);
-    display: inline-block;
-    margin-bottom: $line-height / 2;
-
-    a {
-      display: block;
-      padding: $line-height / 2;
-
-      &:hover {
-        background: $highlight;
-        text-decoration: none;
-      }
-    }
-
-    .heading-name {
-      padding: $line-height / 2;
-    }
-
-    span {
-      color: $text;
-      display: block;
-      font-size: $small-font-size;
-    }
-  }
-}
-
 .progress-votes {
   position: relative;
 

--- a/app/components/budgets/budget_component.html.erb
+++ b/app/components/budgets/budget_component.html.erb
@@ -23,7 +23,7 @@
 
       <% unless budget.informing? %>
         <div class="map inline">
-          <h3><%= t("budgets.index.map") %></h3>
+          <h2><%= t("budgets.index.map") %></h2>
           <%= render_map(nil, "budgets", false, nil, coordinates) %>
         </div>
       <% end %>

--- a/app/components/budgets/budget_component.html.erb
+++ b/app/components/budgets/budget_component.html.erb
@@ -1,0 +1,32 @@
+<div class="budget-header">
+  <div class="row">
+    <div class="small-12 column">
+      <h1><%= budget.name %></h1>
+      <div class="description">
+        <%= auto_link_already_sanitized_html wysiwyg(budget.description) %>
+      </div>
+
+      <p>
+        <%= link_to t("budgets.index.section_header.help"), "#section_help" %>
+      </p>
+    </div>
+  </div>
+</div>
+
+<%= render Budgets::SubheaderComponent.new(budget) %>
+<%= render Budgets::PhasesComponent.new(budget) %>
+
+<div id="budget_info" class="budget-info">
+  <div class="row margin-top">
+    <div class="small-12 column">
+      <%= render Budgets::GroupsAndHeadingsComponent.new(budget) %>
+
+      <% unless budget.informing? %>
+        <div class="map inline">
+          <h3><%= t("budgets.index.map") %></h3>
+          <%= render_map(nil, "budgets", false, nil, coordinates) %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/budgets/budget_component.rb
+++ b/app/components/budgets/budget_component.rb
@@ -1,0 +1,22 @@
+class Budgets::BudgetComponent < ApplicationComponent
+  delegate :wysiwyg, :auto_link_already_sanitized_html, :render_map, to: :helpers
+  attr_reader :budget
+
+  def initialize(budget)
+    @budget = budget
+  end
+
+  private
+
+    def coordinates
+      return unless budget.present?
+
+      if budget.publishing_prices_or_later? && budget.investments.selected.any?
+        investments = budget.investments.selected
+      else
+        investments = budget.investments
+      end
+
+      MapLocation.where(investment_id: investments).map(&:json_data)
+    end
+end

--- a/app/components/budgets/footer_component.html.erb
+++ b/app/components/budgets/footer_component.html.erb
@@ -1,0 +1,10 @@
+<div class="row">
+  <div class="small-12 column">
+    <div id="section_help" class="margin" data-magellan-target="section_help">
+      <p class="lead">
+        <strong><%= t("budgets.index.section_footer.title") %></strong>
+      </p>
+      <p><%= t("budgets.index.section_footer.description") %></p>
+    </div>
+  </div>
+</div>

--- a/app/components/budgets/footer_component.rb
+++ b/app/components/budgets/footer_component.rb
@@ -1,0 +1,2 @@
+class Budgets::FooterComponent < ApplicationComponent
+end

--- a/app/components/budgets/groups_and_headings_component.html.erb
+++ b/app/components/budgets/groups_and_headings_component.html.erb
@@ -4,16 +4,13 @@
     <ul class="headings-list">
       <% group.headings.sort_by_name.each do |heading| %>
         <li class="heading">
-          <% unless budget.informing? || budget.finished? %>
-            <%= link_to budget_investments_path(budget.id,
-                                                heading_id: heading.id) do %>
-              <%= heading_name_and_price_html(heading) %>
-            <% end %>
-          <% else %>
-            <div class="heading-name">
-              <%= heading_name_and_price_html(heading) %>
-            </div>
-          <% end %>
+          <%= link_to_unless(
+            (budget.informing? || budget.finished?),
+            heading.name,
+            budget_investments_path(budget.id, heading_id: heading.id)
+          ) %>
+
+          <%= price(heading) %>
         </li>
       <% end %>
     </ul>

--- a/app/components/budgets/groups_and_headings_component.html.erb
+++ b/app/components/budgets/groups_and_headings_component.html.erb
@@ -1,9 +1,9 @@
 <div id="groups_and_headings" class="groups-and-headings">
   <% budget.groups.each do |group| %>
     <h2 id="<%= group.name.parameterize %>"><%= group.name %></h2>
-    <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
+    <ul class="headings-list">
       <% group.headings.sort_by_name.each do |heading| %>
-        <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
+        <li class="heading">
           <% unless budget.informing? || budget.finished? %>
             <%= link_to budget_investments_path(budget.id,
                                                 heading_id: heading.id) do %>

--- a/app/components/budgets/groups_and_headings_component.html.erb
+++ b/app/components/budgets/groups_and_headings_component.html.erb
@@ -1,0 +1,21 @@
+<div id="groups_and_headings" class="groups-and-headings">
+  <% budget.groups.each do |group| %>
+    <h2 id="<%= group.name.parameterize %>"><%= group.name %></h2>
+    <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
+      <% group.headings.sort_by_name.each do |heading| %>
+        <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
+          <% unless budget.informing? || budget.finished? %>
+            <%= link_to budget_investments_path(budget.id,
+                                                heading_id: heading.id) do %>
+              <%= heading_name_and_price_html(heading) %>
+            <% end %>
+          <% else %>
+            <div class="heading-name">
+              <%= heading_name_and_price_html(heading) %>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/components/budgets/groups_and_headings_component.rb
+++ b/app/components/budgets/groups_and_headings_component.rb
@@ -1,0 +1,16 @@
+class Budgets::GroupsAndHeadingsComponent < ApplicationComponent
+  attr_reader :budget
+
+  def initialize(budget)
+    @budget = budget
+  end
+
+  private
+
+    def heading_name_and_price_html(heading)
+      tag.div do
+        concat(heading.name + " ")
+        concat(tag.span(budget.formatted_heading_price(heading)))
+      end
+    end
+end

--- a/app/components/budgets/groups_and_headings_component.rb
+++ b/app/components/budgets/groups_and_headings_component.rb
@@ -7,10 +7,7 @@ class Budgets::GroupsAndHeadingsComponent < ApplicationComponent
 
   private
 
-    def heading_name_and_price_html(heading)
-      tag.div do
-        concat(heading.name + " ")
-        concat(tag.span(budget.formatted_heading_price(heading)))
-      end
+    def price(heading)
+      tag.span(budget.formatted_heading_price(heading))
     end
 end

--- a/app/components/budgets/investments/info_component.html.erb
+++ b/app/components/budgets/investments/info_component.html.erb
@@ -1,0 +1,24 @@
+<p class="investment-project-info">
+  <%= l investment.created_at.to_date %>
+
+  <% if investment.author.hidden? || investment.author.erased? %>
+    <span class="bullet">&nbsp;&bull;&nbsp;</span>
+    <span class="author">
+      <%= t("budgets.investments.show.author_deleted") %>
+    </span>
+  <% else %>
+    <span class="bullet">&nbsp;&bull;&nbsp;</span>
+    <span class="author">
+      <%= investment.author.name %>
+    </span>
+    <% if investment.author.official? %>
+      <span class="bullet">&nbsp;&bull;&nbsp;</span>
+      <span class="label round level-<%= investment.author.official_level %>">
+        <%= investment.author.official_position %>
+      </span>
+    <% end %>
+  <% end %>
+
+  <span class="bullet">&nbsp;&bull;&nbsp;</span>
+  <%= investment.heading.name %>
+</p>

--- a/app/components/budgets/investments/info_component.rb
+++ b/app/components/budgets/investments/info_component.rb
@@ -1,0 +1,7 @@
+class Budgets::Investments::InfoComponent < ApplicationComponent
+  attr_reader :investment
+
+  def initialize(investment)
+    @investment = investment
+  end
+end

--- a/app/controllers/budgets/ballot/lines_controller.rb
+++ b/app/controllers/budgets/ballot/lines_controller.rb
@@ -7,7 +7,6 @@ module Budgets
       before_action :load_tag_cloud
       before_action :load_categories
       before_action :load_investments
-      before_action :load_ballot_referer
 
       authorize_resource :budget
       authorize_resource :ballot
@@ -65,10 +64,6 @@ module Budgets
 
         def load_categories
           @categories = Tag.category.order(:name)
-        end
-
-        def load_ballot_referer
-          @ballot_referer = session[:ballot_referer]
         end
 
         def load_map

--- a/app/controllers/budgets/ballots_controller.rb
+++ b/app/controllers/budgets/ballots_controller.rb
@@ -4,7 +4,6 @@ module Budgets
     before_action :load_budget
     authorize_resource :budget
     before_action :load_ballot
-    after_action :store_referer, only: [:show]
 
     def show
       authorize! :show, @ballot
@@ -21,10 +20,6 @@ module Budgets
       def load_ballot
         query = Budget::Ballot.where(user: current_user, budget: @budget)
         @ballot = @budget.balloting? ? query.first_or_create! : query.first_or_initialize
-      end
-
-      def store_referer
-        session[:ballot_referer] = request.referer
       end
   end
 end

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -1,13 +1,11 @@
 class BudgetsController < ApplicationController
   include FeatureFlags
   include BudgetsHelper
-  include InvestmentFilters
   feature_flag :budgets
 
   before_action :load_budget, only: :show
+  before_action :load_current_budget, only: :index
   load_and_authorize_resource
-  before_action :set_default_investment_filter, only: :show
-  has_filters investment_filters, only: :show
 
   respond_to :html, :js
 
@@ -17,12 +15,15 @@ class BudgetsController < ApplicationController
 
   def index
     @finished_budgets = @budgets.finished.order(created_at: :desc)
-    @budgets_coordinates = current_budget_map_locations
   end
 
   private
 
     def load_budget
       @budget = Budget.find_by_slug_or_id! params[:id]
+    end
+
+    def load_current_budget
+      @budget = current_budget
     end
 end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -56,18 +56,6 @@ module BudgetsHelper
     budget.published? || current_user&.administrator?
   end
 
-  def current_budget_map_locations
-    return unless current_budget.present?
-
-    if current_budget.publishing_prices_or_later? && current_budget.investments.selected.any?
-      investments = current_budget.investments.selected
-    else
-      investments = current_budget.investments
-    end
-
-    MapLocation.where(investment_id: investments).map(&:json_data)
-  end
-
   def display_calculate_winners_button?(budget)
     budget.balloting_or_later?
   end

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -5,13 +5,6 @@ module BudgetsHelper
     end
   end
 
-  def heading_name_and_price_html(heading, budget)
-    tag.div do
-      concat(heading.name + " ")
-      concat(tag.span(budget.formatted_heading_price(heading)))
-    end
-  end
-
   def csv_params
     csv_params = params.clone.merge(format: :csv)
     csv_params = csv_params.to_unsafe_h.map { |k, v| [k.to_sym, v] }.to_h

--- a/app/views/budgets/ballot/_ballot.html.erb
+++ b/app/views/budgets/ballot/_ballot.html.erb
@@ -1,6 +1,6 @@
 <div class="budget-header">
   <div class="row">
-    <%= back_link_to @ballot_referer %>
+    <%= back_link_to session[:ballot_referer] %>
 
     <h1 class="text-center"><%= t("budgets.ballots.show.title") %></h1>
 

--- a/app/views/budgets/groups/show.html.erb
+++ b/app/views/budgets/groups/show.html.erb
@@ -5,7 +5,7 @@
 <div class="budget-header">
   <div class="row">
     <div class="small-12 medium-9 column">
-      <%= back_link_to budgets_path %>
+      <%= back_link_to budget_path(@budget) %>
       <h2><%= t("budgets.groups.show.title") %></h2>
     </div>
   </div>

--- a/app/views/budgets/groups/show.html.erb
+++ b/app/views/budgets/groups/show.html.erb
@@ -35,8 +35,7 @@
                   class="<%= css_for_ballot_heading(heading) %>">
               <%= link_to heading.name,
                           budget_investments_path(heading_id: heading.id,
-                                                  filter: @current_filter),
-                          data: { turbolinks: false } %><br>
+                                                  filter: @current_filter) %><br>
             </span>
           <% end %>
         </div>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -6,42 +6,12 @@
   <%= render "shared/canonical", href: budgets_url %>
 <% end %>
 
-<% if current_budget.present? %>
-  <div class="budget-header">
-    <div class="row">
-      <div class="small-12 column">
-        <h1><%= current_budget.name %></h1>
-        <div class="description">
-          <%= auto_link_already_sanitized_html wysiwyg(current_budget.description) %>
-        </div>
-        <p>
-          <%= link_to t("budgets.index.section_header.help"), "#section_help" %>
-        </p>
-      </div>
-    </div>
-  </div>
+<% if @budget.present? %>
+  <%= render Budgets::BudgetComponent.new(@budget) %>
 
-  <%= render Budgets::SubheaderComponent.new(current_budget) %>
-  <%= render Budgets::PhasesComponent.new(current_budget) %>
-
-  <div id="budget_info" class="budget-info">
-    <div class="row margin-top">
-      <div class="small-12 column">
-        <%= render Budgets::GroupsAndHeadingsComponent.new(current_budget) %>
-
-        <% unless current_budget.informing? %>
-          <div class="map inline">
-            <h3><%= t("budgets.index.map") %></h3>
-            <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-
-    <% if @finished_budgets.present? %>
-      <%= render "finished", budgets: @finished_budgets %>
-    <% end %>
-  </div>
+  <% if @finished_budgets.present? %>
+    <%= render "finished", budgets: @finished_budgets %>
+  <% end %>
 <% else %>
   <div class="budget-header margin-bottom">
     <div class="row">

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -27,28 +27,7 @@
   <div id="budget_info" class="budget-info">
     <div class="row margin-top">
       <div class="small-12 column">
-
-        <div id="groups_and_headings" class="groups-and-headings">
-          <% current_budget.groups.each do |group| %>
-            <h2 id="<%= group.name.parameterize %>"><%= group.name %></h2>
-            <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
-              <% group.headings.sort_by_name.each do |heading| %>
-                <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
-                  <% unless current_budget.informing? || current_budget.finished? %>
-                    <%= link_to budget_investments_path(current_budget.id,
-                                                        heading_id: heading.id) do %>
-                      <%= heading_name_and_price_html(heading, current_budget) %>
-                    <% end %>
-                  <% else %>
-                    <div class="heading-name">
-                      <%= heading_name_and_price_html(heading, current_budget) %>
-                    </div>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-        </div>
+        <%= render Budgets::GroupsAndHeadingsComponent.new(current_budget) %>
 
         <% unless current_budget.informing? %>
           <div class="map inline">

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -60,13 +60,4 @@
   </div>
 <% end %>
 
-<div class="row">
-  <div class="small-12 column">
-    <div id="section_help" class="margin" data-magellan-target="section_help">
-      <p class="lead">
-        <strong><%= t("budgets.index.section_footer.title") %></strong>
-      </p>
-      <p><%= t("budgets.index.section_footer.description") %></p>
-    </div>
-  </div>
-</div>
+<%= render Budgets::FooterComponent.new %>

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -4,7 +4,7 @@
 
       <div class="row">
         <div class="small-12 column">
-          <%= back_link_to budgets_path %>
+          <%= back_link_to budget_path(@budget) %>
 
           <% if can? :show, @ballot %>
             <%= link_to t("budgets.investments.header.check_ballot"),

--- a/app/views/budgets/investments/_investment.html.erb
+++ b/app/views/budgets/investments/_investment.html.erb
@@ -21,30 +21,8 @@
           <% cache [locale_and_user_status(investment), "index", investment, investment.author] do %>
             <h3><%= link_to investment.title, namespaced_budget_investment_path(investment) %></h3>
 
-            <p class="investment-project-info">
-              <%= l investment.created_at.to_date %>
+            <%= render Budgets::Investments::InfoComponent.new(investment) %>
 
-              <% if investment.author.hidden? || investment.author.erased? %>
-                <span class="bullet">&nbsp;&bull;&nbsp;</span>
-                <span class="author">
-                  <%= t("budgets.investments.show.author_deleted") %>
-                </span>
-              <% else %>
-                <span class="bullet">&nbsp;&bull;&nbsp;</span>
-                <span class="author">
-                  <%= investment.author.name %>
-                </span>
-                <% if investment.author.official? %>
-                  <span class="bullet">&nbsp;&bull;&nbsp;</span>
-                  <span class="label round level-<%= investment.author.official_level %>">
-                    <%= investment.author.official_position %>
-                  </span>
-                <% end %>
-              <% end %>
-
-              <span class="bullet">&nbsp;&bull;&nbsp;</span>
-              <%= investment.heading.name %>
-            </p>
             <div class="investment-project-description">
               <%= wysiwyg(investment.description) %>
               <div class="truncate"></div>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -61,13 +61,13 @@
     <% end %>
 
     <p>
-      <%= link_to budget_path(@budget) do %>
+      <%= link_to budget_investments_path(@budget, heading_id: @heading) do %>
         <small><%= t("budgets.results.investment_proyects") %></small>
       <% end %><br>
-      <%= link_to budget_path(@budget, filter: "unfeasible") do %>
+      <%= link_to budget_investments_path(@budget, heading_id: @heading, filter: "unfeasible") do %>
         <small><%= t("budgets.results.unfeasible_investment_proyects") %></small>
       <% end %><br>
-      <%= link_to budget_path(@budget, filter: "unselected") do %>
+      <%= link_to budget_investments_path(@budget, heading_id: @heading, filter: "unselected") do %>
         <small><%= t("budgets.results.not_selected_investment_proyects") %></small>
       <% end %>
     </p>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -35,8 +35,7 @@
                 <%= link_to group.name,
                             budget_investments_path(@budget,
                               heading_id: group.headings.first.id,
-                              filter: @current_filter),
-                            data: { turbolinks: false } %>
+                              filter: @current_filter) %>
               <% else %>
                 <%= link_to group.name,
                             budget_group_path(@budget, group,

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -1,75 +1,9 @@
+<%= render Shared::BannerComponent.new("budgets") %>
+<% provide :title do %><%= @budget.name %><% end %>
+
 <% content_for :canonical do %>
   <%= render "shared/canonical", href: budget_url(@budget, filter: @current_filter) %>
 <% end %>
 
-<div class="budget-header">
-  <div class="row">
-    <div class="small-12 column">
-      <%= back_link_to budgets_path %>
-
-      <h1><%= @budget.name %></h1>
-
-      <%= auto_link_already_sanitized_html wysiwyg(@budget.description) %>
-    </div>
-  </div>
-</div>
-
-<%= render Budgets::SubheaderComponent.new(@budget) %>
-
-<div class="row margin">
-  <div class="small-12 medium-9 column">
-    <% if @current_filter == "unfeasible" %>
-      <h3 class="margin-bottom"><%= t("budgets.show.unfeasible_title") %></h3>
-    <% elsif @current_filter == "unselected" %>
-      <h3 class="margin-bottom"><%= t("budgets.show.unselected_title") %></h3>
-    <% end %>
-    <table class="table-fixed">
-      <thead>
-        <th><%= t("budgets.show.group") %></th>
-      </thead>
-      <tbody>
-        <% @budget.groups.each do |group| %>
-          <tr>
-            <td>
-              <% if group.single_heading_group? %>
-                <%= link_to group.name,
-                            budget_investments_path(@budget,
-                              heading_id: group.headings.first.id,
-                              filter: @current_filter) %>
-              <% else %>
-                <%= link_to group.name,
-                            budget_group_path(@budget, group,
-                              filter: @current_filter) %>
-              <% end %>
-              <br>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
-
-<% if @budget.balloting_or_later? %>
-  <% unless @current_filter == "unfeasible" %>
-    <div class="row">
-      <div class="small-12 column">
-        <small>
-          <%= link_to t("budgets.show.unfeasible"),
-                      budget_path(@budget, filter: "unfeasible") %>
-        </small>
-      </div>
-    </div>
-  <% end %>
-
-  <% unless @current_filter == "unselected" %>
-    <div class="row">
-      <div class="small-12 column">
-        <small>
-          <%= link_to t("budgets.show.unselected"),
-                      budget_path(@budget, filter: "unselected") %>
-        </small>
-      </div>
-    </div>
-  <% end %>
-<% end %>
+<%= render Budgets::BudgetComponent.new(@budget) %>
+<%= render Budgets::FooterComponent.new %>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -178,11 +178,6 @@ en:
         one: "You have selected <strong>1</strong> project out of <strong>%{limit}</strong>"
         other: "You have selected <strong>%{count}</strong> projects out of <strong>%{limit}</strong>"
     show:
-      group: Group
-      unfeasible_title: Unfeasible investments
-      unfeasible: See unfeasible investments
-      unselected_title: Investments not selected for balloting phase
-      unselected: See investments not selected for balloting phase
       see_results: See results
     results:
       link: Results

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -178,11 +178,6 @@ es:
         one: "Has seleccionado <strong>1</strong> proyecto de <strong>%{limit}</strong>"
         other: "Has seleccionado <strong>%{count}</strong> proyectos de <strong>%{limit}</strong>"
     show:
-      group: Grupo
-      unfeasible_title: Proyectos de gasto inviables
-      unfeasible: Ver los proyectos inviables
-      unselected_title: Proyectos no seleccionados para la votación final
-      unselected: Ver los proyectos no seleccionados para la votación final
       see_results: Ver resultados
     results:
       link: Resultados

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -422,28 +422,45 @@ describe "Ballots" do
     end
   end
 
-  scenario "Back link after removing an investment from Ballot", :js do
-    create(:budget_investment, :selected, heading: new_york, price: 10, title: "Sully monument")
+  describe "Back link", :js do
+    scenario "after adding and removing an investment from the ballot" do
+      create(:budget_investment, :selected, heading: new_york, price: 10, title: "Sully monument")
 
-    login_as(user)
-    visit budget_investments_path(budget, heading_id: new_york.id)
-    add_to_ballot("Sully monument")
+      login_as(user)
+      visit budget_investments_path(budget, heading_id: new_york.id)
+      add_to_ballot("Sully monument")
 
-    within(".budget-heading") do
-      click_link "Check and confirm my ballot"
+      within(".budget-heading") do
+        click_link "Check and confirm my ballot"
+      end
+
+      expect(page).to have_content("You have voted one investment")
+
+      within(".ballot-list li", text: "Sully monument") do
+        find(".icon-x").click
+      end
+
+      expect(page).to have_content("You have voted 0 investments")
+
+      click_link "Go back"
+
+      expect(page).to have_current_path(budget_investments_path(budget, heading_id: new_york.id))
     end
 
-    expect(page).to have_content("You have voted one investment")
+    scenario "before adding any investments" do
+      login_as(user)
+      visit budget_investments_path(budget, heading_id: new_york.id)
 
-    within(".ballot-list li", text: "Sully monument") do
-      find(".icon-x").click
+      within(".budget-heading") do
+        click_link "Check and confirm my ballot"
+      end
+
+      expect(page).to have_content("You have voted 0 investments")
+
+      click_link "Go back"
+
+      expect(page).to have_current_path(budget_investments_path(budget, heading_id: new_york.id))
     end
-
-    expect(page).to have_content("You have voted 0 investments")
-
-    click_link "Go back"
-
-    expect(page).to have_current_path(budget_investments_path(budget, heading_id: new_york.id))
   end
 
   context "Permissions" do

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -118,7 +118,7 @@ describe "Budgets" do
       visit budgets_path
 
       within("#budget_info") do
-        expect(page).not_to have_link "#{heading.name} €1,000,000"
+        expect(page).not_to have_link heading.name
         expect(page).to have_content "#{heading.name} €1,000,000"
 
         expect(page).not_to have_link("List of all investment projects")
@@ -136,7 +136,7 @@ describe "Budgets" do
       visit budgets_path
 
       within("#budget_info") do
-        expect(page).not_to have_link "#{heading.name} €1,000,000"
+        expect(page).not_to have_link heading.name
         expect(page).to have_content "#{heading.name} €1,000,000"
 
         expect(page).to have_css("div.map")

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -307,7 +307,7 @@ describe "Budgets" do
       map_locations << { longitude: 40.123456789, latitude: "********" }
       map_locations << { longitude: "**********", latitude: 3.12345678 }
 
-      budget_map_locations = map_locations.map do |map_location|
+      coordinates = map_locations.map do |map_location|
         {
           lat: map_location[:latitude],
           long: map_location[:longitude],
@@ -317,8 +317,7 @@ describe "Budgets" do
         }
       end
 
-      allow_any_instance_of(BudgetsHelper).
-      to receive(:current_budget_map_locations).and_return(budget_map_locations)
+      allow_any_instance_of(Budgets::BudgetComponent).to receive(:coordinates).and_return(coordinates)
 
       visit budgets_path
 
@@ -329,61 +328,32 @@ describe "Budgets" do
   end
 
   context "Show" do
-    scenario "List all groups" do
-      create(:budget_group, budget: budget)
-      create(:budget_group, budget: budget)
-
-      visit budget_path(budget)
-
-      budget.groups.each { |group| expect(page).to have_link(group.name) }
-    end
-
     scenario "Links to unfeasible and selected if balloting or later" do
       budget = create(:budget, :selecting)
       group = create(:budget_group, budget: budget)
 
-      visit budget_path(budget)
-
-      expect(page).not_to have_link "See unfeasible investments"
-      expect(page).not_to have_link "See investments not selected for balloting phase"
-
-      click_link group.name
+      visit budget_group_path(budget, group)
 
       expect(page).not_to have_link "See unfeasible investments"
       expect(page).not_to have_link "See investments not selected for balloting phase"
 
       budget.update!(phase: :publishing_prices)
 
-      visit budget_path(budget)
-
-      expect(page).not_to have_link "See unfeasible investments"
-      expect(page).not_to have_link "See investments not selected for balloting phase"
-
-      click_link group.name
+      visit budget_group_path(budget, group)
 
       expect(page).not_to have_link "See unfeasible investments"
       expect(page).not_to have_link "See investments not selected for balloting phase"
 
       budget.update!(phase: :balloting)
 
-      visit budget_path(budget)
-
-      expect(page).to have_link "See unfeasible investments"
-      expect(page).to have_link "See investments not selected for balloting phase"
-
-      click_link group.name
+      visit budget_group_path(budget, group)
 
       expect(page).to have_link "See unfeasible investments"
       expect(page).to have_link "See investments not selected for balloting phase"
 
       budget.update!(phase: :finished)
 
-      visit budget_path(budget)
-
-      expect(page).to have_link "See unfeasible investments"
-      expect(page).to have_link "See investments not selected for balloting phase"
-
-      click_link group.name
+      visit budget_group_path(budget, group)
 
       expect(page).to have_link "See unfeasible investments"
       expect(page).to have_link "See investments not selected for balloting phase"
@@ -399,8 +369,7 @@ describe "Budgets" do
       heading3 = create(:budget_heading, group: group2, name: "Brooklyn")
       heading4 = create(:budget_heading, group: group2, name: "Queens")
 
-      visit budget_path(budget)
-      click_link "New York"
+      visit budget_group_path(budget, group1)
 
       expect(page).to have_css("#budget_heading_#{heading1.id}")
       expect(page).to have_css("#budget_heading_#{heading2.id}")

--- a/spec/system/budgets/groups_spec.rb
+++ b/spec/system/budgets/groups_spec.rb
@@ -68,5 +68,13 @@ describe "Budget Groups" do
       expect(page).to have_link "Southwest"
       expect(page).not_to have_link "See investments not selected for balloting phase unfeasible investments"
     end
+
+    scenario "Back link", :js do
+      visit budget_group_path(budget, group)
+
+      click_link "Go back"
+
+      expect(page).to have_current_path budget_path(budget)
+    end
   end
 end

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1230,7 +1230,7 @@ describe "Budget Investments" do
 
       first(:link, "Participatory budgeting").click
 
-      click_link "More hospitals €666,666"
+      click_link "More hospitals"
 
       within("#budget_investment_#{investment1.id}") do
         expect(page).to have_content investment1.title

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -88,6 +88,10 @@ describe "Budget Investments" do
         expect(page).not_to have_content(unfeasible_investment.title)
       end
     end
+
+    click_link "Go back"
+
+    expect(page).to have_current_path budget_path(budget)
   end
 
   scenario "Index view mode" do

--- a/spec/system/tags/budget_investments_spec.rb
+++ b/spec/system/tags/budget_investments_spec.rb
@@ -256,8 +256,7 @@ describe "Tags" do
         end
 
         login_as(admin) if budget.drafting?
-        visit budget_path(budget)
-        click_link group.name
+        visit budget_investments_path(budget, heading: heading.id)
 
         within "#tag-cloud" do
           click_link new_tag
@@ -305,8 +304,7 @@ describe "Tags" do
         end
 
         login_as(admin) if budget.drafting?
-        visit budget_path(budget)
-        click_link group.name
+        visit budget_investments_path(budget, heading: heading.id)
 
         within "#categories" do
           click_link tag_medio_ambiente.name


### PR DESCRIPTION
## References

* This is part of pull request #4198
* Depends on pull request #4396

## Objectives

* Make current and past budgets pages consistent

## Visual changes

### Before these changes

![The budget page offers links to the investments for each of its groups](https://user-images.githubusercontent.com/35156/111239640-dad9f480-85f9-11eb-803d-6515bcfa5ffa.png)

### After these changes

![The budget page offers links to the investments for each of its headings, a description of the current phase and a map showing the location of the investments ](https://user-images.githubusercontent.com/35156/111239636-d8779a80-85f9-11eb-8721-99259a7c8642.png)
