### PR TITLE
Use a driver supporting JavaScript in system tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     services:
       postgres:
         image: postgres:10.10

--- a/app/components/budgets/phases_component.rb
+++ b/app/components/budgets/phases_component.rb
@@ -21,7 +21,7 @@ class Budgets::PhasesComponent < ApplicationComponent
     end
 
     def phase_dom_id(phase)
-      "#{phases.index(phase) + 1}-#{phase.name.parameterize}"
+      "phase-#{phases.index(phase) + 1}-#{phase.name.parameterize}"
     end
 
     def prev_phase_dom_id(phase)

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -16,7 +16,7 @@ class Admin::BannersController < Admin::BaseController
   def create
     @banner = Banner.new(banner_params)
     if @banner.save
-      redirect_to admin_banners_path
+      redirect_to admin_banners_path, notice: t("admin.banners.create.notice")
     else
       render :new
     end
@@ -24,7 +24,7 @@ class Admin::BannersController < Admin::BaseController
 
   def update
     if @banner.update(banner_params)
-      redirect_to admin_banners_path
+      redirect_to admin_banners_path, notice: t("admin.banners.update.notice")
     else
       render :edit
     end

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -36,12 +36,16 @@ en:
           budgets: Participatory budgeting
           help_page: Help page
           sdg: SDG
+      create:
+        notice: "Banner created successfully"
       edit:
         editing: Edit banner
         form:
           submit_button: Save changes
       new:
         creating: Create banner
+      update:
+        notice: "Banner updated successfully"
     activity:
       show:
         action: Action

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -36,12 +36,16 @@ es:
           budgets: Presupuestos participativos
           help_page: Página de ayuda
           sdg: ODS
+      create:
+        notice: "Banner creado correctamente"
       edit:
         editing: Editar el banner
         form:
           submit_button: Guardar cambios
       new:
         creating: Crear banner
+      update:
+        notice: "Banner actualizado correctamente"
     activity:
       show:
         action: Acción

--- a/spec/components/shared/banner_component_spec.rb
+++ b/spec/components/shared/banner_component_spec.rb
@@ -2,9 +2,24 @@ require "rails_helper"
 
 describe Shared::BannerComponent, type: :component do
   it "renders given a banner" do
-    render_inline Shared::BannerComponent.new(create(:banner, title: "Vote now!"))
+    banner = create(:banner,
+                    title: "Vote now!",
+                    description: "Banner description",
+                    target_url:  "http://www.url.com",
+                    post_started_at: (Time.current - 4.days),
+                    post_ended_at:   (Time.current + 10.days),
+                    background_color: "#FF0000",
+                    font_color: "#FFFFFF"
+                   )
+
+    render_inline Shared::BannerComponent.new(banner)
 
     expect(page.find(".banner")).to have_content "Vote now!"
+    expect(page.find(".banner")).to have_content "Banner description"
+    expect(page.find(".banner")[:style]).to eq("background-color:#FF0000;")
+    expect(page.find("h2")[:style]).to eq("color:#FFFFFF;")
+    expect(page.find("h3")[:style]).to eq("color:#FFFFFF;")
+    expect(page).to have_link href: "http://www.url.com"
   end
 
   it "renders given a section" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,7 @@ end
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     "goog:chromeOptions" => {
-      args: %W[headless no-sandbox window-size=1200,600 proxy-server=127.0.0.1:#{Capybara::Webmock.port_number}]
+      args: %W[headless no-sandbox window-size=1200,800 proxy-server=127.0.0.1:#{Capybara::Webmock.port_number}]
     }
   )
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,7 @@ end
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     "goog:chromeOptions" => {
-      args: %W[headless no-sandbox window-size=1200,800 proxy-server=127.0.0.1:#{Capybara::Webmock.port_number}]
+      args: %W[headless no-sandbox window-size=1200,800 proxy-server=#{Capybara.app_host}:#{Capybara::Webmock.port_number}]
     }
   )
 

--- a/spec/shared/system/admin_milestoneable.rb
+++ b/spec/shared/system/admin_milestoneable.rb
@@ -108,7 +108,7 @@ shared_examples "admin_milestoneable" do |factory_name, path_name|
     end
 
     context "Delete" do
-      scenario "Remove milestone" do
+      scenario "Remove milestone", :no_js do
         create(:milestone, milestoneable: milestoneable, title: "Title will it remove")
 
         visit path

--- a/spec/shared/system/admin_progressable.rb
+++ b/spec/shared/system/admin_progressable.rb
@@ -28,7 +28,7 @@ shared_examples "admin_progressable" do |factory_name, path_name|
     end
 
     context "New" do
-      scenario "Primary progress bar", :js do
+      scenario "Primary progress bar" do
         visit path
         click_link "Create new progress bar"
 
@@ -46,7 +46,7 @@ shared_examples "admin_progressable" do |factory_name, path_name|
         expect(page).to have_content "Primary progress bar"
       end
 
-      scenario "Secondary progress bar", :js do
+      scenario "Secondary progress bar" do
         visit path
         click_link "Create new progress bar"
 
@@ -66,7 +66,7 @@ shared_examples "admin_progressable" do |factory_name, path_name|
     end
 
     context "Edit" do
-      scenario "Primary progress bar", :js do
+      scenario "Primary progress bar" do
         bar = create(:progress_bar, progressable: progressable)
 
         visit path
@@ -86,7 +86,7 @@ shared_examples "admin_progressable" do |factory_name, path_name|
         end
       end
 
-      scenario "Secondary progress bar", :js do
+      scenario "Secondary progress bar" do
         bar = create(:progress_bar, :secondary, progressable: progressable)
 
         visit path
@@ -108,7 +108,7 @@ shared_examples "admin_progressable" do |factory_name, path_name|
     end
 
     context "Delete" do
-      scenario "Remove progress bar", :js do
+      scenario "Remove progress bar" do
         bar = create(:progress_bar, progressable: progressable, percentage: 34)
 
         visit path

--- a/spec/shared/system/admin_progressable.rb
+++ b/spec/shared/system/admin_progressable.rb
@@ -108,11 +108,11 @@ shared_examples "admin_progressable" do |factory_name, path_name|
     end
 
     context "Delete" do
-      scenario "Remove progress bar" do
+      scenario "Remove progress bar", :js do
         bar = create(:progress_bar, progressable: progressable, percentage: 34)
 
         visit path
-        within("#progress_bar_#{bar.id}") { click_link "Delete" }
+        within("#progress_bar_#{bar.id}") { accept_confirm { click_link "Delete" } }
 
         expect(page).to have_content "Progress bar deleted successfully"
         expect(page).not_to have_content "34%"

--- a/spec/shared/system/documentable.rb
+++ b/spec/shared/system/documentable.rb
@@ -95,37 +95,37 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
   end
 
   context "Destroy" do
-    scenario "Should show success notice after successful document upload" do
+    scenario "Should show success notice after successful document upload", :js do
       login_as documentable.author
 
       visit send(documentable_path, arguments)
 
       within "#document_#{document.id}" do
-        click_on "Delete document"
+        accept_confirm { click_link "Delete document" }
       end
 
       expect(page).to have_content "Document was deleted successfully."
     end
 
-    scenario "Should hide documents tab if there is no documents" do
+    scenario "Should hide documents tab if there is no documents", :js do
       login_as documentable.author
 
       visit send(documentable_path, arguments)
 
       within "#document_#{document.id}" do
-        click_on "Delete document"
+        accept_confirm { click_link "Delete document" }
       end
 
       expect(page).not_to have_content "Documents (0)"
     end
 
-    scenario "Should redirect to documentable path after successful deletion" do
+    scenario "Should redirect to documentable path after successful deletion", :js do
       login_as documentable.author
 
       visit send(documentable_path, arguments)
 
       within "#document_#{document.id}" do
-        click_on "Delete document"
+        accept_confirm { click_link "Delete document" }
       end
 
       within "##{ActionView::RecordIdentifier.dom_id(documentable)}" do

--- a/spec/shared/system/documentable.rb
+++ b/spec/shared/system/documentable.rb
@@ -95,7 +95,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
   end
 
   context "Destroy" do
-    scenario "Should show success notice after successful document upload", :js do
+    scenario "Should show success notice after successful document upload" do
       login_as documentable.author
 
       visit send(documentable_path, arguments)
@@ -107,7 +107,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       expect(page).to have_content "Document was deleted successfully."
     end
 
-    scenario "Should hide documents tab if there is no documents", :js do
+    scenario "Should hide documents tab if there is no documents" do
       login_as documentable.author
 
       visit send(documentable_path, arguments)
@@ -119,7 +119,7 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
       expect(page).not_to have_content "Documents (0)"
     end
 
-    scenario "Should redirect to documentable path after successful deletion", :js do
+    scenario "Should redirect to documentable path after successful deletion" do
       login_as documentable.author
 
       visit send(documentable_path, arguments)

--- a/spec/shared/system/flaggable.rb
+++ b/spec/shared/system/flaggable.rb
@@ -21,7 +21,7 @@ shared_examples "flaggable" do |factory_name, admin: false|
     end
   end
 
-  scenario "Flagging as inappropriate", :js do
+  scenario "Flagging as inappropriate" do
     login_as(user)
     visit path
 
@@ -42,7 +42,7 @@ shared_examples "flaggable" do |factory_name, admin: false|
     end
   end
 
-  scenario "Unflagging", :js do
+  scenario "Unflagging" do
     Flag.flag(user, flaggable)
 
     login_as(user)
@@ -67,7 +67,7 @@ shared_examples "flaggable" do |factory_name, admin: false|
     end
   end
 
-  scenario "Flagging and unflagging", :js do
+  scenario "Flagging and unflagging" do
     login_as(user)
     visit path
 
@@ -91,7 +91,7 @@ shared_examples "flaggable" do |factory_name, admin: false|
     end
   end
 
-  scenario "Flagging a comment with a child does not update its children", :js do
+  scenario "Flagging a comment with a child does not update its children" do
     skip "Only for comments" unless flaggable.is_a?(Comment)
 
     child_comment = create(:comment, commentable: flaggable.commentable, parent: flaggable)

--- a/spec/shared/system/followable.rb
+++ b/spec/shared/system/followable.rb
@@ -40,7 +40,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       expect(page).to have_link("Follow #{followable.model_name.human.downcase}")
     end
 
-    scenario "Should display unfollow after user clicks on follow button", :js do
+    scenario "Should display unfollow after user clicks on follow button" do
       user = create(:user)
       login_as(user)
 
@@ -53,7 +53,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       end
     end
 
-    scenario "Should display new follower notice after user clicks on follow button", :js do
+    scenario "Should display new follower notice after user clicks on follow button" do
       user = create(:user)
       login_as(user)
 
@@ -74,7 +74,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       expect(page).to have_link("Following")
     end
 
-    scenario "Updates follow button & show destroy notice after unfollow button is clicked", :js do
+    scenario "Updates follow button & show destroy notice after unfollow button is clicked" do
       user = create(:user, followables: [followable])
       login_as(user)
 
@@ -87,7 +87,7 @@ shared_examples "followable" do |followable_class_name, followable_path, followa
       end
     end
 
-    scenario "Should display destroy follower notice after user clicks on unfollow button", :js do
+    scenario "Should display destroy follower notice after user clicks on unfollow button" do
       user = create(:user, followables: [followable])
       login_as(user)
 

--- a/spec/shared/system/imageable.rb
+++ b/spec/shared/system/imageable.rb
@@ -13,7 +13,7 @@ shared_examples "imageable" do |imageable_factory_name, imageable_path, imageabl
   end
 
   context "Show" do
-    scenario "Show descriptive image when exists", :js do
+    scenario "Show descriptive image when exists" do
       image = create(:image, imageable: imageable)
 
       visit send(imageable_path, imageable_arguments)

--- a/spec/shared/system/mappable.rb
+++ b/spec/shared/system/mappable.rb
@@ -12,7 +12,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
   describe "At #{mappable_new_path}" do
     before { set_arguments(arguments, mappable, mappable_path_arguments) }
 
-    scenario "Should not show marker by default on create #{mappable_factory_name}", :js do
+    scenario "Should not show marker by default on create #{mappable_factory_name}" do
       do_login_for user
       visit send(mappable_new_path, arguments)
 
@@ -23,7 +23,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       end
     end
 
-    scenario "Should show marker on create #{mappable_factory_name} when click on map", :js do
+    scenario "Should show marker on create #{mappable_factory_name} when click on map" do
       do_login_for user
       visit send(mappable_new_path, arguments)
 
@@ -35,7 +35,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       end
     end
 
-    scenario "Should create #{mappable_factory_name} with map", :js do
+    scenario "Should create #{mappable_factory_name} with map" do
       do_login_for user
       visit send(mappable_new_path, arguments)
 
@@ -46,7 +46,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).to have_css(".map_location")
     end
 
-    scenario "Can not display map on #{mappable_factory_name} when not fill marker on map", :js do
+    scenario "Can not display map on #{mappable_factory_name} when not fill marker on map" do
       do_login_for user
       visit send(mappable_new_path, arguments)
 
@@ -58,7 +58,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_css(".map_location")
     end
 
-    scenario "Can not display map on #{mappable_factory_name} when feature.map is disabled", :js do
+    scenario "Can not display map on #{mappable_factory_name} when feature.map is disabled" do
       Setting["feature.map"] = false
       do_login_for user
       visit send(mappable_new_path, arguments)
@@ -82,7 +82,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
     describe "When restoring the page from browser history" do
       before { Setting["org_name"] = "CONSUL" }
 
-      scenario "map should not be duplicated", :js do
+      scenario "map should not be duplicated" do
         do_login_for user
         visit send(mappable_new_path, arguments)
 
@@ -103,7 +103,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
         end
       end
 
-      scenario "keeps marker and zoom defined by the user", :js do
+      scenario "keeps marker and zoom defined by the user" do
         do_login_for user
         visit send(mappable_new_path, arguments)
 
@@ -137,7 +137,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
         end
       end
 
-      scenario "shows marker at map center", :js do
+      scenario "shows marker at map center" do
         do_login_for user
         visit send(mappable_new_path, arguments)
 
@@ -170,7 +170,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       end
     end
 
-    scenario "Skip map", :js do
+    scenario "Skip map" do
       do_login_for user
       visit send(mappable_new_path, arguments)
 
@@ -181,7 +181,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_content "Map location can't be blank"
     end
 
-    scenario "Toggle map", :js do
+    scenario "Toggle map" do
       do_login_for user
       visit send(mappable_new_path, arguments)
 
@@ -200,7 +200,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
   describe "At #{mappable_edit_path}" do
     before { skip } if mappable_edit_path.blank?
 
-    scenario "Should edit map on #{mappable_factory_name} and contain default values", :js do
+    scenario "Should edit map on #{mappable_factory_name} and contain default values" do
       do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
@@ -209,7 +209,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       validate_latitude_longitude(mappable_factory_name)
     end
 
-    scenario "Should edit default values from map on #{mappable_factory_name} edit page", :js do
+    scenario "Should edit default values from map on #{mappable_factory_name} edit page" do
       do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
@@ -222,7 +222,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).to have_selector(".map_location[data-marker-latitude='#{mappable.map_location.latitude}']")
     end
 
-    scenario "Should edit mappable on #{mappable_factory_name} without change map", :js do
+    scenario "Should edit mappable on #{mappable_factory_name} without change map" do
       do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
@@ -235,7 +235,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).to have_selector(".map_location[data-marker-latitude='#{mappable.map_location.latitude}']")
     end
 
-    scenario "Can not display map on #{mappable_factory_name} edit when remove map marker", :js do
+    scenario "Can not display map on #{mappable_factory_name} edit when remove map marker" do
       do_login_for mappable.author
 
       visit send(mappable_edit_path, id: mappable.id)
@@ -246,7 +246,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_css(".map_location")
     end
 
-    scenario "Can not display map on #{mappable_factory_name} edit when feature.map is disabled", :js do
+    scenario "Can not display map on #{mappable_factory_name} edit when feature.map is disabled" do
       Setting["feature.map"] = false
       do_login_for mappable.author
 
@@ -257,7 +257,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_css(".map_location")
     end
 
-    scenario "No errors on update", :js do
+    scenario "No errors on update" do
       skip ""
       do_login_for mappable.author
 
@@ -285,7 +285,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       do_login_for(user) if management
     end
 
-    scenario "Should display map and marker on #{mappable_factory_name} show page", :js do
+    scenario "Should display map and marker on #{mappable_factory_name} show page" do
       arguments[:id] = mappable.id
 
       visit send(mappable_show_path, arguments)
@@ -295,7 +295,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       end
     end
 
-    scenario "Should not display map on #{mappable_factory_name} show when marker is not defined", :js do
+    scenario "Should not display map on #{mappable_factory_name} show when marker is not defined" do
       mappable_without_map = create(mappable_factory_name.to_s.to_sym)
       set_arguments(arguments, mappable_without_map, mappable_path_arguments)
       arguments[:id] = mappable_without_map.id
@@ -305,7 +305,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       expect(page).not_to have_css(".map_location")
     end
 
-    scenario "Should not display map on #{mappable_factory_name} show page when feature.map is disable", :js do
+    scenario "Should not display map on #{mappable_factory_name} show page when feature.map is disable" do
       Setting["feature.map"] = false
       arguments[:id] = mappable.id
 

--- a/spec/shared/system/mappable.rb
+++ b/spec/shared/system/mappable.rb
@@ -282,12 +282,12 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
   describe "At #{mappable_show_path}" do
     before do
       set_arguments(arguments, mappable, mappable_path_arguments)
-      do_login_for(user) if management
     end
 
     scenario "Should display map and marker on #{mappable_factory_name} show page" do
       arguments[:id] = mappable.id
 
+      do_login_for(user) if management
       visit send(mappable_show_path, arguments)
 
       within ".map_location" do
@@ -300,6 +300,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       set_arguments(arguments, mappable_without_map, mappable_path_arguments)
       arguments[:id] = mappable_without_map.id
 
+      do_login_for(user) if management
       visit send(mappable_show_path, arguments)
 
       expect(page).not_to have_css(".map_location")
@@ -309,6 +310,7 @@ shared_examples "mappable" do |mappable_factory_name, mappable_association_name,
       Setting["feature.map"] = false
       arguments[:id] = mappable.id
 
+      do_login_for(user) if management
       visit send(mappable_show_path, arguments)
 
       expect(page).not_to have_css(".map_location")
@@ -318,8 +320,8 @@ end
 
 def do_login_for(user)
   if management
-    login_as_manager
     login_managed_user(user)
+    login_as_manager
   else
     login_as(user)
   end

--- a/spec/shared/system/milestoneable.rb
+++ b/spec/shared/system/milestoneable.rb
@@ -6,7 +6,7 @@ shared_examples "milestoneable" do |factory_name|
   describe "Show milestones" do
     let(:path) { polymorphic_path(milestoneable) }
 
-    scenario "Show milestones", :js do
+    scenario "Show milestones" do
       create(:milestone, milestoneable: milestoneable,
                          description_en: "Last milestone with a link to https://consul.dev",
                          description_es: "Último hito con el link https://consul.dev",
@@ -44,7 +44,7 @@ shared_examples "milestoneable" do |factory_name|
       end
     end
 
-    scenario "Show no_milestones text", :js do
+    scenario "Show no_milestones text" do
       login_as(create(:user))
 
       visit path

--- a/spec/shared/system/nested_documentable.rb
+++ b/spec/shared/system/nested_documentable.rb
@@ -26,7 +26,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
     end
 
     scenario "Should not show new document link when
-              documentable max documents allowed limit is reached", :js do
+              documentable max documents allowed limit is reached" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -37,14 +37,14 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).not_to have_css "#new_document_link"
     end
 
-    scenario "Should not show max documents warning when no documents added", :js do
+    scenario "Should not show max documents warning when no documents added" do
       login_as user_to_login
       visit send(path, arguments)
 
       expect(page).not_to have_css ".max-documents-notice"
     end
 
-    scenario "Should show max documents warning when max documents allowed limit is reached", :js do
+    scenario "Should show max documents warning when max documents allowed limit is reached" do
       login_as user_to_login
       visit send(path, arguments)
       documentable.class.max_documents_allowed.times.each do
@@ -55,7 +55,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_content "Remove document"
     end
 
-    scenario "Should hide max documents warning after any document removal", :js do
+    scenario "Should hide max documents warning after any document removal" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -68,7 +68,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).not_to have_css ".max-documents-notice"
     end
 
-    scenario "Should update nested document file name after choosing a file", :js do
+    scenario "Should update nested document file name after choosing a file" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -88,7 +88,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
     end
 
     scenario "Should update nested document file title with
-              file name after choosing a file when no title defined", :js do
+              file name after choosing a file when no title defined" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -98,7 +98,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
     end
 
     scenario "Should not update nested document file title with
-              file name after choosing a file when title already defined", :js do
+              file name after choosing a file when title already defined" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -119,7 +119,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect_document_has_title(0, "My Title")
     end
 
-    scenario "Should update loading bar style after valid file upload", :js do
+    scenario "Should update loading bar style after valid file upload" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -128,7 +128,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css ".loading-bar.complete"
     end
 
-    scenario "Should update loading bar style after invalid file upload", :js do
+    scenario "Should update loading bar style after invalid file upload" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -140,7 +140,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css ".loading-bar.errors"
     end
 
-    scenario "Should update document cached_attachment field after valid file upload", :js do
+    scenario "Should update document cached_attachment field after valid file upload" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -149,7 +149,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect_document_has_cached_attachment(0, ".pdf")
     end
 
-    scenario "Should not update document cached_attachment field after invalid file upload", :js do
+    scenario "Should not update document cached_attachment field after invalid file upload" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -162,7 +162,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
     end
 
     scenario "Should show document errors after documentable submit with
-              empty document fields", :js do
+              empty document fields" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -174,7 +174,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       end
     end
 
-    scenario "Should delete document after valid file upload and click on remove button", :js do
+    scenario "Should delete document after valid file upload and click on remove button" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -185,7 +185,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
     end
 
     scenario "Should show successful notice when
-              resource filled correctly without any nested documents", :js do
+              resource filled correctly without any nested documents" do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -196,7 +196,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
     end
 
     scenario "Should show successful notice when
-              resource filled correctly and after valid file uploads", :js do
+              resource filled correctly and after valid file uploads" do
       login_as user_to_login
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
@@ -207,7 +207,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_content documentable_success_notice
     end
 
-    scenario "Should show new document after successful creation with one uploaded file", :js do
+    scenario "Should show new document after successful creation with one uploaded file" do
       if documentable_factory_name == "dashboard_action"
         skip("Not render Documents count on dashboard_actions")
       end
@@ -229,7 +229,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
     end
 
     scenario "Should show resource with new document after successful creation with
-              maximum allowed uploaded files", :js do
+              maximum allowed uploaded files" do
       if documentable_factory_name == "dashboard_action"
         skip("Not render Documents count on dashboard_actions")
       end
@@ -258,7 +258,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       end
 
       scenario "Should not show add document button when
-                documentable has reached maximum of documents allowed", :js do
+                documentable has reached maximum of documents allowed" do
         create_list(:document, documentable.class.max_documents_allowed, documentable: documentable)
         login_as user_to_login
         visit send(path, arguments)
@@ -266,7 +266,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
         expect(page).not_to have_css "#new_document_link"
       end
 
-      scenario "Should show add document button after destroy one document", :js do
+      scenario "Should show add document button after destroy one document" do
         create_list(:document, documentable.class.max_documents_allowed, documentable: documentable)
         login_as user_to_login
         visit send(path, arguments)
@@ -278,7 +278,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
         expect(page).to have_css "#new_document_link"
       end
 
-      scenario "Should remove nested field after remove document", :js do
+      scenario "Should remove nested field after remove document" do
         create(:document, documentable: documentable)
         login_as user_to_login
         visit send(path, arguments)

--- a/spec/shared/system/nested_imageable.rb
+++ b/spec/shared/system/nested_imageable.rb
@@ -21,7 +21,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_selector "#new_image_link"
     end
 
-    scenario "Should hide new image link after adding one image", :js do
+    scenario "Should hide new image link after adding one image" do
       login_as user
       visit send(path, arguments)
 
@@ -30,7 +30,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).not_to have_selector "#new_image_link"
     end
 
-    scenario "Should update nested image file name after choosing any file", :js do
+    scenario "Should update nested image file name after choosing any file" do
       login_as user
       visit send(path, arguments)
 
@@ -45,7 +45,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_selector ".file-name", text: "clippy.jpg"
     end
 
-    scenario "Should update nested image file title with file name after choosing a file when no title defined", :js do
+    scenario "Should update nested image file title with file name after choosing a file when no title defined" do
       login_as user
       visit send(path, arguments)
 
@@ -57,7 +57,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect_image_has_title("clippy.jpg")
     end
 
-    scenario "Should not update nested image file title with file name after choosing a file when title already defined", :js do
+    scenario "Should not update nested image file title with file name after choosing a file when title already defined" do
       login_as user
       visit send(path, arguments)
 
@@ -78,7 +78,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       end
     end
 
-    scenario "Should update loading bar style after valid file upload", :js do
+    scenario "Should update loading bar style after valid file upload" do
       login_as user
       visit send(path, arguments)
 
@@ -90,7 +90,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_selector ".loading-bar.complete"
     end
 
-    scenario "Should update loading bar style after invalid file upload", :js do
+    scenario "Should update loading bar style after invalid file upload" do
       login_as user
       visit send(path, arguments)
 
@@ -103,7 +103,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_selector ".loading-bar.errors"
     end
 
-    scenario "Should update image cached_attachment field after valid file upload", :js do
+    scenario "Should update image cached_attachment field after valid file upload" do
       login_as user
       visit send(path, arguments)
 
@@ -115,7 +115,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect_image_has_cached_attachment(".jpg")
     end
 
-    scenario "Should not update image cached_attachment field after invalid file upload", :js do
+    scenario "Should not update image cached_attachment field after invalid file upload" do
       login_as user
       visit send(path, arguments)
 
@@ -128,7 +128,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect_image_has_cached_attachment("")
     end
 
-    scenario "Should show nested image errors after invalid form submit", :js do
+    scenario "Should show nested image errors after invalid form submit" do
       login_as user
       visit send(path, arguments)
 
@@ -144,7 +144,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       end
     end
 
-    scenario "Should remove nested image after valid file upload and click on remove button", :js do
+    scenario "Should remove nested image after valid file upload and click on remove button" do
       login_as user
       visit send(path, arguments)
 
@@ -160,7 +160,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).not_to have_selector("#nested-image .image")
     end
 
-    scenario "Should show successful notice when resource filled correctly without any nested images", :js do
+    scenario "Should show successful notice when resource filled correctly without any nested images" do
       if has_many_images
         skip "no need to test, there are no attributes for the parent resource"
       else
@@ -173,7 +173,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       end
     end
 
-    scenario "Should show successful notice when resource filled correctly and after valid file uploads", :js do
+    scenario "Should show successful notice when resource filled correctly and after valid file uploads" do
       login_as user
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
@@ -190,7 +190,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect(page).to have_content imageable_success_notice
     end
 
-    scenario "Should show new image after successful creation with one uploaded file", :js do
+    scenario "Should show new image after successful creation with one uploaded file" do
       login_as user
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
@@ -222,7 +222,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
         expect(page).to have_css ".image", count: 1
       end
 
-      scenario "Should not show add image button when image already exists", :js do
+      scenario "Should not show add image button when image already exists" do
         create(:image, imageable: imageable)
         login_as user
         visit send(path, arguments)
@@ -230,7 +230,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
         expect(page).not_to have_css "a#new_image_link"
       end
 
-      scenario "Should remove nested field after remove image", :js do
+      scenario "Should remove nested field after remove image" do
         create(:image, imageable: imageable)
         login_as user
         visit send(path, arguments)
@@ -239,7 +239,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
         expect(page).not_to have_css ".image"
       end
 
-      scenario "Should show add image button after remove image", :js do
+      scenario "Should show add image button after remove image" do
         create(:image, imageable: imageable)
         login_as user
         visit send(path, arguments)

--- a/spec/shared/system/notifiable_in_app.rb
+++ b/spec/shared/system/notifiable_in_app.rb
@@ -13,7 +13,7 @@ shared_examples "notifiable in-app" do |factory_name|
     expect(page).to have_link "You have a new notification"
   end
 
-  scenario "A user commented on my notifiable", :js do
+  scenario "A user commented on my notifiable" do
     notification = create(:notification, notifiable: notifiable, user: author)
 
     login_as author
@@ -26,7 +26,7 @@ shared_examples "notifiable in-app" do |factory_name|
     expect(page).to have_xpath "//a[@href='#{notification_path(notification)}']"
   end
 
-  scenario "Multiple users commented on my notifiable", :js do
+  scenario "Multiple users commented on my notifiable" do
     3.times do |n|
       login_as(create(:user, :verified))
 
@@ -48,7 +48,7 @@ shared_examples "notifiable in-app" do |factory_name|
     expect(page).to have_xpath "//a[@href='#{notification_path(Notification.last)}']"
   end
 
-  scenario "A user replied to my comment", :js do
+  scenario "A user replied to my comment" do
     comment = create :comment, commentable: notifiable, user: author
 
     login_as(create(:user, :verified))
@@ -73,7 +73,7 @@ shared_examples "notifiable in-app" do |factory_name|
     expect(page).to have_xpath "//a[@href='#{notification_path(Notification.last)}']"
   end
 
-  scenario "Multiple replies to my comment", :js do
+  scenario "Multiple replies to my comment" do
     comment = create :comment, commentable: notifiable, user: author
 
     3.times do |n|
@@ -100,7 +100,7 @@ shared_examples "notifiable in-app" do |factory_name|
     expect(page).to have_xpath "//a[@href='#{notification_path(Notification.last)}']"
   end
 
-  scenario "Author commented on his own notifiable", :js do
+  scenario "Author commented on his own notifiable" do
     login_as(author)
     visit path_for(notifiable)
 
@@ -117,7 +117,7 @@ shared_examples "notifiable in-app" do |factory_name|
     end
   end
 
-  scenario "Author replied to his own comment", :js do
+  scenario "Author replied to his own comment" do
     comment = create :comment, commentable: notifiable, user: author
 
     login_as author

--- a/spec/shared/system/progressable.rb
+++ b/spec/shared/system/progressable.rb
@@ -1,5 +1,5 @@
 shared_examples "progressable" do |factory_name|
-  describe "Progress bars", :js do
+  describe "Progress bars" do
     let!(:progressable) { create(factory_name) }
     let(:path) { polymorphic_path(progressable) }
 

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -23,7 +23,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(page).not_to have_css("#related-content-list")
   end
 
-  scenario "related contents can be added", :js do
+  scenario "related contents can be added" do
     login_as(user)
     visit relationable.url
 
@@ -86,7 +86,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(page).to have_content("Link not valid. You cannot relate a content to itself")
   end
 
-  scenario "related content can be scored positively", :js do
+  scenario "related content can be scored positively" do
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     login_as(user)
@@ -102,7 +102,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(related_content.opposite_related_content.related_content_scores.find_by(user_id: user.id, related_content_id: related_content.opposite_related_content.id).value).to eq(1)
   end
 
-  scenario "related content can be scored negatively", :js do
+  scenario "related content can be scored negatively" do
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     login_as(user)

--- a/spec/shared/system/remotely_translatable.rb
+++ b/spec/shared/system/remotely_translatable.rb
@@ -16,13 +16,13 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
   end
 
   context "Button to request remote translation" do
-    scenario "should not be present when current locale translation exists", :js do
+    scenario "should not be present when current locale translation exists" do
       visit path
 
       expect(page).not_to have_button("Translate page")
     end
 
-    scenario "should be present when current locale translation does not exists", :js do
+    scenario "should be present when current locale translation does not exists" do
       visit path
 
       select("Español", from: "locale-switcher")
@@ -30,7 +30,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
       expect(page).to have_button("Traducir página")
     end
 
-    scenario "should not be present when new current locale translation exists", :js do
+    scenario "should not be present when new current locale translation exists" do
       add_translations(resource, :es)
       visit path
       expect(page).not_to have_button("Translate page")
@@ -40,7 +40,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
       expect(page).not_to have_button("Traducir página")
     end
 
-    scenario "should not be present when there are no resources to translate", :js do
+    scenario "should not be present when there are no resources to translate" do
       skip("only index_path") if show_path?(path_name)
       resource.destroy!
       visit path
@@ -51,7 +51,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
     end
 
     describe "with delayed job active", :delay_jobs do
-      scenario "should not be present when an equal RemoteTranslation is enqueued", :js do
+      scenario "should not be present when an equal RemoteTranslation is enqueued" do
         create(:remote_translation, remote_translatable: resource, locale: :es)
         visit path
 
@@ -69,7 +69,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         end
       end
 
-      scenario "is not present when a resource translation exists but its comment has not tanslations", :js do
+      scenario "is not present when a resource translation exists but its comment has not tanslations" do
         add_translations(resource, :es)
         create(:comment, commentable: resource)
         visit path
@@ -88,7 +88,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         end
       end
 
-      scenario "display when exists resource translations but the comment does not have a translation", :js do
+      scenario "display when exists resource translations but the comment does not have a translation" do
         add_translations(resource, :es)
         create(:comment, commentable: resource)
         visit path
@@ -99,7 +99,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         expect(page).to have_button("Traducir página")
       end
 
-      scenario "not display when exists resource translations but his comment has tanslations", :js do
+      scenario "not display when exists resource translations but his comment has tanslations" do
         add_translations(resource, :es)
         create_comment_with_translations(resource, :es)
         visit path
@@ -114,7 +114,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
     describe "should evaluate missing translations on featured_debates" do
       before { skip("only debates index path") if path_name != "debates_path" }
 
-      scenario "display when exists featured_debates without tanslations", :js do
+      scenario "display when exists featured_debates without tanslations" do
         add_translations(resource, :es)
         create_featured_debates
         visit path
@@ -129,7 +129,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
     describe "should evaluate missing translations on featured_proposals" do
       before { skip("only proposals index path") if path_name != "proposals_path" }
 
-      scenario "display when exists featured_proposals without tanslations", :js do
+      scenario "display when exists featured_proposals without tanslations" do
         add_translations(resource, :es)
         create_featured_proposals
         visit path
@@ -144,7 +144,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
   context "After click remote translations button" do
     describe "with delayed jobs", :delay_jobs do
-      scenario "the remote translation button should not be present", :js do
+      scenario "the remote translation button should not be present" do
         visit path
         select("Español", from: "locale-switcher")
 
@@ -153,14 +153,14 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         expect(page).not_to have_button("Traducir página")
       end
 
-      scenario "the remote translation is pending to translate", :js do
+      scenario "the remote translation is pending to translate" do
         visit path
         select("Español", from: "locale-switcher")
 
         expect { click_button "Traducir página" }.to change { RemoteTranslation.count }.from(0).to(1)
       end
 
-      scenario "should be present enqueued notice and informative text", :js do
+      scenario "should be present enqueued notice and informative text" do
         visit path
         select("Español", from: "locale-switcher")
 
@@ -170,7 +170,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         expect(page).to have_content("En un breve periodo de tiempo refrescando la página podrá ver todo el contenido en su idioma")
       end
 
-      scenario "should be present only informative text when user visit page with all content enqueued", :js do
+      scenario "should be present only informative text when user visit page with all content enqueued" do
         visit path
         select("Español", from: "locale-switcher")
         click_button "Traducir página"
@@ -186,7 +186,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
     end
 
     describe "without delayed jobs" do
-      scenario "the remote translation button should not be present", :js do
+      scenario "the remote translation button should not be present" do
         microsoft_translate_client_response = generate_response(resource)
         expect_any_instance_of(RemoteTranslations::Microsoft::Client).to receive(:call).and_return(microsoft_translate_client_response)
         visit path
@@ -197,7 +197,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
         expect(page).not_to have_button("Traducir página")
       end
 
-      scenario "the remote translation has been translated and destoyed", :js do
+      scenario "the remote translation has been translated and destoyed" do
         microsoft_translate_client_response = generate_response(resource)
         expect_any_instance_of(RemoteTranslations::Microsoft::Client).to receive(:call).and_return(microsoft_translate_client_response)
         visit path

--- a/spec/shared/system/remotely_translatable.rb
+++ b/spec/shared/system/remotely_translatable.rb
@@ -205,6 +205,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
 
         click_button "Traducir página"
 
+        expect(page).not_to have_button "Traducir página"
         expect(RemoteTranslation.count).to eq(0)
         expect(resource.translations.count).to eq(2)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,10 @@ RSpec.configure do |config|
     driven_by :headless_chrome
   end
 
+  config.before(:each, type: :system, no_js: true) do
+    driven_by :rack_test
+  end
+
   config.before(:each, type: :system) do
     Bullet.start_request
     allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,10 +53,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) do |example|
-    driven_by :rack_test
-  end
-
-  config.before(:each, type: :system, js: true) do
     driven_by :headless_chrome
   end
 

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -15,6 +15,10 @@ module CommonActions
   include Verifications
   include Votes
 
+  def app_host
+    "#{Capybara.app_host}:#{Capybara::Server.ports.values.last}"
+  end
+
   def fill_in_signup_form(email = "manuela@consul.dev", password = "judgementday")
     fill_in "user_username",              with: "Manuela Carmena #{rand(99999)}"
     fill_in "user_email",                 with: email

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -35,7 +35,7 @@ module CommonActions
   def fill_in_proposal
     fill_in "Proposal title", with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
-    fill_in "Proposal text", with: "This is very important because..."
+    fill_in_ckeditor "Proposal text", with: "This is very important because..."
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"

--- a/spec/support/common_actions/emails.rb
+++ b/spec/support/common_actions/emails.rb
@@ -17,9 +17,10 @@ module Emails
   end
 
   def fill_in_newsletter_form(options = {})
-    fill_in "newsletter_subject", with: (options[:subject] || "This is a different subject")
-    select (options[:segment_recipient] || "All users"), from: "newsletter_segment_recipient"
-    fill_in "newsletter_from", with: (options[:from] || "no-reply@consul.dev")
-    fill_in "newsletter_body", with: (options[:body] || "This is a different body")
+    select (options[:segment_recipient] || "All users"), from: "Recipients"
+    fill_in "Subject", with: (options[:subject] || "This is a different subject")
+    fill_in "E-mail address that will appear as sending the newsletter",
+            with: (options[:from] || "no-reply@consul.dev")
+    fill_in "Email content", with: (options[:body] || "This is a different body")
   end
 end

--- a/spec/support/common_actions/emails.rb
+++ b/spec/support/common_actions/emails.rb
@@ -21,6 +21,6 @@ module Emails
     fill_in "Subject", with: (options[:subject] || "This is a different subject")
     fill_in "E-mail address that will appear as sending the newsletter",
             with: (options[:from] || "no-reply@consul.dev")
-    fill_in "Email content", with: (options[:body] || "This is a different body")
+    fill_in_ckeditor "Email content", with: (options[:body] || "This is a different body")
   end
 end

--- a/spec/system/admin/activity_spec.rb
+++ b/spec/system/admin/activity_spec.rb
@@ -27,7 +27,7 @@ describe "Admin activity" do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen" do
+    scenario "Shows moderation activity from moderation screen", :js do
       proposal1 = create(:proposal)
       proposal2 = create(:proposal)
       proposal3 = create(:proposal)
@@ -42,7 +42,9 @@ describe "Admin activity" do
         check "proposal_#{proposal3.id}_check"
       end
 
-      click_on "Hide proposals"
+      accept_confirm { click_button "Hide proposals" }
+
+      expect(page).not_to have_content(proposal1.title)
 
       visit admin_activity_path
 
@@ -51,14 +53,16 @@ describe "Admin activity" do
       expect(page).to have_content(proposal3.title)
     end
 
-    scenario "Shows admin restores" do
+    scenario "Shows admin restores", :js do
       proposal = create(:proposal, :hidden)
 
       visit admin_hidden_proposals_path
 
       within("#proposal_#{proposal.id}") do
-        click_on "Restore"
+        accept_confirm { click_link "Restore" }
       end
+
+      expect(page).to have_content "There are no hidden proposals"
 
       visit admin_activity_path
 
@@ -90,7 +94,7 @@ describe "Admin activity" do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen" do
+    scenario "Shows moderation activity from moderation screen", :js do
       debate1 = create(:debate)
       debate2 = create(:debate)
       debate3 = create(:debate)
@@ -105,7 +109,9 @@ describe "Admin activity" do
         check "debate_#{debate3.id}_check"
       end
 
-      click_on "Hide debates"
+      accept_confirm { click_button "Hide debates" }
+
+      expect(page).not_to have_content(debate1.title)
 
       visit admin_activity_path
 
@@ -114,14 +120,16 @@ describe "Admin activity" do
       expect(page).to have_content(debate3.title)
     end
 
-    scenario "Shows admin restores" do
+    scenario "Shows admin restores", :js do
       debate = create(:debate, :hidden)
 
       visit admin_hidden_debates_path
 
       within("#debate_#{debate.id}") do
-        click_on "Restore"
+        accept_confirm { click_link "Restore" }
       end
+
+      expect(page).to have_content "There are no hidden debates"
 
       visit admin_activity_path
 
@@ -154,7 +162,7 @@ describe "Admin activity" do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen" do
+    scenario "Shows moderation activity from moderation screen", :js do
       comment1 = create(:comment, body: "SPAM")
       comment2 = create(:comment)
       comment3 = create(:comment, body: "Offensive!")
@@ -169,7 +177,9 @@ describe "Admin activity" do
         check "comment_#{comment3.id}_check"
       end
 
-      click_on "Hide comments"
+      accept_confirm { click_button "Hide comments" }
+
+      expect(page).not_to have_content(comment1.body)
 
       visit admin_activity_path
 
@@ -178,14 +188,16 @@ describe "Admin activity" do
       expect(page).to have_content(comment3.body)
     end
 
-    scenario "Shows admin restores" do
+    scenario "Shows admin restores", :js do
       comment = create(:comment, :hidden)
 
       visit admin_hidden_comments_path
 
       within("#comment_#{comment.id}") do
-        click_on "Restore"
+        accept_confirm { click_link "Restore" }
       end
+
+      expect(page).to have_content "There are no hidden comments"
 
       visit admin_activity_path
 
@@ -198,13 +210,13 @@ describe "Admin activity" do
   end
 
   context "User" do
-    scenario "Shows moderation activity on users" do
+    scenario "Shows moderation activity on users", :js do
       proposal = create(:proposal)
 
       visit proposal_path(proposal)
 
       within("#proposal_#{proposal.id}") do
-        click_link "Hide author"
+        accept_confirm { click_link "Hide author" }
 
         expect(page).to have_current_path(debates_path)
       end
@@ -238,7 +250,7 @@ describe "Admin activity" do
       end
     end
 
-    scenario "Shows moderation activity from proposals moderation screen" do
+    scenario "Shows moderation activity from proposals moderation screen", :js do
       proposal1 = create(:proposal)
       proposal2 = create(:proposal)
       proposal3 = create(:proposal)
@@ -253,7 +265,9 @@ describe "Admin activity" do
         check "proposal_#{proposal3.id}_check"
       end
 
-      click_on "Block authors"
+      accept_confirm { click_button "Block authors" }
+
+      expect(page).not_to have_content(proposal1.author.username)
 
       visit admin_activity_path
 
@@ -264,7 +278,7 @@ describe "Admin activity" do
       expect(page).not_to have_content(proposal2.author.username)
     end
 
-    scenario "Shows moderation activity from debates moderation screen" do
+    scenario "Shows moderation activity from debates moderation screen", :js do
       debate1 = create(:debate)
       debate2 = create(:debate)
       debate3 = create(:debate)
@@ -279,7 +293,9 @@ describe "Admin activity" do
         check "debate_#{debate3.id}_check"
       end
 
-      click_on "Block authors"
+      accept_confirm { click_button "Block authors" }
+
+      expect(page).not_to have_content(debate1.author.username)
 
       visit admin_activity_path
 
@@ -290,7 +306,7 @@ describe "Admin activity" do
       expect(page).not_to have_content(debate2.author.username)
     end
 
-    scenario "Shows moderation activity from comments moderation screen" do
+    scenario "Shows moderation activity from comments moderation screen", :js do
       comment1 = create(:comment, body: "SPAM")
       comment2 = create(:comment)
       comment3 = create(:comment, body: "Offensive!")
@@ -305,7 +321,9 @@ describe "Admin activity" do
         check "comment_#{comment3.id}_check"
       end
 
-      click_on "Block authors"
+      accept_confirm { click_button "Block authors" }
+
+      expect(page).not_to have_content comment1.author.username
 
       visit admin_activity_path
 
@@ -316,14 +334,16 @@ describe "Admin activity" do
       expect(page).not_to have_content(comment2.author.username)
     end
 
-    scenario "Shows admin restores" do
+    scenario "Shows admin restores", :js do
       user = create(:user, :hidden)
 
       visit admin_hidden_users_path
 
       within("#user_#{user.id}") do
-        click_on "Restore"
+        accept_confirm { click_link "Restore" }
       end
+
+      expect(page).to have_content "There are no hidden users"
 
       visit admin_activity_path
 

--- a/spec/system/admin/activity_spec.rb
+++ b/spec/system/admin/activity_spec.rb
@@ -8,7 +8,7 @@ describe "Admin activity" do
   end
 
   context "Proposals" do
-    scenario "Shows moderation activity on proposals", :js do
+    scenario "Shows moderation activity on proposals" do
       proposal = create(:proposal)
 
       visit proposal_path(proposal)
@@ -27,7 +27,7 @@ describe "Admin activity" do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen", :js do
+    scenario "Shows moderation activity from moderation screen" do
       proposal1 = create(:proposal)
       proposal2 = create(:proposal)
       proposal3 = create(:proposal)
@@ -53,7 +53,7 @@ describe "Admin activity" do
       expect(page).to have_content(proposal3.title)
     end
 
-    scenario "Shows admin restores", :js do
+    scenario "Shows admin restores" do
       proposal = create(:proposal, :hidden)
 
       visit admin_hidden_proposals_path
@@ -75,7 +75,7 @@ describe "Admin activity" do
   end
 
   context "Debates" do
-    scenario "Shows moderation activity on debates", :js do
+    scenario "Shows moderation activity on debates" do
       debate = create(:debate)
 
       visit debate_path(debate)
@@ -94,7 +94,7 @@ describe "Admin activity" do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen", :js do
+    scenario "Shows moderation activity from moderation screen" do
       debate1 = create(:debate)
       debate2 = create(:debate)
       debate3 = create(:debate)
@@ -120,7 +120,7 @@ describe "Admin activity" do
       expect(page).to have_content(debate3.title)
     end
 
-    scenario "Shows admin restores", :js do
+    scenario "Shows admin restores" do
       debate = create(:debate, :hidden)
 
       visit admin_hidden_debates_path
@@ -142,7 +142,7 @@ describe "Admin activity" do
   end
 
   context "Comments" do
-    scenario "Shows moderation activity on comments", :js do
+    scenario "Shows moderation activity on comments" do
       debate = create(:debate)
       comment = create(:comment, commentable: debate)
 
@@ -162,7 +162,7 @@ describe "Admin activity" do
       end
     end
 
-    scenario "Shows moderation activity from moderation screen", :js do
+    scenario "Shows moderation activity from moderation screen" do
       comment1 = create(:comment, body: "SPAM")
       comment2 = create(:comment)
       comment3 = create(:comment, body: "Offensive!")
@@ -188,7 +188,7 @@ describe "Admin activity" do
       expect(page).to have_content(comment3.body)
     end
 
-    scenario "Shows admin restores", :js do
+    scenario "Shows admin restores" do
       comment = create(:comment, :hidden)
 
       visit admin_hidden_comments_path
@@ -210,7 +210,7 @@ describe "Admin activity" do
   end
 
   context "User" do
-    scenario "Shows moderation activity on users", :js do
+    scenario "Shows moderation activity on users" do
       proposal = create(:proposal)
 
       visit proposal_path(proposal)
@@ -250,7 +250,7 @@ describe "Admin activity" do
       end
     end
 
-    scenario "Shows moderation activity from proposals moderation screen", :js do
+    scenario "Shows moderation activity from proposals moderation screen" do
       proposal1 = create(:proposal)
       proposal2 = create(:proposal)
       proposal3 = create(:proposal)
@@ -278,7 +278,7 @@ describe "Admin activity" do
       expect(page).not_to have_content(proposal2.author.username)
     end
 
-    scenario "Shows moderation activity from debates moderation screen", :js do
+    scenario "Shows moderation activity from debates moderation screen" do
       debate1 = create(:debate)
       debate2 = create(:debate)
       debate3 = create(:debate)
@@ -306,7 +306,7 @@ describe "Admin activity" do
       expect(page).not_to have_content(debate2.author.username)
     end
 
-    scenario "Shows moderation activity from comments moderation screen", :js do
+    scenario "Shows moderation activity from comments moderation screen" do
       comment1 = create(:comment, body: "SPAM")
       comment2 = create(:comment)
       comment3 = create(:comment, body: "Offensive!")
@@ -334,7 +334,7 @@ describe "Admin activity" do
       expect(page).not_to have_content(comment2.author.username)
     end
 
-    scenario "Shows admin restores", :js do
+    scenario "Shows admin restores" do
       user = create(:user, :hidden)
 
       visit admin_hidden_users_path

--- a/spec/system/admin/admin_notifications_spec.rb
+++ b/spec/system/admin/admin_notifications_spec.rb
@@ -113,12 +113,12 @@ describe "Admin Notifications", :admin do
   end
 
   context "Destroy" do
-    scenario "A draft notification can be destroyed" do
+    scenario "A draft notification can be destroyed", :js do
       notification = create(:admin_notification)
 
       visit admin_admin_notifications_path
       within("#admin_notification_#{notification.id}") do
-        click_link "Delete"
+        accept_confirm { click_link "Delete" }
       end
 
       expect(page).to have_content "Notification deleted successfully"

--- a/spec/system/admin/admin_notifications_spec.rb
+++ b/spec/system/admin/admin_notifications_spec.rb
@@ -113,7 +113,7 @@ describe "Admin Notifications", :admin do
   end
 
   context "Destroy" do
-    scenario "A draft notification can be destroyed", :js do
+    scenario "A draft notification can be destroyed" do
       notification = create(:admin_notification)
 
       visit admin_admin_notifications_path
@@ -180,8 +180,8 @@ describe "Admin Notifications", :admin do
     expect(page).to have_content error_message
   end
 
-  context "Send notification", :js do
-    scenario "A draft Admin notification can be sent", :js do
+  context "Send notification" do
+    scenario "A draft Admin notification can be sent" do
       2.times { create(:user) }
       notification = create(:admin_notification, segment_recipient: :all_users)
 
@@ -196,7 +196,7 @@ describe "Admin Notifications", :admin do
       end
     end
 
-    scenario "A sent Admin notification can not be sent", :js do
+    scenario "A sent Admin notification can not be sent" do
       notification = create(:admin_notification, :sent)
 
       visit admin_admin_notification_path(notification)
@@ -204,7 +204,7 @@ describe "Admin Notifications", :admin do
       expect(page).not_to have_link("Send")
     end
 
-    scenario "Admin notification with invalid segment recipient cannot be sent", :js do
+    scenario "Admin notification with invalid segment recipient cannot be sent" do
       invalid_notification = create(:admin_notification)
       invalid_notification.update_column(:segment_recipient, "invalid_segment")
       visit admin_admin_notification_path(invalid_notification)

--- a/spec/system/admin/administrators_spec.rb
+++ b/spec/system/admin/administrators_spec.rb
@@ -29,9 +29,9 @@ describe "Admin administrators" do
     end
   end
 
-  scenario "Delete Administrator" do
+  scenario "Delete Administrator", :js do
     within "#administrator_#{user_administrator.id}" do
-      click_on "Delete"
+      accept_confirm { click_link "Delete" }
     end
 
     within("#administrators") do
@@ -39,9 +39,9 @@ describe "Admin administrators" do
     end
   end
 
-  scenario "Delete Administrator when its the current user" do
+  scenario "Delete Administrator when its the current user", :js do
     within "#administrator_#{admin.id}" do
-      click_on "Delete"
+      accept_confirm { click_link "Delete" }
     end
 
     within("#error") do
@@ -101,11 +101,11 @@ describe "Admin administrators" do
       expect(page).not_to have_content(administrator1.email)
     end
 
-    scenario "Delete after searching" do
+    scenario "Delete after searching", :js do
       fill_in "Search user by name or email", with: administrator2.email
       click_button "Search"
 
-      click_link "Delete"
+      accept_confirm { click_link "Delete" }
 
       expect(page).to have_content(administrator1.email)
       expect(page).not_to have_content(administrator2.email)

--- a/spec/system/admin/administrators_spec.rb
+++ b/spec/system/admin/administrators_spec.rb
@@ -18,7 +18,7 @@ describe "Admin administrators" do
     expect(page).not_to have_content user.name
   end
 
-  scenario "Create Administrator", :js do
+  scenario "Create Administrator" do
     fill_in "search", with: user.email
     click_button "Search"
 
@@ -29,7 +29,7 @@ describe "Admin administrators" do
     end
   end
 
-  scenario "Delete Administrator", :js do
+  scenario "Delete Administrator" do
     within "#administrator_#{user_administrator.id}" do
       accept_confirm { click_link "Delete" }
     end
@@ -39,7 +39,7 @@ describe "Admin administrators" do
     end
   end
 
-  scenario "Delete Administrator when its the current user", :js do
+  scenario "Delete Administrator when its the current user" do
     within "#administrator_#{admin.id}" do
       accept_confirm { click_link "Delete" }
     end
@@ -101,7 +101,7 @@ describe "Admin administrators" do
       expect(page).not_to have_content(administrator1.email)
     end
 
-    scenario "Delete after searching", :js do
+    scenario "Delete after searching" do
       fill_in "Search user by name or email", with: administrator2.email
       click_button "Search"
 

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -88,7 +88,7 @@ describe "Admin banners magement", :admin do
 
     click_button "Save changes"
 
-    expect(page).to have_content "Such banner"
+    expect(page).to have_content "Banner created successfully"
 
     visit proposals_path
 
@@ -158,7 +158,8 @@ describe "Admin banners magement", :admin do
 
     click_button "Save changes"
 
-    visit admin_banners_path
+    expect(page).to have_content "Banner updated successfully"
+
     expect(page).to have_content "Modified title"
     expect(page).to have_content "Edited text"
 

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -69,8 +69,6 @@ describe "Admin banners magement", :admin do
   end
 
   scenario "Publish a banner" do
-    section = WebSection.find_by(name: "proposals")
-
     visit admin_root_path
 
     within("#side_menu") do
@@ -81,12 +79,12 @@ describe "Admin banners magement", :admin do
 
     fill_in "Title", with: "Such banner"
     fill_in "Description", with: "many text wow link"
-    fill_in "banner_target_url", with: "https://www.url.com"
-    fill_in "post_started_at", with: Date.current - 7.days
-    fill_in "post_ended_at", with: Date.current + 7.days
-    fill_in "banner_background_color", with: "#850000"
-    fill_in "banner_font_color", with: "#ffb2b2"
-    check section.name.titleize
+    fill_in "Link", with: "https://www.url.com"
+    fill_in "Post started at", with: Date.current - 7.days
+    fill_in "Post ended at", with: Date.current + 7.days
+    fill_in "Background color", with: "#850000"
+    fill_in "Font color", with: "#ffb2b2"
+    within_fieldset("Sections where it will appear") { check "Proposals" }
 
     click_button "Save changes"
 

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -167,7 +167,7 @@ describe "Admin banners magement", :admin do
     expect(page).not_to have_content "Wrong text"
   end
 
-  scenario "Delete a banner" do
+  scenario "Delete a banner", :js do
     create(:banner, title: "Ugly banner",
                     description: "Bad text",
                     target_url:  "http://www.url.com",
@@ -176,15 +176,11 @@ describe "Admin banners magement", :admin do
                     background_color: "#FF0000",
                     font_color: "#FFFFFF")
 
-    visit admin_root_path
-
-    within("#side_menu") do
-      click_link "Manage banners"
-    end
+    visit admin_banners_path
 
     expect(page).to have_content "Ugly banner"
 
-    click_link "Delete banner"
+    accept_confirm { click_link "Delete banner" }
 
     visit admin_root_path
     expect(page).not_to have_content "Ugly banner"

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -60,7 +60,7 @@ describe "Admin banners magement", :admin do
     end
   end
 
-  scenario "Publish a banner", :js do
+  scenario "Publish a banner" do
     visit admin_root_path
 
     within("#side_menu") do
@@ -89,7 +89,7 @@ describe "Admin banners magement", :admin do
     expect(page).to have_link "Such banner many text wow link", href: "https://www.url.com"
   end
 
-  scenario "Publish a banner with a translation different than the current locale", :js do
+  scenario "Publish a banner with a translation different than the current locale" do
     visit new_admin_banner_path
 
     expect_to_have_language_selected "English"
@@ -110,7 +110,7 @@ describe "Admin banners magement", :admin do
     expect(page).to have_field "Title", with: "En Français"
   end
 
-  scenario "Update banner color when changing from color picker or text_field", :js do
+  scenario "Update banner color when changing from color picker or text_field" do
     visit new_admin_banner_path
 
     fill_in "background_color_input", with: "#850000"
@@ -121,7 +121,7 @@ describe "Admin banners magement", :admin do
     expect(find("#font_color_input").value).to eq("#ffb2b2")
   end
 
-  scenario "Edit banner with live refresh", :js do
+  scenario "Edit banner with live refresh" do
     create(:banner, title: "Hello",
                     description: "Wrong text",
                     target_url:  "http://www.url.com",
@@ -160,7 +160,7 @@ describe "Admin banners magement", :admin do
     expect(page).not_to have_content "Wrong text"
   end
 
-  scenario "Delete a banner", :js do
+  scenario "Delete a banner" do
     create(:banner, title: "Ugly banner",
                     description: "Bad text",
                     target_url:  "http://www.url.com",

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -60,14 +60,6 @@ describe "Admin banners magement", :admin do
     end
   end
 
-  scenario "Banners publication is listed on admin menu" do
-    visit admin_root_path
-
-    within("#side_menu") do
-      expect(page).to have_link "Manage banners"
-    end
-  end
-
   scenario "Publish a banner" do
     visit admin_root_path
 

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -60,10 +60,11 @@ describe "Admin banners magement", :admin do
     end
   end
 
-  scenario "Publish a banner" do
+  scenario "Publish a banner", :js do
     visit admin_root_path
 
     within("#side_menu") do
+      click_link "Site content"
       click_link "Manage banners"
     end
 

--- a/spec/system/admin/budget_groups_spec.rb
+++ b/spec/system/admin/budget_groups_spec.rb
@@ -55,22 +55,22 @@ describe "Admin budget groups", :admin do
       end
     end
 
-    scenario "Delete a group without headings" do
+    scenario "Delete a group without headings", :js do
       group = create(:budget_group, budget: budget)
 
       visit admin_budget_groups_path(budget)
-      within("#budget_group_#{group.id}") { click_link "Delete" }
+      within("#budget_group_#{group.id}") { accept_confirm { click_link "Delete" } }
 
       expect(page).to have_content "Group deleted successfully"
       expect(page).not_to have_selector "#budget_group_#{group.id}"
     end
 
-    scenario "Try to delete a group with headings" do
+    scenario "Try to delete a group with headings", :js do
       group = create(:budget_group, budget: budget)
       create(:budget_heading, group: group)
 
       visit admin_budget_groups_path(budget)
-      within("#budget_group_#{group.id}") { click_link "Delete" }
+      within("#budget_group_#{group.id}") { accept_confirm { click_link "Delete" } }
 
       expect(page).to have_content "You cannot delete a Group that has associated headings"
       expect(page).to have_selector "#budget_group_#{group.id}"

--- a/spec/system/admin/budget_groups_spec.rb
+++ b/spec/system/admin/budget_groups_spec.rb
@@ -55,7 +55,7 @@ describe "Admin budget groups", :admin do
       end
     end
 
-    scenario "Delete a group without headings", :js do
+    scenario "Delete a group without headings" do
       group = create(:budget_group, budget: budget)
 
       visit admin_budget_groups_path(budget)
@@ -65,7 +65,7 @@ describe "Admin budget groups", :admin do
       expect(page).not_to have_selector "#budget_group_#{group.id}"
     end
 
-    scenario "Try to delete a group with headings", :js do
+    scenario "Try to delete a group with headings" do
       group = create(:budget_group, budget: budget)
       create(:budget_heading, group: group)
 
@@ -122,7 +122,7 @@ describe "Admin budget groups", :admin do
       expect(page).to have_field "Maximum number of headings in which a user can select projects", with: "2"
     end
 
-    scenario "Changing name for current locale will update the slug if budget is in draft phase", :js do
+    scenario "Changing name for current locale will update the slug if budget is in draft phase" do
       group = create(:budget_group, budget: budget)
       old_slug = group.slug
 

--- a/spec/system/admin/budget_headings_spec.rb
+++ b/spec/system/admin/budget_headings_spec.rb
@@ -60,22 +60,22 @@ describe "Admin budget headings", :admin do
       end
     end
 
-    scenario "Delete a heading without investments" do
+    scenario "Delete a heading without investments", :js do
       heading = create(:budget_heading, group: group)
 
       visit admin_budget_group_headings_path(budget, group)
-      within("#budget_heading_#{heading.id}") { click_link "Delete" }
+      within("#budget_heading_#{heading.id}") { accept_confirm { click_link "Delete" } }
 
       expect(page).to have_content "Heading deleted successfully"
       expect(page).not_to have_selector "#budget_heading_#{heading.id}"
     end
 
-    scenario "Try to delete a heading with investments" do
+    scenario "Try to delete a heading with investments", :js do
       heading = create(:budget_heading, group: group, name: "Atlantis")
       create(:budget_investment, heading: heading)
 
       visit admin_budget_group_headings_path(budget, group)
-      within(".heading", text: "Atlantis") { click_link "Delete" }
+      within(".heading", text: "Atlantis") { accept_confirm { click_link "Delete" } }
 
       expect(page).to have_content "You cannot delete a Heading that has associated investments"
       expect(page).to have_content "Atlantis"

--- a/spec/system/admin/budget_headings_spec.rb
+++ b/spec/system/admin/budget_headings_spec.rb
@@ -60,7 +60,7 @@ describe "Admin budget headings", :admin do
       end
     end
 
-    scenario "Delete a heading without investments", :js do
+    scenario "Delete a heading without investments" do
       heading = create(:budget_heading, group: group)
 
       visit admin_budget_group_headings_path(budget, group)
@@ -70,7 +70,7 @@ describe "Admin budget headings", :admin do
       expect(page).not_to have_selector "#budget_heading_#{heading.id}"
     end
 
-    scenario "Try to delete a heading with investments", :js do
+    scenario "Try to delete a heading with investments" do
       heading = create(:budget_heading, group: group, name: "Atlantis")
       create(:budget_investment, heading: heading)
 
@@ -119,7 +119,7 @@ describe "Admin budget headings", :admin do
       expect(page).to have_content "can't be blank"
     end
 
-    describe "Max votes is optional", :js do
+    describe "Max votes is optional" do
       scenario "do no show max_ballot_lines field for knapsack budgets" do
         visit new_admin_budget_group_heading_path(budget, group)
 
@@ -159,7 +159,7 @@ describe "Admin budget headings", :admin do
       expect(find_field("Allow content block")).not_to be_checked
     end
 
-    scenario "Changing name for current locale will update the slug if budget is in draft phase", :js do
+    scenario "Changing name for current locale will update the slug if budget is in draft phase" do
       heading = create(:budget_heading, group: group)
       old_slug = heading.slug
 

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -529,7 +529,10 @@ describe "Admin budget investments", :admin do
 
       expect(page).to have_link "Calculate Winner Investments"
 
-      budget.update!(phase: "accepting")
+      select "Accepting projects", from: "Phase"
+      click_button "Update Budget"
+
+      expect(page).to have_content "Participatory budget updated successfully"
 
       visit admin_budget_budget_investments_path(budget)
 

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -1692,7 +1692,7 @@ describe "Admin budget investments", :admin do
     end
   end
 
-  context "Selecting csv" do
+  context "Selecting csv", :no_js do
     scenario "Downloading CSV file" do
       admin = create(:administrator, user: create(:user, username: "Admin"))
       valuator = create(:valuator, user: create(:user, username: "Valuator"))

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -83,7 +83,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "Filtering by budget heading", :js do
+    scenario "Filtering by budget heading" do
       group1 = create(:budget_group, name: "Streets", budget: budget)
       group2 = create(:budget_group, name: "Parks", budget: budget)
 
@@ -130,7 +130,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_link("Plant trees")
     end
 
-    scenario "Filtering by admin", :js do
+    scenario "Filtering by admin" do
       user = create(:user, username: "Admin 1")
       user2 = create(:user, username: "Admin 2")
       administrator = create(:administrator, user: user)
@@ -173,7 +173,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_link("Realocate visitors")
     end
 
-    scenario "Filtering by valuator", :js do
+    scenario "Filtering by valuator" do
       user = create(:user)
       valuator = create(:valuator, user: user, description: "Valuator 1")
       budget.valuators = [valuator]
@@ -206,7 +206,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_link("Realocate visitors")
     end
 
-    scenario "Filtering by valuator group", :js do
+    scenario "Filtering by valuator group" do
       health_group = create(:valuator_group, name: "Health")
       culture_group = create(:valuator_group, name: "Culture")
 
@@ -239,7 +239,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_link("Build a hospital")
     end
 
-    scenario "Filtering by without assigned admin", :js do
+    scenario "Filtering by without assigned admin" do
       create(:budget_investment,
         title: "Investment without admin",
         budget: budget)
@@ -268,7 +268,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_link("Investment with admin")
     end
 
-    scenario "Filtering by without assigned valuator", :js do
+    scenario "Filtering by without assigned valuator" do
       user = create(:user)
       valuator = create(:valuator, user: user)
       create(:budget_investment,
@@ -299,7 +299,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_link("Investment with valuator")
     end
 
-    scenario "Filtering by under valuation", :js do
+    scenario "Filtering by under valuation" do
       user = create(:user)
       valuator = create(:valuator, user: user)
       create(:budget_investment,
@@ -333,7 +333,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_link("Investment with valuation")
     end
 
-    scenario "Filtering by valuation finished", :js do
+    scenario "Filtering by valuation finished" do
       create(:budget_investment,
         title: "Investment valuation open",
         budget: budget)
@@ -362,7 +362,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_link("Investment valuation finished")
     end
 
-    scenario "Filtering by winners", :js do
+    scenario "Filtering by winners" do
       create(:budget_investment,
         :winner,
         :finished,
@@ -514,7 +514,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_select("tag_name", options: ["All tags", "Accessibility"])
     end
 
-    scenario "Disable 'Calculate winner' button if incorrect phase", :js do
+    scenario "Disable 'Calculate winner' button if incorrect phase" do
       budget.update!(phase: "reviewing_ballots")
 
       visit admin_budget_budget_investments_path(budget)
@@ -550,7 +550,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_link "Calculate Winner Investments"
     end
 
-    scenario "Filtering by minimum number of votes", :js do
+    scenario "Filtering by minimum number of votes" do
       group_1 = create(:budget_group, budget: budget)
       group_2 = create(:budget_group, budget: budget)
       parks   = create(:budget_heading, group: group_1)
@@ -586,7 +586,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_link("Road 100 supports")
     end
 
-    scenario "Filtering by maximum number of votes", :js do
+    scenario "Filtering by maximum number of votes" do
       group_1 = create(:budget_group, budget: budget)
       group_2 = create(:budget_group, budget: budget)
       parks   = create(:budget_heading, group: group_1)
@@ -622,7 +622,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_link("Road 100 supports")
     end
 
-    scenario "Combination of checkbox with text search", :js do
+    scenario "Combination of checkbox with text search" do
       user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
       budget.administrators = [administrator]
@@ -660,7 +660,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_content("Selected")
     end
 
-    scenario "Combination of select with text search", :js do
+    scenario "Combination of select with text search" do
       create(:budget_investment, :feasible, :finished, budget: budget, title: "Educate the children")
       create(:budget_investment, :feasible, :finished, budget: budget, title: "More schools")
       create(:budget_investment, budget: budget, title: "More hospitals")
@@ -694,7 +694,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_content("Selected")
     end
 
-    scenario "Combination of checkbox with text search and checkbox", :js do
+    scenario "Combination of checkbox with text search and checkbox" do
       user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
       budget.administrators = [administrator]
@@ -808,7 +808,7 @@ describe "Admin budget investments", :admin do
     end
   end
 
-  context "Sorting", :js do
+  context "Sorting" do
     before do
       create(:budget_investment, title: "B First Investment", budget: budget, cached_votes_up: 50)
       create(:budget_investment, title: "A Second Investment", budget: budget, cached_votes_up: 25)
@@ -935,7 +935,7 @@ describe "Admin budget investments", :admin do
   end
 
   context "Show" do
-    scenario "Show the investment details", :js do
+    scenario "Show the investment details" do
       user = create(:user, username: "Rachel", email: "rachel@valuators.org")
       valuator = create(:valuator, user: user)
       budget_investment = create(:budget_investment,
@@ -969,7 +969,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "Show image and documents on investment details", :js do
+    scenario "Show image and documents on investment details" do
       budget_investment = create(:budget_investment,
                                   :with_image,
                                   :unfeasible,
@@ -1014,7 +1014,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_content("Hide")
     end
 
-    scenario "If budget is finished, investment cannot be edited or valuation comments created", :js do
+    scenario "If budget is finished, investment cannot be edited or valuation comments created" do
       finished_budget = create(:budget, :finished)
       budget_investment = create(:budget_investment,
                                   budget: finished_budget,
@@ -1033,7 +1033,7 @@ describe "Admin budget investments", :admin do
   end
 
   context "Edit" do
-    scenario "Change title, incompatible, description or heading", :js do
+    scenario "Change title, incompatible, description or heading" do
       budget_investment = create(:budget_investment, :incompatible)
       create(:budget_heading, group: budget_investment.group, name: "Barbate")
 
@@ -1066,7 +1066,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_content "Mark as incompatible"
     end
 
-    scenario "Add administrator", :js do
+    scenario "Add administrator" do
       budget_investment = create(:budget_investment)
       user = create(:user, username: "Marta", email: "marta@admins.org")
       create(:administrator, user: user, description: "Marta desc")
@@ -1087,7 +1087,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_content "Assigned administrator: Marta"
     end
 
-    scenario "Add valuators", :js do
+    scenario "Add valuators" do
       budget_investment = create(:budget_investment)
 
       user1 = create(:user, username: "Valentina", email: "v1@valuators.org")
@@ -1172,7 +1172,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "Adds existing valuation tags", :js do
+    scenario "Adds existing valuation tags" do
       budget_investment1 = create(:budget_investment)
       budget_investment1.set_tag_list_on(:valuation_tags, "Education, Health")
       budget_investment1.save!
@@ -1261,7 +1261,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_content "Refugees, Solidarity"
     end
 
-    scenario "Shows alert when 'Valuation finished' is checked", :js do
+    scenario "Shows alert when 'Valuation finished' is checked" do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -1276,7 +1276,7 @@ describe "Admin budget investments", :admin do
 
     # The feature tested in this scenario works as expected but some underlying reason
     # we're not aware of makes it fail at random
-    xscenario "Shows alert with unfeasible status when 'Valuation finished' is checked", :js do
+    xscenario "Shows alert with unfeasible status when 'Valuation finished' is checked" do
       budget_investment = create(:budget_investment, :unfeasible)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -1289,7 +1289,7 @@ describe "Admin budget investments", :admin do
       expect(valuation).to be_checked
     end
 
-    scenario "Undoes check in 'Valuation finished' if user clicks 'cancel' on alert", :js do
+    scenario "Undoes check in 'Valuation finished' if user clicks 'cancel' on alert" do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -1356,7 +1356,7 @@ describe "Admin budget investments", :admin do
       create(:budget_investment, :undecided, budget: budget, title: "Undecided project")
     end
 
-    scenario "Filtering by valuation and selection", :js do
+    scenario "Filtering by valuation and selection" do
       visit admin_budget_budget_investments_path(budget)
 
       click_link "Advanced filters"
@@ -1401,7 +1401,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_content(winner_bi.title)
     end
 
-    scenario "Aggregating results", :js do
+    scenario "Aggregating results" do
       visit admin_budget_budget_investments_path(budget)
 
       click_link "Advanced filters"
@@ -1427,7 +1427,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_content(feasible_vf_bi.title)
     end
 
-    scenario "Showing the selection buttons", :js do
+    scenario "Showing the selection buttons" do
       visit admin_budget_budget_investments_path(budget)
 
       within("#budget_investment_#{unfeasible_bi.id}") do
@@ -1477,7 +1477,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "Selecting an investment", :js do
+    scenario "Selecting an investment" do
       visit admin_budget_budget_investments_path(budget)
 
       within("#budget_investment_#{feasible_vf_bi.id}") do
@@ -1496,7 +1496,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "Unselecting an investment", :js do
+    scenario "Unselecting an investment" do
       visit admin_budget_budget_investments_path(budget)
       click_link "Advanced filters"
 
@@ -1526,7 +1526,7 @@ describe "Admin budget investments", :admin do
     describe "Pagination" do
       before { selected_bi.update(cached_votes_up: 50) }
 
-      scenario "After unselecting an investment", :js do
+      scenario "After unselecting an investment" do
         allow(Budget::Investment).to receive(:default_per_page).and_return(3)
 
         visit admin_budget_budget_investments_path(budget)
@@ -1553,7 +1553,7 @@ describe "Admin budget investments", :admin do
     let(:investment1) { create(:budget_investment, heading: heading) }
     let(:investment2) { create(:budget_investment, heading: heading) }
 
-    scenario "Mark as visible to valuator", :js do
+    scenario "Mark as visible to valuator" do
       investment1.valuators << valuator
       investment2.valuators << valuator
       investment1.update!(administrator: admin)
@@ -1600,7 +1600,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_content investment2.title
     end
 
-    scenario "Unmark as visible to valuator", :js do
+    scenario "Unmark as visible to valuator" do
       budget.update!(phase: "valuating")
 
       investment1.valuators << valuator
@@ -1676,7 +1676,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "Keeps the valuation tags", :js do
+    scenario "Keeps the valuation tags" do
       investment1.set_tag_list_on(:valuation_tags, %w[Possimpible Truthiness])
       investment1.save!
 
@@ -1770,7 +1770,7 @@ describe "Admin budget investments", :admin do
          valuation_finished visible_to_valuators selected]
     end
 
-    scenario "Display default columns", :js do
+    scenario "Display default columns" do
       visit admin_budget_budget_investments_path(budget)
 
       within("table.column-selectable") do
@@ -1783,7 +1783,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "Display incompatible column as default if selected filter was set", :js do
+    scenario "Display incompatible column as default if selected filter was set" do
       visit admin_budget_budget_investments_path(budget, advanced_filters: ["selected"])
 
       within("table.column-selectable") do
@@ -1793,7 +1793,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_content(investment.title)
     end
 
-    scenario "Set cookie with default columns value if undefined", :js do
+    scenario "Set cookie with default columns value if undefined" do
       visit admin_budget_budget_investments_path(budget)
 
       cookies = page.driver.browser.manage.all_cookies
@@ -1804,7 +1804,7 @@ describe "Admin budget investments", :admin do
         "feasibility,price,valuation_finished,visible_to_valuators,selected,incompatible")
     end
 
-    scenario "Use column selector to display visible columns", :js do
+    scenario "Use column selector to display visible columns" do
       visit admin_budget_budget_investments_path(budget)
 
       click_button "Columns"
@@ -1834,7 +1834,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "Cookie will be updated after change columns selection", :js do
+    scenario "Cookie will be updated after change columns selection" do
       visit admin_budget_budget_investments_path(budget)
 
       click_button "Columns"
@@ -1863,7 +1863,7 @@ describe "Admin budget investments", :admin do
         "visible_to_valuators,selected,incompatible,author")
     end
 
-    scenario "Select an investment when some columns are not displayed", :js do
+    scenario "Select an investment when some columns are not displayed" do
       investment.update!(title: "Don't display me, please!")
 
       visit admin_budget_budget_investments_path(budget)
@@ -1878,7 +1878,7 @@ describe "Admin budget investments", :admin do
       end
     end
 
-    scenario "When restoring the page from browser history renders columns selectors only once", :js do
+    scenario "When restoring the page from browser history renders columns selectors only once" do
       visit admin_budget_budget_investments_path(budget)
 
       click_link "Proposals"

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -1034,7 +1034,7 @@ describe "Admin budget investments", :admin do
   end
 
   context "Edit" do
-    scenario "Change title, incompatible, description or heading" do
+    scenario "Change title, incompatible, description or heading", :js do
       budget_investment = create(:budget_investment, :incompatible)
       create(:budget_heading, group: budget_investment.group, name: "Barbate")
 
@@ -1042,7 +1042,7 @@ describe "Admin budget investments", :admin do
       click_link "Edit"
 
       fill_in "Title", with: "Potatoes"
-      fill_in "Description", with: "Carrots"
+      fill_in_ckeditor "Description", with: "Carrots"
       select "#{budget_investment.group.name}: Barbate", from: "budget_investment[heading_id]"
       uncheck "budget_investment_incompatible"
       check "budget_investment_selected"

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -514,7 +514,7 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_select("tag_name", options: ["All tags", "Accessibility"])
     end
 
-    scenario "Disable 'Calculate winner' button if incorrect phase" do
+    scenario "Disable 'Calculate winner' button if incorrect phase", :js do
       budget.update!(phase: "reviewing_ballots")
 
       visit admin_budget_budget_investments_path(budget)
@@ -536,6 +536,7 @@ describe "Admin budget investments", :admin do
 
       visit admin_budget_budget_investments_path(budget)
 
+      click_link "Advanced filters"
       check "Winners"
       click_button "Filter"
 
@@ -1086,7 +1087,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_content "Assigned administrator: Marta"
     end
 
-    scenario "Add valuators" do
+    scenario "Add valuators", :js do
       budget_investment = create(:budget_investment)
 
       user1 = create(:user, username: "Valentina", email: "v1@valuators.org")
@@ -1098,6 +1099,8 @@ describe "Admin budget investments", :admin do
       create(:valuator, user: user2)
 
       visit edit_admin_budget_path(budget_investment.budget)
+
+      click_link "Select valuators"
 
       check "Valentina"
       check "Val"

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -807,7 +807,7 @@ describe "Admin budget investments", :admin do
     end
   end
 
-  context "Sorting" do
+  context "Sorting", :js do
     before do
       create(:budget_investment, title: "B First Investment", budget: budget, cached_votes_up: 50)
       create(:budget_investment, title: "A Second Investment", budget: budget, cached_votes_up: 25)
@@ -831,7 +831,7 @@ describe "Admin budget investments", :admin do
         expect("B First Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("C Third Investment")
         within("th", text: "ID") do
-          expect(page).to have_css(".icon-sortable.desc")
+          expect(page).to have_css ".icon-sortable.desc", visible: :all
         end
       end
 
@@ -841,7 +841,7 @@ describe "Admin budget investments", :admin do
         expect("A Second Investment").to appear_before("B First Investment")
         expect("B First Investment").to appear_before("C Third Investment")
         within("th", text: "Title") do
-          expect(page).to have_css(".icon-sortable.desc")
+          expect(page).to have_css ".icon-sortable.desc", visible: :all
         end
       end
 
@@ -851,7 +851,7 @@ describe "Admin budget investments", :admin do
         expect("C Third Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("B First Investment")
         within("th", text: "Supports") do
-          expect(page).to have_css(".icon-sortable.desc")
+          expect(page).to have_css ".icon-sortable.desc", visible: :all
         end
       end
     end
@@ -863,7 +863,7 @@ describe "Admin budget investments", :admin do
         expect("C Third Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("B First Investment")
         within("th", text: "ID") do
-          expect(page).to have_css(".icon-sortable.asc")
+          expect(page).to have_css ".icon-sortable.asc", visible: :all
         end
       end
 
@@ -873,7 +873,7 @@ describe "Admin budget investments", :admin do
         expect("C Third Investment").to appear_before("B First Investment")
         expect("B First Investment").to appear_before("A Second Investment")
         within("th", text: "Title") do
-          expect(page).to have_css(".icon-sortable.asc")
+          expect(page).to have_css ".icon-sortable.asc", visible: :all
         end
       end
 
@@ -883,7 +883,7 @@ describe "Admin budget investments", :admin do
         expect("B First Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("C Third Investment")
         within("th", text: "Supports") do
-          expect(page).to have_css(".icon-sortable.asc")
+          expect(page).to have_css ".icon-sortable.asc", visible: :all
         end
       end
     end
@@ -895,7 +895,7 @@ describe "Admin budget investments", :admin do
         expect("B First Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("C Third Investment")
         within("th", text: "ID") do
-          expect(page).to have_css(".icon-sortable.desc")
+          expect(page).to have_css ".icon-sortable.desc", visible: :all
         end
       end
 
@@ -905,7 +905,7 @@ describe "Admin budget investments", :admin do
         expect("A Second Investment").to appear_before("B First Investment")
         expect("B First Investment").to appear_before("C Third Investment")
         within("th", text: "Title") do
-          expect(page).to have_css(".icon-sortable.desc")
+          expect(page).to have_css ".icon-sortable.desc", visible: :all
         end
       end
 
@@ -915,7 +915,7 @@ describe "Admin budget investments", :admin do
         expect("C Third Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("B First Investment")
         within("th", text: "Supports") do
-          expect(page).to have_css(".icon-sortable.desc")
+          expect(page).to have_css ".icon-sortable.desc", visible: :all
         end
       end
     end
@@ -927,7 +927,7 @@ describe "Admin budget investments", :admin do
         expect("B First Investment").to appear_before("A Second Investment")
         expect("A Second Investment").to appear_before("C Third Investment")
         within("th", text: "ID") do
-          expect(page).to have_css(".icon-sortable.desc")
+          expect(page).to have_css ".icon-sortable.desc", visible: :all
         end
       end
     end

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -934,7 +934,7 @@ describe "Admin budget investments", :admin do
   end
 
   context "Show" do
-    scenario "Show the investment details" do
+    scenario "Show the investment details", :js do
       user = create(:user, username: "Rachel", email: "rachel@valuators.org")
       valuator = create(:valuator, user: user)
       budget_investment = create(:budget_investment,
@@ -948,27 +948,27 @@ describe "Admin budget investments", :admin do
 
       visit admin_budget_budget_investments_path(budget_investment.budget)
 
-      click_link budget_investment.title
+      within_window(window_opened_by { click_link budget_investment.title }) do
+        expect(page).to have_content("Investment preview")
+        expect(page).to have_content(budget_investment.title)
+        expect(page).to have_content(budget_investment.description)
+        expect(page).to have_content(budget_investment.author.name)
+        expect(page).to have_content(budget_investment.heading.name)
+        expect(page).to have_content("1234")
+        expect(page).to have_content("1000")
+        expect(page).to have_content("Unfeasible")
+        expect(page).to have_content("It is impossible")
+        expect(page).to have_content("Ana (ana@admins.org)")
 
-      expect(page).to have_content("Investment preview")
-      expect(page).to have_content(budget_investment.title)
-      expect(page).to have_content(budget_investment.description)
-      expect(page).to have_content(budget_investment.author.name)
-      expect(page).to have_content(budget_investment.heading.name)
-      expect(page).to have_content("1234")
-      expect(page).to have_content("1000")
-      expect(page).to have_content("Unfeasible")
-      expect(page).to have_content("It is impossible")
-      expect(page).to have_content("Ana (ana@admins.org)")
+        within("#assigned_valuators") do
+          expect(page).to have_content("Rachel (rachel@valuators.org)")
+        end
 
-      within("#assigned_valuators") do
-        expect(page).to have_content("Rachel (rachel@valuators.org)")
+        expect(page).to have_button "Publish comment"
       end
-
-      expect(page).to have_button "Publish comment"
     end
 
-    scenario "Show image and documents on investment details" do
+    scenario "Show image and documents on investment details", :js do
       budget_investment = create(:budget_investment,
                                   :with_image,
                                   :unfeasible,
@@ -980,22 +980,22 @@ describe "Admin budget investments", :admin do
 
       visit admin_budget_budget_investments_path(budget_investment.budget)
 
-      click_link budget_investment.title
-
-      expect(page).to have_content(budget_investment.title)
-      expect(page).to have_content(budget_investment.description)
-      expect(page).to have_content(budget_investment.author.name)
-      expect(page).to have_content(budget_investment.heading.name)
-      expect(page).to have_content("Investment preview")
-      expect(page).to have_content(budget_investment.image.title)
-      expect(page).to have_content("Documents (1)")
-      expect(page).to have_content(document.title)
-      expect(page).to have_content("Download file")
-      expect(page).to have_content("1234")
-      expect(page).to have_content("1000")
-      expect(page).to have_content("Unfeasible")
-      expect(page).to have_content("It is impossible")
-      expect(page).to have_content("Ana (ana@admins.org)")
+      within_window(window_opened_by { click_link budget_investment.title }) do
+        expect(page).to have_content(budget_investment.title)
+        expect(page).to have_content(budget_investment.description)
+        expect(page).to have_content(budget_investment.author.name)
+        expect(page).to have_content(budget_investment.heading.name)
+        expect(page).to have_content("Investment preview")
+        expect(page).to have_content(budget_investment.image.title)
+        expect(page).to have_content("Documents (1)")
+        expect(page).to have_content(document.title)
+        expect(page).to have_content("Download file")
+        expect(page).to have_content("1234")
+        expect(page).to have_content("1000")
+        expect(page).to have_content("Unfeasible")
+        expect(page).to have_content("It is impossible")
+        expect(page).to have_content("Ana (ana@admins.org)")
+      end
     end
 
     scenario "Does not show related content or hide links on preview" do
@@ -1013,23 +1013,21 @@ describe "Admin budget investments", :admin do
       expect(page).not_to have_content("Hide")
     end
 
-    scenario "If budget is finished, investment cannot be edited or valuation comments created" do
-      # Only milestones can be managed
-
+    scenario "If budget is finished, investment cannot be edited or valuation comments created", :js do
       finished_budget = create(:budget, :finished)
       budget_investment = create(:budget_investment,
                                   budget: finished_budget,
                                   administrator: administrator)
       visit admin_budget_budget_investments_path(budget_investment.budget)
 
-      click_link budget_investment.title
+      within_window(window_opened_by { click_link budget_investment.title }) do
+        expect(page).not_to have_link "Edit"
+        expect(page).not_to have_link "Edit classification"
+        expect(page).not_to have_link "Edit dossier"
+        expect(page).to have_link "Create new milestone"
 
-      expect(page).not_to have_link "Edit"
-      expect(page).not_to have_link "Edit classification"
-      expect(page).not_to have_link "Edit dossier"
-      expect(page).to have_link "Create new milestone"
-
-      expect(page).not_to have_button "Publish comment"
+        expect(page).not_to have_button "Publish comment"
+      end
     end
   end
 

--- a/spec/system/admin/budget_phases_spec.rb
+++ b/spec/system/admin/budget_phases_spec.rb
@@ -32,6 +32,8 @@ describe "Admin budget phases" do
         within("tr", text: "Accepting projects") { click_link "Edit phase" }
       end
 
+      expect(page).to have_css "h2", exact_text: "Edit Participatory budget - Accepting projects"
+
       fill_in "Name", with: "My phase custom name"
       click_button "Save changes"
 

--- a/spec/system/admin/budget_phases_spec.rb
+++ b/spec/system/admin/budget_phases_spec.rb
@@ -4,7 +4,7 @@ describe "Admin budget phases" do
   let(:budget) { create(:budget) }
 
   context "Edit", :admin do
-    scenario "Update phase", :js do
+    scenario "Update phase" do
       visit edit_admin_budget_budget_phase_path(budget, budget.current_phase)
 
       fill_in "start_date", with: Date.current + 1.day

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Admin budgets", :admin do
   context "Load" do
-    let!(:budget) { create(:budget, slug: "budget_slug") }
+    before { create(:budget, slug: "budget_slug") }
 
     scenario "finds budget by slug" do
       visit edit_admin_budget_path("budget_slug")

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -26,7 +26,7 @@ describe "Admin budgets", :admin do
       expect(page).to have_content "Accepting projects"
     end
 
-    scenario "Filters by phase" do
+    scenario "Filters by phase", :js do
       drafting_budget  = create(:budget, :drafting)
       accepting_budget = create(:budget, :accepting)
       selecting_budget = create(:budget, :selecting)
@@ -41,7 +41,7 @@ describe "Admin budgets", :admin do
       expect(page).to have_content(finished_budget.name)
 
       within "#budget_#{finished_budget.id}" do
-        expect(page).to have_content("Completed")
+        expect(page).to have_content("COMPLETED")
       end
 
       click_link "Finished"

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -26,7 +26,7 @@ describe "Admin budgets", :admin do
       expect(page).to have_content "Accepting projects"
     end
 
-    scenario "Filters by phase", :js do
+    scenario "Filters by phase" do
       drafting_budget  = create(:budget, :drafting)
       accepting_budget = create(:budget, :accepting)
       selecting_budget = create(:budget, :selecting)
@@ -94,7 +94,7 @@ describe "Admin budgets", :admin do
       expect(page).to have_select "Final voting style", selected: "Knapsack"
     end
 
-    scenario "Create budget - Approval voting", :js do
+    scenario "Create budget - Approval voting" do
       admin = Administrator.first
 
       visit admin_budgets_path
@@ -134,7 +134,7 @@ describe "Admin budgets", :admin do
       expect(page).to have_css("small.form-error", text: "has already been taken")
     end
 
-    scenario "Do not show results and stats settings on new budget", :js do
+    scenario "Do not show results and stats settings on new budget" do
       visit new_admin_budget_path
 
       expect(page).not_to have_content "Show results and stats"
@@ -144,7 +144,7 @@ describe "Admin budgets", :admin do
     end
   end
 
-  context "Create", :js do
+  context "Create" do
     scenario "A new budget is always created in draft mode" do
       visit admin_budgets_path
       click_link "Create new budget"
@@ -161,7 +161,7 @@ describe "Admin budgets", :admin do
     end
   end
 
-  context "Publish", :js do
+  context "Publish" do
     let(:budget) { create(:budget, :drafting) }
 
     scenario "Can preview budget before it is published" do
@@ -275,7 +275,7 @@ describe "Admin budgets", :admin do
       end
     end
 
-    scenario "Show results and stats settings", :js do
+    scenario "Show results and stats settings" do
       visit edit_admin_budget_path(budget)
 
       within_fieldset "Show results and stats" do
@@ -285,7 +285,7 @@ describe "Admin budgets", :admin do
       end
     end
 
-    scenario "Changing name for current locale will update the slug if budget is in draft phase", :js do
+    scenario "Changing name for current locale will update the slug if budget is in draft phase" do
       budget.update!(published: false)
       old_slug = budget.slug
 
@@ -321,7 +321,7 @@ describe "Admin budgets", :admin do
       expect(page).to have_current_path(admin_budgets_path)
     end
 
-    scenario "Deselect all selected staff", :js do
+    scenario "Deselect all selected staff" do
       admin = Administrator.first
       valuator = create(:valuator)
 
@@ -347,7 +347,7 @@ describe "Admin budgets", :admin do
   end
 
   context "Calculate Budget's Winner Investments" do
-    scenario "For a Budget in reviewing balloting", :js do
+    scenario "For a Budget in reviewing balloting" do
       budget = create(:budget, :reviewing_ballots)
       heading = create(:budget_heading, budget: budget, price: 4)
       unselected = create(:budget_investment, :unselected, heading: heading, price: 1,

--- a/spec/system/admin/dashboard/actions_spec.rb
+++ b/spec/system/admin/dashboard/actions_spec.rb
@@ -47,8 +47,8 @@ describe "Admin dashboard actions", :admin do
     end
 
     scenario "Creates a new action" do
-      fill_in "dashboard_action_title", with: action.title
-      fill_in "dashboard_action_description", with: action.description
+      fill_in "Title", with: action.title
+      fill_in "Description", with: action.description
 
       click_button "Save"
 

--- a/spec/system/admin/dashboard/actions_spec.rb
+++ b/spec/system/admin/dashboard/actions_spec.rb
@@ -21,7 +21,7 @@ describe "Admin dashboard actions", :admin do
         expect(page).to have_content("Email")
         expect(page).to have_content("Poster")
 
-        expect(page).to have_selector("a", text: "Edit", count: 3)
+        expect(page).to have_link "Edit", count: 3
       end
     end
 

--- a/spec/system/admin/dashboard/actions_spec.rb
+++ b/spec/system/admin/dashboard/actions_spec.rb
@@ -46,7 +46,7 @@ describe "Admin dashboard actions", :admin do
       click_link "Create resource or action"
     end
 
-    scenario "Creates a new action", :js do
+    scenario "Creates a new action" do
       fill_in "Title", with: action.title
       fill_in_ckeditor "Description", with: action.description
 
@@ -93,7 +93,7 @@ describe "Admin dashboard actions", :admin do
       visit admin_dashboard_actions_path
     end
 
-    scenario "deletes the action", js: true do
+    scenario "deletes the action" do
       page.accept_confirm do
         click_link "Delete"
       end
@@ -101,7 +101,7 @@ describe "Admin dashboard actions", :admin do
       expect(page).not_to have_content(action.title)
     end
 
-    scenario "can not delete actions that have been executed", js: true do
+    scenario "can not delete actions that have been executed" do
       _executed_action = create(:dashboard_executed_action, action: action)
 
       page.accept_confirm do

--- a/spec/system/admin/dashboard/actions_spec.rb
+++ b/spec/system/admin/dashboard/actions_spec.rb
@@ -46,9 +46,9 @@ describe "Admin dashboard actions", :admin do
       click_link "Create resource or action"
     end
 
-    scenario "Creates a new action" do
+    scenario "Creates a new action", :js do
       fill_in "Title", with: action.title
-      fill_in "Description", with: action.description
+      fill_in_ckeditor "Description", with: action.description
 
       click_button "Save"
 

--- a/spec/system/admin/emails/emails_download_spec.rb
+++ b/spec/system/admin/emails/emails_download_spec.rb
@@ -22,7 +22,7 @@ describe "Admin download user emails" do
       admin_without_email.update_column(:email, nil)
     end
 
-    scenario "returns the selected users segment csv file" do
+    scenario "returns the selected users segment csv file", :no_js do
       visit admin_emails_download_index_path
 
       within("#admin_download_emails") do

--- a/spec/system/admin/emails/emails_download_spec.rb
+++ b/spec/system/admin/emails/emails_download_spec.rb
@@ -39,7 +39,7 @@ describe "Admin download user emails" do
     end
   end
 
-  scenario "Download button is not disabled after being clicked", :js do
+  scenario "Download button is not disabled after being clicked" do
     visit admin_emails_download_index_path
     click_button "Download emails list"
 

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -98,12 +98,12 @@ describe "Admin newsletter emails", :admin do
     expect(page).to have_content "This is a body"
   end
 
-  scenario "Destroy" do
+  scenario "Destroy", :js do
     newsletter = create(:newsletter)
 
     visit admin_newsletters_path
     within("#newsletter_#{newsletter.id}") do
-      click_link "Delete"
+      accept_confirm { click_link "Delete" }
     end
 
     expect(page).to have_content "Newsletter deleted successfully"

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -58,7 +58,7 @@ describe "Admin newsletter emails", :admin do
     end
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     visit admin_newsletters_path
     click_link "New newsletter"
 
@@ -76,7 +76,7 @@ describe "Admin newsletter emails", :admin do
     expect(page).to have_content "This is a body"
   end
 
-  scenario "Update", :js do
+  scenario "Update" do
     newsletter = create(:newsletter)
 
     visit admin_newsletters_path
@@ -98,7 +98,7 @@ describe "Admin newsletter emails", :admin do
     expect(page).to have_content "This is a body"
   end
 
-  scenario "Destroy", :js do
+  scenario "Destroy" do
     newsletter = create(:newsletter)
 
     visit admin_newsletters_path
@@ -128,8 +128,8 @@ describe "Admin newsletter emails", :admin do
     expect(page).to have_content error_message
   end
 
-  context "Send newsletter", :js do
-    scenario "Sends newsletter emails", :js do
+  context "Send newsletter" do
+    scenario "Sends newsletter emails" do
       newsletter = create(:newsletter)
       visit admin_newsletter_path(newsletter)
 
@@ -138,7 +138,7 @@ describe "Admin newsletter emails", :admin do
       expect(page).to have_content "Newsletter sent successfully"
     end
 
-    scenario "Invalid newsletter cannot be sent", :js do
+    scenario "Invalid newsletter cannot be sent" do
       invalid_newsletter = create(:newsletter)
       invalid_newsletter.update_column(:segment_recipient, "invalid_segment")
       visit admin_newsletter_path(invalid_newsletter)
@@ -147,7 +147,7 @@ describe "Admin newsletter emails", :admin do
     end
   end
 
-  context "Counter of emails sent", :js do
+  context "Counter of emails sent" do
     scenario "Display counter" do
       newsletter = create(:newsletter, segment_recipient: "administrators")
       visit admin_newsletter_path(newsletter)
@@ -161,7 +161,7 @@ describe "Admin newsletter emails", :admin do
     end
   end
 
-  scenario "Select list of users to send newsletter", :js do
+  scenario "Select list of users to send newsletter" do
     UserSegments::SEGMENTS.each do |user_segment|
       visit new_admin_newsletter_path
 

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -58,7 +58,7 @@ describe "Admin newsletter emails", :admin do
     end
   end
 
-  scenario "Create" do
+  scenario "Create", :js do
     visit admin_newsletters_path
     click_link "New newsletter"
 
@@ -76,7 +76,7 @@ describe "Admin newsletter emails", :admin do
     expect(page).to have_content "This is a body"
   end
 
-  scenario "Update" do
+  scenario "Update", :js do
     newsletter = create(:newsletter)
 
     visit admin_newsletters_path
@@ -161,7 +161,7 @@ describe "Admin newsletter emails", :admin do
     end
   end
 
-  scenario "Select list of users to send newsletter" do
+  scenario "Select list of users to send newsletter", :js do
     UserSegments::SEGMENTS.each do |user_segment|
       visit new_admin_newsletter_path
 

--- a/spec/system/admin/feature_flags_spec.rb
+++ b/spec/system/admin/feature_flags_spec.rb
@@ -14,7 +14,7 @@ describe "Admin feature flags", :admin do
     end
   end
 
-  scenario "Disable a participatory process", :show_exceptions do
+  scenario "Disable a participatory process", :show_exceptions, :js do
     setting = Setting.find_by(key: "process.budgets")
     budget = create(:budget)
 
@@ -24,10 +24,11 @@ describe "Admin feature flags", :admin do
     within("#edit_setting_#{setting.id}") do
       expect(page).to have_button "Disable"
       expect(page).not_to have_button "Enable"
-      click_button "Disable"
+
+      accept_confirm { click_button "Disable" }
     end
 
-    visit admin_root_path
+    expect(page).to have_content "Value updated"
 
     within("#side_menu") do
       expect(page).not_to have_link "Participatory budgets"
@@ -43,7 +44,7 @@ describe "Admin feature flags", :admin do
     expect(page).to have_content "Internal server error"
   end
 
-  scenario "Enable a disabled participatory process" do
+  scenario "Enable a disabled participatory process", :js do
     Setting["process.budgets"] = nil
     setting = Setting.find_by(key: "process.budgets")
 
@@ -59,25 +60,28 @@ describe "Admin feature flags", :admin do
     within("#edit_setting_#{setting.id}") do
       expect(page).to have_button "Enable"
       expect(page).not_to have_button "Disable"
-      click_button "Enable"
+
+      accept_confirm { click_button "Enable" }
     end
 
-    visit admin_root_path
+    expect(page).to have_content "Value updated"
 
     within("#side_menu") do
       expect(page).to have_link "Participatory budgets"
     end
   end
 
-  scenario "Disable a feature" do
+  scenario "Disable a feature", :js do
     setting = Setting.find_by(key: "feature.twitter_login")
 
     visit admin_settings_path
+    click_link "Features"
 
     within("#edit_setting_#{setting.id}") do
       expect(page).to have_button "Disable"
       expect(page).not_to have_button "Enable"
-      click_button "Disable"
+
+      accept_confirm { click_button "Disable" }
     end
 
     expect(page).to have_content "Value updated"
@@ -88,15 +92,17 @@ describe "Admin feature flags", :admin do
     end
   end
 
-  scenario "Enable a disabled feature" do
+  scenario "Enable a disabled feature", :js do
     setting = Setting.find_by(key: "feature.map")
 
     visit admin_settings_path
+    click_link "Features"
 
     within("#edit_setting_#{setting.id}") do
       expect(page).to have_button "Enable"
       expect(page).not_to have_button "Disable"
-      click_button "Enable"
+
+      accept_confirm { click_button "Enable" }
     end
 
     expect(page).to have_content "Value updated"

--- a/spec/system/admin/feature_flags_spec.rb
+++ b/spec/system/admin/feature_flags_spec.rb
@@ -5,12 +5,12 @@ describe "Admin feature flags", :admin do
     Setting["process.budgets"] = true
   end
 
-  scenario "Enabled features are listed on menu" do
+  scenario "Enabled features are listed on menu", :js do
     visit admin_root_path
 
     within("#side_menu") do
       expect(page).to have_link "Participatory budgets"
-      expect(page).to have_link "Hidden debates"
+      expect(page).to have_link "Debates"
     end
   end
 

--- a/spec/system/admin/feature_flags_spec.rb
+++ b/spec/system/admin/feature_flags_spec.rb
@@ -5,7 +5,7 @@ describe "Admin feature flags", :admin do
     Setting["process.budgets"] = true
   end
 
-  scenario "Enabled features are listed on menu", :js do
+  scenario "Enabled features are listed on menu" do
     visit admin_root_path
 
     within("#side_menu") do
@@ -14,7 +14,7 @@ describe "Admin feature flags", :admin do
     end
   end
 
-  scenario "Disable a participatory process", :show_exceptions, :js do
+  scenario "Disable a participatory process", :show_exceptions do
     setting = Setting.find_by(key: "process.budgets")
     budget = create(:budget)
 
@@ -44,7 +44,7 @@ describe "Admin feature flags", :admin do
     expect(page).to have_content "Internal server error"
   end
 
-  scenario "Enable a disabled participatory process", :js do
+  scenario "Enable a disabled participatory process" do
     Setting["process.budgets"] = nil
     setting = Setting.find_by(key: "process.budgets")
 
@@ -71,7 +71,7 @@ describe "Admin feature flags", :admin do
     end
   end
 
-  scenario "Disable a feature", :js do
+  scenario "Disable a feature" do
     setting = Setting.find_by(key: "feature.twitter_login")
 
     visit admin_settings_path
@@ -92,7 +92,7 @@ describe "Admin feature flags", :admin do
     end
   end
 
-  scenario "Enable a disabled feature", :js do
+  scenario "Enable a disabled feature" do
     setting = Setting.find_by(key: "feature.map")
 
     visit admin_settings_path

--- a/spec/system/admin/geozones_spec.rb
+++ b/spec/system/admin/geozones_spec.rb
@@ -66,25 +66,25 @@ describe "Admin geozones", :admin do
     end
   end
 
-  scenario "Delete geozone with no associated elements" do
+  scenario "Delete geozone with no associated elements", :js do
     geozone = create(:geozone, name: "Delete me!")
 
     visit admin_geozones_path
 
-    within("#geozone_#{geozone.id}") { click_link "Delete" }
+    within("#geozone_#{geozone.id}") { accept_confirm { click_link "Delete" } }
 
     expect(page).to have_content "Geozone successfully deleted"
     expect(page).not_to have_content("Delete me!")
     expect(Geozone.where(id: geozone.id)).to be_empty
   end
 
-  scenario "Delete geozone with associated element" do
+  scenario "Delete geozone with associated element", :js do
     geozone = create(:geozone, name: "Delete me!")
     create(:proposal, geozone: geozone)
 
     visit admin_geozones_path
 
-    within("#geozone_#{geozone.id}") { click_link "Delete" }
+    within("#geozone_#{geozone.id}") { accept_confirm { click_link "Delete" } }
 
     expect(page).to have_content "This geozone can't be deleted since there are elements attached to it"
 

--- a/spec/system/admin/geozones_spec.rb
+++ b/spec/system/admin/geozones_spec.rb
@@ -11,10 +11,13 @@ describe "Admin geozones", :admin do
     expect(page).to have_content(retiro.name)
   end
 
-  scenario "Create new geozone" do
+  scenario "Create new geozone", :js do
     visit admin_root_path
 
-    within("#side_menu") { click_link "Manage geozones" }
+    within("#side_menu") do
+      click_link "Settings"
+      click_link "Manage geozones"
+    end
 
     click_link "Create geozone"
 

--- a/spec/system/admin/geozones_spec.rb
+++ b/spec/system/admin/geozones_spec.rb
@@ -11,7 +11,7 @@ describe "Admin geozones", :admin do
     expect(page).to have_content(retiro.name)
   end
 
-  scenario "Create new geozone", :js do
+  scenario "Create new geozone" do
     visit admin_root_path
 
     within("#side_menu") do
@@ -69,7 +69,7 @@ describe "Admin geozones", :admin do
     end
   end
 
-  scenario "Delete geozone with no associated elements", :js do
+  scenario "Delete geozone with no associated elements" do
     geozone = create(:geozone, name: "Delete me!")
 
     visit admin_geozones_path
@@ -81,7 +81,7 @@ describe "Admin geozones", :admin do
     expect(Geozone.where(id: geozone.id)).to be_empty
   end
 
-  scenario "Delete geozone with associated element", :js do
+  scenario "Delete geozone with associated element" do
     geozone = create(:geozone, name: "Delete me!")
     create(:proposal, geozone: geozone)
 

--- a/spec/system/admin/hidden_budget_investments_spec.rb
+++ b/spec/system/admin/hidden_budget_investments_spec.rb
@@ -86,7 +86,7 @@ describe "Admin hidden budget investments", :admin do
 
     click_on("Restore", match: :first, exact: true)
 
-    expect(current_url).to include("filter=with_confirmed_hide")
-    expect(current_url).to include("page=2")
+    expect(page).to have_current_path(/filter=with_confirmed_hide/)
+    expect(page).to have_current_path(/page=2/)
   end
 end

--- a/spec/system/admin/hidden_budget_investments_spec.rb
+++ b/spec/system/admin/hidden_budget_investments_spec.rb
@@ -13,12 +13,12 @@ describe "Admin hidden budget investments", :admin do
     expect(page).to have_content(investment.description)
   end
 
-  scenario "Restore" do
+  scenario "Restore", :js do
     investment = create(:budget_investment, :hidden, heading: heading)
 
     visit admin_hidden_budget_investments_path
 
-    click_link "Restore"
+    accept_confirm { click_link "Restore" }
 
     expect(page).not_to have_content(investment.title)
 
@@ -78,13 +78,13 @@ describe "Admin hidden budget investments", :admin do
     expect(page).to have_content("Confirmed investment")
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  scenario "Action links remember the pagination setting and the filter", :js do
     allow(Budget::Investment).to receive(:default_per_page).and_return(2)
     4.times { create(:budget_investment, :hidden, :with_confirmed_hide, heading: heading) }
 
     visit admin_hidden_budget_investments_path(filter: "with_confirmed_hide", page: 2)
 
-    click_on("Restore", match: :first, exact: true)
+    accept_confirm { click_link "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_budget_investments_spec.rb
+++ b/spec/system/admin/hidden_budget_investments_spec.rb
@@ -13,7 +13,7 @@ describe "Admin hidden budget investments", :admin do
     expect(page).to have_content(investment.description)
   end
 
-  scenario "Restore", :js do
+  scenario "Restore" do
     investment = create(:budget_investment, :hidden, heading: heading)
 
     visit admin_hidden_budget_investments_path
@@ -78,7 +78,7 @@ describe "Admin hidden budget investments", :admin do
     expect(page).to have_content("Confirmed investment")
   end
 
-  scenario "Action links remember the pagination setting and the filter", :js do
+  scenario "Action links remember the pagination setting and the filter" do
     allow(Budget::Investment).to receive(:default_per_page).and_return(2)
     4.times { create(:budget_investment, :hidden, :with_confirmed_hide, heading: heading) }
 

--- a/spec/system/admin/hidden_comments_spec.rb
+++ b/spec/system/admin/hidden_comments_spec.rb
@@ -127,7 +127,7 @@ describe "Admin hidden comments", :admin do
 
     click_on("Restore", match: :first, exact: true)
 
-    expect(current_url).to include("filter=with_confirmed_hide")
-    expect(current_url).to include("page=2")
+    expect(page).to have_current_path(/filter=with_confirmed_hide/)
+    expect(page).to have_current_path(/page=2/)
   end
 end

--- a/spec/system/admin/hidden_comments_spec.rb
+++ b/spec/system/admin/hidden_comments_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Admin hidden comments", :admin do
-  scenario "Do not show comments from blocked users" do
+  scenario "Do not show comments from blocked users", :js do
     comment = create(:comment, :hidden, body: "SPAM from SPAMMER")
     proposal = create(:proposal, author: comment.author)
     create(:comment, commentable: proposal, user: comment.author, body: "Good Proposal!")
@@ -11,11 +11,15 @@ describe "Admin hidden comments", :admin do
     expect(page).not_to have_content("Good Proposal!")
 
     visit proposal_path(proposal)
+
     within("#proposal_#{proposal.id}") do
-      click_link "Hide author"
+      accept_confirm { click_link "Hide author" }
     end
 
+    expect(page).to have_current_path debates_path
+
     visit admin_hidden_comments_path
+
     expect(page).not_to have_content("SPAM from SPAMMER")
     expect(page).not_to have_content("Good Proposal!")
   end
@@ -59,11 +63,11 @@ describe "Admin hidden comments", :admin do
     expect(page).not_to have_link("This is SPAM comment on proposal")
   end
 
-  scenario "Restore" do
+  scenario "Restore", :js do
     comment = create(:comment, :hidden, body: "Not really SPAM")
     visit admin_hidden_comments_path
 
-    click_link "Restore"
+    accept_confirm { click_link "Restore" }
 
     expect(page).not_to have_content(comment.body)
 
@@ -119,13 +123,13 @@ describe "Admin hidden comments", :admin do
     expect(page).to have_content("Confirmed comment")
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  scenario "Action links remember the pagination setting and the filter", :js do
     allow(Comment).to receive(:default_per_page).and_return(2)
     4.times { create(:comment, :hidden, :with_confirmed_hide) }
 
     visit admin_hidden_comments_path(filter: "with_confirmed_hide", page: 2)
 
-    click_on("Restore", match: :first, exact: true)
+    accept_confirm { click_link "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_comments_spec.rb
+++ b/spec/system/admin/hidden_comments_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Admin hidden comments", :admin do
-  scenario "Do not show comments from blocked users", :js do
+  scenario "Do not show comments from blocked users" do
     comment = create(:comment, :hidden, body: "SPAM from SPAMMER")
     proposal = create(:proposal, author: comment.author)
     create(:comment, commentable: proposal, user: comment.author, body: "Good Proposal!")
@@ -63,7 +63,7 @@ describe "Admin hidden comments", :admin do
     expect(page).not_to have_link("This is SPAM comment on proposal")
   end
 
-  scenario "Restore", :js do
+  scenario "Restore" do
     comment = create(:comment, :hidden, body: "Not really SPAM")
     visit admin_hidden_comments_path
 
@@ -123,7 +123,7 @@ describe "Admin hidden comments", :admin do
     expect(page).to have_content("Confirmed comment")
   end
 
-  scenario "Action links remember the pagination setting and the filter", :js do
+  scenario "Action links remember the pagination setting and the filter" do
     allow(Comment).to receive(:default_per_page).and_return(2)
     4.times { create(:comment, :hidden, :with_confirmed_hide) }
 

--- a/spec/system/admin/hidden_debates_spec.rb
+++ b/spec/system/admin/hidden_debates_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
-describe "Admin hidden debates", :admin do
+describe "Admin hidden debates", :admin, :js do
   scenario "Restore" do
     debate = create(:debate, :hidden)
     visit admin_hidden_debates_path
 
-    click_link "Restore"
+    accept_confirm { click_link "Restore" }
 
     expect(page).not_to have_content(debate.title)
 
@@ -65,13 +65,13 @@ describe "Admin hidden debates", :admin do
     expect(page).to have_content("Confirmed debate")
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  scenario "Action links remember the pagination setting and the filter", :js do
     allow(Debate).to receive(:default_per_page).and_return(2)
     4.times { create(:debate, :hidden, :with_confirmed_hide) }
 
     visit admin_hidden_debates_path(filter: "with_confirmed_hide", page: 2)
 
-    click_on("Restore", match: :first, exact: true)
+    accept_confirm { click_link "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_debates_spec.rb
+++ b/spec/system/admin/hidden_debates_spec.rb
@@ -73,7 +73,7 @@ describe "Admin hidden debates", :admin do
 
     click_on("Restore", match: :first, exact: true)
 
-    expect(current_url).to include("filter=with_confirmed_hide")
-    expect(current_url).to include("page=2")
+    expect(page).to have_current_path(/filter=with_confirmed_hide/)
+    expect(page).to have_current_path(/page=2/)
   end
 end

--- a/spec/system/admin/hidden_debates_spec.rb
+++ b/spec/system/admin/hidden_debates_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Admin hidden debates", :admin, :js do
+describe "Admin hidden debates", :admin do
   scenario "Restore" do
     debate = create(:debate, :hidden)
     visit admin_hidden_debates_path
@@ -65,7 +65,7 @@ describe "Admin hidden debates", :admin, :js do
     expect(page).to have_content("Confirmed debate")
   end
 
-  scenario "Action links remember the pagination setting and the filter", :js do
+  scenario "Action links remember the pagination setting and the filter" do
     allow(Debate).to receive(:default_per_page).and_return(2)
     4.times { create(:debate, :hidden, :with_confirmed_hide) }
 

--- a/spec/system/admin/hidden_proposals_spec.rb
+++ b/spec/system/admin/hidden_proposals_spec.rb
@@ -83,7 +83,7 @@ describe "Admin hidden proposals", :admin do
 
     click_on("Restore", match: :first, exact: true)
 
-    expect(current_url).to include("filter=with_confirmed_hide")
-    expect(current_url).to include("page=2")
+    expect(page).to have_current_path(/filter=with_confirmed_hide/)
+    expect(page).to have_current_path(/page=2/)
   end
 end

--- a/spec/system/admin/hidden_proposals_spec.rb
+++ b/spec/system/admin/hidden_proposals_spec.rb
@@ -11,11 +11,11 @@ describe "Admin hidden proposals", :admin do
     expect(page).to have_content(proposal.video_url)
   end
 
-  scenario "Restore" do
+  scenario "Restore", :js do
     proposal = create(:proposal, :hidden)
     visit admin_hidden_proposals_path
 
-    click_link "Restore"
+    accept_confirm { click_link "Restore" }
 
     expect(page).not_to have_content(proposal.title)
 
@@ -75,13 +75,13 @@ describe "Admin hidden proposals", :admin do
     expect(page).to have_content("Confirmed proposal")
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  scenario "Action links remember the pagination setting and the filter", :js do
     allow(Proposal).to receive(:default_per_page).and_return(2)
     4.times { create(:proposal, :hidden, :with_confirmed_hide) }
 
     visit admin_hidden_proposals_path(filter: "with_confirmed_hide", page: 2)
 
-    click_on("Restore", match: :first, exact: true)
+    accept_confirm { click_link "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_proposals_spec.rb
+++ b/spec/system/admin/hidden_proposals_spec.rb
@@ -1,13 +1,16 @@
 require "rails_helper"
 
 describe "Admin hidden proposals", :admin do
-  scenario "List shows all relevant info" do
+  scenario "List shows all relevant info", :js do
     proposal = create(:proposal, :hidden)
     visit admin_hidden_proposals_path
 
     expect(page).to have_content(proposal.title)
     expect(page).to have_content(proposal.summary)
     expect(page).to have_content(proposal.description)
+
+    find("td", text: proposal.summary).hover
+
     expect(page).to have_content(proposal.video_url)
   end
 

--- a/spec/system/admin/hidden_proposals_spec.rb
+++ b/spec/system/admin/hidden_proposals_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Admin hidden proposals", :admin do
-  scenario "List shows all relevant info", :js do
+  scenario "List shows all relevant info" do
     proposal = create(:proposal, :hidden)
     visit admin_hidden_proposals_path
 
@@ -14,7 +14,7 @@ describe "Admin hidden proposals", :admin do
     expect(page).to have_content(proposal.video_url)
   end
 
-  scenario "Restore", :js do
+  scenario "Restore" do
     proposal = create(:proposal, :hidden)
     visit admin_hidden_proposals_path
 
@@ -78,7 +78,7 @@ describe "Admin hidden proposals", :admin do
     expect(page).to have_content("Confirmed proposal")
   end
 
-  scenario "Action links remember the pagination setting and the filter", :js do
+  scenario "Action links remember the pagination setting and the filter" do
     allow(Proposal).to receive(:default_per_page).and_return(2)
     4.times { create(:proposal, :hidden, :with_confirmed_hide) }
 

--- a/spec/system/admin/hidden_users_spec.rb
+++ b/spec/system/admin/hidden_users_spec.rb
@@ -84,7 +84,7 @@ describe "Admin hidden users", :admin do
 
     click_on("Restore", match: :first, exact: true)
 
-    expect(current_url).to include("filter=with_confirmed_hide")
-    expect(current_url).to include("page=2")
+    expect(page).to have_current_path(/filter=with_confirmed_hide/)
+    expect(page).to have_current_path(/page=2/)
   end
 end

--- a/spec/system/admin/hidden_users_spec.rb
+++ b/spec/system/admin/hidden_users_spec.rb
@@ -17,11 +17,11 @@ describe "Admin hidden users", :admin do
     expect(page).to have_content(comment2.body)
   end
 
-  scenario "Restore" do
+  scenario "Restore", :js do
     user = create(:user, :hidden)
     visit admin_hidden_users_path
 
-    click_link "Restore"
+    accept_confirm { click_link "Restore" }
 
     expect(page).not_to have_content(user.username)
 
@@ -76,13 +76,13 @@ describe "Admin hidden users", :admin do
     expect(page).to have_content("Confirmed user")
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  scenario "Action links remember the pagination setting and the filter", :js do
     allow(User).to receive(:default_per_page).and_return(2)
     4.times { create(:user, :hidden, :with_confirmed_hide) }
 
     visit admin_hidden_users_path(filter: "with_confirmed_hide", page: 2)
 
-    click_on("Restore", match: :first, exact: true)
+    accept_confirm { click_link "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_users_spec.rb
+++ b/spec/system/admin/hidden_users_spec.rb
@@ -17,7 +17,7 @@ describe "Admin hidden users", :admin do
     expect(page).to have_content(comment2.body)
   end
 
-  scenario "Restore", :js do
+  scenario "Restore" do
     user = create(:user, :hidden)
     visit admin_hidden_users_path
 
@@ -76,7 +76,7 @@ describe "Admin hidden users", :admin do
     expect(page).to have_content("Confirmed user")
   end
 
-  scenario "Action links remember the pagination setting and the filter", :js do
+  scenario "Action links remember the pagination setting and the filter" do
     allow(User).to receive(:default_per_page).and_return(2)
     4.times { create(:user, :hidden, :with_confirmed_hide) }
 

--- a/spec/system/admin/homepage/homepage_spec.rb
+++ b/spec/system/admin/homepage/homepage_spec.rb
@@ -26,7 +26,7 @@ describe "Homepage", :admin do
   end
 
   context "Feeds" do
-    scenario "Proposals", :js do
+    scenario "Proposals" do
       5.times { create(:proposal) }
 
       visit admin_homepage_path
@@ -46,7 +46,7 @@ describe "Homepage", :admin do
       expect(page).not_to have_css("#feed_proposals.medium-8")
     end
 
-    scenario "Debates", :js do
+    scenario "Debates" do
       5.times { create(:debate) }
 
       visit admin_homepage_path
@@ -65,7 +65,7 @@ describe "Homepage", :admin do
       expect(page).not_to have_css("#feed_debates.medium-4")
     end
 
-    scenario "Proposals and debates", :js do
+    scenario "Proposals and debates" do
       3.times { create(:proposal) }
       3.times { create(:debate) }
 
@@ -94,7 +94,7 @@ describe "Homepage", :admin do
       end
     end
 
-    scenario "Processes", :js do
+    scenario "Processes" do
       5.times { create(:legislation_process) }
 
       visit admin_homepage_path
@@ -112,7 +112,7 @@ describe "Homepage", :admin do
     xscenario "Deactivate"
   end
 
-  scenario "Cards", :js do
+  scenario "Cards" do
     card1 = create(:widget_card, label: "Card1 label",
                                  title: "Card1 text",
                                  description: "Card1 description",

--- a/spec/system/admin/homepage/homepage_spec.rb
+++ b/spec/system/admin/homepage/homepage_spec.rb
@@ -112,7 +112,7 @@ describe "Homepage", :admin do
     xscenario "Deactivate"
   end
 
-  scenario "Cards" do
+  scenario "Cards", :js do
     card1 = create(:widget_card, label: "Card1 label",
                                  title: "Card1 text",
                                  description: "Card1 description",
@@ -130,8 +130,8 @@ describe "Homepage", :admin do
     expect(page).to have_css(".card", count: 2)
 
     within("#widget_card_#{card1.id}") do
-      expect(page).to have_content("Card1 label")
-      expect(page).to have_content("Card1 text")
+      expect(page).to have_content("CARD1 LABEL")
+      expect(page).to have_content("CARD1 TEXT")
       expect(page).to have_content("Card1 description")
       expect(page).to have_content("Link1 text")
       expect(page).to have_link(href: "consul1.dev")
@@ -139,8 +139,8 @@ describe "Homepage", :admin do
     end
 
     within("#widget_card_#{card2.id}") do
-      expect(page).to have_content("Card2 label")
-      expect(page).to have_content("Card2 text")
+      expect(page).to have_content("CARD2 LABEL")
+      expect(page).to have_content("CARD2 TEXT")
       expect(page).to have_content("Card2 description")
       expect(page).to have_content("Link2 text")
       expect(page).to have_link(href: "consul2.dev")

--- a/spec/system/admin/legislation/draft_versions_spec.rb
+++ b/spec/system/admin/legislation/draft_versions_spec.rb
@@ -18,7 +18,7 @@ describe "Admin legislation draft versions", :admin do
   end
 
   context "Create" do
-    scenario "Valid legislation draft version" do
+    scenario "Valid legislation draft version", :js do
       create(:legislation_process, title: "An example legislation process")
 
       visit admin_root_path
@@ -35,7 +35,7 @@ describe "Admin legislation draft versions", :admin do
 
       fill_in "Version title", with: "Version 3"
       fill_in "Changes", with: "Version 3 changes"
-      fill_in "Text", with: "Version 3 body"
+      fill_in_markdown_editor "Text", with: "Version 3 body"
 
       within("form .end") do
         click_button "Create version"

--- a/spec/system/admin/legislation/draft_versions_spec.rb
+++ b/spec/system/admin/legislation/draft_versions_spec.rb
@@ -18,7 +18,7 @@ describe "Admin legislation draft versions", :admin do
   end
 
   context "Create" do
-    scenario "Valid legislation draft version", :js do
+    scenario "Valid legislation draft version" do
       create(:legislation_process, title: "An example legislation process")
 
       visit admin_root_path
@@ -47,7 +47,7 @@ describe "Admin legislation draft versions", :admin do
   end
 
   context "Update" do
-    scenario "Valid legislation draft version", :js do
+    scenario "Valid legislation draft version" do
       process = create(:legislation_process, title: "An example legislation process")
       create(:legislation_draft_version, title: "Version 1", process: process)
 
@@ -75,7 +75,7 @@ describe "Admin legislation draft versions", :admin do
     end
   end
 
-  context "Changing content with the markdown editor", :js do
+  context "Changing content with the markdown editor" do
     let(:prompt) { "You've edited the text without saving it. Do you confirm to leave the page?" }
     let(:version) { create(:legislation_draft_version, body: "Version 1") }
     let(:path) do

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -66,6 +66,7 @@ describe "Admin collaborative legislation", :admin do
       base_date = Date.current
 
       within_fieldset text: "Draft phase" do
+        check "Enabled"
         fill_in "Start", with: base_date - 3.days
         fill_in "End", with: base_date - 1.day
       end
@@ -76,16 +77,21 @@ describe "Admin collaborative legislation", :admin do
       end
 
       within_fieldset "Debate phase" do
+        check "Enabled"
         fill_in "Start", with: base_date
         fill_in "End", with: base_date + 2.days
       end
 
       within_fieldset "Comments phase" do
+        check "Enabled"
         fill_in "Start", with: base_date + 3.days
         fill_in "End", with: base_date + 5.days
       end
 
+      check "legislation_process[draft_publication_enabled]"
       fill_in "Draft publication date", with: base_date + 3.days
+
+      check "legislation_process[result_publication_enabled]"
       fill_in "Final result publication date", with: base_date + 7.days
 
       click_button "Create process"
@@ -98,6 +104,11 @@ describe "Admin collaborative legislation", :admin do
       expect(page).to have_content "An example legislation process"
       expect(page).not_to have_content "Summary of the process"
       expect(page).to have_content "Describing the process"
+
+      within(".legislation-process-list") do
+        expect(page).to have_link text: "Debate"
+        expect(page).to have_link text: "Comments"
+      end
 
       visit legislation_processes_path
 

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -64,17 +64,29 @@ describe "Admin collaborative legislation", :admin do
       fill_in "Description", with: "Describing the process"
 
       base_date = Date.current
-      fill_in "legislation_process[start_date]", with: base_date
-      fill_in "legislation_process[end_date]", with: base_date + 5.days
 
-      fill_in "legislation_process[debate_start_date]", with: base_date
-      fill_in "legislation_process[debate_end_date]", with: base_date + 2.days
-      fill_in "legislation_process[draft_start_date]", with: base_date - 3.days
-      fill_in "legislation_process[draft_end_date]", with: base_date - 1.day
-      fill_in "legislation_process[draft_publication_date]", with: base_date + 3.days
-      fill_in "legislation_process[allegations_start_date]", with: base_date + 3.days
-      fill_in "legislation_process[allegations_end_date]", with: base_date + 5.days
-      fill_in "legislation_process[result_publication_date]", with: base_date + 7.days
+      within_fieldset text: "Draft phase" do
+        fill_in "Start", with: base_date - 3.days
+        fill_in "End", with: base_date - 1.day
+      end
+
+      within_fieldset "Process" do
+        fill_in "Start", with: base_date
+        fill_in "End", with: base_date + 5.days
+      end
+
+      within_fieldset "Debate phase" do
+        fill_in "Start", with: base_date
+        fill_in "End", with: base_date + 2.days
+      end
+
+      within_fieldset "Comments phase" do
+        fill_in "Start", with: base_date + 3.days
+        fill_in "End", with: base_date + 5.days
+      end
+
+      fill_in "Draft publication date", with: base_date + 3.days
+      fill_in "Final result publication date", with: base_date + 7.days
 
       click_button "Create process"
 
@@ -110,12 +122,17 @@ describe "Admin collaborative legislation", :admin do
       fill_in "Description", with: "Describing the process"
 
       base_date = Date.current - 2.days
-      fill_in "legislation_process[start_date]", with: base_date
-      fill_in "legislation_process[end_date]", with: base_date + 5.days
 
-      fill_in "legislation_process[draft_start_date]", with: base_date
-      fill_in "legislation_process[draft_end_date]", with: base_date + 3.days
-      check "legislation_process[draft_phase_enabled]"
+      within_fieldset text: "Draft phase" do
+        check "Enabled"
+        fill_in "Start", with: base_date
+        fill_in "End", with: base_date + 3.days
+      end
+
+      within_fieldset "Process" do
+        fill_in "Start", with: base_date
+        fill_in "End", with: base_date + 5.days
+      end
 
       click_button "Create process"
 
@@ -141,8 +158,12 @@ describe "Admin collaborative legislation", :admin do
       fill_in "Summary", with: "Summary of the process"
 
       base_date = Date.current
-      fill_in "legislation_process[start_date]", with: base_date
-      fill_in "legislation_process[end_date]", with: base_date + 5.days
+
+      within_fieldset "Process" do
+        fill_in "Start", with: base_date
+        fill_in "End", with: base_date + 5.days
+      end
+
       imageable_attach_new_file(create(:image), Rails.root.join("spec/fixtures/files/clippy.jpg"))
 
       click_button "Create process"

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -163,7 +163,7 @@ describe "Admin collaborative legislation", :admin do
       expect(page).not_to have_content "Describing the process"
     end
 
-    scenario "Create a legislation process with an image", :js do
+    scenario "Create a legislation process with an image" do
       visit new_admin_legislation_process_path
       fill_in "Process Title", with: "An example legislation process"
       fill_in "Summary", with: "Summary of the process"
@@ -251,7 +251,7 @@ describe "Admin collaborative legislation", :admin do
       expect(page).not_to have_content "Draft publication"
     end
 
-    scenario "Enabling/disabling a phase enables/disables its date fields", :js do
+    scenario "Enabling/disabling a phase enables/disables its date fields" do
       process.update!(published: false)
 
       visit edit_admin_legislation_process_path(process)
@@ -273,7 +273,7 @@ describe "Admin collaborative legislation", :admin do
       expect(page).to have_field "end_date", disabled: false, with: "2008-08-08"
     end
 
-    scenario "Enabling/disabling a phase does not enable/disable another phase date fields", :js do
+    scenario "Enabling/disabling a phase does not enable/disable another phase date fields" do
       process.update!(draft_phase_enabled: false, draft_publication_enabled: false)
 
       visit edit_admin_legislation_process_path(process)
@@ -309,7 +309,7 @@ describe "Admin collaborative legislation", :admin do
       expect(page).to have_field("Categories", with: "bicycles, pollution, recycling")
     end
 
-    scenario "Edit milestones summary", :js do
+    scenario "Edit milestones summary" do
       visit admin_legislation_process_milestones_path(process)
 
       expect(page).not_to have_link "Remove language"
@@ -353,7 +353,7 @@ describe "Admin collaborative legislation", :admin do
       Setting["sdg.process.legislation"] = true
     end
 
-    scenario "create Collaborative Legislation with sdg related list", :js do
+    scenario "create Collaborative Legislation with sdg related list" do
       visit new_admin_legislation_process_path
       fill_in "Process Title", with: "Legislation process with SDG related content"
       within_fieldset "Process" do
@@ -370,7 +370,7 @@ describe "Admin collaborative legislation", :admin do
       end
     end
 
-    scenario "edit Collaborative Legislation with sdg related list", :js do
+    scenario "edit Collaborative Legislation with sdg related list" do
       process = create(:legislation_process, title: "Legislation process with SDG related content")
       process.sdg_goals = [SDG::Goal[1], SDG::Goal[17]]
       visit edit_admin_legislation_process_path(process)

--- a/spec/system/admin/legislation/proposals_spec.rb
+++ b/spec/system/admin/legislation/proposals_spec.rb
@@ -15,7 +15,7 @@ describe "Admin collaborative legislation", :admin do
       end
     end
 
-    scenario "Selecting legislation proposals", :js do
+    scenario "Selecting legislation proposals" do
       proposal = create(:legislation_proposal, cached_votes_score: 10)
 
       visit admin_legislation_process_proposals_path(proposal.legislation_process_id)
@@ -26,7 +26,7 @@ describe "Admin collaborative legislation", :admin do
       end
     end
 
-    scenario "Sorting legislation proposals by title", js: true do
+    scenario "Sorting legislation proposals by title" do
       process = create(:legislation_process)
       create(:legislation_proposal, title: "bbbb", legislation_process_id: process.id)
       create(:legislation_proposal, title: "aaaa", legislation_process_id: process.id)
@@ -42,7 +42,7 @@ describe "Admin collaborative legislation", :admin do
       end
     end
 
-    scenario "Sorting legislation proposals by supports", js: true do
+    scenario "Sorting legislation proposals by supports" do
       process = create(:legislation_process)
       create(:legislation_proposal, cached_votes_score: 10, legislation_process_id: process.id)
       create(:legislation_proposal, cached_votes_score: 30, legislation_process_id: process.id)
@@ -58,7 +58,7 @@ describe "Admin collaborative legislation", :admin do
       end
     end
 
-    scenario "Sorting legislation proposals by Id", js: true do
+    scenario "Sorting legislation proposals by Id" do
       process = create(:legislation_process)
       proposal1 = create(:legislation_proposal, title: "bbbb", legislation_process_id: process.id)
       proposal2 = create(:legislation_proposal, title: "aaaa", legislation_process_id: process.id)

--- a/spec/system/admin/legislation/questions_spec.rb
+++ b/spec/system/admin/legislation/questions_spec.rb
@@ -41,7 +41,7 @@ describe "Admin legislation questions", :admin do
   end
 
   context "Update" do
-    scenario "Valid legislation question", :js do
+    scenario "Valid legislation question" do
       create(:legislation_question, title: "Question 2", process: process)
 
       visit admin_root_path
@@ -66,7 +66,7 @@ describe "Admin legislation questions", :admin do
   end
 
   context "Delete" do
-    scenario "Legislation question", :js do
+    scenario "Legislation question" do
       create(:legislation_question, title: "Question 1", process: process)
       question = create(:legislation_question, title: "Question 2", process: process)
       question_option = create(:legislation_question_option, question: question, value: "Yes")
@@ -100,7 +100,7 @@ describe "Admin legislation questions", :admin do
       end
     end
 
-    scenario "Edit an existing option", :js do
+    scenario "Edit an existing option" do
       create(:legislation_question_option, question: question, value: "Original")
 
       visit edit_question_url
@@ -113,7 +113,7 @@ describe "Admin legislation questions", :admin do
       expect(page).to have_field(field_en[:id], with: "Changed")
     end
 
-    scenario "Remove an option", :js do
+    scenario "Remove an option" do
       create(:legislation_question_option, question: question, value: "Yes")
       create(:legislation_question_option, question: question, value: "No")
 
@@ -139,7 +139,7 @@ describe "Admin legislation questions", :admin do
         question.update!(title_en: "Title in English", title_es: "Título en Español")
       end
 
-      scenario "Add translation for question option", :js do
+      scenario "Add translation for question option" do
         visit edit_question_url
 
         click_on "Add option"
@@ -160,7 +160,7 @@ describe "Admin legislation questions", :admin do
         expect(page).to have_field(field_es[:id], with: "Opción 1")
       end
 
-      scenario "Add new question option after changing active locale", :js do
+      scenario "Add new question option after changing active locale" do
         visit edit_question_url
 
         select "Español", from: :select_language

--- a/spec/system/admin/local_census_records_spec.rb
+++ b/spec/system/admin/local_census_records_spec.rb
@@ -134,11 +134,12 @@ describe "Admin local census records", :admin do
     let!(:local_census_record) { create(:local_census_record) }
     let!(:deleted_document_number) { local_census_record.document_number }
 
-    scenario "Should show successful destroy notice" do
+    scenario "Should show successful destroy notice", :js do
       visit admin_local_census_records_path
 
       expect(page).to have_content deleted_document_number
-      click_on "Delete"
+
+      accept_confirm { click_on "Delete" }
 
       expect(page).to have_content "Local census record removed successfully!"
       expect(page).not_to have_content deleted_document_number

--- a/spec/system/admin/local_census_records_spec.rb
+++ b/spec/system/admin/local_census_records_spec.rb
@@ -57,7 +57,7 @@ describe "Admin local census records", :admin do
         expect(page).not_to have_content local_census_record.document_number
       end
 
-      scenario "Should show matching records by document number", :js do
+      scenario "Should show matching records by document number" do
         visit admin_local_census_records_path
 
         fill_in :search, with: "X66777888"
@@ -134,7 +134,7 @@ describe "Admin local census records", :admin do
     let!(:local_census_record) { create(:local_census_record) }
     let!(:deleted_document_number) { local_census_record.document_number }
 
-    scenario "Should show successful destroy notice", :js do
+    scenario "Should show successful destroy notice" do
       visit admin_local_census_records_path
 
       expect(page).to have_content deleted_document_number

--- a/spec/system/admin/managers_spec.rb
+++ b/spec/system/admin/managers_spec.rb
@@ -25,8 +25,8 @@ describe "Admin managers", :admin do
     end
   end
 
-  scenario "Delete Manager" do
-    click_link "Delete"
+  scenario "Delete Manager", :js do
+    accept_confirm { click_link "Delete" }
 
     within("#managers") do
       expect(page).not_to have_content manager.name
@@ -82,11 +82,11 @@ describe "Admin managers", :admin do
       expect(page).not_to have_content(manager1.email)
     end
 
-    scenario "Delete after searching" do
+    scenario "Delete after searching", :js do
       fill_in "Search user by name or email", with: manager2.email
       click_button "Search"
 
-      click_link "Delete"
+      accept_confirm { click_link "Delete" }
 
       expect(page).to have_content(manager1.email)
       expect(page).not_to have_content(manager2.email)

--- a/spec/system/admin/managers_spec.rb
+++ b/spec/system/admin/managers_spec.rb
@@ -14,7 +14,7 @@ describe "Admin managers", :admin do
     expect(page).not_to have_content user.name
   end
 
-  scenario "Create Manager", :js do
+  scenario "Create Manager" do
     fill_in "search", with: user.email
     click_button "Search"
 
@@ -25,7 +25,7 @@ describe "Admin managers", :admin do
     end
   end
 
-  scenario "Delete Manager", :js do
+  scenario "Delete Manager" do
     accept_confirm { click_link "Delete" }
 
     within("#managers") do
@@ -82,7 +82,7 @@ describe "Admin managers", :admin do
       expect(page).not_to have_content(manager1.email)
     end
 
-    scenario "Delete after searching", :js do
+    scenario "Delete after searching" do
       fill_in "Search user by name or email", with: manager2.email
       click_button "Search"
 

--- a/spec/system/admin/milestone_statuses_spec.rb
+++ b/spec/system/admin/milestone_statuses_spec.rb
@@ -72,13 +72,13 @@ describe "Admin milestone statuses", :admin do
   end
 
   context "Delete" do
-    scenario "Hides status" do
+    scenario "Hides status", :js do
       status = create(:milestone_status)
 
       visit admin_milestone_statuses_path
 
       within("#milestone_status_#{status.id}") do
-        click_link "Delete"
+        accept_confirm { click_link "Delete" }
       end
 
       expect(page).not_to have_content status.name

--- a/spec/system/admin/milestone_statuses_spec.rb
+++ b/spec/system/admin/milestone_statuses_spec.rb
@@ -72,7 +72,7 @@ describe "Admin milestone statuses", :admin do
   end
 
   context "Delete" do
-    scenario "Hides status", :js do
+    scenario "Hides status" do
       status = create(:milestone_status)
 
       visit admin_milestone_statuses_path

--- a/spec/system/admin/moderators_spec.rb
+++ b/spec/system/admin/moderators_spec.rb
@@ -25,8 +25,8 @@ describe "Admin moderators", :admin do
     end
   end
 
-  scenario "Delete Moderator" do
-    click_link "Delete"
+  scenario "Delete Moderator", :js do
+    accept_confirm { click_link "Delete" }
 
     within("#moderators") do
       expect(page).not_to have_content moderator.name
@@ -82,11 +82,11 @@ describe "Admin moderators", :admin do
       expect(page).not_to have_content(moderator1.email)
     end
 
-    scenario "Delete after searching" do
+    scenario "Delete after searching", :js do
       fill_in "Search user by name or email", with: moderator2.email
       click_button "Search"
 
-      click_link "Delete"
+      accept_confirm { click_link "Delete" }
 
       expect(page).to have_content(moderator1.email)
       expect(page).not_to have_content(moderator2.email)

--- a/spec/system/admin/moderators_spec.rb
+++ b/spec/system/admin/moderators_spec.rb
@@ -14,7 +14,7 @@ describe "Admin moderators", :admin do
     expect(page).not_to have_content user.name
   end
 
-  scenario "Create Moderator", :js do
+  scenario "Create Moderator" do
     fill_in "search", with: user.email
     click_button "Search"
 
@@ -25,7 +25,7 @@ describe "Admin moderators", :admin do
     end
   end
 
-  scenario "Delete Moderator", :js do
+  scenario "Delete Moderator" do
     accept_confirm { click_link "Delete" }
 
     within("#moderators") do
@@ -82,7 +82,7 @@ describe "Admin moderators", :admin do
       expect(page).not_to have_content(moderator1.email)
     end
 
-    scenario "Delete after searching", :js do
+    scenario "Delete after searching" do
       fill_in "Search user by name or email", with: moderator2.email
       click_button "Search"
 

--- a/spec/system/admin/organizations_spec.rb
+++ b/spec/system/admin/organizations_spec.rb
@@ -210,7 +210,7 @@ describe "Admin::Organizations" do
 
     click_on("Verify", match: :first)
 
-    expect(current_url).to include("filter=pending")
-    expect(current_url).to include("page=2")
+    expect(page).to have_current_path(/filter=pending/)
+    expect(page).to have_current_path(/page=2/)
   end
 end

--- a/spec/system/admin/poll/active_polls_spec.rb
+++ b/spec/system/admin/poll/active_polls_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Admin Active polls", :admin do
-  scenario "Add", :js do
+  scenario "Add" do
     expect(ActivePoll.first).to be nil
 
     visit admin_polls_path
@@ -14,7 +14,7 @@ describe "Admin Active polls", :admin do
     expect(ActivePoll.first.description).to eq "<p>Active polls description</p>\r\n"
   end
 
-  scenario "Edit", :js do
+  scenario "Edit" do
     create(:active_poll, description_en: "Old description")
 
     visit polls_path

--- a/spec/system/admin/poll/booth_assigments_spec.rb
+++ b/spec/system/admin/poll/booth_assigments_spec.rb
@@ -207,7 +207,7 @@ describe "Admin booths assignments", :admin do
       end
     end
 
-    scenario "Doesn't show system recounts for old polls" do
+    scenario "Doesn't show system recounts for old polls", :js do
       poll = create(:poll, :old)
       booth_assignment = create(:poll_booth_assignment, poll: poll)
 
@@ -215,6 +215,8 @@ describe "Admin booths assignments", :admin do
       create(:poll_recount, booth_assignment: booth_assignment, total_amount: 10)
 
       visit admin_poll_booth_assignment_path(poll, booth_assignment)
+
+      click_link "Recounts"
 
       within("#totals") do
         within("#total_final") do

--- a/spec/system/admin/poll/booth_assigments_spec.rb
+++ b/spec/system/admin/poll/booth_assigments_spec.rb
@@ -5,7 +5,7 @@ describe "Admin booths assignments", :admin do
     let!(:poll) { create(:poll) }
     let!(:booth) { create(:poll_booth) }
 
-    scenario "List Polls and Booths to manage", :js do
+    scenario "List Polls and Booths to manage" do
       second_poll = create(:poll)
       second_booth = create(:poll_booth)
 
@@ -24,7 +24,7 @@ describe "Admin booths assignments", :admin do
       expect(page).to have_content(second_booth.name)
     end
 
-    scenario "Does not hide the Polls menu", :js do
+    scenario "Does not hide the Polls menu" do
       visit booth_assignments_admin_polls_path
 
       within("#admin_menu") { expect(page).to have_link "Polls" }
@@ -40,7 +40,7 @@ describe "Admin booths assignments", :admin do
       expect(page).not_to have_content "Poll from user's proposal"
     end
 
-    scenario "Assign booth to poll", :js do
+    scenario "Assign booth to poll" do
       visit admin_poll_path(poll)
       within("#poll-resources") do
         click_link "Booths (0)"
@@ -77,7 +77,7 @@ describe "Admin booths assignments", :admin do
       expect(page).to have_content booth.name
     end
 
-    scenario "Unassign booth from poll", :js do
+    scenario "Unassign booth from poll" do
       create(:poll_booth_assignment, poll: poll, booth: booth)
 
       visit admin_poll_path(poll)
@@ -116,7 +116,7 @@ describe "Admin booths assignments", :admin do
       expect(page).not_to have_content booth.name
     end
 
-    scenario "Unassing booth whith associated shifts", :js do
+    scenario "Unassing booth whith associated shifts" do
       officer = create(:poll_officer)
       create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
       create(:poll_shift, booth: booth, officer: officer)
@@ -207,7 +207,7 @@ describe "Admin booths assignments", :admin do
       end
     end
 
-    scenario "Doesn't show system recounts for old polls", :js do
+    scenario "Doesn't show system recounts for old polls" do
       poll = create(:poll, :old)
       booth_assignment = create(:poll_booth_assignment, poll: poll)
 

--- a/spec/system/admin/poll/booths_spec.rb
+++ b/spec/system/admin/poll/booths_spec.rb
@@ -1,22 +1,24 @@
 require "rails_helper"
 
 describe "Admin booths", :admin do
-  scenario "Index empty" do
+  scenario "Index empty", :js do
     visit admin_root_path
 
     within("#side_menu") do
+      click_link "Voting booths"
       click_link "Booths location"
     end
 
     expect(page).to have_content "There are no active booths for any upcoming poll."
   end
 
-  scenario "Index" do
+  scenario "Index", :js do
     3.times { create(:poll_booth) }
 
     visit admin_root_path
 
     within("#side_menu") do
+      click_link "Voting booths"
       click_link "Booths location"
     end
 
@@ -30,13 +32,14 @@ describe "Admin booths", :admin do
     expect(page).not_to have_content "There are no booths"
   end
 
-  scenario "Available" do
+  scenario "Available", :js do
     booth_for_current_poll = create(:poll_booth, polls: [create(:poll, :current)])
     booth_for_expired_poll = create(:poll_booth, polls: [create(:poll, :expired)])
 
     visit admin_root_path
 
     within("#side_menu") do
+      click_link "Voting booths"
       click_link "Manage shifts"
     end
 

--- a/spec/system/admin/poll/booths_spec.rb
+++ b/spec/system/admin/poll/booths_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Admin booths", :admin do
-  scenario "Index empty", :js do
+  scenario "Index empty" do
     visit admin_root_path
 
     within("#side_menu") do
@@ -12,7 +12,7 @@ describe "Admin booths", :admin do
     expect(page).to have_content "There are no active booths for any upcoming poll."
   end
 
-  scenario "Index", :js do
+  scenario "Index" do
     3.times { create(:poll_booth) }
 
     visit admin_root_path
@@ -32,7 +32,7 @@ describe "Admin booths", :admin do
     expect(page).not_to have_content "There are no booths"
   end
 
-  scenario "Available", :js do
+  scenario "Available" do
     booth_for_current_poll = create(:poll_booth, polls: [create(:poll, :current)])
     booth_for_expired_poll = create(:poll_booth, polls: [create(:poll, :expired)])
 

--- a/spec/system/admin/poll/officer_assignments_spec.rb
+++ b/spec/system/admin/poll/officer_assignments_spec.rb
@@ -19,7 +19,7 @@ describe "Officer Assignments", :admin do
     end
   end
 
-  scenario "Search", :js do
+  scenario "Search" do
     poll = create(:poll)
 
     create(:poll_officer, name: "John Snow", polls: [poll])

--- a/spec/system/admin/poll/officers_spec.rb
+++ b/spec/system/admin/poll/officers_spec.rb
@@ -25,8 +25,8 @@ describe "Admin poll officers", :admin do
     end
   end
 
-  scenario "Delete" do
-    click_link "Delete position"
+  scenario "Delete", :js do
+    accept_confirm { click_link "Delete position" }
 
     expect(page).not_to have_css "#officers"
   end

--- a/spec/system/admin/poll/officers_spec.rb
+++ b/spec/system/admin/poll/officers_spec.rb
@@ -14,7 +14,7 @@ describe "Admin poll officers", :admin do
     expect(page).not_to have_content user.name
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     fill_in "search", with: user.email
     click_button "Search"
 
@@ -25,7 +25,7 @@ describe "Admin poll officers", :admin do
     end
   end
 
-  scenario "Delete", :js do
+  scenario "Delete" do
     accept_confirm { click_link "Delete position" }
 
     expect(page).not_to have_css "#officers"

--- a/spec/system/admin/poll/polls_spec.rb
+++ b/spec/system/admin/poll/polls_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Admin polls", :admin do
-  scenario "Index empty", :js do
+  scenario "Index empty" do
     visit admin_root_path
 
     click_link "Polls"
@@ -9,7 +9,7 @@ describe "Admin polls", :admin do
     expect(page).to have_content "There are no polls"
   end
 
-  scenario "Index show polls list order by starts at date", :js do
+  scenario "Index show polls list order by starts at date" do
     poll_1 = create(:poll, name: "Poll first",  starts_at: 15.days.ago)
     poll_2 = create(:poll, name: "Poll second", starts_at: 1.month.ago)
     poll_3 = create(:poll, name: "Poll third",  starts_at: 2.days.ago)
@@ -110,7 +110,7 @@ describe "Admin polls", :admin do
   end
 
   context "Destroy" do
-    scenario "Can destroy poll without questions", :js do
+    scenario "Can destroy poll without questions" do
       poll = create(:poll)
 
       visit admin_polls_path
@@ -123,7 +123,7 @@ describe "Admin polls", :admin do
       expect(page).to have_content("There are no polls.")
     end
 
-    scenario "Can destroy poll with questions and answers", :js do
+    scenario "Can destroy poll with questions and answers" do
       poll = create(:poll, name: "Do you support CONSUL?")
       create(:poll_question, :yes_no, poll: poll)
 
@@ -140,7 +140,7 @@ describe "Admin polls", :admin do
       expect(Poll::Question::Answer.count).to eq(0)
     end
 
-    scenario "Can destroy polls with answers including videos", :js do
+    scenario "Can destroy polls with answers including videos" do
       poll = create(:poll, name: "Do you support CONSUL?")
       create(:poll_answer_video, poll: poll)
 
@@ -153,7 +153,7 @@ describe "Admin polls", :admin do
       expect(page).to have_content "Poll deleted successfully"
     end
 
-    scenario "Can't destroy poll with votes", :js do
+    scenario "Can't destroy poll with votes" do
       poll = create(:poll)
       create(:poll_question, poll: poll)
       create(:poll_voter, :from_booth, :valid_document, poll: poll)
@@ -201,7 +201,7 @@ describe "Admin polls", :admin do
 
   context "Officers" do
     context "Poll show" do
-      scenario "No officers", :js do
+      scenario "No officers" do
         poll = create(:poll)
         visit admin_poll_path(poll)
         click_link "Officers (0)"
@@ -209,7 +209,7 @@ describe "Admin polls", :admin do
         expect(page).to have_content "There are no officers assigned to this poll"
       end
 
-      scenario "Officer list", :js do
+      scenario "Officer list" do
         poll = create(:poll)
         booth = create(:poll_booth, polls: [poll])
 
@@ -237,7 +237,7 @@ describe "Admin polls", :admin do
 
   context "Questions" do
     context "Poll show" do
-      scenario "Question list", :js do
+      scenario "Question list" do
         poll = create(:poll)
         question = create(:poll_question, poll: poll)
         other_question = create(:poll_question)
@@ -254,7 +254,7 @@ describe "Admin polls", :admin do
 
   context "Recounting" do
     context "Poll show" do
-      scenario "No recounts", :js do
+      scenario "No recounts" do
         poll = create(:poll)
         visit admin_poll_path(poll)
         click_link "Recounting"
@@ -262,7 +262,7 @@ describe "Admin polls", :admin do
         expect(page).to have_content "There is nothing to be recounted"
       end
 
-      scenario "Recounts list", :js do
+      scenario "Recounts list" do
         poll = create(:poll)
         booth_assignment = create(:poll_booth_assignment, poll: poll)
         booth_assignment_recounted = create(:poll_booth_assignment, poll: poll)
@@ -342,7 +342,7 @@ describe "Admin polls", :admin do
 
   context "Results" do
     context "Poll show" do
-      scenario "No results", :js do
+      scenario "No results" do
         poll = create(:poll)
         visit admin_poll_path(poll)
         click_link "Results"
@@ -425,7 +425,7 @@ describe "Admin polls", :admin do
         expect(page).not_to have_content "Results by booth"
       end
 
-      scenario "Results by answer", :js do
+      scenario "Results by answer" do
         poll = create(:poll)
         booth_assignment_1 = create(:poll_booth_assignment, poll: poll)
         booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
@@ -523,7 +523,7 @@ describe "Admin polls", :admin do
       Setting["sdg.process.polls"] = true
     end
 
-    scenario "create poll with sdg related list", :js do
+    scenario "create poll with sdg related list" do
       visit new_admin_poll_path
       fill_in "Name", with: "Upcoming poll with SDG related content"
       fill_in "Start Date", with: 1.week.from_now
@@ -540,7 +540,7 @@ describe "Admin polls", :admin do
       end
     end
 
-    scenario "edit poll with sdg related list", :js do
+    scenario "edit poll with sdg related list" do
       poll = create(:poll, name: "Upcoming poll with SDG related content")
       poll.sdg_goals = [SDG::Goal[1], SDG::Goal[17]]
       visit edit_admin_poll_path(poll)

--- a/spec/system/admin/poll/questions/answers/answers_spec.rb
+++ b/spec/system/admin/poll/questions/answers/answers_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 describe "Answers", :admin do
-  scenario "Create" do
+  scenario "Create", :js do
     question = create(:poll_question)
 
     visit admin_question_path(question)
     click_link "Add answer"
 
     fill_in "Answer", with: "The answer is always 42"
-    fill_in "Description", with: "The Hitchhiker's Guide To The Universe"
+    fill_in_ckeditor "Description", with: "The Hitchhiker's Guide To The Universe"
 
     click_button "Save"
 
@@ -16,7 +16,7 @@ describe "Answers", :admin do
     expect(page).to have_content "The Hitchhiker's Guide To The Universe"
   end
 
-  scenario "Create second answer and place after the first one" do
+  scenario "Create second answer and place after the first one", :js do
     question = create(:poll_question)
     create(:poll_question_answer, title: "First", question: question, given_order: 1)
 
@@ -24,7 +24,7 @@ describe "Answers", :admin do
     click_link "Add answer"
 
     fill_in "Answer", with: "Second"
-    fill_in "Description", with: "Description"
+    fill_in_ckeditor "Description", with: "Description"
 
     click_button "Save"
 

--- a/spec/system/admin/poll/questions/answers/answers_spec.rb
+++ b/spec/system/admin/poll/questions/answers/answers_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Answers", :admin do
-  scenario "Create", :js do
+  scenario "Create" do
     question = create(:poll_question)
 
     visit admin_question_path(question)
@@ -16,7 +16,7 @@ describe "Answers", :admin do
     expect(page).to have_content "The Hitchhiker's Guide To The Universe"
   end
 
-  scenario "Create second answer and place after the first one", :js do
+  scenario "Create second answer and place after the first one" do
     question = create(:poll_question)
     create(:poll_question_answer, title: "First", question: question, given_order: 1)
 
@@ -54,7 +54,7 @@ describe "Answers", :admin do
     expect("Another title").to appear_before("New title")
   end
 
-  scenario "Reorder", :js do
+  scenario "Reorder" do
     question = create(:poll_question)
     create(:poll_question_answer, question: question, title: "First", given_order: 1)
     create(:poll_question_answer, question: question, title: "Last", given_order: 2)

--- a/spec/system/admin/poll/questions/answers/documents/documents_spec.rb
+++ b/spec/system/admin/poll/questions/answers/documents/documents_spec.rb
@@ -21,7 +21,7 @@ describe "Documents", :admin do
     end
   end
 
-  scenario "Remove document from answer", :js do
+  scenario "Remove document from answer" do
     answer = create(:poll_question_answer)
     document = create(:document, documentable: answer)
 

--- a/spec/system/admin/poll/questions/answers/images/images_spec.rb
+++ b/spec/system/admin/poll/questions/answers/images/images_spec.rb
@@ -30,7 +30,7 @@ describe "Images", :admin do
     end
   end
 
-  scenario "Add image to answer", :js do
+  scenario "Add image to answer" do
     answer = create(:poll_question_answer)
     image = create(:image)
 
@@ -46,7 +46,7 @@ describe "Images", :admin do
     expect(page).to have_content("clippy.jpg")
   end
 
-  scenario "Remove image from answer", :js do
+  scenario "Remove image from answer" do
     answer = create(:poll_question_answer)
     image = create(:image, imageable: answer)
 

--- a/spec/system/admin/poll/questions_spec.rb
+++ b/spec/system/admin/poll/questions_spec.rb
@@ -15,30 +15,30 @@ describe "Admin poll questions", :admin do
 
     within("#poll_question_#{question1.id}") do
       expect(page).to have_content(question1.title)
-      expect(page).to have_content("Edit answers")
-      expect(page).to have_content("Edit")
-      expect(page).to have_content("Delete")
+      expect(page).to have_link "Edit answers"
+      expect(page).to have_link "Edit"
+      expect(page).to have_link "Delete"
     end
 
     visit admin_poll_path(poll2)
     expect(page).to have_content(poll2.name)
 
     within("#poll_question_#{question2.id}") do
-      expect(page).to have_content(question2.title)
-      expect(page).to have_content("Edit answers")
-      expect(page).to have_content("Edit")
-      expect(page).to have_content("Delete")
+      expect(page).to have_content question2.title
+      expect(page).to have_link "Edit answers"
+      expect(page).to have_link "Edit"
+      expect(page).to have_link "Delete"
     end
 
     visit admin_poll_path(poll3)
     expect(page).to have_content(poll3.name)
 
     within("#poll_question_#{question3.id}") do
-      expect(page).to have_content(question3.title)
-      expect(page).to have_link("(See proposal)", href: proposal_path(question3.proposal))
-      expect(page).to have_content("Edit answers")
-      expect(page).to have_content("Edit")
-      expect(page).to have_content("Delete")
+      expect(page).to have_content question3.title
+      expect(page).to have_link "(See proposal)", href: proposal_path(question3.proposal)
+      expect(page).to have_link "Edit answers"
+      expect(page).to have_link "Edit"
+      expect(page).to have_link "Delete"
     end
   end
 

--- a/spec/system/admin/poll/questions_spec.rb
+++ b/spec/system/admin/poll/questions_spec.rb
@@ -134,7 +134,7 @@ describe "Admin poll questions", :admin do
     expect(page).not_to have_content(old_title)
   end
 
-  scenario "Destroy" do
+  scenario "Destroy", :js do
     poll = create(:poll)
     question1 = create(:poll_question, poll: poll)
     question2 = create(:poll_question, poll: poll)
@@ -142,7 +142,7 @@ describe "Admin poll questions", :admin do
     visit admin_poll_path(poll)
 
     within("#poll_question_#{question1.id}") do
-      click_link "Delete"
+      accept_confirm { click_link "Delete" }
     end
 
     expect(page).not_to have_content(question1.title)

--- a/spec/system/admin/poll/questions_spec.rb
+++ b/spec/system/admin/poll/questions_spec.rb
@@ -134,7 +134,7 @@ describe "Admin poll questions", :admin do
     expect(page).not_to have_content(old_title)
   end
 
-  scenario "Destroy", :js do
+  scenario "Destroy" do
     poll = create(:poll)
     question1 = create(:poll_question, poll: poll)
     question2 = create(:poll_question, poll: poll)
@@ -152,7 +152,7 @@ describe "Admin poll questions", :admin do
   pending "Mark all city by default when creating a poll question from a successful proposal"
 
   context "Poll select box" do
-    scenario "translates the poll name in options", :js do
+    scenario "translates the poll name in options" do
       poll = create(:poll, name_en: "Name in English", name_es: "Nombre en Español")
       proposal = create(:proposal)
 
@@ -167,7 +167,7 @@ describe "Admin poll questions", :admin do
                                   options: ["Seleccionar votación", poll.name_es])
     end
 
-    scenario "uses fallback if name is not translated to current locale", :js do
+    scenario "uses fallback if name is not translated to current locale" do
       unless globalize_french_fallbacks.first == :es
         skip("Spec only useful when French falls back to Spanish")
       end

--- a/spec/system/admin/poll/shifts_spec.rb
+++ b/spec/system/admin/poll/shifts_spec.rb
@@ -159,7 +159,7 @@ describe "Admin shifts", :admin do
     expect(page).to have_content "A date must be selected"
   end
 
-  scenario "Destroy" do
+  scenario "Destroy", :js do
     poll = create(:poll, :current)
     booth = create(:poll_booth, polls: [poll])
     officer = create(:poll_officer)
@@ -174,14 +174,14 @@ describe "Admin shifts", :admin do
 
     expect(page).to have_css(".shift", count: 1)
     within("#shift_#{shift.id}") do
-      click_link "Remove"
+      accept_confirm { click_link "Remove" }
     end
 
     expect(page).to have_content "Shift removed"
     expect(page).to have_css(".shift", count: 0)
   end
 
-  scenario "Try to destroy with associated recount" do
+  scenario "Try to destroy with associated recount", :js do
     assignment = create(:poll_booth_assignment)
     officer_assignment = create(:poll_officer_assignment, booth_assignment: assignment)
     create(:poll_recount, booth_assignment: assignment, officer_assignment: officer_assignment)
@@ -198,7 +198,7 @@ describe "Admin shifts", :admin do
 
     expect(page).to have_css(".shift", count: 1)
     within("#shift_#{shift.id}") do
-      click_link "Remove"
+      accept_confirm { click_link "Remove" }
     end
 
     expect(page).not_to have_content "Shift removed"
@@ -206,7 +206,7 @@ describe "Admin shifts", :admin do
     expect(page).to have_css(".shift", count: 1)
   end
 
-  scenario "try to destroy with associated partial results" do
+  scenario "try to destroy with associated partial results", :js do
     assignment = create(:poll_booth_assignment)
     officer_assignment = create(:poll_officer_assignment, booth_assignment: assignment)
     create(:poll_partial_result,
@@ -225,7 +225,7 @@ describe "Admin shifts", :admin do
 
     expect(page).to have_css(".shift", count: 1)
     within("#shift_#{shift.id}") do
-      click_link "Remove"
+      accept_confirm { click_link "Remove" }
     end
 
     expect(page).not_to have_content "Shift removed"

--- a/spec/system/admin/poll/shifts_spec.rb
+++ b/spec/system/admin/poll/shifts_spec.rb
@@ -25,7 +25,7 @@ describe "Admin shifts", :admin do
     expect(page).to have_content officer.email
   end
 
-  scenario "Create Vote Collection Shift and Recount & Scrutiny Shift on same date", :js do
+  scenario "Create Vote Collection Shift and Recount & Scrutiny Shift on same date" do
     create(:poll)
     poll = create(:poll, :current)
     booth = create(:poll_booth, polls: [poll, create(:poll, :expired)])
@@ -88,7 +88,7 @@ describe "Admin shifts", :admin do
     end
   end
 
-  scenario "Vote Collection Shift and Recount & Scrutiny Shift don't include already assigned dates to officer", :js do
+  scenario "Vote Collection Shift and Recount & Scrutiny Shift don't include already assigned dates to officer" do
     poll = create(:poll, :current)
     booth = create(:poll_booth, polls: [poll])
     officer = create(:poll_officer)
@@ -120,7 +120,7 @@ describe "Admin shifts", :admin do
     expect(page).to have_select("shift_date_recount_scrutiny_date", options: ["Select day", *recount_scrutiny_dates])
   end
 
-  scenario "Change option from Recount & Scrutinity to Collect Votes", :js do
+  scenario "Change option from Recount & Scrutinity to Collect Votes" do
     booth = create(:poll_booth)
     officer = create(:poll_officer)
 
@@ -138,7 +138,7 @@ describe "Admin shifts", :admin do
     expect(page).to have_select("shift_date_vote_collection_date", options: ["Voting days ended"])
   end
 
-  scenario "Error on create", :js do
+  scenario "Error on create" do
     poll = create(:poll, :current)
     booth = create(:poll_booth, polls: [poll])
     officer = create(:poll_officer)
@@ -159,7 +159,7 @@ describe "Admin shifts", :admin do
     expect(page).to have_content "A date must be selected"
   end
 
-  scenario "Destroy", :js do
+  scenario "Destroy" do
     poll = create(:poll, :current)
     booth = create(:poll_booth, polls: [poll])
     officer = create(:poll_officer)
@@ -181,7 +181,7 @@ describe "Admin shifts", :admin do
     expect(page).to have_css(".shift", count: 0)
   end
 
-  scenario "Try to destroy with associated recount", :js do
+  scenario "Try to destroy with associated recount" do
     assignment = create(:poll_booth_assignment)
     officer_assignment = create(:poll_officer_assignment, booth_assignment: assignment)
     create(:poll_recount, booth_assignment: assignment, officer_assignment: officer_assignment)
@@ -206,7 +206,7 @@ describe "Admin shifts", :admin do
     expect(page).to have_css(".shift", count: 1)
   end
 
-  scenario "try to destroy with associated partial results", :js do
+  scenario "try to destroy with associated partial results" do
     assignment = create(:poll_booth_assignment)
     officer_assignment = create(:poll_officer_assignment, booth_assignment: assignment)
     create(:poll_partial_result,

--- a/spec/system/admin/proposal_notifications_spec.rb
+++ b/spec/system/admin/proposal_notifications_spec.rb
@@ -9,11 +9,11 @@ describe "Admin proposal notifications", :admin do
     expect(page).to have_content(proposal_notification.body)
   end
 
-  scenario "Restore" do
+  scenario "Restore", :js do
     proposal_notification = create(:proposal_notification, :hidden, created_at: Date.current - 5.days)
     visit admin_hidden_proposal_notifications_path
 
-    click_link "Restore"
+    accept_confirm { click_link "Restore" }
 
     expect(page).not_to have_content(proposal_notification.title)
 
@@ -74,13 +74,13 @@ describe "Admin proposal notifications", :admin do
     expect(page).to have_content("Confirmed notification")
   end
 
-  scenario "Action links remember the pagination setting and the filter" do
+  scenario "Action links remember the pagination setting and the filter", :js do
     allow(ProposalNotification).to receive(:default_per_page).and_return(2)
     4.times { create(:proposal_notification, :hidden, :with_confirmed_hide) }
 
     visit admin_hidden_proposal_notifications_path(filter: "with_confirmed_hide", page: 2)
 
-    click_on("Restore", match: :first, exact: true)
+    accept_confirm { click_link "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/proposal_notifications_spec.rb
+++ b/spec/system/admin/proposal_notifications_spec.rb
@@ -82,7 +82,7 @@ describe "Admin proposal notifications", :admin do
 
     click_on("Restore", match: :first, exact: true)
 
-    expect(current_url).to include("filter=with_confirmed_hide")
-    expect(current_url).to include("page=2")
+    expect(page).to have_current_path(/filter=with_confirmed_hide/)
+    expect(page).to have_current_path(/page=2/)
   end
 end

--- a/spec/system/admin/proposal_notifications_spec.rb
+++ b/spec/system/admin/proposal_notifications_spec.rb
@@ -9,7 +9,7 @@ describe "Admin proposal notifications", :admin do
     expect(page).to have_content(proposal_notification.body)
   end
 
-  scenario "Restore", :js do
+  scenario "Restore" do
     proposal_notification = create(:proposal_notification, :hidden, created_at: Date.current - 5.days)
     visit admin_hidden_proposal_notifications_path
 
@@ -74,7 +74,7 @@ describe "Admin proposal notifications", :admin do
     expect(page).to have_content("Confirmed notification")
   end
 
-  scenario "Action links remember the pagination setting and the filter", :js do
+  scenario "Action links remember the pagination setting and the filter" do
     allow(ProposalNotification).to receive(:default_per_page).and_return(2)
     4.times { create(:proposal_notification, :hidden, :with_confirmed_hide) }
 

--- a/spec/system/admin/proposals_spec.rb
+++ b/spec/system/admin/proposals_spec.rb
@@ -23,7 +23,7 @@ describe "Admin proposals", :admin do
       expect(page).not_to have_content "Build a monument"
     end
 
-    scenario "Select a proposal", :js do
+    scenario "Select a proposal" do
       proposal = create(:proposal)
 
       visit admin_proposals_path
@@ -34,7 +34,7 @@ describe "Admin proposals", :admin do
       expect(proposal.reload.selected?).to be true
     end
 
-    scenario "Unselect a proposal", :js do
+    scenario "Unselect a proposal" do
       proposal = create(:proposal, :selected)
 
       visit admin_proposals_path

--- a/spec/system/admin/sdg/managers_spec.rb
+++ b/spec/system/admin/sdg/managers_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Admin SDG managers", :js do
+describe "Admin SDG managers" do
   let!(:user) { create(:user) }
   let!(:sdg_manager) { create(:sdg_manager) }
 

--- a/spec/system/admin/settings_spec.rb
+++ b/spec/system/admin/settings_spec.rb
@@ -40,7 +40,7 @@ describe "Admin settings", :admin do
     scenario "When `Map settings` tab content is shown map should be initialized" do
       visit admin_settings_path
 
-      find("#map-tab").click
+      click_link "Map configuration"
 
       expect(page).to have_css("#admin-map.leaflet-container")
     end
@@ -51,7 +51,7 @@ describe "Admin settings", :admin do
       Setting["feature.map"] = false
 
       visit admin_settings_path
-      find("#map-tab").click
+      click_link "Map configuration"
 
       expect(page).to have_content "To show the map to users you must enable " \
                                    '"Proposals and budget investments geolocation" ' \
@@ -63,7 +63,7 @@ describe "Admin settings", :admin do
       Setting["feature.map"] = true
 
       visit admin_settings_path
-      find("#map-tab").click
+      click_link "Map configuration"
 
       expect(page).to have_css("#admin-map")
       expect(page).not_to have_content "To show the map to users you must enable " \
@@ -96,7 +96,7 @@ describe "Admin settings", :admin do
       Setting["feature.map"] = true
 
       visit admin_settings_path
-      find("#map-tab").click
+      click_link "Map configuration"
       find("#admin-map").click
       within "#map-form" do
         click_on "Update"
@@ -211,7 +211,7 @@ describe "Admin settings", :admin do
         map_setting = Setting.create!(key: "map.whatever")
 
         visit admin_settings_path
-        find("#map-tab").click
+        click_link "Map configuration"
 
         within("#edit_setting_#{map_setting.id}") do
           fill_in "setting_#{map_setting.id}", with: "New value"

--- a/spec/system/admin/settings_spec.rb
+++ b/spec/system/admin/settings_spec.rb
@@ -108,31 +108,31 @@ describe "Admin settings", :admin do
   end
 
   describe "Update content types" do
-    scenario "stores the correct mime types" do
-      setting = Setting.create!(key: "upload.images.content_types", value: "image/png")
+    scenario "stores the correct mime types", :js do
+      Setting["uploads.images.content_types"] = "image/png"
+      setting = Setting.find_by!(key: "uploads.images.content_types")
+
       visit admin_settings_path
-      find("#images-and-documents-tab").click
+      click_link "Images and documents"
 
       within "#edit_setting_#{setting.id}" do
-        expect(find("#png")).to be_checked
-        expect(find("#jpg")).not_to be_checked
-        expect(find("#gif")).not_to be_checked
+        expect(find_field("PNG")).to be_checked
+        expect(find_field("JPG")).not_to be_checked
+        expect(find_field("GIF")).not_to be_checked
 
-        check "gif"
+        check "GIF"
 
         click_button "Update"
       end
 
       expect(page).to have_content "Value updated"
-      expect(Setting["upload.images.content_types"]).to include "image/png"
-      expect(Setting["upload.images.content_types"]).to include "image/gif"
 
-      visit admin_settings_path(anchor: "tab-images-and-documents")
+      click_link "Images and documents"
 
       within "#edit_setting_#{setting.id}" do
-        expect(find("#png")).to be_checked
-        expect(find("#gif")).to be_checked
-        expect(find("#jpg")).not_to be_checked
+        expect(find_field("PNG")).to be_checked
+        expect(find_field("GIF")).to be_checked
+        expect(find_field("JPG")).not_to be_checked
       end
     end
   end

--- a/spec/system/admin/settings_spec.rb
+++ b/spec/system/admin/settings_spec.rb
@@ -26,7 +26,7 @@ describe "Admin settings", :admin do
     expect(page).to have_content "Value updated"
   end
 
-  describe "Map settings initialization", :js do
+  describe "Map settings initialization" do
     before do
       Setting["feature.map"] = true
     end
@@ -84,7 +84,7 @@ describe "Admin settings", :admin do
       expect(page).to have_content "Map configuration updated succesfully"
     end
 
-    scenario "Should display marker by default", :js do
+    scenario "Should display marker by default" do
       Setting["feature.map"] = true
 
       visit admin_settings_path
@@ -93,7 +93,7 @@ describe "Admin settings", :admin do
       expect(find("#longitude", visible: :hidden).value).to eq "0.0"
     end
 
-    scenario "Should update marker", :js do
+    scenario "Should update marker" do
       Setting["feature.map"] = true
 
       visit admin_settings_path
@@ -109,7 +109,7 @@ describe "Admin settings", :admin do
   end
 
   describe "Update content types" do
-    scenario "stores the correct mime types", :js do
+    scenario "stores the correct mime types" do
       Setting["uploads.images.content_types"] = "image/png"
       setting = Setting.find_by!(key: "uploads.images.content_types")
 
@@ -172,7 +172,7 @@ describe "Admin settings", :admin do
         Setting["feature.remote_census"] = true
       end
 
-      scenario "On #tab-remote-census-configuration", :js do
+      scenario "On #tab-remote-census-configuration" do
         remote_census_setting = create(:setting, key: "remote_census.general.whatever")
 
         visit admin_settings_path
@@ -188,7 +188,7 @@ describe "Admin settings", :admin do
       end
     end
 
-    scenario "On #tab-configuration", :js do
+    scenario "On #tab-configuration" do
       configuration_setting = Setting.create!(key: "whatever")
 
       visit admin_settings_path
@@ -208,7 +208,7 @@ describe "Admin settings", :admin do
         Setting["feature.map"] = true
       end
 
-      scenario "On #tab-map-configuration", :js do
+      scenario "On #tab-map-configuration" do
         map_setting = Setting.create!(key: "map.whatever")
 
         visit admin_settings_path
@@ -224,7 +224,7 @@ describe "Admin settings", :admin do
       end
     end
 
-    scenario "On #tab-proposals", :js do
+    scenario "On #tab-proposals" do
       proposal_dashboard_setting = Setting.create!(key: "proposals.whatever")
 
       visit admin_settings_path
@@ -239,7 +239,7 @@ describe "Admin settings", :admin do
       expect(page).to have_css("div#tab-proposals.is-active")
     end
 
-    scenario "On #tab-participation-processes", :js do
+    scenario "On #tab-participation-processes" do
       process_setting = Setting.create!(key: "process.whatever")
 
       visit admin_settings_path
@@ -253,7 +253,7 @@ describe "Admin settings", :admin do
       expect(page).to have_css("div#tab-participation-processes.is-active")
     end
 
-    scenario "On #tab-feature-flags", :js do
+    scenario "On #tab-feature-flags" do
       feature_setting = Setting.create!(key: "feature.whatever")
 
       visit admin_settings_path
@@ -267,7 +267,7 @@ describe "Admin settings", :admin do
       expect(page).to have_css("div#tab-feature-flags.is-active")
     end
 
-    scenario "On #tab-sdg-configuration", :js do
+    scenario "On #tab-sdg-configuration" do
       Setting["feature.sdg"] = true
       Setting.create!(key: "sdg.whatever")
       login_as(create(:administrator).user)
@@ -285,7 +285,7 @@ describe "Admin settings", :admin do
   end
 
   describe "Skip verification" do
-    scenario "deactivate skip verification", :js do
+    scenario "deactivate skip verification" do
       Setting["feature.user.skip_verification"] = "true"
       setting = Setting.find_by(key: "feature.user.skip_verification")
 
@@ -299,7 +299,7 @@ describe "Admin settings", :admin do
       expect(page).to have_content "Value updated"
     end
 
-    scenario "activate skip verification", :js do
+    scenario "activate skip verification" do
       Setting["feature.user.skip_verification"] = nil
       setting = Setting.find_by(key: "feature.user.skip_verification")
 
@@ -316,7 +316,7 @@ describe "Admin settings", :admin do
     end
   end
 
-  describe "SDG configuration tab", :js do
+  describe "SDG configuration tab" do
     scenario "is enabled when the sdg feature is enabled" do
       Setting["feature.sdg"] = true
       login_as(create(:administrator).user)

--- a/spec/system/admin/settings_spec.rb
+++ b/spec/system/admin/settings_spec.rb
@@ -75,6 +75,7 @@ describe "Admin settings", :admin do
       Setting["feature.map"] = true
 
       visit admin_settings_path
+      click_link "Map configuration"
 
       within "#map-form" do
         click_on "Update"

--- a/spec/system/admin/site_customization/content_blocks_spec.rb
+++ b/spec/system/admin/site_customization/content_blocks_spec.rb
@@ -81,14 +81,14 @@ describe "Admin custom content blocks", :admin do
   end
 
   context "Delete" do
-    scenario "From index page" do
+    scenario "From index page", :js do
       block = create(:site_customization_content_block)
       visit   admin_site_customization_content_blocks_path
 
       expect(page).to have_content("#{block.name} (#{block.locale})")
       expect(page).to have_content(block.body)
 
-      click_link "Delete block"
+      accept_confirm { click_link "Delete block" }
 
       expect(page).not_to have_content("#{block.name} (#{block.locale})")
       expect(page).not_to have_content(block.body)

--- a/spec/system/admin/site_customization/content_blocks_spec.rb
+++ b/spec/system/admin/site_customization/content_blocks_spec.rb
@@ -13,10 +13,11 @@ describe "Admin custom content blocks", :admin do
   end
 
   context "Create" do
-    scenario "Valid custom block" do
+    scenario "Valid custom block", :js do
       visit admin_root_path
 
       within("#side_menu") do
+        click_link "Settings"
         click_link "Custom content blocks"
       end
 
@@ -35,12 +36,13 @@ describe "Admin custom content blocks", :admin do
       expect(page).to have_content "Some custom content"
     end
 
-    scenario "Invalid custom block" do
+    scenario "Invalid custom block", :js do
       create(:site_customization_content_block)
 
       visit admin_root_path
 
       within("#side_menu") do
+        click_link "Settings"
         click_link "Custom content blocks"
       end
 
@@ -61,12 +63,13 @@ describe "Admin custom content blocks", :admin do
   end
 
   context "Update" do
-    scenario "Valid custom block" do
+    scenario "Valid custom block", :js do
       create(:site_customization_content_block)
 
       visit admin_root_path
 
       within("#side_menu") do
+        click_link "Settings"
         click_link "Custom content blocks"
       end
 

--- a/spec/system/admin/site_customization/content_blocks_spec.rb
+++ b/spec/system/admin/site_customization/content_blocks_spec.rb
@@ -13,7 +13,7 @@ describe "Admin custom content blocks", :admin do
   end
 
   context "Create" do
-    scenario "Valid custom block", :js do
+    scenario "Valid custom block" do
       visit admin_root_path
 
       within("#side_menu") do
@@ -36,7 +36,7 @@ describe "Admin custom content blocks", :admin do
       expect(page).to have_content "Some custom content"
     end
 
-    scenario "Invalid custom block", :js do
+    scenario "Invalid custom block" do
       create(:site_customization_content_block)
 
       visit admin_root_path
@@ -63,7 +63,7 @@ describe "Admin custom content blocks", :admin do
   end
 
   context "Update" do
-    scenario "Valid custom block", :js do
+    scenario "Valid custom block" do
       create(:site_customization_content_block)
 
       visit admin_root_path
@@ -84,7 +84,7 @@ describe "Admin custom content blocks", :admin do
   end
 
   context "Delete" do
-    scenario "From index page", :js do
+    scenario "From index page" do
       block = create(:site_customization_content_block)
       visit   admin_site_customization_content_blocks_path
 

--- a/spec/system/admin/site_customization/documents_spec.rb
+++ b/spec/system/admin/site_customization/documents_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Documents", :admin do
-  scenario "Navigation", :js do
+  scenario "Navigation" do
     visit admin_root_path
 
     within("#side_menu") do
@@ -68,7 +68,7 @@ describe "Documents", :admin do
     expect(page).to have_content "Invalid document"
   end
 
-  scenario "Destroy", :js do
+  scenario "Destroy" do
     document = create(:document, :admin)
 
     visit admin_site_customization_documents_path

--- a/spec/system/admin/site_customization/images_spec.rb
+++ b/spec/system/admin/site_customization/images_spec.rb
@@ -18,11 +18,7 @@ describe "Admin custom images", :admin do
   end
 
   scenario "Upload valid jpg image" do
-    visit admin_root_path
-
-    within("#side_menu") do
-      click_link "Custom images"
-    end
+    visit admin_site_customization_images_path
 
     within("tr#image_map") do
       attach_file "site_customization_image_image", "spec/fixtures/files/custom_map.jpg"
@@ -36,11 +32,8 @@ describe "Admin custom images", :admin do
   scenario "Image is replaced on front views" do
     budget = create(:budget)
     group = create(:budget_group, budget: budget)
-    visit admin_root_path
 
-    within("#side_menu") do
-      click_link "Custom images"
-    end
+    visit admin_site_customization_images_path
 
     within("tr#image_map") do
       attach_file "site_customization_image_image", "spec/fixtures/files/custom_map.jpg"
@@ -84,11 +77,7 @@ describe "Admin custom images", :admin do
   end
 
   scenario "Upload invalid image" do
-    visit admin_root_path
-
-    within("#side_menu") do
-      click_link "Custom images"
-    end
+    visit admin_site_customization_images_path
 
     within("tr#image_social_media_icon") do
       attach_file "site_customization_image_image", "spec/fixtures/files/logo_header.png"
@@ -100,11 +89,7 @@ describe "Admin custom images", :admin do
   end
 
   scenario "Delete image" do
-    visit admin_root_path
-
-    within("#side_menu") do
-      click_link "Custom images"
-    end
+    visit admin_site_customization_images_path
 
     within("tr#image_social_media_icon") do
       attach_file "site_customization_image_image", "spec/fixtures/files/social_media_icon.png"

--- a/spec/system/admin/site_customization/images_spec.rb
+++ b/spec/system/admin/site_customization/images_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Admin custom images", :admin do
-  scenario "Upload valid png image", :js do
+  scenario "Upload valid png image" do
     visit admin_root_path
 
     within("#side_menu") do

--- a/spec/system/admin/site_customization/images_spec.rb
+++ b/spec/system/admin/site_customization/images_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 describe "Admin custom images", :admin do
-  scenario "Upload valid png image" do
+  scenario "Upload valid png image", :js do
     visit admin_root_path
 
     within("#side_menu") do
+      click_link "Settings"
       click_link "Custom images"
     end
 

--- a/spec/system/admin/site_customization/information_texts_spec.rb
+++ b/spec/system/admin/site_customization/information_texts_spec.rb
@@ -51,7 +51,7 @@ describe "Admin custom information texts", :admin do
   end
 
   context "Globalization" do
-    scenario "Add a translation", :js do
+    scenario "Add a translation" do
       key = "debates.index.section_footer.title"
 
       visit admin_site_customization_information_texts_path
@@ -70,7 +70,7 @@ describe "Admin custom information texts", :admin do
       expect(page).not_to have_content "Aide sur les débats"
     end
 
-    scenario "Update a translation", :js do
+    scenario "Update a translation" do
       key = "proposals.show.share"
       create(:i18n_content, key: key, value_fr: "Partager la proposition")
 
@@ -89,7 +89,7 @@ describe "Admin custom information texts", :admin do
       expect(page).not_to have_content "Partager la proposition"
     end
 
-    scenario "Remove a translation", :js do
+    scenario "Remove a translation" do
       first_key = "debates.form.debate_title"
       debate_title = create(:i18n_content, key: first_key,
                                            value_en: "Custom debate title",

--- a/spec/system/admin/site_customization/pages_spec.rb
+++ b/spec/system/admin/site_customization/pages_spec.rb
@@ -29,10 +29,11 @@ describe "Admin custom pages", :admin do
   end
 
   context "Create" do
-    scenario "Valid custom page" do
+    scenario "Valid custom page", :js do
       visit admin_root_path
 
       within("#side_menu") do
+        click_link "Site content"
         click_link "Custom pages"
       end
 
@@ -44,7 +45,7 @@ describe "Admin custom pages", :admin do
       fill_in "Title", with: "An example custom page"
       fill_in "Subtitle", with: "Page subtitle"
       fill_in "site_customization_page_slug", with: "example-page"
-      fill_in "Content", with: "This page is about..."
+      fill_in_ckeditor "Content", with: "This page is about..."
 
       click_button "Create Custom page"
 

--- a/spec/system/admin/site_customization/pages_spec.rb
+++ b/spec/system/admin/site_customization/pages_spec.rb
@@ -29,7 +29,7 @@ describe "Admin custom pages", :admin do
   end
 
   context "Create" do
-    scenario "Valid custom page", :js do
+    scenario "Valid custom page" do
       visit admin_root_path
 
       within("#side_menu") do
@@ -59,7 +59,7 @@ describe "Admin custom pages", :admin do
       create(:site_customization_page, title: "An example custom page", slug: "custom-example-page")
     end
 
-    scenario "Valid custom page", :js do
+    scenario "Valid custom page" do
       visit admin_root_path
 
       within("#side_menu") do
@@ -81,7 +81,7 @@ describe "Admin custom pages", :admin do
       expect(page).to have_content "another-custom-example-page"
     end
 
-    scenario "Allows images in CKEditor", :js do
+    scenario "Allows images in CKEditor" do
       visit edit_admin_site_customization_page_path(custom_page)
       fill_in_ckeditor "Content", with: "Will add an image"
 

--- a/spec/system/admin/site_customization/pages_spec.rb
+++ b/spec/system/admin/site_customization/pages_spec.rb
@@ -59,10 +59,11 @@ describe "Admin custom pages", :admin do
       create(:site_customization_page, title: "An example custom page", slug: "custom-example-page")
     end
 
-    scenario "Valid custom page" do
+    scenario "Valid custom page", :js do
       visit admin_root_path
 
       within("#side_menu") do
+        click_link "Site content"
         click_link "Custom pages"
       end
 

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 describe "Stats", :admin do
-  before do
-    visit root_path
-  end
-
   context "Summary" do
     scenario "General" do
       create(:debate)

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Stats", :admin do
-  context "Summary", :js do
+  context "Summary" do
     scenario "General" do
       create(:debate)
       2.times { create(:proposal) }
@@ -30,7 +30,7 @@ describe "Stats", :admin do
     end
   end
 
-  context "Users", :js do
+  context "Users" do
     scenario "Summary" do
       1.times { create(:user, :level_three) }
       2.times { create(:user, :level_two) }
@@ -86,13 +86,13 @@ describe "Stats", :admin do
     end
   end
 
-  describe "Budget investments", :js do
+  describe "Budget investments" do
     context "Supporting phase" do
       let(:budget) { create(:budget) }
       let(:group_all_city) { create(:budget_group, budget: budget) }
       let!(:heading_all_city) { create(:budget_heading, group: group_all_city) }
 
-      scenario "Number of supports in investment projects", :js do
+      scenario "Number of supports in investment projects" do
         group_2 = create(:budget_group, budget: budget)
 
         create(:budget_investment, heading: create(:budget_heading, group: group_2), voters: [create(:user)])
@@ -216,7 +216,7 @@ describe "Stats", :admin do
   end
 
   context "graphs" do
-    scenario "event graphs", :js do
+    scenario "event graphs" do
       campaign = create(:campaign)
 
       visit root_path(track_id: campaign.track_id)
@@ -393,7 +393,7 @@ describe "Stats", :admin do
     end
   end
 
-  context "SDG", :js do
+  context "SDG" do
     scenario "Shows SDG stats link when SDG feature is enabled" do
       Setting["feature.sdg"] = true
 

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Stats", :admin do
-  context "Summary" do
+  context "Summary", :js do
     scenario "General" do
       create(:debate)
       2.times { create(:proposal) }
@@ -10,10 +10,10 @@ describe "Stats", :admin do
 
       visit admin_stats_path
 
-      expect(page).to have_content "Debates 1"
-      expect(page).to have_content "Proposals 2"
-      expect(page).to have_content "Comments 3"
-      expect(page).to have_content "Visits 4"
+      expect(page).to have_content "DEBATES\n1"
+      expect(page).to have_content "PROPOSALS\n2"
+      expect(page).to have_content "COMMENTS\n3"
+      expect(page).to have_content "VISITS\n4"
     end
 
     scenario "Votes" do
@@ -23,14 +23,14 @@ describe "Stats", :admin do
 
       visit admin_stats_path
 
-      expect(page).to have_content "Debate votes 1"
-      expect(page).to have_content "Proposal votes 2"
-      expect(page).to have_content "Comment votes 3"
-      expect(page).to have_content "Total votes 6"
+      expect(page).to have_content "DEBATE VOTES\n1"
+      expect(page).to have_content "PROPOSAL VOTES\n2"
+      expect(page).to have_content "COMMENT VOTES\n3"
+      expect(page).to have_content "TOTAL VOTES\n6"
     end
   end
 
-  context "Users" do
+  context "Users", :js do
     scenario "Summary" do
       1.times { create(:user, :level_three) }
       2.times { create(:user, :level_two) }
@@ -38,11 +38,11 @@ describe "Stats", :admin do
 
       visit admin_stats_path
 
-      expect(page).to have_content "Level three users 1"
-      expect(page).to have_content "Level two users 2"
-      expect(page).to have_content "Verified users 3"
-      expect(page).to have_content "Unverified users 4"
-      expect(page).to have_content "Total users 7"
+      expect(page).to have_content "LEVEL THREE USERS\n1"
+      expect(page).to have_content "LEVEL TWO USERS\n2"
+      expect(page).to have_content "VERIFIED USERS\n3"
+      expect(page).to have_content "UNVERIFIED USERS\n4"
+      expect(page).to have_content "TOTAL USERS\n7"
     end
 
     scenario "Do not count erased users" do
@@ -52,11 +52,11 @@ describe "Stats", :admin do
 
       visit admin_stats_path
 
-      expect(page).to have_content "Level three users 0"
-      expect(page).to have_content "Level two users 0"
-      expect(page).to have_content "Verified users 0"
-      expect(page).to have_content "Unverified users 1"
-      expect(page).to have_content "Total users 1"
+      expect(page).to have_content "LEVEL THREE USERS\n0"
+      expect(page).to have_content "LEVEL TWO USERS\n0"
+      expect(page).to have_content "VERIFIED USERS\n0"
+      expect(page).to have_content "UNVERIFIED USERS\n1"
+      expect(page).to have_content "TOTAL USERS\n1"
     end
 
     scenario "Do not count hidden users" do
@@ -66,11 +66,11 @@ describe "Stats", :admin do
 
       visit admin_stats_path
 
-      expect(page).to have_content "Level three users 0"
-      expect(page).to have_content "Level two users 0"
-      expect(page).to have_content "Verified users 0"
-      expect(page).to have_content "Unverified users 1"
-      expect(page).to have_content "Total users 1"
+      expect(page).to have_content "LEVEL THREE USERS\n0"
+      expect(page).to have_content "LEVEL TWO USERS\n0"
+      expect(page).to have_content "VERIFIED USERS\n0"
+      expect(page).to have_content "UNVERIFIED USERS\n1"
+      expect(page).to have_content "TOTAL USERS\n1"
     end
 
     scenario "Level 2 user Graph" do
@@ -82,17 +82,17 @@ describe "Stats", :admin do
 
       visit admin_stats_path
 
-      expect(page).to have_content "Level two users 1"
+      expect(page).to have_content "LEVEL TWO USERS\n1"
     end
   end
 
-  describe "Budget investments" do
+  describe "Budget investments", :js do
     context "Supporting phase" do
       let(:budget) { create(:budget) }
       let(:group_all_city) { create(:budget_group, budget: budget) }
       let!(:heading_all_city) { create(:budget_heading, group: group_all_city) }
 
-      scenario "Number of supports in investment projects" do
+      scenario "Number of supports in investment projects", :js do
         group_2 = create(:budget_group, budget: budget)
 
         create(:budget_investment, heading: create(:budget_heading, group: group_2), voters: [create(:user)])
@@ -104,7 +104,7 @@ describe "Stats", :admin do
           click_link "Supporting phase"
         end
 
-        expect(page).to have_content "Votes 3"
+        expect(page).to have_content "VOTES\n3"
         expect(page).to have_link "Go back", count: 1
       end
 
@@ -123,7 +123,7 @@ describe "Stats", :admin do
           click_link "Supporting phase"
         end
 
-        expect(page).to have_content "Participants 2"
+        expect(page).to have_content "PARTICIPANTS\n2"
       end
 
       scenario "Number of users that have supported investments projects per geozone" do
@@ -196,7 +196,7 @@ describe "Stats", :admin do
           click_link "Final voting"
         end
 
-        expect(page).to have_content "Votes 3"
+        expect(page).to have_content "VOTES\n3"
       end
 
       scenario "Number of users that have voted a investment project" do
@@ -210,7 +210,7 @@ describe "Stats", :admin do
           click_link "Final voting"
         end
 
-        expect(page).to have_content "Participants 2"
+        expect(page).to have_content "PARTICIPANTS\n2"
       end
     end
   end

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "System Emails" do
+describe "System Emails", :js do
   let(:admin) { create(:administrator) }
 
   before do
@@ -84,10 +84,10 @@ describe "System Emails" do
       visit admin_system_email_view_path("proposal_notification_digest")
 
       expect(page).to have_content("Proposal notifications in")
-      expect(page).to have_link("Proposal A Title", href: proposal_url(proposal_a,
-                                                    anchor: "tab-notifications"))
-      expect(page).to have_link("Proposal B Title", href: proposal_url(proposal_b,
-                                                    anchor: "tab-notifications"))
+      expect(page).to have_link("Proposal A Title",
+                                href: proposal_url(proposal_a, anchor: "tab-notifications", host: app_host))
+      expect(page).to have_link("Proposal B Title",
+                                href: proposal_url(proposal_b, anchor: "tab-notifications", host: app_host))
       expect(page).to have_content("Proposal A Notification Body")
       expect(page).to have_content("Proposal B Notification Body")
     end
@@ -102,9 +102,9 @@ describe "System Emails" do
       expect(page).to have_content "Cleaner city"
       expect(page).to have_content "Budget for 2019"
 
-      expect(page).to have_link "Participatory Budgets", href: budgets_url
+      expect(page).to have_link "Participatory Budgets", href: budgets_url(host: app_host)
 
-      share_url = budget_investment_url(budget, investment, anchor: "social-share")
+      share_url = budget_investment_url(budget, investment, anchor: "social-share", host: app_host)
       expect(page).to have_link "Share your project", href: share_url
     end
 
@@ -116,7 +116,7 @@ describe "System Emails" do
       expect(page).to have_content "Your investment project '#{investment.code}' has been selected"
       expect(page).to have_content "Start to get votes, share your investment project"
 
-      share_url = budget_investment_url(budget, investment, anchor: "social-share")
+      share_url = budget_investment_url(budget, investment, anchor: "social-share", host: app_host)
       expect(page).to have_link "Share your investment project", href: share_url
     end
 
@@ -152,7 +152,7 @@ describe "System Emails" do
       expect(page).to have_content "There is a new comment from #{commenter.name}"
       expect(page).to have_content comment.body
 
-      expect(page).to have_link "Let's do...", href: debate_url(debate)
+      expect(page).to have_link "Let's do...", href: debate_url(debate, host: app_host)
     end
 
     scenario "#reply" do
@@ -169,7 +169,7 @@ describe "System Emails" do
       expect(page).to have_content "There is a new response from #{replier.name}"
       expect(page).to have_content reply.body
 
-      expect(page).to have_link "Let's do...", href: comment_url(reply)
+      expect(page).to have_link "Let's do...", href: comment_url(reply, host: app_host)
     end
 
     scenario "#direct_message_for_receiver" do
@@ -179,7 +179,7 @@ describe "System Emails" do
       expect(page).to have_content "Message's Title"
       expect(page).to have_content "This is a sample of message's content."
 
-      expect(page).to have_link "Reply to #{admin.user.name}", href: user_url(admin.user)
+      expect(page).to have_link "Reply to #{admin.user.name}", href: user_url(admin.user, host: app_host)
     end
 
     scenario "#direct_message_for_sender" do
@@ -197,7 +197,7 @@ describe "System Emails" do
 
       expect(page).to have_content "Confirm your account using the following link"
 
-      expect(page).to have_link "this link", href: email_url(email_verification_token: "abc")
+      expect(page).to have_link "this link", href: email_url(email_verification_token: "abc", host: app_host)
     end
 
     scenario "#user_invite" do
@@ -257,7 +257,7 @@ describe "System Emails" do
       expect(page).to have_content comment.body
 
       expect(page).to have_link "Cleaner city",
-        href: admin_budget_budget_investment_url(investment.budget, investment, anchor: "comments")
+        href: admin_budget_budget_investment_url(investment.budget, investment, anchor: "comments", host: app_host)
     end
   end
 
@@ -277,12 +277,12 @@ describe "System Emails" do
       visit admin_system_email_preview_pending_path("proposal_notification_digest")
 
       expect(page).to have_content("This is the content pending to be sent")
-      expect(page).to have_link("Proposal A", href: proposal_url(proposal_a))
-      expect(page).to have_link("Proposal B", href: proposal_url(proposal_b))
-      expect(page).to have_link("Proposal A Title", href: proposal_url(proposal_a,
-                                                    anchor: "tab-notifications"))
-      expect(page).to have_link("Proposal B Title", href: proposal_url(proposal_b,
-                                                    anchor: "tab-notifications"))
+      expect(page).to have_link("Proposal A", href: proposal_url(proposal_a, host: app_host))
+      expect(page).to have_link("Proposal B", href: proposal_url(proposal_b, host: app_host))
+      expect(page).to have_link("Proposal A Title",
+                                href: proposal_url(proposal_a, anchor: "tab-notifications", host: app_host))
+      expect(page).to have_link("Proposal B Title",
+                                href: proposal_url(proposal_b, anchor: "tab-notifications", host: app_host))
     end
 
     scenario "#moderate_pending" do

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "System Emails", :js do
+describe "System Emails" do
   let(:admin) { create(:administrator) }
 
   before do

--- a/spec/system/admin/tags_spec.rb
+++ b/spec/system/admin/tags_spec.rb
@@ -29,7 +29,7 @@ describe "Admin tags", :admin do
     expect(page).to have_content "important issues"
   end
 
-  scenario "Delete" do
+  scenario "Delete", :js do
     tag2 = create(:tag, :category, name: "bad tag")
     create(:debate, tag_list: "bad tag")
 
@@ -39,15 +39,14 @@ describe "Admin tags", :admin do
     expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
-      click_link "Delete topic"
+      accept_confirm { click_link "Delete topic" }
     end
 
-    visit admin_tags_path
-    expect(page).to have_content "Existence"
     expect(page).not_to have_content "bad tag"
+    expect(page).to have_content "Existence"
   end
 
-  scenario "Delete tag with hidden taggables" do
+  scenario "Delete tag with hidden taggables", :js do
     tag2 = create(:tag, :category, name: "bad tag")
     debate = create(:debate, tag_list: "bad tag")
     debate.hide
@@ -58,12 +57,11 @@ describe "Admin tags", :admin do
     expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
-      click_link "Delete topic"
+      accept_confirm { click_link "Delete topic" }
     end
 
-    visit admin_tags_path
-    expect(page).to have_content "Existence"
     expect(page).not_to have_content "bad tag"
+    expect(page).to have_content "Existence"
   end
 
   context "Manage only tags of kind category" do

--- a/spec/system/admin/tags_spec.rb
+++ b/spec/system/admin/tags_spec.rb
@@ -29,7 +29,7 @@ describe "Admin tags", :admin do
     expect(page).to have_content "important issues"
   end
 
-  scenario "Delete", :js do
+  scenario "Delete" do
     tag2 = create(:tag, :category, name: "bad tag")
     create(:debate, tag_list: "bad tag")
 
@@ -46,7 +46,7 @@ describe "Admin tags", :admin do
     expect(page).to have_content "Existence"
   end
 
-  scenario "Delete tag with hidden taggables", :js do
+  scenario "Delete tag with hidden taggables" do
     tag2 = create(:tag, :category, name: "bad tag")
     debate = create(:debate, tag_list: "bad tag")
     debate.hide

--- a/spec/system/admin/translatable_spec.rb
+++ b/spec/system/admin/translatable_spec.rb
@@ -13,7 +13,7 @@ describe "Admin edit translatable records", :admin do
     end.to_h
   end
 
-  context "Add a translation", :js do
+  context "Add a translation" do
     context "Input fields" do
       let(:translatable) { create(:budget_heading) }
       let(:path) { admin_polymorphic_path(translatable, action: :edit) }
@@ -99,7 +99,7 @@ describe "Admin edit translatable records", :admin do
       end
     end
 
-    context "Locale with non-underscored name", :js do
+    context "Locale with non-underscored name" do
       let(:translatable) { create(:legislation_question) }
       let(:path) { edit_admin_legislation_process_question_path(translatable.process, translatable) }
 
@@ -118,7 +118,7 @@ describe "Admin edit translatable records", :admin do
     end
   end
 
-  context "Add an invalid translation", :js do
+  context "Add an invalid translation" do
     let(:translatable) { create(:budget_investment) }
 
     context "Input field" do
@@ -181,7 +181,7 @@ describe "Admin edit translatable records", :admin do
     end
   end
 
-  context "Update a translation", :js do
+  context "Update a translation" do
     context "Input fields" do
       let(:translatable) { create(:widget_card) }
       let(:path) { edit_admin_widget_card_path(translatable) }
@@ -240,7 +240,7 @@ describe "Admin edit translatable records", :admin do
       end
     end
 
-    context "Change value of a translated field to blank", :js do
+    context "Change value of a translated field to blank" do
       let(:translatable) { create(:poll) }
       let(:path) { edit_admin_poll_path(translatable) }
 
@@ -259,7 +259,7 @@ describe "Admin edit translatable records", :admin do
     end
   end
 
-  context "Update a translation with invalid data", :js do
+  context "Update a translation with invalid data" do
     context "Input fields" do
       let(:translatable) { create(:banner) }
 
@@ -305,7 +305,7 @@ describe "Admin edit translatable records", :admin do
     end
   end
 
-  context "Update a translation not having the current locale", :js do
+  context "Update a translation not having the current locale" do
     let(:translatable) { create(:legislation_process) }
 
     before do
@@ -330,7 +330,7 @@ describe "Admin edit translatable records", :admin do
     end
   end
 
-  context "Remove a translation", :js do
+  context "Remove a translation" do
     let(:translatable) { create(:budget_group) }
     let(:path) { edit_admin_budget_group_path(translatable.budget, translatable) }
 
@@ -351,7 +351,7 @@ describe "Admin edit translatable records", :admin do
     end
   end
 
-  context "Remove all translations", :js do
+  context "Remove all translations" do
     let(:translatable) { create(:milestone) }
 
     scenario "Shows an error message" do
@@ -366,7 +366,7 @@ describe "Admin edit translatable records", :admin do
     end
   end
 
-  context "Remove a translation with invalid data", :js do
+  context "Remove a translation with invalid data" do
     let(:translatable) { create(:poll_question) }
     let(:path) { edit_admin_question_path(translatable) }
 
@@ -392,7 +392,7 @@ describe "Admin edit translatable records", :admin do
     end
   end
 
-  context "Current locale translation does not exist", :js do
+  context "Current locale translation does not exist" do
     context "For all translatable except ActivePoll and Budget::Phase" do
       let(:translatable) { create(:admin_notification, segment_recipient: "all_users") }
 
@@ -455,7 +455,7 @@ describe "Admin edit translatable records", :admin do
     end
   end
 
-  context "Globalize javascript interface", :js do
+  context "Globalize javascript interface" do
     let(:translatable) { create(:i18n_content) }
     let(:content) { translatable }
     let(:path) { admin_site_customization_information_texts_path }

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -16,10 +16,10 @@ describe "Admin users" do
     expect(page).to have_content admin.email
   end
 
-  scenario "The username links to their public profile" do
-    click_link user.name
-
-    expect(page).to have_current_path(user_path(user))
+  scenario "The username links to their public profile", :js do
+    within_window(window_opened_by { click_link user.name }) do
+      expect(page).to have_current_path(user_path(user))
+    end
   end
 
   scenario "Show active or erased users using filters" do

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -16,7 +16,7 @@ describe "Admin users" do
     expect(page).to have_content admin.email
   end
 
-  scenario "The username links to their public profile", :js do
+  scenario "The username links to their public profile" do
     within_window(window_opened_by { click_link user.name }) do
       expect(page).to have_current_path(user_path(user))
     end

--- a/spec/system/admin/valuator_groups_spec.rb
+++ b/spec/system/admin/valuator_groups_spec.rb
@@ -63,11 +63,11 @@ describe "Valuator groups", :admin do
     expect(page).to have_content "Health and Sports"
   end
 
-  scenario "Delete" do
+  scenario "Delete", :js do
     create(:valuator_group)
 
     visit admin_valuator_groups_path
-    click_link "Delete"
+    accept_confirm { click_link "Delete" }
 
     expect(page).to have_content "Valuator group deleted successfully"
     expect(page).to have_content "There are no valuator groups"

--- a/spec/system/admin/valuator_groups_spec.rb
+++ b/spec/system/admin/valuator_groups_spec.rb
@@ -63,7 +63,7 @@ describe "Valuator groups", :admin do
     expect(page).to have_content "Health and Sports"
   end
 
-  scenario "Delete", :js do
+  scenario "Delete" do
     create(:valuator_group)
 
     visit admin_valuator_groups_path

--- a/spec/system/admin/valuators_spec.rb
+++ b/spec/system/admin/valuators_spec.rb
@@ -50,8 +50,8 @@ describe "Admin valuators", :admin do
     expect(page).not_to have_content "Can edit dossier"
   end
 
-  scenario "Destroy" do
-    click_link "Delete"
+  scenario "Destroy", :js do
+    accept_confirm { click_link "Delete" }
 
     within("#valuators") do
       expect(page).not_to have_content(valuator.name)

--- a/spec/system/admin/valuators_spec.rb
+++ b/spec/system/admin/valuators_spec.rb
@@ -21,7 +21,7 @@ describe "Admin valuators", :admin do
     expect(page).not_to have_content(user.name)
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     fill_in "search", with: user.email
     click_button "Search"
 
@@ -50,7 +50,7 @@ describe "Admin valuators", :admin do
     expect(page).not_to have_content "Can edit dossier"
   end
 
-  scenario "Destroy", :js do
+  scenario "Destroy" do
     accept_confirm { click_link "Delete" }
 
     within("#valuators") do

--- a/spec/system/admin/widgets/cards_spec.rb
+++ b/spec/system/admin/widgets/cards_spec.rb
@@ -188,14 +188,14 @@ describe "Cards", :admin do
         expect(page).to have_css("#widget_card_#{card_3.id}.medium-2")
       end
 
-      scenario "Show label only if it is present" do
+      scenario "Show label only if it is present", :js do
         card_1 = create(:widget_card, cardable: custom_page, title: "Card one", label: "My label")
         card_2 = create(:widget_card, cardable: custom_page, title: "Card two")
 
         visit custom_page.url
 
         within("#widget_card_#{card_1.id}") do
-          expect(page).to have_selector("span", text: "My label")
+          expect(page).to have_selector("span", text: "MY LABEL")
         end
 
         within("#widget_card_#{card_2.id}") do

--- a/spec/system/admin/widgets/cards_spec.rb
+++ b/spec/system/admin/widgets/cards_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Cards", :admin do
-  scenario "Create", :js do
+  scenario "Create" do
     visit admin_homepage_path
     click_link "Create card"
 
@@ -29,7 +29,7 @@ describe "Cards", :admin do
     end
   end
 
-  scenario "Create with errors", :js do
+  scenario "Create with errors" do
     visit admin_homepage_path
     click_link "Create card"
     click_button "Create card"
@@ -100,7 +100,7 @@ describe "Cards", :admin do
     end
   end
 
-  scenario "Remove", :js do
+  scenario "Remove" do
     card = create(:widget_card)
 
     visit admin_homepage_path
@@ -143,7 +143,7 @@ describe "Cards", :admin do
       end
     end
 
-    scenario "Create with errors", :js do
+    scenario "Create with errors" do
       visit admin_homepage_path
       click_link "Create header"
       click_button "Create header"
@@ -155,7 +155,7 @@ describe "Cards", :admin do
     context "Page card" do
       let!(:custom_page) { create(:site_customization_page, :published) }
 
-      scenario "Create", :js do
+      scenario "Create" do
         visit admin_site_customization_pages_path
 
         within "#site_customization_page_#{custom_page.id}" do
@@ -188,7 +188,7 @@ describe "Cards", :admin do
         expect(page).to have_css("#widget_card_#{card_3.id}.medium-2")
       end
 
-      scenario "Show label only if it is present", :js do
+      scenario "Show label only if it is present" do
         card_1 = create(:widget_card, cardable: custom_page, title: "Card one", label: "My label")
         card_2 = create(:widget_card, cardable: custom_page, title: "Card two")
 
@@ -203,7 +203,7 @@ describe "Cards", :admin do
         end
       end
 
-      scenario "Edit", :js do
+      scenario "Edit" do
         create(:widget_card, cardable: custom_page, title: "Original title")
 
         visit admin_site_customization_page_widget_cards_path(custom_page)
@@ -226,7 +226,7 @@ describe "Cards", :admin do
         expect(page).not_to have_content "Original title"
       end
 
-      scenario "Destroy", :js do
+      scenario "Destroy" do
         create(:widget_card, cardable: custom_page, title: "Card title")
 
         visit admin_site_customization_page_widget_cards_path(custom_page)

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -42,7 +42,7 @@ describe "Admin" do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario "Access as SDG manager is not authorized", :js do
+  scenario "Access as SDG manager is not authorized" do
     create(:sdg_manager, user: user)
     login_as(user)
     visit admin_root_path
@@ -68,7 +68,7 @@ describe "Admin" do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Admin access links", :admin, :js do
+  scenario "Admin access links", :admin do
     Setting["feature.sdg"] = true
 
     visit root_path
@@ -81,7 +81,7 @@ describe "Admin" do
     expect(page).to have_link("SDG content")
   end
 
-  scenario "Admin dashboard", :admin, :js do
+  scenario "Admin dashboard", :admin do
     visit root_path
 
     click_link "Menu"
@@ -93,7 +93,7 @@ describe "Admin" do
     expect(page).not_to have_css("#valuation_menu")
   end
 
-  scenario "Admin menu does not hide active elements", :js, :admin do
+  scenario "Admin menu does not hide active elements", :admin do
     visit admin_budgets_path
 
     within("#admin_menu") do

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -68,10 +68,11 @@ describe "Admin" do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Admin access links", :admin do
+  scenario "Admin access links", :admin, :js do
     Setting["feature.sdg"] = true
 
     visit root_path
+    click_link "Menu"
 
     expect(page).to have_link("Administration")
     expect(page).to have_link("Moderation")
@@ -80,9 +81,10 @@ describe "Admin" do
     expect(page).to have_link("SDG content")
   end
 
-  scenario "Admin dashboard", :admin do
+  scenario "Admin dashboard", :admin, :js do
     visit root_path
 
+    click_link "Menu"
     click_link "Administration"
 
     expect(page).to have_current_path(admin_root_path)

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -66,6 +66,7 @@ describe "Advanced search" do
 
   context "Search by author type" do
     scenario "Public employee" do
+      Setting["official_level_1_name"] = "Official position 1"
       ana = create :user, official_level: 1
       john = create :user, official_level: 2
 
@@ -76,7 +77,7 @@ describe "Advanced search" do
       visit debates_path
 
       click_link "Advanced search"
-      select Setting["official_level_1_name"], from: "advanced_search_official_level"
+      select "Official position 1", from: "advanced_search_official_level"
       click_button "Filter"
 
       expect(page).to have_content("There are 2 debates")
@@ -89,6 +90,7 @@ describe "Advanced search" do
     end
 
     scenario "Municipal Organization" do
+      Setting["official_level_2_name"] = "Official position 2"
       ana = create :user, official_level: 2
       john = create :user, official_level: 3
 
@@ -99,7 +101,7 @@ describe "Advanced search" do
       visit proposals_path
 
       click_link "Advanced search"
-      select Setting["official_level_2_name"], from: "advanced_search_official_level"
+      select "Official position 2", from: "advanced_search_official_level"
       click_button "Filter"
 
       expect(page).to have_content("There are 2 citizen proposals")
@@ -112,6 +114,7 @@ describe "Advanced search" do
     end
 
     scenario "General director" do
+      Setting["official_level_3_name"] = "Official position 3"
       ana = create :user, official_level: 3
       john = create :user, official_level: 4
 
@@ -122,7 +125,7 @@ describe "Advanced search" do
       visit budget_investments_path(budget)
 
       click_link "Advanced search"
-      select Setting["official_level_3_name"], from: "advanced_search_official_level"
+      select "Official position 3", from: "advanced_search_official_level"
       click_button "Filter"
 
       expect(page).to have_content("There are 2 investments")
@@ -135,6 +138,7 @@ describe "Advanced search" do
     end
 
     scenario "City councillor" do
+      Setting["official_level_4_name"] = "Official position 4"
       ana = create :user, official_level: 4
       john = create :user, official_level: 5
 
@@ -145,7 +149,7 @@ describe "Advanced search" do
       visit debates_path
 
       click_link "Advanced search"
-      select Setting["official_level_4_name"], from: "advanced_search_official_level"
+      select "Official position 4", from: "advanced_search_official_level"
       click_button "Filter"
 
       expect(page).to have_content("There are 2 debates")
@@ -158,6 +162,7 @@ describe "Advanced search" do
     end
 
     scenario "Mayoress" do
+      Setting["official_level_5_name"] = "Official position 5"
       ana = create :user, official_level: 5
       john = create :user, official_level: 4
 
@@ -168,7 +173,7 @@ describe "Advanced search" do
       visit proposals_path
 
       click_link "Advanced search"
-      select Setting["official_level_5_name"], from: "advanced_search_official_level"
+      select "Official position 5", from: "advanced_search_official_level"
       click_button "Filter"
 
       expect(page).to have_content("There are 2 citizen proposals")
@@ -310,6 +315,7 @@ describe "Advanced search" do
       end
 
       scenario "Search by multiple filters" do
+        Setting["official_level_1_name"] = "Official position 1"
         ana  = create :user, official_level: 1
         john = create :user, official_level: 1
 
@@ -321,7 +327,7 @@ describe "Advanced search" do
 
         click_link "Advanced search"
         fill_in "Write the text", with: "Schwifty"
-        select Setting["official_level_1_name"], from: "advanced_search_official_level"
+        select "Official position 1", from: "advanced_search_official_level"
         select "Last 24 hours", from: "js-advanced-search-date-min"
 
         click_button "Filter"
@@ -334,18 +340,20 @@ describe "Advanced search" do
       end
 
       scenario "Maintain advanced search criteria" do
+        Setting["official_level_1_name"] = "Official position 1"
+
         visit debates_path
         click_link "Advanced search"
 
         fill_in "Write the text", with: "Schwifty"
-        select Setting["official_level_1_name"], from: "advanced_search_official_level"
+        select "Official position 1", from: "advanced_search_official_level"
         select "Last 24 hours", from: "js-advanced-search-date-min"
 
         click_button "Filter"
 
         within "#js-advanced-search" do
           expect(page).to have_selector("input[name='search'][value='Schwifty']")
-          expect(page).to have_select("advanced_search[official_level]", selected: Setting["official_level_1_name"])
+          expect(page).to have_select("advanced_search[official_level]", selected: "Official position 1")
           expect(page).to have_select("advanced_search[date_min]", selected: "Last 24 hours")
         end
       end

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Advanced search", :js do
+describe "Advanced search" do
   let(:budget)  { create(:budget, name: "Big Budget") }
   let(:heading) { create(:budget_heading, budget: budget, name: "More hospitals") }
 

--- a/spec/system/banners_spec.rb
+++ b/spec/system/banners_spec.rb
@@ -1,25 +1,16 @@
 require "rails_helper"
 
 describe "Banner" do
-  scenario "The banner is shown correctly" do
-    create(:web_section, name: "homepage")
-    banner = create(:banner, title: "Hello",
-                      description: "Banner description",
-                      target_url:  "http://www.url.com",
-                      post_started_at: (Time.current - 4.days),
-                      post_ended_at:   (Time.current + 10.days),
-                      background_color: "#FF0000",
-                      font_color: "#FFFFFF")
-    section = WebSection.where(name: "homepage").last
-    create(:banner_section, web_section: section, banner_id: banner.id)
+  scenario "Only renders banners in the right section" do
+    create(:banner,
+           web_sections: [WebSection.find_by!(name: "homepage")],
+           description: "Banner description",
+           post_started_at: (Time.current - 4.days),
+           post_ended_at:   (Time.current + 10.days))
 
     visit root_path
 
-    within(".banner") do
-      expect(page).to have_content("Banner description")
-      expect(find("h2")[:style]).to eq("color:#{banner.font_color};")
-      expect(find("h3")[:style]).to eq("color:#{banner.font_color};")
-    end
+    within(".banner") { expect(page).to have_content("Banner description") }
 
     visit debates_path
 

--- a/spec/system/budget_polls/ballot_sheets_spec.rb
+++ b/spec/system/budget_polls/ballot_sheets_spec.rb
@@ -15,7 +15,7 @@ describe "Poll budget ballot sheets" do
       set_officing_booth(booth)
     end
 
-    scenario "Budget polls are visible", :js do
+    scenario "Budget polls are visible" do
       visit root_path
 
       click_link "Menu"
@@ -125,7 +125,7 @@ describe "Poll budget ballot sheets" do
       expect(page).to have_content("CSV data can't be blank")
     end
 
-    scenario "Shift booth has to be selected", :js do
+    scenario "Shift booth has to be selected" do
       visit new_officing_poll_ballot_sheet_path(poll)
 
       fill_in "data", with: "1234;5678"
@@ -144,7 +144,7 @@ describe "Poll budget ballot sheets" do
       set_officing_booth(booth)
     end
 
-    scenario "Ballot sheet information is displayed", :js do
+    scenario "Ballot sheet information is displayed" do
       officer_assignment = create(:poll_officer_assignment, officer: poll_officer)
       ballot_sheet = create(:poll_ballot_sheet, poll: poll, officer_assignment: officer_assignment)
 

--- a/spec/system/budget_polls/ballot_sheets_spec.rb
+++ b/spec/system/budget_polls/ballot_sheets_spec.rb
@@ -15,8 +15,10 @@ describe "Poll budget ballot sheets" do
       set_officing_booth(booth)
     end
 
-    scenario "Budget polls are visible" do
+    scenario "Budget polls are visible", :js do
       visit root_path
+
+      click_link "Menu"
       click_link "Polling officers"
 
       within("#side_menu") do

--- a/spec/system/budget_polls/budgets_spec.rb
+++ b/spec/system/budget_polls/budgets_spec.rb
@@ -20,7 +20,7 @@ describe "Admin Budgets", :admin do
       expect(Poll.last.budget).to eq(budget)
     end
 
-    scenario "Create poll in current locale if the budget does not have a poll associated", :js do
+    scenario "Create poll in current locale if the budget does not have a poll associated" do
       budget = create(:budget,
                       name_en: "Budget for climate change",
                       name_fr: "Budget pour le changement climatique")

--- a/spec/system/budget_polls/voter_spec.rb
+++ b/spec/system/budget_polls/voter_spec.rb
@@ -15,7 +15,7 @@ describe "BudgetPolls", :with_frozen_time do
   end
 
   context "Offline" do
-    scenario "A citizen can cast a paper vote", :js do
+    scenario "A citizen can cast a paper vote" do
       login_through_form_as_officer(officer.user)
 
       visit new_officing_residence_path
@@ -46,7 +46,7 @@ describe "BudgetPolls", :with_frozen_time do
       end
     end
 
-    scenario "A citizen cannot vote offline again", :js do
+    scenario "A citizen cannot vote offline again" do
       login_through_form_as_officer(officer.user)
 
       visit new_officing_residence_path
@@ -66,7 +66,7 @@ describe "BudgetPolls", :with_frozen_time do
       end
     end
 
-    scenario "A citizen cannot vote online after voting offline", :js do
+    scenario "A citizen cannot vote online after voting offline" do
       login_through_form_as_officer(officer.user)
 
       visit new_officing_residence_path
@@ -91,7 +91,7 @@ describe "BudgetPolls", :with_frozen_time do
   end
 
   context "Online" do
-    scenario "A citizen can cast vote online", :js do
+    scenario "A citizen can cast vote online" do
       login_as(user)
       visit budget_investment_path(budget, investment)
 
@@ -101,7 +101,7 @@ describe "BudgetPolls", :with_frozen_time do
       end
     end
 
-    scenario "A citizen cannot vote online again", :js do
+    scenario "A citizen cannot vote online again" do
       login_as(user)
       visit budget_investment_path(budget, investment)
 
@@ -118,7 +118,7 @@ describe "BudgetPolls", :with_frozen_time do
       end
     end
 
-    scenario "A citizen cannot vote offline after voting online", :js do
+    scenario "A citizen cannot vote offline after voting online" do
       login_as(user)
       visit budget_investment_path(budget, investment)
 

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -32,7 +32,7 @@ describe "Ballots" do
       login_as(user)
     end
 
-    scenario "finds ballot lines using budget slug", :js do
+    scenario "finds ballot lines using budget slug" do
       visit budget_investments_path("budget_slug", states, california)
       add_to_ballot("More rain")
 
@@ -106,7 +106,7 @@ describe "Ballots" do
     end
 
     context "Adding and Removing Investments" do
-      scenario "Add a investment", :js do
+      scenario "Add a investment" do
         create(:budget_investment, :selected, heading: new_york, price: 10000, title: "Bring back King Kong")
         create(:budget_investment, :selected, heading: new_york, price: 20000, title: "Paint cabs black")
 
@@ -134,7 +134,7 @@ describe "Ballots" do
         end
       end
 
-      scenario "Removing a investment", :js do
+      scenario "Removing a investment" do
         investment = create(:budget_investment, :selected, heading: new_york, price: 10000, balloters: [user])
 
         visit budget_investments_path(budget, heading_id: new_york)
@@ -163,7 +163,7 @@ describe "Ballots" do
         end
       end
 
-      scenario "the Map shoud be visible before and after", :js do
+      scenario "the Map shoud be visible before and after" do
         create(:budget_investment, :selected, heading: new_york, price: 10000, title: "More bridges")
 
         visit budget_investments_path(budget, heading_id: new_york)
@@ -192,7 +192,7 @@ describe "Ballots" do
 
     #Break up or simplify with helpers
     context "Balloting in multiple headings" do
-      scenario "Independent progress bar for headings", :js do
+      scenario "Independent progress bar for headings" do
         city_heading      = create(:budget_heading, group: city,      name: "All city",   price: 10000000)
         district_heading1 = create(:budget_heading, group: districts, name: "District 1", price: 1000000)
         district_heading2 = create(:budget_heading, group: districts, name: "District 2", price: 2000000)
@@ -250,7 +250,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "Display progress bar after first vote", :js do
+    scenario "Display progress bar after first vote" do
       create(:budget_investment, :selected, heading: new_york, price: 10000, title: "Park expansion")
 
       visit budget_investments_path(budget, heading_id: new_york.id)
@@ -266,7 +266,7 @@ describe "Ballots" do
   context "Groups" do
     before { login_as(user) }
 
-    scenario "Select my heading", :js do
+    scenario "Select my heading" do
       create(:budget_investment, :selected, heading: california, title: "Green beach")
 
       visit budget_investments_path(budget, heading_id: california)
@@ -279,7 +279,7 @@ describe "Ballots" do
       expect(page).to have_css("#budget_heading_#{california.id}.is-active")
     end
 
-    scenario "Change my heading", :js do
+    scenario "Change my heading" do
       create(:budget_investment, :selected, heading: california, title: "Early ShakeAlert", balloters: [user])
       create(:budget_investment, :selected, heading: new_york, title: "Avengers Tower")
 
@@ -311,7 +311,7 @@ describe "Ballots" do
     end
   end
 
-  context "Showing the ballot", :js do
+  context "Showing the ballot" do
     scenario "Displaying the correct group, heading, count & amount" do
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
@@ -358,7 +358,7 @@ describe "Ballots" do
     end
   end
 
-  scenario "Removing investments from ballot", :js do
+  scenario "Removing investments from ballot" do
     investment = create(:budget_investment, :selected, price: 10, heading: new_york)
     user = create(:user, :level_two, ballot_lines: [investment])
 
@@ -375,7 +375,7 @@ describe "Ballots" do
     expect(page).to have_content("You have voted 0 investments")
   end
 
-  scenario "Removing investments from ballot (sidebar)", :js do
+  scenario "Removing investments from ballot (sidebar)" do
     investment1 = create(:budget_investment, :selected, price: 10000, heading: new_york)
     investment2 = create(:budget_investment, :selected, price: 20000, heading: new_york)
     user = create(:user, :level_two, ballot_lines: [investment1, investment2])
@@ -410,7 +410,7 @@ describe "Ballots" do
     end
   end
 
-  describe "Back link", :js do
+  describe "Back link" do
     scenario "after adding and removing an investment from the ballot" do
       create(:budget_investment, :selected, heading: new_york, price: 10, title: "Sully monument")
 
@@ -452,7 +452,7 @@ describe "Ballots" do
   end
 
   context "Permissions" do
-    scenario "User not logged in", :js do
+    scenario "User not logged in" do
       investment = create(:budget_investment, :selected, heading: new_york)
 
       visit budget_investments_path(budget, heading_id: new_york.id)
@@ -465,7 +465,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "User not verified", :js do
+    scenario "User not verified" do
       unverified_user = create(:user)
       investment = create(:budget_investment, :selected, heading: new_york)
 
@@ -480,7 +480,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "User is organization", :js do
+    scenario "User is organization" do
       org = create(:organization)
       investment = create(:budget_investment, :selected, heading: new_york)
 
@@ -515,7 +515,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "Different district", :js do
+    scenario "Different district" do
       bi1 = create(:budget_investment, :selected, heading: california)
       bi2 = create(:budget_investment, :selected, heading: new_york)
       user = create(:user, :level_two, ballot_lines: [bi1])
@@ -531,7 +531,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "Insufficient funds (on page load)", :js do
+    scenario "Insufficient funds (on page load)" do
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)
       bi2 = create(:budget_investment, :selected, heading: california, price: 500)
       user = create(:user, :level_two, ballot_lines: [bi1])
@@ -547,7 +547,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "Insufficient funds (added after create)", :js do
+    scenario "Insufficient funds (added after create)" do
       create(:budget_investment, :selected, heading: california, price: 600, title: "Build replicants")
       create(:budget_investment, :selected, heading: california, price: 500, title: "Build terminators")
 
@@ -571,7 +571,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "Insufficient funds (removed after destroy)", :js do
+    scenario "Insufficient funds (removed after destroy)" do
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)
       bi2 = create(:budget_investment, :selected, heading: california, price: 500)
       user = create(:user, :level_two, ballot_lines: [bi1])
@@ -599,7 +599,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "Insufficient funds (removed after destroying from sidebar)", :js do
+    scenario "Insufficient funds (removed after destroying from sidebar)" do
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)
       bi2 = create(:budget_investment, :selected, heading: california, price: 500)
       user = create(:user, :level_two, ballot_lines: [bi1])
@@ -628,7 +628,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "Edge case voting a non-elegible investment", :js do
+    scenario "Edge case voting a non-elegible investment" do
       investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000)
 
       in_browser(:user) do
@@ -662,7 +662,7 @@ describe "Ballots" do
       end
     end
 
-    scenario "Balloting is disabled when budget isn't in the balotting phase", :js do
+    scenario "Balloting is disabled when budget isn't in the balotting phase" do
       budget.update!(phase: "accepting")
 
       bi1 = create(:budget_investment, :selected, heading: california, price: 600)

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -84,8 +84,8 @@ describe "Budgets" do
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
 
-      heading1 = create(:budget_heading, group: group1)
-      heading2 = create(:budget_heading, group: group2)
+      heading1 = create(:budget_heading, group: group1, price: 1_000_000)
+      heading2 = create(:budget_heading, group: group2, price: 2_000_000)
 
       visit budgets_path locale: :es
 
@@ -93,9 +93,9 @@ describe "Budgets" do
         expect(page).to have_content group1.name
         expect(page).to have_content group2.name
         expect(page).to have_content heading1.name
-        expect(page).to have_content budget.formatted_heading_price(heading1)
+        expect(page).to have_content "1.000.000 €"
         expect(page).to have_content heading2.name
-        expect(page).to have_content budget.formatted_heading_price(heading2)
+        expect(page).to have_content "2.000.000 €"
       end
     end
 

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -217,9 +217,9 @@ describe "Budgets" do
 
     click_link "Custom name for accepting phase"
 
-    within("#2-custom-name-for-accepting-phase") do
-      expect(page).to have_link("Previous phase", href: "#1-custom-name-for-informing-phase")
-      expect(page).to have_link("Next phase", href: "#3-custom-name-for-selecting-phase")
+    within("#phase-2-custom-name-for-accepting-phase") do
+      expect(page).to have_link "Previous phase", href: "#phase-1-custom-name-for-informing-phase"
+      expect(page).to have_link "Next phase", href: "#phase-3-custom-name-for-selecting-phase"
     end
   end
 

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -16,7 +16,7 @@ describe "Budgets" do
   end
 
   context "Index" do
-    scenario "Show normal index with links" do
+    scenario "Show normal index with links", :js do
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
       heading1 = create(:budget_heading, group: group1)
@@ -33,7 +33,7 @@ describe "Budgets" do
       end
 
       within(".budget-subheader") do
-        expect(page).to have_content "Current phase"
+        expect(page).to have_content "CURRENT PHASE"
         expect(page).to have_content "Information"
       end
 
@@ -99,7 +99,7 @@ describe "Budgets" do
       end
     end
 
-    scenario "Show informing index without links" do
+    scenario "Show informing index without links", :js do
       budget.update!(phase: "informing")
       heading = create(:budget_heading, budget: budget)
 
@@ -107,7 +107,7 @@ describe "Budgets" do
 
       within("#budget_info") do
         expect(page).not_to have_link heading.name
-        expect(page).to have_content "#{heading.name} €1,000,000"
+        expect(page).to have_content "#{heading.name}\n€1,000,000"
 
         expect(page).not_to have_link("List of all investment projects")
         expect(page).not_to have_link("List of all unfeasible investment projects")
@@ -117,7 +117,7 @@ describe "Budgets" do
       end
     end
 
-    scenario "Show finished index without heading links" do
+    scenario "Show finished index without heading links", :js do
       budget.update!(phase: "finished")
       heading = create(:budget_heading, budget: budget)
 
@@ -125,7 +125,7 @@ describe "Budgets" do
 
       within("#budget_info") do
         expect(page).not_to have_link heading.name
-        expect(page).to have_content "#{heading.name} €1,000,000"
+        expect(page).to have_content "#{heading.name}\n€1,000,000"
 
         expect(page).to have_css("div.map")
       end

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -16,7 +16,7 @@ describe "Budgets" do
   end
 
   context "Index" do
-    scenario "Show normal index with links", :js do
+    scenario "Show normal index with links" do
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
       heading1 = create(:budget_heading, group: group1)
@@ -99,7 +99,7 @@ describe "Budgets" do
       end
     end
 
-    scenario "Show informing index without links", :js do
+    scenario "Show informing index without links" do
       budget.update!(phase: "informing")
       heading = create(:budget_heading, budget: budget)
 
@@ -117,7 +117,7 @@ describe "Budgets" do
       end
     end
 
-    scenario "Show finished index without heading links", :js do
+    scenario "Show finished index without heading links" do
       budget.update!(phase: "finished")
       heading = create(:budget_heading, budget: budget)
 
@@ -149,7 +149,7 @@ describe "Budgets" do
     end
   end
 
-  scenario "Index shows only published phases", :js do
+  scenario "Index shows only published phases" do
     budget.update!(phase: :finished)
     phases = budget.phases
 
@@ -230,7 +230,7 @@ describe "Budgets" do
       Setting["feature.map"] = true
     end
 
-    scenario "Display investment's map location markers", :js do
+    scenario "Display investment's map location markers" do
       investment1 = create(:budget_investment, heading: heading)
       investment2 = create(:budget_investment, heading: heading)
       investment3 = create(:budget_investment, heading: heading)
@@ -246,7 +246,7 @@ describe "Budgets" do
       end
     end
 
-    scenario "Display all investment's map location if there are no selected", :js do
+    scenario "Display all investment's map location if there are no selected" do
       budget.update!(phase: :publishing_prices)
 
       investment1 = create(:budget_investment, heading: heading)
@@ -266,7 +266,7 @@ describe "Budgets" do
       end
     end
 
-    scenario "Display only selected investment's map location from publishing prices phase", :js do
+    scenario "Display only selected investment's map location from publishing prices phase" do
       budget.update!(phase: :publishing_prices)
 
       investment1 = create(:budget_investment, :selected, heading: heading)
@@ -286,7 +286,7 @@ describe "Budgets" do
       end
     end
 
-    scenario "Skip invalid map markers", :js do
+    scenario "Skip invalid map markers" do
       map_locations = []
 
       investment = create(:budget_investment, heading: heading)

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -149,7 +149,7 @@ describe "Budgets" do
     end
   end
 
-  scenario "Index shows only published phases" do
+  scenario "Index shows only published phases", :js do
     budget.update!(phase: :finished)
     phases = budget.phases
 
@@ -185,35 +185,15 @@ describe "Budgets" do
 
     visit budgets_path
 
-    expect(page).not_to have_content "Description of reviewing phase"
-    expect(page).not_to have_content "January 11, 2018 - January 20, 2018"
-    expect(page).not_to have_content "Description of valuating phase"
-    expect(page).not_to have_content "February 10, 2018 - February 20, 2018"
-    expect(page).not_to have_content "Description of publishing_prices phase"
-    expect(page).not_to have_content "February 21, 2018 - March 01, 2018"
-    expect(page).not_to have_content "Description of reviewing_ballots phase"
-    expect(page).not_to have_content "March 11, 2018 - March 20, 2018"
+    expect(page).not_to have_link "Reviewing projects"
+    expect(page).not_to have_link "Valuating projects"
+    expect(page).not_to have_link "Publishing projects prices"
+    expect(page).not_to have_link "Reviewing voting"
+
+    click_link "Custom name for informing phase"
 
     expect(page).to have_content "Description of informing phase"
     expect(page).to have_content "December 30, 2017 - December 31, 2017"
-    expect(page).to have_content "Description of accepting phase"
-    expect(page).to have_content "January 01, 2018 - January 20, 2018"
-    expect(page).to have_content "Description of selecting phase"
-    expect(page).to have_content "January 21, 2018 - March 01, 2018"
-    expect(page).to have_content "Description of balloting phase"
-    expect(page).to have_content "March 02, 2018 - March 20, 2018"
-    expect(page).to have_content "Description of finished phase"
-    expect(page).to have_content "March 21, 2018 - March 29, 2018"
-
-    expect(page).to have_css(".tabs-panel.is-active", count: 1)
-
-    within("#budget_phases_tabs") do
-      expect(page).to have_link "Custom name for informing phase"
-      expect(page).to have_link "Custom name for accepting phase"
-      expect(page).to have_link "Custom name for selecting phase"
-      expect(page).to have_link phases.balloting.name
-      expect(page).to have_link "Current phase #{phases.finished.name}"
-    end
 
     click_link "Custom name for accepting phase"
 
@@ -221,6 +201,26 @@ describe "Budgets" do
       expect(page).to have_link "Previous phase", href: "#phase-1-custom-name-for-informing-phase"
       expect(page).to have_link "Next phase", href: "#phase-3-custom-name-for-selecting-phase"
     end
+
+    expect(page).to have_content "Description of accepting phase"
+    expect(page).to have_content "January 01, 2018 - January 20, 2018"
+
+    click_link "Custom name for selecting phase"
+
+    expect(page).to have_content "Description of selecting phase"
+    expect(page).to have_content "January 21, 2018 - March 01, 2018"
+
+    click_link "Voting projects"
+
+    expect(page).to have_content "Description of balloting phase"
+    expect(page).to have_content "March 02, 2018 - March 20, 2018"
+
+    click_link "Current phase Finished budget"
+
+    expect(page).to have_content "Description of finished phase"
+    expect(page).to have_content "March 21, 2018 - March 29, 2018"
+
+    expect(page).to have_css(".tabs-panel.is-active", count: 1)
   end
 
   context "Index map" do

--- a/spec/system/budgets/executions_spec.rb
+++ b/spec/system/budgets/executions_spec.rb
@@ -60,7 +60,7 @@ describe "Executions" do
     expect(page).not_to have_content(empty_heading.name)
   end
 
-  scenario "Show message when there are no winning investments with the selected status", :js do
+  scenario "Show message when there are no winning investments with the selected status" do
     create(:milestone_status, name: I18n.t("seeds.budgets.statuses.executed"))
 
     visit budget_path(budget)
@@ -152,7 +152,7 @@ describe "Executions" do
       expect(page).to have_content("#{status2.name} (1)")
     end
 
-    scenario "by milestone status", :js do
+    scenario "by milestone status" do
       create(:milestone, milestoneable: investment1, status: status1)
       create(:milestone, milestoneable: investment2, status: status2)
       create(:milestone_status, name: I18n.t("seeds.budgets.statuses.executing_project"))
@@ -181,7 +181,7 @@ describe "Executions" do
       expect(page).not_to have_content(investment2.title)
     end
 
-    scenario "are based on latest milestone status", :js do
+    scenario "are based on latest milestone status" do
       create(:milestone, milestoneable: investment1,
                          publication_date: 1.month.ago,
                          status: status1)
@@ -201,7 +201,7 @@ describe "Executions" do
       expect(page).to have_content(investment1.title)
     end
 
-    scenario "milestones with future dates are not shown", :js do
+    scenario "milestones with future dates are not shown" do
       create(:milestone, milestoneable: investment1,
                          publication_date: Date.yesterday,
                          status: status1)
@@ -221,7 +221,7 @@ describe "Executions" do
       expect(page).not_to have_content(investment1.title)
     end
 
-    scenario "by milestone tag, only display tags for winner investments", :js do
+    scenario "by milestone tag, only display tags for winner investments" do
       create(:milestone, milestoneable: investment1, status: status1)
       create(:milestone, milestoneable: investment2, status: status2)
       create(:milestone, milestoneable: investment3, status: status2)

--- a/spec/system/budgets/groups_spec.rb
+++ b/spec/system/budgets/groups_spec.rb
@@ -26,7 +26,7 @@ describe "Budget Groups" do
       expect(first_heading.name).to appear_before(last_heading.name)
     end
 
-    scenario "Links to investment filters", :js do
+    scenario "Links to investment filters" do
       create(:budget_heading, group: group, name: "Southwest")
       budget.update!(phase: "finished")
 
@@ -45,7 +45,7 @@ describe "Budget Groups" do
       expect(page).not_to have_link "See investments not selected for balloting phase unfeasible investments"
     end
 
-    scenario "Back link", :js do
+    scenario "Back link" do
       visit budget_group_path(budget, group)
 
       click_link "Go back"

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -997,7 +997,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Author can destroy while on the accepting phase" do
+    scenario "Author can destroy while on the accepting phase", :js do
       user = create(:user, :level_two)
       investment1 = create(:budget_investment, heading: heading, price: 10000, author: user)
 
@@ -1006,7 +1006,8 @@ describe "Budget Investments" do
 
       within("#budget_investment_#{investment1.id}") do
         expect(page).to have_content(investment1.title)
-        click_link("Delete")
+
+        accept_confirm { click_link("Delete") }
       end
 
       visit user_path(user, tab: :budget_investments)

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -372,8 +372,8 @@ describe "Budget Investments" do
         expect(medium_proposal.title).to appear_before(worst_proposal.title)
       end
 
-      expect(current_url).to include("order=confidence_score")
-      expect(current_url).to include("page=1")
+      expect(page).to have_current_path(/order=confidence_score/)
+      expect(page).to have_current_path(/page=1/)
     end
 
     scenario "Each user has a different and consistent random budget investment order" do
@@ -1192,8 +1192,8 @@ describe "Budget Investments" do
         expect(mid_investment.title).to appear_before(low_investment.title)
       end
 
-      expect(current_url).to include("order=price")
-      expect(current_url).to include("page=1")
+      expect(page).to have_current_path(/order=price/)
+      expect(page).to have_current_path(/page=1/)
     end
 
     scenario "Show" do

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -501,7 +501,7 @@ describe "Budget Investments" do
   context "Phase I - Accepting" do
     before { budget.update(phase: "accepting") }
 
-    scenario "Create with invisible_captcha honeypot field" do
+    scenario "Create with invisible_captcha honeypot field", :no_js do
       login_as(author)
       visit new_budget_investment_path(budget)
 

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -112,7 +112,7 @@ describe "Budget Investments" do
     end
   end
 
-  scenario "Index should show a map if heading has coordinates defined", :js do
+  scenario "Index should show a map if heading has coordinates defined" do
     create(:budget_investment, heading: heading)
     visit budget_investments_path(budget, heading_id: heading.id)
     within("#sidebar") do
@@ -128,7 +128,7 @@ describe "Budget Investments" do
     end
   end
 
-  scenario "Index filter by status", :js do
+  scenario "Index filter by status" do
     budget.update!(phase: "finished")
 
     create(:budget_investment, :feasible, heading: heading, title: "Feasible investment")
@@ -240,7 +240,7 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "unfeasible", :js do
+      scenario "unfeasible" do
         investment1 = create(:budget_investment, :unfeasible, :finished, heading: heading)
         investment2 = create(:budget_investment, :feasible, heading: heading)
 
@@ -305,7 +305,7 @@ describe "Budget Investments" do
       expect(order).to eq(new_order)
     end
 
-    scenario "Random order maintained with pagination", :js do
+    scenario "Random order maintained with pagination" do
       (per_page + 2).times { create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
@@ -338,7 +338,7 @@ describe "Budget Investments" do
       expect(order).to eq(new_order)
     end
 
-    scenario "Investments are not repeated with random order", :js do
+    scenario "Investments are not repeated with random order" do
       (per_page + 2).times { create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, order: "random")
@@ -376,7 +376,7 @@ describe "Budget Investments" do
       expect(page).to have_current_path(/page=1/)
     end
 
-    scenario "Each user has a different and consistent random budget investment order", :js do
+    scenario "Each user has a different and consistent random budget investment order" do
       (per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
       first_user_investments_order = nil
       second_user_investments_order = nil
@@ -518,7 +518,7 @@ describe "Budget Investments" do
       expect(page).to have_current_path(budget_investments_path(budget))
     end
 
-    scenario "Create budget investment too fast", :js do
+    scenario "Create budget investment too fast" do
       allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
 
       login_as(author)
@@ -535,7 +535,7 @@ describe "Budget Investments" do
       expect(page).to have_current_path(new_budget_investment_path(budget))
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       login_as(author)
 
       visit new_budget_investment_path(budget)
@@ -562,7 +562,7 @@ describe "Budget Investments" do
       expect(page).to have_content "Build a skyscraper"
     end
 
-    scenario "Edit", :js do
+    scenario "Edit" do
       daniel = create(:user, :level_two)
 
       create(:budget_investment, heading: heading, title: "Get Schwifty", author: daniel, created_at: 1.day.ago)
@@ -619,7 +619,7 @@ describe "Budget Investments" do
     context "Suggest" do
       factory = :budget_investment
 
-      scenario "Show up to 5 suggestions", :js do
+      scenario "Show up to 5 suggestions" do
         %w[first second third fourth fifth sixth].each do |ordinal|
           create(factory, title: "#{ordinal.titleize} #{factory}, has search term", budget: budget)
         end
@@ -634,7 +634,7 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "No found suggestions", :js do
+      scenario "No found suggestions" do
         %w[first second third fourth fifth sixth].each do |ordinal|
           create(factory, title: "#{ordinal.titleize} #{factory}, has search term", budget: budget)
         end
@@ -648,7 +648,7 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "Don't show suggestions from a different budget", :js do
+      scenario "Don't show suggestions from a different budget" do
         %w[first second third fourth fifth sixth].each do |ordinal|
           create(factory, title: "#{ordinal.titleize} #{factory}, has search term", budget: budget)
         end
@@ -919,7 +919,7 @@ describe "Budget Investments" do
     expect(page).to have_content("This investment project has not been selected for balloting phase")
   end
 
-  scenario "Show title (no message)", :js do
+  scenario "Show title (no message)" do
     investment = create(:budget_investment,
                         :feasible,
                         :finished,
@@ -997,7 +997,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Author can destroy while on the accepting phase", :js do
+    scenario "Author can destroy while on the accepting phase" do
       user = create(:user, :level_two)
       investment1 = create(:budget_investment, heading: heading, price: 10000, author: user)
 
@@ -1020,7 +1020,7 @@ describe "Budget Investments" do
     end
 
     context "Popup alert to vote only in one heading per group" do
-      scenario "When supporting in the first heading group", :js do
+      scenario "When supporting in the first heading group" do
         carabanchel = create(:budget_heading, group: group)
         salamanca   = create(:budget_heading, group: group)
 
@@ -1035,7 +1035,7 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "When already supported in the group", :js do
+      scenario "When already supported in the group" do
         carabanchel = create(:budget_heading, group: group)
         salamanca   = create(:budget_heading, group: group)
 
@@ -1050,7 +1050,7 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "When supporting in another group", :js do
+      scenario "When supporting in another group" do
         heading = create(:budget_heading, group: group)
 
         group2 = create(:budget_group, budget: budget)
@@ -1068,7 +1068,7 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "When supporting in a group with a single heading", :js do
+      scenario "When supporting in a group with a single heading" do
         all_city_investment = create(:budget_investment, heading: heading)
 
         login_as(author)
@@ -1080,7 +1080,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Sidebar in show should display support text", :js do
+    scenario "Sidebar in show should display support text" do
       investment = create(:budget_investment, budget: budget)
       visit budget_investment_path(budget, investment)
 
@@ -1095,7 +1095,7 @@ describe "Budget Investments" do
       budget.update(phase: "valuating")
     end
 
-    scenario "Sidebar in show should display support text and count", :js do
+    scenario "Sidebar in show should display support text and count" do
       investment = create(:budget_investment, :selected, budget: budget, voters: [create(:user)])
 
       visit budget_investment_path(budget, investment)
@@ -1116,7 +1116,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Show should display support text and count", :js do
+    scenario "Show should display support text and count" do
       investment = create(:budget_investment, budget: budget, heading: heading, voters: [create(:user)])
 
       visit budget_investment_path(budget, investment)
@@ -1209,7 +1209,7 @@ describe "Budget Investments" do
       expect(page).to have_content "€10,000"
     end
 
-    scenario "Sidebar in show should display vote text", :js do
+    scenario "Sidebar in show should display vote text" do
       investment = create(:budget_investment, :selected, budget: budget)
       visit budget_investment_path(budget, investment)
 
@@ -1218,7 +1218,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Confirm", :js do
+    scenario "Confirm" do
       budget.update!(phase: "balloting")
       user = create(:user, :level_two)
 
@@ -1276,7 +1276,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Highlight voted heading except with unfeasible filter", :js do
+    scenario "Highlight voted heading except with unfeasible filter" do
       budget.update!(phase: "balloting")
       user = create(:user, :level_two)
 
@@ -1304,7 +1304,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Ballot is visible", :js do
+    scenario "Ballot is visible" do
       login_as(author)
 
       visit budget_investments_path(budget, heading_id: heading.id)
@@ -1394,7 +1394,7 @@ describe "Budget Investments" do
   end
 
   context "sidebar map" do
-    scenario "Display 6 investment's markers on sidebar map", :js do
+    scenario "Display 6 investment's markers on sidebar map" do
       investment1 = create(:budget_investment, heading: heading)
       investment2 = create(:budget_investment, heading: heading)
       investment3 = create(:budget_investment, heading: heading)
@@ -1416,7 +1416,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Display 2 investment's markers on sidebar map", :js do
+    scenario "Display 2 investment's markers on sidebar map" do
       investment1 = create(:budget_investment, heading: heading)
       investment2 = create(:budget_investment, heading: heading)
 
@@ -1430,7 +1430,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Display only investment's related to the current heading", :js do
+    scenario "Display only investment's related to the current heading" do
       heading_2 = create(:budget_heading, name: "Madrid", group: group)
 
       investment1 = create(:budget_investment, heading: heading)
@@ -1454,7 +1454,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Do not display investment's, since they're all related to other heading", :js do
+    scenario "Do not display investment's, since they're all related to other heading" do
       heading_2 = create(:budget_heading, name: "Madrid", group: group)
 
       investment1 = create(:budget_investment, heading: heading_2)
@@ -1472,7 +1472,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Shows all investments and not only the ones on the current page", :js do
+    scenario "Shows all investments and not only the ones on the current page" do
       stub_const("#{Budgets::InvestmentsController}::PER_PAGE", 2)
 
       3.times do
@@ -1505,7 +1505,7 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "Contains edit button in the accepting phase", :js do
+      scenario "Contains edit button in the accepting phase" do
         investment = create(:budget_investment, heading: heading, author: author)
 
         login_as(author)
@@ -1518,7 +1518,7 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "Contains remove image button in phases different from accepting", :js do
+      scenario "Contains remove image button in phases different from accepting" do
         budget.update!(phase: "reviewing")
         investment = create(:budget_investment, :with_image, heading: heading, author: author)
 
@@ -1541,7 +1541,7 @@ describe "Budget Investments" do
       budget.update!(phase: "accepting")
     end
 
-    scenario "create budget investment with sdg related list", :js do
+    scenario "create budget investment with sdg related list" do
       login_as(author)
       visit new_budget_investment_path(budget)
       select heading.name, from: "Heading"
@@ -1555,7 +1555,7 @@ describe "Budget Investments" do
       within(".sdg-goal-tag-list") { expect(page).to have_link "1. No Poverty" }
     end
 
-    scenario "edit budget investment with sdg related list", :js do
+    scenario "edit budget investment with sdg related list" do
       investment = create(:budget_investment, heading: heading, author: author)
       investment.sdg_goals = [SDG::Goal[1], SDG::Goal[2]]
       login_as(author)

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -305,7 +305,7 @@ describe "Budget Investments" do
       expect(order).to eq(new_order)
     end
 
-    scenario "Random order maintained with pagination" do
+    scenario "Random order maintained with pagination", :js do
       (per_page + 2).times { create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
@@ -314,10 +314,10 @@ describe "Budget Investments" do
       expect(order).not_to be_empty
 
       click_link "Next"
-      expect(page).to have_content "You're on page 2"
+      expect(page).to have_css ".pagination .current", text: "2"
 
       click_link "Previous"
-      expect(page).to have_content "You're on page 1"
+      expect(page).to have_css ".pagination .current", text: "1"
 
       new_order = all(".budget-investment h3").map(&:text)
       expect(order).to eq(new_order)
@@ -338,7 +338,7 @@ describe "Budget Investments" do
       expect(order).to eq(new_order)
     end
 
-    scenario "Investments are not repeated with random order" do
+    scenario "Investments are not repeated with random order", :js do
       (per_page + 2).times { create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, order: "random")
@@ -346,7 +346,7 @@ describe "Budget Investments" do
       first_page_investments = investments_order
 
       click_link "Next"
-      expect(page).to have_content "You're on page 2"
+      expect(page).to have_css ".pagination .current", text: "2"
 
       second_page_investments = investments_order
 
@@ -376,7 +376,7 @@ describe "Budget Investments" do
       expect(page).to have_current_path(/page=1/)
     end
 
-    scenario "Each user has a different and consistent random budget investment order" do
+    scenario "Each user has a different and consistent random budget investment order", :js do
       (per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
       first_user_investments_order = nil
       second_user_investments_order = nil
@@ -395,20 +395,20 @@ describe "Budget Investments" do
 
       in_browser(:one) do
         click_link "Next"
-        expect(page).to have_content "You're on page 2"
+        expect(page).to have_css ".pagination .current", text: "2"
 
         click_link "Previous"
-        expect(page).to have_content "You're on page 1"
+        expect(page).to have_css ".pagination .current", text: "1"
 
         expect(investments_order).to eq(first_user_investments_order)
       end
 
       in_browser(:two) do
         click_link "Next"
-        expect(page).to have_content "You're on page 2"
+        expect(page).to have_css ".pagination .current", text: "2"
 
         click_link "Previous"
-        expect(page).to have_content "You're on page 1"
+        expect(page).to have_css ".pagination .current", text: "1"
 
         expect(investments_order).to eq(second_user_investments_order)
       end
@@ -919,7 +919,7 @@ describe "Budget Investments" do
     expect(page).to have_content("This investment project has not been selected for balloting phase")
   end
 
-  scenario "Show title (no message)" do
+  scenario "Show title (no message)", :js do
     investment = create(:budget_investment,
                         :feasible,
                         :finished,
@@ -932,7 +932,7 @@ describe "Budget Investments" do
     visit budget_investment_path(budget, id: investment.id)
 
     within("aside") do
-      expect(page).to have_content("Investment project")
+      expect(page).to have_content("INVESTMENT PROJECT")
       expect(page).to have_css(".label-budget-investment")
     end
   end
@@ -1080,12 +1080,12 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Sidebar in show should display support text" do
+    scenario "Sidebar in show should display support text", :js do
       investment = create(:budget_investment, budget: budget)
       visit budget_investment_path(budget, investment)
 
       within("aside") do
-        expect(page).to have_content "Supports"
+        expect(page).to have_content "SUPPORTS"
       end
     end
   end
@@ -1095,13 +1095,13 @@ describe "Budget Investments" do
       budget.update(phase: "valuating")
     end
 
-    scenario "Sidebar in show should display support text and count" do
+    scenario "Sidebar in show should display support text and count", :js do
       investment = create(:budget_investment, :selected, budget: budget, voters: [create(:user)])
 
       visit budget_investment_path(budget, investment)
 
       within("aside") do
-        expect(page).to have_content "Supports"
+        expect(page).to have_content "SUPPORTS"
         expect(page).to have_content "1 support"
       end
     end
@@ -1116,13 +1116,13 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Show should display support text and count" do
+    scenario "Show should display support text and count", :js do
       investment = create(:budget_investment, budget: budget, heading: heading, voters: [create(:user)])
 
       visit budget_investment_path(budget, investment)
 
       within("#budget_investment_#{investment.id}") do
-        expect(page).to have_content "Supports"
+        expect(page).to have_content "SUPPORTS"
         expect(page).to have_content "1 support"
       end
     end
@@ -1209,12 +1209,12 @@ describe "Budget Investments" do
       expect(page).to have_content "€10,000"
     end
 
-    scenario "Sidebar in show should display vote text" do
+    scenario "Sidebar in show should display vote text", :js do
       investment = create(:budget_investment, :selected, budget: budget)
       visit budget_investment_path(budget, investment)
 
       within("aside") do
-        expect(page).to have_content "Votes"
+        expect(page).to have_content "VOTES"
       end
     end
 
@@ -1304,7 +1304,7 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Ballot is visible" do
+    scenario "Ballot is visible", :js do
       login_as(author)
 
       visit budget_investments_path(budget, heading_id: heading.id)
@@ -1313,7 +1313,7 @@ describe "Budget Investments" do
       expect(page).to have_css("#progress_bar")
 
       within("#sidebar") do
-        expect(page).to have_content("My ballot")
+        expect(page).to have_content("MY BALLOT")
         expect(page).to have_link("Submit my ballot")
       end
     end
@@ -1505,20 +1505,20 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "Contains edit button in the accepting phase" do
+      scenario "Contains edit button in the accepting phase", :js do
         investment = create(:budget_investment, heading: heading, author: author)
 
         login_as(author)
         visit budget_investment_path(budget, investment)
 
         within("aside") do
-          expect(page).to have_content "Author"
+          expect(page).to have_content "AUTHOR"
           expect(page).to have_link "Edit"
           expect(page).not_to have_link "Remove image"
         end
       end
 
-      scenario "Contains remove image button in phases different from accepting" do
+      scenario "Contains remove image button in phases different from accepting", :js do
         budget.update!(phase: "reviewing")
         investment = create(:budget_investment, :with_image, heading: heading, author: author)
 
@@ -1526,7 +1526,7 @@ describe "Budget Investments" do
         visit budget_investment_path(budget, investment)
 
         within("aside") do
-          expect(page).to have_content "Author"
+          expect(page).to have_content "AUTHOR"
           expect(page).not_to have_link "Edit"
           expect(page).to have_link "Remove image"
         end

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -518,7 +518,7 @@ describe "Budget Investments" do
       expect(page).to have_current_path(budget_investments_path(budget))
     end
 
-    scenario "Create budget investment too fast" do
+    scenario "Create budget investment too fast", :js do
       allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
 
       login_as(author)
@@ -526,7 +526,7 @@ describe "Budget Investments" do
 
       select  heading.name, from: "budget_investment_heading_id"
       fill_in "Title", with: "I am a bot"
-      fill_in "Description", with: "This is the description"
+      fill_in_ckeditor "Description", with: "This is the description"
       check   "budget_investment_terms_of_service"
 
       click_button "Create Investment"
@@ -535,14 +535,14 @@ describe "Budget Investments" do
       expect(page).to have_current_path(new_budget_investment_path(budget))
     end
 
-    scenario "Create" do
+    scenario "Create", :js do
       login_as(author)
 
       visit new_budget_investment_path(budget)
 
       select  heading.name, from: "budget_investment_heading_id"
       fill_in "Title", with: "Build a skyscraper"
-      fill_in "Description", with: "I want to live in a high tower over the clouds"
+      fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
       fill_in "budget_investment_location", with: "City center"
       fill_in "budget_investment_organization_name", with: "T.I.A."
       fill_in "budget_investment_tag_list", with: "Towers"

--- a/spec/system/budgets/results_spec.rb
+++ b/spec/system/budgets/results_spec.rb
@@ -48,7 +48,7 @@ describe "Results" do
     end
   end
 
-  scenario "Show non winner & incomaptible investments", :js do
+  scenario "Show non winner & incomaptible investments" do
     visit budget_path(budget)
     click_link "See results"
     click_link "Show all"
@@ -112,7 +112,7 @@ describe "Results" do
     expect(page).to have_content "You do not have permission to carry out the action"
   end
 
-  scenario "No incompatible investments", :js do
+  scenario "No incompatible investments" do
     investment3.incompatible = false
     investment3.save!
 

--- a/spec/system/budgets/votes_spec.rb
+++ b/spec/system/budgets/votes_spec.rb
@@ -36,7 +36,7 @@ describe "Votes" do
         end
       end
 
-      scenario "Create from investments' index", :js do
+      scenario "Create from investments' index" do
         create(:budget_investment, heading: heading)
 
         visit budget_investments_path(budget, heading_id: heading.id)
@@ -59,7 +59,7 @@ describe "Votes" do
         expect(page).to have_content "No supports"
       end
 
-      scenario "Trying to vote multiple times", :js do
+      scenario "Trying to vote multiple times" do
         visit budget_investment_path(budget, investment)
 
         within(".supports") do
@@ -70,7 +70,7 @@ describe "Votes" do
         end
       end
 
-      scenario "Create from investment show", :js do
+      scenario "Create from investment show" do
         visit budget_investment_path(budget, investment)
 
         within(".supports") do
@@ -83,7 +83,7 @@ describe "Votes" do
       end
     end
 
-    scenario "Disable voting on investments", :js do
+    scenario "Disable voting on investments" do
       budget.update!(phase: "reviewing")
       investment = create(:budget_investment, heading: heading)
 
@@ -116,7 +116,7 @@ describe "Votes" do
         group.update(max_votable_headings: 2)
       end
 
-      scenario "From Index", :js do
+      scenario "From Index" do
         visit budget_investments_path(budget, heading_id: new_york.id)
 
         within("#budget_investment_#{new_york_investment.id}") do
@@ -157,7 +157,7 @@ describe "Votes" do
         end
       end
 
-      scenario "From show", :js do
+      scenario "From show" do
         visit budget_investment_path(budget, new_york_investment)
 
         accept_confirm { find(".in-favor a").click }
@@ -187,7 +187,7 @@ describe "Votes" do
                                          "Share it!"
       end
 
-      scenario "Confirm message shows the right text", :js do
+      scenario "Confirm message shows the right text" do
         visit budget_investments_path(budget, heading_id: new_york.id)
         find(".in-favor a").click
 
@@ -200,7 +200,7 @@ describe "Votes" do
     let(:budget) { create(:budget, :balloting, :approval) }
     before { login_as(manuela) }
 
-    scenario "Budget limit is ignored", :js do
+    scenario "Budget limit is ignored" do
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group, max_ballot_lines: 2)
       investment1 = create(:budget_investment, :selected, heading: heading, price: heading.price)

--- a/spec/system/ckeditor_spec.rb
+++ b/spec/system/ckeditor_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "CKEditor" do
-  scenario "is present before & after turbolinks update page", :js do
+  scenario "is present before & after turbolinks update page" do
     author = create(:user)
     login_as(author)
 
@@ -15,7 +15,7 @@ describe "CKEditor" do
     expect(page).to have_css ".translatable-fields[data-locale='en'] .cke_wysiwyg_frame"
   end
 
-  scenario "uploading an image through the upload tab", :js, :admin do
+  scenario "uploading an image through the upload tab", :admin do
     visit new_admin_site_customization_page_path
     fill_in_ckeditor "Content", with: "Filling in to make sure CKEditor is loaded"
     find(".cke_button__image").click
@@ -38,7 +38,7 @@ describe "CKEditor" do
     expect(page).to have_css "img[src$='clippy.jpg']"
   end
 
-  scenario "cannot upload attachments through link tab", :js, :admin do
+  scenario "cannot upload attachments through link tab", :admin do
     visit new_admin_site_customization_page_path
     fill_in_ckeditor "Content", with: "Filling in to make sure CKEditor is loaded"
     find(".cke_button__link").click
@@ -49,7 +49,7 @@ describe "CKEditor" do
   end
 
   context "When navigating back to editor page using browser history back" do
-    scenario "display ckeditor unsaved contents", :js, :admin do
+    scenario "display ckeditor unsaved contents", :admin do
       visit new_admin_newsletter_path
       fill_in_ckeditor "Email content", with: "This is an unsaved body"
       click_link "Newsletters"

--- a/spec/system/comments/budget_investments_spec.rb
+++ b/spec/system/comments/budget_investments_spec.rb
@@ -58,7 +58,7 @@ describe "Commenting Budget::Investments" do
     expect(page).to have_current_path(comment_path(comment))
   end
 
-  scenario "Collapsable comments", :js do
+  scenario "Collapsable comments" do
     parent_comment = create(:comment, body: "Main comment", commentable: investment)
     child_comment  = create(:comment, body: "First subcomment", commentable: investment, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: investment, parent: child_comment)
@@ -197,7 +197,7 @@ describe "Commenting Budget::Investments" do
     end
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     login_as(user)
     visit budget_investment_path(investment.budget, investment)
 
@@ -213,7 +213,7 @@ describe "Commenting Budget::Investments" do
     end
   end
 
-  scenario "Errors on create", :js do
+  scenario "Errors on create" do
     login_as(user)
     visit budget_investment_path(investment.budget, investment)
 
@@ -222,7 +222,7 @@ describe "Commenting Budget::Investments" do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario "Reply", :js do
+  scenario "Reply" do
     citizen = create(:user, username: "Ana")
     manuela = create(:user, username: "Manuela")
     comment = create(:comment, commentable: investment, user: citizen)
@@ -244,7 +244,7 @@ describe "Commenting Budget::Investments" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}")
   end
 
-  scenario "Reply update parent comment responses count", :js do
+  scenario "Reply update parent comment responses count" do
     comment = create(:comment, commentable: investment)
 
     login_as(create(:user))
@@ -259,7 +259,7 @@ describe "Commenting Budget::Investments" do
     end
   end
 
-  scenario "Reply show parent comments responses when hidden", :js do
+  scenario "Reply show parent comments responses when hidden" do
     comment = create(:comment, commentable: investment)
     create(:comment, commentable: investment, parent: comment)
 
@@ -276,7 +276,7 @@ describe "Commenting Budget::Investments" do
     end
   end
 
-  scenario "Errors on reply", :js do
+  scenario "Errors on reply" do
     comment = create(:comment, commentable: investment, user: user)
 
     login_as(user)
@@ -290,7 +290,7 @@ describe "Commenting Budget::Investments" do
     end
   end
 
-  scenario "N replies", :js do
+  scenario "N replies" do
     parent = create(:comment, commentable: investment)
 
     7.times do
@@ -315,7 +315,7 @@ describe "Commenting Budget::Investments" do
   end
 
   describe "Moderators" do
-    scenario "can create comment as a moderator", :js do
+    scenario "can create comment as a moderator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -333,7 +333,7 @@ describe "Commenting Budget::Investments" do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    scenario "can create reply as a moderator" do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -372,7 +372,7 @@ describe "Commenting Budget::Investments" do
 
   describe "Administrators" do
     context "comment as administrator" do
-      scenario "can create comment", :js do
+      scenario "can create comment" do
         admin = create(:administrator)
 
         login_as(admin.user)
@@ -390,7 +390,7 @@ describe "Commenting Budget::Investments" do
         end
       end
 
-      scenario "display administrator description on admin views", :js do
+      scenario "display administrator description on admin views" do
         admin = create(:administrator, description: "user description")
 
         login_as(admin.user)
@@ -415,7 +415,7 @@ describe "Commenting Budget::Investments" do
         end
       end
 
-      scenario "display administrator id on public views", :js do
+      scenario "display administrator id on public views" do
         admin = create(:administrator, description: "user description")
 
         login_as(admin.user)
@@ -433,7 +433,7 @@ describe "Commenting Budget::Investments" do
         end
       end
 
-      scenario "can create reply as an administrator", :js do
+      scenario "can create reply as an administrator" do
         citizen = create(:user, username: "Ana")
         manuela = create(:user, username: "Manuela")
         admin   = create(:administrator, user: manuela)
@@ -460,7 +460,7 @@ describe "Commenting Budget::Investments" do
         expect(page).to have_css "div.is-admin"
       end
 
-      scenario "public users not see admin description", :js do
+      scenario "public users not see admin description" do
         manuela = create(:user, username: "Manuela")
         admin   = create(:administrator, user: manuela)
         comment = create(:comment,
@@ -516,7 +516,7 @@ describe "Commenting Budget::Investments" do
       end
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       visit budget_investment_path(budget, investment)
 
       within("#comment_#{comment.id}_votes") do
@@ -534,7 +534,7 @@ describe "Commenting Budget::Investments" do
       end
     end
 
-    scenario "Update", :js do
+    scenario "Update" do
       visit budget_investment_path(budget, investment)
 
       within("#comment_#{comment.id}_votes") do
@@ -558,7 +558,7 @@ describe "Commenting Budget::Investments" do
       end
     end
 
-    scenario "Trying to vote multiple times", :js do
+    scenario "Trying to vote multiple times" do
       visit budget_investment_path(budget, investment)
 
       within("#comment_#{comment.id}_votes") do

--- a/spec/system/comments/budget_investments_spec.rb
+++ b/spec/system/comments/budget_investments_spec.rb
@@ -7,7 +7,7 @@ describe "Commenting Budget::Investments" do
   it_behaves_like "flaggable", :budget_investment_comment
 
   scenario "Index" do
-    3.times { create(:comment, commentable: investment) }
+    not_valuations = 3.times.map { create(:comment, commentable: investment) }
     create(:comment, :valuation, commentable: investment, subject: "Not viable")
 
     visit budget_investment_path(investment.budget, investment)
@@ -16,7 +16,7 @@ describe "Commenting Budget::Investments" do
     expect(page).not_to have_content("Not viable")
 
     within("#comments") do
-      Comment.not_valuations.last(3).each do |comment|
+      not_valuations.each do |comment|
         expect(page).to have_content comment.user.name
         expect(page).to have_content I18n.l(comment.created_at, format: :datetime)
         expect(page).to have_content comment.body

--- a/spec/system/comments/budget_investments_valuation_spec.rb
+++ b/spec/system/comments/budget_investments_valuation_spec.rb
@@ -58,7 +58,7 @@ describe "Internal valuation comments on Budget::Investments" do
       end
     end
 
-    scenario "Collapsable comments", :js do
+    scenario "Collapsable comments" do
       parent_comment = create(:comment, :valuation, author: valuator_user, body: "Main comment",
                                                     commentable: investment)
       child_comment  = create(:comment, :valuation, author: valuator_user, body: "First subcomment",
@@ -171,7 +171,7 @@ describe "Internal valuation comments on Budget::Investments" do
       expect(comment.errors.size).to eq(1)
     end
 
-    scenario "Create comment", :js do
+    scenario "Create comment" do
       visit valuation_budget_budget_investment_path(budget, investment)
 
       fill_in "Leave your comment", with: "Have you thought about...?"
@@ -185,7 +185,7 @@ describe "Internal valuation comments on Budget::Investments" do
       expect(page).not_to have_content("Have you thought about...?")
     end
 
-    scenario "Errors on create without comment text", :js do
+    scenario "Errors on create without comment text" do
       visit valuation_budget_budget_investment_path(budget, investment)
 
       click_button "Publish comment"
@@ -193,7 +193,7 @@ describe "Internal valuation comments on Budget::Investments" do
       expect(page).to have_content "Can't be blank"
     end
 
-    scenario "Reply to existing valuation", :js do
+    scenario "Reply to existing valuation" do
       comment = create(:comment, :valuation, author: admin_user, commentable: investment)
 
       login_as(valuator_user)
@@ -216,7 +216,7 @@ describe "Internal valuation comments on Budget::Investments" do
       expect(page).not_to have_content("It will be done next week.")
     end
 
-    scenario "Reply update parent comment responses count", :js do
+    scenario "Reply update parent comment responses count" do
       comment = create(:comment, :valuation, author: admin_user, commentable: investment)
 
       login_as(valuator_user)
@@ -231,7 +231,7 @@ describe "Internal valuation comments on Budget::Investments" do
       end
     end
 
-    scenario "Reply show parent comments responses when hidden", :js do
+    scenario "Reply show parent comments responses when hidden" do
       comment = create(:comment, :valuation, author: admin_user, commentable: investment)
       create(:comment, :valuation, author: admin_user, commentable: investment, parent: comment)
 
@@ -248,7 +248,7 @@ describe "Internal valuation comments on Budget::Investments" do
       end
     end
 
-    scenario "Errors on reply without comment text", :js do
+    scenario "Errors on reply without comment text" do
       comment = create(:comment, :valuation, author: admin_user, commentable: investment)
 
       visit valuation_budget_budget_investment_path(budget, investment)
@@ -261,7 +261,7 @@ describe "Internal valuation comments on Budget::Investments" do
       end
     end
 
-    scenario "Multiple nested replies", :js do
+    scenario "Multiple nested replies" do
       parent = create(:comment, :valuation, author: valuator_user, commentable: investment)
 
       7.times do
@@ -291,7 +291,7 @@ describe "Internal valuation comments on Budget::Investments" do
   end
 
   describe "Administrators" do
-    scenario "can create valuation comment as an administrator", :js do
+    scenario "can create valuation comment as an administrator" do
       login_as(admin_user)
       visit valuation_budget_budget_investment_path(budget, investment)
 
@@ -307,7 +307,7 @@ describe "Internal valuation comments on Budget::Investments" do
       end
     end
 
-    scenario "can create valuation reply as an administrator", :js do
+    scenario "can create valuation reply as an administrator" do
       comment = create(:comment, :valuation, author: valuator_user, commentable: investment)
 
       login_as(admin_user)
@@ -332,7 +332,7 @@ describe "Internal valuation comments on Budget::Investments" do
     end
   end
 
-  scenario "Send email notification", :js do
+  scenario "Send email notification" do
     ActionMailer::Base.deliveries = []
 
     login_as(admin_user)

--- a/spec/system/comments/debates_spec.rb
+++ b/spec/system/comments/debates_spec.rb
@@ -8,12 +8,12 @@ describe "Commenting debates" do
 
   scenario "Index" do
     3.times { create(:comment, commentable: debate) }
+    comment = Comment.includes(:user).last
 
     visit debate_path(debate)
 
     expect(page).to have_css(".comment", count: 3)
 
-    comment = Comment.last
     within first(".comment") do
       expect(page).to have_content comment.user.name
       expect(page).to have_content I18n.l(comment.created_at, format: :datetime)

--- a/spec/system/comments/debates_spec.rb
+++ b/spec/system/comments/debates_spec.rb
@@ -55,7 +55,7 @@ describe "Commenting debates" do
     expect(page).to have_current_path(comment_path(comment))
   end
 
-  scenario "Collapsable comments", :js do
+  scenario "Collapsable comments" do
     parent_comment = create(:comment, body: "Main comment", commentable: debate)
     child_comment  = create(:comment, body: "First subcomment", commentable: debate, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: debate, parent: child_comment)
@@ -92,7 +92,7 @@ describe "Commenting debates" do
     expect(page).not_to have_content grandchild_comment.body
   end
 
-  scenario "can collapse comments after adding a reply", :js do
+  scenario "can collapse comments after adding a reply" do
     create(:comment, body: "Main comment", commentable: debate)
 
     login_as(user)
@@ -213,7 +213,7 @@ describe "Commenting debates" do
     end
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     login_as(user)
     visit debate_path(debate)
 
@@ -226,7 +226,7 @@ describe "Commenting debates" do
     end
   end
 
-  scenario "Errors on create", :js do
+  scenario "Errors on create" do
     login_as(user)
     visit debate_path(debate)
 
@@ -235,7 +235,7 @@ describe "Commenting debates" do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario "Reply", :js do
+  scenario "Reply" do
     citizen = create(:user, username: "Ana")
     manuela = create(:user, username: "Manuela")
     comment = create(:comment, commentable: debate, user: citizen)
@@ -257,7 +257,7 @@ describe "Commenting debates" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}")
   end
 
-  scenario "Reply to reply", :js do
+  scenario "Reply to reply" do
     create(:comment, commentable: debate, body: "Any estimates?")
 
     login_as(create(:user))
@@ -282,7 +282,7 @@ describe "Commenting debates" do
     end
   end
 
-  scenario "Reply update parent comment responses count", :js do
+  scenario "Reply update parent comment responses count" do
     comment = create(:comment, commentable: debate)
 
     login_as(create(:user))
@@ -297,7 +297,7 @@ describe "Commenting debates" do
     end
   end
 
-  scenario "Reply show parent comments responses when hidden", :js do
+  scenario "Reply show parent comments responses when hidden" do
     comment = create(:comment, commentable: debate)
     create(:comment, commentable: debate, parent: comment)
 
@@ -314,7 +314,7 @@ describe "Commenting debates" do
     end
   end
 
-  scenario "Errors on reply", :js do
+  scenario "Errors on reply" do
     comment = create(:comment, commentable: debate, user: user)
 
     login_as(user)
@@ -328,7 +328,7 @@ describe "Commenting debates" do
     end
   end
 
-  scenario "N replies", :js do
+  scenario "N replies" do
     parent = create(:comment, commentable: debate)
 
     7.times do
@@ -352,7 +352,7 @@ describe "Commenting debates" do
     end
   end
 
-  scenario "Submit button is disabled after clicking", :js do
+  scenario "Submit button is disabled after clicking" do
     debate = create(:debate)
     login_as(user)
     visit debate_path(debate)
@@ -366,7 +366,7 @@ describe "Commenting debates" do
   end
 
   describe "Moderators" do
-    scenario "can create comment as a moderator", :js do
+    scenario "can create comment as a moderator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -384,7 +384,7 @@ describe "Commenting debates" do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    scenario "can create reply as a moderator" do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -422,7 +422,7 @@ describe "Commenting debates" do
   end
 
   describe "Administrators" do
-    scenario "can create comment as an administrator", :js do
+    scenario "can create comment as an administrator" do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -440,7 +440,7 @@ describe "Commenting debates" do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    scenario "can create reply as an administrator" do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       admin   = create(:administrator, user: manuela)
@@ -503,7 +503,7 @@ describe "Commenting debates" do
       end
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       visit debate_path(debate)
 
       within("#comment_#{comment.id}_votes") do
@@ -521,7 +521,7 @@ describe "Commenting debates" do
       end
     end
 
-    scenario "Update", :js do
+    scenario "Update" do
       visit debate_path(debate)
 
       within("#comment_#{comment.id}_votes") do
@@ -545,7 +545,7 @@ describe "Commenting debates" do
       end
     end
 
-    scenario "Trying to vote multiple times", :js do
+    scenario "Trying to vote multiple times" do
       visit debate_path(debate)
 
       within("#comment_#{comment.id}_votes") do

--- a/spec/system/comments/legislation_annotations_spec.rb
+++ b/spec/system/comments/legislation_annotations_spec.rb
@@ -61,7 +61,7 @@ describe "Commenting legislation questions" do
     expect(page).to have_current_path(comment_path(comment))
   end
 
-  scenario "Collapsable comments", :js do
+  scenario "Collapsable comments" do
     parent_comment = legislation_annotation.comments.first
     child_comment  = create(:comment, body: "First subcomment", commentable: legislation_annotation, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: legislation_annotation, parent: child_comment)
@@ -229,7 +229,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     login_as(user)
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
                                                             legislation_annotation.draft_version,
@@ -244,7 +244,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Errors on create", :js do
+  scenario "Errors on create" do
     login_as(user)
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
                                                             legislation_annotation.draft_version,
@@ -255,7 +255,7 @@ describe "Commenting legislation questions" do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario "Reply", :js do
+  scenario "Reply" do
     citizen = create(:user, username: "Ana")
     manuela = create(:user, username: "Manuela")
     legislation_annotation = create(:legislation_annotation, author: citizen)
@@ -280,7 +280,7 @@ describe "Commenting legislation questions" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}")
   end
 
-  scenario "Reply update parent comment responses count", :js do
+  scenario "Reply update parent comment responses count" do
     manuela = create(:user, :level_two, username: "Manuela")
     legislation_annotation = create(:legislation_annotation)
     comment = legislation_annotation.comments.first
@@ -299,7 +299,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Reply show parent comments responses when hidden", :js do
+  scenario "Reply show parent comments responses when hidden" do
     manuela = create(:user, :level_two, username: "Manuela")
     legislation_annotation = create(:legislation_annotation)
     comment = legislation_annotation.comments.first
@@ -320,7 +320,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Errors on reply", :js do
+  scenario "Errors on reply" do
     comment = legislation_annotation.comments.first
 
     login_as(user)
@@ -336,7 +336,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "N replies", :js do
+  scenario "N replies" do
     parent = create(:comment, commentable: legislation_annotation)
 
     7.times do
@@ -366,7 +366,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Submit button is disabled after clicking", :js do
+  scenario "Submit button is disabled after clicking" do
     legislation_annotation = create(:legislation_annotation)
     login_as(user)
 
@@ -383,7 +383,7 @@ describe "Commenting legislation questions" do
   end
 
   describe "Moderators" do
-    scenario "can create comment as a moderator", :js do
+    scenario "can create comment as a moderator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -403,7 +403,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    scenario "can create reply as a moderator" do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -446,7 +446,7 @@ describe "Commenting legislation questions" do
   end
 
   describe "Administrators" do
-    scenario "can create comment as an administrator", :js do
+    scenario "can create comment as an administrator" do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -466,7 +466,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    scenario "can create reply as an administrator" do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       admin   = create(:administrator, user: manuela)
@@ -536,7 +536,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       visit legislation_process_draft_version_annotation_path(annotation.draft_version.process,
                                                               annotation.draft_version,
                                                               annotation)
@@ -556,7 +556,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "Update", :js do
+    scenario "Update" do
       visit legislation_process_draft_version_annotation_path(annotation.draft_version.process,
                                                               annotation.draft_version,
                                                               annotation)
@@ -582,7 +582,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "Trying to vote multiple times", :js do
+    scenario "Trying to vote multiple times" do
       visit legislation_process_draft_version_annotation_path(annotation.draft_version.process,
                                                               annotation.draft_version,
                                                               annotation)
@@ -608,7 +608,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  describe "Merged comment threads", :js do
+  describe "Merged comment threads" do
     let!(:draft_version) { create(:legislation_draft_version, :published) }
     let!(:annotation1) do
       create(:legislation_annotation, draft_version: draft_version, text: "my annotation",

--- a/spec/system/comments/legislation_annotations_spec.rb
+++ b/spec/system/comments/legislation_annotations_spec.rb
@@ -8,6 +8,7 @@ describe "Commenting legislation questions" do
 
   scenario "Index" do
     3.times { create(:comment, commentable: legislation_annotation) }
+    comment = Comment.includes(:user).last
 
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
                                                             legislation_annotation.draft_version,
@@ -15,7 +16,6 @@ describe "Commenting legislation questions" do
 
     expect(page).to have_css(".comment", count: 4)
 
-    comment = Comment.last
     within first(".comment") do
       expect(page).to have_content comment.user.name
       expect(page).to have_content I18n.l(comment.created_at, format: :datetime)

--- a/spec/system/comments/legislation_questions_spec.rb
+++ b/spec/system/comments/legislation_questions_spec.rb
@@ -12,12 +12,12 @@ describe "Commenting legislation questions" do
 
   scenario "Index" do
     3.times { create(:comment, commentable: legislation_question) }
+    comment = Comment.includes(:user).last
 
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 
     expect(page).to have_css(".comment", count: 3)
 
-    comment = Comment.last
     within first(".comment") do
       expect(page).to have_content comment.user.name
       expect(page).to have_content I18n.l(comment.created_at, format: :datetime)

--- a/spec/system/comments/legislation_questions_spec.rb
+++ b/spec/system/comments/legislation_questions_spec.rb
@@ -60,7 +60,7 @@ describe "Commenting legislation questions" do
     expect(page).to have_current_path(comment_path(comment))
   end
 
-  scenario "Collapsable comments", :js do
+  scenario "Collapsable comments" do
     parent_comment = create(:comment, body: "Main comment", commentable: legislation_question)
     child_comment  = create(:comment, body: "First subcomment", commentable: legislation_question, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: legislation_question, parent: child_comment)
@@ -199,7 +199,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     login_as(user)
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 
@@ -212,7 +212,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Errors on create", :js do
+  scenario "Errors on create" do
     login_as(user)
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 
@@ -221,7 +221,7 @@ describe "Commenting legislation questions" do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario "Unverified user can't create comments", :js do
+  scenario "Unverified user can't create comments" do
     unverified_user = create :user
     login_as(unverified_user)
 
@@ -230,7 +230,7 @@ describe "Commenting legislation questions" do
     expect(page).to have_content "To participate verify your account"
   end
 
-  scenario "Can't create comments if debate phase is not open", :js do
+  scenario "Can't create comments if debate phase is not open" do
     process.update!(debate_start_date: Date.current - 2.days, debate_end_date: Date.current - 1.day)
     login_as(user)
 
@@ -239,7 +239,7 @@ describe "Commenting legislation questions" do
     expect(page).to have_content "Closed phase"
   end
 
-  scenario "Reply", :js do
+  scenario "Reply" do
     citizen = create(:user, username: "Ana")
     manuela = create(:user, :level_two, username: "Manuela")
     comment = create(:comment, commentable: legislation_question, user: citizen)
@@ -261,7 +261,7 @@ describe "Commenting legislation questions" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}")
   end
 
-  scenario "Reply update parent comment responses count", :js do
+  scenario "Reply update parent comment responses count" do
     manuela = create(:user, :level_two, username: "Manuela")
     comment = create(:comment, commentable: legislation_question)
 
@@ -277,7 +277,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Reply show parent comments responses when hidden", :js do
+  scenario "Reply show parent comments responses when hidden" do
     manuela = create(:user, :level_two, username: "Manuela")
     comment = create(:comment, commentable: legislation_question)
     create(:comment, commentable: legislation_question, parent: comment)
@@ -295,7 +295,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Errors on reply", :js do
+  scenario "Errors on reply" do
     comment = create(:comment, commentable: legislation_question, user: user)
 
     login_as(user)
@@ -309,7 +309,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "N replies", :js do
+  scenario "N replies" do
     parent = create(:comment, commentable: legislation_question)
 
     7.times do
@@ -332,7 +332,7 @@ describe "Commenting legislation questions" do
     end
   end
 
-  scenario "Submit button is disabled after clicking", :js do
+  scenario "Submit button is disabled after clicking" do
     login_as(user)
     visit legislation_process_question_path(legislation_question.process, legislation_question)
 
@@ -345,7 +345,7 @@ describe "Commenting legislation questions" do
   end
 
   describe "Moderators" do
-    scenario "can create comment as a moderator", :js do
+    scenario "can create comment as a moderator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -363,7 +363,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    scenario "can create reply as a moderator" do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -401,7 +401,7 @@ describe "Commenting legislation questions" do
   end
 
   describe "Administrators" do
-    scenario "can create comment as an administrator", :js do
+    scenario "can create comment as an administrator" do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -419,7 +419,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    scenario "can create reply as an administrator" do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       admin   = create(:administrator, user: manuela)
@@ -482,7 +482,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       visit legislation_process_question_path(question.process, question)
 
       within("#comment_#{comment.id}_votes") do
@@ -500,7 +500,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "Update", :js do
+    scenario "Update" do
       visit legislation_process_question_path(question.process, question)
 
       within("#comment_#{comment.id}_votes") do
@@ -524,7 +524,7 @@ describe "Commenting legislation questions" do
       end
     end
 
-    scenario "Trying to vote multiple times", :js do
+    scenario "Trying to vote multiple times" do
       visit legislation_process_question_path(question.process, question)
 
       within("#comment_#{comment.id}_votes") do

--- a/spec/system/comments/polls_spec.rb
+++ b/spec/system/comments/polls_spec.rb
@@ -54,7 +54,7 @@ describe "Commenting polls" do
     expect(page).to have_current_path(comment_path(comment))
   end
 
-  scenario "Collapsable comments", :js do
+  scenario "Collapsable comments" do
     parent_comment = create(:comment, body: "Main comment", commentable: poll)
     child_comment  = create(:comment, body: "First subcomment", commentable: poll, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: poll, parent: child_comment)
@@ -193,7 +193,7 @@ describe "Commenting polls" do
     end
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     login_as(user)
     visit poll_path(poll)
 
@@ -209,7 +209,7 @@ describe "Commenting polls" do
     end
   end
 
-  scenario "Errors on create", :js do
+  scenario "Errors on create" do
     login_as(user)
     visit poll_path(poll)
 
@@ -218,7 +218,7 @@ describe "Commenting polls" do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario "Reply", :js do
+  scenario "Reply" do
     citizen = create(:user, username: "Ana")
     manuela = create(:user, username: "Manuela")
     comment = create(:comment, commentable: poll, user: citizen)
@@ -240,7 +240,7 @@ describe "Commenting polls" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}")
   end
 
-  scenario "Reply update parent comment responses count", :js do
+  scenario "Reply update parent comment responses count" do
     comment = create(:comment, commentable: poll)
 
     login_as(create(:user))
@@ -255,7 +255,7 @@ describe "Commenting polls" do
     end
   end
 
-  scenario "Reply show parent comments responses when hidden", :js do
+  scenario "Reply show parent comments responses when hidden" do
     comment = create(:comment, commentable: poll)
     create(:comment, commentable: poll, parent: comment)
 
@@ -272,7 +272,7 @@ describe "Commenting polls" do
     end
   end
 
-  scenario "Errors on reply", :js do
+  scenario "Errors on reply" do
     comment = create(:comment, commentable: poll, user: user)
 
     login_as(user)
@@ -286,7 +286,7 @@ describe "Commenting polls" do
     end
   end
 
-  scenario "N replies", :js do
+  scenario "N replies" do
     parent = create(:comment, commentable: poll)
 
     7.times do
@@ -311,7 +311,7 @@ describe "Commenting polls" do
   end
 
   describe "Moderators" do
-    scenario "can create comment as a moderator", :js do
+    scenario "can create comment as a moderator" do
       skip "Feature not implemented yet, review soon"
 
       moderator = create(:moderator)
@@ -331,7 +331,7 @@ describe "Commenting polls" do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    scenario "can create reply as a moderator" do
       skip "Feature not implemented yet, review soon"
 
       citizen = create(:user, username: "Ana")
@@ -373,7 +373,7 @@ describe "Commenting polls" do
   end
 
   describe "Administrators" do
-    scenario "can create comment as an administrator", :js do
+    scenario "can create comment as an administrator" do
       skip "Feature not implemented yet, review soon"
 
       admin = create(:administrator)
@@ -393,7 +393,7 @@ describe "Commenting polls" do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    scenario "can create reply as an administrator" do
       skip "Feature not implemented yet, review soon"
 
       citizen = create(:user, username: "Ana")
@@ -460,7 +460,7 @@ describe "Commenting polls" do
       end
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       visit poll_path(poll)
 
       within("#comment_#{comment.id}_votes") do
@@ -478,7 +478,7 @@ describe "Commenting polls" do
       end
     end
 
-    scenario "Update", :js do
+    scenario "Update" do
       visit poll_path(poll)
 
       within("#comment_#{comment.id}_votes") do
@@ -502,7 +502,7 @@ describe "Commenting polls" do
       end
     end
 
-    scenario "Trying to vote multiple times", :js do
+    scenario "Trying to vote multiple times" do
       visit poll_path(poll)
 
       within("#comment_#{comment.id}_votes") do

--- a/spec/system/comments/polls_spec.rb
+++ b/spec/system/comments/polls_spec.rb
@@ -6,12 +6,12 @@ describe "Commenting polls" do
 
   scenario "Index" do
     3.times { create(:comment, commentable: poll) }
+    comment = Comment.includes(:user).last
 
     visit poll_path(poll)
 
     expect(page).to have_css(".comment", count: 3)
 
-    comment = Comment.last
     within first(".comment") do
       expect(page).to have_content comment.user.name
       expect(page).to have_content I18n.l(comment.created_at, format: :datetime)

--- a/spec/system/comments/proposals_spec.rb
+++ b/spec/system/comments/proposals_spec.rb
@@ -54,7 +54,7 @@ describe "Commenting proposals" do
     expect(page).to have_current_path(comment_path(comment))
   end
 
-  scenario "Collapsable comments", :js do
+  scenario "Collapsable comments" do
     parent_comment = create(:comment, body: "Main comment", commentable: proposal)
     child_comment  = create(:comment, body: "First subcomment", commentable: proposal, parent: parent_comment)
     grandchild_comment = create(:comment, body: "Last subcomment", commentable: proposal, parent: child_comment)
@@ -193,7 +193,7 @@ describe "Commenting proposals" do
     end
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     login_as(user)
     visit proposal_path(proposal)
 
@@ -209,7 +209,7 @@ describe "Commenting proposals" do
     end
   end
 
-  scenario "Errors on create", :js do
+  scenario "Errors on create" do
     login_as(user)
     visit proposal_path(proposal)
 
@@ -218,7 +218,7 @@ describe "Commenting proposals" do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario "Reply", :js do
+  scenario "Reply" do
     citizen = create(:user, username: "Ana")
     manuela = create(:user, username: "Manuela")
     comment = create(:comment, commentable: proposal, user: citizen)
@@ -240,7 +240,7 @@ describe "Commenting proposals" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}")
   end
 
-  scenario "Reply update parent comment responses count", :js do
+  scenario "Reply update parent comment responses count" do
     comment = create(:comment, commentable: proposal)
 
     login_as(create(:user))
@@ -255,7 +255,7 @@ describe "Commenting proposals" do
     end
   end
 
-  scenario "Reply show parent comments responses when hidden", :js do
+  scenario "Reply show parent comments responses when hidden" do
     comment = create(:comment, commentable: proposal)
     create(:comment, commentable: proposal, parent: comment)
 
@@ -272,7 +272,7 @@ describe "Commenting proposals" do
     end
   end
 
-  scenario "Errors on reply", :js do
+  scenario "Errors on reply" do
     comment = create(:comment, commentable: proposal, user: user)
 
     login_as(user)
@@ -286,7 +286,7 @@ describe "Commenting proposals" do
     end
   end
 
-  scenario "N replies", :js do
+  scenario "N replies" do
     parent = create(:comment, commentable: proposal)
 
     7.times do
@@ -311,7 +311,7 @@ describe "Commenting proposals" do
   end
 
   describe "Moderators" do
-    scenario "can create comment as a moderator", :js do
+    scenario "can create comment as a moderator" do
       moderator = create(:moderator)
 
       login_as(moderator.user)
@@ -329,7 +329,7 @@ describe "Commenting proposals" do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    scenario "can create reply as a moderator" do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       moderator = create(:moderator, user: manuela)
@@ -367,7 +367,7 @@ describe "Commenting proposals" do
   end
 
   describe "Administrators" do
-    scenario "can create comment as an administrator", :js do
+    scenario "can create comment as an administrator" do
       admin = create(:administrator)
 
       login_as(admin.user)
@@ -385,7 +385,7 @@ describe "Commenting proposals" do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    scenario "can create reply as an administrator" do
       citizen = create(:user, username: "Ana")
       manuela = create(:user, username: "Manuela")
       admin   = create(:administrator, user: manuela)
@@ -448,7 +448,7 @@ describe "Commenting proposals" do
       end
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       visit proposal_path(proposal)
 
       within("#comment_#{comment.id}_votes") do
@@ -466,7 +466,7 @@ describe "Commenting proposals" do
       end
     end
 
-    scenario "Update", :js do
+    scenario "Update" do
       visit proposal_path(proposal)
 
       within("#comment_#{comment.id}_votes") do
@@ -490,7 +490,7 @@ describe "Commenting proposals" do
       end
     end
 
-    scenario "Trying to vote multiple times", :js do
+    scenario "Trying to vote multiple times" do
       visit proposal_path(proposal)
 
       within("#comment_#{comment.id}_votes") do

--- a/spec/system/comments/proposals_spec.rb
+++ b/spec/system/comments/proposals_spec.rb
@@ -8,12 +8,12 @@ describe "Commenting proposals" do
 
   scenario "Index" do
     3.times { create(:comment, commentable: proposal) }
+    comment = Comment.includes(:user).last
 
     visit proposal_path(proposal)
 
     expect(page).to have_css(".comment", count: 3)
 
-    comment = Comment.last
     within first(".comment") do
       expect(page).to have_content comment.user.name
       expect(page).to have_content I18n.l(comment.created_at, format: :datetime)

--- a/spec/system/comments/topics_spec.rb
+++ b/spec/system/comments/topics_spec.rb
@@ -57,7 +57,7 @@ describe "Commenting topics from proposals" do
     expect(page).to have_current_path(comment_path(comment))
   end
 
-  scenario "Collapsable comments", :js do
+  scenario "Collapsable comments" do
     community = proposal.community
     topic = create(:topic, community: community)
     parent_comment = create(:comment, body: "Main comment", commentable: topic)
@@ -211,7 +211,7 @@ describe "Commenting topics from proposals" do
     end
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     community = proposal.community
     topic = create(:topic, community: community)
 
@@ -230,7 +230,7 @@ describe "Commenting topics from proposals" do
     end
   end
 
-  scenario "Errors on create", :js do
+  scenario "Errors on create" do
     community = proposal.community
     topic = create(:topic, community: community)
 
@@ -242,7 +242,7 @@ describe "Commenting topics from proposals" do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario "Reply", :js do
+  scenario "Reply" do
     community = proposal.community
     topic = create(:topic, community: community)
     citizen = create(:user, username: "Ana")
@@ -266,7 +266,7 @@ describe "Commenting topics from proposals" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}")
   end
 
-  scenario "Reply update parent comment responses count", :js do
+  scenario "Reply update parent comment responses count" do
     community = proposal.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic)
@@ -283,7 +283,7 @@ describe "Commenting topics from proposals" do
     end
   end
 
-  scenario "Reply show parent comments responses when hidden", :js do
+  scenario "Reply show parent comments responses when hidden" do
     community = proposal.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic)
@@ -302,7 +302,7 @@ describe "Commenting topics from proposals" do
     end
   end
 
-  scenario "Errors on reply", :js do
+  scenario "Errors on reply" do
     community = proposal.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic, user: user)
@@ -318,7 +318,7 @@ describe "Commenting topics from proposals" do
     end
   end
 
-  scenario "N replies", :js do
+  scenario "N replies" do
     community = proposal.community
     topic = create(:topic, community: community)
     parent = create(:comment, commentable: topic)
@@ -347,7 +347,7 @@ describe "Commenting topics from proposals" do
   end
 
   describe "Moderators" do
-    scenario "can create comment as a moderator", :js do
+    scenario "can create comment as a moderator" do
       community = proposal.community
       topic = create(:topic, community: community)
       moderator = create(:moderator)
@@ -367,7 +367,7 @@ describe "Commenting topics from proposals" do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    scenario "can create reply as a moderator" do
       community = proposal.community
       topic = create(:topic, community: community)
       citizen = create(:user, username: "Ana")
@@ -409,7 +409,7 @@ describe "Commenting topics from proposals" do
   end
 
   describe "Administrators" do
-    scenario "can create comment as an administrator", :js do
+    scenario "can create comment as an administrator" do
       community = proposal.community
       topic = create(:topic, community: community)
       admin = create(:administrator)
@@ -429,7 +429,7 @@ describe "Commenting topics from proposals" do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    scenario "can create reply as an administrator" do
       community = proposal.community
       topic = create(:topic, community: community)
       citizen = create(:user, username: "Ana")
@@ -498,7 +498,7 @@ describe "Commenting topics from proposals" do
       end
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       visit community_topic_path(proposal.community, topic)
 
       within("#comment_#{comment.id}_votes") do
@@ -516,7 +516,7 @@ describe "Commenting topics from proposals" do
       end
     end
 
-    scenario "Update", :js do
+    scenario "Update" do
       visit community_topic_path(proposal.community, topic)
 
       within("#comment_#{comment.id}_votes") do
@@ -540,7 +540,7 @@ describe "Commenting topics from proposals" do
       end
     end
 
-    scenario "Trying to vote multiple times", :js do
+    scenario "Trying to vote multiple times" do
       visit community_topic_path(proposal.community, topic)
 
       within("#comment_#{comment.id}_votes") do
@@ -604,7 +604,7 @@ describe "Commenting topics from budget investments" do
     expect(page).to have_link "Go back to #{topic.title}", href: community_topic_path(community, topic)
   end
 
-  scenario "Collapsable comments", :js do
+  scenario "Collapsable comments" do
     community = investment.community
     topic = create(:topic, community: community)
     parent_comment = create(:comment, body: "Main comment", commentable: topic)
@@ -753,7 +753,7 @@ describe "Commenting topics from budget investments" do
     end
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     community = investment.community
     topic = create(:topic, community: community)
 
@@ -772,7 +772,7 @@ describe "Commenting topics from budget investments" do
     end
   end
 
-  scenario "Errors on create", :js do
+  scenario "Errors on create" do
     community = investment.community
     topic = create(:topic, community: community)
 
@@ -784,7 +784,7 @@ describe "Commenting topics from budget investments" do
     expect(page).to have_content "Can't be blank"
   end
 
-  scenario "Reply", :js do
+  scenario "Reply" do
     community = investment.community
     topic = create(:topic, community: community)
     citizen = create(:user, username: "Ana")
@@ -808,7 +808,7 @@ describe "Commenting topics from budget investments" do
     expect(page).not_to have_selector("#js-comment-form-comment_#{comment.id}")
   end
 
-  scenario "Errors on reply", :js do
+  scenario "Errors on reply" do
     community = investment.community
     topic = create(:topic, community: community)
     comment = create(:comment, commentable: topic, user: user)
@@ -824,7 +824,7 @@ describe "Commenting topics from budget investments" do
     end
   end
 
-  scenario "N replies", :js do
+  scenario "N replies" do
     community = investment.community
     topic = create(:topic, community: community)
     parent = create(:comment, commentable: topic)
@@ -853,7 +853,7 @@ describe "Commenting topics from budget investments" do
   end
 
   describe "Moderators" do
-    scenario "can create comment as a moderator", :js do
+    scenario "can create comment as a moderator" do
       community = investment.community
       topic = create(:topic, community: community)
       moderator = create(:moderator)
@@ -873,7 +873,7 @@ describe "Commenting topics from budget investments" do
       end
     end
 
-    scenario "can create reply as a moderator", :js do
+    scenario "can create reply as a moderator" do
       community = investment.community
       topic = create(:topic, community: community)
       citizen = create(:user, username: "Ana")
@@ -915,7 +915,7 @@ describe "Commenting topics from budget investments" do
   end
 
   describe "Administrators" do
-    scenario "can create comment as an administrator", :js do
+    scenario "can create comment as an administrator" do
       community = investment.community
       topic = create(:topic, community: community)
       admin = create(:administrator)
@@ -935,7 +935,7 @@ describe "Commenting topics from budget investments" do
       end
     end
 
-    scenario "can create reply as an administrator", :js do
+    scenario "can create reply as an administrator" do
       community = investment.community
       topic = create(:topic, community: community)
       citizen = create(:user, username: "Ana")
@@ -1004,7 +1004,7 @@ describe "Commenting topics from budget investments" do
       end
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       visit community_topic_path(investment.community, topic)
 
       within("#comment_#{comment.id}_votes") do
@@ -1022,7 +1022,7 @@ describe "Commenting topics from budget investments" do
       end
     end
 
-    scenario "Update", :js do
+    scenario "Update" do
       visit community_topic_path(investment.community, topic)
 
       within("#comment_#{comment.id}_votes") do
@@ -1046,7 +1046,7 @@ describe "Commenting topics from budget investments" do
       end
     end
 
-    scenario "Trying to vote multiple times", :js do
+    scenario "Trying to vote multiple times" do
       visit community_topic_path(investment.community, topic)
 
       within("#comment_#{comment.id}_votes") do

--- a/spec/system/comments/topics_spec.rb
+++ b/spec/system/comments/topics_spec.rb
@@ -10,12 +10,12 @@ describe "Commenting topics from proposals" do
     community = proposal.community
     topic = create(:topic, community: community)
     create_list(:comment, 3, commentable: topic)
+    comment = Comment.includes(:user).last
 
     visit community_topic_path(community, topic)
 
     expect(page).to have_css(".comment", count: 3)
 
-    comment = Comment.last
     within first(".comment") do
       expect(page).to have_content comment.user.name
       expect(page).to have_content I18n.l(comment.created_at, format: :datetime)
@@ -574,12 +574,12 @@ describe "Commenting topics from budget investments" do
     community = investment.community
     topic = create(:topic, community: community)
     create_list(:comment, 3, commentable: topic)
+    comment = Comment.includes(:user).last
 
     visit community_topic_path(community, topic)
 
     expect(page).to have_css(".comment", count: 3)
 
-    comment = Comment.last
     within first(".comment") do
       expect(page).to have_content comment.user.name
       expect(page).to have_content I18n.l(comment.created_at, format: :datetime)

--- a/spec/system/communities_spec.rb
+++ b/spec/system/communities_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Communities" do
   context "Show" do
-    scenario "Should display default content" do
+    scenario "Should display default content", :js do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -10,7 +10,7 @@ describe "Communities" do
 
       visit community_path(community)
 
-      expect(page).to have_content "Proposal community"
+      expect(page).to have_content "PROPOSAL COMMUNITY"
       expect(page).to have_content proposal.title
       expect(page).to have_content "Participate in the community of this proposal"
       expect(page).to have_link("Create topic", href: new_community_topic_path(community))

--- a/spec/system/communities_spec.rb
+++ b/spec/system/communities_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Communities" do
   context "Show" do
-    scenario "Should display default content", :js do
+    scenario "Should display default content" do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)

--- a/spec/system/dashboard/dashboard_spec.rb
+++ b/spec/system/dashboard/dashboard_spec.rb
@@ -23,7 +23,7 @@ describe "Proposal's dashboard" do
     expect(page).not_to have_link("Publish proposal")
   end
 
-  scenario "Dashboard progress shows current goal", js: true do
+  scenario "Dashboard progress shows current goal" do
     goal = create(:dashboard_action, :resource, :active,
                                      required_supports: proposal.votes_for.size + 1_000)
     future_goal = create(:dashboard_action, :resource, :active,
@@ -71,7 +71,7 @@ describe "Proposal's dashboard" do
     expect(page).to have_button("Show description")
   end
 
-  scenario "Dashboard progress do not display from the fourth proposed actions", js: true do
+  scenario "Dashboard progress do not display from the fourth proposed actions" do
     create_list(:dashboard_action, 4, :proposed_action, :active)
     action_5 = create(:dashboard_action, :proposed_action, :active)
 
@@ -81,7 +81,7 @@ describe "Proposal's dashboard" do
   end
 
   scenario "Dashboard progress display link to new page for proposed actions when
-            there are more than four proposed actions", js: true do
+            there are more than four proposed actions" do
     create_list(:dashboard_action, 4, :proposed_action, :active)
     create(:dashboard_action, :proposed_action, :active)
 
@@ -91,7 +91,7 @@ describe "Proposal's dashboard" do
   end
 
   scenario "Dashboard progress do not display link to new page for proposed actions
-            when there are less than five proposed actions", js: true do
+            when there are less than five proposed actions" do
     create_list(:dashboard_action, 4, :proposed_action, :active)
 
     visit progress_proposal_dashboard_path(proposal)
@@ -262,7 +262,7 @@ describe "Proposal's dashboard" do
     expect(page).to have_link(feature.title)
   end
 
-  scenario "Request resource with admin request", js: true do
+  scenario "Request resource with admin request" do
     feature = create(:dashboard_action, :resource, :active, :admin_request)
 
     visit proposal_dashboard_path(proposal)
@@ -273,7 +273,7 @@ describe "Proposal's dashboard" do
                                  "as soon as possible to inform you about it.")
   end
 
-  scenario "Request already requested resource with admin request", js: true do
+  scenario "Request already requested resource with admin request" do
     feature = create(:dashboard_action, :resource, :active, :admin_request)
 
     visit proposal_dashboard_path(proposal)
@@ -298,7 +298,7 @@ describe "Proposal's dashboard" do
                                  "as soon as possible to inform you about it.")
   end
 
-  scenario "Resource without admin request do not have a request link", js: true do
+  scenario "Resource without admin request do not have a request link" do
     feature = create(:dashboard_action, :resource, :active)
 
     visit proposal_dashboard_path(proposal)
@@ -323,9 +323,10 @@ describe "Proposal's dashboard" do
     expect(page).to have_content("This proposal is archived and can not request resources.")
   end
 
-  scenario "Dashboard has a link to dashboard community", js: true do
+  scenario "Dashboard has a link to dashboard community" do
     visit proposal_dashboard_path(proposal)
 
+    expect(page).to have_link("Community")
     click_link "Community"
 
     expect(page).to have_content("Participants")
@@ -334,7 +335,7 @@ describe "Proposal's dashboard" do
     expect(page).to have_link("Access the community")
   end
 
-  scenario "Dashboard has a link to recommended_actions if there is any", js: true do
+  scenario "Dashboard has a link to recommended_actions if there is any" do
     expect(page).not_to have_link("Recommended actions")
 
     create_list(:dashboard_action, 3, :proposed_action, :active)
@@ -379,7 +380,7 @@ describe "Proposal's dashboard" do
                                                             anchor: "tab-notifications"))
   end
 
-  scenario "Dashboard has a related content section", :js do
+  scenario "Dashboard has a related content section" do
     related_debate = create(:debate)
     related_proposal = create(:proposal)
 
@@ -407,7 +408,7 @@ describe "Proposal's dashboard" do
   end
 
   scenario "On recommended actions section display from the fourth proposed actions
-            when click see_proposed_actions_link", js: true do
+            when click see_proposed_actions_link" do
     create_list(:dashboard_action, 4, :proposed_action, :active)
     action_5 = create(:dashboard_action, :proposed_action, :active)
 
@@ -421,7 +422,7 @@ describe "Proposal's dashboard" do
     expect(page).not_to have_content(action_5.title)
   end
 
-  scenario "On recommended actions section display four proposed actions", js: true do
+  scenario "On recommended actions section display four proposed actions" do
     create_list(:dashboard_action, 4, :proposed_action, :active)
     action_5 = create(:dashboard_action, :proposed_action, :active)
 
@@ -431,7 +432,7 @@ describe "Proposal's dashboard" do
   end
 
   scenario "On recommended actions section display link for toggle when there are
-            more than four proposed actions", js: true do
+            more than four proposed actions" do
     create_list(:dashboard_action, 4, :proposed_action, :active)
     create(:dashboard_action, :proposed_action, :active)
 
@@ -441,7 +442,7 @@ describe "Proposal's dashboard" do
   end
 
   scenario "On recommended actions section do not display link for toggle when
-            there are less than five proposed actions", js: true do
+            there are less than five proposed actions" do
     create_list(:dashboard_action, 4, :proposed_action, :active)
 
     visit recommended_actions_proposal_dashboard_path(proposal.to_param)

--- a/spec/system/dashboard/dashboard_spec.rb
+++ b/spec/system/dashboard/dashboard_spec.rb
@@ -1,31 +1,25 @@
 require "rails_helper"
 
 describe "Proposal's dashboard" do
-  let!(:proposal) { create(:proposal, :draft) }
+  let(:proposal) { create(:proposal, :draft) }
+  before { login_as(proposal.author) }
 
-  before do
-    login_as(proposal.author)
+  scenario "Navigation" do
     visit proposal_dashboard_path(proposal)
-  end
 
-  scenario "Dashboard has a link to my proposal" do
     expect(page).to have_link("Edit my proposal")
-  end
-
-  scenario "My proposal has a link to edit the proposal" do
     expect(page).to have_link("Edit proposal")
-  end
-
-  scenario "My proposal has a link to retire the proposal" do
     expect(page).to have_link("Retire proposal")
-  end
-
-  scenario "My proposal has a link to publish the proposal" do
     expect(page).to have_link("Publish proposal")
+    expect(page).to have_link("Polls")
+    expect(page).to have_link("E-mail")
+    expect(page).to have_link("Poster")
   end
 
   scenario "Publish link dissapears after proposal's publication" do
+    visit proposal_dashboard_path(proposal)
     click_link "Publish proposal"
+
     expect(page).not_to have_link("Publish proposal")
   end
 
@@ -261,18 +255,6 @@ describe "Proposal's dashboard" do
     end
   end
 
-  scenario "Dashboard has a link to polls feature" do
-    expect(page).to have_link("Polls")
-  end
-
-  scenario "Dashboard has a link to e-mail feature" do
-    expect(page).to have_link("E-mail")
-  end
-
-  scenario "Dashboard has a link to poster feature" do
-    expect(page).to have_link("Poster")
-  end
-
   scenario "Dashboard has a link to resources on main menu" do
     feature = create(:dashboard_action, :resource, :active)
 
@@ -342,7 +324,8 @@ describe "Proposal's dashboard" do
   end
 
   scenario "Dashboard has a link to dashboard community", js: true do
-    expect(page).to have_link("Community")
+    visit proposal_dashboard_path(proposal)
+
     click_link "Community"
 
     expect(page).to have_content("Participants")
@@ -364,6 +347,8 @@ describe "Proposal's dashboard" do
   end
 
   scenario "Dashboard has a link to messages" do
+    visit proposal_dashboard_path(proposal)
+
     expect(page).to have_link("Message to users")
 
     within("#side_menu") do
@@ -403,6 +388,8 @@ describe "Proposal's dashboard" do
 
     create(:related_content, parent_relationable: proposal,
                              child_relationable: related_proposal, author: build(:user))
+
+    visit proposal_dashboard_path(proposal)
 
     within("#side_menu") do
       click_link "Related content"
@@ -497,7 +484,8 @@ describe "Proposal's dashboard" do
 
   describe "detect_new_actions_after_last_login" do
     before do
-      proposal.author.update(last_sign_in_at: Date.yesterday)
+      visit proposal_dashboard_path(proposal)
+      proposal.author.update!(last_sign_in_at: Date.yesterday)
     end
 
     scenario "Display tag 'new' on resouce when it is new for author since last login" do

--- a/spec/system/dashboard/dashboard_spec.rb
+++ b/spec/system/dashboard/dashboard_spec.rb
@@ -379,7 +379,7 @@ describe "Proposal's dashboard" do
                                                             anchor: "tab-notifications"))
   end
 
-  scenario "Dashboard has a related content section" do
+  scenario "Dashboard has a related content section", :js do
     related_debate = create(:debate)
     related_proposal = create(:proposal)
 
@@ -399,9 +399,9 @@ describe "Proposal's dashboard" do
 
     within(".dashboard-related-content") do
       expect(page).to have_content("Related content (2)")
-      expect(page).to have_selector(".related-content-title", text: "Proposal")
+      expect(page).to have_selector(".related-content-title", text: "PROPOSAL")
       expect(page).to have_link related_proposal.title
-      expect(page).to have_selector(".related-content-title", text: "Debate")
+      expect(page).to have_selector(".related-content-title", text: "DEBATE")
       expect(page).to have_link related_debate.title
     end
   end

--- a/spec/system/dashboard/polls_spec.rb
+++ b/spec/system/dashboard/polls_spec.rb
@@ -12,7 +12,7 @@ describe "Polls" do
     expect(page).to have_link("Polls")
   end
 
-  scenario "Create a poll", :js do
+  scenario "Create a poll" do
     click_link "Polls"
     click_link "Create poll"
 
@@ -41,7 +41,7 @@ describe "Polls" do
     expect(page).to have_content I18n.l(start_date.to_date)
   end
 
-  describe "Datepicker", :js do
+  describe "Datepicker" do
     scenario "displays the expected format when changing the date field" do
       visit new_proposal_dashboard_poll_path(proposal)
 
@@ -79,7 +79,7 @@ describe "Polls" do
     end
   end
 
-  scenario "Create a poll redirects back to form when invalid data", js: true do
+  scenario "Create a poll redirects back to form when invalid data" do
     click_link "Polls"
     click_link "Create poll"
 
@@ -104,7 +104,7 @@ describe "Polls" do
     expect(page).to have_content "Poll updated successfully"
   end
 
-  scenario "Edit poll redirects back when invalid data", js: true do
+  scenario "Edit poll redirects back when invalid data" do
     poll = create(:poll, related: proposal, starts_at: 1.week.from_now)
 
     visit proposal_dashboard_polls_path(proposal)
@@ -142,7 +142,7 @@ describe "Polls" do
     end
   end
 
-  scenario "Edit poll should allow to remove questions", :js do
+  scenario "Edit poll should allow to remove questions" do
     poll = create(:poll, related: proposal, starts_at: 1.week.from_now)
     create(:poll_question, poll: poll)
     create(:poll_question, poll: poll)
@@ -165,7 +165,7 @@ describe "Polls" do
     expect(page).to have_css ".nested-fields", count: 1
   end
 
-  scenario "Edit poll should allow to remove answers", :js do
+  scenario "Edit poll should allow to remove answers" do
     poll = create(:poll, related: proposal, starts_at: 1.week.from_now)
     create(:poll_question, :yes_no, poll: poll)
     visit proposal_dashboard_polls_path(proposal)
@@ -189,7 +189,7 @@ describe "Polls" do
     end
   end
 
-  scenario "Can destroy poll without responses", :js do
+  scenario "Can destroy poll without responses" do
     poll = create(:poll, related: proposal)
 
     visit proposal_dashboard_polls_path(proposal)
@@ -202,7 +202,7 @@ describe "Polls" do
     expect(page).not_to have_content(poll.name)
   end
 
-  scenario "Can't destroy poll with responses", :js do
+  scenario "Can't destroy poll with responses" do
     poll = create(:poll, related: proposal)
     create(:poll_question, poll: poll)
     create(:poll_voter, poll: poll)
@@ -247,7 +247,7 @@ describe "Polls" do
     end
   end
 
-  scenario "View results redirects to results in public zone", js: true do
+  scenario "View results redirects to results in public zone" do
     poll = create(:poll, :expired, related: proposal)
 
     visit proposal_dashboard_polls_path(proposal)
@@ -261,7 +261,7 @@ describe "Polls" do
     end
   end
 
-  scenario "Enable and disable results", :js do
+  scenario "Enable and disable results" do
     create(:poll, related: proposal)
 
     visit proposal_dashboard_polls_path(proposal)

--- a/spec/system/dashboard/poster_spec.rb
+++ b/spec/system/dashboard/poster_spec.rb
@@ -30,7 +30,7 @@ describe "Poster" do
     expect(page).to have_link("Download")
   end
 
-  scenario "PDF contains the proposal details", js: true do
+  scenario "PDF contains the proposal details" do
     click_link "Download"
 
     page.driver.browser.switch_to.window page.driver.browser.window_handles.last do

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -772,33 +772,31 @@ describe "Debates" do
     end
   end
 
-  scenario "Mark/Unmark a debate as featured", :admin do
+  scenario "Mark/Unmark a debate as featured", :admin, :js do
     debate = create(:debate)
 
     visit debates_path
     within("#debates") do
-      expect(page).not_to have_content "Featured"
+      expect(page).not_to have_content "FEATURED"
     end
 
     click_link debate.title
-
-    click_link "Featured"
-
-    visit debates_path
+    accept_confirm { click_link "Featured" }
 
     within("#debates") do
-      expect(page).to have_content "Featured"
+      expect(page).to have_content "FEATURED"
     end
 
     within("#featured-debates") do
       expect(page).to have_content debate.title
+
+      click_link debate.title
     end
 
-    visit debate_path(debate)
-    click_link "Unmark featured"
+    accept_confirm { click_link "Unmark featured" }
 
     within("#debates") do
-      expect(page).not_to have_content "Featured"
+      expect(page).not_to have_content "FEATURED"
     end
   end
 

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -408,8 +408,8 @@ describe "Debates" do
         expect(medium_debate.title).to appear_before(worst_debate.title)
       end
 
-      expect(current_url).to include("order=confidence_score")
-      expect(current_url).to include("page=1")
+      expect(page).to have_current_path(/order=confidence_score/)
+      expect(page).to have_current_path(/page=1/)
     end
 
     scenario "Debates are ordered by newest", :js do
@@ -427,8 +427,8 @@ describe "Debates" do
         expect(medium_debate.title).to appear_before(worst_debate.title)
       end
 
-      expect(current_url).to include("order=created_at")
-      expect(current_url).to include("page=1")
+      expect(page).to have_current_path(/order=created_at/)
+      expect(page).to have_current_path(/page=1/)
     end
 
     context "Recommendations" do
@@ -494,8 +494,8 @@ describe "Debates" do
           expect(medium_debate.title).to appear_before(worst_debate.title)
         end
 
-        expect(current_url).to include("order=recommendations")
-        expect(current_url).to include("page=1")
+        expect(page).to have_current_path(/order=recommendations/)
+        expect(page).to have_current_path(/page=1/)
       end
 
       scenario "are not shown if account setting is disabled" do

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -201,13 +201,13 @@ describe "Debates" do
     expect(page).to have_content("-6 votes")
   end
 
-  scenario "Create" do
+  scenario "Create", :js do
     author = create(:user)
     login_as(author)
 
     visit new_debate_path
     fill_in "Debate title", with: "A title for a debate"
-    fill_in "Initial debate text", with: "This is very important because..."
+    fill_in_ckeditor "Initial debate text", with: "This is very important because..."
     check "debate_terms_of_service"
 
     click_button "Start a debate"
@@ -236,7 +236,7 @@ describe "Debates" do
     expect(page).to have_current_path(debates_path)
   end
 
-  scenario "Create debate too fast" do
+  scenario "Create debate too fast", :js do
     allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
 
     author = create(:user)
@@ -244,7 +244,7 @@ describe "Debates" do
 
     visit new_debate_path
     fill_in "Debate title", with: "I am a bot"
-    fill_in "Initial debate text", with: "This is the description"
+    fill_in_ckeditor "Initial debate text", with: "This is the description"
     check "debate_terms_of_service"
 
     click_button "Start a debate"
@@ -281,13 +281,13 @@ describe "Debates" do
     expect(page.html).not_to include "&lt;p&gt;This is"
   end
 
-  scenario "Autolinking is applied to description" do
+  scenario "Autolinking is applied to description", :js do
     author = create(:user)
     login_as(author)
 
     visit new_debate_path
     fill_in "Debate title", with: "Testing auto link"
-    fill_in "Initial debate text", with: "<p>This is a link www.example.org</p>"
+    fill_in_ckeditor "Initial debate text", with: "This is a link www.example.org"
     check "debate_terms_of_service"
 
     click_button "Start a debate"
@@ -347,7 +347,7 @@ describe "Debates" do
     expect(page).to have_content "You do not have permission to"
   end
 
-  scenario "Update should be posible for the author of an editable debate" do
+  scenario "Update should be posible for the author of an editable debate", :js do
     debate = create(:debate)
     login_as(debate.author)
 
@@ -355,7 +355,7 @@ describe "Debates" do
     expect(page).to have_current_path(edit_debate_path(debate))
 
     fill_in "Debate title", with: "End child poverty"
-    fill_in "Initial debate text", with: "Let's do something to end child poverty"
+    fill_in_ckeditor "Initial debate text", with: "Let's do something to end child poverty"
 
     click_button "Save changes"
 

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -90,7 +90,7 @@ describe "Debates" do
     expect(page.html).to include "<title>#{debate.title}</title>"
   end
 
-  describe "Social share buttons", :js do
+  describe "Social share buttons" do
     context "On desktop browsers" do
       scenario "Shows links to share on facebook and twitter" do
         visit debate_path(create(:debate))
@@ -201,7 +201,7 @@ describe "Debates" do
     expect(page).to have_content("-6 votes")
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     author = create(:user)
     login_as(author)
 
@@ -236,7 +236,7 @@ describe "Debates" do
     expect(page).to have_current_path(debates_path)
   end
 
-  scenario "Create debate too fast", :js do
+  scenario "Create debate too fast" do
     allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
 
     author = create(:user)
@@ -281,7 +281,7 @@ describe "Debates" do
     expect(page.html).not_to include "&lt;p&gt;This is"
   end
 
-  scenario "Autolinking is applied to description", :js do
+  scenario "Autolinking is applied to description" do
     author = create(:user)
     login_as(author)
 
@@ -347,7 +347,7 @@ describe "Debates" do
     expect(page).to have_content "You do not have permission to"
   end
 
-  scenario "Update should be posible for the author of an editable debate", :js do
+  scenario "Update should be posible for the author of an editable debate" do
     debate = create(:debate)
     login_as(debate.author)
 
@@ -376,7 +376,7 @@ describe "Debates" do
   end
 
   describe "Debate index order filters" do
-    scenario "Default order is hot_score", :js do
+    scenario "Default order is hot_score" do
       best_debate = create(:debate, title: "Best")
       best_debate.update_column(:hot_score, 10)
       worst_debate = create(:debate, title: "Worst")
@@ -390,7 +390,7 @@ describe "Debates" do
       expect(medium_debate.title).to appear_before(worst_debate.title)
     end
 
-    scenario "Debates are ordered by confidence_score", :js do
+    scenario "Debates are ordered by confidence_score" do
       best_debate = create(:debate, title: "Best")
       best_debate.update_column(:confidence_score, 10)
       worst_debate = create(:debate, title: "Worst")
@@ -412,7 +412,7 @@ describe "Debates" do
       expect(page).to have_current_path(/page=1/)
     end
 
-    scenario "Debates are ordered by newest", :js do
+    scenario "Debates are ordered by newest" do
       best_debate = create(:debate, title: "Best", created_at: Time.current)
       medium_debate = create(:debate, title: "Medium", created_at: Time.current - 1.hour)
       worst_debate = create(:debate, title: "Worst", created_at: Time.current - 1.day)
@@ -509,7 +509,7 @@ describe "Debates" do
         expect(page).not_to have_link("recommendations")
       end
 
-      scenario "are automatically disabled when dismissed from index", :js do
+      scenario "are automatically disabled when dismissed from index" do
         proposal = create(:proposal, tag_list: "Sport")
         user     = create(:user, followables: [proposal])
 
@@ -574,7 +574,7 @@ describe "Debates" do
       end
     end
 
-    scenario "Order by relevance by default", :js do
+    scenario "Order by relevance by default" do
       create(:debate, title: "Show you got",      cached_votes_up: 10)
       create(:debate, title: "Show what you got", cached_votes_up: 1)
       create(:debate, title: "Show you got",      cached_votes_up: 100)
@@ -592,7 +592,7 @@ describe "Debates" do
       end
     end
 
-    scenario "Reorder results maintaing search", :js do
+    scenario "Reorder results maintaing search" do
       create(:debate, title: "Show you got",      cached_votes_up: 10,  created_at: 1.week.ago)
       create(:debate, title: "Show what you got", cached_votes_up: 1,   created_at: 1.month.ago)
       create(:debate, title: "Show you got",      cached_votes_up: 100, created_at: Time.current)
@@ -738,7 +738,7 @@ describe "Debates" do
   end
 
   context "Suggesting debates" do
-    scenario "Shows up to 5 suggestions", :js do
+    scenario "Shows up to 5 suggestions" do
       create(:debate, title: "First debate has 1 vote", cached_votes_up: 1)
       create(:debate, title: "Second debate has 2 votes", cached_votes_up: 2)
       create(:debate, title: "Third debate has 3 votes", cached_votes_up: 3)
@@ -757,7 +757,7 @@ describe "Debates" do
       end
     end
 
-    scenario "No found suggestions", :js do
+    scenario "No found suggestions" do
       create(:debate, title: "First debate has 10 vote", cached_votes_up: 10)
       create(:debate, title: "Second debate has 2 votes", cached_votes_up: 2)
 
@@ -772,7 +772,7 @@ describe "Debates" do
     end
   end
 
-  scenario "Mark/Unmark a debate as featured", :admin, :js do
+  scenario "Mark/Unmark a debate as featured", :admin do
     debate = create(:debate)
 
     visit debates_path
@@ -800,7 +800,7 @@ describe "Debates" do
     end
   end
 
-  scenario "Index include featured debates", :admin, :js do
+  scenario "Index include featured debates", :admin do
     create(:debate, featured_at: Time.current)
     create(:debate)
 
@@ -829,7 +829,7 @@ describe "Debates" do
       Setting["sdg.process.debates"] = true
     end
 
-    scenario "create debate with sdg related list", :js do
+    scenario "create debate with sdg related list" do
       login_as(user)
       visit new_debate_path
       fill_in "Debate title", with: "A title for a debate related with SDG related content"
@@ -842,7 +842,7 @@ describe "Debates" do
       within(".sdg-goal-tag-list") { expect(page).to have_link "1. No Poverty" }
     end
 
-    scenario "edit debate with sdg related list", :js do
+    scenario "edit debate with sdg related list" do
       debate = create(:debate, author: user)
       debate.sdg_goals = [SDG::Goal[1], SDG::Goal[2]]
       login_as(user)

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -263,7 +263,7 @@ describe "Debates" do
     expect(page).to have_content error_message
   end
 
-  scenario "JS injection is prevented but safe html is respected" do
+  scenario "JS injection is prevented but safe html is respected", :no_js do
     author = create(:user)
     login_as(author)
 
@@ -297,7 +297,7 @@ describe "Debates" do
     expect(page).to have_link("www.example.org", href: "http://www.example.org")
   end
 
-  scenario "JS injection is prevented but autolinking is respected" do
+  scenario "JS injection is prevented but autolinking is respected", :no_js do
     author = create(:user)
     js_injection_string = "<script>alert('hey')</script> <a href=\"javascript:alert('surprise!')\">click me<a/> http://example.org"
     login_as(author)

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -800,13 +800,14 @@ describe "Debates" do
     end
   end
 
-  scenario "Index include featured debates", :admin do
+  scenario "Index include featured debates", :admin, :js do
     create(:debate, featured_at: Time.current)
     create(:debate)
 
     visit debates_path
+
     within("#debates") do
-      expect(page).to have_content("Featured")
+      expect(page).to have_content("FEATURED")
     end
   end
 

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -219,7 +219,7 @@ describe "Debates" do
     expect(page).to have_content I18n.l(Debate.last.created_at.to_date)
   end
 
-  scenario "Create with invisible_captcha honeypot field" do
+  scenario "Create with invisible_captcha honeypot field", :no_js do
     author = create(:user)
     login_as(author)
 

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -373,9 +373,9 @@ describe "Emails" do
       login_as(valuator.user)
       visit edit_valuation_budget_budget_investment_path(budget, investment)
 
-      choose "budget_investment_feasibility_unfeasible"
-      fill_in "budget_investment_unfeasibility_explanation", with: "This is not legal as stated in Article 34.9"
-      find_field("budget_investment[valuation_finished]").click
+      within_fieldset("Feasibility") { choose "Unfeasible" }
+      fill_in "Feasibility explanation", with: "This is not legal as stated in Article 34.9"
+      check "Valuation finished"
       click_button "Save changes"
 
       expect(page).to have_content "Dossier updated"

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -342,13 +342,13 @@ describe "Emails" do
     let(:budget)   { create(:budget) }
     let!(:heading) { create(:budget_heading, name: "More hospitals", budget: budget) }
 
-    scenario "Investment created" do
+    scenario "Investment created", :js do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
       select  heading.name, from: "budget_investment_heading_id"
       fill_in "Title", with: "Build a hospital"
-      fill_in "Description", with: "We have lots of people that require medical attention"
+      fill_in_ckeditor "Description", with: "We have lots of people that require medical attention"
       check   "budget_investment_terms_of_service"
 
       click_button "Create Investment"
@@ -464,7 +464,7 @@ describe "Emails" do
   end
 
   context "Newsletter", :admin do
-    scenario "Send newsletter email to selected users" do
+    scenario "Send newsletter email to selected users", :js do
       user_with_newsletter_in_segment_1 = create(:user, :with_proposal, newsletter: true)
       user_with_newsletter_in_segment_2 = create(:user, :with_proposal, newsletter: true)
       user_with_newsletter_not_in_segment = create(:user, newsletter: true)
@@ -476,7 +476,7 @@ describe "Emails" do
 
       expect(page).to have_content "Newsletter created successfully"
 
-      click_link "Send"
+      accept_confirm { click_link "Send" }
 
       expect(page).to have_content "Newsletter sent successfully"
 

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -178,7 +178,7 @@ describe "Emails" do
   context "Comment replies" do
     let(:user) { create(:user, email_on_comment_reply: true) }
 
-    scenario "Send email on comment reply", :js do
+    scenario "Send email on comment reply" do
       reply_to(user)
 
       email = open_last_email
@@ -190,12 +190,12 @@ describe "Emails" do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario "Do not send email about own replies to own comments", :js do
+    scenario "Do not send email about own replies to own comments" do
       reply_to(user, user)
       expect { open_last_email }.to raise_error("No email has been sent!")
     end
 
-    scenario "Do not send email about comment reply unless set in preferences", :js do
+    scenario "Do not send email about comment reply unless set in preferences" do
       user.update!(email_on_comment_reply: false)
       reply_to(user)
       expect { open_last_email }.to raise_error("No email has been sent!")
@@ -344,7 +344,7 @@ describe "Emails" do
     let(:budget)   { create(:budget) }
     let!(:heading) { create(:budget_heading, name: "More hospitals", budget: budget) }
 
-    scenario "Investment created", :js do
+    scenario "Investment created" do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
@@ -367,7 +367,7 @@ describe "Emails" do
       expect(email).to have_body_text(budget_path(budget))
     end
 
-    scenario "Unfeasible investment", :js do
+    scenario "Unfeasible investment" do
       budget.update!(phase: "valuating")
       valuator = create(:valuator)
       investment = create(:budget_investment, author: author, budget: budget, valuators: [valuator])
@@ -435,7 +435,7 @@ describe "Emails" do
   end
 
   context "Polls" do
-    scenario "Send email on poll comment reply", :js do
+    scenario "Send email on poll comment reply" do
       user1 = create(:user, email_on_comment_reply: true)
       user2 = create(:user)
       poll = create(:poll, author: create(:user))
@@ -466,7 +466,7 @@ describe "Emails" do
   end
 
   context "Newsletter", :admin do
-    scenario "Send newsletter email to selected users", :js do
+    scenario "Send newsletter email to selected users" do
       user_with_newsletter_in_segment_1 = create(:user, :with_proposal, newsletter: true)
       user_with_newsletter_in_segment_2 = create(:user, :with_proposal, newsletter: true)
       user_with_newsletter_not_in_segment = create(:user, newsletter: true)

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -209,6 +209,8 @@ describe "Emails" do
     fill_in_signup_form
     click_button "Registrarse"
 
+    expect(page).to have_content "visita el enlace para activar tu cuenta."
+
     email = open_last_email
     expect(email).to deliver_to("manuela@consul.dev")
     expect(email).to have_body_text(user_confirmation_path)

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -365,7 +365,7 @@ describe "Emails" do
       expect(email).to have_body_text(budget_path(budget))
     end
 
-    scenario "Unfeasible investment" do
+    scenario "Unfeasible investment", :js do
       budget.update!(phase: "valuating")
       valuator = create(:valuator)
       investment = create(:budget_investment, author: author, budget: budget, valuators: [valuator])
@@ -375,7 +375,7 @@ describe "Emails" do
 
       within_fieldset("Feasibility") { choose "Unfeasible" }
       fill_in "Feasibility explanation", with: "This is not legal as stated in Article 34.9"
-      check "Valuation finished"
+      accept_confirm { check "Valuation finished" }
       click_button "Save changes"
 
       expect(page).to have_content "Dossier updated"
@@ -477,6 +477,8 @@ describe "Emails" do
       expect(page).to have_content "Newsletter created successfully"
 
       click_link "Send"
+
+      expect(page).to have_content "Newsletter sent successfully"
 
       expect(unread_emails_for(user_with_newsletter_in_segment_1.email).count).to eq 1
       expect(unread_emails_for(user_with_newsletter_in_segment_2.email).count).to eq 1

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -105,7 +105,7 @@ describe "Home" do
     end
   end
 
-  describe "IE alert" do
+  describe "IE alert", :no_js do
     scenario "IE visitors are presented with an alert until they close it", :page_driver do
       # Selenium API does not include page request/response inspection methods
       # so we must use Capybara::RackTest driver to set the browser's headers

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -62,7 +62,7 @@ describe "Legislation Draft Versions" do
       expect(page).to have_content("Current version")
     end
 
-    it "switches to another version with js", :js do
+    it "switches to another version with js" do
       visit legislation_process_draft_version_path(process, original)
       expect(page).to have_content("Original version")
 
@@ -72,7 +72,7 @@ describe "Legislation Draft Versions" do
       expect(page).to have_content("Current version")
     end
 
-    scenario "show more info button", :js do
+    scenario "show more info button" do
       process.update!(additional_info: "Text for additional info of the process")
       visit legislation_process_draft_version_path(process, original)
 
@@ -83,7 +83,7 @@ describe "Legislation Draft Versions" do
       expect(page).to have_content "Text for additional info of the process"
     end
 
-    scenario "show help gif", :js do
+    scenario "show help gif" do
       visit legislation_process_draft_version_path(process, original)
 
       click_button text: "How can I comment this document?"
@@ -162,7 +162,7 @@ describe "Legislation Draft Versions" do
       expect(page).to have_content("Changes for second version")
     end
 
-    it "switches to another version with js", :js do
+    it "switches to another version with js" do
       visit legislation_process_draft_version_changes_path(process, original)
       expect(page).to have_content("Changes for first version")
 
@@ -173,7 +173,7 @@ describe "Legislation Draft Versions" do
     end
   end
 
-  context "Annotations", :js do
+  context "Annotations" do
     let(:user) { create(:user) }
     let(:draft_version) { create(:legislation_draft_version, :published) }
 
@@ -299,7 +299,7 @@ describe "Legislation Draft Versions" do
     end
   end
 
-  context "Merged annotations", :js do
+  context "Merged annotations" do
     let(:user) { create(:user) }
     let(:draft_version) { create(:legislation_draft_version, :published) }
 
@@ -364,7 +364,7 @@ describe "Legislation Draft Versions" do
         expect(page).to have_content("quote for version 2")
       end
 
-      scenario "with js", :js do
+      scenario "with js" do
         visit legislation_process_draft_version_annotations_path(process, original)
         expect(page).to have_content("quote for version 1")
 

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -51,7 +51,7 @@ describe "Legislation Draft Versions" do
       end
     end
 
-    it "switches to another version without js" do
+    it "switches to another version without js", :no_js do
       visit legislation_process_draft_version_path(process, original)
       expect(page).to have_content("Original version")
 
@@ -151,7 +151,7 @@ describe "Legislation Draft Versions" do
       end
     end
 
-    it "switches to another version without js" do
+    it "switches to another version without js", :no_js do
       visit legislation_process_draft_version_changes_path(process, original)
       expect(page).to have_content("Changes for first version")
 
@@ -353,7 +353,7 @@ describe "Legislation Draft Versions" do
                ranges: [{ "start" => "/p[1]", "startOffset" => 11, "end" => "/p[1]", "endOffset" => 30 }])
       end
 
-      scenario "without js" do
+      scenario "without js", :no_js do
         visit legislation_process_draft_version_annotations_path(process, original)
         expect(page).to have_content("quote for version 1")
 

--- a/spec/system/legislation/processes_spec.rb
+++ b/spec/system/legislation/processes_spec.rb
@@ -162,17 +162,17 @@ describe "Legislation" do
         end
       end
 
-      scenario "show draft publication and final result publication dates" do
+      scenario "show draft publication and final result publication dates", :js do
         process = create(:legislation_process, draft_publication_date: Date.new(2019, 01, 10),
                                                result_publication_date: Date.new(2019, 01, 20))
 
         visit legislation_process_path(process)
 
         within("aside") do
-          expect(page).to have_content("Draft publication")
-          expect(page).to have_content("10 Jan 2019")
-          expect(page).to have_content("Final result publication")
-          expect(page).to have_content("20 Jan 2019")
+          expect(page).to have_content "DRAFT PUBLICATION"
+          expect(page).to have_content "10 Jan 2019"
+          expect(page).to have_content "FINAL RESULT PUBLICATION"
+          expect(page).to have_content "20 Jan 2019"
         end
       end
 

--- a/spec/system/legislation/processes_spec.rb
+++ b/spec/system/legislation/processes_spec.rb
@@ -41,7 +41,7 @@ describe "Legislation" do
       end
     end
 
-    scenario "Processes are sorted by descending start date", :js do
+    scenario "Processes are sorted by descending start date" do
       create(:legislation_process, title: "Process 1", start_date: 3.days.ago)
       create(:legislation_process, title: "Process 2", start_date: 2.days.ago)
       create(:legislation_process, title: "Process 3", start_date: Date.yesterday)
@@ -128,7 +128,7 @@ describe "Legislation" do
       end
     end
 
-    scenario "Show SDG tags when feature is enabled", :js do
+    scenario "Show SDG tags when feature is enabled" do
       Setting["feature.sdg"] = true
       Setting["sdg.process.legislation"] = true
 
@@ -162,7 +162,7 @@ describe "Legislation" do
         end
       end
 
-      scenario "show draft publication and final result publication dates", :js do
+      scenario "show draft publication and final result publication dates" do
         process = create(:legislation_process, draft_publication_date: Date.new(2019, 01, 10),
                                                result_publication_date: Date.new(2019, 01, 20))
 
@@ -187,7 +187,7 @@ describe "Legislation" do
         end
       end
 
-      scenario "show additional info button", :js do
+      scenario "show additional info button" do
         process = create(:legislation_process, additional_info: "Text for additional info of the process")
 
         visit legislation_process_path(process)
@@ -227,7 +227,7 @@ describe "Legislation" do
         expect(page).to have_current_path new_legislation_process_proposal_path(process)
       end
 
-      scenario "Show SDG tags when feature is enabled", :js do
+      scenario "Show SDG tags when feature is enabled" do
         Setting["feature.sdg"] = true
         Setting["sdg.process.legislation"] = true
 

--- a/spec/system/legislation/proposals_spec.rb
+++ b/spec/system/legislation/proposals_spec.rb
@@ -36,7 +36,7 @@ describe "Legislation Proposals" do
       let(:user2)    { create(:user) }
       let(:per_page) { 12 }
 
-      scenario "Each user has a different and consistent random proposals order", :js do
+      scenario "Each user has a different and consistent random proposals order" do
         first_user_proposals_order = nil
         second_user_proposals_order = nil
 
@@ -66,7 +66,7 @@ describe "Legislation Proposals" do
       end
     end
 
-    scenario "Random order maintained with pagination", :js do
+    scenario "Random order maintained with pagination" do
       login_as user
       visit legislation_process_proposals_path(process)
       first_page_proposals_order = legislation_proposals_order
@@ -82,7 +82,7 @@ describe "Legislation Proposals" do
       expect(legislation_proposals_order).to eq(first_page_proposals_order)
     end
 
-    scenario "Does not crash when the seed is not a number", :js do
+    scenario "Does not crash when the seed is not a number" do
       login_as user
       visit legislation_process_proposals_path(process, random_seed: "Spoof")
 
@@ -137,7 +137,7 @@ describe "Legislation Proposals" do
     all("[id^='legislation_proposal_']").map { |e| e[:id] }
   end
 
-  scenario "Create a legislation proposal with an image", :js do
+  scenario "Create a legislation proposal with an image" do
     create(:legislation_proposal, process: process)
 
     login_as user
@@ -200,7 +200,7 @@ describe "Legislation Proposals" do
     expect(page).to have_content("-6 votes")
   end
 
-  scenario "Show link to process on show", :js do
+  scenario "Show link to process on show" do
     create(:legislation_proposal, legislation_process_id: process.id)
 
     visit legislation_process_proposal_path(proposal.process, proposal)
@@ -211,7 +211,7 @@ describe "Legislation Proposals" do
     end
   end
 
-  scenario "Shows proposal tags as proposals filter", :js do
+  scenario "Shows proposal tags as proposals filter" do
     create(:legislation_proposal, process: process, tag_list: "Culture", title: "Open concert")
     create(:legislation_proposal, process: process, tag_list: "Sports", title: "Baseball field")
 
@@ -226,7 +226,7 @@ describe "Legislation Proposals" do
     expect(page).to have_content "Open concert"
   end
 
-  scenario "Show proposal tags on show when SDG is enabled", :js do
+  scenario "Show proposal tags on show when SDG is enabled" do
     Setting["feature.sdg"] = true
     Setting["sdg.process.legislation"] = true
 

--- a/spec/system/legislation/proposals_spec.rb
+++ b/spec/system/legislation/proposals_spec.rb
@@ -82,11 +82,11 @@ describe "Legislation Proposals" do
       expect(legislation_proposals_order).to eq(first_page_proposals_order)
     end
 
-    scenario "Does not crash when the seed is not a number" do
+    scenario "Does not crash when the seed is not a number", :js do
       login_as user
       visit legislation_process_proposals_path(process, random_seed: "Spoof")
 
-      expect(page).to have_content "You're on page 1"
+      expect(page).to have_content "Random"
     end
   end
 
@@ -200,13 +200,13 @@ describe "Legislation Proposals" do
     expect(page).to have_content("-6 votes")
   end
 
-  scenario "Show link to process on show" do
+  scenario "Show link to process on show", :js do
     create(:legislation_proposal, legislation_process_id: process.id)
 
     visit legislation_process_proposal_path(proposal.process, proposal)
 
     within(".process-proposal") do
-      expect(page).to have_content("Collaborative legislation process")
+      expect(page).to have_content("COLLABORATIVE LEGISLATION PROCESS")
       expect(page).to have_link(process.title)
     end
   end

--- a/spec/system/legislation/questions_spec.rb
+++ b/spec/system/legislation/questions_spec.rb
@@ -63,7 +63,7 @@ describe "Legislation" do
       expect(page).not_to have_content("Next question")
     end
 
-    scenario "answer question" do
+    scenario "answer question", :no_js do
       question = process.questions.first
       create(:legislation_question_option, question: question, value: "Yes")
       create(:legislation_question_option, question: question, value: "No")
@@ -93,7 +93,7 @@ describe "Legislation" do
       expect(option.reload.answers_count).to eq(1)
     end
 
-    scenario "cannot answer question when phase not open" do
+    scenario "cannot answer question when phase not open", :no_js do
       process.update!(debate_end_date: Date.current - 1.day)
       question = process.questions.first
       create(:legislation_question_option, question: question, value: "Yes")

--- a/spec/system/legislation/questions_spec.rb
+++ b/spec/system/legislation/questions_spec.rb
@@ -14,7 +14,7 @@ describe "Legislation" do
       create(:legislation_question, process: process, title: "Question 3")
     end
 
-    scenario "shows question list" do
+    scenario "shows question list", :js do
       visit legislation_process_path(process)
 
       expect(page).to have_content("Participate in the debate")
@@ -26,17 +26,17 @@ describe "Legislation" do
       click_link "Question 1"
 
       expect(page).to have_content("Question 1")
-      expect(page).to have_content("Next question")
+      expect(page).to have_content("NEXT QUESTION")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 2")
-      expect(page).to have_content("Next question")
+      expect(page).to have_content("NEXT QUESTION")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 3")
-      expect(page).not_to have_content("Next question")
+      expect(page).not_to have_content("NEXT QUESTION")
     end
 
     scenario "shows question page" do
@@ -46,21 +46,21 @@ describe "Legislation" do
       expect(page).to have_content("Open answers (0)")
     end
 
-    scenario "shows next question link in question page" do
+    scenario "shows next question link in question page", :js do
       visit legislation_process_question_path(process, process.questions.first)
 
       expect(page).to have_content("Question 1")
-      expect(page).to have_content("Next question")
+      expect(page).to have_content("NEXT QUESTION")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 2")
-      expect(page).to have_content("Next question")
+      expect(page).to have_content("NEXT QUESTION")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 3")
-      expect(page).not_to have_content("Next question")
+      expect(page).not_to have_content("NEXT QUESTION")
     end
 
     scenario "answer question", :no_js do

--- a/spec/system/legislation/questions_spec.rb
+++ b/spec/system/legislation/questions_spec.rb
@@ -14,7 +14,7 @@ describe "Legislation" do
       create(:legislation_question, process: process, title: "Question 3")
     end
 
-    scenario "shows question list", :js do
+    scenario "shows question list" do
       visit legislation_process_path(process)
 
       expect(page).to have_content("Participate in the debate")
@@ -46,7 +46,7 @@ describe "Legislation" do
       expect(page).to have_content("Open answers (0)")
     end
 
-    scenario "shows next question link in question page", :js do
+    scenario "shows next question link in question page" do
       visit legislation_process_question_path(process, process.questions.first)
 
       expect(page).to have_content("Question 1")

--- a/spec/system/legislation/summary_spec.rb
+++ b/spec/system/legislation/summary_spec.rb
@@ -165,7 +165,7 @@ describe "Legislation" do
       expect(page).to have_link "Comment 3"
     end
 
-    scenario "excel download" do
+    scenario "excel download", :no_js do
       visit summary_legislation_process_path(process)
       click_link "Download summary"
 

--- a/spec/system/localization_spec.rb
+++ b/spec/system/localization_spec.rb
@@ -30,7 +30,7 @@ describe "Localization" do
     expect(page).to have_select("locale-switcher", selected: "English")
   end
 
-  scenario "Changing the locale", :js do
+  scenario "Changing the locale" do
     visit "/"
     expect(page).to have_content("Language")
 
@@ -40,7 +40,7 @@ describe "Localization" do
     expect(page).to have_select("locale-switcher", selected: "Español")
   end
 
-  scenario "Keeps query parameters while using protected redirects", :js do
+  scenario "Keeps query parameters while using protected redirects" do
     visit "/debates?order=created_at&host=evil.dev"
 
     select("Español", from: "locale-switcher")

--- a/spec/system/management/account_spec.rb
+++ b/spec/system/management/account_spec.rb
@@ -1,16 +1,11 @@
 require "rails_helper"
 
 describe "Account" do
-  before do
-    login_as_manager
-  end
-
   scenario "Should not allow unverified users to edit their account" do
     user = create(:user)
     login_managed_user(user)
 
-    visit management_root_path
-
+    login_as_manager
     click_link "Reset password via email"
 
     expect(page).to have_content "No verified user logged in yet"
@@ -20,6 +15,7 @@ describe "Account" do
     user = create(:user, :level_two)
     login_managed_user(user)
 
+    login_as_manager
     visit management_account_path
 
     click_link "Delete user"
@@ -33,8 +29,8 @@ describe "Account" do
   scenario "Send reset password email to currently managed user session" do
     user = create(:user, :level_three)
     login_managed_user(user)
-    visit management_root_path
 
+    login_as_manager
     click_link "Reset password via email"
 
     click_link "Send reset password email"
@@ -49,8 +45,8 @@ describe "Account" do
   scenario "Manager changes the password by hand (writen by them)" do
     user = create(:user, :level_three)
     login_managed_user(user)
-    visit management_root_path
 
+    login_as_manager
     click_link "Reset password manually"
 
     find(:css, "input[id$='user_password']").set("new_password")
@@ -69,8 +65,8 @@ describe "Account" do
   scenario "Manager generates random password" do
     user = create(:user, :level_three)
     login_managed_user(user)
-    visit management_root_path
 
+    login_as_manager
     click_link "Reset password manually"
     click_link "Generate random password"
 
@@ -90,8 +86,8 @@ describe "Account" do
   scenario "The password is printed" do
     user = create(:user, :level_three)
     login_managed_user(user)
-    visit management_root_path
 
+    login_as_manager
     click_link "Reset password manually"
 
     find(:css, "input[id$='user_password']").set("another_new_password")

--- a/spec/system/management/account_spec.rb
+++ b/spec/system/management/account_spec.rb
@@ -16,7 +16,7 @@ describe "Account" do
     expect(page).to have_content "No verified user logged in yet"
   end
 
-  scenario "Delete a user account", :js do
+  scenario "Delete a user account" do
     user = create(:user, :level_two)
     login_managed_user(user)
 
@@ -66,7 +66,7 @@ describe "Account" do
     expect(page).to have_content "You have been signed in successfully."
   end
 
-  scenario "Manager generates random password", :js do
+  scenario "Manager generates random password" do
     user = create(:user, :level_three)
     login_managed_user(user)
     visit management_root_path
@@ -87,7 +87,7 @@ describe "Account" do
     expect(page).to have_content "You have been signed in successfully."
   end
 
-  scenario "The password is printed", :js do
+  scenario "The password is printed" do
     user = create(:user, :level_three)
     login_managed_user(user)
     visit management_root_path

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -5,8 +5,12 @@ describe "Budget Investments" do
   let(:budget)  { create(:budget, :selecting, name: "2033", slug: "budget_slug") }
   let(:group)   { create(:budget_group, budget: budget, name: "Whole city") }
   let(:heading) { create(:budget_heading, group: group, name: "Health") }
+  let(:user)    { create(:user, :level_two) }
 
-  before { login_as_manager(manager) }
+  before do
+    login_managed_user(user)
+    login_as_manager(manager)
+  end
 
   it_behaves_like "mappable",
                   "budget_investment",
@@ -19,9 +23,6 @@ describe "Budget Investments" do
 
   context "Load" do
     let(:investment) { create(:budget_investment, budget: budget) }
-    let(:user)       { create(:user, :level_two) }
-
-    before { login_managed_user(user) }
 
     scenario "finds investment using budget slug" do
       visit management_budget_investment_path("budget_slug", investment)
@@ -34,10 +35,6 @@ describe "Budget Investments" do
     before { heading.budget.update(phase: "accepting") }
 
     scenario "Creating budget investments on behalf of someone, selecting a budget" do
-      user = create(:user, :level_two)
-
-      login_managed_user(user)
-
       click_link "Create budget investment"
       within "#budget_#{budget.id}" do
         click_link "Create budget investment"
@@ -72,8 +69,7 @@ describe "Budget Investments" do
     end
 
     scenario "Should not allow unverified users to create budget investments" do
-      user = create(:user)
-      login_managed_user(user)
+      login_managed_user(create(:user))
 
       click_link "Create budget investment"
 
@@ -86,7 +82,6 @@ describe "Budget Investments" do
       create(:budget_investment, budget: budget, title: "More parks")
       create(:budget_investment, budget: budget, title: "No more parks")
       create(:budget_investment, budget: budget, title: "Plant trees")
-      login_managed_user(create(:user, :level_two))
 
       click_link "Create budget investment"
       within "#budget_#{budget.id}" do
@@ -108,9 +103,6 @@ describe "Budget Investments" do
     scenario "by title" do
       budget_investment1 = create(:budget_investment, budget: budget, title: "Show me what you got")
       budget_investment2 = create(:budget_investment, budget: budget, title: "Get Schwifty")
-
-      user = create(:user, :level_two)
-      login_managed_user(user)
 
       click_link "Support budget investments"
       expect(page).to have_content(budget.name)
@@ -137,9 +129,6 @@ describe "Budget Investments" do
       budget_investment2 = create(:budget_investment, budget: budget, title: "Let's go",
                                                       heading: create(:budget_heading, name: "Area 52"))
 
-      user = create(:user, :level_two)
-      login_managed_user(user)
-
       click_link "Support budget investments"
       expect(page).to have_content(budget.name)
       within "#budget_#{budget.id}" do
@@ -163,9 +152,6 @@ describe "Budget Investments" do
   scenario "Listing" do
     budget_investment1 = create(:budget_investment, budget: budget, title: "Show me what you got")
     budget_investment2 = create(:budget_investment, budget: budget, title: "Get Schwifty")
-
-    user = create(:user, :level_two)
-    login_managed_user(user)
 
     click_link "Support budget investments"
     expect(page).to have_content(budget.name)
@@ -200,9 +186,6 @@ describe "Budget Investments" do
     reviewing_ballots_budget = create(:budget, :reviewing_ballots)
     finished = create(:budget, :finished)
 
-    user = create(:user, :level_two)
-    login_managed_user(user)
-
     click_link "Create budget investment"
 
     expect(page).to have_content(accepting_budget.name)
@@ -230,8 +213,6 @@ describe "Budget Investments" do
     admin = create(:administrator)
     login_as(admin.user)
 
-    user = create(:user, :level_two)
-    login_managed_user(user)
     visit management_sign_in_path
 
     click_link "Create budget investment"
@@ -249,9 +230,6 @@ describe "Budget Investments" do
   context "Supporting" do
     scenario "Supporting budget investments on behalf of someone in index view" do
       budget_investment = create(:budget_investment, heading: heading)
-
-      user = create(:user, :level_two)
-      login_managed_user(user)
 
       click_link "Support budget investments"
       expect(page).to have_content(budget.name)
@@ -272,9 +250,6 @@ describe "Budget Investments" do
     xscenario "Supporting budget investments on behalf of someone in show view" do
       budget_investment = create(:budget_investment, budget: budget)
 
-      user = create(:user, :level_two)
-      login_managed_user(user)
-
       click_link "Support budget investments"
       expect(page).to have_content(budget.name)
       within "#budget_#{budget.id}" do
@@ -291,10 +266,8 @@ describe "Budget Investments" do
     end
 
     scenario "Should not allow unverified users to vote proposals" do
+      login_managed_user(create(:user))
       create(:budget_investment, budget: budget)
-
-      user = create(:user)
-      login_managed_user(user)
 
       click_link "Support budget investments"
 
@@ -354,9 +327,6 @@ describe "Budget Investments" do
                                   budget: budget,
                                   heading: another_heading,
                                   title: "Add new districts to the city")
-
-      user = create(:user, :level_two)
-      login_managed_user(user)
 
       click_link "Print budget investments"
 

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -33,7 +33,7 @@ describe "Budget Investments" do
   context "Create" do
     before { heading.budget.update(phase: "accepting") }
 
-    scenario "Creating budget investments on behalf of someone, selecting a budget", :js do
+    scenario "Creating budget investments on behalf of someone, selecting a budget" do
       user = create(:user, :level_two)
 
       login_managed_user(user)
@@ -80,7 +80,7 @@ describe "Budget Investments" do
       expect(page).to have_content "User is not verified"
     end
 
-    scenario "Shows suggestions to unverified managers", :js do
+    scenario "Shows suggestions to unverified managers" do
       expect(manager.user.level_two_or_three_verified?).to be false
 
       create(:budget_investment, budget: budget, title: "More parks")
@@ -247,7 +247,7 @@ describe "Budget Investments" do
   end
 
   context "Supporting" do
-    scenario "Supporting budget investments on behalf of someone in index view", :js do
+    scenario "Supporting budget investments on behalf of someone in index view" do
       budget_investment = create(:budget_investment, heading: heading)
 
       user = create(:user, :level_two)
@@ -269,7 +269,7 @@ describe "Budget Investments" do
     end
 
     # This test passes ok locally but fails on the last two lines in Travis
-    xscenario "Supporting budget investments on behalf of someone in show view", :js do
+    xscenario "Supporting budget investments on behalf of someone in show view" do
       budget_investment = create(:budget_investment, budget: budget)
 
       user = create(:user, :level_two)
@@ -332,7 +332,7 @@ describe "Budget Investments" do
       expect(page).to have_link("Print", href: "javascript:window.print();")
     end
 
-    scenario "Filtering budget investments by heading to be printed", :js do
+    scenario "Filtering budget investments by heading to be printed" do
       district_9 = create(:budget_heading, group: group, name: "District Nine")
       another_heading = create(:budget_heading, group: group)
       low_investment = create(:budget_investment,

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -7,10 +7,7 @@ describe "Budget Investments" do
   let(:heading) { create(:budget_heading, group: group, name: "Health") }
   let(:user)    { create(:user, :level_two) }
 
-  before do
-    login_managed_user(user)
-    login_as_manager(manager)
-  end
+  before { login_managed_user(user) }
 
   it_behaves_like "mappable",
                   "budget_investment",
@@ -25,6 +22,7 @@ describe "Budget Investments" do
     let(:investment) { create(:budget_investment, budget: budget) }
 
     scenario "finds investment using budget slug" do
+      login_as_manager(manager)
       visit management_budget_investment_path("budget_slug", investment)
 
       expect(page).to have_content investment.title
@@ -35,6 +33,7 @@ describe "Budget Investments" do
     before { heading.budget.update(phase: "accepting") }
 
     scenario "Creating budget investments on behalf of someone, selecting a budget" do
+      login_as_manager(manager)
       click_link "Create budget investment"
       within "#budget_#{budget.id}" do
         click_link "Create budget investment"
@@ -71,6 +70,7 @@ describe "Budget Investments" do
     scenario "Should not allow unverified users to create budget investments" do
       login_managed_user(create(:user))
 
+      login_as_manager(manager)
       click_link "Create budget investment"
 
       expect(page).to have_content "User is not verified"
@@ -83,6 +83,7 @@ describe "Budget Investments" do
       create(:budget_investment, budget: budget, title: "No more parks")
       create(:budget_investment, budget: budget, title: "Plant trees")
 
+      login_as_manager(manager)
       click_link "Create budget investment"
       within "#budget_#{budget.id}" do
         click_link "Create budget investment"
@@ -104,6 +105,7 @@ describe "Budget Investments" do
       budget_investment1 = create(:budget_investment, budget: budget, title: "Show me what you got")
       budget_investment2 = create(:budget_investment, budget: budget, title: "Get Schwifty")
 
+      login_as_manager(manager)
       click_link "Support budget investments"
       expect(page).to have_content(budget.name)
       within "#budget_#{budget.id}" do
@@ -129,6 +131,7 @@ describe "Budget Investments" do
       budget_investment2 = create(:budget_investment, budget: budget, title: "Let's go",
                                                       heading: create(:budget_heading, name: "Area 52"))
 
+      login_as_manager(manager)
       click_link "Support budget investments"
       expect(page).to have_content(budget.name)
       within "#budget_#{budget.id}" do
@@ -153,6 +156,7 @@ describe "Budget Investments" do
     budget_investment1 = create(:budget_investment, budget: budget, title: "Show me what you got")
     budget_investment2 = create(:budget_investment, budget: budget, title: "Get Schwifty")
 
+    login_as_manager(manager)
     click_link "Support budget investments"
     expect(page).to have_content(budget.name)
     within "#budget_#{budget.id}" do
@@ -186,6 +190,7 @@ describe "Budget Investments" do
     reviewing_ballots_budget = create(:budget, :reviewing_ballots)
     finished = create(:budget, :finished)
 
+    login_as_manager(manager)
     click_link "Create budget investment"
 
     expect(page).to have_content(accepting_budget.name)
@@ -207,11 +212,7 @@ describe "Budget Investments" do
     reviewing_ballots_budget = create(:budget, :reviewing_ballots)
     finished = create(:budget, :finished)
 
-    visit root_path
-    click_link "Sign out"
-
-    admin = create(:administrator)
-    login_as(admin.user)
+    login_as(create(:administrator).user)
 
     visit management_sign_in_path
 
@@ -231,6 +232,7 @@ describe "Budget Investments" do
     scenario "Supporting budget investments on behalf of someone in index view" do
       budget_investment = create(:budget_investment, heading: heading)
 
+      login_as_manager(manager)
       click_link "Support budget investments"
       expect(page).to have_content(budget.name)
       within "#budget_#{budget.id}" do
@@ -250,6 +252,7 @@ describe "Budget Investments" do
     xscenario "Supporting budget investments on behalf of someone in show view" do
       budget_investment = create(:budget_investment, budget: budget)
 
+      login_as_manager(manager)
       click_link "Support budget investments"
       expect(page).to have_content(budget.name)
       within "#budget_#{budget.id}" do
@@ -269,6 +272,7 @@ describe "Budget Investments" do
       login_managed_user(create(:user))
       create(:budget_investment, budget: budget)
 
+      login_as_manager(manager)
       click_link "Support budget investments"
 
       expect(page).to have_content "User is not verified"
@@ -279,6 +283,7 @@ describe "Budget Investments" do
     scenario "Printing budget investments" do
       16.times { create(:budget_investment, heading: heading) }
 
+      login_as_manager(manager)
       click_link "Print budget investments"
 
       expect(page).to have_content(budget.name)
@@ -295,6 +300,7 @@ describe "Budget Investments" do
 
       voted_investment = create(:budget_investment, :selected, heading: heading, balloters: [create(:user)])
 
+      login_as_manager(manager)
       click_link "Print budget investments"
 
       within "#budget_#{budget.id}" do
@@ -328,6 +334,7 @@ describe "Budget Investments" do
                                   heading: another_heading,
                                   title: "Add new districts to the city")
 
+      login_as_manager(manager)
       click_link "Print budget investments"
 
       expect(page).to have_content(budget.name)

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -33,7 +33,7 @@ describe "Budget Investments" do
   context "Create" do
     before { heading.budget.update(phase: "accepting") }
 
-    scenario "Creating budget investments on behalf of someone, selecting a budget" do
+    scenario "Creating budget investments on behalf of someone, selecting a budget", :js do
       user = create(:user, :level_two)
 
       login_managed_user(user)
@@ -52,7 +52,7 @@ describe "Budget Investments" do
 
       select "Health", from: "budget_investment_heading_id"
       fill_in "Title", with: "Build a park in my neighborhood"
-      fill_in "Description", with: "There is no parks here..."
+      fill_in_ckeditor "Description", with: "There is no parks here..."
       fill_in "budget_investment_location", with: "City center"
       fill_in "budget_investment_organization_name", with: "T.I.A."
       fill_in "budget_investment_tag_list", with: "green"

--- a/spec/system/management/document_verifications_spec.rb
+++ b/spec/system/management/document_verifications_spec.rb
@@ -1,13 +1,10 @@
 require "rails_helper"
 
 describe "DocumentVerifications" do
-  before do
-    login_as_manager
-  end
-
   scenario "Verifying a level 3 user shows an 'already verified' page" do
     user = create(:user, :level_three)
 
+    login_as_manager
     visit management_document_verifications_path
     fill_in "document_verification_document_number", with: user.document_number
     click_button "Check document"
@@ -18,6 +15,7 @@ describe "DocumentVerifications" do
   scenario "Verifying a level 2 user displays the verification form" do
     user = create(:user, :level_two)
 
+    login_as_manager
     visit management_document_verifications_path
     fill_in "document_verification_document_number", with: user.document_number
     click_button "Check document"
@@ -37,6 +35,7 @@ describe "DocumentVerifications" do
         expect_any_instance_of(Verification::Management::Document).to receive(:in_census?).
                                                                       and_return(false)
 
+        login_as_manager
         visit management_document_verifications_path
         fill_in "document_verification_document_number", with: "inexisting"
         click_button "Check document"
@@ -45,6 +44,7 @@ describe "DocumentVerifications" do
       end
 
       scenario "Verifying a user which does exists in the census but not in the db redirects allows sending an email" do
+        login_as_manager
         visit management_document_verifications_path
         fill_in "document_verification_document_number", with: "12345678Z"
         click_button "Check document"
@@ -58,6 +58,7 @@ describe "DocumentVerifications" do
         expect_any_instance_of(Verification::Management::Document).to receive(:in_census?).
                                                                       and_return(false)
 
+        login_as_manager
         visit management_document_verifications_path
         fill_in "document_verification_document_number", with: "12345678Z"
         select_date "31-December-1980", from: "document_verification_date_of_birth"
@@ -71,6 +72,7 @@ describe "DocumentVerifications" do
                 redirects allows sending an email" do
         mock_valid_remote_census_response
 
+        login_as_manager
         visit management_document_verifications_path
         fill_in "document_verification_document_number", with: "12345678Z"
         select_date "31-December-1980", from: "document_verification_date_of_birth"
@@ -83,6 +85,7 @@ describe "DocumentVerifications" do
   end
 
   scenario "Document number is format-standarized" do
+    login_as_manager
     visit management_document_verifications_path
     fill_in "document_verification_document_number", with: "12345 - h"
     click_button "Check document"
@@ -93,6 +96,7 @@ describe "DocumentVerifications" do
   scenario "User age is checked" do
     expect_any_instance_of(Verification::Management::Document).to receive(:under_age?).and_return(true)
 
+    login_as_manager
     visit management_document_verifications_path
     fill_in "document_verification_document_number", with: "12345678Z"
     click_button "Check document"

--- a/spec/system/management/localization_spec.rb
+++ b/spec/system/management/localization_spec.rb
@@ -1,11 +1,8 @@
 require "rails_helper"
 
 describe "Localization" do
-  before do
-    login_as_manager
-  end
-
   scenario "Wrong locale" do
+    login_as_manager
     visit management_root_path(locale: :es)
     visit management_root_path(locale: :klingon)
 
@@ -13,7 +10,7 @@ describe "Localization" do
   end
 
   scenario "Available locales appear in the locale switcher" do
-    visit management_root_path
+    login_as_manager
 
     within(".locale-form .js-location-changer") do
       expect(page).to have_content "Español"
@@ -22,13 +19,13 @@ describe "Localization" do
   end
 
   scenario "The current locale is selected" do
-    visit management_root_path
+    login_as_manager
     expect(page).to have_select("locale-switcher", selected: "English")
     expect(page).to have_text("Management")
   end
 
   scenario "Changing the locale" do
-    visit management_root_path
+    login_as_manager
     expect(page).to have_content("Language")
 
     select("Español", from: "locale-switcher")
@@ -40,7 +37,7 @@ describe "Localization" do
   scenario "Locale switcher not present if only one locale" do
     allow(I18n).to receive(:available_locales).and_return([:en])
 
-    visit management_root_path
+    login_as_manager
     expect(page).not_to have_content("Language")
     expect(page).not_to have_css("div.locale")
   end

--- a/spec/system/management/localization_spec.rb
+++ b/spec/system/management/localization_spec.rb
@@ -27,7 +27,7 @@ describe "Localization" do
     expect(page).to have_text("Management")
   end
 
-  scenario "Changing the locale", :js do
+  scenario "Changing the locale" do
     visit management_root_path
     expect(page).to have_content("Language")
 

--- a/spec/system/management/managed_users_spec.rb
+++ b/spec/system/management/managed_users_spec.rb
@@ -1,12 +1,9 @@
 require "rails_helper"
 
 describe "Managed User" do
-  before do
-    login_as_manager
-  end
-
   context "Currently managed user" do
     scenario "No managed user" do
+      login_as_manager
       visit management_document_verifications_path
       expect(page).not_to have_css ".account-info"
     end
@@ -14,6 +11,7 @@ describe "Managed User" do
     scenario "User is already level three verified" do
       user = create(:user, :level_three)
 
+      login_as_manager
       visit management_document_verifications_path
       fill_in "document_verification_document_number", with: user.document_number
       click_button "Check document"
@@ -31,6 +29,7 @@ describe "Managed User" do
     scenario "User becomes verified as level three" do
       user = create(:user, :level_two)
 
+      login_as_manager
       visit management_document_verifications_path
       fill_in "document_verification_document_number", with: user.document_number
       click_button "Check document"
@@ -50,10 +49,9 @@ describe "Managed User" do
     end
 
     scenario "User becomes verified as level two (pending email confirmation for level three)" do
-      login_as_manager
-
       user = create(:user)
 
+      login_as_manager
       visit management_document_verifications_path
       fill_in "document_verification_document_number", with: "12345678Z"
       click_button "Check document"
@@ -141,6 +139,7 @@ describe "Managed User" do
   scenario "Close the currently managed user session" do
     user = create(:user, :level_three)
 
+    login_as_manager
     visit management_document_verifications_path
     fill_in "document_verification_document_number", with: user.document_number
     click_button "Check document"

--- a/spec/system/management/proposals_spec.rb
+++ b/spec/system/management/proposals_spec.rb
@@ -214,8 +214,8 @@ describe "Proposals" do
 
       expect(page).to have_selector(".js-order-selector[data-order='created_at']")
 
-      expect(current_url).to include("order=created_at")
-      expect(current_url).to include("page=1")
+      expect(page).to have_current_path(/order=created_at/)
+      expect(page).to have_current_path(/page=1/)
 
       within(".proposals-list") do
         expect(medium_proposal.title).to appear_before(best_proposal.title)

--- a/spec/system/management/proposals_spec.rb
+++ b/spec/system/management/proposals_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
 describe "Proposals" do
+  let(:user) { create(:user, :level_two) }
+
   before do
+    login_managed_user(user)
     login_as_manager
   end
 
   context "Create" do
     scenario "Creating proposals on behalf of someone" do
-      user = create(:user, :level_two)
-      login_managed_user(user)
-
       click_link "Create proposal"
 
       within(".account-info") do
@@ -40,8 +40,7 @@ describe "Proposals" do
     end
 
     scenario "Should not allow unverified users to create proposals" do
-      user = create(:user)
-      login_managed_user(user)
+      login_managed_user(create(:user))
 
       click_link "Create proposal"
 
@@ -53,9 +52,6 @@ describe "Proposals" do
     scenario "When path matches the friendly url" do
       proposal = create(:proposal)
 
-      user = create(:user, :level_two)
-      login_managed_user(user)
-
       right_path = management_proposal_path(proposal)
       visit right_path
 
@@ -64,9 +60,6 @@ describe "Proposals" do
 
     scenario "When path does not match the friendly url" do
       proposal = create(:proposal)
-
-      user = create(:user, :level_two)
-      login_managed_user(user)
 
       right_path = management_proposal_path(proposal)
       old_path = "#{management_proposals_path}/#{proposal.id}-something-else"
@@ -79,7 +72,6 @@ describe "Proposals" do
     scenario "Successful proposal" do
       proposal = create(:proposal, :successful, title: "Success!")
 
-      login_managed_user(create(:user, :level_two))
       visit management_proposal_path(proposal)
 
       expect(page).to have_content("Success!")
@@ -89,9 +81,6 @@ describe "Proposals" do
   scenario "Searching" do
     proposal1 = create(:proposal, title: "Show me what you got")
     proposal2 = create(:proposal, title: "Get Schwifty")
-
-    user = create(:user, :level_two)
-    login_managed_user(user)
 
     click_link "Support proposals"
 
@@ -112,9 +101,6 @@ describe "Proposals" do
   scenario "Listing" do
     proposal1 = create(:proposal, title: "Show me what you got")
     proposal2 = create(:proposal, title: "Get Schwifty")
-
-    user = create(:user, :level_two)
-    login_managed_user(user)
 
     click_link "Support proposals"
 
@@ -140,9 +126,6 @@ describe "Proposals" do
     let!(:proposal) { create(:proposal) }
 
     scenario "Voting proposals on behalf of someone in index view" do
-      user = create(:user, :level_two)
-      login_managed_user(user)
-
       click_link "Support proposals"
 
       within(".proposals-list") do
@@ -155,9 +138,6 @@ describe "Proposals" do
     end
 
     scenario "Voting proposals on behalf of someone in show view" do
-      user = create(:user, :level_two)
-      login_managed_user(user)
-
       click_link "Support proposals"
 
       within(".proposals-list") { click_link proposal.title }
@@ -171,8 +151,7 @@ describe "Proposals" do
     end
 
     scenario "Should not allow unverified users to vote proposals" do
-      user = create(:user)
-      login_managed_user(user)
+      login_managed_user(create(:user))
 
       click_link "Support proposals"
 
@@ -197,9 +176,6 @@ describe "Proposals" do
       best_proposal.update_column(:confidence_score, 10)
       medium_proposal = create(:proposal, title: "Medium proposal")
       medium_proposal.update_column(:confidence_score, 5)
-
-      user = create(:user, :level_two)
-      login_managed_user(user)
 
       click_link "Print proposals"
 

--- a/spec/system/management/proposals_spec.rb
+++ b/spec/system/management/proposals_spec.rb
@@ -6,7 +6,7 @@ describe "Proposals" do
   end
 
   context "Create" do
-    scenario "Creating proposals on behalf of someone" do
+    scenario "Creating proposals on behalf of someone", :js do
       user = create(:user, :level_two)
       login_managed_user(user)
 
@@ -21,7 +21,7 @@ describe "Proposals" do
 
       fill_in "Proposal title", with: "Help refugees"
       fill_in "Proposal summary", with: "In summary, what we want is..."
-      fill_in "Proposal text", with: "This is very important because..."
+      fill_in_ckeditor "Proposal text", with: "This is very important because..."
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yRYFKcMa_Ek"
       check "proposal_terms_of_service"
 

--- a/spec/system/management/proposals_spec.rb
+++ b/spec/system/management/proposals_spec.rb
@@ -5,11 +5,11 @@ describe "Proposals" do
 
   before do
     login_managed_user(user)
-    login_as_manager
   end
 
   context "Create" do
     scenario "Creating proposals on behalf of someone" do
+      login_as_manager
       click_link "Create proposal"
 
       within(".account-info") do
@@ -42,6 +42,7 @@ describe "Proposals" do
     scenario "Should not allow unverified users to create proposals" do
       login_managed_user(create(:user))
 
+      login_as_manager
       click_link "Create proposal"
 
       expect(page).to have_content "User is not verified"
@@ -53,6 +54,7 @@ describe "Proposals" do
       proposal = create(:proposal)
 
       right_path = management_proposal_path(proposal)
+      login_as_manager
       visit right_path
 
       expect(page).to have_current_path(right_path)
@@ -63,6 +65,8 @@ describe "Proposals" do
 
       right_path = management_proposal_path(proposal)
       old_path = "#{management_proposals_path}/#{proposal.id}-something-else"
+
+      login_as_manager
       visit old_path
 
       expect(page).not_to have_current_path(old_path)
@@ -72,6 +76,7 @@ describe "Proposals" do
     scenario "Successful proposal" do
       proposal = create(:proposal, :successful, title: "Success!")
 
+      login_as_manager
       visit management_proposal_path(proposal)
 
       expect(page).to have_content("Success!")
@@ -82,6 +87,7 @@ describe "Proposals" do
     proposal1 = create(:proposal, title: "Show me what you got")
     proposal2 = create(:proposal, title: "Get Schwifty")
 
+    login_as_manager
     click_link "Support proposals"
 
     fill_in "search", with: "what you got"
@@ -102,6 +108,7 @@ describe "Proposals" do
     proposal1 = create(:proposal, title: "Show me what you got")
     proposal2 = create(:proposal, title: "Get Schwifty")
 
+    login_as_manager
     click_link "Support proposals"
 
     expect(page).to have_current_path(management_proposals_path)
@@ -126,6 +133,7 @@ describe "Proposals" do
     let!(:proposal) { create(:proposal) }
 
     scenario "Voting proposals on behalf of someone in index view" do
+      login_as_manager
       click_link "Support proposals"
 
       within(".proposals-list") do
@@ -138,6 +146,7 @@ describe "Proposals" do
     end
 
     scenario "Voting proposals on behalf of someone in show view" do
+      login_as_manager
       click_link "Support proposals"
 
       within(".proposals-list") { click_link proposal.title }
@@ -153,6 +162,7 @@ describe "Proposals" do
     scenario "Should not allow unverified users to vote proposals" do
       login_managed_user(create(:user))
 
+      login_as_manager
       click_link "Support proposals"
 
       expect(page).to have_content "User is not verified"
@@ -163,6 +173,7 @@ describe "Proposals" do
     scenario "Printing proposals" do
       6.times { create(:proposal) }
 
+      login_as_manager
       click_link "Print proposals"
 
       expect(page).to have_css(".proposal", count: 5)
@@ -177,6 +188,7 @@ describe "Proposals" do
       medium_proposal = create(:proposal, title: "Medium proposal")
       medium_proposal.update_column(:confidence_score, 5)
 
+      login_as_manager
       click_link "Print proposals"
 
       expect(page).to have_selector(".js-order-selector[data-order='confidence_score']")

--- a/spec/system/management/proposals_spec.rb
+++ b/spec/system/management/proposals_spec.rb
@@ -6,7 +6,7 @@ describe "Proposals" do
   end
 
   context "Create" do
-    scenario "Creating proposals on behalf of someone", :js do
+    scenario "Creating proposals on behalf of someone" do
       user = create(:user, :level_two)
       login_managed_user(user)
 
@@ -76,7 +76,7 @@ describe "Proposals" do
       expect(page).to have_current_path(right_path)
     end
 
-    scenario "Successful proposal", :js do
+    scenario "Successful proposal" do
       proposal = create(:proposal, :successful, title: "Success!")
 
       login_managed_user(create(:user, :level_two))
@@ -139,7 +139,7 @@ describe "Proposals" do
   context "Voting" do
     let!(:proposal) { create(:proposal) }
 
-    scenario "Voting proposals on behalf of someone in index view", :js do
+    scenario "Voting proposals on behalf of someone in index view" do
       user = create(:user, :level_two)
       login_managed_user(user)
 
@@ -154,7 +154,7 @@ describe "Proposals" do
       expect(page).to have_current_path(management_proposals_path)
     end
 
-    scenario "Voting proposals on behalf of someone in show view", :js do
+    scenario "Voting proposals on behalf of someone in show view" do
       user = create(:user, :level_two)
       login_managed_user(user)
 
@@ -190,7 +190,7 @@ describe "Proposals" do
       expect(page).to have_css("a[href='javascript:window.print();']", text: "Print")
     end
 
-    scenario "Filtering proposals to be printed", :js do
+    scenario "Filtering proposals to be printed" do
       worst_proposal = create(:proposal, title: "Worst proposal")
       worst_proposal.update_column(:confidence_score, 2)
       best_proposal = create(:proposal, title: "Best proposal")

--- a/spec/system/management/users_spec.rb
+++ b/spec/system/management/users_spec.rb
@@ -1,11 +1,8 @@
 require "rails_helper"
 
 describe "Users" do
-  before do
-    login_as_manager
-  end
-
   scenario "Create a level 3 user with email from scratch" do
+    login_as_manager
     visit management_document_verifications_path
     fill_in "document_verification_document_number", with: "12345678Z"
     click_button "Check document"
@@ -46,6 +43,7 @@ describe "Users" do
   end
 
   scenario "Create a level 3 user without email from scratch" do
+    login_as_manager
     visit management_document_verifications_path
     fill_in "document_verification_document_number", with: "12345678Z"
     click_button "Check document"
@@ -74,6 +72,7 @@ describe "Users" do
   scenario "Delete a level 2 user account from document verification page" do
     level_2_user = create(:user, :level_two, document_number: "12345678Z")
 
+    login_as_manager
     visit management_document_verifications_path
     fill_in "document_verification_document_number", with: "12345678Z"
     click_button "Check document"

--- a/spec/system/management/users_spec.rb
+++ b/spec/system/management/users_spec.rb
@@ -71,7 +71,7 @@ describe "Users" do
     expect(user.date_of_birth).to have_content Date.new(1980, 12, 31)
   end
 
-  scenario "Delete a level 2 user account from document verification page", :js do
+  scenario "Delete a level 2 user account from document verification page" do
     level_2_user = create(:user, :level_two, document_number: "12345678Z")
 
     visit management_document_verifications_path

--- a/spec/system/management_spec.rb
+++ b/spec/system/management_spec.rb
@@ -1,15 +1,14 @@
 require "rails_helper"
 
-describe "Management" do
+describe "Management", :js do
   let(:user) { create(:user) }
 
   scenario "Should show admin menu if logged user is admin" do
     create(:administrator, user: user)
     login_as(user)
+
     visit root_path
-
-    expect(page).to have_link("Management")
-
+    click_link "Menu"
     click_link "Management"
 
     expect(page).to have_content("My content")
@@ -22,8 +21,7 @@ describe "Management" do
     login_as(user)
     visit root_path
 
-    expect(page).to have_link("Management")
-
+    click_link "Menu"
     click_link "Management"
 
     expect(page).not_to have_content("My content")

--- a/spec/system/management_spec.rb
+++ b/spec/system/management_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Management", :js do
+describe "Management" do
   let(:user) { create(:user) }
 
   scenario "Should show admin menu if logged user is admin" do

--- a/spec/system/moderation/budget_investments_spec.rb
+++ b/spec/system/moderation/budget_investments_spec.rb
@@ -50,7 +50,7 @@ describe "Moderate budget investments" do
     end
 
     describe "moderate in bulk" do
-      describe "When an investment has been selected for moderation" do
+      describe "When an investment has been selected for moderation", :js do
         before do
           visit moderation_budget_investments_path
 
@@ -66,7 +66,8 @@ describe "Moderate budget investments" do
         end
 
         scenario "Hide the investment" do
-          click_button "Hide budget investments"
+          accept_confirm { click_button "Hide budget investments" }
+
           expect(page).not_to have_css("investment_#{investment.id}")
 
           investment.reload
@@ -75,7 +76,8 @@ describe "Moderate budget investments" do
         end
 
         scenario "Block the author" do
-          click_button "Block authors"
+          accept_confirm { click_button "Block authors" }
+
           expect(page).not_to have_css("investment_#{investment.id}")
 
           investment.reload
@@ -84,7 +86,8 @@ describe "Moderate budget investments" do
         end
 
         scenario "Ignore the investment" do
-          click_button "Mark as viewed"
+          accept_confirm { click_button "Mark as viewed" }
+
           expect(page).not_to have_css("investment_#{investment.id}")
 
           investment.reload
@@ -111,13 +114,13 @@ describe "Moderate budget investments" do
         end
       end
 
-      scenario "remembering page, filter and order" do
+      scenario "remembering page, filter and order", :js do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:budget_investment, 4, heading: heading, author: create(:user))
 
         visit moderation_budget_investments_path(filter: "all", page: "2", order: "created_at")
 
-        click_button "Mark as viewed"
+        accept_confirm { click_button "Mark as viewed" }
 
         expect(page).to have_selector(".js-order-selector[data-order='created_at']")
 

--- a/spec/system/moderation/budget_investments_spec.rb
+++ b/spec/system/moderation/budget_investments_spec.rb
@@ -121,9 +121,9 @@ describe "Moderate budget investments" do
 
         expect(page).to have_selector(".js-order-selector[data-order='created_at']")
 
-        expect(current_url).to include("filter=all")
-        expect(current_url).to include("page=2")
-        expect(current_url).to include("order=created_at")
+        expect(page).to have_current_path(/filter=all/)
+        expect(page).to have_current_path(/page=2/)
+        expect(page).to have_current_path(/order=created_at/)
       end
     end
 

--- a/spec/system/moderation/budget_investments_spec.rb
+++ b/spec/system/moderation/budget_investments_spec.rb
@@ -6,7 +6,7 @@ describe "Moderate budget investments" do
   let(:mod)         { create(:moderator) }
   let!(:investment) { create(:budget_investment, heading: heading, author: create(:user)) }
 
-  scenario "Hiding an investment", :js do
+  scenario "Hiding an investment" do
     login_as(mod.user)
     visit budget_investment_path(budget, investment)
 
@@ -19,7 +19,7 @@ describe "Moderate budget investments" do
     expect(page).not_to have_content(investment.title)
   end
 
-  scenario "Hiding an investment's author", :js do
+  scenario "Hiding an investment's author" do
     login_as(mod.user)
     visit budget_investment_path(budget, investment)
 
@@ -50,7 +50,7 @@ describe "Moderate budget investments" do
     end
 
     describe "moderate in bulk" do
-      describe "When an investment has been selected for moderation", :js do
+      describe "When an investment has been selected for moderation" do
         before do
           visit moderation_budget_investments_path
 
@@ -98,7 +98,7 @@ describe "Moderate budget investments" do
         end
       end
 
-      scenario "select all/none", :js do
+      scenario "select all/none" do
         create_list(:budget_investment, 2, heading: heading, author: create(:user))
 
         visit moderation_budget_investments_path
@@ -114,7 +114,7 @@ describe "Moderate budget investments" do
         end
       end
 
-      scenario "remembering page, filter and order", :js do
+      scenario "remembering page, filter and order" do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:budget_investment, 4, heading: heading, author: create(:user))
 

--- a/spec/system/moderation/comments_spec.rb
+++ b/spec/system/moderation/comments_spec.rb
@@ -134,9 +134,9 @@ describe "Moderate comments" do
 
         expect(page).to have_selector(".js-order-selector[data-order='newest']")
 
-        expect(current_url).to include("filter=all")
-        expect(current_url).to include("page=2")
-        expect(current_url).to include("order=newest")
+        expect(page).to have_current_path(/filter=all/)
+        expect(page).to have_current_path(/page=2/)
+        expect(page).to have_current_path(/order=newest/)
       end
     end
 

--- a/spec/system/moderation/comments_spec.rb
+++ b/spec/system/moderation/comments_spec.rb
@@ -69,7 +69,7 @@ describe "Moderate comments" do
     end
 
     describe "moderate in bulk" do
-      describe "When a comment has been selected for moderation" do
+      describe "When a comment has been selected for moderation", :js do
         let!(:comment) { create(:comment) }
 
         before do
@@ -86,21 +86,24 @@ describe "Moderate comments" do
         end
 
         scenario "Hide the comment" do
-          click_on "Hide comments"
+          accept_confirm { click_button "Hide comments" }
+
           expect(page).not_to have_css("comment_#{comment.id}")
           expect(comment.reload).to be_hidden
           expect(comment.user).not_to be_hidden
         end
 
         scenario "Block the user" do
-          click_on "Block authors"
+          accept_confirm { click_button "Block authors" }
+
           expect(page).not_to have_css("comment_#{comment.id}")
           expect(comment.reload).to be_hidden
           expect(comment.user).to be_hidden
         end
 
         scenario "Ignore the comment" do
-          click_on "Mark as viewed"
+          accept_confirm { click_button "Mark as viewed" }
+
           expect(page).not_to have_css("comment_#{comment.id}")
           expect(comment.reload).to be_ignored_flag
           expect(comment.reload).not_to be_hidden
@@ -124,13 +127,13 @@ describe "Moderate comments" do
         end
       end
 
-      scenario "remembering page, filter and order" do
+      scenario "remembering page, filter and order", :js do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:comment, 4)
 
         visit moderation_comments_path(filter: "all", page: "2", order: "newest")
 
-        click_on "Mark as viewed"
+        accept_confirm { click_button "Mark as viewed" }
 
         expect(page).to have_selector(".js-order-selector[data-order='newest']")
 

--- a/spec/system/moderation/comments_spec.rb
+++ b/spec/system/moderation/comments_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Moderate comments" do
-  scenario "Hide", :js do
+  scenario "Hide" do
     citizen = create(:user)
     moderator = create(:moderator)
 
@@ -69,7 +69,7 @@ describe "Moderate comments" do
     end
 
     describe "moderate in bulk" do
-      describe "When a comment has been selected for moderation", :js do
+      describe "When a comment has been selected for moderation" do
         let!(:comment) { create(:comment) }
 
         before do
@@ -111,7 +111,7 @@ describe "Moderate comments" do
         end
       end
 
-      scenario "select all/none", :js do
+      scenario "select all/none" do
         create_list(:comment, 2)
 
         visit moderation_comments_path
@@ -127,7 +127,7 @@ describe "Moderate comments" do
         end
       end
 
-      scenario "remembering page, filter and order", :js do
+      scenario "remembering page, filter and order" do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:comment, 4)
 

--- a/spec/system/moderation/debates_spec.rb
+++ b/spec/system/moderation/debates_spec.rb
@@ -42,7 +42,7 @@ describe "Moderate debates" do
     end
 
     describe "moderate in bulk" do
-      describe "When a debate has been selected for moderation" do
+      describe "When a debate has been selected for moderation", :js do
         let!(:debate) { create(:debate) }
 
         before do
@@ -59,21 +59,24 @@ describe "Moderate debates" do
         end
 
         scenario "Hide the debate" do
-          click_on "Hide debates"
+          accept_confirm { click_button "Hide debates" }
+
           expect(page).not_to have_css("debate_#{debate.id}")
           expect(debate.reload).to be_hidden
           expect(debate.author).not_to be_hidden
         end
 
         scenario "Block the author" do
-          click_on "Block authors"
+          accept_confirm { click_button "Block authors" }
+
           expect(page).not_to have_css("debate_#{debate.id}")
           expect(debate.reload).to be_hidden
           expect(debate.author).to be_hidden
         end
 
         scenario "Ignore the debate" do
-          click_on "Mark as viewed"
+          accept_confirm { click_button "Mark as viewed" }
+
           expect(page).not_to have_css("debate_#{debate.id}")
           expect(debate.reload).to be_ignored_flag
           expect(debate.reload).not_to be_hidden
@@ -97,13 +100,13 @@ describe "Moderate debates" do
         end
       end
 
-      scenario "remembering page, filter and order" do
+      scenario "remembering page, filter and order", :js do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:debate, 4)
 
         visit moderation_debates_path(filter: "all", page: "2", order: "created_at")
 
-        click_on "Mark as viewed"
+        accept_confirm { click_button "Mark as viewed" }
 
         expect(page).to have_selector(".js-order-selector[data-order='created_at']")
 

--- a/spec/system/moderation/debates_spec.rb
+++ b/spec/system/moderation/debates_spec.rb
@@ -107,9 +107,9 @@ describe "Moderate debates" do
 
         expect(page).to have_selector(".js-order-selector[data-order='created_at']")
 
-        expect(current_url).to include("filter=all")
-        expect(current_url).to include("page=2")
-        expect(current_url).to include("order=created_at")
+        expect(page).to have_current_path(/filter=all/)
+        expect(page).to have_current_path(/page=2/)
+        expect(page).to have_current_path(/order=created_at/)
       end
     end
 

--- a/spec/system/moderation/debates_spec.rb
+++ b/spec/system/moderation/debates_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Moderate debates" do
-  scenario "Hide", :js do
+  scenario "Hide" do
     citizen = create(:user)
     moderator = create(:moderator)
 
@@ -42,7 +42,7 @@ describe "Moderate debates" do
     end
 
     describe "moderate in bulk" do
-      describe "When a debate has been selected for moderation", :js do
+      describe "When a debate has been selected for moderation" do
         let!(:debate) { create(:debate) }
 
         before do
@@ -84,7 +84,7 @@ describe "Moderate debates" do
         end
       end
 
-      scenario "select all/none", :js do
+      scenario "select all/none" do
         create_list(:debate, 2)
 
         visit moderation_debates_path
@@ -100,7 +100,7 @@ describe "Moderate debates" do
         end
       end
 
-      scenario "remembering page, filter and order", :js do
+      scenario "remembering page, filter and order" do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:debate, 4)
 

--- a/spec/system/moderation/legislation_proposals_spec.rb
+++ b/spec/system/moderation/legislation_proposals_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Moderate legislation proposals" do
-  scenario "Hide", :js do
+  scenario "Hide" do
     citizen               = create(:user)
     legislation_process   = create(:legislation_process)
     legislation_proposal  = create(:legislation_proposal, legislation_process_id: legislation_process.id)

--- a/spec/system/moderation/proposal_notifications_spec.rb
+++ b/spec/system/moderation/proposal_notifications_spec.rb
@@ -110,9 +110,9 @@ describe "Moderate proposal notifications" do
 
         expect(page).to have_selector(".js-order-selector[data-order='created_at']")
 
-        expect(current_url).to include("filter=all")
-        expect(current_url).to include("page=2")
-        expect(current_url).to include("order=created_at")
+        expect(page).to have_current_path(/filter=all/)
+        expect(page).to have_current_path(/page=2/)
+        expect(page).to have_current_path(/order=created_at/)
       end
     end
 

--- a/spec/system/moderation/proposal_notifications_spec.rb
+++ b/spec/system/moderation/proposal_notifications_spec.rb
@@ -24,13 +24,14 @@ describe "Moderate proposal notifications" do
     expect(page).to have_content "Notifications (0)"
   end
 
-  scenario "Can not hide own proposal notification" do
+  scenario "Can not hide own proposal notification", :js do
     moderator = create(:moderator)
     proposal = create(:proposal, author: moderator.user)
     proposal_notification = create(:proposal_notification, proposal: proposal, created_at: Date.current - 4.days)
 
     login_as(moderator.user)
     visit proposal_path(proposal)
+    click_link "Notifications (1)"
 
     within("#proposal_notification_#{proposal_notification.id}") do
       expect(page).not_to have_link("Hide")

--- a/spec/system/moderation/proposal_notifications_spec.rb
+++ b/spec/system/moderation/proposal_notifications_spec.rb
@@ -45,7 +45,7 @@ describe "Moderate proposal notifications" do
     end
 
     describe "moderate in bulk" do
-      describe "When a proposal has been selected for moderation" do
+      describe "When a proposal has been selected for moderation", :js do
         let!(:proposal_notification) { create(:proposal_notification, created_at: Date.current - 4.days) }
 
         before do
@@ -60,7 +60,8 @@ describe "Moderate proposal notifications" do
         end
 
         scenario "Hide the proposal" do
-          click_on "Hide proposals"
+          accept_confirm { click_button "Hide proposals" }
+
           expect(page).not_to have_css("#proposal_notification_#{proposal_notification.id}")
           expect(proposal_notification.reload).to be_hidden
           expect(proposal_notification.author).not_to be_hidden
@@ -69,7 +70,9 @@ describe "Moderate proposal notifications" do
         scenario "Block the author" do
           author = create(:user)
           proposal_notification.update!(author: author)
-          click_on "Block authors"
+
+          accept_confirm { click_button "Block authors" }
+
           expect(page).not_to have_css("#proposal_notification_#{proposal_notification.id}")
           expect(proposal_notification.reload).to be_hidden
           expect(author.reload).to be_hidden
@@ -100,13 +103,13 @@ describe "Moderate proposal notifications" do
         end
       end
 
-      scenario "remembering page, filter and order" do
+      scenario "remembering page, filter and order", :js do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:proposal, 4)
 
         visit moderation_proposal_notifications_path(filter: "all", page: "2", order: "created_at")
 
-        click_button "Mark as viewed"
+        accept_confirm { click_button "Mark as viewed" }
 
         expect(page).to have_selector(".js-order-selector[data-order='created_at']")
 

--- a/spec/system/moderation/proposal_notifications_spec.rb
+++ b/spec/system/moderation/proposal_notifications_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Moderate proposal notifications" do
-  scenario "Hide", :js do
+  scenario "Hide" do
     citizen   = create(:user)
     proposal  = create(:proposal)
     proposal_notification = create(:proposal_notification, proposal: proposal, created_at: Date.current - 4.days)
@@ -24,7 +24,7 @@ describe "Moderate proposal notifications" do
     expect(page).to have_content "Notifications (0)"
   end
 
-  scenario "Can not hide own proposal notification", :js do
+  scenario "Can not hide own proposal notification" do
     moderator = create(:moderator)
     proposal = create(:proposal, author: moderator.user)
     proposal_notification = create(:proposal_notification, proposal: proposal, created_at: Date.current - 4.days)
@@ -46,7 +46,7 @@ describe "Moderate proposal notifications" do
     end
 
     describe "moderate in bulk" do
-      describe "When a proposal has been selected for moderation", :js do
+      describe "When a proposal has been selected for moderation" do
         let!(:proposal_notification) { create(:proposal_notification, created_at: Date.current - 4.days) }
 
         before do
@@ -88,7 +88,7 @@ describe "Moderate proposal notifications" do
         end
       end
 
-      scenario "select all/none", :js do
+      scenario "select all/none" do
         create_list(:proposal_notification, 2)
 
         visit moderation_proposal_notifications_path
@@ -104,7 +104,7 @@ describe "Moderate proposal notifications" do
         end
       end
 
-      scenario "remembering page, filter and order", :js do
+      scenario "remembering page, filter and order" do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:proposal, 4)
 

--- a/spec/system/moderation/proposal_notifications_spec.rb
+++ b/spec/system/moderation/proposal_notifications_spec.rb
@@ -75,7 +75,7 @@ describe "Moderate proposal notifications" do
           expect(author.reload).to be_hidden
         end
 
-        scenario "Ignore the proposal" do
+        scenario "Ignore the proposal", :no_js do
           click_button "Mark as viewed"
 
           expect(proposal_notification.reload).to be_ignored

--- a/spec/system/moderation/proposals_spec.rb
+++ b/spec/system/moderation/proposals_spec.rb
@@ -43,7 +43,7 @@ describe "Moderate proposals" do
     describe "moderate in bulk" do
       let!(:proposal) { create(:proposal) }
 
-      describe "When a proposal has been selected for moderation" do
+      describe "When a proposal has been selected for moderation", :js do
         before do
           visit moderation_proposals_path
           within(".menu.simple") do
@@ -58,21 +58,24 @@ describe "Moderate proposals" do
         end
 
         scenario "Hide the proposal" do
-          click_on "Hide proposals"
+          accept_confirm { click_button "Hide proposals" }
+
           expect(page).not_to have_css("proposal_#{proposal.id}")
           expect(proposal.reload).to be_hidden
           expect(proposal.author).not_to be_hidden
         end
 
         scenario "Block the author" do
-          click_on "Block authors"
+          accept_confirm { click_button "Block authors" }
+
           expect(page).not_to have_css("proposal_#{proposal.id}")
           expect(proposal.reload).to be_hidden
           expect(proposal.author).to be_hidden
         end
 
         scenario "Ignore the proposal" do
-          click_button "Mark as viewed"
+          accept_confirm { click_button "Mark as viewed" }
+
           expect(page).not_to have_css("proposal_#{proposal.id}")
           expect(proposal.reload).to be_ignored_flag
           expect(proposal.reload).not_to be_hidden
@@ -96,13 +99,13 @@ describe "Moderate proposals" do
         end
       end
 
-      scenario "remembering page, filter and order" do
+      scenario "remembering page, filter and order", :js do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:proposal, 4)
 
         visit moderation_proposals_path(filter: "all", page: "2", order: "created_at")
 
-        click_button "Mark as viewed"
+        accept_confirm { click_button "Mark as viewed" }
 
         expect(page).to have_selector(".js-order-selector[data-order='created_at']")
 

--- a/spec/system/moderation/proposals_spec.rb
+++ b/spec/system/moderation/proposals_spec.rb
@@ -106,9 +106,9 @@ describe "Moderate proposals" do
 
         expect(page).to have_selector(".js-order-selector[data-order='created_at']")
 
-        expect(current_url).to include("filter=all")
-        expect(current_url).to include("page=2")
-        expect(current_url).to include("order=created_at")
+        expect(page).to have_current_path(/filter=all/)
+        expect(page).to have_current_path(/page=2/)
+        expect(page).to have_current_path(/order=created_at/)
       end
     end
 

--- a/spec/system/moderation/proposals_spec.rb
+++ b/spec/system/moderation/proposals_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Moderate proposals" do
-  scenario "Hide", :js do
+  scenario "Hide" do
     citizen   = create(:user)
     proposal  = create(:proposal)
     moderator = create(:moderator)
@@ -43,7 +43,7 @@ describe "Moderate proposals" do
     describe "moderate in bulk" do
       let!(:proposal) { create(:proposal) }
 
-      describe "When a proposal has been selected for moderation", :js do
+      describe "When a proposal has been selected for moderation" do
         before do
           visit moderation_proposals_path
           within(".menu.simple") do
@@ -83,7 +83,7 @@ describe "Moderate proposals" do
         end
       end
 
-      scenario "select all/none", :js do
+      scenario "select all/none" do
         create_list(:proposal, 2)
 
         visit moderation_proposals_path
@@ -99,7 +99,7 @@ describe "Moderate proposals" do
         end
       end
 
-      scenario "remembering page, filter and order", :js do
+      scenario "remembering page, filter and order" do
         stub_const("#{ModerateActions}::PER_PAGE", 2)
         create_list(:proposal, 4)
 

--- a/spec/system/moderation/users_spec.rb
+++ b/spec/system/moderation/users_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Moderate users" do
-  scenario "Hide" do
+  scenario "Hide", :js do
     citizen = create(:user)
     moderator = create(:moderator)
 
@@ -24,7 +24,7 @@ describe "Moderate users" do
     visit debate_path(debate1)
 
     within("#debate_#{debate1.id}") do
-      click_link "Hide author"
+      accept_confirm { click_link "Hide author" }
     end
 
     expect(page).to have_current_path(debates_path)

--- a/spec/system/moderation/users_spec.rb
+++ b/spec/system/moderation/users_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Moderate users" do
-  scenario "Hide", :js do
+  scenario "Hide" do
     citizen = create(:user)
     moderator = create(:moderator)
 

--- a/spec/system/moderation_spec.rb
+++ b/spec/system/moderation_spec.rb
@@ -1,13 +1,16 @@
 require "rails_helper"
 
-describe "Moderation" do
+describe "Moderation", :js do
   let(:user) { create(:user) }
 
   scenario "Access as regular user is not authorized" do
     login_as(user)
+
     visit root_path
 
+    expect(page).not_to have_link("Menu")
     expect(page).not_to have_link("Moderation")
+
     visit moderation_root_path
 
     expect(page).not_to have_current_path(moderation_root_path)
@@ -17,11 +20,13 @@ describe "Moderation" do
 
   scenario "Access as valuator is not authorized" do
     create(:valuator, user: user)
-
     login_as(user)
+
     visit root_path
+    click_link "Menu"
 
     expect(page).not_to have_link("Moderation")
+
     visit moderation_root_path
 
     expect(page).not_to have_current_path(moderation_root_path)
@@ -31,11 +36,13 @@ describe "Moderation" do
 
   scenario "Access as manager is not authorized" do
     create(:manager, user: user)
-
     login_as(user)
+
     visit root_path
+    click_link "Menu"
 
     expect(page).not_to have_link("Moderation")
+
     visit moderation_root_path
 
     expect(page).not_to have_current_path(moderation_root_path)
@@ -45,9 +52,10 @@ describe "Moderation" do
 
   scenario "Access as SDG manager is not authorized", :js do
     create(:sdg_manager, user: user)
-
     login_as(user)
+
     visit root_path
+    click_link "Menu"
 
     expect(page).not_to have_link("Moderation")
 
@@ -60,11 +68,13 @@ describe "Moderation" do
 
   scenario "Access as poll officer is not authorized" do
     create(:poll_officer, user: user)
-
     login_as(user)
+
     visit root_path
+    click_link "Menu"
 
     expect(page).not_to have_link("Moderation")
+
     visit moderation_root_path
 
     expect(page).not_to have_current_path(moderation_root_path)
@@ -77,9 +87,8 @@ describe "Moderation" do
 
     login_as(user)
     visit root_path
-
-    expect(page).to have_link("Moderation")
-    click_on "Moderation"
+    click_link "Menu"
+    click_link "Moderation"
 
     expect(page).to have_current_path(moderation_root_path)
     expect(page).not_to have_content "You do not have permission to access this page"
@@ -90,9 +99,8 @@ describe "Moderation" do
 
     login_as(user)
     visit root_path
-
-    expect(page).to have_link("Moderation")
-    click_on "Moderation"
+    click_link "Menu"
+    click_link "Moderation"
 
     expect(page).to have_current_path(moderation_root_path)
     expect(page).not_to have_content "You do not have permission to access this page"
@@ -101,7 +109,9 @@ describe "Moderation" do
   scenario "Moderation access links" do
     create(:moderator, user: user)
     login_as(user)
+
     visit root_path
+    click_link "Menu"
 
     expect(page).to have_link("Moderation")
     expect(page).not_to have_link("Administration")
@@ -116,8 +126,9 @@ describe "Moderation" do
     scenario "Contains correct elements" do
       create(:moderator, user: user)
       login_as(user)
-      visit root_path
 
+      visit root_path
+      click_link "Menu"
       click_link "Moderation"
 
       expect(page).to have_link("Go back to OrgName")

--- a/spec/system/moderation_spec.rb
+++ b/spec/system/moderation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Moderation", :js do
+describe "Moderation" do
   let(:user) { create(:user) }
 
   scenario "Access as regular user is not authorized" do
@@ -50,7 +50,7 @@ describe "Moderation", :js do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario "Access as SDG manager is not authorized", :js do
+  scenario "Access as SDG manager is not authorized" do
     create(:sdg_manager, user: user)
     login_as(user)
 

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -155,7 +155,8 @@ describe "Notifications" do
       expect(page).to have_content("Notification body")
 
       first("#notification_#{notification.id} a").click
-      expect(page.current_url).to eq("https://www.external.link.dev/")
+
+      expect(page).to have_current_path "https://www.external.link.dev/", url: true
     end
 
     scenario "With internal link", :js do

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -52,7 +52,7 @@ describe "Notifications" do
     expect(page).to have_css ".notification", count: 1
   end
 
-  scenario "Mark as read", :js do
+  scenario "Mark as read" do
     notification1 = create(:notification, user: user)
     notification2 = create(:notification, user: user)
 
@@ -78,7 +78,7 @@ describe "Notifications" do
     expect(page).to have_css(".notification", count: 0)
   end
 
-  scenario "Mark as unread", :js do
+  scenario "Mark as unread" do
     notification1 = create(:notification, :read, user: user)
     notification2 = create(:notification, user: user)
 
@@ -159,7 +159,7 @@ describe "Notifications" do
       expect(page).to have_current_path "https://www.external.link.dev/", url: true
     end
 
-    scenario "With internal link", :js do
+    scenario "With internal link" do
       admin_notification.update!(link: "/stats")
 
       visit notifications_path

--- a/spec/system/officing/residence_spec.rb
+++ b/spec/system/officing/residence_spec.rb
@@ -89,7 +89,7 @@ describe "Residence", :with_frozen_time do
     end
   end
 
-  scenario "Verify booth", :js do
+  scenario "Verify booth" do
     booth = create(:poll_booth)
     poll = create(:poll)
 

--- a/spec/system/officing/results_spec.rb
+++ b/spec/system/officing/results_spec.rb
@@ -19,12 +19,13 @@ describe "Officing Results", :with_frozen_time do
     set_officing_booth(booth)
   end
 
-  scenario "Only polls where user is officer for results are accessible" do
+  scenario "Only polls where user is officer for results are accessible", :js do
     not_allowed_poll_1 = create(:poll, :expired)
     not_allowed_poll_2 = create(:poll, officers: [poll_officer], ends_at: 1.day.ago)
     not_allowed_poll_3 = create(:poll, officers: [poll_officer])
 
     visit root_path
+    click_link "Menu"
     click_link "Polling officers"
 
     expect(page).to have_content("Poll officing")

--- a/spec/system/officing/results_spec.rb
+++ b/spec/system/officing/results_spec.rb
@@ -19,7 +19,7 @@ describe "Officing Results", :with_frozen_time do
     set_officing_booth(booth)
   end
 
-  scenario "Only polls where user is officer for results are accessible", :js do
+  scenario "Only polls where user is officer for results are accessible" do
     not_allowed_poll_1 = create(:poll, :expired)
     not_allowed_poll_2 = create(:poll, officers: [poll_officer], ends_at: 1.day.ago)
     not_allowed_poll_3 = create(:poll, officers: [poll_officer])

--- a/spec/system/officing/voters_spec.rb
+++ b/spec/system/officing/voters_spec.rb
@@ -13,7 +13,7 @@ describe "Voters" do
     set_officing_booth(booth)
   end
 
-  scenario "Can vote", :js do
+  scenario "Can vote" do
     create(:poll_officer_assignment, officer: officer)
 
     visit new_officing_residence_path
@@ -67,7 +67,7 @@ describe "Voters" do
     end
   end
 
-  scenario "Had already verified his residence, but is not level 2 yet", :js do
+  scenario "Had already verified his residence, but is not level 2 yet" do
     user = create(:user, residence_verified_at: Time.current, document_type: "1", document_number: "12345678Z")
     expect(user).not_to be_level_two_verified
 
@@ -159,7 +159,7 @@ describe "Voters" do
     end
   end
 
-  scenario "Store officer and booth information", :js do
+  scenario "Store officer and booth information" do
     create(:user, :in_census, id: rand(9999999))
     poll1 = create(:poll, name: "¿Quieres que XYZ sea aprobado?")
     poll2 = create(:poll, name: "Pregunta de votación de prueba")

--- a/spec/system/officing_spec.rb
+++ b/spec/system/officing_spec.rb
@@ -42,7 +42,7 @@ describe "Poll Officing" do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario "Access as SDG manager is not authorized", :js do
+  scenario "Access as SDG manager is not authorized" do
     create(:sdg_manager, user: user)
     login_as(user)
     visit root_path
@@ -83,7 +83,7 @@ describe "Poll Officing" do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario "Access as an administrator with poll officer role is authorized", :js do
+  scenario "Access as an administrator with poll officer role is authorized" do
     create(:administrator, user: user)
     create(:poll_officer, user: user)
     create(:poll)
@@ -97,7 +97,7 @@ describe "Poll Officing" do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Access as an poll officer is authorized", :js do
+  scenario "Access as an poll officer is authorized" do
     create(:poll_officer, user: user)
     create(:poll)
     login_as(user)
@@ -110,7 +110,7 @@ describe "Poll Officing" do
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Poll officer access links", :js do
+  scenario "Poll officer access links" do
     create(:poll)
     create(:poll_officer, user: user)
     login_as(user)
@@ -124,7 +124,7 @@ describe "Poll Officing" do
     expect(page).not_to have_link("Moderation")
   end
 
-  scenario "Officing dashboard", :js do
+  scenario "Officing dashboard" do
     create(:poll_officer, user: user)
     create(:poll)
     login_as(user)
@@ -141,7 +141,7 @@ describe "Poll Officing" do
     expect(page).not_to have_css("#moderation_menu")
   end
 
-  scenario "Officing dashboard available for multiple sessions", :js, :with_frozen_time do
+  scenario "Officing dashboard available for multiple sessions", :with_frozen_time do
     poll = create(:poll)
     booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)

--- a/spec/system/officing_spec.rb
+++ b/spec/system/officing_spec.rb
@@ -83,38 +83,40 @@ describe "Poll Officing" do
     expect(page).to have_content "You do not have permission to access this page"
   end
 
-  scenario "Access as an administrator with poll officer role is authorized" do
+  scenario "Access as an administrator with poll officer role is authorized", :js do
     create(:administrator, user: user)
     create(:poll_officer, user: user)
     create(:poll)
     login_as(user)
     visit root_path
 
-    expect(page).to have_link("Polling officers")
-    click_on "Polling officers"
+    click_link "Menu"
+    click_link "Polling officers"
 
     expect(page).to have_current_path(officing_root_path)
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Access as an poll officer is authorized" do
+  scenario "Access as an poll officer is authorized", :js do
     create(:poll_officer, user: user)
     create(:poll)
     login_as(user)
     visit root_path
 
-    expect(page).to have_link("Polling officers")
-    click_on "Polling officers"
+    click_link "Menu"
+    click_link "Polling officers"
 
     expect(page).to have_current_path(officing_root_path)
     expect(page).not_to have_content "You do not have permission to access this page"
   end
 
-  scenario "Poll officer access links" do
+  scenario "Poll officer access links", :js do
     create(:poll)
     create(:poll_officer, user: user)
     login_as(user)
     visit root_path
+
+    click_link "Menu"
 
     expect(page).to have_link("Polling officers")
     expect(page).not_to have_link("Valuation")
@@ -122,12 +124,13 @@ describe "Poll Officing" do
     expect(page).not_to have_link("Moderation")
   end
 
-  scenario "Officing dashboard" do
+  scenario "Officing dashboard", :js do
     create(:poll_officer, user: user)
     create(:poll)
     login_as(user)
     visit root_path
 
+    click_link "Menu"
     click_link "Polling officers"
 
     expect(page).to have_current_path(officing_root_path)

--- a/spec/system/organizations_spec.rb
+++ b/spec/system/organizations_spec.rb
@@ -22,7 +22,7 @@ describe "Organizations" do
     expect(user.organization).not_to be_verified
   end
 
-  scenario "Create with invisible_captcha honeypot field" do
+  scenario "Create with invisible_captcha honeypot field", :no_js do
     visit new_organization_registration_path
 
     fill_in "user_organization_attributes_name",  with: "robot"

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -67,7 +67,7 @@ describe "Polls" do
       expect(page).not_to have_link("Expired")
     end
 
-    scenario "Displays icon correctly", :js do
+    scenario "Displays icon correctly" do
       create_list(:poll, 3)
 
       visit polls_path
@@ -94,7 +94,7 @@ describe "Polls" do
       expect(page).to have_content("This poll is not available on your geozone")
     end
 
-    scenario "Already participated in a poll", :js do
+    scenario "Already participated in a poll" do
       poll_with_question = create(:poll)
       question = create(:poll_question, :yes_no, poll: poll_with_question)
 
@@ -125,7 +125,7 @@ describe "Polls" do
       expect(page).to have_link("Poll with results", href: results_poll_path(poll.slug))
     end
 
-    scenario "Shows SDG tags when feature is enabled", :js do
+    scenario "Shows SDG tags when feature is enabled" do
       Setting["feature.sdg"] = true
       Setting["sdg.process.polls"] = true
 
@@ -198,7 +198,7 @@ describe "Polls" do
       end
     end
 
-    scenario "Answer images are shown", :js do
+    scenario "Answer images are shown" do
       question = create(:poll_question, :yes_no, poll: poll)
       create(:image, imageable: question.question_answers.first, title: "The yes movement")
 
@@ -207,7 +207,7 @@ describe "Polls" do
       expect(page).to have_css "img[alt='The yes movement']"
     end
 
-    scenario "Buttons to slide through images work back and forth", :js do
+    scenario "Buttons to slide through images work back and forth" do
       question = create(:poll_question, :yes_no, poll: poll)
       create(:image, imageable: question.question_answers.last, title: "The no movement")
       create(:image, imageable: question.question_answers.last, title: "No movement planning")
@@ -331,7 +331,7 @@ describe "Polls" do
       end
     end
 
-    scenario "Level 2 users answering", :js do
+    scenario "Level 2 users answering" do
       poll.update!(geozone_restricted: true)
       poll.geozones << geozone
 
@@ -349,7 +349,7 @@ describe "Polls" do
       end
     end
 
-    scenario "Level 2 users changing answer", :js do
+    scenario "Level 2 users changing answer" do
       poll.update!(geozone_restricted: true)
       poll.geozones << geozone
 
@@ -372,7 +372,7 @@ describe "Polls" do
       end
     end
 
-    scenario "Level 2 votes, signs out, signs in, votes again", :js do
+    scenario "Level 2 votes, signs out, signs in, votes again" do
       poll.update!(geozone_restricted: true)
       poll.geozones << geozone
 
@@ -410,7 +410,7 @@ describe "Polls" do
       end
     end
 
-    scenario "Shows SDG tags when feature is enabled", :js do
+    scenario "Shows SDG tags when feature is enabled" do
       Setting["feature.sdg"] = true
       Setting["sdg.process.polls"] = true
 
@@ -429,7 +429,7 @@ describe "Polls" do
     let(:booth) { create(:poll_booth) }
     let(:officer) { create(:poll_officer) }
 
-    scenario "Already voted on booth cannot vote on website", :js do
+    scenario "Already voted on booth cannot vote on website" do
       create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
       create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth, date: Date.current)
       question = create(:poll_question, :yes_no, poll: poll)

--- a/spec/system/polls/results_spec.rb
+++ b/spec/system/polls/results_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Poll Results" do
-  scenario "List each Poll question", :js do
+  scenario "List each Poll question" do
     user1 = create(:user, :level_two)
     user2 = create(:user, :level_two)
     user3 = create(:user, :level_two)

--- a/spec/system/polls/voter_spec.rb
+++ b/spec/system/polls/voter_spec.rb
@@ -16,7 +16,7 @@ describe "Voter" do
       create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
     end
 
-    scenario "Voting via web - Standard", :js do
+    scenario "Voting via web - Standard" do
       user = create(:user, :level_two)
 
       login_as user
@@ -31,7 +31,7 @@ describe "Voter" do
       expect(Poll::Voter.first.origin).to eq("web")
     end
 
-    scenario "Voting via web as unverified user", :js do
+    scenario "Voting via web as unverified user" do
       user = create(:user, :incomplete_verification)
 
       login_as user
@@ -46,7 +46,7 @@ describe "Voter" do
       expect(page).not_to have_content("You have already participated in this poll. If you vote again it will be overwritten")
     end
 
-    scenario "Voting in booth", :js do
+    scenario "Voting in booth" do
       login_through_form_as_officer(officer.user)
 
       visit new_officing_residence_path
@@ -92,7 +92,7 @@ describe "Voter" do
         expect(page).to have_link "The person has decided not to vote at this time"
       end
 
-      scenario "Hides not to vote at this time button if already voted", :js do
+      scenario "Hides not to vote at this time button if already voted" do
         login_through_form_as_officer(officer.user)
 
         visit new_officing_residence_path
@@ -116,7 +116,7 @@ describe "Voter" do
     context "Trying to vote the same poll in booth and web" do
       let!(:user) { create(:user, :in_census) }
 
-      scenario "Trying to vote in web and then in booth", :js do
+      scenario "Trying to vote in web and then in booth" do
         login_as user
         vote_for_poll_via_web(poll, question, answer_yes.title)
         expect(Poll::Voter.count).to eq(1)
@@ -133,7 +133,7 @@ describe "Voter" do
         expect(page).to have_content "Has already participated in this poll"
       end
 
-      scenario "Trying to vote in booth and then in web", :js do
+      scenario "Trying to vote in booth and then in web" do
         login_through_form_as_officer(officer.user)
 
         vote_for_poll_via_booth
@@ -164,7 +164,7 @@ describe "Voter" do
         end
       end
 
-      scenario "Trying to vote in web again", :js do
+      scenario "Trying to vote in web again" do
         login_as user
         vote_for_poll_via_web(poll, question, answer_yes.title)
         expect(Poll::Voter.count).to eq(1)
@@ -190,7 +190,7 @@ describe "Voter" do
       end
     end
 
-    scenario "Voting in poll and then verifiying account", :js do
+    scenario "Voting in poll and then verifiying account" do
       user = create(:user)
 
       login_through_form_as_officer(officer.user)
@@ -230,7 +230,7 @@ describe "Voter" do
     end
 
     context "Side menu" do
-      scenario "'Validate document' menu item with votable polls", :js do
+      scenario "'Validate document' menu item with votable polls" do
         login_through_form_as_officer(officer.user)
 
         visit new_officing_residence_path
@@ -252,7 +252,7 @@ describe "Voter" do
         end
       end
 
-      scenario "'Validate document' menu item without votable polls", :js do
+      scenario "'Validate document' menu item without votable polls" do
         create(:poll_voter, poll: poll, user: create(:user, :in_census))
 
         login_through_form_as_officer(officer.user)

--- a/spec/system/proposal_notifications_spec.rb
+++ b/spec/system/proposal_notifications_spec.rb
@@ -77,12 +77,13 @@ describe "Proposal Notifications" do
 
   scenario "Show notifications" do
     proposal = create(:proposal)
-    _notification1 = create(:proposal_notification,
-                             proposal: proposal, title: "Hey guys",
-                             body: "Just wanted to let you know that...")
-    _notification2 = create(:proposal_notification,
-                             proposal: proposal, title: "Another update",
-                             body: "We are almost there please share with your peoples!")
+
+    create(:proposal_notification,
+            proposal: proposal, title: "Hey guys",
+            body: "Just wanted to let you know that...")
+    create(:proposal_notification,
+            proposal: proposal, title: "Another update",
+            body: "We are almost there please share with your peoples!")
 
     visit proposal_path(proposal)
 

--- a/spec/system/proposal_notifications_spec.rb
+++ b/spec/system/proposal_notifications_spec.rb
@@ -75,7 +75,7 @@ describe "Proposal Notifications" do
     expect(Notification.count).to eq(0)
   end
 
-  scenario "Show notifications" do
+  scenario "Show notifications", :js do
     proposal = create(:proposal)
 
     create(:proposal_notification,
@@ -86,6 +86,7 @@ describe "Proposal Notifications" do
             body: "We are almost there please share with your peoples!")
 
     visit proposal_path(proposal)
+    click_link "Notifications (2)"
 
     expect(page).to have_content "Hey guys"
     expect(page).to have_content "Just wanted to let you know that..."

--- a/spec/system/proposal_notifications_spec.rb
+++ b/spec/system/proposal_notifications_spec.rb
@@ -26,7 +26,7 @@ describe "Proposal Notifications" do
     expect(page).to have_content "Please share it with others so we can make it happen!"
   end
 
-  scenario "Send a notification (Active voter)" do
+  scenario "Send a notification (Active voter)", :no_js do
     proposal = create(:proposal)
 
     create(:user, :level_two, votables: [proposal], followables: [proposal])
@@ -35,7 +35,7 @@ describe "Proposal Notifications" do
     expect(Notification.count).to eq(1)
   end
 
-  scenario "Send a notification (Follower)" do
+  scenario "Send a notification (Follower)", :no_js do
     proposal = create(:proposal)
 
     create(:user, :level_two, followables: [proposal])
@@ -44,7 +44,7 @@ describe "Proposal Notifications" do
     expect(Notification.count).to eq(1)
   end
 
-  scenario "Send a notification (Follower and Voter)" do
+  scenario "Send a notification (Follower and Voter)", :no_js do
     proposal = create(:proposal)
 
     create(:user, followables: [proposal], votables: [proposal])
@@ -55,7 +55,7 @@ describe "Proposal Notifications" do
     expect(Notification.count).to eq(2)
   end
 
-  scenario "Send a notification (Blocked voter)" do
+  scenario "Send a notification (Blocked voter)", :no_js do
     proposal = create(:proposal)
     voter = create(:user, :level_two, votables: [proposal])
 
@@ -65,7 +65,7 @@ describe "Proposal Notifications" do
     expect(Notification.count).to eq(0)
   end
 
-  scenario "Send a notification (Erased voter)" do
+  scenario "Send a notification (Erased voter)", :no_js do
     proposal = create(:proposal)
     voter = create(:user, :level_two, votables: [proposal])
 

--- a/spec/system/proposal_notifications_spec.rb
+++ b/spec/system/proposal_notifications_spec.rb
@@ -75,7 +75,7 @@ describe "Proposal Notifications" do
     expect(Notification.count).to eq(0)
   end
 
-  scenario "Show notifications", :js do
+  scenario "Show notifications" do
     proposal = create(:proposal)
 
     create(:proposal_notification,
@@ -176,7 +176,7 @@ describe "Proposal Notifications" do
   end
 
   context "In-app notifications from the proposal's author" do
-    scenario "Voters who are followed should receive a notification", :js do
+    scenario "Voters who are followed should receive a notification" do
       author = create(:user)
       proposal = create(:proposal, author: author)
 
@@ -229,7 +229,7 @@ describe "Proposal Notifications" do
       expect(page).to have_css ".notification", count: 0
     end
 
-    scenario "Followers should receive a notification", :js do
+    scenario "Followers should receive a notification" do
       author = create(:user)
       proposal = create(:proposal, author: author)
 
@@ -282,7 +282,7 @@ describe "Proposal Notifications" do
       expect(page).to have_css ".notification", count: 0
     end
 
-    scenario "Proposal hidden", :js do
+    scenario "Proposal hidden" do
       author = create(:user)
       user = create(:user)
       proposal = create(:proposal, author: author, voters: [user], followers: [user])
@@ -311,7 +311,7 @@ describe "Proposal Notifications" do
       expect(page).to have_content "This resource is not available anymore"
     end
 
-    scenario "Proposal retired by author", :js do
+    scenario "Proposal retired by author" do
       author = create(:user)
       user = create(:user)
       proposal = create(:proposal, author: author, voters: [user])
@@ -327,7 +327,7 @@ describe "Proposal Notifications" do
         Setting[:proposal_notification_minimum_interval_in_days] = 0
       end
 
-      scenario "for the same proposal", :js do
+      scenario "for the same proposal" do
         author = create(:user)
         proposal = create(:proposal, author: author)
         user = create(:user, followables: [proposal])

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -812,8 +812,8 @@ describe "Proposals" do
         expect(medium_proposal.title).to appear_before(worst_proposal.title)
       end
 
-      expect(current_url).to include("order=confidence_score")
-      expect(current_url).to include("page=1")
+      expect(page).to have_current_path(/order=confidence_score/)
+      expect(page).to have_current_path(/page=1/)
     end
 
     scenario "Proposals are ordered by newest", :js do
@@ -830,8 +830,8 @@ describe "Proposals" do
         expect(medium_proposal.title).to appear_before(worst_proposal.title)
       end
 
-      expect(current_url).to include("order=created_at")
-      expect(current_url).to include("page=1")
+      expect(page).to have_current_path(/order=created_at/)
+      expect(page).to have_current_path(/page=1/)
     end
 
     context "Recommendations" do
@@ -897,8 +897,8 @@ describe "Proposals" do
           expect(medium_proposal.title).to appear_before(worst_proposal.title)
         end
 
-        expect(current_url).to include("order=recommendations")
-        expect(current_url).to include("page=1")
+        expect(page).to have_current_path(/order=recommendations/)
+        expect(page).to have_current_path(/page=1/)
       end
 
       scenario "are not shown if account setting is disabled" do

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -135,7 +135,7 @@ describe "Proposals" do
     expect(page).not_to have_selector ".js-follow"
   end
 
-  describe "Social share buttons", :js do
+  describe "Social share buttons" do
     context "On desktop browsers" do
       scenario "Shows links to share on facebook and twitter" do
         visit proposal_path(create(:proposal))
@@ -228,7 +228,7 @@ describe "Proposals" do
       end
     end
 
-    scenario "After using the browser's back button, social buttons will have one screen reader", :js do
+    scenario "After using the browser's back button, social buttons will have one screen reader" do
       Setting["org_name"] = "CONSUL"
       proposal = create(:proposal)
       visit proposal_path(proposal)
@@ -242,7 +242,7 @@ describe "Proposals" do
     end
   end
 
-  describe "Sticky support button on medium and up screens", :js do
+  describe "Sticky support button on medium and up screens" do
     scenario "is shown anchored to top" do
       proposal = create(:proposal)
       visit proposals_path
@@ -255,7 +255,7 @@ describe "Proposals" do
     end
   end
 
-  describe "Show sticky support button on mobile screens", :js do
+  describe "Show sticky support button on mobile screens" do
     let!(:window_size) { Capybara.current_window.size }
 
     before do
@@ -357,7 +357,7 @@ describe "Proposals" do
     expect(page).to have_css "meta[property='og:title'][content=\'#{proposal.title}\']", visible: :hidden
   end
 
-  scenario "Create and publish", :js do
+  scenario "Create and publish" do
     author = create(:user)
     login_as(author)
 
@@ -411,7 +411,7 @@ describe "Proposals" do
     expect(page).to have_current_path(proposals_path)
   end
 
-  scenario "Create proposal too fast", :js do
+  scenario "Create proposal too fast" do
     allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
 
     author = create(:user)
@@ -431,7 +431,7 @@ describe "Proposals" do
     expect(page).to have_current_path(new_proposal_path)
   end
 
-  scenario "Responsible name is stored for anonymous users", :js do
+  scenario "Responsible name is stored for anonymous users" do
     author = create(:user)
     login_as(author)
 
@@ -452,7 +452,7 @@ describe "Proposals" do
     expect(Proposal.last.responsible_name).to eq("Isabel Garcia")
   end
 
-  scenario "Responsible name field is not shown for verified users", :js do
+  scenario "Responsible name field is not shown for verified users" do
     author = create(:user, :level_two)
     login_as(author)
 
@@ -505,7 +505,7 @@ describe "Proposals" do
     expect(page.html).not_to include "&lt;p&gt;This is"
   end
 
-  scenario "Autolinking is applied to description", :js do
+  scenario "Autolinking is applied to description" do
     author = create(:user)
     login_as(author)
 
@@ -563,7 +563,7 @@ describe "Proposals" do
   end
 
   context "Geozones" do
-    scenario "Default whole city", :js do
+    scenario "Default whole city" do
       author = create(:user)
       login_as(author)
 
@@ -581,7 +581,7 @@ describe "Proposals" do
       end
     end
 
-    scenario "Specific geozone", :js do
+    scenario "Specific geozone" do
       create(:geozone, name: "California")
       create(:geozone, name: "New York")
       login_as(create(:user))
@@ -609,7 +609,7 @@ describe "Proposals" do
   end
 
   context "Retired proposals" do
-    scenario "Retire", :js do
+    scenario "Retire" do
       proposal = create(:proposal)
       login_as(proposal.author)
 
@@ -640,7 +640,7 @@ describe "Proposals" do
       expect(page).to have_content "There are three other better proposals with the same subject"
     end
 
-    scenario "Fields are mandatory", :js do
+    scenario "Fields are mandatory" do
       proposal = create(:proposal)
       login_as(proposal.author)
 
@@ -749,7 +749,7 @@ describe "Proposals" do
     Setting["max_votes_for_proposal_edit"] = 1000
   end
 
-  scenario "Update should be posible for the author of an editable proposal", :js do
+  scenario "Update should be posible for the author of an editable proposal" do
     proposal = create(:proposal)
     login_as(proposal.author)
 
@@ -781,7 +781,7 @@ describe "Proposals" do
   end
 
   describe "Proposal index order filters" do
-    scenario "Default order is hot_score", :js do
+    scenario "Default order is hot_score" do
       best_proposal = create(:proposal, title: "Best proposal")
       best_proposal.update_column(:hot_score, 10)
       worst_proposal = create(:proposal, title: "Worst proposal")
@@ -795,7 +795,7 @@ describe "Proposals" do
       expect(medium_proposal.title).to appear_before(worst_proposal.title)
     end
 
-    scenario "Proposals are ordered by confidence_score", :js do
+    scenario "Proposals are ordered by confidence_score" do
       best_proposal = create(:proposal, title: "Best proposal")
       best_proposal.update_column(:confidence_score, 10)
       worst_proposal = create(:proposal, title: "Worst proposal")
@@ -816,7 +816,7 @@ describe "Proposals" do
       expect(page).to have_current_path(/page=1/)
     end
 
-    scenario "Proposals are ordered by newest", :js do
+    scenario "Proposals are ordered by newest" do
       best_proposal = create(:proposal, title: "Best proposal", created_at: Time.current)
       medium_proposal = create(:proposal, title: "Medium proposal", created_at: Time.current - 1.hour)
       worst_proposal = create(:proposal, title: "Worst proposal", created_at: Time.current - 1.day)
@@ -912,7 +912,7 @@ describe "Proposals" do
         expect(page).not_to have_link("recommendations")
       end
 
-      scenario "are automatically disabled when dismissed from index", :js do
+      scenario "are automatically disabled when dismissed from index" do
         proposal = create(:proposal, tag_list: "Sport")
         user     = create(:user, followables: [proposal])
 
@@ -1185,7 +1185,7 @@ describe "Proposals" do
       end
     end
 
-    scenario "Order by relevance by default", :js do
+    scenario "Order by relevance by default" do
       create(:proposal, title: "In summary", summary: "Title content too", cached_votes_up: 10)
       create(:proposal, title: "Title content", summary: "Summary", cached_votes_up: 1)
       create(:proposal, title: "Title here", summary: "Content here", cached_votes_up: 100)
@@ -1203,7 +1203,7 @@ describe "Proposals" do
       end
     end
 
-    scenario "Reorder results maintaing search", :js do
+    scenario "Reorder results maintaing search" do
       create(:proposal, title: "Show you got",      cached_votes_up: 10,  created_at: 1.week.ago)
       create(:proposal, title: "Show what you got", cached_votes_up: 1,   created_at: 1.month.ago)
       create(:proposal, title: "Show you got",      cached_votes_up: 100, created_at: Time.current)
@@ -1355,7 +1355,7 @@ describe "Proposals" do
         create(:proposal, geozone: new_york, title: "Sully monument")
       end
 
-      scenario "From map" do
+      scenario "From map", :no_js do
         visit proposals_path
 
         click_link "map"
@@ -1408,7 +1408,7 @@ describe "Proposals" do
   end
 
   context "Suggesting proposals" do
-    scenario "Show up to 5 suggestions", :js do
+    scenario "Show up to 5 suggestions" do
       create(:proposal, title: "First proposal, has search term")
       create(:proposal, title: "Second title")
       create(:proposal, title: "Third proposal, has search term")
@@ -1427,7 +1427,7 @@ describe "Proposals" do
       end
     end
 
-    scenario "No found suggestions", :js do
+    scenario "No found suggestions" do
       create(:proposal, title: "First proposal").update_column(:confidence_score, 10)
       create(:proposal, title: "Second proposal").update_column(:confidence_score, 8)
 
@@ -1584,7 +1584,7 @@ describe "Successful proposals" do
       Setting["feature.user.skip_verification"] = "true"
     end
 
-    scenario "Create", :js do
+    scenario "Create" do
       author = create(:user)
       login_as(author)
 
@@ -1617,7 +1617,7 @@ describe "Successful proposals" do
       Setting["sdg.process.proposals"] = true
     end
 
-    scenario "create proposal with sdg related list", :js do
+    scenario "create proposal with sdg related list" do
       login_as(user)
       visit new_proposal_path
       fill_in "Proposal title", with: "A title for a proposal related with SDG related content"
@@ -1631,7 +1631,7 @@ describe "Successful proposals" do
       within(".sdg-goal-tag-list") { expect(page).to have_link "1. No Poverty" }
     end
 
-    scenario "edit proposal with sdg related list", :js do
+    scenario "edit proposal with sdg related list" do
       proposal = create(:proposal, author: user)
       proposal.sdg_goals = [SDG::Goal[1], SDG::Goal[2]]
       login_as(user)

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -609,7 +609,7 @@ describe "Proposals" do
   end
 
   context "Retired proposals" do
-    scenario "Retire" do
+    scenario "Retire", :js do
       proposal = create(:proposal)
       login_as(proposal.author)
 
@@ -622,15 +622,15 @@ describe "Proposals" do
         click_link "Edit my proposal"
       end
 
-      click_link "Retire proposal"
+      within_window(window_opened_by { click_link "Retire proposal" }) do
+        expect(page).to have_current_path(retire_form_proposal_path(proposal))
 
-      expect(page).to have_current_path(retire_form_proposal_path(proposal))
+        select "Duplicated", from: "proposal_retired_reason"
+        fill_in "Explanation", with: "There are three other better proposals with the same subject"
+        click_button "Retire proposal"
 
-      select "Duplicated", from: "proposal_retired_reason"
-      fill_in "Explanation", with: "There are three other better proposals with the same subject"
-      click_button "Retire proposal"
-
-      expect(page).to have_content "Proposal retired"
+        expect(page).to have_content "Proposal retired"
+      end
 
       visit proposal_path(proposal)
 

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -482,7 +482,7 @@ describe "Proposals" do
     expect(page).to have_content error_message
   end
 
-  scenario "JS injection is prevented but safe html is respected" do
+  scenario "JS injection is prevented but safe html is respected", :no_js do
     author = create(:user)
     login_as(author)
 
@@ -526,7 +526,7 @@ describe "Proposals" do
     expect(page).to have_link("www.example.org", href: "http://www.example.org")
   end
 
-  scenario "JS injection is prevented but autolinking is respected" do
+  scenario "JS injection is prevented but autolinking is respected", :no_js do
     author = create(:user)
     js_injection_string = "<script>alert('hey')</script> <a href=\"javascript:alert('surprise!')\">click me<a/> http://example.org"
     login_as(author)

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -392,7 +392,7 @@ describe "Proposals" do
     expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)
   end
 
-  scenario "Create with invisible_captcha honeypot field" do
+  scenario "Create with invisible_captcha honeypot field", :no_js do
     author = create(:user)
     login_as(author)
 

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -357,7 +357,7 @@ describe "Proposals" do
     expect(page).to have_css "meta[property='og:title'][content=\'#{proposal.title}\']", visible: :hidden
   end
 
-  scenario "Create and publish" do
+  scenario "Create and publish", :js do
     author = create(:user)
     login_as(author)
 
@@ -365,7 +365,7 @@ describe "Proposals" do
 
     fill_in "Proposal title", with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
-    fill_in "Proposal text", with: "This is very important because..."
+    fill_in_ckeditor "Proposal text", with: "This is very important because..."
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_tag_list", with: "Refugees, Solidarity"
@@ -411,7 +411,7 @@ describe "Proposals" do
     expect(page).to have_current_path(proposals_path)
   end
 
-  scenario "Create proposal too fast" do
+  scenario "Create proposal too fast", :js do
     allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(Float::INFINITY)
 
     author = create(:user)
@@ -420,7 +420,7 @@ describe "Proposals" do
     visit new_proposal_path
     fill_in "Proposal title", with: "I am a bot"
     fill_in "Proposal summary", with: "This is the summary"
-    fill_in "Proposal text", with: "This is the description"
+    fill_in_ckeditor "Proposal text", with: "This is the description"
     fill_in "proposal_responsible_name", with: "Some other robot"
     check "proposal_terms_of_service"
 
@@ -431,14 +431,14 @@ describe "Proposals" do
     expect(page).to have_current_path(new_proposal_path)
   end
 
-  scenario "Responsible name is stored for anonymous users" do
+  scenario "Responsible name is stored for anonymous users", :js do
     author = create(:user)
     login_as(author)
 
     visit new_proposal_path
     fill_in "Proposal title", with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
-    fill_in "Proposal text", with: "This is very important because..."
+    fill_in_ckeditor "Proposal text", with: "This is very important because..."
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"
@@ -452,7 +452,7 @@ describe "Proposals" do
     expect(Proposal.last.responsible_name).to eq("Isabel Garcia")
   end
 
-  scenario "Responsible name field is not shown for verified users" do
+  scenario "Responsible name field is not shown for verified users", :js do
     author = create(:user, :level_two)
     login_as(author)
 
@@ -461,7 +461,7 @@ describe "Proposals" do
 
     fill_in "Proposal title", with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
-    fill_in "Proposal text", with: "This is very important because..."
+    fill_in_ckeditor "Proposal text", with: "This is very important because..."
     check "proposal_terms_of_service"
 
     click_button "Create proposal"
@@ -505,14 +505,14 @@ describe "Proposals" do
     expect(page.html).not_to include "&lt;p&gt;This is"
   end
 
-  scenario "Autolinking is applied to description" do
+  scenario "Autolinking is applied to description", :js do
     author = create(:user)
     login_as(author)
 
     visit new_proposal_path
     fill_in "Proposal title", with: "Testing auto link"
     fill_in "Proposal summary", with: "In summary, what we want is..."
-    fill_in "Proposal text", with: "<p>This is a link www.example.org</p>"
+    fill_in_ckeditor "Proposal text", with: "This is a link www.example.org"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"
 
@@ -563,7 +563,7 @@ describe "Proposals" do
   end
 
   context "Geozones" do
-    scenario "Default whole city" do
+    scenario "Default whole city", :js do
       author = create(:user)
       login_as(author)
 
@@ -581,7 +581,7 @@ describe "Proposals" do
       end
     end
 
-    scenario "Specific geozone" do
+    scenario "Specific geozone", :js do
       create(:geozone, name: "California")
       create(:geozone, name: "New York")
       login_as(create(:user))
@@ -590,7 +590,7 @@ describe "Proposals" do
 
       fill_in "Proposal title", with: "Help refugees"
       fill_in "Proposal summary", with: "In summary, what we want is..."
-      fill_in "Proposal text", with: "This is very important because..."
+      fill_in_ckeditor "Proposal text", with: "This is very important because..."
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
       fill_in "proposal_responsible_name", with: "Isabel Garcia"
       check "proposal_terms_of_service"
@@ -749,7 +749,7 @@ describe "Proposals" do
     Setting["max_votes_for_proposal_edit"] = 1000
   end
 
-  scenario "Update should be posible for the author of an editable proposal" do
+  scenario "Update should be posible for the author of an editable proposal", :js do
     proposal = create(:proposal)
     login_as(proposal.author)
 
@@ -758,7 +758,7 @@ describe "Proposals" do
 
     fill_in "Proposal title", with: "End child poverty"
     fill_in "Proposal summary", with: "Basically..."
-    fill_in "Proposal text", with: "Let's do something to end child poverty"
+    fill_in_ckeditor "Proposal text", with: "Let's do something to end child poverty"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
 
     click_button "Save changes"
@@ -1584,7 +1584,7 @@ describe "Successful proposals" do
       Setting["feature.user.skip_verification"] = "true"
     end
 
-    scenario "Create" do
+    scenario "Create", :js do
       author = create(:user)
       login_as(author)
 
@@ -1598,7 +1598,7 @@ describe "Successful proposals" do
 
       fill_in "Proposal title", with: "Help refugees"
       fill_in "Proposal summary", with: "In summary what we want is..."
-      fill_in "Proposal text", with: "This is very important because..."
+      fill_in_ckeditor "Proposal text", with: "This is very important because..."
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
       fill_in "proposal_tag_list", with: "Refugees, Solidarity"
       check "proposal_terms_of_service"

--- a/spec/system/registration_form_spec.rb
+++ b/spec/system/registration_form_spec.rb
@@ -65,7 +65,6 @@ describe "Registration form" do
     visit new_user_registration_path
 
     fill_in "user_username",              with: "robot"
-    fill_in "user_address",               with: "This is the honeypot field"
     fill_in "user_email",                 with: "robot@robot.com"
     fill_in "user_password",              with: "destroyallhumans"
     fill_in "user_password_confirmation", with: "destroyallhumans"

--- a/spec/system/registration_form_spec.rb
+++ b/spec/system/registration_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Registration form" do
-  scenario "username is not available", :js do
+  scenario "username is not available" do
     user = create(:user)
 
     visit new_user_registration_path
@@ -13,7 +13,7 @@ describe "Registration form" do
     expect(page).to have_content I18n.t("devise_views.users.registrations.new.username_is_not_available")
   end
 
-  scenario "username is available", :js do
+  scenario "username is available" do
     visit new_user_registration_path
     expect(page).not_to have_content I18n.t("devise_views.users.registrations.new.username_is_available")
 
@@ -43,7 +43,7 @@ describe "Registration form" do
     expect(new_user.redeemable_code).to be_nil
   end
 
-  scenario "Create with invisible_captcha honeypot field" do
+  scenario "Create with invisible_captcha honeypot field", :no_js do
     visit new_user_registration_path
 
     fill_in "user_username",              with: "robot"

--- a/spec/system/sdg/filters_spec.rb
+++ b/spec/system/sdg/filters_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "SDG filters", :js do
+describe "SDG filters" do
   before do
     Setting["feature.sdg"] = true
     Setting["sdg.process.budgets"] = true

--- a/spec/system/sdg/goals_spec.rb
+++ b/spec/system/sdg/goals_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "SDG Goals", :js do
+describe "SDG Goals" do
   before do
     Setting["feature.sdg"] = true
     Setting["sdg.process.debates"] = true

--- a/spec/system/sdg_management/goals_spec.rb
+++ b/spec/system/sdg_management/goals_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Goals", :js do
+describe "Goals" do
   before { login_as(create(:sdg_manager).user) }
 
   describe "Index" do

--- a/spec/system/sdg_management/homepage_spec.rb
+++ b/spec/system/sdg_management/homepage_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "SDG homepage configuration", :js do
+describe "SDG homepage configuration" do
   before do
     Setting["feature.sdg"] = true
     login_as(create(:sdg_manager).user)

--- a/spec/system/sdg_management/local_targets_spec.rb
+++ b/spec/system/sdg_management/local_targets_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Local Targets", :js do
+describe "Local Targets" do
   before do
     login_as(create(:administrator).user)
     Setting["feature.sdg"] = true

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "SDG Relations", :js do
+describe "SDG Relations" do
   before do
     login_as(create(:administrator).user)
     Setting["feature.sdg"] = true

--- a/spec/system/sdg_management/sdg_spec.rb
+++ b/spec/system/sdg_management/sdg_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "SDG Management" do
   before { login_as(create(:administrator).user) }
 
-  context "SDG feature flag is enabled", :js do
+  context "SDG feature flag is enabled" do
     before { Setting["feature.sdg"] = true }
 
     scenario "shows the SDG content link" do
@@ -17,7 +17,7 @@ describe "SDG Management" do
   context "SDG feature is disabled" do
     before { Setting["feature.sdg"] = false }
 
-    scenario "does not show the SDG Content link", :js do
+    scenario "does not show the SDG Content link" do
       visit root_path
       click_link "Menu"
 

--- a/spec/system/sdg_management/targets_spec.rb
+++ b/spec/system/sdg_management/targets_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Targets", :js do
+describe "Targets" do
   before do
     login_as(create(:administrator).user)
     Setting["feature.sdg"] = true

--- a/spec/system/sdg_management_spec.rb
+++ b/spec/system/sdg_management_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "SDGManagement", :js do
+describe "SDGManagement" do
   let(:user) { create(:user) }
 
   before { Setting["feature.sdg"] = true }

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Sessions" do
-  scenario "Staying in the same page after doing login/logout" do
+  scenario "Staying in the same page after doing login/logout", :js do
     user = create(:user, sign_in_count: 10)
     debate = create(:debate)
 
@@ -13,6 +13,8 @@ describe "Sessions" do
 
     expect(page).to have_content("You have been signed in successfully")
     expect(page).to have_current_path(debate_path(debate))
+
+    within("#notice") { click_button "Close" }
 
     click_link "Sign out"
 

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Sessions" do
-  scenario "Staying in the same page after doing login/logout", :js do
+  scenario "Staying in the same page after doing login/logout" do
     user = create(:user, sign_in_count: 10)
     debate = create(:debate)
 

--- a/spec/system/site_customization/custom_pages_spec.rb
+++ b/spec/system/site_customization/custom_pages_spec.rb
@@ -87,7 +87,7 @@ describe "Custom Pages" do
         expect(page).to have_content("Subtitle for custom page")
       end
 
-      scenario "Show widget cards for that page", :js do
+      scenario "Show widget cards for that page" do
         custom_page = create(:site_customization_page, :published)
         create(:widget_card, cardable: custom_page, title: "Card Highlights")
 

--- a/spec/system/site_customization/custom_pages_spec.rb
+++ b/spec/system/site_customization/custom_pages_spec.rb
@@ -87,13 +87,13 @@ describe "Custom Pages" do
         expect(page).to have_content("Subtitle for custom page")
       end
 
-      scenario "Show widget cards for that page" do
+      scenario "Show widget cards for that page", :js do
         custom_page = create(:site_customization_page, :published)
         create(:widget_card, cardable: custom_page, title: "Card Highlights")
 
         visit custom_page.url
 
-        expect(page).to have_content "Card Highlights"
+        expect(page).to have_content "CARD HIGHLIGHTS"
       end
     end
   end

--- a/spec/system/site_customization/information_texts_spec.rb
+++ b/spec/system/site_customization/information_texts_spec.rb
@@ -28,7 +28,7 @@ describe "Custom information texts", :admin do
     end
   end
 
-  scenario "Show custom text with options", :js do
+  scenario "Show custom text with options" do
     user = create(:user, username: "Rachel")
     create(:budget_investment, author_id: user.id)
 

--- a/spec/system/social_media_meta_tags_spec.rb
+++ b/spec/system/social_media_meta_tags_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Social media meta tags" do
+describe "Social media meta tags", :js do
   context "Setting social media meta tags" do
     let(:meta_keywords) { "citizen, participation, open government" }
     let(:meta_title) { "CONSUL" }
@@ -28,14 +28,12 @@ describe "Social media meta tags" do
       expect(page).to have_meta "twitter:site", with: twitter_handle
       expect(page).to have_meta "twitter:title", with: meta_title
       expect(page).to have_meta "twitter:description", with: meta_description
-      expect(page).to have_meta "twitter:image",
-                                 with: "#{Capybara.app_host}/social_media_icon_twitter.png"
-
+      expect(page).to have_meta "twitter:image", with: "#{app_host}/social_media_icon_twitter.png"
       expect(page).to have_property "og:title", with: meta_title
       expect(page).to have_property "article:publisher", with: url
       expect(page).to have_property "article:author", with: "https://www.facebook.com/#{facebook_handle}"
-      expect(page).to have_property "og:url", with: "#{Capybara.app_host}/"
-      expect(page).to have_property "og:image", with: "#{Capybara.app_host}/social_media_icon.png"
+      expect(page).to have_property "og:url", with: "#{app_host}/"
+      expect(page).to have_property "og:image", with: "#{app_host}/social_media_icon.png"
       expect(page).to have_property "og:site_name", with: org_name
       expect(page).to have_property "og:description", with: meta_description
     end

--- a/spec/system/social_media_meta_tags_spec.rb
+++ b/spec/system/social_media_meta_tags_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Social media meta tags", :js do
+describe "Social media meta tags" do
   context "Setting social media meta tags" do
     let(:meta_keywords) { "citizen, participation, open government" }
     let(:meta_title) { "CONSUL" }

--- a/spec/system/stats_spec.rb
+++ b/spec/system/stats_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Stats" do
+describe "Stats", :js do
   context "Summary" do
     scenario "General" do
       create(:debate)
@@ -10,10 +10,10 @@ describe "Stats" do
 
       visit stats_path
 
-      expect(page).to have_content "Debates 1"
-      expect(page).to have_content "Proposals 2"
-      expect(page).to have_content "Comments 3"
-      expect(page).to have_content "Visits 4"
+      expect(page).to have_content "DEBATES\n1"
+      expect(page).to have_content "PROPOSALS\n2"
+      expect(page).to have_content "COMMENTS\n3"
+      expect(page).to have_content "VISITS\n4"
     end
 
     scenario "Votes" do
@@ -23,10 +23,10 @@ describe "Stats" do
 
       visit stats_path
 
-      expect(page).to have_content "Votes on debates 1"
-      expect(page).to have_content "Votes on proposals 2"
-      expect(page).to have_content "Votes on comments 3"
-      expect(page).to have_content "Total votes 6"
+      expect(page).to have_content "VOTES ON DEBATES\n1"
+      expect(page).to have_content "VOTES ON PROPOSALS\n2"
+      expect(page).to have_content "VOTES ON COMMENTS\n3"
+      expect(page).to have_content "TOTAL VOTES\n6"
     end
 
     scenario "Users" do
@@ -36,8 +36,8 @@ describe "Stats" do
 
       visit stats_path
 
-      expect(page).to have_content "Verified users 3"
-      expect(page).to have_content "Unverified users 2"
+      expect(page).to have_content "VERIFIED USERS\n3"
+      expect(page).to have_content "UNVERIFIED USERS\n2"
     end
   end
 end

--- a/spec/system/stats_spec.rb
+++ b/spec/system/stats_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Stats", :js do
+describe "Stats" do
   context "Summary" do
     scenario "General" do
       create(:debate)

--- a/spec/system/tags/budget_investments_spec.rb
+++ b/spec/system/tags/budget_investments_spec.rb
@@ -61,14 +61,14 @@ describe "Tags" do
     expect(page).to have_content(tag_economia.name)
   end
 
-  scenario "Create with custom tags" do
+  scenario "Create with custom tags", :js do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
 
     select  heading.name, from: "budget_investment_heading_id"
     fill_in "Title", with: "Build a skyscraper"
-    fill_in "Description", with: "I want to live in a high tower over the clouds"
+    fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
 
     fill_in "budget_investment_tag_list", with: "#{tag_medio_ambiente.name}, #{tag_economia.name}"
@@ -149,14 +149,14 @@ describe "Tags" do
     end
   end
 
-  scenario "Create with too many tags" do
+  scenario "Create with too many tags", :js do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
 
     select  heading.name, from: "budget_investment_heading_id"
     fill_in "Title", with: "Build a skyscraper"
-    fill_in "Description", with: "I want to live in a high tower over the clouds"
+    fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
 
     fill_in "budget_investment_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
@@ -167,14 +167,14 @@ describe "Tags" do
     expect(page).to have_content "tags must be less than or equal to 6"
   end
 
-  scenario "Create with dangerous strings" do
+  scenario "Create with dangerous strings", :js do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
 
     select  heading.name, from: "budget_investment_heading_id"
     fill_in "Title", with: "Build a skyscraper"
-    fill_in "Description", with: "I want to live in a high tower over the clouds"
+    fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
 
     fill_in "budget_investment_tag_list", with: "user_id=1, &a=3, <script>alert('hey');</script>"

--- a/spec/system/tags/budget_investments_spec.rb
+++ b/spec/system/tags/budget_investments_spec.rb
@@ -61,7 +61,7 @@ describe "Tags" do
     expect(page).to have_content(tag_economia.name)
   end
 
-  scenario "Create with custom tags", :js do
+  scenario "Create with custom tags" do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
@@ -80,7 +80,7 @@ describe "Tags" do
     expect(page).to have_content tag_medio_ambiente.name
   end
 
-  scenario "Category with category tags", :js do
+  scenario "Category with category tags" do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
@@ -101,7 +101,7 @@ describe "Tags" do
     end
   end
 
-  scenario "Turbolinks sanity check from budget's show", :js do
+  scenario "Turbolinks sanity check from budget's show" do
     create(:tag, name: "Education", kind: "category")
     create(:tag, name: "Health",    kind: "category")
 
@@ -125,7 +125,7 @@ describe "Tags" do
     end
   end
 
-  scenario "Turbolinks sanity check from budget heading's show", :js do
+  scenario "Turbolinks sanity check from budget heading's show" do
     create(:tag, name: "Education", kind: "category")
     create(:tag, name: "Health",    kind: "category")
 
@@ -149,7 +149,7 @@ describe "Tags" do
     end
   end
 
-  scenario "Create with too many tags", :js do
+  scenario "Create with too many tags" do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)
@@ -167,7 +167,7 @@ describe "Tags" do
     expect(page).to have_content "tags must be less than or equal to 6"
   end
 
-  scenario "Create with dangerous strings", :js do
+  scenario "Create with dangerous strings" do
     login_as(author)
 
     visit new_budget_investment_path(budget_id: budget.id)

--- a/spec/system/tags/budget_investments_spec.rb
+++ b/spec/system/tags/budget_investments_spec.rb
@@ -94,8 +94,9 @@ describe "Tags" do
     click_button "Create Investment"
 
     expect(page).to have_content "Investment created successfully."
+    expect(page).to have_content "Build a skyscraper"
 
-    within "#tags_budget_investment_#{Budget::Investment.last.id}" do
+    within ".tags" do
       expect(page).to have_content tag_economia.name
       expect(page).not_to have_content tag_medio_ambiente.name
     end
@@ -118,8 +119,9 @@ describe "Tags" do
     click_button "Create Investment"
 
     expect(page).to have_content "Investment created successfully."
+    expect(page).to have_content "Build a skyscraper"
 
-    within "#tags_budget_investment_#{Budget::Investment.last.id}" do
+    within ".tags" do
       expect(page).to have_content "Education"
       expect(page).not_to have_content "Health"
     end
@@ -142,8 +144,9 @@ describe "Tags" do
     click_button "Create Investment"
 
     expect(page).to have_content "Investment created successfully."
+    expect(page).to have_content "Build a skyscraper"
 
-    within "#tags_budget_investment_#{Budget::Investment.last.id}" do
+    within ".tags" do
       expect(page).to have_content "Education"
       expect(page).not_to have_content "Health"
     end

--- a/spec/system/tags/debates_spec.rb
+++ b/spec/system/tags/debates_spec.rb
@@ -60,13 +60,13 @@ describe "Tags" do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario "Create" do
+  scenario "Create", :js do
     user = create(:user)
     login_as(user)
 
     visit new_debate_path
     fill_in "Debate title", with: "Title"
-    fill_in "Initial debate text", with: "Description"
+    fill_in_ckeditor "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda"
@@ -79,13 +79,13 @@ describe "Tags" do
     expect(page).to have_content "Impuestos"
   end
 
-  scenario "Create with too many tags" do
+  scenario "Create with too many tags", :js do
     user = create(:user)
     login_as(user)
 
     visit new_debate_path
     fill_in "Debate title", with: "Title"
-    fill_in "Initial debate text", with: "Description"
+    fill_in_ckeditor "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
@@ -96,14 +96,14 @@ describe "Tags" do
     expect(page).to have_content "tags must be less than or equal to 6"
   end
 
-  scenario "Create with dangerous strings" do
+  scenario "Create with dangerous strings", :js do
     user = create(:user)
     login_as(user)
 
     visit new_debate_path
 
     fill_in "Debate title", with: "A test of dangerous strings"
-    fill_in "Initial debate text", with: "A description suitable for this test"
+    fill_in_ckeditor "Initial debate text", with: "A description suitable for this test"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "user_id=1, &a=3, <script>alert('hey');</script>"

--- a/spec/system/tags/debates_spec.rb
+++ b/spec/system/tags/debates_spec.rb
@@ -60,7 +60,7 @@ describe "Tags" do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     user = create(:user)
     login_as(user)
 
@@ -79,7 +79,7 @@ describe "Tags" do
     expect(page).to have_content "Impuestos"
   end
 
-  scenario "Create with too many tags", :js do
+  scenario "Create with too many tags" do
     user = create(:user)
     login_as(user)
 
@@ -96,7 +96,7 @@ describe "Tags" do
     expect(page).to have_content "tags must be less than or equal to 6"
   end
 
-  scenario "Create with dangerous strings", :js do
+  scenario "Create with dangerous strings" do
     user = create(:user)
     login_as(user)
 

--- a/spec/system/tags/proposals_spec.rb
+++ b/spec/system/tags/proposals_spec.rb
@@ -59,7 +59,7 @@ describe "Tags" do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario "Create with custom tags", :js do
+  scenario "Create with custom tags" do
     user = create(:user)
     login_as(user)
 
@@ -81,7 +81,7 @@ describe "Tags" do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario "Category with category tags", :js do
+  scenario "Category with category tags" do
     create(:tag, :category, name: "Education")
     create(:tag, :category, name: "Health")
 
@@ -108,7 +108,7 @@ describe "Tags" do
     end
   end
 
-  scenario "Create with too many tags", :js do
+  scenario "Create with too many tags" do
     user = create(:user)
     login_as(user)
 
@@ -125,7 +125,7 @@ describe "Tags" do
     expect(page).to have_content "tags must be less than or equal to 6"
   end
 
-  scenario "Create with dangerous strings", :js do
+  scenario "Create with dangerous strings" do
     author = create(:user)
     login_as(author)
 

--- a/spec/system/tags/proposals_spec.rb
+++ b/spec/system/tags/proposals_spec.rb
@@ -59,14 +59,14 @@ describe "Tags" do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario "Create with custom tags" do
+  scenario "Create with custom tags", :js do
     user = create(:user)
     login_as(user)
 
     visit new_proposal_path
     fill_in "Proposal title", with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
-    fill_in "Proposal text", with: "This is very important because..."
+    fill_in_ckeditor "Proposal text", with: "This is very important because..."
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_tag_list", with: "Economía, Hacienda"
     check "proposal_terms_of_service"
@@ -108,13 +108,13 @@ describe "Tags" do
     end
   end
 
-  scenario "Create with too many tags" do
+  scenario "Create with too many tags", :js do
     user = create(:user)
     login_as(user)
 
     visit new_proposal_path
     fill_in "Proposal title", with: "Title"
-    fill_in "Proposal text", with: "Description"
+    fill_in_ckeditor "Proposal text", with: "Description"
     check "proposal_terms_of_service"
 
     fill_in "proposal_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"
@@ -125,7 +125,7 @@ describe "Tags" do
     expect(page).to have_content "tags must be less than or equal to 6"
   end
 
-  scenario "Create with dangerous strings" do
+  scenario "Create with dangerous strings", :js do
     author = create(:user)
     login_as(author)
 
@@ -133,7 +133,7 @@ describe "Tags" do
 
     fill_in "Proposal title", with: "A test of dangerous strings"
     fill_in "Proposal summary", with: "In summary, what we want is..."
-    fill_in "Proposal text", with: "A description suitable for this test"
+    fill_in_ckeditor "Proposal text", with: "A description suitable for this test"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"
 

--- a/spec/system/tags_spec.rb
+++ b/spec/system/tags_spec.rb
@@ -53,7 +53,7 @@ describe "Tags" do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario "Create", :js do
+  scenario "Create" do
     user = create(:user)
     login_as(user)
 
@@ -72,7 +72,7 @@ describe "Tags" do
     expect(page).to have_content "Impuestos"
   end
 
-  scenario "Create with too many tags", :js do
+  scenario "Create with too many tags" do
     user = create(:user)
     login_as(user)
 

--- a/spec/system/tags_spec.rb
+++ b/spec/system/tags_spec.rb
@@ -53,13 +53,13 @@ describe "Tags" do
     expect(page).to have_content "Hacienda"
   end
 
-  scenario "Create" do
+  scenario "Create", :js do
     user = create(:user)
     login_as(user)
 
     visit new_debate_path
     fill_in "Debate title", with: "Title"
-    fill_in "Initial debate text", with: "Description"
+    fill_in_ckeditor "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda"
@@ -72,13 +72,13 @@ describe "Tags" do
     expect(page).to have_content "Impuestos"
   end
 
-  scenario "Create with too many tags" do
+  scenario "Create with too many tags", :js do
     user = create(:user)
     login_as(user)
 
     visit new_debate_path
     fill_in "Debate title", with: "Title"
-    fill_in "Initial debate text", with: "Description"
+    fill_in_ckeditor "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
     fill_in "debate_tag_list", with: "Impuestos, Economía, Hacienda, Sanidad, Educación, Política, Igualdad"

--- a/spec/system/topics_spec.rb
+++ b/spec/system/topics_spec.rb
@@ -6,7 +6,7 @@ describe "Topics" do
   end
 
   context "New" do
-    scenario "Create new topic link should redirect to sign up for anonymous users", :js do
+    scenario "Create new topic link should redirect to sign up for anonymous users" do
       proposal = create(:proposal)
       community = proposal.community
 
@@ -18,7 +18,7 @@ describe "Topics" do
       expect(page).to have_current_path(new_user_session_path)
     end
 
-    scenario "Can access to new topic page with user logged", :js do
+    scenario "Can access to new topic page with user logged" do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -30,7 +30,7 @@ describe "Topics" do
       expect(page).to have_content "Create a topic"
     end
 
-    scenario "Should have content on new topic page", :js do
+    scenario "Should have content on new topic page" do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -50,7 +50,7 @@ describe "Topics" do
   end
 
   context "Create" do
-    scenario "Can create a new topic", :js do
+    scenario "Can create a new topic" do
       proposal = create(:proposal)
       community = proposal.community
       user = create(:user)
@@ -65,7 +65,7 @@ describe "Topics" do
       expect(page).to have_current_path(community_path(community))
     end
 
-    scenario "Can not create a new topic when user not logged", :js do
+    scenario "Can not create a new topic when user not logged" do
       proposal = create(:proposal)
       community = proposal.community
 

--- a/spec/system/tracks_spec.rb
+++ b/spec/system/tracks_spec.rb
@@ -47,8 +47,8 @@ describe "Tracking" do
       visit account_path
       click_link "Verify my account"
 
-      expect(page.html).to include "data-track-event-category=verification"
-      expect(page.html).to include "data-track-event-action=start_census"
+      expect(page).to have_selector "[data-track-event-category='verification']", visible: :all
+      expect(page).to have_selector "[data-track-event-action='start_census']", visible: :all
     end
 
     scenario "Verification: success census & start sms" do
@@ -64,8 +64,8 @@ describe "Tracking" do
       fill_in "sms_phone", with: "611111111"
       click_button "Send"
 
-      expect(page.html).to include "data-track-event-category=verification"
-      expect(page.html).to include "data-track-event-action=start_sms"
+      expect(page).to have_selector "[data-track-event-category='verification']", visible: :all
+      expect(page).to have_selector "[data-track-event-action='start_sms']", visible: :all
     end
 
     scenario "Verification: success sms" do
@@ -85,8 +85,8 @@ describe "Tracking" do
       fill_in "sms_confirmation_code", with: user.sms_confirmation_code
       click_button "Send"
 
-      expect(page.html).to include "data-track-event-category=verification"
-      expect(page.html).to include "data-track-event-action=success_sms"
+      expect(page).to have_selector "[data-track-event-category='verification']", visible: :all
+      expect(page).to have_selector "[data-track-event-action='success_sms']", visible: :all
     end
 
     scenario "Verification: letter" do
@@ -108,8 +108,8 @@ describe "Tracking" do
 
       click_link "Send me a letter with the code"
 
-      expect(page.html).to include "data-track-event-category=verification"
-      expect(page.html).to include "data-track-event-action=start_letter"
+      expect(page).to have_selector "[data-track-event-category='verification']", visible: :all
+      expect(page).to have_selector "[data-track-event-action='start_letter']", visible: :all
     end
   end
 end

--- a/spec/system/translatable_spec.rb
+++ b/spec/system/translatable_spec.rb
@@ -8,7 +8,7 @@ describe "Public area translatable records" do
     login_as(user)
   end
 
-  context "New records", :js do
+  context "New records" do
     scenario "Add only single translation at once" do
       visit new_debate_path
 
@@ -108,7 +108,7 @@ describe "Public area translatable records" do
     end
   end
 
-  context "Globalize javascript interface", :js do
+  context "Globalize javascript interface" do
     scenario "Highlight current locale" do
       visit new_debate_path
 
@@ -181,7 +181,7 @@ describe "Public area translatable records" do
     end
   end
 
-  context "Existing records", :js do
+  context "Existing records" do
     before { translatable.update(attributes.merge(author: user)) }
 
     let(:attributes) do

--- a/spec/system/user_invites_spec.rb
+++ b/spec/system/user_invites_spec.rb
@@ -1,11 +1,8 @@
 require "rails_helper"
 
 describe "User invites" do
-  before do
-    login_as_manager
-  end
-
   scenario "Send invitations" do
+    login_as_manager
     visit new_management_user_invite_path
 
     fill_in "emails", with: "john@example.com, ana@example.com, isable@example.com"

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -46,11 +46,11 @@ describe "Users" do
       end
 
       scenario "Sign in with username" do
-        create(:user, username: "👻👽👾🤖", email: "ash@nostromo.dev", password: "xenomorph")
+        create(:user, username: "中村広", email: "ash@nostromo.dev", password: "xenomorph")
 
         visit "/"
         click_link "Sign in"
-        fill_in "user_login",    with: "👻👽👾🤖"
+        fill_in "user_login",    with: "中村広"
         fill_in "user_password", with: "xenomorph"
         click_button "Enter"
 

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -57,7 +57,7 @@ describe "Users" do
         expect(page).to have_content "You have been signed in successfully."
       end
 
-      scenario "Avoid username-email collisions", :js do
+      scenario "Avoid username-email collisions" do
         u1 = create(:user, username: "Spidey", email: "peter@nyc.dev", password: "greatpower")
         u2 = create(:user, username: "peter@nyc.dev", email: "venom@nyc.dev", password: "symbiote")
 
@@ -213,7 +213,7 @@ describe "Users" do
         }
       end
 
-      scenario "Sign up when Oauth provider has a verified email", :js do
+      scenario "Sign up when Oauth provider has a verified email" do
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_verified_email)
 
         visit "/"
@@ -232,7 +232,7 @@ describe "Users" do
         expect(page).to have_field("user_email", with: "manuelacarmena@example.com")
       end
 
-      scenario "Sign up when Oauth provider has an unverified email", :js do
+      scenario "Sign up when Oauth provider has an unverified email" do
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_email)
 
         visit "/"
@@ -260,7 +260,7 @@ describe "Users" do
         expect(page).to have_field("user_email", with: "manuelacarmena@example.com")
       end
 
-      scenario "Sign up, when no email was provided by OAuth provider", :js do
+      scenario "Sign up, when no email was provided by OAuth provider" do
         OmniAuth.config.add_mock(:twitter, twitter_hash)
 
         visit "/"
@@ -304,7 +304,7 @@ describe "Users" do
         expect_not_to_be_signed_in
       end
 
-      scenario "Sign in, user was already signed up with OAuth", :js do
+      scenario "Sign in, user was already signed up with OAuth" do
         user = create(:user, email: "manuela@consul.dev", password: "judgementday")
         create(:identity, uid: "12345", provider: "twitter", user: user)
         OmniAuth.config.add_mock(:twitter, twitter_hash)
@@ -352,7 +352,7 @@ describe "Users" do
         expect(page).to have_field("user_email", with: "manuelacarmena@example.com")
       end
 
-      scenario "Try to register with the email of an already existing user, when no email was provided by oauth", :js do
+      scenario "Try to register with the email of an already existing user, when no email was provided by oauth" do
         create(:user, username: "peter", email: "manuela@example.com")
         OmniAuth.config.add_mock(:twitter, twitter_hash)
 
@@ -389,7 +389,7 @@ describe "Users" do
         expect(page).to have_field("user_email", with: "somethingelse@example.com")
       end
 
-      scenario "Try to register with the email of an already existing user, when an unconfirmed email was provided by oauth", :js do
+      scenario "Try to register with the email of an already existing user, when an unconfirmed email was provided by oauth" do
         create(:user, username: "peter", email: "manuelacarmena@example.com")
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_email)
 
@@ -434,7 +434,7 @@ describe "Users" do
 
       before { Setting["feature.wordpress_login"] = true }
 
-      scenario "Sign up", :js do
+      scenario "Sign up" do
         OmniAuth.config.add_mock(:wordpress_oauth2, wordpress_hash)
 
         visit "/"
@@ -462,7 +462,7 @@ describe "Users" do
         expect(page).to have_field("user_email", with: "manuelacarmena@example.com")
       end
 
-      scenario "Try to register with username and email of an already existing user", :js do
+      scenario "Try to register with username and email of an already existing user" do
         create(:user, username: "manuela", email: "manuelacarmena@example.com", password: "judgementday")
         OmniAuth.config.add_mock(:wordpress_oauth2, wordpress_hash)
 

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -57,7 +57,7 @@ describe "Users" do
         expect(page).to have_content "You have been signed in successfully."
       end
 
-      scenario "Avoid username-email collisions" do
+      scenario "Avoid username-email collisions", :js do
         u1 = create(:user, username: "Spidey", email: "peter@nyc.dev", password: "greatpower")
         u2 = create(:user, username: "peter@nyc.dev", email: "venom@nyc.dev", password: "symbiote")
 
@@ -78,6 +78,7 @@ describe "Users" do
 
         expect(page).to have_content "You have been signed out successfully."
 
+        within("#notice") { click_button "Close" }
         click_link "Sign in"
         fill_in "user_login",    with: "peter@nyc.dev"
         fill_in "user_password", with: "symbiote"
@@ -212,7 +213,7 @@ describe "Users" do
         }
       end
 
-      scenario "Sign up when Oauth provider has a verified email" do
+      scenario "Sign up when Oauth provider has a verified email", :js do
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_verified_email)
 
         visit "/"
@@ -222,14 +223,16 @@ describe "Users" do
 
         expect_to_be_signed_in
 
+        within("#notice") { click_button "Close" }
         click_link "My account"
+
         expect(page).to have_field("account_username", with: "manuela")
 
         visit edit_user_registration_path
         expect(page).to have_field("user_email", with: "manuelacarmena@example.com")
       end
 
-      scenario "Sign up when Oauth provider has an unverified email" do
+      scenario "Sign up when Oauth provider has an unverified email", :js do
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_email)
 
         visit "/"
@@ -248,14 +251,16 @@ describe "Users" do
         click_link "Sign in with Twitter"
         expect_to_be_signed_in
 
+        within("#notice") { click_button "Close" }
         click_link "My account"
+
         expect(page).to have_field("account_username", with: "manuela")
 
         visit edit_user_registration_path
         expect(page).to have_field("user_email", with: "manuelacarmena@example.com")
       end
 
-      scenario "Sign up, when no email was provided by OAuth provider" do
+      scenario "Sign up, when no email was provided by OAuth provider", :js do
         OmniAuth.config.add_mock(:twitter, twitter_hash)
 
         visit "/"
@@ -276,7 +281,9 @@ describe "Users" do
         click_link "Sign in with Twitter"
         expect_to_be_signed_in
 
+        within("#notice") { click_button "Close" }
         click_link "My account"
+
         expect(page).to have_field("account_username", with: "manuela")
 
         visit edit_user_registration_path
@@ -297,7 +304,7 @@ describe "Users" do
         expect_not_to_be_signed_in
       end
 
-      scenario "Sign in, user was already signed up with OAuth" do
+      scenario "Sign in, user was already signed up with OAuth", :js do
         user = create(:user, email: "manuela@consul.dev", password: "judgementday")
         create(:identity, uid: "12345", provider: "twitter", user: user)
         OmniAuth.config.add_mock(:twitter, twitter_hash)
@@ -308,7 +315,9 @@ describe "Users" do
 
         expect_to_be_signed_in
 
+        within("#notice") { click_button "Close" }
         click_link "My account"
+
         expect(page).to have_field("account_username", with: user.username)
 
         visit edit_user_registration_path
@@ -343,7 +352,7 @@ describe "Users" do
         expect(page).to have_field("user_email", with: "manuelacarmena@example.com")
       end
 
-      scenario "Try to register with the email of an already existing user, when no email was provided by oauth" do
+      scenario "Try to register with the email of an already existing user, when no email was provided by oauth", :js do
         create(:user, username: "peter", email: "manuela@example.com")
         OmniAuth.config.add_mock(:twitter, twitter_hash)
 
@@ -371,14 +380,16 @@ describe "Users" do
         click_link "Sign in with Twitter"
         expect_to_be_signed_in
 
+        within("#notice") { click_button "Close" }
         click_link "My account"
+
         expect(page).to have_field("account_username", with: "manuela")
 
         visit edit_user_registration_path
         expect(page).to have_field("user_email", with: "somethingelse@example.com")
       end
 
-      scenario "Try to register with the email of an already existing user, when an unconfirmed email was provided by oauth" do
+      scenario "Try to register with the email of an already existing user, when an unconfirmed email was provided by oauth", :js do
         create(:user, username: "peter", email: "manuelacarmena@example.com")
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_email)
 
@@ -402,7 +413,9 @@ describe "Users" do
         click_link "Sign in with Twitter"
         expect_to_be_signed_in
 
+        within("#notice") { click_button "Close" }
         click_link "My account"
+
         expect(page).to have_field("account_username", with: "manuela")
 
         visit edit_user_registration_path
@@ -421,7 +434,7 @@ describe "Users" do
 
       before { Setting["feature.wordpress_login"] = true }
 
-      scenario "Sign up" do
+      scenario "Sign up", :js do
         OmniAuth.config.add_mock(:wordpress_oauth2, wordpress_hash)
 
         visit "/"
@@ -440,14 +453,16 @@ describe "Users" do
         click_link "Sign in with Wordpress"
         expect_to_be_signed_in
 
+        within("#notice") { click_button "Close" }
         click_link "My account"
+
         expect(page).to have_field("account_username", with: "manuela")
 
         visit edit_user_registration_path
         expect(page).to have_field("user_email", with: "manuelacarmena@example.com")
       end
 
-      scenario "Try to register with username and email of an already existing user" do
+      scenario "Try to register with username and email of an already existing user", :js do
         create(:user, username: "manuela", email: "manuelacarmena@example.com", password: "judgementday")
         OmniAuth.config.add_mock(:wordpress_oauth2, wordpress_hash)
 
@@ -479,7 +494,9 @@ describe "Users" do
 
         expect_to_be_signed_in
 
+        within("#notice") { click_button "Close" }
         click_link "My account"
+
         expect(page).to have_field("account_username", with: "manuela2")
 
         visit edit_user_registration_path

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -113,7 +113,7 @@ describe "Users" do
       end
     end
 
-    scenario "Show alert when user wants to delete a budget investment", :js do
+    scenario "Show alert when user wants to delete a budget investment" do
       user = create(:user, :level_two)
       budget = create(:budget, :accepting)
       budget_investment = create(:budget_investment, author_id: user.id, budget: budget)
@@ -407,7 +407,7 @@ describe "Users" do
       expect(page).not_to have_content("0 Following")
     end
 
-    scenario "Active following tab by default when follows filters selected", :js do
+    scenario "Active following tab by default when follows filters selected" do
       create(:proposal, author: user, followers: [user])
 
       visit user_path(user, filter: "follows")
@@ -458,7 +458,7 @@ describe "Users" do
         expect(page).to have_content proposal.title
       end
 
-      scenario "Retired proposals do not have a link to the dashboard", js: true do
+      scenario "Retired proposals do not have a link to the dashboard" do
         proposal = create(:proposal, :retired, author: user)
         login_as user
 
@@ -516,7 +516,7 @@ describe "Users" do
   end
 
   describe "Initials" do
-    scenario "display SVG avatars when loaded into the DOM", :js do
+    scenario "display SVG avatars when loaded into the DOM" do
       login_as(create(:user))
       visit debate_path(create(:debate))
 

--- a/spec/system/valuation/budget_investments_spec.rb
+++ b/spec/system/valuation/budget_investments_spec.rb
@@ -379,14 +379,16 @@ describe "Valuation budget investments" do
       end
     end
 
-    scenario "Finish valuation" do
+    scenario "Finish valuation", :js do
       investment.update!(visible_to_valuators: true)
 
       visit valuation_budget_budget_investment_path(budget, investment)
       click_link "Edit dossier"
 
-      find_field("budget_investment[valuation_finished]").click
+      accept_confirm { find_field("budget_investment[valuation_finished]").click }
       click_button "Save changes"
+
+      expect(page).to have_content "Dossier updated"
 
       visit valuation_budget_budget_investments_path(budget)
       expect(page).not_to have_content investment.title

--- a/spec/system/valuation/budget_investments_spec.rb
+++ b/spec/system/valuation/budget_investments_spec.rb
@@ -442,17 +442,13 @@ describe "Valuation budget investments" do
       end
     end
 
-    scenario "Validates price formats" do
+    scenario "Validates price formats on the server side", :no_js do
       investment.update!(visible_to_valuators: true)
 
-      visit valuation_budget_budget_investments_path(budget)
+      visit edit_valuation_budget_budget_investment_path(budget, investment)
 
-      within("#budget_investment_#{investment.id}") do
-        click_link "Edit dossier"
-      end
-
-      fill_in "budget_investment_price", with: "12345,98"
-      fill_in "budget_investment_price_first_year", with: "9876.6"
+      fill_in "Price (€)", with: "12345,98"
+      fill_in "Cost during the first year (€) (optional, data not public)", with: "9876.6"
       click_button "Save changes"
 
       expect(page).to have_content("2 errors")

--- a/spec/system/valuation/budget_investments_spec.rb
+++ b/spec/system/valuation/budget_investments_spec.rb
@@ -415,10 +415,14 @@ describe "Valuation budget investments" do
         login_as(admin.user)
         visit edit_valuation_budget_budget_investment_path(budget, investment)
 
-        expect(page).to have_selector("input[id='budget_investment_feasibility_undecided']")
-        expect(page).to have_selector("textarea[id='budget_investment_unfeasibility_explanation']")
-        expect(page).to have_selector("input[name='budget_investment[valuation_finished]']")
-        expect(page).to have_button("Save changes")
+        within_fieldset "Feasibility" do
+          expect(page).to have_field "Undefined", type: :radio
+          expect(page).to have_field "Feasible", type: :radio
+        end
+
+        expect(page).to have_field "Feasibility explanation", type: :textarea
+        expect(page).to have_field "Valuation finished", type: :checkbox
+        expect(page).to have_button "Save changes"
       end
 
       scenario "Valuators that are not admins cannot reopen or modify a finished valuation" do

--- a/spec/system/valuation/budget_investments_spec.rb
+++ b/spec/system/valuation/budget_investments_spec.rb
@@ -20,8 +20,10 @@ describe "Valuation budget investments" do
     end
   end
 
-  scenario "Display link to valuation section" do
+  scenario "Display link to valuation section", :js do
     visit root_path
+    click_link "Menu"
+
     expect(page).to have_link "Valuation", href: valuation_root_path
   end
 

--- a/spec/system/valuation/budget_investments_spec.rb
+++ b/spec/system/valuation/budget_investments_spec.rb
@@ -418,6 +418,8 @@ describe "Valuation budget investments" do
         within_fieldset "Feasibility" do
           expect(page).to have_field "Undefined", type: :radio
           expect(page).to have_field "Feasible", type: :radio
+
+          choose "Unfeasible"
         end
 
         expect(page).to have_field "Feasibility explanation", type: :textarea

--- a/spec/system/valuation/budget_investments_spec.rb
+++ b/spec/system/valuation/budget_investments_spec.rb
@@ -20,7 +20,7 @@ describe "Valuation budget investments" do
     end
   end
 
-  scenario "Display link to valuation section", :js do
+  scenario "Display link to valuation section" do
     visit root_path
     click_link "Menu"
 
@@ -87,7 +87,7 @@ describe "Valuation budget investments" do
       expect(page).to have_css(".budget_investment", count: 2)
     end
 
-    scenario "Index filtering by heading", :js do
+    scenario "Index filtering by heading" do
       group = create(:budget_group, budget: budget)
       valuating_heading = create(:budget_heading, name: "Only Valuating", group: group)
       valuating_finished_heading = create(:budget_heading, name: "Valuating&Finished", group: group)
@@ -326,7 +326,7 @@ describe "Valuation budget investments" do
       expect(find("#budget_investment_feasibility_undecided")).to be_checked
     end
 
-    scenario "Feasibility selection makes proper fields visible", :js do
+    scenario "Feasibility selection makes proper fields visible" do
       feasible_fields = ["Price (€)", "Cost during the first year (€)", "Price explanation",
                          "Time scope"]
       unfeasible_fields = ["Feasibility explanation"]
@@ -381,7 +381,7 @@ describe "Valuation budget investments" do
       end
     end
 
-    scenario "Finish valuation", :js do
+    scenario "Finish valuation" do
       investment.update!(visible_to_valuators: true)
 
       visit valuation_budget_budget_investment_path(budget, investment)

--- a/spec/system/valuation_spec.rb
+++ b/spec/system/valuation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Valuation" do
+describe "Valuation", :js do
   let(:user) { create(:user) }
 
   context "Access" do
@@ -8,7 +8,9 @@ describe "Valuation" do
       login_as(user)
       visit root_path
 
+      expect(page).not_to have_link("Menu")
       expect(page).not_to have_link("Valuation")
+
       visit valuation_root_path
 
       expect(page).not_to have_current_path(valuation_root_path)
@@ -19,9 +21,12 @@ describe "Valuation" do
     scenario "Access as moderator is not authorized" do
       create(:moderator, user: user)
       login_as(user)
+
       visit root_path
+      click_link "Menu"
 
       expect(page).not_to have_link("Valuation")
+
       visit valuation_root_path
 
       expect(page).not_to have_current_path(valuation_root_path)
@@ -32,9 +37,12 @@ describe "Valuation" do
     scenario "Access as manager is not authorized" do
       create(:manager, user: user)
       login_as(user)
+
       visit root_path
+      click_link "Menu"
 
       expect(page).not_to have_link("Valuation")
+
       visit valuation_root_path
 
       expect(page).not_to have_current_path(valuation_root_path)
@@ -45,9 +53,12 @@ describe "Valuation" do
     scenario "Access as SDG manager is not authorized" do
       create(:sdg_manager, user: user)
       login_as(user)
+
       visit root_path
+      click_link "Menu"
 
       expect(page).not_to have_link("Valuation")
+
       visit valuation_root_path
 
       expect(page).not_to have_current_path(valuation_root_path)
@@ -58,9 +69,12 @@ describe "Valuation" do
     scenario "Access as poll officer is not authorized" do
       create(:poll_officer, user: user)
       login_as(user)
+
       visit root_path
+      click_link "Menu"
 
       expect(page).not_to have_link("Valuation")
+
       visit valuation_root_path
 
       expect(page).not_to have_current_path(valuation_root_path)
@@ -71,12 +85,11 @@ describe "Valuation" do
     scenario "Access as a valuator is authorized" do
       create(:valuator, user: user)
       create(:budget)
-
       login_as(user)
-      visit root_path
 
-      expect(page).to have_link("Valuation")
-      click_on "Valuation"
+      visit root_path
+      click_link "Menu"
+      click_link "Valuation"
 
       expect(page).to have_current_path(valuation_root_path)
       expect(page).not_to have_content "You do not have permission to access this page"
@@ -85,12 +98,11 @@ describe "Valuation" do
     scenario "Access as an administrator is authorized" do
       create(:administrator, user: user)
       create(:budget)
-
       login_as(user)
-      visit root_path
 
-      expect(page).to have_link("Valuation")
-      click_on "Valuation"
+      visit root_path
+      click_link "Menu"
+      click_link "Valuation"
 
       expect(page).to have_current_path(valuation_root_path)
       expect(page).not_to have_content "You do not have permission to access this page"
@@ -100,9 +112,10 @@ describe "Valuation" do
   scenario "Valuation access links" do
     create(:valuator, user: user)
     create(:budget)
-
     login_as(user)
+
     visit root_path
+    click_link "Menu"
 
     expect(page).to have_link("Valuation")
     expect(page).not_to have_link("Administration")
@@ -116,6 +129,7 @@ describe "Valuation" do
     login_as(user)
     visit root_path
 
+    click_link "Menu"
     click_link "Valuation"
 
     expect(page).to have_current_path(valuation_root_path)

--- a/spec/system/valuation_spec.rb
+++ b/spec/system/valuation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Valuation", :js do
+describe "Valuation" do
   let(:user) { create(:user) }
 
   context "Access" do

--- a/spec/system/votes_spec.rb
+++ b/spec/system/votes_spec.rb
@@ -74,7 +74,7 @@ describe "Votes" do
         end
       end
 
-      scenario "Update", :js do
+      scenario "Update" do
         visit debate_path(create(:debate))
 
         find(".in-favor a").click
@@ -99,7 +99,7 @@ describe "Votes" do
         expect(page).to have_content "1 vote"
       end
 
-      scenario "Trying to vote multiple times", :js do
+      scenario "Trying to vote multiple times" do
         visit debate_path(create(:debate))
 
         find(".in-favor a").click
@@ -136,7 +136,7 @@ describe "Votes" do
         end
       end
 
-      scenario "Create from debate show", :js do
+      scenario "Create from debate show" do
         visit debate_path(create(:debate))
 
         find(".in-favor a").click
@@ -154,7 +154,7 @@ describe "Votes" do
         expect(page).to have_content "1 vote"
       end
 
-      scenario "Create in index", :js do
+      scenario "Create in index" do
         create(:debate)
         visit debates_path
 
@@ -211,7 +211,7 @@ describe "Votes" do
         expect(page).to have_content "No supports"
       end
 
-      scenario "Trying to vote multiple times", :js do
+      scenario "Trying to vote multiple times" do
         visit proposal_path(proposal)
 
         within(".supports") do
@@ -233,7 +233,7 @@ describe "Votes" do
         end
       end
 
-      scenario "Create from proposal show", :js do
+      scenario "Create from proposal show" do
         visit proposal_path(proposal)
 
         within(".supports") do
@@ -244,7 +244,7 @@ describe "Votes" do
         end
       end
 
-      scenario "Create in listed proposal in index", :js do
+      scenario "Create in listed proposal in index" do
         visit proposals_path
 
         within("#proposal_#{proposal.id}") do
@@ -256,7 +256,7 @@ describe "Votes" do
         expect(page).to have_current_path(proposals_path)
       end
 
-      scenario "Create in featured proposal in index", :js do
+      scenario "Create in featured proposal in index" do
         visit proposals_path
 
         within("#proposal_#{proposal.id}") do
@@ -269,7 +269,7 @@ describe "Votes" do
     end
   end
 
-  scenario "Not logged user trying to vote debates", :js do
+  scenario "Not logged user trying to vote debates" do
     debate = create(:debate)
 
     visit debates_path
@@ -279,7 +279,7 @@ describe "Votes" do
     end
   end
 
-  scenario "Not logged user trying to vote proposals", :js do
+  scenario "Not logged user trying to vote proposals" do
     proposal = create(:proposal)
 
     visit proposals_path
@@ -295,7 +295,7 @@ describe "Votes" do
     end
   end
 
-  scenario "Not logged user trying to vote comments in debates", :js do
+  scenario "Not logged user trying to vote comments in debates" do
     debate = create(:debate)
     comment = create(:comment, commentable: debate)
 
@@ -306,7 +306,7 @@ describe "Votes" do
     end
   end
 
-  scenario "Not logged user trying to vote comments in proposals", :js do
+  scenario "Not logged user trying to vote comments in proposals" do
     proposal = create(:proposal)
     comment = create(:comment, commentable: proposal)
 
@@ -317,7 +317,7 @@ describe "Votes" do
     end
   end
 
-  scenario "Anonymous user trying to vote debates", :js do
+  scenario "Anonymous user trying to vote debates" do
     user = create(:user)
     debate = create(:debate)
 
@@ -339,7 +339,7 @@ describe "Votes" do
     end
   end
 
-  scenario "Anonymous user trying to vote proposals", :js do
+  scenario "Anonymous user trying to vote proposals" do
     user = create(:user)
     proposal = create(:proposal)
 

--- a/spec/system/xss_spec.rb
+++ b/spec/system/xss_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Cross-Site Scripting protection", :js do
+describe "Cross-Site Scripting protection" do
   let(:attack_code) { "<script>document.body.remove()</script>" }
 
   scenario "valuators in admin investments index", :admin do


### PR DESCRIPTION
## References

* System tests were introduced in pull request #3621

## Objectives

* Test the way the application behaves in browsers supporting JavaScript (about 98% of existing browsers)
* Use selenium/chromedrive as the default driver, so we don't have to remember to add a `:js` tag on every test we write
* Make usability issues more obvious in system tests

## Notes

In the past, using a headless browser in tests made the test suite much slower because we had to use database cleaner to truncate the database after each test. With system tests, however, we use database transactions to make sure data is removed between tests, and so the speed difference isn't that big.