### PR TITLE
Expire cache when users follow/unfollow

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -3,13 +3,12 @@ class FollowsController < ApplicationController
   load_and_authorize_resource
 
   def create
-    @follow = current_user.follows.create!(follow_params)
+    @follow.save!
     flash.now[:notice] = t("shared.followable.#{followable_translation_key(@follow.followable)}.create.notice")
     render :refresh_follow_button
   end
 
   def destroy
-    @follow = Follow.find(params[:id])
     @follow.destroy!
     flash.now[:notice] = t("shared.followable.#{followable_translation_key(@follow.followable)}.destroy.notice")
     render :refresh_follow_button

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -3,7 +3,7 @@ class FollowsController < ApplicationController
   load_and_authorize_resource
 
   def create
-    @follow = Follow.create!(user: current_user, followable: find_followable)
+    @follow = current_user.follows.create!(follow_params)
     flash.now[:notice] = t("shared.followable.#{followable_translation_key(@follow.followable)}.create.notice")
     render :refresh_follow_button
   end
@@ -17,8 +17,8 @@ class FollowsController < ApplicationController
 
   private
 
-    def find_followable
-      params[:followable_type].constantize.find(params[:followable_id])
+    def follow_params
+      params.permit(:followable_type, :followable_id)
     end
 
     def followable_translation_key(followable)

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -69,7 +69,7 @@ module Abilities
       can [:flag, :unflag], Budget::Investment
       cannot [:flag, :unflag], Budget::Investment, author_id: user.id
 
-      can [:create, :destroy], Follow
+      can [:create, :destroy], Follow, user_id: user.id
 
       can [:destroy], Document do |document|
         document.documentable&.author_id == user.id

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -3,6 +3,5 @@ class Follow < ApplicationRecord
   belongs_to :followable, polymorphic: true
 
   validates :user_id, presence: true
-  validates :followable_id, presence: true
-  validates :followable_type, presence: true
+  validates :followable, presence: true
 end

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -12,6 +12,7 @@
           investment.image,
           investment.author,
           Flag.flagged?(current_user, investment),
+          investment.followed_by?(current_user),
           @investment_votes] do %>
   <section class="budget-investment-show" id="<%= dom_id(investment) %>">
 

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -17,6 +17,7 @@
           @proposal,
           @proposal.author,
           Flag.flagged?(current_user, @proposal),
+          @proposal.followed_by?(current_user),
           @proposal_votes] do %>
   <div class="proposal-show">
     <div id="<%= dom_id(@proposal) %>" class="row">

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -119,6 +119,16 @@ describe Abilities::Common do
     end
   end
 
+  describe "follows" do
+    let(:other_user) { create(:user) }
+
+    it { should be_able_to(:create, build(:follow, :followed_proposal, user: user)) }
+    it { should_not be_able_to(:create, build(:follow, :followed_proposal, user: other_user)) }
+
+    it { should be_able_to(:destroy, create(:follow, :followed_proposal, user: user)) }
+    it { should_not be_able_to(:destroy, create(:follow, :followed_proposal, user: other_user)) }
+  end
+
   describe "other users" do
     let(:other_user) { create(:user) }
 

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -21,4 +21,16 @@ describe Follow do
     follow.followable_type = nil
     expect(follow).not_to be_valid
   end
+
+  it "is not valid with an invalid followable_type" do
+    follow.followable_type = "NotARealModel"
+
+    expect { follow.valid? }.to raise_exception "uninitialized constant NotARealModel"
+  end
+
+  it "is not valid with the ID of a non-existent record" do
+    follow.followable_id = Proposal.last.id + 1
+
+    expect(follow).not_to be_valid
+  end
 end


### PR DESCRIPTION
## References

* Closes #4224

## Objectives

* Make sure we display the right button to follow/unfollow proposals or budget investments after users reload the page
* Make sure users cannot delete other people's follows
* Reduce the number of security warnings reported by brakeman