### PR TITLE
Fix accessibility issues in budgets index

### DIFF
--- a/app/assets/stylesheets/budgets/investments-list.scss
+++ b/app/assets/stylesheets/budgets/investments-list.scss
@@ -62,7 +62,7 @@
 
     .price-title,
     .supports-title {
-      color: #7b7b7b;
+      color: #696969;
       font-size: $small-font-size;
       text-transform: uppercase;
       width: 100%;

--- a/app/components/budgets/phases_component.html.erb
+++ b/app/components/budgets/phases_component.html.erb
@@ -55,7 +55,7 @@
 
           <% if phase.image.present? %>
             <div class="budget-phase-image">
-              <%= image_tag phase.image.attachment.url(:large) %>
+              <%= image_tag phase.image.attachment.url(:large), alt: "" %>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
## References

* These issues were introduced in pull requests #4507 and #4510

## Objectives

* Increase contrast in "Price" and "Supports" text in investments list
* Reduce issues for screen reader users accessing phases images
* Fix invalid HTML

## Notes

The "alt" text is just a quick patch which partially solves the accessibility problem. The image doesn't necessarily need to be a decorative one, so administrators should have the option to provide an alternative text for the images.