### PR TITLE
Use relative units as base font size

### DIFF
--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -10,7 +10,7 @@
 // 1. CONSUL variables
 // --------------------
 
-$base-font-size:      17px;
+$base-font-size:      rem-calc(17);
 $base-line:           rem-calc(26);
 $small-font-size:     rem-calc(14);
 $line-height:         rem-calc(24);

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1200,7 +1200,7 @@ table {
     }
 
     label {
-      font-size: 17px;
+      font-size: $base-font-size;
       line-height: 1.5rem;
     }
   }


### PR DESCRIPTION
## References

* [Understanding WCAG 2.0 success criterion 1.4.4](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html)
* [Web Accessibility Initiative styling tutorial](https://www.w3.org/WAI/tutorials/page-structure/styling/)

## Objectives

Make sure all text is resized when users increase the font size in their browser's preferences.

## Visual Changes

### Before these changes

When users change their font-size preference to 24px:

![The text in the main navigation and the articles' headers remains with a fixed size of 17px, meaning the text in the articles' summaries is larger than the text in the articles' headers](https://user-images.githubusercontent.com/35156/119124736-4a70c380-ba31-11eb-86d7-e95490288042.png)

### After these changes

When users change their font-size preference to 24px:

![All text is increased proportionally and the text in headers is larger than the text in summaries](https://user-images.githubusercontent.com/35156/119124840-670cfb80-ba31-11eb-869b-19547c308699.png)

## Notes

Even if most browsers can zoom to somehow overcome this issue, for users with a font-size larger than 16px it's still annoying. And, in our case, we use relative units most of the time but absolute units in some places. This leads to situations where some of the text gets larger when users increase their font size while some of the text remains the same. As seen above, sometimes this results in titles having a smaller size than regular text below it. Quoting the Web Accessibility Initiative guide for styles:
    
> The user needs to be able to resize the text to 200% of its size anywhere on the page, without the text being cut off or overlapping other text. The font size should be defined in relative units, such as percentages, em or rem. It is not possible to zoom text set in pixels independently from the rest of the page in some browsers.