### PR TITLE
Fix advanced search button position

### DIFF
--- a/app/assets/javascripts/advanced_search.js
+++ b/app/assets/javascripts/advanced_search.js
@@ -4,10 +4,6 @@
     advanced_search_terms: function() {
       return $("#js-advanced-search").data("advanced-search-terms");
     },
-    toggle_form: function(event) {
-      event.preventDefault();
-      $("#js-advanced-search").slideToggle();
-    },
     toggle_date_options: function() {
       if ($("#js-advanced-search-date-min").val() === "custom") {
         $("#js-custom-date").show();
@@ -23,8 +19,9 @@
         App.AdvancedSearch.toggle_date_options();
       }
       $("#js-advanced-search-title").on({
-        click: function(event) {
-          App.AdvancedSearch.toggle_form(event);
+        click: function() {
+          $(this).attr("aria-expanded", !JSON.parse($(this).attr("aria-expanded")));
+          $("#js-advanced-search").slideToggle();
         }
       });
       $("#js-advanced-search-date-min").on({

--- a/app/assets/javascripts/advanced_search.js
+++ b/app/assets/javascripts/advanced_search.js
@@ -1,9 +1,6 @@
 (function() {
   "use strict";
   App.AdvancedSearch = {
-    advanced_search_terms: function() {
-      return $("#js-advanced-search").data("advanced-search-terms");
-    },
     toggle_date_options: function() {
       if ($("#js-advanced-search-date-min").val() === "custom") {
         $("#js-custom-date").show();
@@ -18,15 +15,15 @@
 
       toggle_button.removeAttr("hidden");
 
-      if (App.AdvancedSearch.advanced_search_terms()) {
+      if (toggle_button.attr("aria-expanded") === "true") {
         App.AdvancedSearch.toggle_date_options();
       } else {
-        $("#js-advanced-search").hide();
+        toggle_button.next().hide();
       }
       toggle_button.on({
         click: function() {
           $(this).attr("aria-expanded", !JSON.parse($(this).attr("aria-expanded")));
-          $("#js-advanced-search").slideToggle();
+          $(this).next().slideToggle();
         }
       });
       $("#js-advanced-search-date-min").on({

--- a/app/assets/javascripts/advanced_search.js
+++ b/app/assets/javascripts/advanced_search.js
@@ -14,11 +14,16 @@
       }
     },
     initialize: function() {
+      var toggle_button = $("#js-advanced-search-title");
+
+      toggle_button.removeAttr("hidden");
+
       if (App.AdvancedSearch.advanced_search_terms()) {
-        $("#js-advanced-search").show();
         App.AdvancedSearch.toggle_date_options();
+      } else {
+        $("#js-advanced-search").hide();
       }
-      $("#js-advanced-search-title").on({
+      toggle_button.on({
         click: function() {
           $(this).attr("aria-expanded", !JSON.parse($(this).attr("aria-expanded")));
           $("#js-advanced-search").slideToggle();

--- a/app/assets/stylesheets/advanced_search.scss
+++ b/app/assets/stylesheets/advanced_search.scss
@@ -1,6 +1,7 @@
 .advanced-search-form {
   @include grid-row-nest;
-  position: relative;
+  display: flex;
+  flex-direction: column;
 
   @include breakpoint(large) {
     .filter {
@@ -32,13 +33,12 @@
     cursor: pointer;
     margin-top: $line-height;
     margin-bottom: $line-height;
+    max-width: max-content;
 
     @include breakpoint(medium) {
-      float: right;
+      align-self: flex-end;
       margin-bottom: 0;
       margin-top: $line-height / 4;
-      position: absolute;
-      right: 0;
     }
 
     &:focus {

--- a/app/assets/stylesheets/advanced_search.scss
+++ b/app/assets/stylesheets/advanced_search.scss
@@ -17,6 +17,7 @@
 }
 
 .advanced-search-form {
+  @include grid-row-nest;
 
   @include breakpoint(large) {
     .filter {

--- a/app/assets/stylesheets/advanced_search.scss
+++ b/app/assets/stylesheets/advanced_search.scss
@@ -1,23 +1,6 @@
-.advanced-search {
-  color: $link;
-  cursor: pointer;
-  margin: $line-height 0;
-
-  @include breakpoint(medium) {
-    float: right;
-    margin-bottom: 0;
-    margin-top: $line-height / 4;
-    position: absolute;
-    right: 0;
-  }
-
-  &:focus {
-    outline: $outline-focus;
-  }
-}
-
 .advanced-search-form {
   @include grid-row-nest;
+  position: relative;
 
   @include breakpoint(large) {
     .filter {
@@ -40,6 +23,26 @@
 
     .submit {
       width: 25%;
+    }
+  }
+
+  > [aria-expanded] {
+    @include xy-gutters;
+    color: $link;
+    cursor: pointer;
+    margin-top: $line-height;
+    margin-bottom: $line-height;
+
+    @include breakpoint(medium) {
+      float: right;
+      margin-bottom: 0;
+      margin-top: $line-height / 4;
+      position: absolute;
+      right: 0;
+    }
+
+    &:focus {
+      outline: $outline-focus;
     }
   }
 

--- a/app/assets/stylesheets/advanced_search.scss
+++ b/app/assets/stylesheets/advanced_search.scss
@@ -1,4 +1,6 @@
 .advanced-search {
+  color: $link;
+  cursor: pointer;
   float: left;
   margin: $line-height 0;
   position: inherit;
@@ -9,6 +11,10 @@
     margin-top: $line-height / 4;
     position: absolute;
     right: 0;
+  }
+
+  &:focus {
+    outline: $outline-focus;
   }
 }
 

--- a/app/assets/stylesheets/advanced_search.scss
+++ b/app/assets/stylesheets/advanced_search.scss
@@ -3,7 +3,6 @@
   cursor: pointer;
   float: left;
   margin: $line-height 0;
-  position: inherit;
 
   @include breakpoint(medium) {
     float: right;

--- a/app/assets/stylesheets/advanced_search.scss
+++ b/app/assets/stylesheets/advanced_search.scss
@@ -1,7 +1,6 @@
 .advanced-search {
   color: $link;
   cursor: pointer;
-  float: left;
   margin: $line-height 0;
 
   @include breakpoint(medium) {

--- a/app/components/shared/advanced_search_component.html.erb
+++ b/app/components/shared/advanced_search_component.html.erb
@@ -1,11 +1,9 @@
-<div class="relative">
+<%= form_tag request.path, id: "advanced_search_form", class: "advanced-search-form", method: :get do %>
   <button type="button" aria-expanded="<%= advanced_search.present? %>" id="js-advanced-search-title" class="advanced-search small" hidden>
     <%= t("shared.advanced_search.title") %>
   </button>
-</div>
 
-<%= form_tag request.path, id: "advanced_search_form", class: "advanced-search-form", method: :get do %>
-  <div id="js-advanced-search" data-advanced-search-terms="<%= advanced_search.present? %>">
+  <div>
     <div class="general-search">
       <label for="search">
         <%= t("shared.advanced_search.general") %>

--- a/app/components/shared/advanced_search_component.html.erb
+++ b/app/components/shared/advanced_search_component.html.erb
@@ -1,11 +1,11 @@
 <div class="relative">
-  <button type="button" aria-expanded="<%= advanced_search.present? %>" id="js-advanced-search-title" class="advanced-search small">
+  <button type="button" aria-expanded="<%= advanced_search.present? %>" id="js-advanced-search-title" class="advanced-search small" hidden>
     <%= t("shared.advanced_search.title") %>
   </button>
 </div>
 
 <%= form_tag request.path, id: "advanced_search_form", class: "advanced-search-form", method: :get do %>
-  <div id="js-advanced-search" data-advanced-search-terms="<%= advanced_search.present? %>" style="display: none">
+  <div id="js-advanced-search" data-advanced-search-terms="<%= advanced_search.present? %>">
     <div class="general-search">
       <label for="search">
         <%= t("shared.advanced_search.general") %>

--- a/app/components/shared/advanced_search_component.html.erb
+++ b/app/components/shared/advanced_search_component.html.erb
@@ -1,5 +1,7 @@
 <div class="relative">
-  <%= link_to t("shared.advanced_search.title"), "#advanced_search_form", id: "js-advanced-search-title", class: "advanced-search small" %>
+  <button type="button" aria-expanded="<%= advanced_search.present? %>" id="js-advanced-search-title" class="advanced-search small">
+    <%= t("shared.advanced_search.title") %>
+  </button>
 </div>
 
 <div class="row advanced-search-form">

--- a/app/components/shared/advanced_search_component.html.erb
+++ b/app/components/shared/advanced_search_component.html.erb
@@ -4,69 +4,65 @@
   </button>
 </div>
 
-<div class="row advanced-search-form">
-  <%= form_tag request.path, id: "advanced_search_form", method: :get do %>
-    <div id="js-advanced-search" data-advanced-search-terms="<%= advanced_search.present? %>" style="display: none">
-
-      <div class="general-search">
-        <label for="search">
-          <%= t("shared.advanced_search.general") %>
-        </label>
-        <%= text_field_tag "search", params[:search],
-                           placeholder: t("shared.advanced_search.general_placeholder") %>
-      </div>
-
-      <div class="date-filters">
-        <div class="filter">
-          <label for="js-advanced-search-date-min"><%= t("shared.advanced_search.date") %></label>
-          <%= select_tag("advanced_search[date_min]", date_range_options,
-                        include_blank: t("shared.advanced_search.date_range_blank"),
-                        id: "js-advanced-search-date-min") %>
-        </div>
-
-        <div id="js-custom-date" class="custom-date-filters" style="display: none">
-          <div class="filter">
-            <label for="advanced_search_date_min">
-              <%= t("shared.advanced_search.from") %> (<%= t("shared.advanced_search.date_placeholder") %>)
-            </label>
-            <%= text_field_tag "advanced_search[date_min]",
-                                advanced_search[:date_min],
-                                class: "js-calendar" %>
-          </div>
-          <div class="filter">
-            <label for="advanced_search_date_max">
-              <%= t("shared.advanced_search.to") %> (<%= t("shared.advanced_search.date_placeholder") %>)
-            </label>
-            <%= text_field_tag "advanced_search[date_max]",
-                                advanced_search[:date_max],
-                                class: "js-calendar" %>
-          </div>
-        </div>
-      </div>
-
-      <div class="filter">
-        <label for="advanced_search_official_level"><%= t("shared.advanced_search.author_type") %></label>
-        <%= select_tag("advanced_search[official_level]", official_level_search_options,
-                      include_blank: t("shared.advanced_search.author_type_blank")) %>
-      </div>
-
-      <% if sdg? %>
-        <div class="filter">
-          <label for="advanced_search_goal"><%= t("shared.advanced_search.goal") %></label>
-          <%= select_tag("advanced_search[goal]", goal_options,
-                        include_blank: t("shared.advanced_search.goal_blank")) %>
-        </div>
-        <div class="filter">
-          <label for="advanced_search_target"><%= t("shared.advanced_search.target") %></label>
-          <%= select_tag("advanced_search[target]", target_options,
-                        include_blank: t("shared.advanced_search.target_blank")) %>
-        </div>
-      <% end %>
-
-      <div class="submit">
-        <%= submit_tag t("shared.advanced_search.search"), class: "button expanded" %>
-      </div>
-
+<%= form_tag request.path, id: "advanced_search_form", class: "advanced-search-form", method: :get do %>
+  <div id="js-advanced-search" data-advanced-search-terms="<%= advanced_search.present? %>" style="display: none">
+    <div class="general-search">
+      <label for="search">
+        <%= t("shared.advanced_search.general") %>
+      </label>
+      <%= text_field_tag "search", params[:search],
+                         placeholder: t("shared.advanced_search.general_placeholder") %>
     </div>
-  <% end %>
-</div>
+
+    <div class="date-filters">
+      <div class="filter">
+        <label for="js-advanced-search-date-min"><%= t("shared.advanced_search.date") %></label>
+        <%= select_tag("advanced_search[date_min]", date_range_options,
+                      include_blank: t("shared.advanced_search.date_range_blank"),
+                      id: "js-advanced-search-date-min") %>
+      </div>
+
+      <div id="js-custom-date" class="custom-date-filters" style="display: none">
+        <div class="filter">
+          <label for="advanced_search_date_min">
+            <%= t("shared.advanced_search.from") %> (<%= t("shared.advanced_search.date_placeholder") %>)
+          </label>
+          <%= text_field_tag "advanced_search[date_min]",
+                              advanced_search[:date_min],
+                              class: "js-calendar" %>
+        </div>
+        <div class="filter">
+          <label for="advanced_search_date_max">
+            <%= t("shared.advanced_search.to") %> (<%= t("shared.advanced_search.date_placeholder") %>)
+          </label>
+          <%= text_field_tag "advanced_search[date_max]",
+                              advanced_search[:date_max],
+                              class: "js-calendar" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="filter">
+      <label for="advanced_search_official_level"><%= t("shared.advanced_search.author_type") %></label>
+      <%= select_tag("advanced_search[official_level]", official_level_search_options,
+                    include_blank: t("shared.advanced_search.author_type_blank")) %>
+    </div>
+
+    <% if sdg? %>
+      <div class="filter">
+        <label for="advanced_search_goal"><%= t("shared.advanced_search.goal") %></label>
+        <%= select_tag("advanced_search[goal]", goal_options,
+                      include_blank: t("shared.advanced_search.goal_blank")) %>
+      </div>
+      <div class="filter">
+        <label for="advanced_search_target"><%= t("shared.advanced_search.target") %></label>
+        <%= select_tag("advanced_search[target]", target_options,
+                      include_blank: t("shared.advanced_search.target_blank")) %>
+      </div>
+    <% end %>
+
+    <div class="submit">
+      <%= submit_tag t("shared.advanced_search.search"), class: "button expanded" %>
+    </div>
+  </div>
+<% end %>

--- a/spec/components/shared/advanced_search_component_spec.rb
+++ b/spec/components/shared/advanced_search_component_spec.rb
@@ -13,7 +13,7 @@ describe Shared::AdvancedSearchComponent, type: :component do
     it "hides the button to show the form" do
       render_inline component
 
-      expect(page).to have_button "Advanced search", visible: :hidden
+      expect(page.find("form")).to have_button "Advanced search", visible: :hidden
     end
   end
 

--- a/spec/components/shared/advanced_search_component_spec.rb
+++ b/spec/components/shared/advanced_search_component_spec.rb
@@ -1,9 +1,23 @@
 require "rails_helper"
 
 describe Shared::AdvancedSearchComponent, type: :component do
-  describe "SDG filter" do
-    let(:component) { Shared::AdvancedSearchComponent.new }
+  let(:component) { Shared::AdvancedSearchComponent.new }
 
+  context "JavaScript disabled" do
+    it "renders the form" do
+      render_inline component
+
+      expect(page).to have_button "Filter"
+    end
+
+    it "hides the button to show the form" do
+      render_inline component
+
+      expect(page).to have_button "Advanced search", visible: :hidden
+    end
+  end
+
+  describe "SDG filter" do
     before do
       Setting["feature.sdg"] = true
       Setting["sdg.process.proposals"] = true

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -11,7 +11,7 @@ describe "Advanced search" do
 
     visit debates_path
 
-    click_link "Advanced search"
+    click_button "Advanced search"
     fill_in "Write the text", with: "Schwifty"
     click_button "Filter"
 
@@ -31,7 +31,7 @@ describe "Advanced search" do
 
     visit proposals_path
 
-    click_link "Advanced search"
+    click_button "Advanced search"
     fill_in "Write the text", with: "Schwifty"
     click_button "Filter"
 
@@ -51,7 +51,7 @@ describe "Advanced search" do
 
     visit budget_investments_path(budget)
 
-    click_link "Advanced search"
+    click_button "Advanced search"
     fill_in "Write the text", with: "Schwifty"
     click_button "Filter"
 
@@ -76,7 +76,7 @@ describe "Advanced search" do
 
       visit debates_path
 
-      click_link "Advanced search"
+      click_button "Advanced search"
       select "Official position 1", from: "advanced_search_official_level"
       click_button "Filter"
 
@@ -100,7 +100,7 @@ describe "Advanced search" do
 
       visit proposals_path
 
-      click_link "Advanced search"
+      click_button "Advanced search"
       select "Official position 2", from: "advanced_search_official_level"
       click_button "Filter"
 
@@ -124,7 +124,7 @@ describe "Advanced search" do
 
       visit budget_investments_path(budget)
 
-      click_link "Advanced search"
+      click_button "Advanced search"
       select "Official position 3", from: "advanced_search_official_level"
       click_button "Filter"
 
@@ -148,7 +148,7 @@ describe "Advanced search" do
 
       visit debates_path
 
-      click_link "Advanced search"
+      click_button "Advanced search"
       select "Official position 4", from: "advanced_search_official_level"
       click_button "Filter"
 
@@ -172,7 +172,7 @@ describe "Advanced search" do
 
       visit proposals_path
 
-      click_link "Advanced search"
+      click_button "Advanced search"
       select "Official position 5", from: "advanced_search_official_level"
       click_button "Filter"
 
@@ -194,7 +194,7 @@ describe "Advanced search" do
 
           visit budget_investments_path(budget)
 
-          click_link "Advanced search"
+          click_button "Advanced search"
           select "Last 24 hours", from: "js-advanced-search-date-min"
           click_button "Filter"
 
@@ -214,7 +214,7 @@ describe "Advanced search" do
 
           visit debates_path
 
-          click_link "Advanced search"
+          click_button "Advanced search"
           select "Last week", from: "js-advanced-search-date-min"
           click_button "Filter"
 
@@ -234,7 +234,7 @@ describe "Advanced search" do
 
           visit proposals_path
 
-          click_link "Advanced search"
+          click_button "Advanced search"
           select "Last month", from: "js-advanced-search-date-min"
           click_button "Filter"
 
@@ -254,7 +254,7 @@ describe "Advanced search" do
 
           visit budget_investments_path(budget)
 
-          click_link "Advanced search"
+          click_button "Advanced search"
           select "Last year", from: "js-advanced-search-date-min"
           click_button "Filter"
 
@@ -275,7 +275,7 @@ describe "Advanced search" do
 
         visit debates_path
 
-        click_link "Advanced search"
+        click_button "Advanced search"
         select "Customized", from: "js-advanced-search-date-min"
         fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
         fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
@@ -298,7 +298,7 @@ describe "Advanced search" do
 
         visit proposals_path
 
-        click_link "Advanced search"
+        click_button "Advanced search"
         select "Customized", from: "js-advanced-search-date-min"
         fill_in "advanced_search_date_min", with: 4000.years.ago.strftime("%d/%m/%Y")
         fill_in "advanced_search_date_max", with: "13/13/2199"
@@ -325,7 +325,7 @@ describe "Advanced search" do
 
         visit budget_investments_path(budget)
 
-        click_link "Advanced search"
+        click_button "Advanced search"
         fill_in "Write the text", with: "Schwifty"
         select "Official position 1", from: "advanced_search_official_level"
         select "Last 24 hours", from: "js-advanced-search-date-min"
@@ -343,7 +343,7 @@ describe "Advanced search" do
         Setting["official_level_1_name"] = "Official position 1"
 
         visit debates_path
-        click_link "Advanced search"
+        click_button "Advanced search"
 
         fill_in "Write the text", with: "Schwifty"
         select "Official position 1", from: "advanced_search_official_level"
@@ -360,7 +360,7 @@ describe "Advanced search" do
 
       scenario "Maintain custom date search criteria" do
         visit proposals_path
-        click_link "Advanced search"
+        click_button "Advanced search"
 
         select "Customized", from: "js-advanced-search-date-min"
         fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
@@ -391,7 +391,7 @@ describe "Advanced search" do
         create(:budget_investment, title: "Hospital", heading: heading, sdg_goals: [SDG::Goal[3]])
 
         visit budget_investments_path(budget)
-        click_link "Advanced search"
+        click_button "Advanced search"
         select "6. Clean Water and Sanitation", from: "By SDG"
         click_button "Filter"
 
@@ -413,7 +413,7 @@ describe "Advanced search" do
         create(:debate, title: "Preschool", sdg_targets: [SDG::Target["4.2"]])
 
         visit debates_path
-        click_link "Advanced search"
+        click_button "Advanced search"
         select "4.2", from: "By target"
         click_button "Filter"
 
@@ -429,7 +429,7 @@ describe "Advanced search" do
       scenario "Dynamic target options depending on the selected goal" do
         visit proposals_path
 
-        click_link "Advanced search"
+        click_button "Advanced search"
         select "1. No Poverty", from: "By SDG"
 
         expect(page).to have_select "By target",

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -351,7 +351,7 @@ describe "Advanced search" do
 
         click_button "Filter"
 
-        within "#js-advanced-search" do
+        within ".advanced-search-form" do
           expect(page).to have_selector("input[name='search'][value='Schwifty']")
           expect(page).to have_select("advanced_search[official_level]", selected: "Official position 1")
           expect(page).to have_select("advanced_search[date_min]", selected: "Last 24 hours")
@@ -370,7 +370,7 @@ describe "Advanced search" do
 
         expect(page).to have_content("citizen proposals cannot be found")
 
-        within "#js-advanced-search" do
+        within ".advanced-search-form" do
           expect(page).to have_select("advanced_search[date_min]", selected: "Customized")
           expect(page).to have_selector("input[name='advanced_search[date_min]'][value*='#{7.days.ago.strftime("%d/%m/%Y")}']")
           expect(page).to have_selector("input[name='advanced_search[date_max]'][value*='#{1.day.ago.strftime("%d/%m/%Y")}']")


### PR DESCRIPTION
## References

* One of the issues addressed here was introduced in pull request #4300

## Objectives

* Use a button instead of a link to toggle the form, so screen reader users are notified of the "collapsed" and "expanded" button states
* Fix advanced search toggle button position on small screens
* Fix advanced search toggle button position on large screens
* Support advanced search with JavaScript disabled

## Visual Changes

### Before these changes

On small screens:

![The link to hide the advanced search form appears between the label of the first field and the first field](https://user-images.githubusercontent.com/35156/123718279-07e7a580-d87f-11eb-9d64-aa3d13ef8656.png)

On large screens, using a font size of 20px:

![The links to sort results overlap with the link to show the advanced search form](https://user-images.githubusercontent.com/35156/123718283-0ae29600-d87f-11eb-99f3-0b734f5081a6.png)

### After these changes

On small screens:

![The button to hide the advanced search form appears before the label of the first field](https://user-images.githubusercontent.com/35156/123718290-0e761d00-d87f-11eb-8167-c8551dbf2277.png)

On large screens, using a font size of 20px:

![The button to show the advanced search form appears before the links to sort results](https://user-images.githubusercontent.com/35156/123718295-11710d80-d87f-11eb-8a82-ba08073d3479.png)
