### PR TITLE
Use icons with text in admin table actions

### DIFF
--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -74,6 +74,7 @@ $outline-focus:     3px solid #ffbf47 !default;
 
 $input-height:      $line-height * 2 !default;
 
+$font-icon-margin: rem-calc(4) !default;
 $icon-width: $line-height * 2 !default;
 
 $off-screen-left: -1000rem !default;

--- a/app/assets/stylesheets/admin/budgets/drafting.scss
+++ b/app/assets/stylesheets/admin/budgets/drafting.scss
@@ -23,6 +23,10 @@
   .preview-link {
     @include has-fa-icon(eye, regular);
     @include hollow-button;
+
+    &::before {
+      margin-right: $font-icon-margin;
+    }
   }
 
   .publish-link {

--- a/app/assets/stylesheets/admin/budgets/help.scss
+++ b/app/assets/stylesheets/admin/budgets/help.scss
@@ -36,7 +36,6 @@
   &::after {
     bottom: $padding / 2;
     color: $white;
-    margin-right: 0;
     position: absolute;
     right: calc(#{$padding} + #{$quote-padding});
   }

--- a/app/assets/stylesheets/admin/table_actions.scss
+++ b/app/assets/stylesheets/admin/table_actions.scss
@@ -6,33 +6,23 @@
   }
 
   a {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    font-size: 0.9em;
+    line-height: $global-lineheight;
+    margin-right: 1em;
     position: relative;
-
-    > :first-child {
-      @include bottom-tooltip;
-      left: $off-screen-left;
-      opacity: 0;
-      transform: translateX(-50%);
-      transition: opacity 0.3s, left 0s 0.3s;
-    }
+    text-align: center;
 
     &:hover,
     &:focus {
       color: $link-hover;
-
-      > :first-child {
-        left: 50%;
-        opacity: 1;
-        transition: opacity 0.4s 0.2s;
-      }
-    }
-
-    &:not(:focus) > :first-child:hover {
-      left: $off-screen-left;
     }
 
     &::before {
-      font-size: rem-calc(18);
+      font-size: 1.6em;
+      margin-right: 0 !important;
     }
   }
 
@@ -42,7 +32,14 @@
 
   .destroy-link {
     @include has-fa-icon(trash-alt, regular);
-    color: $alert-color;
+  }
+
+  .destroy-link,
+  .destroy-role-link,
+  .destroy-officer-link,
+  .reject-link,
+  .confirm-hide-link {
+    color: darken($alert-color, 5%);
   }
 
   .show-link,
@@ -66,17 +63,23 @@
   .destroy-officer-link,
   .reject-link {
     @include has-fa-icon(user-times, solid);
-    color: $alert-color;
   }
 
   .restore-link {
     @include has-fa-icon(undo, solid);
-    color: $warning-color;
+  }
+
+  .restore-link,
+  .investments-link {
+    color: darken($warning-color, 20%);
+
+    &::before {
+      color: $warning-color;
+    }
   }
 
   .confirm-hide-link {
     @include has-fa-icon(flag, regular);
-    color: $alert-color;
   }
 
   .verify-link {
@@ -108,7 +111,6 @@
 
   .investments-link {
     @include has-fa-icon(coins, solid);
-    color: $warning-color;
   }
 
   .groups-link,

--- a/app/assets/stylesheets/admin/table_actions.scss
+++ b/app/assets/stylesheets/admin/table_actions.scss
@@ -22,7 +22,6 @@
 
     &::before {
       font-size: 1.6em;
-      margin-right: 0 !important;
     }
   }
 

--- a/app/assets/stylesheets/budgets/ballot/investment.scss
+++ b/app/assets/stylesheets/budgets/ballot/investment.scss
@@ -33,10 +33,6 @@
     position: absolute;
     right: $close-icon-margin;
     top: $close-icon-margin;
-
-    &::before {
-      margin-right: 0;
-    }
   }
 
   &:hover {

--- a/app/assets/stylesheets/budgets/investments-list.scss
+++ b/app/assets/stylesheets/budgets/investments-list.scss
@@ -71,7 +71,6 @@
     &::after {
       font-size: 2em;
       margin-left: auto;
-      margin-right: 0;
       transform: translateY(-25%);
     }
   }

--- a/app/assets/stylesheets/budgets/investments/ballot.scss
+++ b/app/assets/stylesheets/budgets/investments/ballot.scss
@@ -6,5 +6,9 @@
     color: $brand-secondary;
     font-weight: bold;
     margin-top: $line-height;
+
+    &::before {
+      margin-right: $font-icon-margin;
+    }
   }
 }

--- a/app/assets/stylesheets/budgets/phases.scss
+++ b/app/assets/stylesheets/budgets/phases.scss
@@ -204,7 +204,6 @@
       &::after {
         font-weight: bold;
         margin-left: 0.5em;
-        margin-right: 0;
       }
     }
   }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1470,6 +1470,7 @@ table {
 
   &::before {
     font-size: rem-calc(24);
+    margin-right: $font-icon-margin;
   }
 }
 
@@ -1863,6 +1864,7 @@ table {
 
     .show-children::before,
     .collapse-children::before {
+      margin-right: $font-icon-margin;
       transform: translateY(-1px);
     }
 
@@ -1891,6 +1893,7 @@ table {
     }
 
     &::before {
+      margin-right: $font-icon-margin;
       transform: translateY(-1px);
     }
   }
@@ -2455,6 +2458,10 @@ table {
     &.score-negative {
       @include has-fa-icon(times, solid);
       color: $color-alert;
+    }
+
+    &::before {
+      margin-right: $font-icon-margin;
     }
   }
 }

--- a/app/assets/stylesheets/mixins/icons.scss
+++ b/app/assets/stylesheets/mixins/icons.scss
@@ -1,7 +1,6 @@
 %font-icon {
   @extend %fa-icon;
   font-family: "Font Awesome 5 Free";
-  margin-right: rem-calc(4);
   vertical-align: middle;
 }
 

--- a/app/assets/stylesheets/notification_item.scss
+++ b/app/assets/stylesheets/notification_item.scss
@@ -7,8 +7,8 @@
     @include has-fa-icon(circle, solid, after);
 
     &::before {
-      @include breakpoint(medium) {
-        margin-right: 0;
+      @include breakpoint(small only) {
+        margin-right: $font-icon-margin;
       }
     }
 
@@ -18,7 +18,6 @@
 
       color: #ecf00b;
       font-size: $circle-icon-size;
-      margin-right: 0;
       position: absolute;
       left: $notification-icon-size - rem-calc(5);
       top: $menu-link-top-padding - $circle-icon-size / 2;

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1215,7 +1215,6 @@
 
       &::after {
         margin-left: $line-height / 4;
-        margin-right: 0;
       }
     }
   }

--- a/app/components/admin/budget_phases/phases_component.html.erb
+++ b/app/components/admin/budget_phases/phases_component.html.erb
@@ -31,8 +31,7 @@
         <td>
           <%= render Admin::TableActionsComponent.new(phase,
             actions: [:edit],
-            edit_path: edit_path(phase),
-            edit_text: t("admin.budgets.edit.edit_phase")
+            edit_path: edit_path(phase)
           ) %>
         </td>
       </tr>

--- a/app/components/admin/budgets/table_actions_component.html.erb
+++ b/app/components/admin/budgets/table_actions_component.html.erb
@@ -1,5 +1,4 @@
 <%= render Admin::TableActionsComponent.new(budget,
-  edit_text: t("admin.budgets.index.edit_budget"),
   destroy_confirmation: t("admin.actions.confirm_delete", resource_name: t("admin.budgets.shared.resource_name"),
                                                           name: budget.name)
   ) do %>

--- a/app/components/admin/budgets/table_actions_component.rb
+++ b/app/components/admin/budgets/table_actions_component.rb
@@ -1,5 +1,4 @@
 class Admin::Budgets::TableActionsComponent < ApplicationComponent
-  include TableActionLink
   attr_reader :budget
 
   def initialize(budget)

--- a/app/components/admin/hidden_table_actions_component.rb
+++ b/app/components/admin/hidden_table_actions_component.rb
@@ -1,5 +1,4 @@
 class Admin::HiddenTableActionsComponent < ApplicationComponent
-  include TableActionLink
   attr_reader :record
 
   def initialize(record)

--- a/app/components/admin/organizations/table_actions_component.rb
+++ b/app/components/admin/organizations/table_actions_component.rb
@@ -1,5 +1,4 @@
 class Admin::Organizations::TableActionsComponent < ApplicationComponent
-  include TableActionLink
   delegate :can?, to: :controller
   attr_reader :organization
 

--- a/app/components/admin/roles/table_actions_component.rb
+++ b/app/components/admin/roles/table_actions_component.rb
@@ -1,5 +1,4 @@
 class Admin::Roles::TableActionsComponent < ApplicationComponent
-  include TableActionLink
   attr_reader :record, :actions
 
   def initialize(record, actions: [:destroy])

--- a/app/components/admin/table_actions_component.rb
+++ b/app/components/admin/table_actions_component.rb
@@ -1,5 +1,4 @@
 class Admin::TableActionsComponent < ApplicationComponent
-  include TableActionLink
   include Admin::Namespace
   attr_reader :record, :options
 

--- a/app/components/concerns/table_action_link.rb
+++ b/app/components/concerns/table_action_link.rb
@@ -1,7 +1,0 @@
-module TableActionLink
-  extend ActiveSupport::Concern
-
-  def link_to(text, url, **options)
-    super(tag.span(text), url, options)
-  end
-end

--- a/app/views/admin/banners/index.html.erb
+++ b/app/views/admin/banners/index.html.erb
@@ -20,12 +20,7 @@
       <tr>
         <td><%= banner.post_started_at %></td>
         <td><%= banner.post_ended_at %></td>
-        <td>
-          <%= render Admin::TableActionsComponent.new(banner,
-            edit_text: t("admin.banners.index.edit"),
-            destroy_text: t("admin.banners.index.delete")
-          ) %>
-        </td>
+        <td><%= render Admin::TableActionsComponent.new(banner) %></td>
       </tr>
       <tr>
         <td colspan="3">

--- a/app/views/admin/milestones/_milestones.html.erb
+++ b/app/views/admin/milestones/_milestones.html.erb
@@ -53,11 +53,7 @@
               <% end %>
             <% end %>
           </td>
-          <td>
-            <%= render Admin::TableActionsComponent.new(milestone,
-              destroy_text: t("admin.milestones.index.delete")
-            ) %>
-          </td>
+          <td><%= render Admin::TableActionsComponent.new(milestone) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/officials/index.html.erb
+++ b/app/views/admin/officials/index.html.erb
@@ -28,8 +28,7 @@
           <td>
             <%= render Admin::TableActionsComponent.new(
               actions: [:edit],
-              edit_path: edit_admin_official_path(official),
-              edit_text: t("admin.officials.search.edit_official")
+              edit_path: edit_admin_official_path(official)
             ) %>
           </td>
         </tr>

--- a/app/views/admin/officials/search.html.erb
+++ b/app/views/admin/officials/search.html.erb
@@ -35,7 +35,7 @@
             <%= render Admin::TableActionsComponent.new(
               actions: [:edit],
               edit_path: edit_admin_official_path(user),
-              edit_text: user.official? ? t("admin.officials.search.edit_official") : t("admin.officials.search.make_official")
+              edit_text: (t("admin.officials.search.make_official") unless user.official?)
               ) %>
           </td>
         </tr>

--- a/app/views/admin/poll/booths/_booth.html.erb
+++ b/app/views/admin/poll/booths/_booth.html.erb
@@ -13,10 +13,7 @@
                             class: "shifts-link" %>
       <% end %>
     <% else %>
-      <%= render Admin::TableActionsComponent.new(booth,
-        actions: [:edit],
-        edit_text: t("admin.booths.booth.edit")
-      ) %>
+      <%= render Admin::TableActionsComponent.new(booth, actions: [:edit]) %>
     <% end %>
   </td>
 </tr>

--- a/app/views/admin/site_customization/content_blocks/index.html.erb
+++ b/app/views/admin/site_customization/content_blocks/index.html.erb
@@ -34,10 +34,7 @@
         <td><%= link_to "#{content_block.name} (#{content_block.locale})", edit_admin_site_customization_content_block_path(content_block) %></td>
         <td><%= raw content_block.body %></td>
         <td>
-          <%= render Admin::TableActionsComponent.new(content_block,
-            actions: [:destroy],
-            destroy_text: t("admin.site_customization.content_blocks.index.delete")
-          ) %>
+          <%= render Admin::TableActionsComponent.new(content_block, actions: [:destroy]) %>
         </td>
       </tr>
     <% end %>
@@ -48,7 +45,6 @@
         <td>
           <%= render Admin::TableActionsComponent.new(
             actions: [:destroy],
-            destroy_text: t("admin.site_customization.content_blocks.index.delete"),
             destroy_path: admin_site_customization_delete_heading_content_block_path(content_block)
           ) %>
         </td>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -30,7 +30,7 @@
         <% end %>
       </td>
       <td id="tag_<%= tag.id %>">
-        <%= render Admin::TableActionsComponent.new(tag, actions: [:destroy], destroy_text: t("admin.tags.destroy")) %>
+        <%= render Admin::TableActionsComponent.new(tag, actions: [:destroy]) %>
       </td>
     </tr>
   <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -67,7 +67,7 @@ en:
         no_activity: There are no moderators activity.
     budgets:
       actions:
-        preview: "Preview budget"
+        preview: "Preview"
       index:
         title: Participatory budgets
         new_link: Create new budget
@@ -76,7 +76,7 @@ en:
           all: All
           open: Open
           finished: Finished
-        budget_investments: Manage projects
+        budget_investments: Investment projects
         table_budget_type: "Type"
         table_completed: Completed
         table_draft: "Draft"
@@ -87,8 +87,8 @@ en:
         type_multiple: "Multiple headings"
         type_pending: "Pending: No headings yet"
         type_single: "Single heading"
-        edit_groups: Edit headings groups
-        admin_ballots: Admin ballots
+        edit_groups: Heading groups
+        admin_ballots: Ballots
         no_budgets: "There are no budgets."
       create:
         notice: New participatory budget created successfully!
@@ -152,7 +152,7 @@ en:
     budget_groups:
       name: "Name"
       headings_name: "Headings"
-      headings_manage: "Manage headings"
+      headings_manage: "Headings"
       no_groups: "There are no groups."
       amount:
         one: "There is 1 group"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -21,8 +21,6 @@ en:
       index:
         title: Banners
         create: Create banner
-        edit: Edit banner
-        delete: Delete banner
         filters:
           all: All
           with_active: Active
@@ -90,7 +88,6 @@ en:
         type_pending: "Pending: No headings yet"
         type_single: "Single heading"
         edit_groups: Edit headings groups
-        edit_budget: Edit budget
         admin_ballots: Admin ballots
         no_budgets: "There are no budgets."
       create:
@@ -109,7 +106,6 @@ en:
         duration: "Duration"
         enabled: Enabled
         actions: Actions
-        edit_phase: Edit phase
         enable_phase: "Enable %{phase} phase"
         active: Active
         blank_dates: Dates are blank
@@ -354,7 +350,6 @@ en:
         table_publication_date: "Publication date"
         table_status: Status
         table_actions: "Actions"
-        delete: "Delete milestone"
         no_milestones: "Don't have defined milestones"
         image: "Image"
         show_image: "Show image"
@@ -1207,7 +1202,6 @@ en:
         location: "Location"
       booth:
         shifts: "Manage shifts"
-        edit: "Edit booth"
     officials:
       edit:
         destroy: Remove "Official" status
@@ -1229,7 +1223,6 @@ en:
       level_4: Level 4
       level_5: Level 5
       search:
-        edit_official: Edit official
         make_official: Make official
         title: "Official positions: User search"
         no_results: Official positions not found.
@@ -1513,7 +1506,6 @@ en:
         title: "Sustainable Development Goals - Stats"
     tags:
       create: Create topic
-      destroy: Delete topic
       index:
         add_tag: Add a new proposal topic
         title: Proposal topics

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1593,7 +1593,7 @@ en:
           create: Create new page
           delete: Delete page
           title: Custom Pages
-          see_page: See page
+          see_page: View
         new:
           title: Create new custom page
           slug_help: "Text to identify this page on URL, for example <code>https://consulproject.org/page-slug</code>"
@@ -1603,7 +1603,7 @@ en:
           updated_at: Updated at
           title: Title
           slug: Slug
-          see_cards: See Cards
+          see_cards: Manage cards
         cards:
           cards_title: cards
           create_card: Create card

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -67,7 +67,7 @@ es:
         no_activity: No hay actividad de moderadores.
     budgets:
       actions:
-        preview: "Previsualizar presupuesto"
+        preview: "Previsualizar"
       index:
         title: Presupuestos participativos
         new_link: Crear nuevo presupuesto
@@ -76,7 +76,7 @@ es:
           all: Todos
           open: Abiertos
           finished: Terminados
-        budget_investments: Gestionar proyectos de gasto
+        budget_investments: Proyectos de gasto
         table_budget_type: "Tipo"
         table_completed: Completado
         table_draft: "Borrador"
@@ -87,8 +87,8 @@ es:
         type_multiple: "Múltiples partidas"
         type_pending: "Pendiente: Aún no hay partidas"
         type_single: "Partida única"
-        edit_groups: Editar grupos de partidas
-        admin_ballots: Gestionar urnas
+        edit_groups: Grupos de partidas
+        admin_ballots: Urnas
         no_budgets: "No hay presupuestos participativos."
       create:
         notice: '¡Presupuestos participativos creados con éxito!'
@@ -152,7 +152,7 @@ es:
     budget_groups:
       name: "Nombre"
       headings_name: "Partidas"
-      headings_manage: "Gestionar partidas"
+      headings_manage: "Partidas"
       no_groups: "No hay grupos."
       amount:
         one: "Hay 1 grupo de partidas presupuestarias"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -21,8 +21,6 @@ es:
       index:
         title: Banners
         create: Crear un banner
-        edit: Editar banner
-        delete: Eliminar banner
         filters:
           all: Todos
           with_active: Activos
@@ -90,7 +88,6 @@ es:
         type_pending: "Pendiente: Aún no hay partidas"
         type_single: "Partida única"
         edit_groups: Editar grupos de partidas
-        edit_budget: Editar presupuesto
         admin_ballots: Gestionar urnas
         no_budgets: "No hay presupuestos participativos."
       create:
@@ -109,7 +106,6 @@ es:
         duration: "Duración"
         enabled: Habilitada
         actions: Acciones
-        edit_phase: Editar fase
         enable_phase: "Habilitar fase de %{phase}"
         active: Activa
         blank_dates: Sin fechas
@@ -354,7 +350,6 @@ es:
         table_publication_date: "Fecha de publicación"
         table_status: Estado
         table_actions: "Acciones"
-        delete: "Eliminar hito"
         no_milestones: "No hay hitos definidos"
         image: "Imagen"
         show_image: "Mostrar imagen"
@@ -1206,7 +1201,6 @@ es:
         location: "Ubicación"
       booth:
         shifts: "Asignar turnos"
-        edit: "Editar urna"
     officials:
       edit:
         destroy: Eliminar condición de 'Cargo Público'
@@ -1228,7 +1222,6 @@ es:
       level_4: Nivel 4
       level_5: Nivel 5
       search:
-        edit_official: Editar cargo público
         make_official: Convertir en cargo público
         title: "Cargos Públicos: Búsqueda de usuarios"
         no_results: No se han encontrado cargos públicos.
@@ -1512,7 +1505,6 @@ es:
         title: "Objetivos de Desarrollo Sostenible - Estadísticas"
     tags:
       create: Crear tema
-      destroy: Eliminar tema
       index:
         add_tag: Añade un nuevo tema de propuesta
         title: Temas de propuesta

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1592,7 +1592,7 @@ es:
           create: Crear nueva página
           delete: Borrar página
           title: Páginas
-          see_page: Ver página
+          see_page: Ver
         new:
           title: Página nueva
           slug_help: "Texto que identifica esta página en la URL, por ejemplo <code>https://consulproject.org/slug-de-pagina</code>"
@@ -1602,7 +1602,7 @@ es:
           updated_at: Última actualización
           title: Título
           slug: Slug
-          see_cards: Ver tarjetas
+          see_cards: Tarjetas
         cards:
           cards_title: tarjetas
           create_card: Crear tarjeta

--- a/spec/components/admin/budgets/table_actions_component_spec.rb
+++ b/spec/components/admin/budgets/table_actions_component_spec.rb
@@ -14,7 +14,7 @@ describe Admin::Budgets::TableActionsComponent, type: :component do
     expect(page).to have_css "a", count: 6
     expect(page).to have_link "Manage projects", href: /investments/
     expect(page).to have_link "Edit headings groups", href: /groups/
-    expect(page).to have_link "Edit budget", href: /edit/
+    expect(page).to have_link "Edit", href: /edit/
     expect(page).to have_link "Admin ballots"
     expect(page).to have_link "Preview budget", href: /budgets/
     expect(page).to have_link "Delete", href: /budgets/

--- a/spec/components/admin/budgets/table_actions_component_spec.rb
+++ b/spec/components/admin/budgets/table_actions_component_spec.rb
@@ -12,18 +12,18 @@ describe Admin::Budgets::TableActionsComponent, type: :component do
     render_inline component
 
     expect(page).to have_css "a", count: 6
-    expect(page).to have_link "Manage projects", href: /investments/
-    expect(page).to have_link "Edit headings groups", href: /groups/
+    expect(page).to have_link "Investment projects", href: /investments/
+    expect(page).to have_link "Heading groups", href: /groups/
     expect(page).to have_link "Edit", href: /edit/
-    expect(page).to have_link "Admin ballots"
-    expect(page).to have_link "Preview budget", href: /budgets/
+    expect(page).to have_link "Ballots"
+    expect(page).to have_link "Preview", href: /budgets/
     expect(page).to have_link "Delete", href: /budgets/
   end
 
   it "renders link to create new poll for budgets without polls" do
     render_inline component
 
-    expect(page).to have_css "a[href*='polls'][data-method='post']", text: "Admin ballots"
+    expect(page).to have_css "a[href*='polls'][data-method='post']", text: "Ballots"
   end
 
   it "renders link to manage ballots for budgets with polls" do
@@ -31,6 +31,6 @@ describe Admin::Budgets::TableActionsComponent, type: :component do
 
     render_inline component
 
-    expect(page).to have_link "Admin ballots", href: /booth_assignments/
+    expect(page).to have_link "Ballots", href: /booth_assignments/
   end
 end

--- a/spec/shared/system/admin_milestoneable.rb
+++ b/spec/shared/system/admin_milestoneable.rb
@@ -108,12 +108,12 @@ shared_examples "admin_milestoneable" do |factory_name, path_name|
     end
 
     context "Delete" do
-      scenario "Remove milestone", :no_js do
+      scenario "Remove milestone" do
         create(:milestone, milestoneable: milestoneable, title: "Title will it remove")
 
         visit path
 
-        click_link "Delete milestone"
+        accept_confirm { click_link "Delete milestone" }
 
         expect(page).not_to have_content "Title will it remove"
       end

--- a/spec/shared/system/admin_milestoneable.rb
+++ b/spec/shared/system/admin_milestoneable.rb
@@ -113,7 +113,7 @@ shared_examples "admin_milestoneable" do |factory_name, path_name|
 
         visit path
 
-        accept_confirm { click_link "Delete milestone" }
+        accept_confirm { click_link "Delete" }
 
         expect(page).not_to have_content "Title will it remove"
       end

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -104,7 +104,7 @@ describe "Admin banners magement", :admin do
     fill_in "Post ended at", with: Date.current + 1.week
 
     click_button "Save changes"
-    click_link "Edit banner"
+    click_link "Edit"
 
     expect_to_have_language_selected "Français"
     expect(page).to have_field "Title", with: "En Français"
@@ -137,7 +137,7 @@ describe "Admin banners magement", :admin do
       click_link "Manage banners"
     end
 
-    click_link "Edit banner"
+    click_link "Edit"
 
     fill_in "Title", with: "Modified title"
     fill_in "Description", with: "Edited text"
@@ -173,7 +173,7 @@ describe "Admin banners magement", :admin do
 
     expect(page).to have_content "Ugly banner"
 
-    accept_confirm { click_link "Delete banner" }
+    accept_confirm { click_link "Delete" }
 
     visit admin_root_path
     expect(page).not_to have_content "Ugly banner"

--- a/spec/system/admin/budget_groups_spec.rb
+++ b/spec/system/admin/budget_groups_spec.rb
@@ -37,21 +37,21 @@ describe "Admin budget groups", :admin do
         expect(page).to have_content(group1.name)
         expect(page).to have_content(group1.max_votable_headings)
         expect(page).to have_content(group1.headings.count)
-        expect(page).to have_link "Manage headings"
+        expect(page).to have_link "Headings"
       end
 
       within "#budget_group_#{group2.id}" do
         expect(page).to have_content(group2.name)
         expect(page).to have_content(group2.max_votable_headings)
         expect(page).to have_content(group2.headings.count)
-        expect(page).to have_link "Manage headings"
+        expect(page).to have_link "Headings"
       end
 
       within "#budget_group_#{group3.id}" do
         expect(page).to have_content(group3.name)
         expect(page).to have_content(group3.max_votable_headings)
         expect(page).to have_content(group3.headings.count)
-        expect(page).to have_link "Manage headings"
+        expect(page).to have_link "Headings"
       end
     end
 

--- a/spec/system/admin/budget_phases_spec.rb
+++ b/spec/system/admin/budget_phases_spec.rb
@@ -29,7 +29,7 @@ describe "Admin budget phases" do
         expect(page).to have_content "Accepting projects"
         expect(page).not_to have_content "My phase custom name"
 
-        within("tr", text: "Accepting projects") { click_link "Edit phase" }
+        within("tr", text: "Accepting projects") { click_link "Edit" }
       end
 
       expect(page).to have_css "h2", exact_text: "Edit phase - Accepting projects"

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -227,7 +227,7 @@ describe "Admin budgets", :admin do
 
         within_table "Phases" do
           within "tr", text: "Information" do
-            expect(page).to have_link "Edit phase"
+            expect(page).to have_link "Edit"
           end
         end
       end

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -116,7 +116,7 @@ describe "Admin budgets", :admin do
     scenario "Can preview budget before it is published" do
       visit edit_admin_budget_path(budget)
 
-      within_window(window_opened_by { click_link "Preview budget" }) do
+      within_window(window_opened_by { click_link "Preview" }) do
         expect(page).to have_current_path budget_path(budget)
       end
     end
@@ -130,7 +130,7 @@ describe "Admin budgets", :admin do
       expect(page).not_to have_content "This participatory budget is in draft mode"
       expect(page).not_to have_link "Publish budget"
 
-      within_window(window_opened_by { click_link "Preview budget" }) do
+      within_window(window_opened_by { click_link "Preview" }) do
         expect(page).to have_current_path budget_path(budget)
       end
     end

--- a/spec/system/admin/budgets_wizard/budgets_spec.rb
+++ b/spec/system/admin/budgets_wizard/budgets_spec.rb
@@ -88,7 +88,7 @@ describe "Budgets wizard, first step", :admin do
       expect(page).to have_content "New participatory budget created successfully!"
 
       within("#side_menu") { click_link "Participatory budgets" }
-      within("tr", text: "M30 - Summer campaign") { click_link "Edit budget" }
+      within("tr", text: "M30 - Summer campaign") { click_link "Edit" }
 
       expect(page).to have_content "This participatory budget is in draft mode"
       expect(page).to have_link "Preview budget"

--- a/spec/system/admin/budgets_wizard/budgets_spec.rb
+++ b/spec/system/admin/budgets_wizard/budgets_spec.rb
@@ -91,7 +91,7 @@ describe "Budgets wizard, first step", :admin do
       within("tr", text: "M30 - Summer campaign") { click_link "Edit" }
 
       expect(page).to have_content "This participatory budget is in draft mode"
-      expect(page).to have_link "Preview budget"
+      expect(page).to have_link "Preview"
       expect(page).to have_link "Publish budget"
     end
   end

--- a/spec/system/admin/budgets_wizard/phases_spec.rb
+++ b/spec/system/admin/budgets_wizard/phases_spec.rb
@@ -56,7 +56,7 @@ describe "Budgets wizard, phases step", :admin do
 
       expect(page).to have_css ".creation-timeline"
 
-      within("tr", text: "Selecting projects") { click_link "Edit phase" }
+      within("tr", text: "Selecting projects") { click_link "Edit" }
       fill_in "Name", with: "Choosing projects"
       click_button "Save changes"
 
@@ -86,7 +86,7 @@ describe "Budgets wizard, phases step", :admin do
     scenario "update phase in single heading budget" do
       visit admin_budgets_wizard_budget_budget_phases_path(budget, mode: "single")
 
-      within("tr", text: "Selecting projects") { click_link "Edit phase" }
+      within("tr", text: "Selecting projects") { click_link "Edit" }
       fill_in "Name", with: "Choosing projects"
       click_button "Save changes"
 

--- a/spec/system/admin/budgets_wizard/wizard_spec.rb
+++ b/spec/system/admin/budgets_wizard/wizard_spec.rb
@@ -107,7 +107,7 @@ describe "Budgets creation wizard", :admin do
 
     expect(page).to have_css ".budget-phases-table"
 
-    within("tr", text: "Voting projects") { click_link "Edit phase" }
+    within("tr", text: "Voting projects") { click_link "Edit" }
     fill_in "Name", with: "Custom phase name"
     uncheck "Phase enabled"
     click_button "Save changes"

--- a/spec/system/admin/budgets_wizard/wizard_spec.rb
+++ b/spec/system/admin/budgets_wizard/wizard_spec.rb
@@ -27,13 +27,13 @@ describe "Budgets creation wizard", :admin do
     expect(page).to have_content "Phases configured successfully"
 
     within "tr", text: "Single heading budget" do
-      click_link "Edit headings groups"
+      click_link "Heading groups"
     end
 
     expect(page).to have_content "There is 1 group"
 
     within "tr", text: "Single heading budget" do
-      click_link "Manage headings"
+      click_link "Headings"
     end
 
     expect(page).to have_content "There is 1 heading"
@@ -124,7 +124,7 @@ describe "Budgets creation wizard", :admin do
     expect(page).to have_content "Phases configured successfully"
 
     within "tr", text: "Multiple headings budget" do
-      click_link "Edit headings groups"
+      click_link "Heading groups"
     end
 
     expect(page).to have_content "There are 2 groups"
@@ -135,7 +135,7 @@ describe "Budgets creation wizard", :admin do
     end
 
     within "tr", text: "Districts" do
-      click_link "Manage headings"
+      click_link "Headings"
     end
 
     expect(page).to have_content "There are 2 headings"

--- a/spec/system/admin/officials_spec.rb
+++ b/spec/system/admin/officials_spec.rb
@@ -15,7 +15,7 @@ describe "Admin officials", :admin do
 
   scenario "Edit an official" do
     visit admin_officials_path
-    click_link "Edit official"
+    click_link "Edit"
 
     expect(page).to have_current_path(edit_admin_official_path(official))
 

--- a/spec/system/admin/poll/booths_spec.rb
+++ b/spec/system/admin/poll/booths_spec.rb
@@ -47,7 +47,7 @@ describe "Admin booths", :admin do
 
     expect(page).to have_content booth_for_current_poll.name
     expect(page).not_to have_content booth_for_expired_poll.name
-    expect(page).not_to have_link "Edit booth"
+    expect(page).not_to have_link "Edit"
   end
 
   scenario "Show" do
@@ -82,7 +82,7 @@ describe "Admin booths", :admin do
 
     within("#booth_#{booth.id}") do
       expect(page).not_to have_link "Manage shifts"
-      click_link "Edit booth"
+      click_link "Edit"
     end
 
     fill_in "poll_booth_name", with: "Next booth"

--- a/spec/system/admin/site_customization/content_blocks_spec.rb
+++ b/spec/system/admin/site_customization/content_blocks_spec.rb
@@ -91,7 +91,7 @@ describe "Admin custom content blocks", :admin do
       expect(page).to have_content("#{block.name} (#{block.locale})")
       expect(page).to have_content(block.body)
 
-      accept_confirm { click_link "Delete block" }
+      accept_confirm { click_link "Delete" }
 
       expect(page).not_to have_content("#{block.name} (#{block.locale})")
       expect(page).not_to have_content(block.body)

--- a/spec/system/admin/tags_spec.rb
+++ b/spec/system/admin/tags_spec.rb
@@ -39,7 +39,7 @@ describe "Admin tags", :admin do
     expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
-      accept_confirm { click_link "Delete topic" }
+      accept_confirm { click_link "Delete" }
     end
 
     expect(page).not_to have_content "bad tag"
@@ -57,7 +57,7 @@ describe "Admin tags", :admin do
     expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
-      accept_confirm { click_link "Delete topic" }
+      accept_confirm { click_link "Delete" }
     end
 
     expect(page).not_to have_content "bad tag"

--- a/spec/system/admin/widgets/cards_spec.rb
+++ b/spec/system/admin/widgets/cards_spec.rb
@@ -163,7 +163,7 @@ describe "Cards", :admin do
         visit admin_site_customization_pages_path
 
         within "#site_customization_page_#{custom_page.id}" do
-          click_link "See Cards"
+          click_link "Manage cards"
         end
 
         click_link "Create card"

--- a/spec/system/budget_polls/budgets_spec.rb
+++ b/spec/system/budget_polls/budgets_spec.rb
@@ -8,7 +8,7 @@ describe "Admin Budgets", :admin do
 
       visit admin_budgets_path
 
-      click_link "Admin ballots"
+      click_link "Ballots"
 
       expect(page).to have_current_path(/admin\/polls\/\d+/)
       expect(page).to have_content(budget.name)
@@ -37,7 +37,7 @@ describe "Admin Budgets", :admin do
       visit admin_budgets_path
 
       within "#budget_#{budget.id}" do
-        expect(page).to have_link "Admin ballots", href: admin_poll_booth_assignments_path(poll)
+        expect(page).to have_link "Ballots", href: admin_poll_booth_assignments_path(poll)
       end
     end
   end


### PR DESCRIPTION
## References

* We started using icon in the admin section in pull request #4218
* [Understanding Success Criterion 1.4.13: Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus)
* [The best icon is a text label](https://thomasbyttebier.be/blog/the-best-icon-is-a-text-label)
* [Inclusive components: tooltips and toggletips](https://inclusive-components.design/tooltips-toggletips/)

## Objectives

* Make it easier for users to understand which actions are available
* Avoid usability and accessibility issues 
* Unify and simplify texts in admin actions
* Increase the size and the space between icons so it's easier for users to click on / touch the icon they want

## Visual Changes

### Before these changes

![The pages table shows a picture icon and an eye icon; the mouse cursor is over the eye icon and a "See page" tooltip is shown](https://user-images.githubusercontent.com/35156/121823834-024b6680-cca8-11eb-965c-01810d7b35d2.png)

![The budgets table shows three icons: orange coins, a green chart pie, and a blue box](https://user-images.githubusercontent.com/35156/121823836-037c9380-cca8-11eb-836f-e66ea20ad792.png)

![The hidden proposals table shows an arrow icon like the ones used in "undo" actions and a red flag icon](https://user-images.githubusercontent.com/35156/121823831-0081a300-cca8-11eb-9237-60e50be337f7.png)

### After these changes

![The pages table shows the texts "Manage cards" below the picture icon and "View" below the eye icon](https://user-images.githubusercontent.com/35156/121823749-936e0d80-cca7-11eb-9f56-1d78b9abc5e0.png)

![The budgets table shows the texts "Investment projects" below the coins, "Heading groups" below the chart pie, and "Ballots" below the box](https://user-images.githubusercontent.com/35156/121823751-9406a400-cca7-11eb-87ec-2223e891dd72.png)

![The hidden proposals table shows the texts "Restore" below the "undo-like" arrow and "Confirm moderation" below the flag icon](https://user-images.githubusercontent.com/35156/121823748-923ce080-cca7-11eb-90ad-813f588685ad.png)

## Notes

For an explanation about the usability and accessibility issues related to tooltips, check the message of the first commit in this pull request.