### PR TITLE
Fix custom system emails preview

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1205,7 +1205,7 @@ table {
 // 11. Newsletters
 // -----------------
 
-.newsletter-body-content {
+.admin .newsletter-body-content {
 
   table,
   tbody,

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -42,17 +42,17 @@
 </div>
 
 <div class="newsletter-body-content">
-  <%= render file: "app/views/layouts/_mailer_header.html.erb" %>
+  <%= render "layouts/mailer_header" %>
 
   <table cellpadding="0" cellspacing="0" border="0" style="background: #fff; margin: 0 auto; max-width: 700px; width:100%;">
     <tbody>
       <tr>
-        <%= render file: "app/views/mailer/newsletter.html.erb" %>
+        <%= render template: "mailer/newsletter" %>
       </tr>
     </tbody>
   </table>
 
-  <%= render file: "app/views/layouts/_mailer_footer.html.erb" %>
+  <%= render "layouts/mailer_footer" %>
 </div>
 
 <% if @newsletter.draft? && @newsletter.valid_segment_recipient? %>

--- a/app/views/admin/system_emails/view.html.erb
+++ b/app/views/admin/system_emails/view.html.erb
@@ -21,16 +21,16 @@
     <%= t("admin.newsletters.show.body_help_text") %>
   </p>
   <div class="newsletter-body-content">
-    <%= render file: "app/views/layouts/_mailer_header.html.erb" %>
+    <%= render "layouts/mailer_header" %>
 
     <table cellpadding="0" cellspacing="0" border="0" style="background: #fff; margin: 0 auto; max-width: 700px; width:100%;">
       <tbody>
         <tr>
-          <%= render file: "app/views/mailer/#{@system_email}.html.erb" %>
+          <%= render template: "mailer/#{@system_email}" %>
         </tr>
       </tbody>
     </table>
 
-    <%= render file: "app/views/layouts/_mailer_footer.html.erb" %>
+    <%= render "layouts/mailer_footer" %>
   </div>
 </div>


### PR DESCRIPTION
## Objectives
Now if you add a view in `/custom/mailer/` it will not show up in the `admin/system_emails` preview.

This PR:

- Hide the border on system emails preview tables.
- Render the custom mailer views if exists.

## Visual Changes

### Before
![before](https://user-images.githubusercontent.com/631897/121004037-7c528b80-c78e-11eb-9a8c-22f7f0ada64e.png)

### After
![after](https://user-images.githubusercontent.com/631897/121004054-7fe61280-c78e-11eb-98a1-c48c24d62f56.png)

## Notes

I don't know any other way to check if a custom file exists than using `File.exist?`, or if it's possible to check this with a capybara spec. 😅  

So feel free to modify or refactor my commit. 🙏🏻 😌 
