### PR TITLE
Make campaign specs more robust

### DIFF
--- a/spec/system/campaigns_spec.rb
+++ b/spec/system/campaigns_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe "Email campaigns", :admin do
-  let(:campaign1) { create(:campaign) }
-  let(:campaign2) { create(:campaign) }
+  let!(:campaign1) { create(:campaign) }
+  let!(:campaign2) { create(:campaign) }
 
   scenario "Track email templates" do
     3.times { visit root_path(track_id: campaign1.track_id) }

--- a/spec/system/campaigns_spec.rb
+++ b/spec/system/campaigns_spec.rb
@@ -21,7 +21,7 @@ describe "Email campaigns", :admin do
 
   scenario "Do not track erroneous track_ids" do
     visit root_path(track_id: campaign1.track_id)
-    visit root_path(track_id: "999")
+    visit root_path(track_id: Campaign.last.id + 1)
 
     visit admin_stats_path
     click_link campaign1.name


### PR DESCRIPTION
## References

* One of these tests failed in our [test run 1858, job 3](https://github.com/consul/consul/runs/2952333023)

## Objectives

* Make sure campaigns are created in the database before testing they don't appear on the page
* Make sure we use non-existent IDs when testing visits to non-existent campaigns
* Try to fix a `PG::ProtocolViolation` error we got in out test, which might be caused by creating records in the test after the browser process had started