### PR TITLE
Add missing attribute to budget strong params

### DIFF
--- a/app/controllers/admin/budgets_wizard/budgets_controller.rb
+++ b/app/controllers/admin/budgets_wizard/budgets_controller.rb
@@ -37,8 +37,8 @@ class Admin::BudgetsWizard::BudgetsController < Admin::BudgetsWizard::BaseContro
     end
 
     def allowed_params
-      valid_attributes = [:currency_symbol, :voting_style, administrator_ids: [], valuator_ids: [],
-                          image_attributes: image_attributes]
+      valid_attributes = [:currency_symbol, :voting_style, :main_link_url, administrator_ids: [],
+                          valuator_ids: [], image_attributes: image_attributes]
 
       valid_attributes + [translation_params(Budget)]
     end

--- a/spec/system/admin/budgets_wizard/budgets_spec.rb
+++ b/spec/system/admin/budgets_wizard/budgets_spec.rb
@@ -8,6 +8,9 @@ describe "Budgets wizard, first step", :admin do
       click_link "Create multiple headings budget"
 
       fill_in "Name", with: "M30 - Summer campaign"
+      fill_in "Text on the link", with: "Participate now!"
+      fill_in "The link takes you to (add a link)", with: "https://consulproject.org"
+      fill_in "Name", with: "M30 - Summer campaign"
       click_button "Continue to groups"
 
       expect(page).to have_content "New participatory budget created successfully!"


### PR DESCRIPTION
## References
We forgot to add it at #4501.


## Objectives

The budget `main_link_url` input content was filtered out by strong params. Add the missing attribute to budget strong params so the input value reaches its destination.
