### PR TITLE
Fix investment support in management section

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -35,7 +35,7 @@
                 <%= render "/budgets/investments/votes",
                   investment: investment,
                   investment_votes: investment_votes,
-                  vote_url: vote_budget_investment_path(investment.budget, investment, value: "yes") %>
+                  vote_url: namespaced_budget_investment_vote_path(investment, value: "yes") %>
               </div>
             </div>
           <% elsif investment.should_show_vote_count? %>

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -284,9 +284,9 @@ describe "Budget Investments" do
       end
     end
 
-    # This test passes ok locally but fails on the last two lines in Travis
-    xscenario "Supporting budget investments on behalf of someone in show view" do
+    scenario "Supporting budget investments on behalf of someone in show view" do
       budget_investment = create(:budget_investment, budget: budget)
+      manager.user.update!(level_two_verified_at: Time.current)
 
       login_managed_user(user)
       login_as_manager(manager)
@@ -300,9 +300,36 @@ describe "Budget Investments" do
         click_link budget_investment.title
       end
 
+      expect(page).to have_css "h1", exact_text: budget_investment.title
+
       find(".js-in-favor a").click
+
       expect(page).to have_content "1 support"
-      expect(page).to have_content "You have already supported this. Share it!"
+      expect(page).to have_content "You have already supported this investment project. Share it!"
+
+      refresh
+
+      expect(page).to have_content "1 support"
+      expect(page).to have_content "You have already supported this investment project. Share it!"
+    end
+
+    scenario "Support investments on behalf of someone else when there are more headings" do
+      create(:budget_investment, heading: heading, title: "Default heading investment")
+      create(:budget_investment, heading: create(:budget_heading, group: group))
+
+      login_managed_user(user)
+      login_as_manager(manager)
+
+      visit management_budget_investments_path(budget)
+      click_link "Default heading investment"
+
+      expect(page).to have_css "h1", exact_text: "Default heading investment"
+
+      accept_confirm { find(".js-in-favor a").click }
+
+      expect(page).to have_content "1 support"
+      expect(page).to have_content "You have already supported this investment project. Share it!"
+      expect(page).to have_content "CONSUL\nMANAGEMENT"
     end
 
     scenario "Should not allow unverified users to vote proposals" do


### PR DESCRIPTION
## Background

When supporting an investment in the management section through the investment view, we were accessing an action in the public investments controller. This meant the manager was the one supporting the investment (as they'd be the `current_user` in this controller) and not the managed user.

In the case of groups with many headings, voting the first time requires a confirmation and then a regular (non-AJAX) request takes place. In this case, users were redirected to the public area instead of remaining in the management area.

## Objectives

* Make sure the right user supports the investment in the management section