### PR TITLE
Simplify using current color on borders

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -155,10 +155,6 @@ $table-header:   #ecf1f6;
     color: $admin-color;
   }
 
-  .dropdown.menu > .is-dropdown-submenu-parent > a::after {
-    border-color: #000 transparent transparent;
-  }
-
   .fieldset {
 
     select {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -581,7 +581,7 @@ code {
   background: #fafafa;
   border-bottom-left-radius: rem-calc(6);
   border-bottom-right-radius: rem-calc(6);
-  border-top: 2px solid #000;
+  border-top: 2px solid;
   font-size: $small-font-size;
   padding: $line-height / 2;
 }

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -451,7 +451,7 @@ code {
   &:hover,
   &:active,
   &:focus {
-    border-bottom: 1px dotted #fff;
+    border-bottom-color: transparent;
     color: #cf2a0e;
   }
 }

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -291,7 +291,6 @@ $table-header:   #ecf1f6;
     }
 
     .is-active {
-      border-bottom: 2px solid $admin-color;
       color: $admin-color;
       font-weight: bold;
     }

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -182,14 +182,13 @@
     background: #feeaeb;
 
     &::before {
-      border: 2px solid #fb9497;
       color: #fb9497;
       content: "\74";
     }
   }
 
   &::before {
-    border: 2px solid #00cb96;
+    border: 2px solid;
     border-radius: rem-calc(40);
     color: #00cb96;
     content: "\6c";

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -340,7 +340,7 @@
 
     &::before {
       background: linear-gradient(to right, rgba(231, 236, 240, 1) 0%, rgba(251, 251, 251, 1) 90%);
-      border-left: 4px solid $brand;
+      border-left: 4px solid;
       content: "";
       height: rem-calc(48);
       left: 0;
@@ -366,7 +366,7 @@
   }
 
   .submenu-active {
-    border-bottom: 2px solid $brand;
+    border-bottom: 2px solid;
 
     .has-tip {
       @include brand-text;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -101,7 +101,7 @@ a {
 
 .button.hollow {
   @include normal-selection;
-  border: 1px solid $link;
+  border: 1px solid;
   color: $link;
 }
 
@@ -346,7 +346,7 @@ a {
 
       &::after {
         background: $brand;
-        border-bottom: 2px solid $brand;
+        border-bottom: 2px solid;
         bottom: 0;
         content: "";
         left: 0;
@@ -726,7 +726,7 @@ body > header,
 
       @include breakpoint(medium) {
         @include brand-text;
-        border-bottom: 2px solid $brand;
+        border-bottom: 2px solid;
       }
     }
   }
@@ -798,7 +798,7 @@ body > header,
 
   .is-active {
     @include brand-text;
-    border-bottom: 2px solid $brand;
+    border-bottom: 2px solid;
 
     &:hover {
       text-decoration: none;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -644,7 +644,7 @@ body > header,
   }
 
   &.is-dropdown-submenu-parent > a::after {
-    border-color: #fff transparent transparent;
+    border-top-color: currentcolor;
   }
 }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -235,7 +235,7 @@ a {
 
     &.is-active {
       @include brand-text;
-      border-bottom: 2px solid $brand;
+      border-bottom: 2px solid;
       padding-bottom: rem-calc(1);
     }
 
@@ -272,7 +272,7 @@ a {
 
     &.is-active {
       @include brand-text;
-      border-bottom: 2px solid $brand;
+      border-bottom: 2px solid;
     }
   }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2497,7 +2497,7 @@ table {
   &:hover,
   &:active,
   &:focus {
-    border-bottom: 1px solid #cf2a0e;
+    border-bottom-style: solid;
     color: #cf2a0e;
     text-decoration: none;
   }

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -29,7 +29,7 @@
   .icon-like,
   .icon-unlike {
     background: #fff;
-    border: 2px solid $text-light;
+    border: 2px solid;
     border-radius: rem-calc(3);
     color: $text-light;
     display: inline-block;
@@ -1577,11 +1577,11 @@
   border-bottom: 1px solid #eee;
 
   .column:nth-child(odd) {
-    border-right: 2px solid $text;
+    border-right: 2px solid;
   }
 
   .answer-divider {
-    border-bottom: 2px solid $text;
+    border-bottom: 2px solid;
     border-right: 0 !important;
     margin-bottom: $line-height;
     padding-bottom: $line-height;
@@ -1776,7 +1776,7 @@
   margin: $line-height 0;
 
   span {
-    border-bottom: 1px solid #000;
+    border-bottom: 1px solid;
   }
 }
 


### PR DESCRIPTION
## References

* Depends on pull request #4514

## Objectives

* Make it easier to customize border colors in other CONSUL installations
* Simplify code

## Notes

Using `currentcolor` is IMHO more expressive, since it shows the intention of styling the border with the same color as the text.

This is particularly useful for CONSUL installations using custom styles. Consider the following code:

```
.is-active {
  border: 1px solid $brand;
  color: $brand;
}
```

If we'd like to customize the way active items look, we'd have to override two colors:

```
.is-active {
  border: 1px solid $brand-secondary;
  color: $brand-secondary;
}
```

Consider the scenario where we use `currentcolor` (which is the default border color):

```
.is-active {
  border: 1px solid;
  color: $brand;
}
```

Now we only need to override one color to change the styles:

```
.is-active {
  color: $brand-secondary;
}
```