### PR TITLE
Publish budgets created in dev seeds

### DIFF
--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -29,14 +29,16 @@ section "Creating Budgets" do
     name_en: "#{I18n.t("seeds.budgets.budget", locale: :en)} #{Date.current.year - 1}",
     name_es: "#{I18n.t("seeds.budgets.budget", locale: :es)} #{Date.current.year - 1}",
     currency_symbol: I18n.t("seeds.budgets.currency"),
-    phase: "finished"
+    phase: "finished",
+    published: true
   )
 
   Budget.create!(
     name_en: "#{I18n.t("seeds.budgets.budget", locale: :en)} #{Date.current.year}",
     name_es: "#{I18n.t("seeds.budgets.budget", locale: :es)} #{Date.current.year}",
     currency_symbol: I18n.t("seeds.budgets.currency"),
-    phase: "accepting"
+    phase: "accepting",
+    published: true
   )
 
   Budget.find_each do |budget|


### PR DESCRIPTION
## References

Related PR: #4369 

## Objectives

Since pull request #4369 (Refactor participatory budgets in draft mode ) budgets have a new field "published" to manage whether they are displayed or not. We update this field in dev_seeds to be able to display budgets on the public page budgets.