### PR TITLE
Use a submit button in budget executions filters

### DIFF
--- a/app/assets/stylesheets/admin/search.scss
+++ b/app/assets/stylesheets/admin/search.scss
@@ -31,12 +31,8 @@
   }
 
   [type="submit"] {
-    @include button($background: $link);
+    @include regular-button;
     border-radius: 0;
     font-size: 1rem;
-
-    &[disabled] {
-      @include button-disabled;
-    }
   }
 }

--- a/app/assets/stylesheets/budgets/executions/filters.scss
+++ b/app/assets/stylesheets/budgets/executions/filters.scss
@@ -1,0 +1,22 @@
+.budget-executions-filters {
+  margin-bottom: $line-height / 2;
+
+  @include breakpoint(medium) {
+    $gap: 1em;
+    align-items: flex-end;
+    display: flex;
+    margin-left: -$gap;
+
+    > * {
+      margin-left: $gap;
+    }
+  }
+
+  select {
+    height: $line-height * 2;
+  }
+
+  [type="submit"] {
+    @include regular-button;
+  }
+}

--- a/app/assets/stylesheets/mixins/buttons.scss
+++ b/app/assets/stylesheets/mixins/buttons.scss
@@ -5,6 +5,10 @@
   &:hover {
     text-decoration: none !important;
   }
+
+  &[disabled] {
+    @include button-disabled;
+  }
 }
 
 %button {

--- a/app/components/budgets/executions/filters_component.html.erb
+++ b/app/components/budgets/executions/filters_component.html.erb
@@ -1,23 +1,24 @@
-<%= form_tag(budget_executions_path(budget), method: :get) do %>
-  <div class="small-12 medium-3 column">
+<%= form_tag(budget_executions_path(budget), method: :get, class: "budget-executions-filters") do %>
+  <div class="filter">
     <%= label_tag :milestone_tag, t("budgets.executions.filters.milestone_tag.label") %>
     <%= select_tag :milestone_tag,
                   options_for_select(
                     options_for_milestone_tags,
                     params[:milestone_tag]
                   ),
-                  class: "js-submit-on-change",
                   prompt: t("budgets.executions.filters.milestone_tag.all",
                   count: budget.investments.winners.with_milestones.count) %>
   </div>
-  <div class="small-12 medium-3 column">
+  <div class="filter">
     <%= label_tag :status, t("budgets.executions.filters.status.label") %>
     <%= select_tag :status,
                   options_from_collection_for_select(statuses,
                   :id, lambda { |s| "#{s.name} (#{filters_select_counts(s.id)})" },
                   params[:status]),
-                  class: "js-submit-on-change",
                   prompt: t("budgets.executions.filters.status.all",
                   count: budget.investments.winners.with_milestones.count) %>
+  </div>
+  <div class="submit">
+    <%= submit_tag t("shared.filter") %>
   </div>
 <% end %>

--- a/app/components/budgets/executions/filters_component.html.erb
+++ b/app/components/budgets/executions/filters_component.html.erb
@@ -1,0 +1,23 @@
+<%= form_tag(budget_executions_path(budget), method: :get) do %>
+  <div class="small-12 medium-3 column">
+    <%= label_tag :milestone_tag, t("budgets.executions.filters.milestone_tag.label") %>
+    <%= select_tag :milestone_tag,
+                  options_for_select(
+                    options_for_milestone_tags,
+                    params[:milestone_tag]
+                  ),
+                  class: "js-submit-on-change",
+                  prompt: t("budgets.executions.filters.milestone_tag.all",
+                  count: budget.investments.winners.with_milestones.count) %>
+  </div>
+  <div class="small-12 medium-3 column">
+    <%= label_tag :status, t("budgets.executions.filters.status.label") %>
+    <%= select_tag :status,
+                  options_from_collection_for_select(statuses,
+                  :id, lambda { |s| "#{s.name} (#{filters_select_counts(s.id)})" },
+                  params[:status]),
+                  class: "js-submit-on-change",
+                  prompt: t("budgets.executions.filters.status.all",
+                  count: budget.investments.winners.with_milestones.count) %>
+  </div>
+<% end %>

--- a/app/components/budgets/executions/filters_component.rb
+++ b/app/components/budgets/executions/filters_component.rb
@@ -1,0 +1,20 @@
+class Budgets::Executions::FiltersComponent < ApplicationComponent
+  attr_reader :budget, :statuses
+
+  def initialize(budget, statuses)
+    @budget = budget
+    @statuses = statuses
+  end
+
+  def options_for_milestone_tags
+    budget.investments_milestone_tags.map do |tag|
+      ["#{tag} (#{budget.investments.winners.by_tag(tag).count})", tag]
+    end
+  end
+
+  private
+
+    def filters_select_counts(status)
+      budget.investments.winners.with_milestone_status_id(status).count
+    end
+end

--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -1,14 +1,4 @@
 module BudgetExecutionsHelper
-  def filters_select_counts(status)
-    @budget.investments.winners.with_milestone_status_id(status).count
-  end
-
-  def options_for_milestone_tags
-    @budget.investments_milestone_tags.map do |tag|
-      ["#{tag} (#{@budget.investments.winners.by_tag(tag).count})", tag]
-    end
-  end
-
   def first_milestone_with_image(investment)
     investment.milestones.order_by_publication_date
                          .select { |milestone| milestone.image.present? }.last

--- a/app/views/budgets/executions/show.html.erb
+++ b/app/views/budgets/executions/show.html.erb
@@ -42,29 +42,7 @@
   </div>
 
   <div class="small-12 medium-9 large-10 column">
-    <%= form_tag(budget_executions_path(@budget), method: :get) do %>
-      <div class="small-12 medium-3 column">
-        <%= label_tag :milestone_tag, t("budgets.executions.filters.milestone_tag.label") %>
-        <%= select_tag :milestone_tag,
-                      options_for_select(
-                        options_for_milestone_tags,
-                        params[:milestone_tag]
-                      ),
-                      class: "js-submit-on-change",
-                      prompt: t("budgets.executions.filters.milestone_tag.all",
-                      count: @budget.investments.winners.with_milestones.count) %>
-      </div>
-      <div class="small-12 medium-3 column">
-        <%= label_tag :status, t("budgets.executions.filters.status.label") %>
-        <%= select_tag :status,
-                      options_from_collection_for_select(@statuses,
-                      :id, lambda { |s| "#{s.name} (#{filters_select_counts(s.id)})" },
-                      params[:status]),
-                      class: "js-submit-on-change",
-                      prompt: t("budgets.executions.filters.status.all",
-                      count: @budget.investments.winners.with_milestones.count) %>
-      </div>
-    <% end %>
+    <%= render Budgets::Executions::FiltersComponent.new(@budget, @statuses) %>
 
     <% if @investments_by_heading.any? %>
       <%= render "budgets/executions/investments" %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -669,6 +669,7 @@ en:
       back: "Go back to my content"
   shared:
     edit: "Edit"
+    filter: "Filter"
     save: "Save"
     delete: "Delete"
     "yes": "Yes"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -669,6 +669,7 @@ es:
       back: "Volver a mi contenido"
   shared:
     edit: "Editar"
+    filter: "Filtrar"
     save: "Guardar"
     delete: "Borrar"
     "yes": "Si"

--- a/spec/components/budgets/executions/filters_component_spec.rb
+++ b/spec/components/budgets/executions/filters_component_spec.rb
@@ -1,17 +1,16 @@
 require "rails_helper"
 
-describe BudgetExecutionsHelper do
-  describe "#options_for_milestone_tags" do
-    let(:budget) { create(:budget) }
+describe Budgets::Executions::FiltersComponent do
+  let(:budget) { create(:budget) }
+  let(:component) { Budgets::Executions::FiltersComponent.new(budget, []) }
 
+  describe "#options_for_milestone_tags" do
     it "does not return duplicate records for tags in different contexts" do
       create(:budget_investment, :winner, budget: budget, milestone_tag_list: ["Multiple"])
       create(:budget_investment, :winner, budget: budget, milestone_tag_list: ["Multiple"])
       create(:budget_investment, :winner, budget: budget, milestone_tag_list: ["Dup"], tag_list: ["Dup"])
 
-      @budget = budget
-
-      expect(options_for_milestone_tags).to eq [["Dup (1)", "Dup"], ["Multiple (2)", "Multiple"]]
+      expect(component.options_for_milestone_tags).to eq [["Dup (1)", "Dup"], ["Multiple (2)", "Multiple"]]
     end
   end
 end

--- a/spec/system/budgets/executions_spec.rb
+++ b/spec/system/budgets/executions_spec.rb
@@ -70,7 +70,7 @@ describe "Executions" do
 
     expect(page).to have_content("No winner investments in this state")
 
-    select "Executed (0)", from: "status"
+    select "Executed (0)", from: "Project's current state"
 
     expect(page).to have_content("No winner investments in this state")
   end
@@ -165,17 +165,17 @@ describe "Executions" do
       expect(page).to have_content(investment1.title)
       expect(page).to have_content(investment2.title)
 
-      select "Studying the project (1)", from: "status"
+      select "Studying the project (1)", from: "Project's current state"
 
       expect(page).to have_content(investment1.title)
       expect(page).not_to have_content(investment2.title)
 
-      select "Bidding (1)", from: "status"
+      select "Bidding (1)", from: "Project's current state"
 
       expect(page).to have_content(investment2.title)
       expect(page).not_to have_content(investment1.title)
 
-      select "Executing the project (0)", from: "status"
+      select "Executing the project (0)", from: "Project's current state"
 
       expect(page).not_to have_content(investment1.title)
       expect(page).not_to have_content(investment2.title)
@@ -194,10 +194,10 @@ describe "Executions" do
       click_link "See results"
       click_link "Milestones"
 
-      select "Studying the project (0)", from: "status"
+      select "Studying the project (0)", from: "Project's current state"
       expect(page).not_to have_content(investment1.title)
 
-      select "Bidding (1)", from: "status"
+      select "Bidding (1)", from: "Project's current state"
       expect(page).to have_content(investment1.title)
     end
 
@@ -214,10 +214,10 @@ describe "Executions" do
       click_link "See results"
       click_link "Milestones"
 
-      select "Studying the project (1)", from: "status"
+      select "Studying the project (1)", from: "Project's current state"
       expect(page).to have_content(investment1.title)
 
-      select "Bidding (0)", from: "status"
+      select "Bidding (0)", from: "Project's current state"
       expect(page).not_to have_content(investment1.title)
     end
 
@@ -240,27 +240,27 @@ describe "Executions" do
       expect(page).to have_content(investment1.title)
       expect(page).to have_content(investment2.title)
 
-      select "tag2 (2)", from: "milestone_tag"
+      select "tag2 (2)", from: "Milestone tag"
 
       expect(page).to have_content(investment1.title)
       expect(page).to have_content(investment2.title)
 
-      select "Studying the project (1)", from: "status"
+      select "Studying the project (1)", from: "Project's current state"
 
       expect(page).to have_content(investment1.title)
       expect(page).not_to have_content(investment2.title)
 
-      select "Bidding (1)", from: "status"
+      select "Bidding (1)", from: "Project's current state"
 
       expect(page).not_to have_content(investment1.title)
       expect(page).to have_content(investment2.title)
 
-      select "tag1 (1)", from: "milestone_tag"
+      select "tag1 (1)", from: "Milestone tag"
 
       expect(page).not_to have_content(investment1.title)
       expect(page).not_to have_content(investment2.title)
 
-      select "All (2)", from: "milestone_tag"
+      select "All (2)", from: "Milestone tag"
 
       expect(page).not_to have_content(investment1.title)
       expect(page).to have_content(investment2.title)

--- a/spec/system/budgets/executions_spec.rb
+++ b/spec/system/budgets/executions_spec.rb
@@ -71,6 +71,7 @@ describe "Executions" do
     expect(page).to have_content("No winner investments in this state")
 
     select "Executed (0)", from: "Project's current state"
+    click_button "Filter"
 
     expect(page).to have_content("No winner investments in this state")
   end
@@ -166,16 +167,19 @@ describe "Executions" do
       expect(page).to have_content(investment2.title)
 
       select "Studying the project (1)", from: "Project's current state"
+      click_button "Filter"
 
       expect(page).to have_content(investment1.title)
       expect(page).not_to have_content(investment2.title)
 
       select "Bidding (1)", from: "Project's current state"
+      click_button "Filter"
 
       expect(page).to have_content(investment2.title)
       expect(page).not_to have_content(investment1.title)
 
       select "Executing the project (0)", from: "Project's current state"
+      click_button "Filter"
 
       expect(page).not_to have_content(investment1.title)
       expect(page).not_to have_content(investment2.title)
@@ -195,9 +199,13 @@ describe "Executions" do
       click_link "Milestones"
 
       select "Studying the project (0)", from: "Project's current state"
+      click_button "Filter"
+
       expect(page).not_to have_content(investment1.title)
 
       select "Bidding (1)", from: "Project's current state"
+      click_button "Filter"
+
       expect(page).to have_content(investment1.title)
     end
 
@@ -215,9 +223,13 @@ describe "Executions" do
       click_link "Milestones"
 
       select "Studying the project (1)", from: "Project's current state"
+      click_button "Filter"
+
       expect(page).to have_content(investment1.title)
 
       select "Bidding (0)", from: "Project's current state"
+      click_button "Filter"
+
       expect(page).not_to have_content(investment1.title)
     end
 
@@ -241,26 +253,26 @@ describe "Executions" do
       expect(page).to have_content(investment2.title)
 
       select "tag2 (2)", from: "Milestone tag"
-
-      expect(page).to have_content(investment1.title)
-      expect(page).to have_content(investment2.title)
-
       select "Studying the project (1)", from: "Project's current state"
+      click_button "Filter"
 
       expect(page).to have_content(investment1.title)
       expect(page).not_to have_content(investment2.title)
 
       select "Bidding (1)", from: "Project's current state"
+      click_button "Filter"
 
       expect(page).not_to have_content(investment1.title)
       expect(page).to have_content(investment2.title)
 
       select "tag1 (1)", from: "Milestone tag"
+      click_button "Filter"
 
       expect(page).not_to have_content(investment1.title)
       expect(page).not_to have_content(investment2.title)
 
       select "All (2)", from: "Milestone tag"
+      click_button "Filter"
 
       expect(page).not_to have_content(investment1.title)
       expect(page).to have_content(investment2.title)


### PR DESCRIPTION
## References

* Continues #4566

## Objectives

* Fix accessibility issues for keyboard users when submitting the form to filter budget executions
* Make it easier to set and submit both filters simultaneously

## Visual Changes

### Before these changes

![The form to filter budget executions has one field on the left of the screen, another one on the right, and no submit button](https://user-images.githubusercontent.com/35156/123828467-cfd57680-d901-11eb-8f31-d8d137943b9d.png)

### After these changes

![The form to filter budget executions has two fields and a submit button, all grouped together](https://user-images.githubusercontent.com/35156/123828474-d106a380-d901-11eb-995c-2f73647823d2.png)
