### PR TITLE
Validate process dates depending on enabled phases 

### DIFF
--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -48,11 +48,10 @@ class Legislation::Process < ApplicationRecord
   validates :end_date, presence: true
 
   %i[draft debate proposals_phase allegations].each do |phase_name|
-    start_attribute = :"#{phase_name}_start_date"
-    end_attribute = :"#{phase_name}_end_date"
+    enabled_attribute = :"#{phase_name.to_s.gsub("_phase", "")}_phase_enabled?"
 
-    validates start_attribute, presence: true, if: :"#{end_attribute}?"
-    validates end_attribute, presence: true, if: :"#{start_attribute}?"
+    validates :"#{phase_name}_start_date", presence: true, if: enabled_attribute
+    validates :"#{phase_name}_end_date", presence: true, if: enabled_attribute
   end
 
   validate :valid_date_ranges

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -52,6 +52,7 @@ class Legislation::Process < ApplicationRecord
   validates :draft_end_date, presence: true, if: :draft_start_date?
   validates :allegations_start_date, presence: true, if: :allegations_end_date?
   validates :allegations_end_date, presence: true, if: :allegations_start_date?
+  validates :proposals_phase_start_date, presence: true, if: :proposals_phase_end_date?
   validates :proposals_phase_end_date, presence: true, if: :proposals_phase_start_date?
   validate :valid_date_ranges
   validates :background_color, format: { allow_blank: true, with: CSS_HEX_COLOR }

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -46,14 +46,15 @@ class Legislation::Process < ApplicationRecord
   validates_translation :title, presence: true
   validates :start_date, presence: true
   validates :end_date, presence: true
-  validates :debate_start_date, presence: true, if: :debate_end_date?
-  validates :debate_end_date, presence: true, if: :debate_start_date?
-  validates :draft_start_date, presence: true, if: :draft_end_date?
-  validates :draft_end_date, presence: true, if: :draft_start_date?
-  validates :allegations_start_date, presence: true, if: :allegations_end_date?
-  validates :allegations_end_date, presence: true, if: :allegations_start_date?
-  validates :proposals_phase_start_date, presence: true, if: :proposals_phase_end_date?
-  validates :proposals_phase_end_date, presence: true, if: :proposals_phase_start_date?
+
+  %i[draft debate proposals_phase allegations].each do |phase_name|
+    start_attribute = :"#{phase_name}_start_date"
+    end_attribute = :"#{phase_name}_end_date"
+
+    validates start_attribute, presence: true, if: :"#{end_attribute}?"
+    validates end_attribute, presence: true, if: :"#{start_attribute}?"
+  end
+
   validate :valid_date_ranges
   validates :background_color, format: { allow_blank: true, with: CSS_HEX_COLOR }
   validates :font_color, format: { allow_blank: true, with: CSS_HEX_COLOR }

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -30,14 +30,14 @@ describe Legislation::Process do
       expect(process.errors.messages[:debate_start_date]).to include("can't be blank")
     end
 
-    it "is invalid if allegations_start_date is present but debate_end_date is not" do
+    it "is invalid if allegations_start_date is present but allegations_end_date is not" do
       process = build(:legislation_process, allegations_start_date: Date.current,
                                             allegations_end_date: "")
       expect(process).to be_invalid
       expect(process.errors.messages[:allegations_end_date]).to include("can't be blank")
     end
 
-    it "is invalid if debate_end_date is present but allegations_start_date is not" do
+    it "is invalid if allegations_end_date is present but allegations_start_date is not" do
       process = build(:legislation_process, allegations_start_date: nil,
                                             allegations_end_date: Date.current)
       expect(process).to be_invalid

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -53,6 +53,14 @@ describe Legislation::Process do
       expect(process.errors.messages[:proposals_phase_end_date]).to include("can't be blank")
     end
 
+    it "is invalid if proposals_phase_end_date is present but proposals_phase_start_date is not" do
+      process = build(:legislation_process, proposals_phase_start_date: nil,
+                      proposals_phase_end_date: Date.current)
+
+      expect(process).to be_invalid
+      expect(process.errors.messages[:proposals_phase_start_date]).to include("can't be blank")
+    end
+
     it "is invalid if allegations_start_date is present but allegations_end_date is not" do
       process = build(:legislation_process, allegations_start_date: Date.current,
                                             allegations_end_date: "")

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -18,61 +18,134 @@ describe Legislation::Process do
   end
 
   describe "dates validations" do
-
-    it "is invalid if draft_start_date is present but draft_end_date is not" do
-      process = build(:legislation_process, draft_start_date: Date.current, draft_end_date: "")
-
-      expect(process).to be_invalid
-      expect(process.errors.messages[:draft_end_date]).to include("can't be blank")
-    end
-
-    it "is invalid if draft_end_date is present but draft_start_date is not" do
-      process = build(:legislation_process, draft_start_date: nil, draft_end_date: Date.current)
+    it "is invalid if draft is enabled but draft_start_date is not present" do
+      process = build(:legislation_process, draft_phase_enabled: true, draft_start_date: nil)
 
       expect(process).to be_invalid
       expect(process.errors.messages[:draft_start_date]).to include("can't be blank")
     end
 
-    it "is invalid if debate_start_date is present but debate_end_date is not" do
-      process = build(:legislation_process, debate_start_date: Date.current, debate_end_date: "")
+    it "is invalid if draft is enabled but draft_end_date is not present" do
+      process = build(:legislation_process, draft_phase_enabled: true, draft_end_date: "")
+
       expect(process).to be_invalid
-      expect(process.errors.messages[:debate_end_date]).to include("can't be blank")
+      expect(process.errors.messages[:draft_end_date]).to include("can't be blank")
     end
 
-    it "is invalid if debate_end_date is present but debate_start_date is not" do
-      process = build(:legislation_process, debate_start_date: nil, debate_end_date: Date.current)
+    it "is invalid if debate phase is enabled but debate_start_date is not present" do
+      process = build(:legislation_process, debate_phase_enabled: true, debate_start_date: nil)
+
       expect(process).to be_invalid
       expect(process.errors.messages[:debate_start_date]).to include("can't be blank")
     end
 
-    it "is invalid if proposals_phase_start_date is present but proposals_phase_end_date is not" do
-      process = build(:legislation_process, proposals_phase_start_date: Date.current,
-                      proposals_phase_end_date: "")
+    it "is invalid if debate phase is enabled but debate_end_date is not present" do
+      process = build(:legislation_process, debate_phase_enabled: true, debate_end_date: "")
 
       expect(process).to be_invalid
-      expect(process.errors.messages[:proposals_phase_end_date]).to include("can't be blank")
+      expect(process.errors.messages[:debate_end_date]).to include("can't be blank")
     end
 
-    it "is invalid if proposals_phase_end_date is present but proposals_phase_start_date is not" do
-      process = build(:legislation_process, proposals_phase_start_date: nil,
-                      proposals_phase_end_date: Date.current)
+    it "is invalid if proposals phase is enabled but proposals_phase_start_date is not present" do
+      process = build(:legislation_process, proposals_phase_enabled: true, proposals_phase_start_date: nil)
 
       expect(process).to be_invalid
       expect(process.errors.messages[:proposals_phase_start_date]).to include("can't be blank")
     end
 
-    it "is invalid if allegations_start_date is present but allegations_end_date is not" do
-      process = build(:legislation_process, allegations_start_date: Date.current,
-                                            allegations_end_date: "")
+    it "is invalid if proposals phase is enabled but proposals_phase_end_date is not present" do
+      process = build(:legislation_process, proposals_phase_enabled: true, proposals_phase_end_date: "")
+
+      expect(process).to be_invalid
+      expect(process.errors.messages[:proposals_phase_end_date]).to include("can't be blank")
+    end
+
+    it "is invalid if allegations phase is enabled but allegations_start_date is not present" do
+      process = build(:legislation_process, allegations_phase_enabled: true,
+                                            allegations_start_date: nil,)
+
+      expect(process).to be_invalid
+      expect(process.errors.messages[:allegations_start_date]).to include("can't be blank")
+    end
+
+    it "is invalid if allegations phase is enabled but allegations_end_date is not present" do
+      process = build(:legislation_process, allegations_phase_enabled: true, allegations_end_date: "")
+
       expect(process).to be_invalid
       expect(process.errors.messages[:allegations_end_date]).to include("can't be blank")
     end
 
-    it "is invalid if allegations_end_date is present but allegations_start_date is not" do
-      process = build(:legislation_process, allegations_start_date: nil,
-                                            allegations_end_date: Date.current)
-      expect(process).to be_invalid
-      expect(process.errors.messages[:allegations_start_date]).to include("can't be blank")
+    it "is valid if start dates are missing and the phase is disabled" do
+      draft_disabled = build(:legislation_process,
+                             draft_phase_enabled: false,
+                             draft_start_date: nil)
+
+      debate_disabled = build(:legislation_process,
+                              debate_phase_enabled: false,
+                              debate_start_date: nil)
+
+      proposals_disabled = build(:legislation_process,
+                                 proposals_phase_enabled: false,
+                                 proposals_phase_start_date: nil)
+
+      allegations_disabled = build(:legislation_process,
+                                   allegations_phase_enabled: false,
+                                   allegations_start_date: nil)
+
+      expect(draft_disabled).to be_valid
+      expect(debate_disabled).to be_valid
+      expect(proposals_disabled).to be_valid
+      expect(allegations_disabled).to be_valid
+    end
+
+    it "is valid if end dates are missing and the phase is disabled" do
+      draft_disabled = build(:legislation_process,
+                             draft_phase_enabled: false,
+                             draft_end_date: nil)
+
+      debate_disabled = build(:legislation_process,
+                              debate_phase_enabled: false,
+                              debate_end_date: nil)
+
+      proposals_disabled = build(:legislation_process,
+                                 proposals_phase_enabled: false,
+                                 proposals_phase_end_date: nil)
+
+      allegations_disabled = build(:legislation_process,
+                                   allegations_phase_enabled: false,
+                                   allegations_end_date: nil)
+
+      expect(draft_disabled).to be_valid
+      expect(debate_disabled).to be_valid
+      expect(proposals_disabled).to be_valid
+      expect(allegations_disabled).to be_valid
+    end
+
+    it "is valid if start and end dates are missing and the phase is disabled" do
+      draft_disabled = build(:legislation_process,
+                             draft_phase_enabled: false,
+                             draft_start_date: nil,
+                             draft_end_date: nil)
+
+      debate_disabled = build(:legislation_process,
+                              debate_phase_enabled: false,
+                              debate_start_date: nil,
+                              debate_end_date: nil)
+
+      proposals_disabled = build(:legislation_process,
+                                 proposals_phase_enabled: false,
+                                 proposals_phase_start_date: nil,
+                                 proposals_phase_end_date: nil)
+
+      allegations_disabled = build(:legislation_process,
+                                   allegations_phase_enabled: false,
+                                   allegations_start_date: nil,
+                                   allegations_end_date: nil)
+
+      expect(draft_disabled).to be_valid
+      expect(debate_disabled).to be_valid
+      expect(proposals_disabled).to be_valid
+      expect(allegations_disabled).to be_valid
     end
   end
 

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -18,6 +18,21 @@ describe Legislation::Process do
   end
 
   describe "dates validations" do
+
+    it "is invalid if draft_start_date is present but draft_end_date is not" do
+      process = build(:legislation_process, draft_start_date: Date.current, draft_end_date: "")
+
+      expect(process).to be_invalid
+      expect(process.errors.messages[:draft_end_date]).to include("can't be blank")
+    end
+
+    it "is invalid if draft_end_date is present but draft_start_date is not" do
+      process = build(:legislation_process, draft_start_date: nil, draft_end_date: Date.current)
+
+      expect(process).to be_invalid
+      expect(process.errors.messages[:draft_start_date]).to include("can't be blank")
+    end
+
     it "is invalid if debate_start_date is present but debate_end_date is not" do
       process = build(:legislation_process, debate_start_date: Date.current, debate_end_date: "")
       expect(process).to be_invalid
@@ -28,6 +43,14 @@ describe Legislation::Process do
       process = build(:legislation_process, debate_start_date: nil, debate_end_date: Date.current)
       expect(process).to be_invalid
       expect(process.errors.messages[:debate_start_date]).to include("can't be blank")
+    end
+
+    it "is invalid if proposals_phase_start_date is present but proposals_phase_end_date is not" do
+      process = build(:legislation_process, proposals_phase_start_date: Date.current,
+                      proposals_phase_end_date: "")
+
+      expect(process).to be_invalid
+      expect(process.errors.messages[:proposals_phase_end_date]).to include("can't be blank")
     end
 
     it "is invalid if allegations_start_date is present but allegations_end_date is not" do

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -289,6 +289,24 @@ describe "Admin collaborative legislation", :admin do
       expect(page).to have_field "draft_publication_date", disabled: true
     end
 
+    scenario "Enabling comments phase with blank dates" do
+      visit edit_admin_legislation_process_path(process)
+
+      within_fieldset "Comments phase" do
+        check "Enabled"
+        fill_in "Start", with: ""
+        fill_in "End", with: ""
+      end
+
+      click_button "Save changes"
+
+      expect(page).to have_content "errors prevented this process from being saved"
+
+      within_fieldset "Comments phase" do
+        expect(page).to have_content "can't be blank"
+      end
+    end
+
     scenario "Change proposal categories" do
       visit edit_admin_legislation_process_path(process)
       within(".admin-content") { click_link "Proposals" }


### PR DESCRIPTION
## References

* Closes #4011

## Objectives

* Fix a bug where the application crashed when enabling a phase and leaving its dates blank

## Notes

Existing invalid data won't be fixed by this pull request, so the application will still crash if invalid data exists. However, it won't be possible to generate new invalid data.