### PR TITLE
Add experimental Gitlab CI integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,49 @@
+stages:
+  - test
+  - lint
+
+tests:
+  image: "ruby:2.6.6"
+  stage: test
+  services:
+    - postgres:10.10
+  cache:
+    key: consul
+    paths:
+      - vendor/
+  variables:
+    POSTGRES_USER: consul
+    RAILS_ENV: test
+    COVERALLS: 1
+  parallel: 5
+  script:
+    - apt-get update && apt-get install -y nodejs chromium
+    - for i in config/*.example; do cp "$i" "${i/.example}"; done
+    - for i in config/*.gitlab; do cp "$i" "${i/.gitlab}"; done
+    - bundle --without development
+    - bundle exec rake db:setup
+    - bundle exec rake assets:precompile > /dev/null 2>&1
+    - bin/knapsack_pro_rspec
+  artifacts:
+    when: on_failure
+    paths:
+      - tmp/screenshots/
+
+# To make this job work, create a Personal Access Token with permissions
+# to comment on your repository and add a variable named
+# PRONTO_GITLAB_API_PRIVATE_TOKEN to your repository CI/CD settings
+# giving it the value of the Personal Access Token
+linters:
+  image: "ruby:2.6.6"
+  stage: lint
+  cache:
+    key: consul
+    paths:
+      - vendor/
+  only:
+    - merge_requests
+  script:
+    - apt-get update && apt-get install -y nodejs cmake pkg-config
+    - bundle --without test
+    - git fetch origin $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
+    - bundle exec pronto run -f gitlab_mr -c origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME

--- a/config/database.yml.gitlab
+++ b/config/database.yml.gitlab
@@ -1,0 +1,11 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  host: postgres
+  pool: 5
+  username: consul
+  password:
+
+test:
+  <<: *default
+  database: consul_test


### PR DESCRIPTION
## References

* [How to run parallel jobs for RSpec tests on GitLab CI Pipeline](https://docs.knapsackpro.com/2019/how-to-run-parallel-jobs-for-rspec-tests-on-gitlab-ci-pipeline-and-speed-up-ruby-javascript-testing)
* [Pronto Gitlab integration](https://github.com/prontolabs/pronto/#gitlab-integration)

## Objectives

Make it easy to run our test suite and lint checks on Gitlab repositories

## Notes

So far there are a few issues:

* Bundled gems don't seem to be cached
* The Ruby version can't be read from .ruby-version and needs to be set manually
* Tests are slower than when run on Github Actions or Travis CI
* There seem to be many flaky tests, maybe because tests are slower (this might actually help us fixing flaky bugs or performance bottlenecks)

An advantage of Gitlab CI is we can access the screenshots taken when a system test fails.