### PR TITLE
Simplify investment form in single heading budgets

### DIFF
--- a/app/assets/stylesheets/budgets/investments/new.scss
+++ b/app/assets/stylesheets/budgets/investments/new.scss
@@ -1,0 +1,74 @@
+.budget-investment-new {
+  $border-width: 4px;
+
+  > * {
+    @include grid-row;
+    @include grid-column-gutter;
+  }
+
+  header {
+    @include has-fa-icon(building, regular, after);
+    align-items: center;
+    border: $border-width solid;
+    color: $brand-secondary;
+    border-bottom-right-radius: rem-calc(12);
+    border-top-right-radius: rem-calc(12);
+    display: flex;
+    margin-bottom: $line-height * 2;
+    margin-top: $line-height * 2;
+
+    @include breakpoint(large) {
+      padding-right: $line-height;
+    }
+
+    &::after {
+      display: none;
+
+      @include breakpoint(large) {
+        display: block;
+        font-size: rem-calc(100);
+        margin-left: $line-height;
+      }
+    }
+
+    h1 {
+      @include brand-background($brand-secondary);
+      @include background-till-left-of-screen;
+      @include has-fa-icon(chart-pie, solid, after);
+      align-items: center;
+      display: flex;
+      flex: 1;
+      font-size: rem-calc(36);
+      margin-bottom: 0;
+      padding: $line-height * 2 0;
+      position: relative;
+
+      @include breakpoint(large) {
+        clip-path: polygon(
+          -100vw -#{$border-width},
+          100% -#{$border-width},
+          calc(100% - #{rem-calc(20)}) 50%,
+          100% calc(100% + #{$border-width}),
+          -100vw calc(100% + #{$border-width})
+        );
+        font-size: rem-calc(44);
+      }
+
+      &::before {
+        top: -$border-width;
+        height: calc(100% + 2 * #{$border-width});
+      }
+
+      &::after {
+        display: none;
+
+        @include breakpoint(medium) {
+          display: block;
+          font-size: 2em;
+          margin-left: auto;
+          margin-right: rem-calc(60);
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/budgets/investments/new.scss
+++ b/app/assets/stylesheets/budgets/investments/new.scss
@@ -41,7 +41,6 @@
       font-size: rem-calc(36);
       margin-bottom: 0;
       padding: $line-height * 2 0;
-      position: relative;
 
       @include breakpoint(large) {
         clip-path: polygon(
@@ -68,6 +67,12 @@
           margin-left: auto;
           margin-right: rem-calc(60);
         }
+      }
+
+      span span {
+        display: block;
+        font-size: 0.75em;
+        margin-top: $line-height / 2;
       }
     }
   }

--- a/app/assets/stylesheets/mixins/colors.scss
+++ b/app/assets/stylesheets/mixins/colors.scss
@@ -1,5 +1,5 @@
-@mixin brand-background($invert-selection: true) {
-  background-color: $brand;
+@mixin brand-background($color: $brand, $invert-selection: true) {
+  background-color: $color;
   color: $white;
 
   @if $invert-selection {

--- a/app/assets/stylesheets/mixins/layouts.scss
+++ b/app/assets/stylesheets/mixins/layouts.scss
@@ -27,3 +27,15 @@
     max-width: none;
   }
 }
+
+@mixin background-till-left-of-screen {
+  &::before {
+    background: inherit;
+    content: "";
+    height: 100%;
+    position: absolute;
+    top: 0;
+    right: 100%;
+    width: 100vw;
+  }
+}

--- a/app/assets/stylesheets/mixins/layouts.scss
+++ b/app/assets/stylesheets/mixins/layouts.scss
@@ -29,6 +29,8 @@
 }
 
 @mixin background-till-left-of-screen {
+  position: relative;
+
   &::before {
     background: inherit;
     content: "";

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -67,6 +67,7 @@ module Budgets
 
     def create
       @investment.author = current_user
+      @investment.heading = @budget.headings.first if @budget.single_heading?
 
       if @investment.save
         Mailer.budget_investment_created(@investment).deliver_later

--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -25,6 +25,7 @@ class Management::Budgets::InvestmentsController < Management::BaseController
   def create
     @investment.terms_of_service = "1"
     @investment.author = managed_user
+    @investment.heading = @budget.headings.first if @budget.single_heading?
 
     if @investment.save
       notice = t("flash.actions.create.notice", resource_name: Budget::Investment.model_name.human, count: 1)

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -162,8 +162,12 @@ class Budget < ApplicationRecord
     current_phase&.balloting_or_later?
   end
 
+  def single_group?
+    groups.one?
+  end
+
   def single_heading?
-    groups.one? && headings.one?
+    single_group? && headings.one?
   end
 
   def heading_price(heading)

--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -30,10 +30,6 @@ class Budget
       all.sort_by(&:name)
     end
 
-    def single_heading_group?
-      headings.count == 1
-    end
-
     private
 
       def generate_slug?

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -48,7 +48,7 @@ class Budget
     end
 
     def name_scoped_by_group
-      group.single_heading_group? ? name : "#{group.name}: #{name}"
+      budget.single_group? ? name : "#{group.name}: #{name}"
     end
 
     def can_be_deleted?

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -3,9 +3,12 @@
   <%= render "shared/errors", resource: @investment %>
 
   <div class="row column">
-    <div class="small-12 medium-8 column">
-      <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true } %>
-    </div>
+    <% unless @budget.single_heading? %>
+      <div class="small-12 medium-8 column">
+        <%= f.select :heading_id, budget_heading_select_options(@budget), { include_blank: true } %>
+      </div>
+    <% end %>
+
     <div class="row">
       <div class="small-12 column">
         <%= render "shared/globalize_locales", resource: @investment %>

--- a/app/views/budgets/investments/new.html.erb
+++ b/app/views/budgets/investments/new.html.erb
@@ -1,7 +1,11 @@
-<div class="budget-investment-new row">
-  <div class="small-12 medium-9 column">
-    <h1><%= t("management.budget_investments.create") %></h1>
+<main class="budget-investment-new">
+  <div>
+    <%= back_link_to budgets_path %>
 
-    <%= render "/budgets/investments/form", form_url: budget_investments_path(@budget) %>
+    <header>
+      <h1><%= t("budgets.investments.form.title") %></h1>
+    </header>
   </div>
-</div>
+
+  <%= render "/budgets/investments/form", form_url: budget_investments_path(@budget) %>
+</main>

--- a/app/views/budgets/investments/new.html.erb
+++ b/app/views/budgets/investments/new.html.erb
@@ -3,7 +3,19 @@
     <%= back_link_to budgets_path %>
 
     <header>
-      <h1><%= t("budgets.investments.form.title") %></h1>
+      <h1>
+        <span>
+          <%= t("budgets.investments.form.title") %>
+
+          <% if @budget.single_heading? %>
+            <span>
+              <%= t("budgets.investments.form.subtitle",
+                    heading: @budget.headings.first.name,
+                    price: @budget.formatted_heading_price(@budget.headings.first)) %>
+            </span>
+          <% end %>
+        </span>
+      </h1>
     </header>
   </div>
 

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -42,7 +42,7 @@ en:
         casted_offline: You have already participated offline
     groups:
       show:
-        title: Select an option
+        title: Select a heading
         unfeasible_title: Unfeasible investments
         unfeasible: See unfeasible investments
         unselected_title: Investments not selected for balloting phase

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -78,6 +78,7 @@ en:
       milestones: Milestones
     investments:
       form:
+        title: "Create a budget investment"
         tag_category_label: "Categories"
         tags_instructions: "Tag this proposal. You can choose from proposed categories or add your own"
         tags_label: Tags

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -79,6 +79,7 @@ en:
     investments:
       form:
         title: "Create a budget investment"
+        subtitle: "%{heading} (%{price})"
         tag_category_label: "Categories"
         tags_instructions: "Tag this proposal. You can choose from proposed categories or add your own"
         tags_label: Tags

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -42,7 +42,7 @@ es:
         casted_offline: Ya has participado presencialmente
     groups:
       show:
-        title: Selecciona una opción
+        title: Selecciona una partida
         unfeasible_title: Proyectos de gasto inviables
         unfeasible: Ver proyectos inviables
         unselected_title: Proyectos no seleccionados para la votación final

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -79,6 +79,7 @@ es:
     investments:
       form:
         title: "Crear nuevo proyecto"
+        subtitle: "%{heading} (%{price})"
         tag_category_label: "Categorías"
         tags_instructions: "Etiqueta este proyecto. Puedes elegir entre las categorías propuestas o introducir las que desees"
         tags_label: Etiquetas

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -78,6 +78,7 @@ es:
       milestones: Seguimiento de proyectos
     investments:
       form:
+        title: "Crear nuevo proyecto"
         tag_category_label: "Categorías"
         tags_instructions: "Etiqueta este proyecto. Puedes elegir entre las categorías propuestas o introducir las que desees"
         tags_label: Etiquetas

--- a/spec/models/budget/heading_spec.rb
+++ b/spec/models/budget/heading_spec.rb
@@ -332,4 +332,33 @@ describe Budget::Heading do
       expect(build(:budget_heading, max_ballot_lines: 0)).not_to be_valid
     end
   end
+
+  describe "#name_scoped_by_group" do
+    it "returns heading name in budgets with a single heading" do
+      heading = create(:budget_heading, group: group, name: "One and only")
+
+      expect(heading.name_scoped_by_group).to eq "One and only"
+    end
+
+    it "returns heading name in budgets with one group and many headings" do
+      schools = create(:budget_heading, group: group, name: "Schools")
+      universities = create(:budget_heading, group: group, name: "Universities")
+
+      expect(schools.name_scoped_by_group).to eq "Schools"
+      expect(universities.name_scoped_by_group).to eq "Universities"
+    end
+
+    it "returns heading name in groups with many headings in budgets with many groups" do
+      education = create(:budget_group, budget: budget, name: "Education")
+      health = create(:budget_group, budget: budget, name: "Health")
+
+      schools = create(:budget_heading, group: education, name: "Schools")
+      universities = create(:budget_heading, group: education, name: "Universities")
+      supplies = create(:budget_heading, group: health, name: "Medical supplies")
+
+      expect(schools.name_scoped_by_group).to eq "Education: Schools"
+      expect(universities.name_scoped_by_group).to eq "Education: Universities"
+      expect(supplies.name_scoped_by_group).to eq "Health: Medical supplies"
+    end
+  end
 end

--- a/spec/shared/system/mappable.rb
+++ b/spec/shared/system/mappable.rb
@@ -319,7 +319,6 @@ def validate_latitude_longitude(mappable_factory_name)
 end
 
 def fill_in_budget_investment_form
-  page.select mappable.heading.name_scoped_by_group, from: :budget_investment_heading_id
   fill_in "Title", with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
   check :budget_investment_terms_of_service

--- a/spec/shared/system/nested_documentable.rb
+++ b/spec/shared/system/nested_documentable.rb
@@ -361,7 +361,6 @@ def documentable_fill_new_valid_dashboard_action
 end
 
 def documentable_fill_new_valid_budget_investment
-  page.select documentable.heading.name_scoped_by_group, from: :budget_investment_heading_id
   fill_in "Title", with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
   check :budget_investment_terms_of_service

--- a/spec/shared/system/nested_imageable.rb
+++ b/spec/shared/system/nested_imageable.rb
@@ -294,7 +294,6 @@ def imageable_fill_new_valid_budget
 end
 
 def imageable_fill_new_valid_budget_investment
-  page.select imageable.heading.name_scoped_by_group, from: :budget_investment_heading_id
   fill_in "Title", with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
   check :budget_investment_terms_of_service

--- a/spec/system/admin/budget_groups_spec.rb
+++ b/spec/system/admin/budget_groups_spec.rb
@@ -161,7 +161,7 @@ describe "Admin budget groups", :admin do
 
       visit budget_group_path(budget, id: "old-english-name")
 
-      expect(page).to have_content "Select an option"
+      expect(page).to have_content "Select a heading"
 
       visit edit_admin_budget_group_path(budget, group)
 
@@ -173,7 +173,7 @@ describe "Admin budget groups", :admin do
 
       visit budget_group_path(budget, id: "new-english-name")
 
-      expect(page).to have_content "Select an option"
+      expect(page).to have_content "Select a heading"
     end
   end
 

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -101,7 +101,7 @@ describe "Admin budget investments", :admin do
       expect(page).to have_link("Change name")
       expect(page).to have_link("Plant trees")
 
-      select "Central Park", from: "heading_id"
+      select "Parks: Central Park", from: "heading_id"
       click_button "Filter"
 
       expect(page).not_to have_link("Realocate visitors")
@@ -1040,7 +1040,7 @@ describe "Admin budget investments", :admin do
 
       fill_in "Title", with: "Potatoes"
       fill_in_ckeditor "Description", with: "Carrots"
-      select "#{budget_investment.group.name}: Barbate", from: "budget_investment[heading_id]"
+      select "Barbate", from: "budget_investment[heading_id]"
       uncheck "budget_investment_incompatible"
       check "budget_investment_selected"
 

--- a/spec/system/budgets/groups_spec.rb
+++ b/spec/system/budgets/groups_spec.rb
@@ -7,12 +7,12 @@ describe "Budget Groups" do
   context "Load" do
     scenario "finds group using budget slug and group slug" do
       visit budget_group_path("budget_slug", "group_slug")
-      expect(page).to have_content "Select an option"
+      expect(page).to have_content "Select a heading"
     end
 
     scenario "finds group using budget id and group id" do
       visit budget_group_path(budget, group)
-      expect(page).to have_content "Select an option"
+      expect(page).to have_content "Select a heading"
     end
   end
 

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -545,6 +545,7 @@ describe "Budget Investments" do
       visit new_budget_investment_path(budget)
 
       expect(page).not_to have_field "budget_investment_heading_id"
+      expect(page).to have_content("#{heading.name} (#{budget.formatted_heading_price(heading)})")
 
       fill_in "Title", with: "Build a skyscraper"
       fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
@@ -576,6 +577,7 @@ describe "Budget Investments" do
 
       visit new_budget_investment_path(budget)
 
+      expect(page).not_to have_content("#{heading.name} (#{budget.formatted_heading_price(heading)})")
       expect(page).to have_select "Heading",
         options: ["", "More hospitals", "Medical supplies", "Even more hospitals"]
 

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -570,18 +570,35 @@ describe "Budget Investments" do
       expect(page).to have_content "Build a skyscraper"
     end
 
-    scenario "Create with multiple headings" do
-      create(:budget_heading, budget: budget, name: "Medical supplies")
-      create(:budget_heading, budget: budget, name: "Even more hospitals")
+    scenario "Create with single group and multiple headings" do
+      create(:budget_heading, group: group, name: "Medical supplies")
+      create(:budget_heading, group: group, name: "Even more hospitals")
+
+      login_as(author)
+
+      visit new_budget_investment_path(budget)
+
+      expect(page).to have_select "Heading",
+        options: ["", "More hospitals", "Medical supplies", "Even more hospitals"]
+      expect(page).not_to have_content "Health"
+    end
+
+    scenario "Create with multiple groups" do
+      education = create(:budget_group, budget: budget, name: "Education")
+
+      create(:budget_heading, group: group, name: "Medical supplies")
+      create(:budget_heading, group: education, name: "Schools")
+
       login_as(author)
 
       visit new_budget_investment_path(budget)
 
       expect(page).not_to have_content("#{heading.name} (#{budget.formatted_heading_price(heading)})")
       expect(page).to have_select "Heading",
-        options: ["", "More hospitals", "Medical supplies", "Even more hospitals"]
+        options: ["", "Health: More hospitals", "Health: Medical supplies", "Education: Schools"]
 
-      select "Medical supplies", from: "Heading"
+      select "Health: Medical supplies", from: "Heading"
+
       fill_in "Title", with: "Build a skyscraper"
       fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
       fill_in "Location additional info", with: "City center"
@@ -755,7 +772,7 @@ describe "Budget Investments" do
 
       select_options = find("#budget_investment_heading_id").all("option").map(&:text)
       expect(select_options).to eq ["",
-                                    "Toda la ciudad",
+                                    "Toda la ciudad: Toda la ciudad",
                                     "Health: More health professionals",
                                     "Health: More hospitals"]
     end

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -511,7 +511,6 @@ describe "Budget Investments" do
       login_as(author)
       visit new_budget_investment_path(budget)
 
-      select  heading.name, from: "budget_investment_heading_id"
       fill_in "Title", with: "I am a bot"
       fill_in "budget_investment_subtitle", with: "This is the honeypot"
       fill_in "Description", with: "This is the description"
@@ -530,7 +529,6 @@ describe "Budget Investments" do
       login_as(author)
       visit new_budget_investment_path(budget)
 
-      select  heading.name, from: "budget_investment_heading_id"
       fill_in "Title", with: "I am a bot"
       fill_in_ckeditor "Description", with: "This is the description"
       check   "budget_investment_terms_of_service"
@@ -541,18 +539,20 @@ describe "Budget Investments" do
       expect(page).to have_current_path(new_budget_investment_path(budget))
     end
 
-    scenario "Create" do
+    scenario "Create with single heading" do
       login_as(author)
 
       visit new_budget_investment_path(budget)
 
-      select  heading.name, from: "budget_investment_heading_id"
+      expect(page).not_to have_field "budget_investment_heading_id"
+
       fill_in "Title", with: "Build a skyscraper"
       fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
-      fill_in "budget_investment_location", with: "City center"
-      fill_in "budget_investment_organization_name", with: "T.I.A."
-      fill_in "budget_investment_tag_list", with: "Towers"
-      check   "budget_investment_terms_of_service"
+      fill_in "Location additional info", with: "City center"
+      fill_in "If you are proposing in the name of a collective/organization, "\
+        "or on behalf of more people, write its name", with: "T.I.A."
+      fill_in "Tags", with: "Towers"
+      check "I agree to the Privacy Policy and the Terms and conditions of use"
 
       click_button "Create Investment"
 
@@ -563,7 +563,42 @@ describe "Budget Investments" do
       expect(page).to have_content "T.I.A."
       expect(page).to have_content "Towers"
 
-      visit user_url(author, filter: :budget_investments)
+      visit user_path(author, filter: :budget_investments)
+
+      expect(page).to have_content "1 Investment"
+      expect(page).to have_content "Build a skyscraper"
+    end
+
+    scenario "Create with multiple headings" do
+      create(:budget_heading, budget: budget, name: "Medical supplies")
+      create(:budget_heading, budget: budget, name: "Even more hospitals")
+      login_as(author)
+
+      visit new_budget_investment_path(budget)
+
+      expect(page).to have_select "Heading",
+        options: ["", "More hospitals", "Medical supplies", "Even more hospitals"]
+
+      select "Medical supplies", from: "Heading"
+      fill_in "Title", with: "Build a skyscraper"
+      fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
+      fill_in "Location additional info", with: "City center"
+      fill_in "If you are proposing in the name of a collective/organization, "\
+        "or on behalf of more people, write its name", with: "T.I.A."
+      fill_in "Tags", with: "Towers"
+      check "I agree to the Privacy Policy and the Terms and conditions of use"
+
+      click_button "Create Investment"
+
+      expect(page).to have_content "Investment created successfully"
+      expect(page).to have_content "Build a skyscraper"
+      expect(page).to have_content "I want to live in a high tower over the clouds"
+      expect(page).to have_content "City center"
+      expect(page).to have_content "T.I.A."
+      expect(page).to have_content "Towers"
+
+      visit user_path(author, filter: :budget_investments)
+
       expect(page).to have_content "1 Investment"
       expect(page).to have_content "Build a skyscraper"
     end
@@ -1561,7 +1596,6 @@ describe "Budget Investments" do
     scenario "create budget investment with sdg related list" do
       login_as(author)
       visit new_budget_investment_path(budget)
-      select heading.name, from: "Heading"
       fill_in "Title", with: "A title for a budget investment related with SDG related content"
       fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
       click_sdg_goal(1)

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -350,7 +350,6 @@ describe "Emails" do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
-      select  heading.name, from: "budget_investment_heading_id"
       fill_in "Title", with: "Build a hospital"
       fill_in_ckeditor "Description", with: "We have lots of people that require medical attention"
       check   "budget_investment_terms_of_service"

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -396,7 +396,7 @@ describe "Budget Investments" do
         expect(page).to have_content(low_investment.title)
       end
 
-      select "Whole city: District Nine", from: "heading_id"
+      select "District Nine", from: "heading_id"
       click_button("Search")
 
       within "#budget-investments" do

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -65,7 +65,6 @@ describe "Budget Investments" do
         expect(page).to have_content user.document_number
       end
 
-      select "Health", from: "budget_investment_heading_id"
       fill_in "Title", with: "Build a park in my neighborhood"
       fill_in_ckeditor "Description", with: "There is no parks here..."
       fill_in "budget_investment_location", with: "City center"

--- a/spec/system/tags/budget_investments_spec.rb
+++ b/spec/system/tags/budget_investments_spec.rb
@@ -66,7 +66,6 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  heading.name, from: "budget_investment_heading_id"
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
@@ -85,7 +84,6 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  heading.name, from: "budget_investment_heading_id"
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
     check "budget_investment_terms_of_service"
@@ -110,7 +108,6 @@ describe "Tags" do
     visit budget_path(budget)
     click_link "Create a budget investment"
 
-    select  heading.name, from: "budget_investment_heading_id"
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
     check "budget_investment_terms_of_service"
@@ -135,7 +132,6 @@ describe "Tags" do
     visit budget_investments_path(budget, heading_id: heading.id)
     click_link "Create a budget investment"
 
-    select  heading.name, from: "budget_investment_heading_id"
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
     check "budget_investment_terms_of_service"
@@ -157,7 +153,6 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  heading.name, from: "budget_investment_heading_id"
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
@@ -175,7 +170,6 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  heading.name, from: "budget_investment_heading_id"
     fill_in "Title", with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"

--- a/spec/system/translatable_spec.rb
+++ b/spec/system/translatable_spec.rb
@@ -47,7 +47,6 @@ describe "Public area translatable records" do
       fill_in "Title", with: "Titre en Français"
       fill_in_ckeditor "Description", with: "Contenu en Français"
 
-      select "Everywhere", from: "budget_investment_heading_id"
       check "budget_investment_terms_of_service"
       click_button "Create Investment"
 
@@ -76,7 +75,6 @@ describe "Public area translatable records" do
       fill_in "Title", with: "Titre en Français"
       fill_in_ckeditor "Description", with: "Contenu en Français"
 
-      select "Everywhere", from: "budget_investment_heading_id"
       check "budget_investment_terms_of_service"
       click_button "Create Investment"
 
@@ -99,7 +97,6 @@ describe "Public area translatable records" do
       visit new_budget_investment_path(budget)
       click_link "Remove language"
 
-      select "Everywhere", from: "budget_investment_heading_id"
       check "budget_investment_terms_of_service"
       click_button "Create Investment"
 


### PR DESCRIPTION
## References

* This is part of pull request #4198

## Objectives

* Simplify the form to create a new investment in single heading budgets
* Add a new header to the form to create a new investment

## Visual changes

TODO.