### PR TITLE
Fix typo in "currently showing" translation

### DIFF
--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -197,7 +197,7 @@ es:
         edit: "Editar partida"
         submit: "Guardar partida"
       group_switcher:
-        currently_showing: "Mostrando las partidas del grupo: %{group}"
+        currently_showing: "Mostrando las partidas del grupo: %{group}."
         different_group: "Ir a partidas de otro grupo"
         the_other_group: "Ir a partidas del grupo %{group}."
       index:


### PR DESCRIPTION
## References

* This bug was introduced in pull request #4531

## Objectives

* Fix a typo in the Spanish translation of the "currently showing" text