### PR TITLE
Hide SDG columns on admin polls if SDG feature is disabled

### DIFF
--- a/app/views/admin/legislation/processes/index.html.erb
+++ b/app/views/admin/legislation/processes/index.html.erb
@@ -20,8 +20,10 @@
         <th class="text-center"><%= t("admin.legislation.processes.process.start_date") %></th>
         <th class="text-center"><%= t("admin.legislation.processes.process.end_date") %></th>
         <th class="text-center"><%= t("admin.legislation.processes.process.comments") %></th>
-        <th class="text-center"><%= SDG::Goal.model_name.human(count: :other).upcase_first %></th>
-        <th class="text-center"><%= SDG::Target.model_name.human(count: :other).upcase_first %></th>
+        <% if feature?(:sdg) %>
+          <th class="text-center"><%= SDG::Goal.model_name.human(count: :other).upcase_first %></th>
+          <th class="text-center"><%= SDG::Target.model_name.human(count: :other).upcase_first %></th>
+        <% end %>
         <th><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
@@ -34,8 +36,10 @@
           <td class="text-center"><%= I18n.l process.start_date %></td>
           <td class="text-center"><%= I18n.l process.end_date %></td>
           <td class="text-center"><%= process.total_comments %></td>
-          <td class="text-center"><%= process.sdg_goal_list %></td>
-          <td class="text-center"><%= process.sdg_target_list %></td>
+          <% if feature?(:sdg) %>
+            <td class="text-center"><%= process.sdg_goal_list %></td>
+            <td class="text-center"><%= process.sdg_target_list %></td>
+          <% end %>
           <td><%= render Admin::TableActionsComponent.new(process) %></td>
         </tr>
       <% end %>

--- a/app/views/admin/poll/polls/_poll.html.erb
+++ b/app/views/admin/poll/polls/_poll.html.erb
@@ -2,8 +2,10 @@
   <td><strong><%= poll.name %></strong></td>
   <td class="text-center"><%= l poll.starts_at.to_date %></td>
   <td class="text-center"><%= l poll.ends_at.to_date %></td>
-  <td class="text-center"><%= poll.sdg_goal_list %></td>
-  <td class="text-center"><%= poll.sdg_target_list %></td>
+  <% if feature?(:sdg) %>
+    <td class="text-center"><%= poll.sdg_goal_list %></td>
+    <td class="text-center"><%= poll.sdg_target_list %></td>
+  <% end %>
   <td>
     <%= render Admin::TableActionsComponent.new(poll,
       destroy_confirmation: t("admin.polls.destroy.alert")

--- a/app/views/admin/poll/polls/index.html.erb
+++ b/app/views/admin/poll/polls/index.html.erb
@@ -14,8 +14,10 @@
       <th class="small-5"><%= t("admin.polls.index.name") %></th>
       <th class="text-center"><%= t("admin.polls.index.start_date") %></th>
       <th class="text-center"><%= t("admin.polls.index.closing_date") %></th>
-      <th class="text-center"><%= SDG::Goal.model_name.human(count: :other).upcase_first %></th>
-      <th class="text-center"><%= SDG::Target.model_name.human(count: :other).upcase_first %></th>
+      <% if feature?(:sdg) %>
+        <th class="text-center"><%= SDG::Goal.model_name.human(count: :other).upcase_first %></th>
+        <th class="text-center"><%= SDG::Target.model_name.human(count: :other).upcase_first %></th>
+      <% end %>
       <th><%= t("admin.actions.actions") %></th>
     </thead>
     <tbody>

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -371,6 +371,22 @@ describe "Admin collaborative legislation", :admin do
       Setting["sdg.process.legislation"] = true
     end
 
+    scenario "do not show SDG columns if disabled" do
+      process = create(:legislation_process, title: "Legislation process with SDG related content")
+      process.sdg_goals = [SDG::Goal[1], SDG::Goal[17]]
+
+      Setting["feature.sdg"] = false
+
+      visit admin_legislation_processes_path
+
+      expect(page).not_to have_content "Goals"
+      expect(page).not_to have_content "Targets"
+
+      within "tr", text: "Legislation process with SDG related content" do
+        expect(page).not_to have_content "1, 17"
+      end
+    end
+
     scenario "create Collaborative Legislation with sdg related list" do
       visit new_admin_legislation_process_path
       fill_in "Process Title", with: "Legislation process with SDG related content"

--- a/spec/system/admin/poll/polls_spec.rb
+++ b/spec/system/admin/poll/polls_spec.rb
@@ -526,6 +526,22 @@ describe "Admin polls", :admin do
       Setting["sdg.process.polls"] = true
     end
 
+    scenario "do not show SDG columns if disabled" do
+      poll = create(:poll, name: "Poll with SDG related content")
+      poll.sdg_goals = [SDG::Goal[1], SDG::Goal[17]]
+
+      Setting["feature.sdg"] = false
+
+      visit admin_polls_path
+
+      expect(page).not_to have_content "Goals"
+      expect(page).not_to have_content "Targets"
+
+      within "tr", text: "Poll with SDG related content" do
+        expect(page).not_to have_content "1, 17"
+      end
+    end
+
     scenario "create poll with sdg related list" do
       visit new_admin_poll_path
       fill_in "Name", with: "Upcoming poll with SDG related content"


### PR DESCRIPTION
## Objectives

Now in `/admin/polls/` and `/admin/legislation/processes` the **Goals** and **Targets** columns appear although the SDG feature is disabled. It can be confusing for administrators because when they edit the poll no SDGs related fields appear.

This PR hide SDG columns on admin polls and processes index if SDG feature is disabled.

## Visual Changes

### Before 
_(with SDG feature disabled)_
<img width="1317" alt="before" src="https://user-images.githubusercontent.com/631897/124258197-6a65cd80-db2d-11eb-9a54-4be09272fc41.png">

### After
_(with SDG feature disabled)_
<img width="1314" alt="after" src="https://user-images.githubusercontent.com/631897/124258207-6cc82780-db2d-11eb-94e5-c956a7802481.png">
