### PR TITLE
Remove dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "06:00"
-    timezone: Europe/Madrid
-  open-pull-requests-limit: 25


### PR DESCRIPTION
## References

* We're trying to avoid issues caused by dependabot/dependabot-core#2198
* Reverts pull request #4406

## Backgrounds

Due to a bug in dependabot, Dependabot would open pull requests on every fork, which would be inconvenient.

## Objectives

Disable dependabot updates until this issue is fixed.

## Notes

Since we currently have almost 50 open pull requests, it shouldn't affect us that much for the time being.