### PR TITLE
Increase font size on extra large screens

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -33,6 +33,10 @@
   @include normal-selection;
 }
 
+html {
+  font-size: calc(0.25em + Max(0.75em, 0.75vw));
+}
+
 html,
 body {
   height: 100%;


### PR DESCRIPTION
## References

* Depends on pull request #4526

## Objectives

* Make the site easier to read for users with extra large screens
* Reduce the amount of blank space at the sides of the content on extra large screens

## Visual Changes

### Before these changes

![At a resolution of 1920x1080, in a browser with a prefered font size of 16px, the content takes 60% of the screen and the font size stays at 16px](https://user-images.githubusercontent.com/35156/121821396-e4c2d080-cc98-11eb-8a08-7aee295b6ccf.png)

### After these changes

![At a resolution of 1920x1080, in a browser with a prefered font size of 16px, the content takes 70% of the screen and the font size increases to 18.4px](https://user-images.githubusercontent.com/35156/121821473-92ce7a80-cc99-11eb-8332-788c0fc49f0a.png)

## Notes

Check the commit message for alternative ways to accomplish similar results and the reasons we chose this one.