### PR TITLE
Fix flaky hidden budget investments spec

### DIFF
--- a/spec/system/admin/hidden_budget_investments_spec.rb
+++ b/spec/system/admin/hidden_budget_investments_spec.rb
@@ -31,7 +31,9 @@ describe "Admin hidden budget investments", :admin do
     investment = create(:budget_investment, :hidden, heading: heading)
     visit admin_hidden_budget_investments_path
 
-    click_link("Pending")
+    click_link "Pending"
+
+    expect(page).not_to have_link "Pending"
     expect(page).to have_content(investment.title)
 
     click_link "Confirm moderation"


### PR DESCRIPTION
## References

* The test failed in our [test run #1694, job 0](https://github.com/consul/consul/runs/2815566553?check_suite_focus=true#step:9:227)

## Objectives

* Make sure the test to confirm hiding a budget investment works properly

## Notes

The test was failing sometimes because the conditions we were checking were the same before and after clicking the "Pending" link. So there was a race condition between the request generated by clicking the "Pending" link and the order to click the "Confirm moderation" link. This sometimes resulted in the "Confirm moderation" link not being correctly clicked.
