### PR TITLE
Fix "Go back" link in stat graphs

### DIFF
--- a/app/views/admin/stats/_graph.html.erb
+++ b/app/views/admin/stats/_graph.html.erb
@@ -1,5 +1,3 @@
-<%= back_link_to %>
-
 <div id="graph" class="small-12 column">
   <h2><%= t "admin.stats.graph.#{name || event}" %> (<%= count %>)</h2>
   <%= chart_tag id: name, event: event %>

--- a/app/views/admin/stats/graph.html.erb
+++ b/app/views/admin/stats/graph.html.erb
@@ -2,4 +2,6 @@
   <%= javascript_include_tag "stat_graphs", "data-turbolinks-track" => "reload" %>
 <% end %>
 
+<%= back_link_to admin_stats_path %>
+
 <%= render "graph", name: @name, event: @event, count: @count %>

--- a/app/views/admin/verifications/index.html.erb
+++ b/app/views/admin/verifications/index.html.erb
@@ -1,3 +1,5 @@
+<%= back_link_to admin_stats_path %>
+
 <h2><%= t("admin.verifications.index.title") %></h2>
 
 <%= render "admin/shared/user_search", url: search_admin_verifications_path %>

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -109,6 +109,7 @@ describe "Stats", :admin do
         end
 
         expect(page).to have_content "Votes 3"
+        expect(page).to have_link "Go back", count: 1
       end
 
       scenario "Number of users that have supported an investment project" do

--- a/spec/system/admin/verifications_spec.rb
+++ b/spec/system/admin/verifications_spec.rb
@@ -9,6 +9,7 @@ describe "Incomplete verifications", :admin do
 
     visit admin_verifications_path
 
+    expect(page).to have_link "Go back", href: admin_stats_path
     expect(page).to have_content(incompletely_verified_user1.username)
     expect(page).to have_content(incompletely_verified_user2.username)
     expect(page).not_to have_content(never_tried_to_verify_user.username)


### PR DESCRIPTION
## Objectives

* Fix a "go back" link appearing twice when visiting stats for a supporting phase.

## Visual changes

### Before these changes

![There are two "go back" links in the stats for a supporting phase](https://user-images.githubusercontent.com/35156/112976652-6d7ba700-9155-11eb-9eb9-0d7274cfaa10.png)

### After these changes

![There is one "go back" link in the stats for a supporting phase](https://user-images.githubusercontent.com/35156/112976660-6fde0100-9155-11eb-843c-398f93120d4d.png)