### PR TITLE
Use a maintained PostgreSQL version in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can access the main website of the project at [http://consulproject.org](htt
 
 **NOTE**: For more detailed instructions check the [docs](https://docs.consulproject.org)
 
-Prerequisites: install git, Ruby 2.6.6, CMake, pkg-config, shared-mime-info, Node.js and PostgreSQL (>=9.4).
+Prerequisites: install git, Ruby 2.6.6, CMake, pkg-config, shared-mime-info, Node.js and PostgreSQL (>=9.5).
 
 ```bash
 git clone https://github.com/consul/consul.git

--- a/README_ES.md
+++ b/README_ES.md
@@ -36,7 +36,7 @@ Puedes acceder a la página principal del proyecto en [http://consulproject.org]
 
 **NOTA**: para unas instrucciones más detalladas consulta la [documentación](https://docs.consulproject.org)
 
-Prerequisitos: tener instalado git, Ruby 2.6.6, CMake, pkg-config, shared-mime-info, Node.js y PostgreSQL (9.4 o superior).
+Prerequisitos: tener instalado git, Ruby 2.6.6, CMake, pkg-config, shared-mime-info, Node.js y PostgreSQL (9.5 o superior).
 
 ```bash
 git clone https://github.com/consul/consul.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
 
     # use the preferred version of the official Postgres image
     # see https://hub.docker.com/_/postgres/
-    image: postgres:9.4.5
+    image: postgres:9.6.21
 
     # persist the database between containers by storing it in a volume
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     # use the preferred version of the official Postgres image
     # see https://hub.docker.com/_/postgres/
     image: postgres:9.6.21
-
+    environment:
+      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
     # persist the database between containers by storing it in a volume
     volumes:
       - docker-example-postgres:/var/lib/postgresql/data
@@ -37,6 +38,7 @@ services:
       - bundle:/usr/local/bundle:delegated
       - "$SSH_AUTH_SOCK:/tmp/agent.sock"
     environment:
+      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
       - SSH_AUTH_SOCK=/tmp/agent.sock
 volumes:
   docker-example-postgres: {}


### PR DESCRIPTION
## References

* Closes #4477

## Objectives

* Use a maintained PostgreSQL in the generated Docker images
* Update documentation about PostgreSQL requirements

## Release notes

If you've used Docker with PostgreSQL 9.4, you'll have to run `pg_upgrade` in your Docker image. In your development environment, alternatively you can remove the volume used to store the database with `docker volume rm <volume_name>`.