### PR TITLE
Fix checkout in Pronto on Dependabot pull requests

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -15,7 +15,7 @@ jobs:
           bundler-cache: true
       - name: Run pronto
         run: |
-          if [ ${{ github.event.pull_request.head.repo.full_name }} == ${{ github.event.pull_request.base.repo.full_name }} ]; then
+          if [[ ${{ github.event.pull_request.head.repo.full_name }} == ${{ github.event.pull_request.base.repo.full_name }} && ${{ github.actor }} != dependabot* ]]; then
             PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}
           else
             bundle exec pronto run --exit-code -c origin/${{ github.base_ref }}


### PR DESCRIPTION
## References

* Continues pull request #4484
* A failure can be found at our [linters run 2412293728](https://github.com/consul/consul/runs/2412293728)
* [GitHub Actions: Workflows triggered by Dependabot PRs will run with read-only permissions](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)

## Objectives

Make sure Pronto runs on pull requests opened by Dependabot.

## Notes

Pull request #4494 was used to confirm these changes work with Dependabot as shown in our [linters run #595](https://github.com/consul/consul/runs/2414752128).