### PR TITLE
Respond with 403 when features are disabled

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,9 @@ module Consul
     # in any CONSUL installations
     config.active_support.use_authenticated_message_encryption = false
 
+    # Handle custom exceptions
+    config.action_dispatch.rescue_responses["FeatureFlags::FeatureDisabled"] = :forbidden
+
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Error 403 | Forbidden: Access disabled</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background: #065687 url('/errors_bg.jpg');
+    color: #2E2F30;
+    font-family: arial, sans-serif;
+    margin: 0;
+    text-align: center;
+  }
+
+  h1 {
+    color: white;
+    font-size: 160px;
+    line-height: 160px;
+    margin: 0;
+  }
+
+  h2 {
+    color: white;
+  }
+
+  div.error {
+    margin-top: -144px;
+    position: absolute;
+    top: 50%;
+    width: 100%;
+  }
+  </style>
+</head>
+
+<body>
+  <div class="error">
+    <h1>403</h1>
+    <h2>Access to this page has been disabled by the administrators.</h2>
+  </div>
+</body>
+</html>

--- a/spec/system/admin/feature_flags_spec.rb
+++ b/spec/system/admin/feature_flags_spec.rb
@@ -36,12 +36,12 @@ describe "Admin feature flags", :admin do
 
     visit budget_path(budget)
 
-    expect(page).to have_content "Internal server error"
+    expect(page).to have_title "Forbidden"
 
     visit admin_budgets_path
 
     expect(page).to have_current_path admin_budgets_path
-    expect(page).to have_content "Internal server error"
+    expect(page).to have_title "Forbidden"
   end
 
   scenario "Enable a disabled participatory process" do


### PR DESCRIPTION
## Background

When administrators disabled features and users tried to access them with the browser, we were responding with a 500 "Internal Server Error" page, which in my humble opinion was incorrect. There was no error at all; the server worked exactly as expected.

## Objectives

* Stop showing error pages when there was no error

## Notes

I think a 403 "Forbidden" code is better; since that feature is disabled, we're refusing to let users access it.

We could also respond with a 404 "Not found", although I wonder whether that'll be confusing when administrators temporarily or accidentally disable a feature.

A similar thing might happen if we responded with a 410 "Gone" code.  Actually this case might be more confusing since users aren't that familiar with this code.

In any case, all these options are better than the 500 error.