### PR TITLE
Disable JavaScript debugging in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.


### PR DESCRIPTION
## Background

While debugging JavaScript is certainly useful, enabling it generates about 100 extra HTTP requests because we include about 100 JavaScript files (including external dependencies and files written by us). Depending on the browser, this might make refreshing the page take a very long time.

## Objectives

* Make the application faster in the development environment