### PR TITLE
replace the word message with notification on proposal notification s…

### DIFF
--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -535,7 +535,7 @@ en:
       comments: Comments
       latest_comments: Latest messages
     messages:
-      send_notification: Send message to proposal followers
+      send_notification: Send notification to proposal followers
       previous_notifications: See previous notifications
     polls:
       index:
@@ -670,9 +670,9 @@ en:
       voted: "You have voted %{answer}"
   proposal_notifications:
     new:
-      title: "Send message"
-      submit_button: "Send message"
-      info_about_receivers: "This message will be sent to <strong>%{count} people</strong> and it will be visible in %{proposal_page}.<br> Messages are not sent immediately, users will receive periodically an email with all proposal notifications."
+      title: "Send notification"
+      submit_button: "Send notification"
+      info_about_receivers: "This notification will be sent to <strong>%{count} people</strong> and it will be visible in %{proposal_page}.<br> Notifications are not sent immediately, users will periodically receive an email with all proposal notifications."
       proposal_page: "the proposal's page"
     show:
       back: "Go back to my content"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -535,7 +535,7 @@ es:
       comments: Comentarios
       latest_comments: Últimos mensajes
     messages:
-      send_notification: Enviar mensaje a los que siguen la propuesta
+      send_notification: Enviar notificación a los que siguen la propuesta
       previous_notifications: Ver notificaciones anteriores
     polls:
       index:
@@ -670,9 +670,9 @@ es:
       voted: "Has votado %{answer}"
   proposal_notifications:
     new:
-      title: "Enviar mensaje"
-      submit_button: "Enviar mensaje"
-      info_about_receivers: "Este mensaje se enviará a <strong>%{count} usuarios</strong> y se publicará en %{proposal_page}.<br> El mensaje no se enviará inmediatamente, los usuarios recibirán periódicamente un email con todas las notificaciones de propuestas."
+      title: "Enviar notificación"
+      submit_button: "Enviar notificación"
+      info_about_receivers: "Esta notificación se enviará a <strong>%{count} usuarios</strong> y se publicará en %{proposal_page}.<br> Las notificaciones no se enviarán inmediatamente, los usuarios recibirán periódicamente un email con todas las notificaciones de propuestas."
       proposal_page: "la página de la propuesta"
     show:
       back: "Volver a mi contenido"

--- a/spec/support/common_actions/notifications.rb
+++ b/spec/support/common_actions/notifications.rb
@@ -39,11 +39,11 @@ module Notifications
       click_link "Message to users"
     end
 
-    click_link "Send message to proposal followers"
+    click_link "Send notification to proposal followers"
 
     fill_in "proposal_notification_title", with: "Thanks for supporting proposal: #{proposal.title}"
     fill_in "proposal_notification_body", with: "Please share it with others! #{proposal.summary}"
-    click_button "Send message"
+    click_button "Send notification"
 
     expect(page).to have_content "Your message has been sent correctly."
     Notification.last

--- a/spec/system/dashboard/dashboard_spec.rb
+++ b/spec/system/dashboard/dashboard_spec.rb
@@ -356,13 +356,13 @@ describe "Proposal's dashboard" do
       click_link "Message to users"
     end
 
-    expect(page).to have_link("Send message to proposal followers")
+    expect(page).to have_link("Send notification to proposal followers")
     expect(page).to have_link("See previous notifications")
   end
 
   scenario "Dashboard has a link to send message to proposal supporters" do
     visit messages_proposal_dashboard_path(proposal)
-    click_link("Send message to proposal followers")
+    click_link("Send notification to proposal followers")
 
     fill_in "Title", with: "Thank you for supporting my proposal"
     fill_in "Message", with: "Please share it with others!"

--- a/spec/system/proposal_notifications_spec.rb
+++ b/spec/system/proposal_notifications_spec.rb
@@ -104,7 +104,7 @@ describe "Proposal Notifications" do
     login_as(author)
     visit new_proposal_notification_path(proposal_id: proposal.id)
 
-    expect(page).to have_content "This message will be sent to 7 people and it will "\
+    expect(page).to have_content "This notification will be sent to 7 people and it will "\
                                  "be visible in the proposal's page"
     expect(page).to have_link("the proposal's page", href: proposal_path(proposal,
                                                      anchor: "comments"))
@@ -120,7 +120,7 @@ describe "Proposal Notifications" do
     login_as(author)
     visit new_proposal_notification_path(proposal_id: proposal.id)
 
-    expect(page).to have_content "This message will be sent to 7 people and it will "\
+    expect(page).to have_content "This notification will be sent to 7 people and it will "\
                                  "be visible in the proposal's page"
     expect(page).to have_link("the proposal's page", href: proposal_path(proposal,
                                                      anchor: "comments"))
@@ -135,7 +135,7 @@ describe "Proposal Notifications" do
     login_as(author)
     visit new_proposal_notification_path(proposal_id: proposal.id)
 
-    expect(page).to have_content "This message will be sent to 1 people and it will "\
+    expect(page).to have_content "This notification will be sent to 1 people and it will "\
                                  "be visible in the proposal's page"
     expect(page).to have_link("the proposal's page", href: proposal_path(proposal,
                                                      anchor: "comments"))

--- a/spec/system/proposal_notifications_spec.rb
+++ b/spec/system/proposal_notifications_spec.rb
@@ -14,7 +14,7 @@ describe "Proposal Notifications" do
       click_link "Message to users"
     end
 
-    click_link "Send message to proposal followers"
+    click_link "Send notification to proposal followers"
 
     fill_in "proposal_notification_title", with: "Thank you for supporting my proposal"
     fill_in "proposal_notification_body", with: "Please share it with "\
@@ -159,7 +159,7 @@ describe "Proposal Notifications" do
         click_link "Message to users"
       end
 
-      expect(page).to have_link "Send message to proposal followers"
+      expect(page).to have_link "Send notification to proposal followers"
     end
 
     scenario "Accessing form directly" do


### PR DESCRIPTION
…creens

This PR attempts to resolve issue https://github.com/consul/consul/issues/2709

There is a closed PR on that issue. I have attempted to incorporate the feedback that was provided on that PR.

## References

https://github.com/consul/consul/issues/2709

https://github.com/consul/consul/pull/2721

## Objectives

Clarify language in the UI to highlight the difference between sending a message and a notification.

## Visual Changes

![notification1](https://user-images.githubusercontent.com/354954/120798236-a2e6ab80-c56f-11eb-8cea-2f59275e8cde.png)

![notification2](https://user-images.githubusercontent.com/354954/120798244-a712c900-c56f-11eb-9ca9-475e4dedab18.png)

I have left the text "Message" above the large text box. That could be "notification text" if we want to entirely eliminate the user of the word message on this screen.
