### PR TITLE
Clear fields in tests before filling them in

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,7 @@ end
 
 Capybara.exact = true
 Capybara.enable_aria_label = true
+Capybara.default_set_options = { clear: :backspace }
 Capybara.disable_animation = true
 
 OmniAuth.config.test_mode = true

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -645,6 +645,10 @@ describe "Ballots" do
         click_button "Save heading"
 
         expect(page).to have_content "Heading updated successfully"
+
+        within "tr", text: "New York" do
+          expect(page).to have_css "td", exact_text: "€10"
+        end
       end
 
       in_browser(:user) do

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -630,6 +630,7 @@ describe "Ballots" do
 
     scenario "Edge case voting a non-elegible investment" do
       investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000)
+      admin_user = create(:administrator).user
 
       in_browser(:user) do
         login_as user
@@ -639,7 +640,7 @@ describe "Ballots" do
       end
 
       in_browser(:admin) do
-        login_as create(:administrator).user
+        login_as admin_user
         visit edit_admin_budget_group_heading_path(budget, states, new_york)
         fill_in "Amount", with: 10
         click_button "Save heading"


### PR DESCRIPTION
## References

* This is a workaround to fix the problem described in teamcapybara/capybara#2419

## Background

There seems to be an issue with capybara or chromedriver which results in `fill_in` sometimes appending to an input rather than overwriting, causing some tests to fail under certain circumstances.

## Objectives

* Add a workaround to avoid flaky specs caused by filling in a field the wrong way

## Notes

We're getting warnings on all tests using the rack driver. I haven't found a way to avoid the `clear: :backspace` option in non-JavaScript tests, so to avoid the annoying warnings we should reduce the number of tests using the rack driver even more.