### PR TITLE
Fix checkout in Pronto on external pull requests

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,8 +7,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - run: |
-          git fetch --no-tags --prune origin +refs/heads/*:refs/remotes/origin/*
+        with:
+          fetch-depth: 0
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/app/assets/javascripts/forms.js
+++ b/app/assets/javascripts/forms.js
@@ -3,7 +3,7 @@
   App.Forms = {
     disableEnter: function() {
       $("form.js-enter-disabled").on("keyup keypress", function(event) {
-        if (event.which === 13) {
+        if (event.which == 13) {
           event.preventDefault();
         }
       });

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -161,7 +161,7 @@ class Debate < ApplicationRecord
 
   def self.debates_orders(user)
     orders = %w[hot_score confidence_score created_at relevance]
-    orders << "recommendations" if Setting["feature.user.recommendations_on_debates"] && user&.recommended_debates
+    orders << "recommendations" if Setting["feature.user.recommendations_on_debates"] && user&.recommended_debates && true
     orders
   end
 end


### PR DESCRIPTION
## References

* The code is based on prontolabs/pronto@4fe28418b6

## Objectives

Make sure our linters run on pull requests opened by external contributors.

## Notes

Pronto will not comment on the pull request itself due to lack of permission. However, it will at least fail/succeed and the failures will be shown in the log of the action.