### PR TITLE
Make confirm alerts show the triggering action

### DIFF
--- a/app/components/moderation/shared/index_component.html.erb
+++ b/app/components/moderation/shared/index_component.html.erb
@@ -21,18 +21,18 @@
   <%= submit_tag t("moderation.#{i18n_namespace}.index.block_authors"),
                  name: "block_authors",
                  class: "button hollow alert",
-                 data: { confirm: t("moderation.#{i18n_namespace}.index.confirm") } %>
+                 data: { confirm: t("moderation.actions.confirm_action", action: t("moderation.#{i18n_namespace}.index.block_authors")) } %>
 
   <div class="float-right">
     <%= submit_tag t("moderation.#{i18n_namespace}.index.hide"),
                    name: "hide_#{table_name}",
                    class: "button hollow alert",
-                   data: { confirm: t("moderation.#{i18n_namespace}.index.confirm") } %>
+                   data: { confirm: t("moderation.actions.confirm_action", action: t("moderation.#{i18n_namespace}.index.hide")) } %>
 
     <%= submit_tag t("moderation.#{i18n_namespace}.index.ignore_flags"),
                    name: "ignore_flags",
                    class: "button hollow",
-                   data: { confirm: t("moderation.#{i18n_namespace}.index.confirm") } %>
+                   data: { confirm: t("moderation.actions.confirm_action", action: t("moderation.#{i18n_namespace}.index.ignore_flags")) } %>
   </div>
 
   <%= paginate records %>

--- a/app/views/admin/poll/questions/answers/images/index.html.erb
+++ b/app/views/admin/poll/questions/answers/images/index.html.erb
@@ -18,6 +18,6 @@
                 class: "delete float-right",
                 method: :delete,
                 remote: true,
-                data: { confirm: t("admin.actions.confirm") } %>
+                data: { confirm: t("admin.actions.confirm_action", action: t("images.remove_image"), name: image.title) } %>
   </div>
 <% end %>

--- a/app/views/budgets/investments/_actions.html.erb
+++ b/app/views/budgets/investments/_actions.html.erb
@@ -1,10 +1,10 @@
 <% if can? :hide, investment %>
   <%= link_to t("admin.actions.hide").capitalize, hide_moderation_budget_investment_path(investment),
-              method: :put, remote: true, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, remote: true, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide"), name: investment.title) } %>
 <% end %>
 
 <% if can? :hide, investment.author %>
   &nbsp;|&nbsp;
   <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(investment.author_id),
-              method: :put, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide_author"), name: investment.author.name) } %>
 <% end %>

--- a/app/views/comments/_actions.html.erb
+++ b/app/views/comments/_actions.html.erb
@@ -12,13 +12,13 @@
                   data: { confirm: t("comments.actions.confirm_delete") } %>
     <% else %>
       <%= link_to t("admin.actions.hide").capitalize, hide_moderation_comment_path(comment),
-                  method: :put, remote: true, data: { confirm: t("admin.actions.confirm") } %>
+                  method: :put, remote: true, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide"), name: comment.body.truncate(32)) } %>
     <% end %>
   <% end %>
 
   <% if can? :hide, comment.user %>
     <span class="divider">&nbsp;&bull;&nbsp;</span>
     <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(comment.user_id),
-                method: :put, data: { confirm: t("admin.actions.confirm") } %>
+                method: :put, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide_author"), name: comment.author.name) } %>
   <% end %>
 </span>

--- a/app/views/debates/_actions.html.erb
+++ b/app/views/debates/_actions.html.erb
@@ -1,21 +1,21 @@
 <% if can? :hide, debate %>
   <%= link_to t("admin.actions.hide").capitalize, hide_moderation_debate_path(debate),
-              method: :put, remote: true, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, remote: true, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide"), name: debate.title) } %>
 <% end %>
 
 <% if can? :hide, debate.author %>
   &nbsp;|&nbsp;
   <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(debate.author_id),
-              method: :put, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide_author"), name: debate.author.name) } %>
 <% end %>
 
 <% if can? :mark_featured, debate %>
   &nbsp;|&nbsp;
   <% if debate.featured? %>
     <%= link_to t("admin.actions.unmark_featured").capitalize, unmark_featured_debate_path(debate),
-              method: :put, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.unmark_featured"), name: debate.title) } %>
   <% else %>
     <%= link_to t("admin.actions.mark_featured").capitalize, mark_featured_debate_path(debate),
-              method: :put, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.mark_featured"), name: debate.title) } %>
   <% end %>
 <% end %>

--- a/app/views/legislation/proposals/_actions.html.erb
+++ b/app/views/legislation/proposals/_actions.html.erb
@@ -1,10 +1,10 @@
 <% if can? :hide, proposal %>
   <%= link_to t("admin.actions.hide").capitalize, hide_moderation_legislation_proposal_path(proposal),
-              method: :put, remote: true, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, remote: true, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide"), name: proposal.title) } %>
 <% end %>
 
 <% if can? :hide, proposal.author %>
   &nbsp;|&nbsp;
   <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(proposal.author_id),
-              method: :put, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide_author"), name: proposal.author.name) } %>
 <% end %>

--- a/app/views/proposal_notifications/_actions.html.erb
+++ b/app/views/proposal_notifications/_actions.html.erb
@@ -3,13 +3,13 @@
     <span class="js-moderation-actions">
       <% if can? :hide, notification %>
         <%= link_to t("admin.actions.hide").capitalize, hide_moderation_proposal_notification_path(notification),
-                    method: :put, remote: true, data: { confirm: t("admin.actions.confirm") } %>
+                    method: :put, remote: true, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide"), name: notification.title) } %>
       <% end %>
 
       <% if can? :hide, notification.author %>
         <span class="divider">&nbsp;&bull;&nbsp;</span>
         <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(notification.author_id),
-                    method: :put, data: { confirm: t("admin.actions.confirm") } %>
+                    method: :put, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide_author"), name: notification.author.name) } %>
       <% end %>
     </span>
   </div>

--- a/app/views/proposals/_actions.html.erb
+++ b/app/views/proposals/_actions.html.erb
@@ -1,10 +1,10 @@
 <% if can? :hide, proposal %>
   <%= link_to t("admin.actions.hide").capitalize, hide_moderation_proposal_path(proposal),
-              method: :put, remote: true, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, remote: true, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide"), name: proposal.title) } %>
 <% end %>
 
 <% if can? :hide, proposal.author %>
   &nbsp;|&nbsp;
   <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(proposal.author_id),
-              method: :put, data: { confirm: t("admin.actions.confirm") } %>
+              method: :put, data: { confirm: t("admin.actions.confirm_action", action: t("admin.actions.hide_author"), name: proposal.author.name) } %>
 <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -4,7 +4,6 @@ en:
       title: Administration
     actions:
       actions: Actions
-      confirm: Are you sure?
       confirm_action: "Are you sure? %{action} \"%{name}\""
       confirm_delete: "Are you sure? This action will delete \"%{name}\" and can't be undone."
       confirm_hide: Confirm moderation

--- a/config/locales/en/moderation.yml
+++ b/config/locales/en/moderation.yml
@@ -1,9 +1,10 @@
 en:
   moderation:
+    actions:
+      confirm_action: "Are you sure? %{action}"
     comments:
       index:
         block_authors: Block authors
-        confirm: Are you sure?
         filter: Filter
         filters:
           all: All
@@ -24,7 +25,6 @@ en:
     debates:
       index:
         block_authors: Block authors
-        confirm: Are you sure?
         filter: Filter
         filters:
           all: All
@@ -51,7 +51,6 @@ en:
     proposals:
       index:
         block_authors: Block authors
-        confirm: Are you sure?
         filter: Filter
         filters:
           all: All
@@ -69,7 +68,6 @@ en:
     budget_investments:
       index:
         block_authors: Block authors
-        confirm: Are you sure?
         filter: Filter
         filters:
           all: All
@@ -87,7 +85,6 @@ en:
     proposal_notifications:
       index:
         block_authors: Block authors
-        confirm: Are you sure?
         filter: Filter
         filters:
           all: All

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -4,7 +4,6 @@ es:
       title: Administración
     actions:
       actions: Acciones
-      confirm: '¿Estás seguro?'
       confirm_action: "¿Estás seguro? %{action} \"%{name}\""
       confirm_delete: "¿Estás seguro? Esta acción borrará \"%{name}\" y no se puede deshacer."
       confirm_hide: Confirmar moderación

--- a/config/locales/es/moderation.yml
+++ b/config/locales/es/moderation.yml
@@ -1,9 +1,10 @@
 es:
   moderation:
+    actions:
+      confirm_action: "¿Estás seguro? %{action}"
     comments:
       index:
         block_authors: Bloquear autores
-        confirm: '¿Estás seguro?'
         filter: Filtro
         filters:
           all: Todos
@@ -24,7 +25,6 @@ es:
     debates:
       index:
         block_authors: Bloquear autores
-        confirm: '¿Estás seguro?'
         filter: Filtrar
         filters:
           all: Todos
@@ -51,7 +51,6 @@ es:
     proposals:
       index:
         block_authors: Bloquear autores
-        confirm: '¿Estás seguro?'
         filter: Filtro
         filters:
           all: Todas
@@ -69,7 +68,6 @@ es:
     budget_investments:
       index:
         block_authors: Bloquear autores
-        confirm: '¿Estás seguro?'
         filter: Filtro
         filters:
           all: Todos
@@ -87,7 +85,6 @@ es:
     proposal_notifications:
       index:
         block_authors: Bloquear autores
-        confirm: '¿Estás seguro?'
         filter: Filtro
         filters:
           all: Todas

--- a/spec/system/admin/activity_spec.rb
+++ b/spec/system/admin/activity_spec.rb
@@ -14,7 +14,7 @@ describe "Admin activity" do
       visit proposal_path(proposal)
 
       within("#proposal_#{proposal.id}") do
-        accept_confirm { click_link "Hide" }
+        accept_confirm("Are you sure? Hide \"#{proposal.title}\"") { click_link "Hide" }
       end
       expect(page).to have_css("#proposal_#{proposal.id}.faded")
 
@@ -43,7 +43,7 @@ describe "Admin activity" do
         check "proposal_#{proposal3.id}_check"
       end
 
-      accept_confirm { click_button "Hide proposals" }
+      accept_confirm("Are you sure? Hide proposals") { click_button "Hide proposals" }
 
       expect(page).not_to have_content(proposal1.title)
 
@@ -60,7 +60,7 @@ describe "Admin activity" do
       visit admin_hidden_proposals_path
 
       within("#proposal_#{proposal.id}") do
-        accept_confirm { click_button "Restore" }
+        accept_confirm("Are you sure? Restore") { click_button "Restore" }
       end
 
       expect(page).to have_content "There are no hidden proposals"
@@ -82,7 +82,7 @@ describe "Admin activity" do
       visit debate_path(debate)
 
       within("#debate_#{debate.id}") do
-        accept_confirm { click_link "Hide" }
+        accept_confirm("Are you sure? Hide \"#{debate.title}\"") { click_link "Hide" }
       end
       expect(page).to have_css("#debate_#{debate.id}.faded")
 
@@ -110,7 +110,7 @@ describe "Admin activity" do
         check "debate_#{debate3.id}_check"
       end
 
-      accept_confirm { click_button "Hide debates" }
+      accept_confirm("Are you sure? Hide debates") { click_button "Hide debates" }
 
       expect(page).not_to have_content(debate1.title)
 
@@ -127,7 +127,7 @@ describe "Admin activity" do
       visit admin_hidden_debates_path
 
       within("#debate_#{debate.id}") do
-        accept_confirm { click_button "Restore" }
+        accept_confirm("Are you sure? Restore") { click_button "Restore" }
       end
 
       expect(page).to have_content "There are no hidden debates"
@@ -150,7 +150,7 @@ describe "Admin activity" do
       visit debate_path(debate)
 
       within("#comment_#{comment.id}") do
-        accept_confirm { click_link "Hide" }
+        accept_confirm("Are you sure? Hide \"#{comment.body}\"") { click_link "Hide" }
         expect(page).to have_css(".faded")
       end
 
@@ -178,7 +178,7 @@ describe "Admin activity" do
         check "comment_#{comment3.id}_check"
       end
 
-      accept_confirm { click_button "Hide comments" }
+      accept_confirm("Are you sure? Hide comments") { click_button "Hide comments" }
 
       expect(page).not_to have_content(comment1.body)
 
@@ -195,7 +195,7 @@ describe "Admin activity" do
       visit admin_hidden_comments_path
 
       within("#comment_#{comment.id}") do
-        accept_confirm { click_button "Restore" }
+        accept_confirm("Are you sure? Restore") { click_button "Restore" }
       end
 
       expect(page).to have_content "There are no hidden comments"
@@ -217,7 +217,7 @@ describe "Admin activity" do
       visit proposal_path(proposal)
 
       within("#proposal_#{proposal.id}") do
-        accept_confirm { click_link "Hide author" }
+        accept_confirm("Are you sure? Hide author \"#{proposal.author.name}\"") { click_link "Hide author" }
 
         expect(page).to have_current_path(debates_path)
       end
@@ -266,7 +266,7 @@ describe "Admin activity" do
         check "proposal_#{proposal3.id}_check"
       end
 
-      accept_confirm { click_button "Block authors" }
+      accept_confirm("Are you sure? Block authors") { click_button "Block authors" }
 
       expect(page).not_to have_content(proposal1.author.username)
 
@@ -294,7 +294,7 @@ describe "Admin activity" do
         check "debate_#{debate3.id}_check"
       end
 
-      accept_confirm { click_button "Block authors" }
+      accept_confirm("Are you sure? Block authors") { click_button "Block authors" }
 
       expect(page).not_to have_content(debate1.author.username)
 
@@ -322,7 +322,7 @@ describe "Admin activity" do
         check "comment_#{comment3.id}_check"
       end
 
-      accept_confirm { click_button "Block authors" }
+      accept_confirm("Are you sure? Block authors") { click_button "Block authors" }
 
       expect(page).not_to have_content comment1.author.username
 
@@ -341,7 +341,7 @@ describe "Admin activity" do
       visit admin_hidden_users_path
 
       within("#user_#{user.id}") do
-        accept_confirm { click_button "Restore" }
+        accept_confirm("Are you sure? Restore") { click_button "Restore" }
       end
 
       expect(page).to have_content "There are no hidden users"

--- a/spec/system/admin/admin_notifications_spec.rb
+++ b/spec/system/admin/admin_notifications_spec.rb
@@ -117,8 +117,10 @@ describe "Admin Notifications", :admin do
       notification = create(:admin_notification)
 
       visit admin_admin_notifications_path
+
+      confirmation = "Are you sure? This action will delete \"#{notification.title}\" and can't be undone."
       within("#admin_notification_#{notification.id}") do
-        accept_confirm { click_button "Delete" }
+        accept_confirm(confirmation) { click_button "Delete" }
       end
 
       expect(page).to have_content "Notification deleted successfully"

--- a/spec/system/admin/administrators_spec.rb
+++ b/spec/system/admin/administrators_spec.rb
@@ -35,8 +35,11 @@ describe "Admin administrators" do
   scenario "Delete Administrator" do
     visit admin_administrators_path
 
+    confirmation = "Are you sure? This action will delete "\
+      "\"#{user_administrator.name}\" and can't be undone."
+
     within "#administrator_#{user_administrator.id}" do
-      accept_confirm { click_button "Delete" }
+      accept_confirm(confirmation) { click_button "Delete" }
     end
 
     within("#administrators") do
@@ -47,8 +50,9 @@ describe "Admin administrators" do
   scenario "Delete Administrator when its the current user" do
     visit admin_administrators_path
 
+    confirmation = "Are you sure? This action will delete \"#{admin.name}\" and can't be undone."
     within "#administrator_#{admin.id}" do
-      accept_confirm { click_button "Delete" }
+      accept_confirm(confirmation) { click_button "Delete" }
     end
 
     within("#error") do
@@ -112,7 +116,8 @@ describe "Admin administrators" do
       fill_in "Search user by name or email", with: administrator2.email
       click_button "Search"
 
-      accept_confirm { click_button "Delete" }
+      confirmation = "Are you sure? This action will delete \"#{administrator2.name}\" and can't be undone."
+      accept_confirm(confirmation) { click_button "Delete" }
 
       expect(page).to have_content(administrator1.email)
       expect(page).not_to have_content(administrator2.email)

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -173,7 +173,9 @@ describe "Admin banners magement", :admin do
 
     expect(page).to have_content "Ugly banner"
 
-    accept_confirm { click_button "Delete" }
+    accept_confirm("Are you sure? This action will delete \"Ugly banner\" and can't be undone.") do
+      click_button "Delete"
+    end
 
     visit admin_root_path
     expect(page).not_to have_content "Ugly banner"

--- a/spec/system/admin/budget_groups_spec.rb
+++ b/spec/system/admin/budget_groups_spec.rb
@@ -50,7 +50,9 @@ describe "Admin budget groups", :admin do
 
       visit admin_budget_path(budget)
 
-      accept_confirm { click_button "Delete Nowhere" }
+      accept_confirm("Are you sure? This action will delete \"Nowhere\" and can't be undone.") do
+        click_button "Delete Nowhere"
+      end
 
       expect(page).to have_content "Group deleted successfully"
       expect(page).not_to have_content "Nowhere"
@@ -62,8 +64,9 @@ describe "Admin budget groups", :admin do
 
       visit admin_budget_path(budget)
 
-      accept_confirm { click_button "Delete Everywhere" }
-
+      accept_confirm("Are you sure? This action will delete \"Everywhere\" and can't be undone.") do
+        click_button "Delete Everywhere"
+      end
       expect(page).to have_content "You cannot delete a Group that has associated headings"
       expect(page).to have_content "Everywhere"
     end

--- a/spec/system/admin/budget_headings_spec.rb
+++ b/spec/system/admin/budget_headings_spec.rb
@@ -51,7 +51,11 @@ describe "Admin budget headings", :admin do
 
       visit admin_budget_path(budget)
 
-      within("tr", text: "Lemuria") { accept_confirm { click_button "Delete" } }
+      within("tr", text: "Lemuria") do
+        accept_confirm("Are you sure? This action will delete \"Lemuria\" and can't be undone.") do
+          click_button "Delete"
+        end
+      end
 
       expect(page).to have_content "Heading deleted successfully"
       expect(page).not_to have_content "Lemuria"
@@ -62,7 +66,12 @@ describe "Admin budget headings", :admin do
       create(:budget_investment, heading: heading)
 
       visit admin_budget_path(budget)
-      within(".heading", text: "Atlantis") { accept_confirm { click_button "Delete" } }
+
+      within(".heading", text: "Atlantis") do
+        accept_confirm("Are you sure? This action will delete \"Atlantis\" and can't be undone.") do
+          click_button "Delete"
+        end
+      end
 
       expect(page).to have_content "You cannot delete a Heading that has associated investments"
       expect(page).to have_content "Atlantis"

--- a/spec/system/admin/dashboard/actions_spec.rb
+++ b/spec/system/admin/dashboard/actions_spec.rb
@@ -94,7 +94,9 @@ describe "Admin dashboard actions", :admin do
     end
 
     scenario "deletes the action" do
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"#{action.title}\" and can't be undone.") do
+        click_button "Delete"
+      end
 
       expect(page).not_to have_content(action.title)
     end
@@ -102,7 +104,9 @@ describe "Admin dashboard actions", :admin do
     scenario "can not delete actions that have been executed" do
       _executed_action = create(:dashboard_executed_action, action: action)
 
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"#{action.title}\" and can't be undone.") do
+        click_button "Delete"
+      end
 
       expect(page).to have_content("Cannot delete record because dependent executed actions exist")
     end

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -101,8 +101,10 @@ describe "Admin newsletter emails", :admin do
     newsletter = create(:newsletter)
 
     visit admin_newsletters_path
+
+    confirmation = "Are you sure? This action will delete \"#{newsletter.subject}\" and can't be undone."
     within("#newsletter_#{newsletter.id}") do
-      accept_confirm { click_button "Delete" }
+      accept_confirm(confirmation) { click_link_or_button "Delete" }
     end
 
     expect(page).to have_content "Newsletter deleted successfully"

--- a/spec/system/admin/geozones_spec.rb
+++ b/spec/system/admin/geozones_spec.rb
@@ -74,7 +74,11 @@ describe "Admin geozones", :admin do
 
     visit admin_geozones_path
 
-    within("#geozone_#{geozone.id}") { accept_confirm { click_button "Delete" } }
+    within("#geozone_#{geozone.id}") do
+      accept_confirm("Are you sure? This action will delete \"Delete me!\" and can't be undone.") do
+        click_button "Delete"
+      end
+    end
 
     expect(page).to have_content "Geozone successfully deleted"
     expect(page).not_to have_content("Delete me!")
@@ -86,7 +90,11 @@ describe "Admin geozones", :admin do
 
     visit admin_geozones_path
 
-    within("#geozone_#{geozone.id}") { accept_confirm { click_button "Delete" } }
+    within("#geozone_#{geozone.id}") do
+      accept_confirm("Are you sure? This action will delete \"Delete me!\" and can't be undone.") do
+        click_button "Delete"
+      end
+    end
 
     expect(page).to have_content "This geozone can't be deleted since there are elements attached to it"
 

--- a/spec/system/admin/hidden_comments_spec.rb
+++ b/spec/system/admin/hidden_comments_spec.rb
@@ -13,7 +13,7 @@ describe "Admin hidden comments", :admin do
     visit proposal_path(proposal)
 
     within("#proposal_#{proposal.id}") do
-      accept_confirm { click_link "Hide author" }
+      accept_confirm("Are you sure? Hide author \"#{proposal.author.name}\"") { click_link "Hide author" }
     end
 
     expect(page).to have_current_path debates_path
@@ -67,7 +67,7 @@ describe "Admin hidden comments", :admin do
     comment = create(:comment, :hidden, body: "Not really SPAM")
     visit admin_hidden_comments_path
 
-    accept_confirm { click_button "Restore" }
+    accept_confirm("Are you sure? Restore") { click_button "Restore" }
 
     expect(page).not_to have_content(comment.body)
 
@@ -128,7 +128,7 @@ describe "Admin hidden comments", :admin do
 
     visit admin_hidden_comments_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_button "Restore", match: :first, exact: true }
+    accept_confirm("Are you sure? Restore") { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_debates_spec.rb
+++ b/spec/system/admin/hidden_debates_spec.rb
@@ -5,7 +5,7 @@ describe "Admin hidden debates", :admin do
     debate = create(:debate, :hidden)
     visit admin_hidden_debates_path
 
-    accept_confirm { click_button "Restore" }
+    accept_confirm("Are you sure? Restore") { click_button "Restore" }
 
     expect(page).not_to have_content(debate.title)
 
@@ -70,7 +70,7 @@ describe "Admin hidden debates", :admin do
 
     visit admin_hidden_debates_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_button "Restore", match: :first, exact: true }
+    accept_confirm("Are you sure? Restore") { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_proposals_spec.rb
+++ b/spec/system/admin/hidden_proposals_spec.rb
@@ -18,7 +18,7 @@ describe "Admin hidden proposals", :admin do
     proposal = create(:proposal, :hidden)
     visit admin_hidden_proposals_path
 
-    accept_confirm { click_button "Restore" }
+    accept_confirm("Are you sure? Restore") { click_button "Restore" }
 
     expect(page).not_to have_content(proposal.title)
 
@@ -83,7 +83,7 @@ describe "Admin hidden proposals", :admin do
 
     visit admin_hidden_proposals_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_button "Restore", match: :first, exact: true }
+    accept_confirm("Are you sure? Restore") { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_users_spec.rb
+++ b/spec/system/admin/hidden_users_spec.rb
@@ -21,7 +21,7 @@ describe "Admin hidden users", :admin do
     user = create(:user, :hidden)
     visit admin_hidden_users_path
 
-    accept_confirm { click_button "Restore" }
+    accept_confirm("Are you sure? Restore \"#{user.name}\"") { click_button "Restore" }
 
     expect(page).not_to have_content(user.username)
 
@@ -78,11 +78,14 @@ describe "Admin hidden users", :admin do
 
   scenario "Action links remember the pagination setting and the filter" do
     allow(User).to receive(:default_per_page).and_return(2)
-    4.times { create(:user, :hidden, :with_confirmed_hide) }
+
+    users = 4.times.map { create(:user, :hidden, :with_confirmed_hide) }
 
     visit admin_hidden_users_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_button "Restore", match: :first, exact: true }
+    accept_confirm("Are you sure? Restore \"#{users[2].name}\"") do
+      click_button "Restore", match: :first, exact: true
+    end
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/local_census_records_spec.rb
+++ b/spec/system/admin/local_census_records_spec.rb
@@ -139,7 +139,10 @@ describe "Admin local census records", :admin do
 
       expect(page).to have_content deleted_document_number
 
-      accept_confirm { click_on "Delete" }
+      confirmation = "Are you sure? This action will delete "\
+        "\"#{local_census_record.title}\" and can't be undone."
+
+      accept_confirm(confirmation) { click_on "Delete" }
 
       expect(page).to have_content "Local census record removed successfully!"
       expect(page).not_to have_content deleted_document_number

--- a/spec/system/admin/managers_spec.rb
+++ b/spec/system/admin/managers_spec.rb
@@ -30,7 +30,9 @@ describe "Admin managers", :admin do
   scenario "Delete Manager" do
     visit admin_managers_path
 
-    accept_confirm { click_button "Delete" }
+    accept_confirm("Are you sure? This action will delete \"#{manager.name}\" and can't be undone.") do
+      click_button "Delete"
+    end
 
     within("#managers") do
       expect(page).not_to have_content manager.name
@@ -90,7 +92,9 @@ describe "Admin managers", :admin do
       fill_in "Search user by name or email", with: manager2.email
       click_button "Search"
 
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"#{manager2.name}\" and can't be undone.") do
+        click_button "Delete"
+      end
 
       expect(page).to have_content(manager1.email)
       expect(page).not_to have_content(manager2.email)

--- a/spec/system/admin/milestone_statuses_spec.rb
+++ b/spec/system/admin/milestone_statuses_spec.rb
@@ -78,7 +78,9 @@ describe "Admin milestone statuses", :admin do
       visit admin_milestone_statuses_path
 
       within("#milestone_status_#{status.id}") do
-        accept_confirm { click_button "Delete" }
+        accept_confirm("Are you sure? This action will delete \"#{status.name}\" and can't be undone.") do
+          click_button "Delete"
+        end
       end
 
       expect(page).not_to have_content status.name

--- a/spec/system/admin/moderators_spec.rb
+++ b/spec/system/admin/moderators_spec.rb
@@ -30,7 +30,9 @@ describe "Admin moderators", :admin do
   scenario "Delete Moderator" do
     visit admin_moderators_path
 
-    accept_confirm { click_button "Delete" }
+    accept_confirm("Are you sure? This action will delete \"#{moderator.name}\" and can't be undone.") do
+      click_button "Delete"
+    end
 
     within("#moderators") do
       expect(page).not_to have_content moderator.name
@@ -90,7 +92,9 @@ describe "Admin moderators", :admin do
       fill_in "Search user by name or email", with: moderator2.email
       click_button "Search"
 
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"#{moderator2.name}\" and can't be undone.") do
+        click_button "Delete"
+      end
 
       expect(page).to have_content(moderator1.email)
       expect(page).not_to have_content(moderator2.email)

--- a/spec/system/admin/poll/officers_spec.rb
+++ b/spec/system/admin/poll/officers_spec.rb
@@ -28,7 +28,9 @@ describe "Admin poll officers", :admin do
   end
 
   scenario "Delete" do
-    accept_confirm { click_button "Delete position" }
+    accept_confirm("Are you sure? This action will delete \"#{officer.name}\" and can't be undone.") do
+      click_button "Delete position"
+    end
 
     expect(page).not_to have_css "#officers"
   end

--- a/spec/system/admin/poll/questions/answers/documents/documents_spec.rb
+++ b/spec/system/admin/poll/questions/answers/documents/documents_spec.rb
@@ -28,7 +28,9 @@ describe "Documents", :admin do
     visit admin_answer_documents_path(answer)
     expect(page).to have_content(document.title)
 
-    accept_confirm { click_button "Delete" }
+    accept_confirm("Are you sure? This action will delete \"#{document.title}\" and can't be undone.") do
+      click_button "Delete"
+    end
 
     expect(page).not_to have_content(document.title)
   end

--- a/spec/system/admin/poll/questions/answers/images/images_spec.rb
+++ b/spec/system/admin/poll/questions/answers/images/images_spec.rb
@@ -53,7 +53,7 @@ describe "Images", :admin do
     expect(page).to have_css("img[title='#{image.title}']")
     expect(page).to have_content(image.title)
 
-    accept_confirm "Are you sure?" do
+    accept_confirm "Are you sure? Remove image \"#{image.title}\"" do
       click_link "Remove image"
     end
 

--- a/spec/system/admin/poll/questions_spec.rb
+++ b/spec/system/admin/poll/questions_spec.rb
@@ -142,7 +142,9 @@ describe "Admin poll questions", :admin do
     visit admin_poll_path(poll)
 
     within("#poll_question_#{question1.id}") do
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"#{question1.title}\" and can't be undone.") do
+        click_button "Delete"
+      end
     end
 
     expect(page).not_to have_content(question1.title)

--- a/spec/system/admin/poll/shifts_spec.rb
+++ b/spec/system/admin/poll/shifts_spec.rb
@@ -174,7 +174,9 @@ describe "Admin shifts", :admin do
 
     expect(page).to have_css(".shift", count: 1)
     within("#shift_#{shift.id}") do
-      accept_confirm { click_button "Remove" }
+      accept_confirm("Are you sure? This action will delete \"#{shift.title}\" and can't be undone.") do
+        click_button "Remove"
+      end
     end
 
     expect(page).to have_content "Shift removed"
@@ -198,7 +200,9 @@ describe "Admin shifts", :admin do
 
     expect(page).to have_css(".shift", count: 1)
     within("#shift_#{shift.id}") do
-      accept_confirm { click_button "Remove" }
+      accept_confirm("Are you sure? This action will delete \"#{shift.title}\" and can't be undone.") do
+        click_button "Remove"
+      end
     end
 
     expect(page).not_to have_content "Shift removed"
@@ -225,7 +229,9 @@ describe "Admin shifts", :admin do
 
     expect(page).to have_css(".shift", count: 1)
     within("#shift_#{shift.id}") do
-      accept_confirm { click_button "Remove" }
+      accept_confirm("Are you sure? This action will delete \"#{shift.title}\" and can't be undone.") do
+        click_button "Remove"
+      end
     end
 
     expect(page).not_to have_content "Shift removed"

--- a/spec/system/admin/proposal_notifications_spec.rb
+++ b/spec/system/admin/proposal_notifications_spec.rb
@@ -13,7 +13,7 @@ describe "Admin proposal notifications", :admin do
     proposal_notification = create(:proposal_notification, :hidden, created_at: Date.current - 5.days)
     visit admin_hidden_proposal_notifications_path
 
-    accept_confirm { click_button "Restore" }
+    accept_confirm("Are you sure? Restore") { click_button "Restore" }
 
     expect(page).not_to have_content(proposal_notification.title)
 
@@ -80,7 +80,7 @@ describe "Admin proposal notifications", :admin do
 
     visit admin_hidden_proposal_notifications_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_button "Restore", match: :first, exact: true }
+    accept_confirm("Are you sure? Restore") { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/sdg/managers_spec.rb
+++ b/spec/system/admin/sdg/managers_spec.rb
@@ -32,7 +32,9 @@ describe "Admin SDG managers" do
   scenario "Delete SDG Manager" do
     visit admin_sdg_managers_path
 
-    accept_confirm { click_button "Delete" }
+    accept_confirm("Are you sure? This action will delete \"#{sdg_manager.name}\" and can't be undone.") do
+      click_button "Delete"
+    end
 
     within("#sdg_managers") do
       expect(page).not_to have_content sdg_manager.name
@@ -90,7 +92,9 @@ describe "Admin SDG managers" do
       fill_in "Search user by name or email", with: sdg_manager2.email
       click_button "Search"
 
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"#{sdg_manager2.name}\" and can't be undone.") do
+        click_button "Delete"
+      end
 
       expect(page).to have_content(sdg_manager1.email)
       expect(page).not_to have_content(sdg_manager2.email)

--- a/spec/system/admin/site_customization/content_blocks_spec.rb
+++ b/spec/system/admin/site_customization/content_blocks_spec.rb
@@ -91,7 +91,9 @@ describe "Admin custom content blocks", :admin do
       expect(page).to have_content("#{block.name} (#{block.locale})")
       expect(page).to have_content(block.body)
 
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"#{block.name}\" and can't be undone.") do
+        click_button "Delete"
+      end
 
       expect(page).not_to have_content("#{block.name} (#{block.locale})")
       expect(page).not_to have_content(block.body)

--- a/spec/system/admin/site_customization/documents_spec.rb
+++ b/spec/system/admin/site_customization/documents_spec.rb
@@ -75,7 +75,9 @@ describe "Documents", :admin do
     visit admin_site_customization_documents_path
 
     within("#document_#{document.id}") do
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"#{document.title}\" and can't be undone.") do
+        click_button "Delete"
+      end
     end
 
     expect(page).to have_content "Document deleted succesfully"

--- a/spec/system/admin/tags_spec.rb
+++ b/spec/system/admin/tags_spec.rb
@@ -39,7 +39,9 @@ describe "Admin tags", :admin do
     expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"Bad tag\" and can't be undone.") do
+        click_link_or_button "Delete"
+      end
     end
 
     expect(page).not_to have_content "bad tag"
@@ -57,7 +59,9 @@ describe "Admin tags", :admin do
     expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"Bad tag\" and can't be undone.") do
+        click_link_or_button "Delete"
+      end
     end
 
     expect(page).not_to have_content "bad tag"

--- a/spec/system/admin/valuator_groups_spec.rb
+++ b/spec/system/admin/valuator_groups_spec.rb
@@ -64,10 +64,12 @@ describe "Valuator groups", :admin do
   end
 
   scenario "Delete" do
-    create(:valuator_group)
+    create(:valuator_group, name: "Economy")
 
     visit admin_valuator_groups_path
-    accept_confirm { click_button "Delete" }
+
+    confirmation = "Are you sure? This action will delete \"Economy\" and can't be undone."
+    accept_confirm(confirmation) { click_button "Delete" }
 
     expect(page).to have_content "Valuator group deleted successfully"
     expect(page).to have_content "There are no valuator groups"

--- a/spec/system/admin/valuators_spec.rb
+++ b/spec/system/admin/valuators_spec.rb
@@ -55,7 +55,9 @@ describe "Admin valuators", :admin do
   scenario "Destroy" do
     visit admin_valuators_path
 
-    accept_confirm { click_button "Delete" }
+    accept_confirm("Are you sure? This action will delete \"#{valuator.name}\" and can't be undone.") do
+      click_button "Delete"
+    end
 
     within("#valuators") do
       expect(page).not_to have_content(valuator.name)

--- a/spec/system/admin/widgets/cards_spec.rb
+++ b/spec/system/admin/widgets/cards_spec.rb
@@ -109,7 +109,9 @@ describe "Cards", :admin do
     visit admin_homepage_path
 
     within("#widget_card_#{card.id}") do
-      accept_confirm { click_button "Delete" }
+      accept_confirm("Are you sure? This action will delete \"#{card.title}\" and can't be undone.") do
+        click_button "Delete"
+      end
     end
 
     expect(page).to have_content "Card removed successfully"
@@ -235,7 +237,9 @@ describe "Cards", :admin do
 
         expect(page).to have_content("Card title")
 
-        accept_confirm { click_button "Delete" }
+        accept_confirm("Are you sure? This action will delete \"Card title\" and can't be undone.") do
+          click_button "Delete"
+        end
 
         expect(page).to have_current_path admin_site_customization_page_widget_cards_path(custom_page)
         expect(page).not_to have_content "Card title"

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -800,7 +800,7 @@ describe "Debates" do
     end
 
     click_link debate.title
-    accept_confirm { click_link "Featured" }
+    accept_confirm("Are you sure? Featured") { click_link "Featured" }
 
     within("#debates") do
       expect(page).to have_content "FEATURED"
@@ -812,7 +812,7 @@ describe "Debates" do
       click_link debate.title
     end
 
-    accept_confirm { click_link "Unmark featured" }
+    accept_confirm("Are you sure? Unmark featured") { click_link "Unmark featured" }
 
     within("#debates") do
       expect(page).not_to have_content "FEATURED"

--- a/spec/system/moderation/budget_investments_spec.rb
+++ b/spec/system/moderation/budget_investments_spec.rb
@@ -10,7 +10,7 @@ describe "Moderate budget investments" do
     login_as(mod.user)
     visit budget_investment_path(budget, investment)
 
-    accept_confirm { click_link "Hide" }
+    accept_confirm("Are you sure? Hide \"#{investment.title}\"") { click_link "Hide" }
 
     expect(page).to have_css(".faded", count: 2)
 
@@ -23,7 +23,7 @@ describe "Moderate budget investments" do
     login_as(mod.user)
     visit budget_investment_path(budget, investment)
 
-    accept_confirm { click_link "Hide author" }
+    accept_confirm("Are you sure? Hide author \"#{investment.author.name}\"") { click_link "Hide author" }
 
     expect(page).to have_current_path(debates_path)
 
@@ -64,7 +64,9 @@ describe "Moderate budget investments" do
         end
 
         scenario "Hide the investment" do
-          accept_confirm { click_button "Hide budget investments" }
+          accept_confirm("Are you sure? Hide budget investments") do
+            click_button "Hide budget investments"
+          end
 
           expect(page).not_to have_css("#investment_#{investment.id}")
 
@@ -78,7 +80,7 @@ describe "Moderate budget investments" do
         end
 
         scenario "Block the author" do
-          accept_confirm { click_button "Block authors" }
+          accept_confirm("Are you sure? Block authors") { click_button "Block authors" }
 
           expect(page).not_to have_css("#investment_#{investment.id}")
 
@@ -124,7 +126,7 @@ describe "Moderate budget investments" do
 
         visit moderation_budget_investments_path(filter: "all", page: "2", order: "created_at")
 
-        accept_confirm { click_button "Mark as viewed" }
+        accept_confirm("Are you sure? Mark as viewed") { click_button "Mark as viewed" }
 
         expect(page).to have_link "Most recent", class: "is-active"
         expect(page).to have_link "Most flagged"

--- a/spec/system/moderation/comments_spec.rb
+++ b/spec/system/moderation/comments_spec.rb
@@ -11,7 +11,7 @@ describe "Moderate comments" do
     visit debate_path(comment.commentable)
 
     within("#comment_#{comment.id}") do
-      accept_confirm { click_link "Hide" }
+      accept_confirm("Are you sure? Hide") { click_link "Hide" }
       expect(page).to have_css(".comment .faded")
     end
 
@@ -84,7 +84,9 @@ describe "Moderate comments" do
         end
 
         scenario "Hide the comment" do
-          accept_confirm { click_button "Hide comments" }
+          accept_confirm("Are you sure? Hide comments") do
+            click_button "Hide comments"
+          end
 
           expect(page).not_to have_css("#comment_#{comment.id}")
 
@@ -98,7 +100,9 @@ describe "Moderate comments" do
         end
 
         scenario "Block the user" do
-          accept_confirm { click_button "Block authors" }
+          accept_confirm("Are you sure? Block authors") do
+            click_button "Block authors"
+          end
 
           expect(page).not_to have_css("#comment_#{comment.id}")
 
@@ -142,7 +146,7 @@ describe "Moderate comments" do
 
         visit moderation_comments_path(filter: "all", page: "2", order: "newest")
 
-        accept_confirm { click_button "Mark as viewed" }
+        accept_confirm("Are you sure? Mark as viewed") { click_button "Mark as viewed" }
 
         expect(page).to have_link "Newest", class: "is-active"
         expect(page).to have_link "Most flagged"

--- a/spec/system/moderation/debates_spec.rb
+++ b/spec/system/moderation/debates_spec.rb
@@ -11,7 +11,7 @@ describe "Moderate debates" do
     visit debate_path(debate)
 
     within("#debate_#{debate.id}") do
-      accept_confirm { click_link "Hide" }
+      accept_confirm("Are you sure? Hide") { click_link "Hide" }
     end
 
     expect(find("div#debate_#{debate.id}.faded")).to have_text debate.title
@@ -57,7 +57,7 @@ describe "Moderate debates" do
         end
 
         scenario "Hide the debate" do
-          accept_confirm { click_button "Hide debates" }
+          accept_confirm("Are you sure? Hide debates") { click_button "Hide debates" }
 
           expect(page).not_to have_css("#debate_#{debate.id}")
 
@@ -71,7 +71,7 @@ describe "Moderate debates" do
         end
 
         scenario "Block the author" do
-          accept_confirm { click_button "Block authors" }
+          accept_confirm("Are you sure? Block authors") { click_button "Block authors" }
 
           expect(page).not_to have_css("#debate_#{debate.id}")
 
@@ -115,7 +115,7 @@ describe "Moderate debates" do
 
         visit moderation_debates_path(filter: "all", page: "2", order: "created_at")
 
-        accept_confirm { click_button "Mark as viewed" }
+        accept_confirm("Are you sure? Mark as viewed") { click_button "Mark as viewed" }
 
         expect(page).to have_link "Newest", class: "is-active"
         expect(page).to have_link "Most flagged"

--- a/spec/system/moderation/legislation_proposals_spec.rb
+++ b/spec/system/moderation/legislation_proposals_spec.rb
@@ -11,7 +11,7 @@ describe "Moderate legislation proposals" do
     visit legislation_process_proposal_path(legislation_process, legislation_proposal)
 
     within("#legislation_proposal_#{legislation_proposal.id}") do
-      accept_confirm { click_link "Hide" }
+      accept_confirm("Are you sure? Hide \"#{legislation_proposal.title}\"") { click_link "Hide" }
     end
 
     expect(page).to have_css("#legislation_proposal_#{legislation_proposal.id}.faded")

--- a/spec/system/moderation/proposal_notifications_spec.rb
+++ b/spec/system/moderation/proposal_notifications_spec.rb
@@ -12,7 +12,7 @@ describe "Moderate proposal notifications" do
     click_link "Notifications (1)"
 
     within("#proposal_notification_#{proposal_notification.id}") do
-      accept_confirm { click_link "Hide" }
+      accept_confirm("Are you sure? Hide") { click_link "Hide" }
     end
 
     expect(page).to have_css("#proposal_notification_#{proposal_notification.id}.faded")
@@ -61,7 +61,7 @@ describe "Moderate proposal notifications" do
         end
 
         scenario "Hide the proposal" do
-          accept_confirm { click_button "Hide proposals" }
+          accept_confirm("Are you sure? Hide proposals") { click_button "Hide proposals" }
 
           expect(page).not_to have_css("#proposal_notification_#{proposal_notification.id}")
 
@@ -78,7 +78,7 @@ describe "Moderate proposal notifications" do
           author = create(:user)
           proposal_notification.update!(author: author)
 
-          accept_confirm { click_button "Block authors" }
+          accept_confirm("Are you sure? Block authors") { click_button "Block authors" }
 
           expect(page).not_to have_css("#proposal_notification_#{proposal_notification.id}")
 
@@ -122,7 +122,7 @@ describe "Moderate proposal notifications" do
 
         visit moderation_proposal_notifications_path(filter: "all", page: "2", order: "created_at")
 
-        accept_confirm { click_button "Mark as viewed" }
+        accept_confirm("Are you sure? Mark as viewed") { click_button "Mark as viewed" }
 
         expect(page).to have_link "Most recent", class: "is-active"
         expect(page).to have_link "Moderated"

--- a/spec/system/moderation/proposals_spec.rb
+++ b/spec/system/moderation/proposals_spec.rb
@@ -10,7 +10,7 @@ describe "Moderate proposals" do
     visit proposal_path(proposal)
 
     within("#proposal_#{proposal.id}") do
-      accept_confirm { click_link "Hide" }
+      accept_confirm("Are you sure? Hide") { click_link "Hide" }
     end
 
     expect(page).to have_css("#proposal_#{proposal.id}.faded")
@@ -56,7 +56,7 @@ describe "Moderate proposals" do
         end
 
         scenario "Hide the proposal" do
-          accept_confirm { click_button "Hide proposals" }
+          accept_confirm("Are you sure? Hide proposals") { click_button "Hide proposals" }
 
           expect(page).not_to have_css("#proposal_#{proposal.id}")
 
@@ -70,7 +70,7 @@ describe "Moderate proposals" do
         end
 
         scenario "Block the author" do
-          accept_confirm { click_button "Block authors" }
+          accept_confirm("Are you sure? Block authors") { click_button "Block authors" }
 
           expect(page).not_to have_css("#proposal_#{proposal.id}")
 
@@ -114,7 +114,7 @@ describe "Moderate proposals" do
 
         visit moderation_proposals_path(filter: "all", page: "2", order: "created_at")
 
-        accept_confirm { click_button "Mark as viewed" }
+        accept_confirm("Are you sure? Mark as viewed") { click_button "Mark as viewed" }
 
         expect(page).to have_link "Most recent", class: "is-active"
         expect(page).to have_link "Most flagged"

--- a/spec/system/moderation/users_spec.rb
+++ b/spec/system/moderation/users_spec.rb
@@ -24,7 +24,7 @@ describe "Moderate users" do
     visit debate_path(debate1)
 
     within("#debate_#{debate1.id}") do
-      accept_confirm { click_link "Hide author" }
+      accept_confirm("Are you sure? Hide author \"#{debate1.author.name}\"") { click_link "Hide author" }
     end
 
     expect(page).to have_current_path(debates_path)

--- a/spec/system/sdg_management/homepage_spec.rb
+++ b/spec/system/sdg_management/homepage_spec.rb
@@ -82,7 +82,9 @@ describe "SDG homepage configuration" do
       visit sdg_management_homepage_path
 
       within ".sdg-header" do
-        accept_confirm { click_button "Delete" }
+        accept_confirm("Are you sure? This action will delete \"SDG Header\" and can't be undone.") do
+          click_button "Delete"
+        end
       end
 
       expect(page).not_to have_content "SDG Header"

--- a/spec/system/sdg_management/local_targets_spec.rb
+++ b/spec/system/sdg_management/local_targets_spec.rb
@@ -86,10 +86,13 @@ describe "Local Targets" do
 
   describe "Destroy" do
     scenario "Shows succesful notice when local target is destroyed successfully" do
-      create(:sdg_local_target, code: "1.1.1")
+      sdg_local_target = create(:sdg_local_target, code: "1.1.1")
       visit sdg_management_local_targets_path
 
-      accept_confirm { click_button "Delete" }
+      confirmation = "Are you sure? This action will delete "\
+        "\"#{sdg_local_target.title}\" and can't be undone."
+
+      accept_confirm(confirmation) { click_button "Delete" }
 
       expect(page).to have_content("Local target deleted successfully")
       expect(page).not_to have_content("1.1.1")


### PR DESCRIPTION
## References

> Related Issues/Pull Requests/errors/etc...

Resolves #4015

## Objectives

> What are the objectives of these changes?

When the user clicks on certain buttons in the app, a confirmation alert is shown. However, this alert only asks the user "Are you sure?", but that doesn't give much information about what he should be sure of.

In this PR, I made the confirmation alerts show the triggering action, with the format:

`Are you sure? %{action}`

For instance, if the user clicks on a 'Hide author' button, the alert now displays 'Hide author: Are you sure?'.

System specs were also updated to check if the confirmation alerts actually showed the triggering action.

## Visual Changes

> Any visual changes? please attach screenshots (or gifs) showing them.
> If modified views are public (not the admin panel), try them in mobile display (with your browser's developer console) and add screenshots.

For example, in a page that has comments:

![01-confirmation-screenshot](https://user-images.githubusercontent.com/72531802/121581186-f2135d00-ca03-11eb-9c18-da1aa119ea4e.png)

I didn't include a mobile screenshot because the dev tools still show the alerts as if it was in a computer, but since this is the standard alert, not much has changed.

## Notes

> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
> Explain any caveats, or important things to notice like deprecations (if any).

Since this PR is already pretty big, I plan to open another one (if/after this one is merged) to update the other locales too.
