### PR TITLE
Reduce duplication in background color definitions

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -226,7 +226,7 @@ $table-header:   #ecf1f6;
       border: $table-border;
 
       &:hover {
-        background: #f3f6f7;
+        background: adjust-color(darken($table-background, 2%), $red: -4, $green: -1);
       }
     }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -711,7 +711,7 @@ table {
 // ---------------
 
 .markdown-editor {
-  background-color: #fff;
+  background-color: $body-background;
 
   .markdown-area,
   .markdown-preview {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -509,10 +509,6 @@ code {
 // 04. Stats
 // ---------
 
-.stats {
-  background: #fff;
-}
-
 .stats-numbers {
   p {
     color: $text-medium;

--- a/app/assets/stylesheets/autocomplete_overrides.scss
+++ b/app/assets/stylesheets/autocomplete_overrides.scss
@@ -14,7 +14,7 @@
   list-style: none;
   padding: $line-height / 4 $line-height / 3;
   display: block;
-  background: #fff;
+  background: $body-background;
   border: 1px solid $border;
   font-size: $small-font-size;
 

--- a/app/assets/stylesheets/budgets/phases.scss
+++ b/app/assets/stylesheets/budgets/phases.scss
@@ -74,7 +74,7 @@
     }
 
     a {
-      background: $white;
+      background: $body-background;
       color: inherit;
       height: 100%;
       padding: $line-height $line-height * 1.5;

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -237,7 +237,6 @@
     background: #fff;
     border: 1px solid $border;
     border-radius: rem-calc(36);
-    color: #000;
     content: "\77";
     font-family: "icons";
     font-size: rem-calc(24);
@@ -264,7 +263,6 @@
   position: relative;
 
   &::before {
-    color: #000;
     font-family: "icons";
     font-size: rem-calc(24);
     left: 6px;

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -234,7 +234,7 @@
   position: relative;
 
   &::before {
-    background: #fff;
+    background: $body-background;
     border: 1px solid $border;
     border-radius: rem-calc(36);
     content: "\77";

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -569,7 +569,7 @@ body > header,
 
       @include breakpoint(medium) {
         @include brand-text;
-        background: #fff;
+        background: $body-background;
         text-align: center;
       }
     }
@@ -585,7 +585,7 @@ body > header,
   .menu {
 
     &.is-dropdown-submenu {
-      background: #fff;
+      background: $body-background;
       color: $text;
       margin: 0;
       margin-top: rem-calc(-12);
@@ -685,7 +685,7 @@ body > header,
 .subnavigation {
 
   @include breakpoint(medium) {
-    background: #fff;
+    background: $body-background;
     color: $text;
     padding-bottom: 0;
   }
@@ -966,7 +966,7 @@ footer {
   text-align: center;
 
   span {
-    background: #fff;
+    background: $body-background;
     box-decoration-break: clone;
     font-weight: bold;
     padding: 0 $line-height / 2;
@@ -991,7 +991,7 @@ footer {
   select {
 
     option {
-      background: #fff;
+      background: $body-background;
       color: $text;
       border: 0;
       outline: none;
@@ -1352,7 +1352,7 @@ form {
   }
 
   &::before {
-    background: #fff;
+    background: $body-background;
     color: $brand;
     content: "\4d";
     font-family: "icons" !important;
@@ -1773,7 +1773,7 @@ table {
     position: relative;
 
     .icon-letter {
-      background: #fff;
+      background: $body-background;
       color: $color-info;
       font-size: rem-calc(24);
       margin-left: -27px;
@@ -1788,7 +1788,7 @@ table {
 // ------------
 
 .comments {
-  background: #fff;
+  background: $body-background;
   background-repeat: repeat-x;
   padding-bottom: $line-height * 4;
 
@@ -2266,7 +2266,7 @@ table {
   }
 
   .recommendation {
-    background: #fff;
+    background: $body-background;
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.15);
     display: block;
     margin-bottom: $line-height / 4;
@@ -2688,9 +2688,9 @@ table {
     }
 
     span {
-      background: #fff;
+      background: $body-background;
       border-radius: rem-calc(4);
-      color: #000;
+      color: $text;
       display: inline-block;
       font-size: $small-font-size;
       font-weight: bold;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -345,7 +345,6 @@ a {
       font-weight: bold;
 
       &::after {
-        background: $brand;
         border-bottom: 2px solid;
         bottom: 0;
         content: "";
@@ -1834,7 +1833,6 @@ table {
   }
 
   .reply {
-    background: #fff;
     border: 1px solid $border;
     border-left: 0;
     border-right: 0;
@@ -2177,7 +2175,6 @@ table {
   .debates-inner,
   .proposals-inner,
   .budget-investments-inner {
-    background: #fff;
     max-height: rem-calc(350);
 
     @include breakpoint(small) {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1433,11 +1433,11 @@ table {
     }
 
     &:nth-child(odd) {
-      background: #fff;
+      background: $table-background;
     }
 
     &:nth-child(even) {
-      background: #fafcfb;
+      background: adjust-color($table-background, $red: -3, $green: -1, $blue: -2);
     }
   }
 

--- a/app/assets/stylesheets/legislation.scss
+++ b/app/assets/stylesheets/legislation.scss
@@ -40,7 +40,6 @@
 // -----------------
 .legislation {
   margin: 0 0 $line-height;
-  background: #fff;
   border: 1px solid;
   border-color: #e5e6e9 #dfe0e4 #d0d1d5;
   border-radius: 0;

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -583,7 +583,6 @@
     }
 
     .calc-comments {
-      background: #fff;
       cursor: auto;
 
       @include breakpoint(small only) {

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -539,7 +539,7 @@
 .fixed-mobile-content {
 
   @include breakpoint(medium down) {
-    background: #fff;
+    background: $body-background;
     margin-bottom: rem-calc(-1) !important;
     padding-top: $line-height / 2;
   }
@@ -598,7 +598,7 @@
 }
 
 %panel {
-  background: #fff;
+  background: $body-background;
   border: 1px solid;
   border-color: #e5e6e9 #dfe0e4 #d0d1d5;
   border-radius: 0;
@@ -1086,7 +1086,7 @@
       margin-top: 0;
 
       &:hover {
-        background: #fff;
+        background: $body-background;
         color: $text;
       }
     }
@@ -1202,7 +1202,7 @@
 }
 
 .jumbo-budget {
-  background: $white;
+  background: $body-background;
   border-bottom: 2px solid $border;
 
   &.budget-heading {
@@ -1405,7 +1405,7 @@
     transition: height 0.3s;
 
     &.is-fixed {
-      background: $white;
+      background: $body-background;
       border-bottom: 2px solid $border;
       height: auto;
       left: 0;
@@ -1631,9 +1631,9 @@
 }
 
 .zoom-link {
-  background: #fff;
+  background: $body-background;
   border-radius: rem-calc(48);
-  color: #000;
+  color: $text;
   font-size: rem-calc(24);
   font-weight: bold;
   height: rem-calc(48);


### PR DESCRIPTION
## References

* Depends on pull request #4520

## Objectives

* Make it easier to change the application's main background color in other CONSUL installations

## Notes

There are many cases where we use colors like `#fff` or `$white`. In many cases I'm not sure whether we mean "use white here" or "use the body background color here". When in doubt, I've left the code the way it was.

We've still got a long way to go until we reach the point where we can easily add new color themes. Before getting there, we need to reduce the number of colors we manually set in our SCSS files and use Sass variables instead (like `$body-background`, `$primary-color`, `$brand`, ...).