### PR TITLE
Fix duplicate support_title I18n key

### DIFF
--- a/app/components/budgets/investment_component.html.erb
+++ b/app/components/budgets/investment_component.html.erb
@@ -8,12 +8,12 @@
   <% if investment.should_show_vote_count? || investment.should_show_price? %>
     <div class="supports-and-price">
       <% if investment.should_show_vote_count? %>
-        <span class="supports-title"><%= t("budgets.investments.investment.support_title") %></span>
+        <span class="supports-title"><%= t("budgets.investments_list.investment.supports") %></span>
         <strong><%= investment.total_votes %></strong>
       <% end %>
 
       <% if investment.should_show_price? %>
-        <span class="price-title"><%= t("budgets.investments.investment.price_title") %></span>
+        <span class="price-title"><%= t("budgets.investments_list.investment.price") %></span>
         <strong><%= investment.formatted_price %></strong>
       <% end %>
     </div>
@@ -26,7 +26,7 @@
       <%= render Budgets::Investments::InfoComponent.new(investment) %>
 
       <%= link_to namespaced_budget_investment_path(investment), class: "read-more" do %>
-        <small><%= t("budgets.investments.index.read_more") %></small>
+        <small><%= t("budgets.investments_list.investment.read_more") %></small>
       <% end %>
     <% end %>
   </div>

--- a/app/components/budgets/investments_list_component.html.erb
+++ b/app/components/budgets/investments_list_component.html.erb
@@ -1,7 +1,7 @@
 <% if investments.any? %>
   <section class="investments-list">
     <header>
-      <h2><%= t("budgets.show.investments_list") %></h2>
+      <h2><%= t("budgets.investments_list.title") %></h2>
     </header>
 
     <% investments.each do |investment| %>
@@ -13,7 +13,7 @@
 <% unless budget.informing? %>
   <div class="row margin-top">
     <div class="small-12 medium-6 large-4 small-centered column margin-top">
-      <%= link_to t("budgets.show.see_all_investments"),
+      <%= link_to t("budgets.investments_list.see_all"),
                   budget_investments_path(budget),
                   class: "button expanded" %>
     </div>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -130,7 +130,6 @@ en:
           random: random
           confidence_score: highest rated
           price: by price
-        read_more: "Read more"
       share:
         message: "I created the investment project %{title} in %{handle}. Create an investment project too!"
       show:
@@ -162,8 +161,6 @@ en:
         confirm_group:
           one: "You can only support investments in %{count} district. If you continue you cannot change the election of your district. Are you sure?"
           other: "You can only support investments in %{count} districts. If you continue you cannot change the election of your district. Are you sure?"
-        price_title: "Price"
-        support_title: "Supports"
         supports:
           one: 1 support
           other: "%{count} supports"
@@ -175,10 +172,15 @@ en:
         change_ballot: "If you change your mind you can remove your votes in %{check_ballot} and start again."
         check_ballot_link: "submit my ballot"
         price: "Total budget"
+    investments_list:
+      investment:
+        price: "Price"
+        read_more: "Read more"
+        supports: "Supports"
+      see_all: "See all investments"
+      title: "List of investments"
     show:
       see_results: See results
-      see_all_investments: "See all investments"
-      investments_list: "List of investments"
     results:
       link: Results
       page_title: "%{budget} - Results"

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -130,7 +130,6 @@ es:
           random: Aleatorios
           confidence_score: Mejor valorados
           price: Por coste
-        read_more: "Leer más"
       share:
         message: "He presentado el proyecto %{title} en %{handle}. ¡Presenta un proyecto tú también!"
       show:
@@ -162,8 +161,6 @@ es:
         confirm_group:
           one: "Sólo puedes apoyar proyectos en %{count} distrito. Si sigues adelante no podrás cambiar la elección de este distrito. ¿Estás seguro/a?"
           other: "Sólo puedes apoyar proyectos en %{count} distritos. Si sigues adelante no podrás cambiar la elección de este distrito. ¿Estás seguro/a?"
-        price_title: "Coste"
-        support_title: "Apoyos"
         supports:
           zero: Sin apoyos
           one: 1 apoyo
@@ -175,10 +172,15 @@ es:
         change_ballot: "Si cambias de opinión puedes borrar tus votos en %{check_ballot} y volver a empezar."
         check_ballot_link: "revisar y confirmar mis votos"
         price: "Presupuesto total"
+    investments_list:
+      investment:
+        price: "Coste"
+        read_more: "Leer más"
+        supports: "Apoyos"
+      see_all: "Ver todos los proyectos"
+      title: "Lista de proyectos"
     show:
       see_results: Ver resultados
-      see_all_investments: "Ver todos los proyectos"
-      investments_list: "Lista de proyectos"
     results:
       link: Resultados
       page_title: "%{budget} - Resultados"

--- a/spec/system/budgets/votes_spec.rb
+++ b/spec/system/budgets/votes_spec.rb
@@ -42,7 +42,7 @@ describe "Votes" do
         visit budget_investments_path(budget, heading_id: heading.id)
 
         within(".supports") do
-          find(".in-favor a").click
+          click_link "Support this project"
 
           expect(page).to have_content "1 support"
           expect(page).to have_content "You have already supported this investment project. "\


### PR DESCRIPTION
## References

* This bug was introduced in pull request #4507

## Background

The key was declared twice and so the first one ("Support this project") was overwritten.

## Objectives

* Make sure the `support_title` key, used as a link title, works properly

## Notes

We're grouping all keys related to the investment list together in order to reduce the chances of this issue happening again (or, at least, in this part of the code).