### PR TITLE
Bump mimemagic to version 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,7 +360,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
## References

* Mimemagic has yanked all versions previous to 0.3.6: minad/mimemagic#98

## Objectives

Make it possible to run `bundle install` and get all dependencies.