### PR TITLE
Fix setting locale to an unavailable one in specs

### DIFF
--- a/spec/lib/tasks/seed_spec.rb
+++ b/spec/lib/tasks/seed_spec.rb
@@ -17,10 +17,11 @@ describe "rake db:seed" do
                 welcome_level_three_verified: "welcome.welcome.title" }
 
       I18n.available_locales.each do |locale|
-        I18n.locale = locale
-        paths.each do |slug, path|
-          site = SiteCustomization::Page.find_by(slug: slug).translations.find_by(locale: locale)
-          expect(site.title).to eq I18n.t(path)
+        I18n.with_locale(locale) do
+          paths.each do |slug, path|
+            site = SiteCustomization::Page.find_by(slug: slug).translations.find_by(locale: locale)
+            expect(site.title).to eq I18n.t(path)
+          end
         end
       end
     ensure


### PR DESCRIPTION
## References

* Continues #4434
* Github actions failure in [run 1103, job 3](https://github.com/consul/consul/runs/2300839891)

## Background

When we assigned `I18n.available_locales = default_locales` in the `ensure` block, `I18n.locale` was set to `:zh-TW`, which is not one of the default locales.

In some cases this resulted in tests failing:

```
I18n::InvalidLocale:
  :"zh-TW" is not a valid locale
```

## Objectives

Fix setting locale to a non-existing one in specs.