### PR TITLE
Fix checkout in Pronto on external pull requests

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,6 +13,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Run Pronto
+      - name: Run pronto
         run: |
-          PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}
+          if [ ${{ github.event.pull_request.head.repo.full_name }} == ${{ github.event.pull_request.base.repo.full_name }} ]; then
+            PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}
+          else
+            bundle exec pronto run --exit-code -c origin/${{ github.base_ref }}
+          fi


### PR DESCRIPTION
## References
Closes #4482 , Closes #4481 

## Objectives

Make sure our linters run on pull requests opened by external contributors.

## Notes

Pronto will not comment on the pull request itself due to lack of permission. However, it will at least fail/succeed and the failures will be shown in the log of the action.
