### PR TITLE
Improve accessibility in form to add related content

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2462,6 +2462,7 @@ table {
 
 .add-related-content {
   display: block;
+  margin-bottom: $line-height;
 
   @include breakpoint(medium) {
     float: right;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2461,11 +2461,17 @@ table {
 }
 
 .add-related-content {
+  color: $link;
+  cursor: pointer;
   display: block;
   margin-bottom: $line-height;
 
   @include breakpoint(medium) {
     float: right;
+  }
+
+  &:focus {
+    outline: $outline-focus;
   }
 
   &[aria-expanded="false"] + form {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2491,21 +2491,12 @@ table {
     @include breakpoint(medium) {
 
       .score-actions {
-        display: none;
         float: right;
       }
     }
 
     &:first-child {
       border-top: 1px solid $border;
-    }
-
-    &:hover {
-      background: #f9f9f9;
-
-      .score-actions {
-        display: block;
-      }
     }
   }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2489,9 +2489,12 @@ table {
     padding: $line-height / 2;
 
     @include breakpoint(medium) {
+      display: flex;
+      justify-content: space-between;
 
-      .score-actions {
-        float: right;
+      > :first-child {
+        flex: 1;
+        margin-right: 1em;
       }
     }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2467,6 +2467,10 @@ table {
   @include breakpoint(medium) {
     float: right;
   }
+
+  &[aria-expanded="false"] + form {
+    display: none;
+  }
 }
 
 .related-content-list {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2529,33 +2529,16 @@ table {
   a {
     font-weight: bold;
     margin-right: $line-height;
-    padding-left: rem-calc(20);
-    position: relative;
     text-decoration: none;
 
-    &.score-positive::before,
-    &.score-negative::before {
-      font-family: "icons";
-      left: 0;
-      position: absolute;
-    }
-
     &.score-positive {
+      @include has-fa-icon(check, solid);
       color: $color-success;
-
-      &::before {
-        color: $color-success;
-        content: "\6c";
-      }
     }
 
     &.score-negative {
+      @include has-fa-icon(times, solid);
       color: $color-alert;
-
-      &::before {
-        color: $color-alert;
-        content: "\76";
-      }
     }
   }
 }

--- a/app/views/relationable/_form.html.erb
+++ b/app/views/relationable/_form.html.erb
@@ -3,24 +3,24 @@
 </button>
 
 <%= form_tag related_contents_path, method: :post, id: "related_content", class: "hide", "data-toggler": ".hide" do %>
-    <label><%= t("related_content.label") %></label>
+  <label><%= t("related_content.label") %></label>
 
-    <p class="help-text" id="related_content_help_text">
-      <%= t("related_content.help", models: t("related_content.content_title").values.to_sentence, org: setting["org_name"]) %>
-    </p>
+  <p class="help-text" id="related_content_help_text">
+    <%= t("related_content.help", models: t("related_content.content_title").values.to_sentence, org: setting["org_name"]) %>
+  </p>
 
-    <div class="input-group">
-      <div class="input-group-field">
-        <%= text_field_tag :url, "",
-                          "aria-describedby": "related_content_help_text",
-                          placeholder: t("related_content.placeholder", url: setting["url"]) %>
+  <div class="input-group">
+    <div class="input-group-field">
+      <%= text_field_tag :url, "",
+                        "aria-describedby": "related_content_help_text",
+                        placeholder: t("related_content.placeholder", url: setting["url"]) %>
 
-        <%= hidden_field_tag :relationable_klass, relationable.class.name %>
-        <%= hidden_field_tag :relationable_id, relationable.id %>
-      </div>
-
-      <div class="input-group-button">
-        <%= submit_tag t("related_content.submit"), class: "button" %>
-      </div>
+      <%= hidden_field_tag :relationable_klass, relationable.class.name %>
+      <%= hidden_field_tag :relationable_id, relationable.id %>
     </div>
-  <% end %>
+
+    <div class="input-group-button">
+      <%= submit_tag t("related_content.submit"), class: "button" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/relationable/_form.html.erb
+++ b/app/views/relationable/_form.html.erb
@@ -1,3 +1,7 @@
+<button type="button" data-toggle="related_content" class="add-related-content">
+  <%= t("related_content.add") %>
+</button>
+
 <%= form_tag related_contents_path, method: :post, id: "related_content", class: "hide", "data-toggler": ".hide" do %>
     <label><%= t("related_content.label") %></label>
 

--- a/app/views/relationable/_form.html.erb
+++ b/app/views/relationable/_form.html.erb
@@ -2,7 +2,7 @@
   <%= t("related_content.add") %>
 </button>
 
-<%= form_tag related_contents_path, method: :post, id: "related_content", class: "hide", "data-toggler": ".hide" do %>
+<%= form_tag related_contents_path, method: :post, id: "related_content", "data-toggler": "unused-toggle-class" do %>
   <label><%= t("related_content.label") %></label>
 
   <p class="help-text" id="related_content_help_text">

--- a/app/views/relationable/_form.html.erb
+++ b/app/views/relationable/_form.html.erb
@@ -3,7 +3,7 @@
 </button>
 
 <%= form_tag related_contents_path, method: :post, id: "related_content", "data-toggler": "unused-toggle-class" do %>
-  <label><%= t("related_content.label") %></label>
+  <label for="url"><%= t("related_content.label") %></label>
 
   <p class="help-text" id="related_content_help_text">
     <%= t("related_content.help", models: t("related_content.content_title").values.to_sentence, org: setting["org_name"]) %>

--- a/app/views/relationable/_related_content.html.erb
+++ b/app/views/relationable/_related_content.html.erb
@@ -5,7 +5,7 @@
       <%= t("related_content.title") %>&nbsp;<span>(<%= relationable.relationed_contents.count %>)</span>
     </h2>
     <% if current_user %>
-      <button type="button" data-toggle="related_content" class="add-related-content" id="add-related-content">
+      <button type="button" data-toggle="related_content" class="add-related-content">
         <%= t("related_content.add") %>
       </button>
     <% end %>

--- a/app/views/relationable/_related_content.html.erb
+++ b/app/views/relationable/_related_content.html.erb
@@ -11,7 +11,9 @@
     <% end %>
   </div>
 
-  <%= render "relationable/form", relationable: relationable %>
+  <% if current_user %>
+    <%= render "relationable/form", relationable: relationable %>
+  <% end %>
 
   <% if @related_contents.present? %>
     <%= render "relationable/related_list", relationable: relationable %>

--- a/app/views/relationable/_related_content.html.erb
+++ b/app/views/relationable/_related_content.html.erb
@@ -1,15 +1,8 @@
 <div class="related-content padding">
 
-  <div class="margin-bottom">
-    <h2 class="inline-block">
-      <%= t("related_content.title") %>&nbsp;<span>(<%= relationable.relationed_contents.count %>)</span>
-    </h2>
-    <% if current_user %>
-      <button type="button" data-toggle="related_content" class="add-related-content">
-        <%= t("related_content.add") %>
-      </button>
-    <% end %>
-  </div>
+  <h2 class="inline-block">
+    <%= t("related_content.title") %>&nbsp;<span>(<%= relationable.relationed_contents.count %>)</span>
+  </h2>
 
   <% if current_user %>
     <%= render "relationable/form", relationable: relationable %>

--- a/app/views/relationable/_related_content.html.erb
+++ b/app/views/relationable/_related_content.html.erb
@@ -5,11 +5,9 @@
       <%= t("related_content.title") %>&nbsp;<span>(<%= relationable.relationed_contents.count %>)</span>
     </h2>
     <% if current_user %>
-      <a>
-        <button type="button" data-toggle="related_content" class="add-related-content" id="add-related-content">
-          <%= t("related_content.add") %>
-        </button>
-      </a>
+      <button type="button" data-toggle="related_content" class="add-related-content" id="add-related-content">
+        <%= t("related_content.add") %>
+      </button>
     <% end %>
   </div>
 

--- a/app/views/relationable/_related_list.html.erb
+++ b/app/views/relationable/_related_list.html.erb
@@ -1,9 +1,10 @@
 <ul class="related-content-list" id="related-content-list">
   <% @related_contents.compact.each do |related| %>
-    <li id="related-content-<%= related.find_related_content(relationable).id %>">
-      <% related_content = related.find_related_content(relationable) %>
+    <% related_content = related.find_related_content(relationable) %>
+
+    <li id="related-content-<%= related_content.id %>">
       <% if current_user && related_content.author != current_user && !related_content.scored_by_user?(current_user) %>
-        <span id="<%= dom_id(related.find_related_content(relationable)) %>" class="js-score-actions score-actions">
+        <span id="<%= dom_id(related_content) %>" class="js-score-actions score-actions">
           <%= render "relationable/score", related: related_content %>
         </span>
       <% end %>

--- a/app/views/relationable/_related_list.html.erb
+++ b/app/views/relationable/_related_list.html.erb
@@ -3,15 +3,17 @@
     <% related_content = related.find_related_content(relationable) %>
 
     <li id="related-content-<%= related_content.id %>">
+      <div>
+        <span class="related-content-title"><%= t("related_content.content_title.#{related.model_name.singular}") %></span><br>
+        <h3 class="inline-block">
+          <%= link_to related.title, related.url %>
+        </h3>
+      </div>
       <% if current_user && related_content.author != current_user && !related_content.scored_by_user?(current_user) %>
         <span id="<%= dom_id(related_content) %>" class="js-score-actions score-actions">
           <%= render "relationable/score", related: related_content %>
         </span>
       <% end %>
-      <span class="related-content-title"><%= t("related_content.content_title.#{related.model_name.singular}") %></span><br>
-      <h3 class="inline-block">
-        <%= link_to related.title, related.url %>
-      </h3>
     </li>
   <% end %>
 </ul>

--- a/app/views/relationable/_score.html.erb
+++ b/app/views/relationable/_score.html.erb
@@ -5,13 +5,11 @@
               score_positive_related_content_path(related),
               method: :put,
               remote: true,
-              id: "score-positive-related-#{related.id}",
               class: "score-positive" %>
 
   <%= link_to t("related_content.score_negative"),
               score_negative_related_content_path(related),
               method: :put,
               remote: true,
-              id: "score-negative-related-#{related.id}",
               class: "score-negative" %>
 </span>

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -97,9 +97,10 @@ shared_examples "relationable" do |relationable_model_name|
     visit relationable.url
 
     within("#related-content-list") do
-      find("#related-content-#{related_content.opposite_related_content.id}").hover
-      find("#score-positive-related-#{related_content.opposite_related_content.id}").click
-      expect(page).not_to have_css "#score-positive-related-#{related_content.opposite_related_content.id}"
+      click_link "Yes"
+
+      expect(page).not_to have_link "Yes"
+      expect(page).not_to have_link "No"
     end
 
     expect(related_content.related_content_scores.find_by(user_id: user.id, related_content_id: related_content.id).value).to eq(1)
@@ -113,9 +114,10 @@ shared_examples "relationable" do |relationable_model_name|
     visit relationable.url
 
     within("#related-content-list") do
-      find("#related-content-#{related_content.opposite_related_content.id}").hover
-      find("#score-negative-related-#{related_content.opposite_related_content.id}").click
-      expect(page).not_to have_css "#score-negative-related-#{related_content.opposite_related_content.id}"
+      click_link "No"
+
+      expect(page).not_to have_link "Yes"
+      expect(page).not_to have_link "No"
     end
 
     expect(related_content.related_content_scores.find_by(user_id: user.id, related_content_id: related_content.id).value).to eq(-1)

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -29,8 +29,11 @@ shared_examples "relationable" do |relationable_model_name|
     visit relationable.url
 
     expect(page).not_to have_css "#related_content"
+    expect(page).to have_css ".add-related-content[aria-expanded='false']"
 
     click_button "Add related content"
+
+    expect(page).to have_css ".add-related-content[aria-expanded='true']"
 
     within("#related_content") do
       fill_in "url", with: "#{url + related1.url}"

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -30,7 +30,7 @@ shared_examples "relationable" do |relationable_model_name|
 
     expect(page).not_to have_selector("#related_content")
 
-    click_on("Add related content")
+    click_button "Add related content"
 
     within("#related_content") do
       fill_in "url", with: "#{url + related1.url}"
@@ -47,7 +47,7 @@ shared_examples "relationable" do |relationable_model_name|
       expect(page).to have_content(relationable.title)
     end
 
-    click_on("Add related content")
+    click_button "Add related content"
 
     within("#related_content") do
       fill_in "url", with: "#{url + related2.url}"
@@ -63,7 +63,7 @@ shared_examples "relationable" do |relationable_model_name|
     login_as(user)
     visit relationable.url
 
-    click_on("Add related content")
+    click_button "Add related content"
 
     within("#related_content") do
       fill_in "url", with: "http://invalidurl.com"
@@ -77,7 +77,7 @@ shared_examples "relationable" do |relationable_model_name|
     login_as(user)
     visit relationable.url
 
-    click_on("Add related content")
+    click_button "Add related content"
 
     within("#related_content") do
       fill_in "url", with: url + relationable.url.to_s

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -10,25 +10,25 @@ shared_examples "relationable" do |relationable_model_name|
 
     visit relationable.url
     within("#related-content-list") do
-      expect(page).to have_content(related1.title)
+      expect(page).to have_content related1.title
     end
 
     visit related1.url
     within("#related-content-list") do
-      expect(page).to have_content(relationable.title)
+      expect(page).to have_content relationable.title
     end
   end
 
   scenario "related contents list is not rendered if there are no relations" do
     visit relationable.url
-    expect(page).not_to have_css("#related-content-list")
+    expect(page).not_to have_css "#related-content-list"
   end
 
   scenario "related contents can be added" do
     login_as(user)
     visit relationable.url
 
-    expect(page).not_to have_selector("#related_content")
+    expect(page).not_to have_css "#related_content"
 
     click_button "Add related content"
 
@@ -38,13 +38,13 @@ shared_examples "relationable" do |relationable_model_name|
     end
 
     within("#related-content-list") do
-      expect(page).to have_content(related1.title)
+      expect(page).to have_content related1.title
     end
 
     visit related1.url
 
     within("#related-content-list") do
-      expect(page).to have_content(relationable.title)
+      expect(page).to have_content relationable.title
     end
 
     click_button "Add related content"
@@ -55,7 +55,7 @@ shared_examples "relationable" do |relationable_model_name|
     end
 
     within("#related-content-list") do
-      expect(page).to have_content(related2.title)
+      expect(page).to have_content related2.title
     end
   end
 
@@ -70,7 +70,7 @@ shared_examples "relationable" do |relationable_model_name|
       click_button "Add"
     end
 
-    expect(page).to have_content("Link not valid. Remember to start with #{url}.")
+    expect(page).to have_content "Link not valid. Remember to start with #{url}."
   end
 
   scenario "returns error when relating content URL to itself" do
@@ -84,7 +84,7 @@ shared_examples "relationable" do |relationable_model_name|
       click_button "Add"
     end
 
-    expect(page).to have_content("Link not valid. You cannot relate a content to itself")
+    expect(page).to have_content "Link not valid. You cannot relate a content to itself"
   end
 
   scenario "related content can be scored positively" do
@@ -96,7 +96,7 @@ shared_examples "relationable" do |relationable_model_name|
     within("#related-content-list") do
       find("#related-content-#{related_content.opposite_related_content.id}").hover
       find("#score-positive-related-#{related_content.opposite_related_content.id}").click
-      expect(page).not_to have_css("#score-positive-related-#{related_content.opposite_related_content.id}")
+      expect(page).not_to have_css "#score-positive-related-#{related_content.opposite_related_content.id}"
     end
 
     expect(related_content.related_content_scores.find_by(user_id: user.id, related_content_id: related_content.id).value).to eq(1)
@@ -112,7 +112,7 @@ shared_examples "relationable" do |relationable_model_name|
     within("#related-content-list") do
       find("#related-content-#{related_content.opposite_related_content.id}").hover
       find("#score-negative-related-#{related_content.opposite_related_content.id}").click
-      expect(page).not_to have_css("#score-negative-related-#{related_content.opposite_related_content.id}")
+      expect(page).not_to have_css "#score-negative-related-#{related_content.opposite_related_content.id}"
     end
 
     expect(related_content.related_content_scores.find_by(user_id: user.id, related_content_id: related_content.id).value).to eq(-1)
@@ -134,6 +134,6 @@ shared_examples "relationable" do |relationable_model_name|
 
     visit relationable.url
 
-    expect(page).not_to have_css("#related-content-list")
+    expect(page).not_to have_css "#related-content-list"
   end
 end

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -36,7 +36,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(page).to have_css ".add-related-content[aria-expanded='true']"
 
     within("#related_content") do
-      fill_in "url", with: "#{url + related1.url}"
+      fill_in "Link to related content", with: "#{url + related1.url}"
       click_button "Add"
     end
 
@@ -53,7 +53,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "url", with: "#{url + related2.url}"
+      fill_in "Link to related content", with: "#{url + related2.url}"
       click_button "Add"
     end
 
@@ -69,7 +69,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "url", with: "http://invalidurl.com"
+      fill_in "Link to related content", with: "http://invalidurl.com"
       click_button "Add"
     end
 
@@ -83,7 +83,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "url", with: url + relationable.url.to_s
+      fill_in "Link to related content", with: url + relationable.url.to_s
       click_button "Add"
     end
 


### PR DESCRIPTION
## Objectives

* Correctly associate the field to enter a related content URL with its label
* Fix the wrong state being announced in the button to show/hide the form to add related content
* Make it more obvious that the button to add related content is clickable
* Make the actions to score related contents available to everyone
* Fix invalid HTML in the button to show/hide the form to add related content

## Visual changes

### Before these changes

The "Add related content" button looks like ordinary text and hovering over related content causes the actions to score them to suddenly appear, sometimes causing the target link to move to a different place:

https://user-images.githubusercontent.com/35156/123143625-16872480-d45b-11eb-951d-5c6d4483b0e9.mp4

### After these changes

![The "Add related content" buttons looks like similar links on the page and the action to score related content are always visible](https://user-images.githubusercontent.com/35156/123144179-b0e76800-d45b-11eb-9cc7-dd1e1619af58.png)