### PR TITLE
Fix admin notification with relative URLs

### DIFF
--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -42,7 +42,7 @@ class AdminNotification < ApplicationRecord
     def complete_link_url
       return unless link.present?
 
-      unless self.link[/\Ahttp:\/\//] || self.link[/\Ahttps:\/\//]
+      unless link =~ /\A(http:\/\/|https:\/\/|\/)/
         self.link = "http://#{self.link}"
       end
     end

--- a/spec/models/admin_notification_spec.rb
+++ b/spec/models/admin_notification_spec.rb
@@ -43,6 +43,13 @@ describe AdminNotification do
       expect(admin_notification.link).to eq("http://www.lol.consul.dev")
     end
 
+    it "does not modify a relative link" do
+      admin_notification.link = "/proposals"
+
+      expect(admin_notification).to be_valid
+      expect(admin_notification.link).to eq("/proposals")
+    end
+
     it "does not modify a link with http://" do
       admin_notification.link = "http://lol.consul.dev"
 

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -158,7 +158,7 @@ describe "Notifications" do
       expect(page.current_url).to eq("https://www.external.link.dev/")
     end
 
-    scenario "With internal link" do
+    scenario "With internal link", :js do
       admin_notification.update!(link: "/stats")
 
       visit notifications_path


### PR DESCRIPTION
## Background

We had a test checking admin notifications worked with relative URLs. Howeter, the test was passing because it was using the rack driver, but on real browsers it wasn't generating the expected URL.

## Objectives

Fix wrong URL being generated on admin notifications with relative URLs.