### PR TITLE
Comment secret key base on production environments

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,7 +1,3 @@
-default: &default
-  secret_key_base: 56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4
-  email_interceptor_recipients: ""
-
 maps: &maps
   map_tiles_provider: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
   map_tiles_provider_attribution: "&copy; <a href=\"http://osm.org/copyright\">OpenStreetMap</a> contributors"
@@ -22,15 +18,15 @@ http_basic_auth: &http_basic_auth
 development:
   http_basic_username: "dev"
   http_basic_password: "pass"
-  <<: *default
+  secret_key_base: 56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4
   <<: *maps
 
 test:
-  <<: *default
+  secret_key_base: 56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4
   <<: *maps
 
 staging:
-  secret_key_base: ""
+  # secret_key_base: ""
   server_name: ""
   # mailer_delivery_method: :smtp
   # smtp_settings:
@@ -43,6 +39,7 @@ staging:
   #   :enable_starttls_auto: true
   force_ssl: true
   delay_jobs: true
+  email_interceptor_recipients: ""
   errbit_host: ""
   errbit_project_key: ""
   errbit_project_id: 1
@@ -52,12 +49,11 @@ staging:
   http_basic_password: ""
   managers_url: ""
   managers_application_key: ""
-  <<: *default
   <<: *maps
   <<: *apis
 
 preproduction:
-  secret_key_base: ""
+  # secret_key_base: ""
   server_name: ""
   # mailer_delivery_method: :smtp
   # smtp_settings:
@@ -70,6 +66,7 @@ preproduction:
   #   :enable_starttls_auto: true
   force_ssl: true
   delay_jobs: true
+  email_interceptor_recipients: ""
   errbit_host: ""
   errbit_project_key: ""
   errbit_project_id: 1
@@ -89,7 +86,7 @@ preproduction:
   <<: *apis
 
 production:
-  secret_key_base: ""
+  # secret_key_base: ""
   server_name: ""
   # mailer_delivery_method: :smtp
   # smtp_settings:


### PR DESCRIPTION
## Background

Although our installer automatically generates a secret key base, installing CONSUL without the installer might result in having an empty secret key base.

## Objectives

Reduce the chance of CONSUL installations having a secret key base or using the sample one we provide for development and test environments.