### PR TITLE
Improve user search by email/name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,8 +113,8 @@ class User < ApplicationRecord
     joins(:comments).where("comments.commentable": commentables).distinct
   end
   scope :by_username_email_or_document_number, ->(search_string) do
-    string = "%#{search_string}%"
-    where("username ILIKE ? OR email ILIKE ? OR document_number ILIKE ?", string, string, string)
+    search = "%#{search_string.strip}%"
+    where("username ILIKE ? OR email ILIKE ? OR document_number ILIKE ?", search, search, search)
   end
   scope :between_ages, ->(from, to) do
     where(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -302,7 +302,7 @@ class User < ApplicationRecord
   end
 
   def self.search(term)
-    term.present? ? where("email = ? OR username ILIKE ?", term, "%#{term}%") : none
+    term.present? ? where("email = ? OR username ILIKE ?", term.strip, "%#{term}%") : none
   end
 
   def self.username_max_length

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -302,7 +302,10 @@ class User < ApplicationRecord
   end
 
   def self.search(term)
-    term.present? ? where("email = ? OR username ILIKE ?", term.strip, "%#{term}%") : none
+    return none if term.blank?
+
+    search = term.strip
+    where("email = ? OR username ILIKE ?", search, "%#{search}%")
   end
 
   def self.username_max_length

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -440,6 +440,14 @@ describe User do
       expect(search).to eq [user1]
     end
 
+    it "find users by name with whitespaces" do
+      user1 = create(:user, username: "Larry Bird")
+      create(:user, username: "Robert Parish")
+      search = User.search(" larry ")
+
+      expect(search).to eq [user1]
+    end
+
     it "returns no results if no search term provided" do
       expect(User.search("    ")).to be_empty
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -416,36 +416,26 @@ describe User do
   end
 
   describe "self.search" do
-    it "find users by email" do
-      user1 = create(:user, email: "larry@consul.dev")
-      create(:user, email: "bird@consul.dev")
-      search = User.search("larry@consul.dev")
+    describe "find users" do
+      let!(:larry) { create(:user, email: "larry@consul.dev", username: "Larry Bird") }
 
-      expect(search).to eq [user1]
-    end
+      before { create(:user, email: "robert@consul.dev", username: "Robert Parish") }
 
-    it "find users by email with whitespaces" do
-      user1 = create(:user, email: "larry@consul.dev")
-      create(:user, email: "bird@consul.dev")
-      search = User.search(" larry@consul.dev ")
+      it "by email" do
+        expect(User.search("larry@consul.dev")).to eq [larry]
+      end
 
-      expect(search).to eq [user1]
-    end
+      it "by email with whitespaces" do
+        expect(User.search(" larry@consul.dev ")).to eq [larry]
+      end
 
-    it "find users by name" do
-      user1 = create(:user, username: "Larry Bird")
-      create(:user, username: "Robert Parish")
-      search = User.search("larry")
+      it "by name" do
+        expect(User.search("larry")).to eq [larry]
+      end
 
-      expect(search).to eq [user1]
-    end
-
-    it "find users by name with whitespaces" do
-      user1 = create(:user, username: "Larry Bird")
-      create(:user, username: "Robert Parish")
-      search = User.search(" larry ")
-
-      expect(search).to eq [user1]
+      it "by name with whitespaces" do
+        expect(User.search(" larry ")).to eq [larry]
+      end
     end
 
     it "returns no results if no search term provided" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -413,6 +413,38 @@ describe User do
         expect(User.erased).not_to include(user3)
       end
     end
+
+    describe ".by_username_email_or_document_number" do
+      let!(:larry) do
+        create(:user, email: "larry@consul.dev", username: "Larry Bird", document_number: "12345678Z")
+      end
+
+      before { create(:user, email: "robert@consul.dev", username: "Robert Parish") }
+
+      it "finds users by email" do
+        expect(User.by_username_email_or_document_number("larry@consul.dev")).to eq [larry]
+      end
+
+      it "finds users by email with whitespaces" do
+        expect(User.by_username_email_or_document_number(" larry@consul.dev ")).to eq [larry]
+      end
+
+      it "finds users by name" do
+        expect(User.by_username_email_or_document_number("larry")).to eq [larry]
+      end
+
+      it "finds users by name with whitespaces" do
+        expect(User.by_username_email_or_document_number(" larry ")).to eq [larry]
+      end
+
+      it "finds users by document_number" do
+        expect(User.by_username_email_or_document_number("12345678Z")).to eq [larry]
+      end
+
+      it "finds users by document_number with whitespaces" do
+        expect(User.by_username_email_or_document_number(" 12345678Z ")).to eq [larry]
+      end
+    end
   end
 
   describe "self.search" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -424,6 +424,14 @@ describe User do
       expect(search).to eq [user1]
     end
 
+    it "find users by email with whitespaces" do
+      user1 = create(:user, email: "larry@consul.dev")
+      create(:user, email: "bird@consul.dev")
+      search = User.search(" larry@consul.dev ")
+
+      expect(search).to eq [user1]
+    end
+
     it "find users by name" do
       user1 = create(:user, username: "Larry Bird")
       create(:user, username: "Robert Parish")


### PR DESCRIPTION
## References

Closes #2149 

## Objectives
Searching by email/name should ignore leading/trailing blank spaces on the text used to search.
