### PR TITLE
Avoid timeouts in Knapsack PRO

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@
 require File.expand_path("../config/application", __FILE__)
 
 Rails.application.load_tasks if Rake::Task.tasks.empty?
-KnapsackPro.load_tasks if defined?(KnapsackPro)
 
 if Rails.env.development?
   require "github_changelog_generator/task"

--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -2,6 +2,7 @@
 if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
   KNAPSACK_PRO_ENDPOINT=https://api-disabled-for-fork.knapsackpro.com \
     KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
+    KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
     bundle exec rake knapsack_pro:rspec # use Regular Mode here always
 else
   # Queue Mode - dynamic tests allocation across CI nodes


### PR DESCRIPTION
## References

* Fixes an issue introduced in pull request #4148
* The method to avoid timeouts [changed in Knapsack PRO version 2.3.0](https://github.com/KnapsackPro/knapsack_pro-ruby/blob/master/CHANGELOG.md#230)

## Objectives

Make the test suite run faster when no Knapsack PRO token is provided.