### PR TITLE
Upload screenshots of failures with GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,3 +49,9 @@ jobs:
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           KNAPSACK_PRO_LOG_LEVEL: info
         run: bin/knapsack_pro_rspec
+      - name: Upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: screenshots
+          path: tmp/screenshots


### PR DESCRIPTION
## References

* We're using GitHub Actions since pull request #4265
* We were already uploading screenshots on Gitlab CI since pull request #4433

## Objectives

Make it easier to debug failing tests.