### PR TITLE
Issue#4013

### DIFF
--- a/app/models/concerns/measurable.rb
+++ b/app/models/concerns/measurable.rb
@@ -13,7 +13,11 @@ module Measurable
     def question_max_length
       140
     end
-
+    
+    def description_min_length
+      10
+    end
+    
     def description_max_length
       6000
     end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -29,7 +29,8 @@ class Debate < ApplicationRecord
   has_many :comments, as: :commentable, inverse_of: :commentable
 
   validates_translation :title, presence: true, length: { in: 4..Debate.title_max_length }
-  validates_translation :description, presence: true, length: { in: 10..Debate.description_max_length }
+  validates_translation :description, presence: true
+  validate :description_sanitized
   validates :author, presence: true
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
@@ -164,4 +165,15 @@ class Debate < ApplicationRecord
     orders << "recommendations" if Setting["feature.user.recommendations_on_debates"] && user&.recommended_debates
     orders
   end
+
+  def description_sanitized
+    real_description_length = ActionView::Base.full_sanitizer.sanitize("#{description}").squish.length
+    if real_description_length < 10
+      errors.add(:description,  I18n.t("errors.messages.too_short.other", count: Debate.description_min_length))
+    end
+    if real_description_length > Debate.description_max_length
+      errors.add(:description, I18n.t("errors.messages.too_long", count: Debate.description_max_length))
+    end
+  end
+
 end

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -20,6 +20,11 @@
         <%= translations_form.text_area :description,
               maxlength: Debate.description_max_length,
               class: "html-area" %>
+        <% if @debate.errors.present? %>
+          <div class="form-error is-visible html-area ">
+            <%= @debate.errors[:description][0]  %>
+          </div>
+        <% end %>
       </div>
     <% end %>
 

--- a/spec/models/concerns/globalizable.rb
+++ b/spec/models/concerns/globalizable.rb
@@ -63,7 +63,7 @@ shared_examples_for "globalizable" do |factory_name|
       record.reload
 
       record.update!(translations_attributes: [
-        { locale: :de }.merge(fields.map { |field| [field, "Deutsch"] }.to_h)
+        { locale: :de }.merge(fields.map { |field| [field, "Deutsche Sprache"] }.to_h)
       ])
 
       record.reload
@@ -102,7 +102,7 @@ shared_examples_for "globalizable" do |factory_name|
       record.reload
 
       record.update!(translations_attributes: [
-        { id: record.translations.first.id }.merge(fields.map { |field| [field, "Cambiado"] }.to_h)
+        { id: record.translations.first.id }.merge(fields.map { |field| [field, "Actualizado"] }.to_h)
       ])
 
       record.reload
@@ -155,8 +155,8 @@ shared_examples_for "globalizable" do |factory_name|
   describe "Fallbacks" do
     before do
       I18n.with_locale(:de) do
-        record.update!(required_fields.map { |field| [field, "Deutsch"] }.to_h)
-        record.update!(attribute => "Deutsch")
+        record.update!(required_fields.map { |field| [field, "Deutsche Sprache"] }.to_h)
+        record.update!(attribute => "Deutsche Sprache")
       end
     end
 
@@ -174,7 +174,7 @@ shared_examples_for "globalizable" do |factory_name|
       Globalize.set_fallbacks_to_all_available_locales
 
       I18n.with_locale(:fr) do
-        expect(record.send(attribute)).to eq "Deutsch"
+        expect(record.send(attribute)).to eq "Deutsche Sprache"
       end
     end
 
@@ -185,7 +185,7 @@ shared_examples_for "globalizable" do |factory_name|
         { id: record.translations.find_by(locale: :en).id, _destroy: true }
       ])
 
-      expect(record.send(attribute)).to eq "Deutsch"
+      expect(record.send(attribute)).to eq "Deutsche Sprache"
     end
   end
 end

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -45,8 +45,13 @@ describe Debate do
     end
 
     it "is not valid when very short" do
-      debate.description = "abc"
+      debate.description = "<a><h1><u>abc</a></h1></u>"
       expect(debate).not_to be_valid
+    end
+
+    it "is valid when very long and sanitized" do
+      debate.description = "<a><h1>a</a></h1>" * 6000
+      expect(debate).to be_valid
     end
 
     it "is not valid when very long" do


### PR DESCRIPTION
## References

Fixes issue#4013

## Objectives

> Changes the method of validating the debate description field. Now the input is sanitized of the html tags before validating.

Nil description:

![Screenshot from 2021-03-22 14-41-50](https://user-images.githubusercontent.com/61836657/112035963-dbedb300-8b1e-11eb-8548-c654eeef79c7.png)

Short description:

![Screenshot from 2021-03-22 14-42-14](https://user-images.githubusercontent.com/61836657/112036028-ee67ec80-8b1e-11eb-8beb-2805a388649c.png)


Long descrption:

![Screenshot from 2021-03-22 14-43-26](https://user-images.githubusercontent.com/61836657/112036038-f2940a00-8b1e-11eb-8c27-ad42f56d6273.png)


## Visual Changes

> The short length description error message now is below the "can't be blank" message.
![Screenshot from 2021-03-22 14-41-50](https://user-images.githubusercontent.com/61836657/112036507-79e17d80-8b1f-11eb-8c48-e15551f49809.png)


## Notes

> No notes.
