### PR TITLE
Fix footer overlap on Internet Explorer 11

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -39,17 +39,21 @@ html {
 
 html,
 body {
-  height: 100%;
   margin: 0;
+}
+
+html {
+  height: 100%;
 }
 
 body {
   display: flex;
   flex-direction: column;
   font-size: $base-font-size;
+  min-height: 100%;
 
   > .wrapper {
-    flex: 1;
+    flex-grow: 1;
   }
 }
 

--- a/app/assets/stylesheets/mixins/layouts.scss
+++ b/app/assets/stylesheets/mixins/layouts.scss
@@ -1,11 +1,12 @@
 @mixin admin-layout {
+  height: 100%;
 
   > header {
     margin-bottom: 0;
   }
 
   > .menu-and-content {
-    flex: 1;
+    flex-grow: 1;
   }
 }
 

--- a/app/assets/stylesheets/widgets/feeds/participation.scss
+++ b/app/assets/stylesheets/widgets/feeds/participation.scss
@@ -17,7 +17,7 @@
       flex-direction: column;
 
       .feed-content {
-        flex: 1;
+        flex-grow: 1;
       }
     }
   }


### PR DESCRIPTION
## References

* This Internet Explorer bug was causing issues since pull request #4239

## Background

There are two bugs in Internet Explorer which caused our footer to be rendered incorrectly.

First, the `flex: 1` property doesn't work so well when `flex-direction` is set to `column`. We're replacing it with `flex-grow: 1`. No need to set other `flex-basis` nor `flex-shrink` in this case since in this case the default values will work just fine.

Second, it didn't handle the body height being set to `100%` so well, and the footer was rendered after that 100% point, even if the content still continued.

## Objectives

Make sure the page can be read by users of all browsers

## Visual changes

These screenshots were taken on Internet Explorer 11.

### Before these changes

![The footer is rendered in the middle of the page, overlapping with the main content](https://user-images.githubusercontent.com/35156/122648468-bb3af680-d129-11eb-8c10-f63da9966466.png)

### After these changes

![There's no overlap and all elements are rendered properly](https://user-images.githubusercontent.com/35156/122648462-b7a76f80-d129-11eb-9ab1-99b1a193df7a.png)

## Notes

These changes cause a different issue since now IE won't handle the `flex-grow: 1` property correctly. This will only affect IE users with very large screens, though, and it's way better than rendering the footer overlapping the main content, so we can live with that. The page won't look as great as in other browser, but it will still be usable.