### PR TITLE
 rake db:seed generates default custom pages for all languages

### DIFF
--- a/db/pages/accessibility.rb
+++ b/db/pages/accessibility.rb
@@ -1,5 +1,4 @@
-if SiteCustomization::Page.find_by(slug: "accessibility").nil?
-  page = SiteCustomization::Page.new(slug: "accessibility", status: "published")
+def generate_content(page)
   page.title = I18n.t("pages.accessibility.title")
 
   content = ""
@@ -93,4 +92,15 @@ if SiteCustomization::Page.find_by(slug: "accessibility").nil?
 
   page.content = content
   page.save!
+end
+
+if SiteCustomization::Page.find_by(slug: "accessibility").nil?
+  page = SiteCustomization::Page.new(slug: "accessibility", status: "published")
+  generate_content(page)
+  I18n.available_locales.each do |locale|
+    I18n.locale = locale 
+    translation = page.translations.build(locale: locale)
+   # Not generating content for :fa, :id and it translations, as they are causing error in line 32
+    generate_content(translation) unless locale == :fa or locale == :id or locale == :it
+  end
 end

--- a/db/pages/accessibility.rb
+++ b/db/pages/accessibility.rb
@@ -104,10 +104,7 @@ end
 
 if SiteCustomization::Page.find_by(slug: "accessibility").nil?
   page = SiteCustomization::Page.new(slug: "accessibility", status: "published")
-  generate_content(page)
   I18n.available_locales.each do |locale|
-    I18n.locale = locale
-    translation = page.translations.build(locale: locale)
-    generate_content(translation)
+    I18n.with_locale(locale) { generate_content(page) }
   end
 end

--- a/db/pages/accessibility.rb
+++ b/db/pages/accessibility.rb
@@ -28,10 +28,12 @@ def generate_content(page)
                 </thead>
                 <tbody>"
   I18n.t("pages.accessibility.keyboard_shortcuts.navigation_table.rows").each do |row|
-    content << "  <tr>
+    if row.present?
+      content << "  <tr>
                     <td class='text-center'>#{row[:key_column]}</td>
                     <td>#{row[:page_column]}</td>
                   </tr>"
+    end
   end
   content << "  </tbody>
               </table>
@@ -52,10 +54,12 @@ def generate_content(page)
                 </thead>
                 <tbody>"
   I18n.t("pages.accessibility.keyboard_shortcuts.browser_table.rows").each do |row|
-    content << "  <tr>
+    if row.present?
+      content << "  <tr>
                     <td>#{row[:browser_column]}</td>
                     <td>#{row[:key_column]}</td>
                   </tr>"
+    end
   end
   content << "  </tbody>
               </table>
@@ -74,17 +78,21 @@ def generate_content(page)
                 </thead>
                 <tbody>"
   I18n.t("pages.accessibility.textsize.browser_settings_table.rows").each do |row|
-    content << "  <tr>
+    if row.present?
+      content << "  <tr>
                     <td>#{row[:browser_column]}</td>
                     <td>#{row[:action_column]}</td>
                   </tr>"
+    end
   end
   content << "  </tbody>
               </table>"
   content << "<p>#{I18n.t("pages.accessibility.textsize.browser_shortcuts_table.description")}</p>
               <ul>"
   I18n.t("pages.accessibility.textsize.browser_shortcuts_table.rows").each do |row|
-    content << "<li><strong>#{row[:shortcut_column]}</strong> #{row[:description_column]}</li>"
+    if row.present?
+      content << "<li><strong>#{row[:shortcut_column]}</strong> #{row[:description_column]}</li>"
+    end
   end
   content << "</ul>
               <h2>#{I18n.t("pages.accessibility.compatibility.title")}</h2>
@@ -98,9 +106,8 @@ if SiteCustomization::Page.find_by(slug: "accessibility").nil?
   page = SiteCustomization::Page.new(slug: "accessibility", status: "published")
   generate_content(page)
   I18n.available_locales.each do |locale|
-    I18n.locale = locale 
+    I18n.locale = locale
     translation = page.translations.build(locale: locale)
-   # Not generating content for :fa, :id and it translations, as they are causing error in line 32
-    generate_content(translation) unless locale == :fa or locale == :id or locale == :it
+    generate_content(translation)
   end
 end

--- a/db/pages/conditions.rb
+++ b/db/pages/conditions.rb
@@ -1,8 +1,17 @@
-if SiteCustomization::Page.find_by(slug: "conditions").nil?
-  page = SiteCustomization::Page.new(slug: "conditions", status: "published")
-  page.print_content_flag = true
+def generate_content(page)
   page.title = I18n.t("pages.conditions.title")
   page.subtitle = I18n.t("pages.conditions.subtitle")
   page.content = "<p>#{I18n.t("pages.conditions.description")}</p>"
   page.save!
+end
+
+if SiteCustomization::Page.find_by(slug: "conditions").nil?
+  page = SiteCustomization::Page.new(slug: "conditions", status: "published")
+  page.print_content_flag = true
+  generate_content(page)
+  I18n.available_locales.each do |locale|
+    I18n.locale = locale
+    translation = page.translations.build(locale: locale)
+    generate_content(translation)
+  end
 end

--- a/db/pages/conditions.rb
+++ b/db/pages/conditions.rb
@@ -8,10 +8,7 @@ end
 if SiteCustomization::Page.find_by(slug: "conditions").nil?
   page = SiteCustomization::Page.new(slug: "conditions", status: "published")
   page.print_content_flag = true
-  generate_content(page)
   I18n.available_locales.each do |locale|
-    I18n.locale = locale
-    translation = page.translations.build(locale: locale)
-    generate_content(translation)
+    I18n.with_locale(locale) { generate_content(page) }
   end
 end

--- a/db/pages/faq.rb
+++ b/db/pages/faq.rb
@@ -5,10 +5,7 @@ def generate_content(page)
 end
 if SiteCustomization::Page.find_by(slug: "faq").nil?
   page = SiteCustomization::Page.new(slug: "faq", status: "published")
-  generate_content(page)
   I18n.available_locales.each do |locale|
-    I18n.locale = locale
-    translation = page.translations.build(locale: locale)
-    generate_content(translation)
+    I18n.with_locale(locale) { generate_content(page) }
   end
 end

--- a/db/pages/faq.rb
+++ b/db/pages/faq.rb
@@ -1,6 +1,14 @@
-if SiteCustomization::Page.find_by(slug: "faq").nil?
-  page = SiteCustomization::Page.new(slug: "faq", status: "published")
+def generate_content(page)
   page.title = I18n.t("pages.help.faq.page.title")
   page.content = "<p>#{I18n.t("pages.help.faq.page.description")}</p>"
   page.save!
+end
+if SiteCustomization::Page.find_by(slug: "faq").nil?
+  page = SiteCustomization::Page.new(slug: "faq", status: "published")
+  generate_content(page)
+  I18n.available_locales.each do |locale|
+    I18n.locale = locale
+    translation = page.translations.build(locale: locale)
+    generate_content(translation)
+  end
 end

--- a/db/pages/privacy.rb
+++ b/db/pages/privacy.rb
@@ -1,7 +1,16 @@
-if SiteCustomization::Page.find_by(slug: "privacy").nil?
-  page = SiteCustomization::Page.new(slug: "privacy", status: "published")
-  page.print_content_flag = true
+def generate_content(page)
   page.title = I18n.t("pages.privacy.title")
   page.content = I18n.t("pages.privacy.subtitle")
   page.save!
+end
+
+if SiteCustomization::Page.find_by(slug: "privacy").nil?
+  page = SiteCustomization::Page.new(slug: "privacy", status: "published")
+  page.print_content_flag = true
+  generate_content(page)
+  I18n.available_locales.each do |locale|
+    I18n.locale = locale
+    translation = page.translations.build(locale: locale)
+    generate_content(translation)
+  end
 end

--- a/db/pages/privacy.rb
+++ b/db/pages/privacy.rb
@@ -7,10 +7,7 @@ end
 if SiteCustomization::Page.find_by(slug: "privacy").nil?
   page = SiteCustomization::Page.new(slug: "privacy", status: "published")
   page.print_content_flag = true
-  generate_content(page)
   I18n.available_locales.each do |locale|
-    I18n.locale = locale
-    translation = page.translations.build(locale: locale)
-    generate_content(translation)
+    I18n.with_locale(locale) { generate_content(page) }
   end
 end

--- a/db/pages/welcome_level_three_verified.rb
+++ b/db/pages/welcome_level_three_verified.rb
@@ -1,5 +1,4 @@
-if SiteCustomization::Page.find_by(slug: "welcome_level_three_verified").nil?
-  page = SiteCustomization::Page.new(slug: "welcome_level_three_verified", status: "published")
+def generate_content(page)
   page.title = I18n.t("welcome.welcome.title")
 
   page.content = "<p>#{I18n.t("welcome.welcome.user_permission_info")}</p>
@@ -16,4 +15,14 @@ if SiteCustomization::Page.find_by(slug: "welcome_level_three_verified").nil?
 
                   <p><a href='/'>#{I18n.t("welcome.welcome.start_using_consul")}</a></p>"
   page.save!
+end
+
+if SiteCustomization::Page.find_by(slug: "welcome_level_three_verified").nil?
+  page = SiteCustomization::Page.new(slug: "welcome_level_three_verified", status: "published")
+  generate_content(page)
+  I18n.available_locales.each do |locale|
+    I18n.locale = locale
+    translation = page.translations.build(locale: locale)
+    generate_content(translation)
+  end
 end

--- a/db/pages/welcome_level_three_verified.rb
+++ b/db/pages/welcome_level_three_verified.rb
@@ -19,10 +19,7 @@ end
 
 if SiteCustomization::Page.find_by(slug: "welcome_level_three_verified").nil?
   page = SiteCustomization::Page.new(slug: "welcome_level_three_verified", status: "published")
-  generate_content(page)
   I18n.available_locales.each do |locale|
-    I18n.locale = locale
-    translation = page.translations.build(locale: locale)
-    generate_content(translation)
+    I18n.with_locale(locale) { generate_content(page) }
   end
 end

--- a/db/pages/welcome_level_two_verified.rb
+++ b/db/pages/welcome_level_two_verified.rb
@@ -24,10 +24,7 @@ def generate_content(page)
 end
 if SiteCustomization::Page.find_by(slug: "welcome_level_two_verified").nil?
   page = SiteCustomization::Page.new(slug: "welcome_level_two_verified", status: "published")
-  generate_content(page)
   I18n.available_locales.each do |locale|
-    I18n.locale = locale
-    translation = page.translations.build(locale: locale)
-    generate_content(translation)
+    I18n.with_locale(locale) { generate_content(page) }
   end
 end

--- a/db/pages/welcome_level_two_verified.rb
+++ b/db/pages/welcome_level_two_verified.rb
@@ -1,5 +1,4 @@
-if SiteCustomization::Page.find_by(slug: "welcome_level_two_verified").nil?
-  page = SiteCustomization::Page.new(slug: "welcome_level_two_verified", status: "published")
+def generate_content(page)
   page.title = I18n.t("welcome.welcome.title")
 
   page.content = "<p>#{I18n.t("welcome.welcome.user_permission_info")}</p>
@@ -22,4 +21,13 @@ if SiteCustomization::Page.find_by(slug: "welcome_level_two_verified").nil?
 
                   <p><a href='/'>#{I18n.t("welcome.welcome.go_to_index")}</a></p>"
   page.save!
+end
+if SiteCustomization::Page.find_by(slug: "welcome_level_two_verified").nil?
+  page = SiteCustomization::Page.new(slug: "welcome_level_two_verified", status: "published")
+  generate_content(page)
+  I18n.available_locales.each do |locale|
+    I18n.locale = locale
+    translation = page.translations.build(locale: locale)
+    generate_content(translation)
+  end
 end

--- a/db/pages/welcome_not_verified.rb
+++ b/db/pages/welcome_not_verified.rb
@@ -24,10 +24,7 @@ def generate_content(page)
 end
 if SiteCustomization::Page.find_by(slug: "welcome_not_verified").nil?
   page = SiteCustomization::Page.new(slug: "welcome_not_verified", status: "published")
-  generate_content(page)
   I18n.available_locales.each do |locale|
-    I18n.locale = locale
-    translation = page.translations.build(locale: locale)
-    generate_content(translation)
+    I18n.with_locale(locale) { generate_content(page) }
   end
 end

--- a/db/pages/welcome_not_verified.rb
+++ b/db/pages/welcome_not_verified.rb
@@ -1,5 +1,4 @@
-if SiteCustomization::Page.find_by(slug: "welcome_not_verified").nil?
-  page = SiteCustomization::Page.new(slug: "welcome_not_verified", status: "published")
+def generate_content(page)
   page.title = I18n.t("welcome.welcome.title")
 
   page.content = "<p>#{I18n.t("welcome.welcome.user_permission_info")}</p>
@@ -22,4 +21,13 @@ if SiteCustomization::Page.find_by(slug: "welcome_not_verified").nil?
 
                   <p><a href='/'>#{I18n.t("welcome.welcome.go_to_index")}</a></p>"
   page.save!
+end
+if SiteCustomization::Page.find_by(slug: "welcome_not_verified").nil?
+  page = SiteCustomization::Page.new(slug: "welcome_not_verified", status: "published")
+  generate_content(page)
+  I18n.available_locales.each do |locale|
+    I18n.locale = locale
+    translation = page.translations.build(locale: locale)
+    generate_content(translation)
+  end
 end

--- a/spec/lib/tasks/seed_spec.rb
+++ b/spec/lib/tasks/seed_spec.rb
@@ -23,8 +23,8 @@ describe "rake db:seed" do
           expect(site.title).to eq I18n.t(path)
         end
       end
+    ensure
+      I18n.available_locales = default_locales
     end
-  ensure
-    I18n.available_locales = default_locales
   end
 end

--- a/spec/lib/tasks/seed_spec.rb
+++ b/spec/lib/tasks/seed_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe "rake db:seed" do
+  it "generates all custom pages translations populated by db:seeds" do
+    default_locales = I18n.available_locales
+    begin
+      I18n.available_locales = [:ar, :bg, :bs, :ca, :cs, :da, :de, :el, :en, :es, :"es-PE", :eu, :fa, :fr,
+        :gl, :he, :hr, :id, :it, :ka, :nl, :oc, :pl, :"pt-BR",
+        :ro, :ru, :sl, :sq, :so, :sr, :sv, :tr, :val, :"zh-CN", :"zh-TW"]
+      SiteCustomization::Page.destroy_all
+      load Rails.root.join("db", "pages.rb")
+
+      paths = { accessibility: "pages.accessibility.title", conditions: "pages.conditions.title",
+                faq: "pages.help.faq.page.title", privacy: "pages.privacy.title",
+                welcome_not_verified: "welcome.welcome.title",
+                welcome_level_two_verified: "welcome.welcome.title",
+                welcome_level_three_verified: "welcome.welcome.title" }
+
+      I18n.available_locales.each do |locale|
+        I18n.locale = locale
+        paths.each do |slug, path|
+          site = SiteCustomization::Page.find_by(slug: slug).translations.find_by(locale: locale)
+          expect(site.title).to eq I18n.t(path)
+        end
+      end
+    end
+  ensure
+    I18n.available_locales = default_locales
+  end
+end

--- a/spec/system/admin/site_customization/pages_spec.rb
+++ b/spec/system/admin/site_customization/pages_spec.rb
@@ -1,12 +1,6 @@
 require "rails_helper"
 
 describe "Admin custom pages", :admin do
-  I18n.available_locales = [:ar, :bg, :bs, :ca, :cs, :da, :de, :el, :en, :es, :"es-PE", :eu, :fa, :fr,
-                                  :gl, :he, :hr, :id, :it, :ka, :nl, :oc, :pl, :"pt-BR",
-                                  :ro, :ru, :sl, :sq, :so, :sr, :sv, :tr, :val, :"zh-CN", :"zh-TW"]
-  SiteCustomization::Page.destroy_all
-  Rails.application.load_seed
-
   context "Index" do
     scenario "lists all created custom pages" do
       custom_page = create(:site_customization_page)
@@ -30,21 +24,6 @@ describe "Admin custom pages", :admin do
       expect(all("[id^='site_customization_page_']").count).to be 7
       slugs.each do |slug|
         expect(page).to have_content slug
-      end
-    end
-
-    scenario "should contain all custom pages translations populated by db:seeds" do
-      paths = { accessibility: "pages.accessibility.title", conditions: "pages.conditions.title",
-                faq: "pages.help.faq.page.title", privacy: "pages.privacy.title",
-                welcome_not_verified: "welcome.welcome.title",
-                welcome_level_two_verified: "welcome.welcome.title",
-                welcome_level_three_verified: "welcome.welcome.title" }
-      I18n.available_locales.each do |locale|
-        I18n.locale = locale
-        paths.each do |slug, path|
-          site = SiteCustomization::Page.find_by(slug: slug).translations.find_by(locale: locale)
-          expect(site.title).to eq I18n.t(path)
-        end
       end
     end
   end

--- a/spec/system/admin/site_customization/pages_spec.rb
+++ b/spec/system/admin/site_customization/pages_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 describe "Admin custom pages", :admin do
+  I18n.available_locales = [:ar, :bg, :bs, :ca, :cs, :da, :de, :el, :en, :es, :"es-PE", :eu, :fa, :fr,
+                                  :gl, :he, :hr, :id, :it, :ka, :nl, :oc, :pl, :"pt-BR",
+                                  :ro, :ru, :sl, :sq, :so, :sr, :sv, :tr, :val, :"zh-CN", :"zh-TW"]
+  SiteCustomization::Page.destroy_all
+  Rails.application.load_seed
+
   context "Index" do
     scenario "lists all created custom pages" do
       custom_page = create(:site_customization_page)
@@ -33,12 +39,12 @@ describe "Admin custom pages", :admin do
                 welcome_not_verified: "welcome.welcome.title",
                 welcome_level_two_verified: "welcome.welcome.title",
                 welcome_level_three_verified: "welcome.welcome.title" }
-      locale = :fr
-      I18n.locale = locale
-
-      paths.each do |slug, path|
-        site = SiteCustomization::Page.find_by(slug: slug).translations.find_by(locale: locale)
-        expect(site.title).to eq I18n.t(path)
+      I18n.available_locales.each do |locale|
+        I18n.locale = locale
+        paths.each do |slug, path|
+          site = SiteCustomization::Page.find_by(slug: slug).translations.find_by(locale: locale)
+          expect(site.title).to eq I18n.t(path)
+        end
       end
     end
   end

--- a/spec/system/admin/site_customization/pages_spec.rb
+++ b/spec/system/admin/site_customization/pages_spec.rb
@@ -26,6 +26,21 @@ describe "Admin custom pages", :admin do
         expect(page).to have_content slug
       end
     end
+
+    scenario "should contain all custom pages translations populated by db:seeds" do
+      paths = { accessibility: "pages.accessibility.title", conditions: "pages.conditions.title",
+                faq: "pages.help.faq.page.title", privacy: "pages.privacy.title",
+                welcome_not_verified: "welcome.welcome.title",
+                welcome_level_two_verified: "welcome.welcome.title",
+                welcome_level_three_verified: "welcome.welcome.title" }
+      locale = :fr
+      I18n.locale = locale
+
+      paths.each do |slug, path|
+        site = SiteCustomization::Page.find_by(slug: slug).translations.find_by(locale: locale)
+        expect(site.title).to eq I18n.t(path)
+      end
+    end
   end
 
   context "Create" do


### PR DESCRIPTION

##   References

>Issue  #4399  

## Objectives

> Every time an institution installs CONSUL it runs rake db:seed task.
In this rake task the following line is executed:

```
# Default custom pages
load Rails.root.join("db", "pages.rb")
```

Currently, these custom pages are only created in the main language.
This pull request makes them generate translations as well so its possible to access them like
`page.translations` 


## Notes

> 

- There was a problem with some of translation files(`:fa` `:id` and `:it`) for _db/pages/accessibility.rb_. It was caused by unnecessary dashes `-`, causing the method to read nul values instead of key-value pairs. After deleting all seems to work like intended.
- Added simple spec to `spec/system/admin/site_customization/pages_spec.rb`. The spec iterates through all generated custom pages, selects the french translation and compares database title record to the output of I18n.t(title_path). It should be enough to assure translation has been generated.

 
