### PR TITLE
Improve home cards

### DIFF
--- a/app/models/widget/card.rb
+++ b/app/models/widget/card.rb
@@ -9,7 +9,7 @@ class Widget::Card < ApplicationRecord
   include Globalizable
 
   validates_translation :title, presence: true
-  validates :link_url, presence: true, if: -> { !header? }
+  validates :link_url, presence: true, if: -> { !header? || link_text.present? }
 
   def self.header
     where(header: true)

--- a/app/models/widget/card.rb
+++ b/app/models/widget/card.rb
@@ -9,6 +9,7 @@ class Widget::Card < ApplicationRecord
   include Globalizable
 
   validates_translation :title, presence: true
+  validates :link_url, presence: true, if: -> { !header? }
 
   def self.header
     where(header: true)

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,13 +1,17 @@
 <% if header.present? %>
-  <div class="jumbo highlight">
+  <div class="header-card jumbo highlight">
     <div class="row">
       <div class="small-12 medium-6 column <%= "medium-9 small-centered text-center" unless header.image.present? %>">
         <span><%= header.label %></span>
         <h1><%= header.title %></h1>
+
         <p class="lead"><%= header.description %></p>
-        <div class="small-12 medium-6 large-4 <%= "small-centered" unless header.image.present? %>">
-          <%= link_to header.link_text, header.link_url, class: "button expanded large" %>
-        </div>
+
+        <% if header.link_text.present? && header.link_url.present? %>
+          <div class="small-12 medium-6 large-4 <%= "small-centered" unless header.image.present? %>">
+            <%= link_to header.link_text, header.link_url, class: "button expanded large" %>
+          </div>
+        <% end %>
       </div>
 
       <% if header.image.present? %>

--- a/db/dev_seeds/sdg.rb
+++ b/db/dev_seeds/sdg.rb
@@ -33,6 +33,7 @@ end
 
 section "Creating SDG homepage cards" do
   SDG::Phase.all.each do |phase|
-    Widget::Card.create!(cardable: phase, title: "#{phase.title} card")
+    Widget::Card.create!(cardable: phase, title: "#{phase.title} card",
+                        link_text: "Link Text", link_url: "/any_path")
   end
 end

--- a/spec/models/widget/card_spec.rb
+++ b/spec/models/widget/card_spec.rb
@@ -17,6 +17,14 @@ describe Widget::Card do
     it "is not valid without a title" do
       expect(build(:widget_card, title: "")).not_to be_valid
     end
+
+    context "regular cards" do
+      it "is not valid without a link_url" do
+        card = build(:widget_card, header: false, link_url: nil)
+
+        expect(card).not_to be_valid
+      end
+    end
   end
 
   describe "#header" do

--- a/spec/models/widget/card_spec.rb
+++ b/spec/models/widget/card_spec.rb
@@ -25,6 +25,30 @@ describe Widget::Card do
         expect(card).not_to be_valid
       end
     end
+
+    context "header cards" do
+      it "is valid with no link_url and no link_text" do
+        header = build(:widget_card, :header, link_text: nil, link_url: nil)
+
+        expect(header).to be_valid
+      end
+
+      it "is not valid with link_text and no link_url" do
+        header = build(:widget_card, :header, link_text: "link text", link_url: nil)
+
+        expect(header).not_to be_valid
+        expect(header.errors.count).to be 1
+        expect(header.errors[:link_url].count).to be 1
+        expect(header.errors[:link_url].first).to eq "can't be blank"
+      end
+
+      it "is valid if link_text and link_url are both provided" do
+        header = build(:widget_card, :header, link_text: "Text link",
+                                              link_url: "https://consulproject.org")
+
+        expect(header).to be_valid
+      end
+    end
   end
 
   describe "#header" do

--- a/spec/system/admin/widgets/cards_spec.rb
+++ b/spec/system/admin/widgets/cards_spec.rb
@@ -172,6 +172,7 @@ describe "Cards", :admin do
           href: admin_site_customization_page_widget_cards_path(custom_page))
 
         fill_in "Title", with: "Card for a custom page"
+        fill_in "Link URL", with: "/any_path"
         click_button "Create card"
 
         expect(page).to have_current_path admin_site_customization_page_widget_cards_path(custom_page)

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -174,4 +174,30 @@ describe "Home" do
 
     expect(page).not_to have_css(".title", text: "Featured")
   end
+
+  describe "Header Card" do
+    scenario "if there is header card with link, the link content is rendered" do
+      create(:widget_card, :header, link_text: "Link text", link_url: "consul.dev")
+
+      visit root_path
+
+      expect(page).to have_link "Link text", href: "consul.dev"
+    end
+
+    scenario "if there is header card without link, the link content is not rendered" do
+      create(:widget_card, :header, link_text: nil, link_url: nil)
+
+      visit root_path
+
+      within(".header-card") { expect(page).not_to have_link }
+    end
+
+    scenario "if there is header card without link and with text, the link content is not rendered" do
+      create(:widget_card, :header, link_text: "", link_url: "", link_text_es: "Link ES", title_es: "ES")
+
+      visit root_path(locale: :es)
+
+      within(".header-card") { expect(page).not_to have_link }
+    end
+  end
 end

--- a/spec/system/sdg_management/homepage_spec.rb
+++ b/spec/system/sdg_management/homepage_spec.rb
@@ -22,6 +22,7 @@ describe "SDG homepage configuration" do
       click_link "Create planning card"
 
       within(".translatable-fields") { fill_in "Title", with: "My planning card" }
+      fill_in "Link URL", with: "/any_path"
       click_button "Create card"
 
       within(".planning-cards") do
@@ -54,6 +55,7 @@ describe "SDG homepage configuration" do
       click_link "Create header"
 
       within(".translatable-fields") { fill_in "Title", with: "My header" }
+      fill_in "Link URL", with: "/any_path"
       click_button "Create card"
 
       within(".sdg-header") do


### PR DESCRIPTION
## Objectives
- Do not show link content section when links fields are not defined in header cards.
- Improve validations for link_url field from Widget::Card
  - Avoid create Widget::Card with header: false without `link_url`.
  - Avoid create header Widget::Card without `link_url` when `link_text` is defined.

## Visual Changes
- Before changes 

we can define header card without link fields:
![Captura de pantalla 2021-06-25 a las 13 18 03](https://user-images.githubusercontent.com/16189/123417828-8fe85980-d5b8-11eb-8b66-90e753722e8b.png)

And we displayed the button without text and without href:
![Captura de pantalla 2021-06-25 a las 13 18 20](https://user-images.githubusercontent.com/16189/123417942-b9a18080-d5b8-11eb-81c6-39aeb4af861f.png)

- After changes
![Captura de pantalla 2021-06-25 a las 13 30 51](https://user-images.githubusercontent.com/16189/123418676-a04d0400-d5b9-11eb-8647-3d9d917e1ec8.png)

