### PR TITLE
Remove Capybara `default_set_options` for non JS system tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,6 @@ end
 
 Capybara.exact = true
 Capybara.enable_aria_label = true
-Capybara.default_set_options = { clear: :backspace }
 Capybara.disable_animation = true
 
 OmniAuth.config.test_mode = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,10 +54,12 @@ RSpec.configure do |config|
 
   config.before(:each, type: :system) do |example|
     driven_by :headless_chrome
+    Capybara.default_set_options = { clear: :backspace }
   end
 
   config.before(:each, type: :system, no_js: true) do
     driven_by :rack_test
+    Capybara.default_set_options = {}
   end
 
   config.before(:each, type: :system) do


### PR DESCRIPTION
## References

* We're getting warnings since pull request #4456

## Background

The next warning is flooding the tests log:

`Options passed to Node#set but the RackTest driver doesn't support any - ignoring`

As the rack test driver does not support any option for the Node#set method, we get rid of all `default_set_options` before each system spec that uses this driver.

From Capybara's docs:
`default_set_options (Hash = {}) - The default options passed to Element#set.`

## Objectives

Do not pass options to rack test driver to get rid of the warning.