### PR TITLE
Increase menu button touch area on small screens

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -159,14 +159,6 @@ $table-header:   #ecf1f6;
     right: 12px;
   }
 
-  .menu-icon {
-
-    &::after {
-      background: #000;
-      box-shadow: 0 7px 0 #000, 0 14px 0 #000;
-    }
-  }
-
   .notifications.unread-notifications::after {
     color: $admin-color;
   }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -667,9 +667,12 @@ body > header,
   }
 }
 
+.menu-button {
+  color: inherit;
+}
+
 .menu-icon {
   @include hamburger($color: currentcolor, $color-hover: currentcolor);
-  color: inherit;
 }
 
 .title-bar {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -668,15 +668,8 @@ body > header,
 }
 
 .menu-icon {
-
-  &.dark {
-
-    &:hover::after,
-    &::after {
-      background: #fff;
-      box-shadow: 0 7px 0 #fff, 0 14px 0 #fff;
-    }
-  }
+  @include hamburger($color: currentcolor, $color-hover: currentcolor);
+  color: inherit;
 }
 
 .title-bar {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -668,11 +668,15 @@ body > header,
 }
 
 .menu-button {
+  border: 1px solid;
+  border-radius: $button-radius;
   color: inherit;
+  padding: 0.6em;
 }
 
 .menu-icon {
   @include hamburger($color: currentcolor, $color-hover: currentcolor);
+  cursor: inherit;
 }
 
 .title-bar {

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -11,8 +11,10 @@
 
   <div class="expanded row admin-top-bar">
     <div class="title-bar" data-responsive-toggle="responsive_menu" data-hide-for="medium">
-      <button class="menu-icon" type="button" data-toggle="responsive_menu"></button>
-      <div class="title-bar-title"><%= t("application.menu") %></div>
+      <button class="menu-button" type="button" data-toggle="responsive_menu">
+        <span class="menu-icon"></span>
+        <span class="title-bar-title"><%= t("application.menu") %></span>
+      </button>
     </div>
 
     <div class="top-bar">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,8 +16,10 @@
     <div class="top-bar">
 
       <span data-responsive-toggle="responsive-menu" data-hide-for="medium" class="float-right">
-        <button type="button" class="menu-icon" data-toggle></button>
-        <%= t("application.menu") %>
+        <button type="button" class="menu-button" data-toggle>
+          <span class="menu-icon"></span>
+          <%= t("application.menu") %>
+        </button>
       </span>
 
       <h1 class="top-bar-title">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,7 @@
     <div class="top-bar">
 
       <span data-responsive-toggle="responsive-menu" data-hide-for="medium" class="float-right">
-        <button type="button" class="menu-icon dark" data-toggle></button>
+        <button type="button" class="menu-icon" data-toggle></button>
         <%= t("application.menu") %>
       </span>
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,6 +98,15 @@ RSpec.configure do |config|
     Delayed::Worker.delay_jobs = false
   end
 
+  config.before(:each, :small_window) do
+    @window_size = Capybara.current_window.size
+    Capybara.current_window.resize_to(639, 479)
+  end
+
+  config.after(:each, :small_window) do
+    Capybara.current_window.resize_to(*@window_size)
+  end
+
   config.before(:each, :remote_translations) do
     allow(RemoteTranslations::Microsoft::AvailableLocales)
       .to receive(:available_locales).and_return(I18n.available_locales.map(&:to_s))

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -104,4 +104,22 @@ describe "Admin" do
       expect(page).to have_link "Participatory budgets"
     end
   end
+
+  describe "Menu button", :admin do
+    scenario "is not present on large screens" do
+      visit admin_root_path
+
+      expect(page).not_to have_button "Menu"
+    end
+
+    scenario "toggles the menu on small screens", :small_window do
+      visit admin_root_path
+
+      expect(page).not_to have_link "My account"
+
+      click_button "Menu"
+
+      expect(page).to have_link "My account"
+    end
+  end
 end

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -103,17 +103,7 @@ describe "Debates" do
       end
     end
 
-    context "On small devices" do
-      let!(:window_size) { Capybara.current_window.size }
-
-      before do
-        Capybara.current_window.resize_to(639, 479)
-      end
-
-      after do
-        Capybara.current_window.resize_to(*window_size)
-      end
-
+    context "On small devices", :small_window do
       scenario "Shows links to share on telegram and whatsapp too" do
         visit debate_path(create(:debate))
 

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -138,6 +138,24 @@ describe "Home" do
     end
   end
 
+  describe "Menu button" do
+    scenario "is not present on large screens" do
+      visit root_path
+
+      expect(page).not_to have_button "Menu"
+    end
+
+    scenario "toggles the menu on small screens", :small_window do
+      visit root_path
+
+      expect(page).not_to have_link "Sign in"
+
+      click_button "Menu"
+
+      expect(page).to have_link "Sign in"
+    end
+  end
+
   scenario "if there are cards, the 'featured' title will render" do
     create(:widget_card,
       title: "Card text",

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -148,17 +148,7 @@ describe "Proposals" do
       end
     end
 
-    context "On small devices" do
-      let!(:window_size) { Capybara.current_window.size }
-
-      before do
-        Capybara.current_window.resize_to(639, 479)
-      end
-
-      after do
-        Capybara.current_window.resize_to(*window_size)
-      end
-
+    context "On small devices", :small_window do
       scenario "Shows links to share on telegram and whatsapp too" do
         visit proposal_path(create(:proposal))
 
@@ -253,17 +243,7 @@ describe "Proposals" do
     end
   end
 
-  describe "Show sticky support button on mobile screens" do
-    let!(:window_size) { Capybara.current_window.size }
-
-    before do
-      Capybara.current_window.resize_to(640, 480)
-    end
-
-    after do
-      Capybara.current_window.resize_to(*window_size)
-    end
-
+  describe "Show sticky support button on small screens", :small_window do
     scenario "On a first visit" do
       proposal = create(:proposal)
       visit proposal_path(proposal)


### PR DESCRIPTION
## Objectives

* Make it easier to touch the menu button on small screens
* Make the "Menu" text show/hide the menu, as some users might expect so
* Let screen readers users with a small screen hear the word "menu" associated to the button
* Simplify styles for the menu button
* Add tests making sure the menu button works properly

## Visual changes

### Before these changes

Note the "menu" text is not clickable.

![The "menu" text lies next to the menu icon and it isn't clear which parts can be clicked](https://user-images.githubusercontent.com/35156/118732984-bd184e00-b83b-11eb-9587-0c9b82f79010.png)

### After these changes

Note the "menu" text and everything between the text and the border is clickable.

![The "menu" text and the menu icon are surrounded by a border in the shape of other buttons the application uses](https://user-images.githubusercontent.com/35156/118732989-c0abd500-b83b-11eb-9d52-751835ece126.png)
