### PR TITLE
Avoid adding compiled assets to version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@
 .ruby-gemset
 
 public/sitemap.xml
+public/assets/
 public/system/
 /public/ckeditor_assets/


### PR DESCRIPTION
## Background

We've seen a few CONSUL repositories where compiled assets have accidentally been added to version control. It's pretty easy if you use something like `git add .` before creating a commit and you've compiled the assets locally.

Having these assets in version control doesn't help and in certain environments it might even have side effects. For instance, we might try updating the source code of a Sass file and might wonder why these changes are ignored in some test or development environments.

## Objectives

Ignore compiled assets so they aren't accidentally added to version control.