### PR TITLE
Fix margin in sign in / sign up forms divider

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1011,15 +1011,17 @@ footer {
 }
 
 .auth-divider {
-  border-bottom: 1px solid $border;
-  height: rem-calc(14);
-  margin: $line-height 0;
+  border-top: 1px solid $border;
+  margin-top: $line-height * 1.5;
   text-align: center;
 
   span {
     background: #fff;
+    box-decoration-break: clone;
     font-weight: bold;
     padding: 0 $line-height / 2;
+    position: relative;
+    top: -$line-height / 2;
   }
 }
 


### PR DESCRIPTION
## Background

When the "Or fill the following form" text was translated to another language or customized by administrators, the text could span over two lines. Since the element had a fixed height, it could overlap with the text below it.

## Objectives

Make sure there's always space between the "Or fill the following form text" and the elements below it.

## Visual Changes

### Before these changes

![On medium-sized screens, there's no margin between the divider text and the element below it](https://user-images.githubusercontent.com/35156/122210212-ae0dd580-cea5-11eb-9606-119b05d78e9d.png)

![On small-sized screens, the divider text and the element below it overlap](https://user-images.githubusercontent.com/35156/122210215-af3f0280-cea5-11eb-8e56-3df730d515b6.png)

### After these changes

![On medium-sized screens, there's the usual margin between the divider text and the element below it](https://user-images.githubusercontent.com/35156/122413268-87739b80-cf86-11eb-8be1-5cf751727a01.png)

![On small-sized screens, there's no margin between the divider text and the element below it](https://user-images.githubusercontent.com/35156/122413298-8cd0e600-cf86-11eb-8d39-8ab05fd1bded.png)