### PR TITLE
Integrate Coveralls with Github Actions

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,13 @@ jobs:
           POSTGRES_USER: consul
           POSTGRES_PASSWORD: ""
     env:
+      CI_BUILD_NUMBER: ${{ github.run_number }}
+      COVERALLS_FLAG_NAME: run-${{ matrix.ci_node_index }}
+      COVERALLS_PARALLEL: true
+      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       PGUSER: consul
       POSTGRES_HOST: postgres
       RAILS_ENV: test
-      COVERALLS: true
     strategy:
       fail-fast: false
       matrix:
@@ -55,3 +58,12 @@ jobs:
         with:
           name: screenshots
           path: tmp/screenshots
+  coveralls:
+    runs-on: ubuntu-18.04
+    needs: tests
+    env:
+      CI_BUILD_NUMBER: ${{ github.run_number }}
+      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+    steps:
+      - name: Finish coveralls
+        run: curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CI_BUILD_NUMBER&payload[status]=done"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,5 @@
 ENV["RAILS_ENV"] ||= "test"
-if ENV["COVERALLS"]
+if ENV["COVERALLS_REPO_TOKEN"]
   require "coveralls"
   Coveralls.wear!("rails")
 end


### PR DESCRIPTION
## References

* While working on pull request #4265 somehow I thought Coveralls worked automatically, but I was wrong
* Based on the instructions to [run Coveralls in parallel builds](https://docs.coveralls.io/parallel-build-webhook)

## Notes

Alternatively we could use the Coveralls GitHub Action [2] which slightly simplifies the workflow configuration and removes the dependency of the coveralls gem. However, it also [adds a dependency on simplecov-lcov and requires configuring it ](https://github.com/coverallsapp/github-action/issues/29#issuecomment-704366557)to generate LCOV files on each run, so the benefits of using it are not that big.