### PR TITLE
Fix SVG icons on old browsers

### DIFF
--- a/app/assets/stylesheets/mixins/icons.scss
+++ b/app/assets/stylesheets/mixins/icons.scss
@@ -6,12 +6,14 @@
 }
 
 %svg-icon {
-  background: currentcolor;
-  content: "";
-  height: 1em;
-  mask-repeat: no-repeat;
-  mask-size: 100% 100%;
-  width: 1em;
+  @supports (mask-image: url()) {
+    background: currentcolor;
+    content: "";
+    height: 1em;
+    mask-repeat: no-repeat;
+    mask-size: 100% 100%;
+    width: 1em;
+  }
 }
 
 %admin-menu-icon {
@@ -37,11 +39,8 @@
     }
   }
 
-  @supports (mask-image: url()) {
-
-    &::#{$position} {
-      @extend %svg-icon;
-      mask-image: image-url("fontawesome/#{$style}/#{$icon}.svg");
-    }
+  &::#{$position} {
+    @extend %svg-icon;
+    mask-image: image-url("fontawesome/#{$style}/#{$icon}.svg");
   }
 }


### PR DESCRIPTION
## References

* We started using SVG icons in pull request #4206

## Objectives

* Properly use an icon font fallback for browsers not supporting SVG icons through mask images

## Visual Changes

All screenshots have been taken on Internet Explorer 11

### Before these changes

![Colored squares are shown instead of icons](https://user-images.githubusercontent.com/35156/122643980-0269bd00-d113-11eb-8763-54e3f2f0f15c.png)

### After these changes

![Icons are shown properly](https://user-images.githubusercontent.com/35156/122643982-04338080-d113-11eb-9815-c9724c57cd0d.png)