### PR TITLE
Do not make suggestions for related titles on edit pages

### DIFF
--- a/app/helpers/suggestions_helper.rb
+++ b/app/helpers/suggestions_helper.rb
@@ -1,0 +1,9 @@
+module SuggestionsHelper
+  def suggest_data(record)
+    {
+      js_suggest_result: "js_suggest_result",
+      js_suggest: ".js-suggest",
+      js_url: polymorphic_path(record.class, action: :suggest)
+    }
+  end
+end

--- a/app/helpers/suggestions_helper.rb
+++ b/app/helpers/suggestions_helper.rb
@@ -1,5 +1,7 @@
 module SuggestionsHelper
   def suggest_data(record)
+    return unless record.new_record?
+
     {
       js_suggest_result: "js_suggest_result",
       js_suggest: ".js-suggest",

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -16,9 +16,7 @@
       <div class="small-12 column">
         <%= translations_form.text_field :title,
               maxlength: Budget::Investment.title_max_length,
-              data: { js_suggest_result: "js_suggest_result",
-                      js_suggest: ".js-suggest",
-                      js_url: suggest_budget_investments_path(@budget) } %>
+              data: suggest_data(@investment) %>
       </div>
       <div class="js-suggest" data-locale="<%= translations_form.locale %>"></div>
 

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -10,9 +10,7 @@
         <%= translations_form.text_field :title,
               maxlength: Debate.title_max_length,
               placeholder: t("debates.form.debate_title"),
-              data: { js_suggest_result: "js_suggest_result",
-                      js_suggest: ".js-suggest",
-                      js_url: suggest_debates_path } %>
+              data: suggest_data(@debate) %>
       </div>
       <div class="js-suggest" data-locale="<%= translations_form.locale %>"></div>
 

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -9,9 +9,7 @@
       <div class="small-12 column">
         <%= translations_form.text_field :title,
               maxlength: Proposal.title_max_length,
-              data: { js_suggest_result: "js_suggest_result",
-                      js_suggest: ".js-suggest",
-                      js_url: suggest_proposals_path } %>
+              data: suggest_data(@proposal) %>
       </div>
       <div class="js-suggest" data-locale="<%= translations_form.locale %>"></div>
 

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -661,6 +661,30 @@ describe "Budget Investments" do
           expect(page).not_to have_content "You are seeing"
         end
       end
+
+      describe "Don't show suggestions" do
+        let(:investment) { create(factory, title: "Title, has search term", budget: budget, author: author) }
+
+        before do
+          login_as(author)
+          visit edit_budget_investment_path(budget, investment)
+        end
+
+        scenario "for edit action" do
+          fill_in "Title", with: "search"
+
+          expect(page).not_to have_content "There is an investment with the term 'search'"
+        end
+
+        scenario "for update action" do
+          fill_in "Title", with: ""
+
+          click_button "Update Investment"
+          fill_in "Title", with: "search"
+
+          expect(page).not_to have_content "There is an investment with the term 'search'"
+        end
+      end
     end
 
     scenario "Ballot is not visible" do

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -770,6 +770,31 @@ describe "Debates" do
         expect(page).not_to have_content "You are seeing"
       end
     end
+
+    describe "Don't show suggestions" do
+      let(:user) { create(:user) }
+      let(:debate) { create(:debate, title: "Debate title, has search term", author: user) }
+
+      before do
+        login_as(user)
+        visit edit_debate_path(debate)
+      end
+
+      scenario "for edit action" do
+        fill_in "Debate title", with: "search"
+
+        expect(page).not_to have_content "There is a debate with the term 'search'"
+      end
+
+      scenario "for update action" do
+        fill_in "Debate title", with: ""
+
+        click_button "Save changes"
+        fill_in "Debate title", with: "search"
+
+        expect(page).not_to have_content "There is a debate with the term 'search'"
+      end
+    end
   end
 
   scenario "Mark/Unmark a debate as featured", :admin do

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -1440,6 +1440,31 @@ describe "Proposals" do
         expect(page).not_to have_content "You are seeing"
       end
     end
+
+    describe "Don't show suggestions" do
+      let(:user) { create(:user) }
+      let(:proposal) { create(:proposal, title: "Proposal title, has search term", author: user) }
+
+      before do
+        login_as(user)
+        visit edit_proposal_path(proposal)
+      end
+
+      scenario "for edit action" do
+        fill_in "Proposal title", with: "search"
+
+        expect(page).not_to have_content "There is a proposal with the term 'search'"
+      end
+
+      scenario "for update action" do
+        fill_in "Proposal title", with: ""
+
+        click_button "Save changes"
+        fill_in "Proposal title", with: "search"
+
+        expect(page).not_to have_content "There is a proposal with the term 'search'"
+      end
+    end
   end
 
   context "Summary" do


### PR DESCRIPTION
## References
Related Issue: #2980 

## Objectives
Disable suggest title feature when editing a resource (Proposal, Debates and Investments)
