### PR TITLE
Fix crash destroying budgets with admins/valuators

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -34,9 +34,9 @@ class Budget < ApplicationRecord
   has_many :headings, through: :groups
   has_many :lines, through: :ballots, class_name: "Budget::Ballot::Line"
   has_many :phases, class_name: "Budget::Phase"
-  has_many :budget_administrators
+  has_many :budget_administrators, dependent: :destroy
   has_many :administrators, through: :budget_administrators
-  has_many :budget_valuators
+  has_many :budget_valuators, dependent: :destroy
   has_many :valuators, through: :budget_valuators
 
   has_one :poll

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -402,4 +402,26 @@ describe Budget do
       end
     end
   end
+
+  describe "#budget_administrators" do
+    it "destroys relation with administrators when destroying the budget" do
+      budget = create(:budget, administrators: [create(:administrator)])
+
+      budget.destroy!
+
+      expect(BudgetAdministrator.count).to be 0
+      expect(Administrator.count).to be 1
+    end
+  end
+
+  describe "#budget_valuators" do
+    it "destroys relation with valuators when destroying the budget" do
+      budget = create(:budget, valuators: [create(:valuator)])
+
+      budget.destroy!
+
+      expect(BudgetValuator.count).to be 0
+      expect(Valuator.count).to be 1
+    end
+  end
 end

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -205,6 +205,18 @@ describe "Admin budgets", :admin do
       expect(page).to have_content("There are no budgets.")
     end
 
+    scenario "Destroy a budget without investments but with administrators and valuators" do
+      budget.administrators << Administrator.first
+      budget.valuators << create(:valuator)
+
+      visit admin_budgets_path
+      click_link "Edit budget"
+      click_link "Delete budget"
+
+      expect(page).to have_content "Budget deleted successfully"
+      expect(page).to have_content "There are no budgets."
+    end
+
     scenario "Try to destroy a budget with investments" do
       create(:budget_investment, heading: heading)
 


### PR DESCRIPTION
## References

* Assigning administrators and valuators to budgets is possible since pull request #3514

## Background

We don't allow deleting a budget with associated investments. However, we allow deleting a budget with associated administrators and valuators. This results in a foreign key violation error:

```
PG::ForeignKeyViolation: ERROR:  update or delete on table "budgets" violates foreign key constraint "fk_rails_c847a52b1d" on table "budget_administrators"
```

## Objectives

* Make it possible to remove budgets without investments but with administrators