### PR TITLE
Fix footer overflow on small screens

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -914,7 +914,7 @@ footer {
   background: #f1f1f1;
   clear: both;
   margin-top: $line-height * 2;
-  min-height: $line-height * 12;
+  padding-bottom: $line-height;
   padding-top: $line-height;
 }
 


### PR DESCRIPTION
## References

* This bug was probably introduced in pull request #4239

## Objectives

Fix the bottom of the footer not having the right color on small screens

## Visual Changes

### Before these changes

![The footer is gray except its bottom part, which is white](https://user-images.githubusercontent.com/35156/116128501-4fa85000-a6c9-11eb-86ac-23594fda78b2.png)

### After these changes

![The whole footer is gray](https://user-images.githubusercontent.com/35156/116128513-520aaa00-a6c9-11eb-8cbf-b28b843c86f9.png)

## Notes

I'm not sure why the `min-height` rule affects this outcome. However, since this rule usually results in footer with quite a bit of empty space at the bottom, we can simpliy remove the rule and use padding to guarantee there's a bit of space between the text in the footer and the bottom of the screen.