### PR TITLE
Add draft info on unpublished budgets 

### DIFF
--- a/app/assets/stylesheets/admin/budgets/index.scss
+++ b/app/assets/stylesheets/admin/budgets/index.scss
@@ -1,7 +1,7 @@
 .admin .budgets-table {
 
-  .budget-completed {
-    @include has-fa-icon(lock, solid);
+  .budget-completed,
+  .budget-draft {
     padding-left: calc(1em + #{rem-calc(10)});
     position: relative;
 
@@ -18,7 +18,22 @@
       font-size: $tiny-font-size;
       font-weight: bold;
       line-height: rem-calc(12);
+    }
+  }
+
+  .budget-completed {
+    @include has-fa-icon(lock, solid);
+
+    span {
       text-transform: uppercase;
+    }
+  }
+
+  .budget-draft {
+    @include has-fa-icon(pencil-alt, solid);
+
+    span {
+      font-style: italic;
     }
   }
 

--- a/app/components/admin/budgets/index_component.html.erb
+++ b/app/components/admin/budgets/index_component.html.erb
@@ -20,7 +20,7 @@
     <tbody>
       <% budgets.each do |budget| %>
         <tr id="<%= dom_id(budget) %>" class="budget">
-          <td class="<%= "budget-completed" if budget.finished? %>">
+          <td class="<%= status_html_class(budget) %>">
             <%= status_text(budget) %>
             <strong><%= budget.name %></strong>
           </td>

--- a/app/components/admin/budgets/index_component.html.erb
+++ b/app/components/admin/budgets/index_component.html.erb
@@ -21,11 +21,7 @@
       <% budgets.each do |budget| %>
         <tr id="<%= dom_id(budget) %>" class="budget">
           <td class="<%= "budget-completed" if budget.finished? %>">
-            <% if budget.finished? %>
-              <span>
-                <%= t("admin.budgets.index.table_completed") %>
-              </span>
-            <% end %>
+            <%= status_text(budget) %>
             <strong><%= budget.name %></strong>
           </td>
           <td>

--- a/app/components/admin/budgets/index_component.rb
+++ b/app/components/admin/budgets/index_component.rb
@@ -30,6 +30,10 @@ class Admin::Budgets::IndexComponent < ApplicationComponent
       Admin::Budgets::DurationComponent.new(budget).duration
     end
 
+    def status_html_class(budget)
+      "budget-completed" if budget.finished?
+    end
+
     def status_text(budget)
       if budget.finished?
         tag.span t("admin.budgets.index.table_completed")

--- a/app/components/admin/budgets/index_component.rb
+++ b/app/components/admin/budgets/index_component.rb
@@ -29,4 +29,10 @@ class Admin::Budgets::IndexComponent < ApplicationComponent
     def duration(budget)
       Admin::Budgets::DurationComponent.new(budget).duration
     end
+
+    def status_text(budget)
+      if budget.finished?
+        tag.span t("admin.budgets.index.table_completed")
+      end
+    end
 end

--- a/app/components/admin/budgets/index_component.rb
+++ b/app/components/admin/budgets/index_component.rb
@@ -31,11 +31,17 @@ class Admin::Budgets::IndexComponent < ApplicationComponent
     end
 
     def status_html_class(budget)
-      "budget-completed" if budget.finished?
+      if budget.drafting?
+        "budget-draft"
+      elsif budget.finished?
+        "budget-completed"
+      end
     end
 
     def status_text(budget)
-      if budget.finished?
+      if budget.drafting?
+        tag.span t("admin.budgets.index.table_draft")
+      elsif budget.finished?
         tag.span t("admin.budgets.index.table_completed")
       end
     end

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -80,6 +80,7 @@ en:
         help: "Participatory budgets allow citizens to propose and decide directly how to spend part of the budget, with monitoring and rigorous evaluation of proposals by the institution."
         budget_investments: Manage projects
         table_completed: Completed
+        table_draft: "Draft"
         table_duration: "Duration"
         table_name: Name
         table_phase: Phase

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -80,6 +80,7 @@ es:
         help: "Los presupuestos participativos permiten que los ciudadanos propongan y decidan de manera directa cómo gastar parte del presupuesto, con un seguimiento y evaluación riguroso de las propuestas por parte de la institución."
         budget_investments: Gestionar proyectos de gasto
         table_completed: Completado
+        table_draft: "Borrador"
         table_duration: "Duración"
         table_name: Nombre
         table_phase: Fase

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -27,7 +27,7 @@ describe "Admin budgets", :admin do
     end
 
     scenario "Filters by phase" do
-      create(:budget, :drafting, name: "Drafting budget")
+      create(:budget, :drafting, name: "Unpublished budget")
       create(:budget, :accepting, name: "Accepting budget")
       create(:budget, :selecting, name: "Selecting budget")
       create(:budget, :balloting, name: "Balloting budget")
@@ -35,10 +35,13 @@ describe "Admin budgets", :admin do
 
       visit admin_budgets_path
 
-      expect(page).to have_content "Drafting budget"
       expect(page).to have_content "Accepting budget"
       expect(page).to have_content "Selecting budget"
       expect(page).to have_content "Balloting budget"
+
+      within "tr", text: "Unpublished budget" do
+        expect(page).to have_content "Draft"
+      end
 
       within "tr", text: "Finished budget" do
         expect(page).to have_content "COMPLETED"
@@ -46,7 +49,7 @@ describe "Admin budgets", :admin do
 
       click_link "Finished"
 
-      expect(page).not_to have_content "Drafting budget"
+      expect(page).not_to have_content "Unpublished budget"
       expect(page).not_to have_content "Accepting budget"
       expect(page).not_to have_content "Selecting budget"
       expect(page).not_to have_content "Balloting budget"
@@ -54,7 +57,7 @@ describe "Admin budgets", :admin do
 
       click_link "Open"
 
-      expect(page).to have_content "Drafting budget"
+      expect(page).to have_content "Unpublished budget"
       expect(page).to have_content "Accepting budget"
       expect(page).to have_content "Selecting budget"
       expect(page).to have_content "Balloting budget"

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -27,36 +27,38 @@ describe "Admin budgets", :admin do
     end
 
     scenario "Filters by phase" do
-      drafting_budget  = create(:budget, :drafting)
-      accepting_budget = create(:budget, :accepting)
-      selecting_budget = create(:budget, :selecting)
-      balloting_budget = create(:budget, :balloting)
-      finished_budget  = create(:budget, :finished)
+      create(:budget, :drafting, name: "Drafting budget")
+      create(:budget, :accepting, name: "Accepting budget")
+      create(:budget, :selecting, name: "Selecting budget")
+      create(:budget, :balloting, name: "Balloting budget")
+      create(:budget, :finished, name: "Finished budget")
 
       visit admin_budgets_path
-      expect(page).to have_content(drafting_budget.name)
-      expect(page).to have_content(accepting_budget.name)
-      expect(page).to have_content(selecting_budget.name)
-      expect(page).to have_content(balloting_budget.name)
-      expect(page).to have_content(finished_budget.name)
 
-      within "#budget_#{finished_budget.id}" do
-        expect(page).to have_content("COMPLETED")
+      expect(page).to have_content "Drafting budget"
+      expect(page).to have_content "Accepting budget"
+      expect(page).to have_content "Selecting budget"
+      expect(page).to have_content "Balloting budget"
+
+      within "tr", text: "Finished budget" do
+        expect(page).to have_content "COMPLETED"
       end
 
       click_link "Finished"
-      expect(page).not_to have_content(drafting_budget.name)
-      expect(page).not_to have_content(accepting_budget.name)
-      expect(page).not_to have_content(selecting_budget.name)
-      expect(page).not_to have_content(balloting_budget.name)
-      expect(page).to have_content(finished_budget.name)
+
+      expect(page).not_to have_content "Drafting budget"
+      expect(page).not_to have_content "Accepting budget"
+      expect(page).not_to have_content "Selecting budget"
+      expect(page).not_to have_content "Balloting budget"
+      expect(page).to have_content "Finished budget"
 
       click_link "Open"
-      expect(page).to have_content(drafting_budget.name)
-      expect(page).to have_content(accepting_budget.name)
-      expect(page).to have_content(selecting_budget.name)
-      expect(page).to have_content(balloting_budget.name)
-      expect(page).not_to have_content(finished_budget.name)
+
+      expect(page).to have_content "Drafting budget"
+      expect(page).to have_content "Accepting budget"
+      expect(page).to have_content "Selecting budget"
+      expect(page).to have_content "Balloting budget"
+      expect(page).not_to have_content "Finished budget"
     end
 
     scenario "Filters are properly highlighted" do


### PR DESCRIPTION
## References

* Draft budgets were added in pull request #4369

## Objectives

* Make it easier to see which budgets have been published and which ones haven't.

## Visual Changes

### Before these changes

![There's no difference between published and unpublished budgets](https://user-images.githubusercontent.com/35156/115553400-a79c1c80-a2ad-11eb-9306-f72ea91fa91c.png)

### After these changes

![Unpublished budgets have an additional icon and the text "Draft" before them](https://user-images.githubusercontent.com/35156/115553408-a9fe7680-a2ad-11eb-9118-f682c25867cb.png)
