### PR TITLE
Fix content and line-height in SVG font icons

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,8 @@
 @import "font-awesome-sprockets";
 @import "font-awesome/variables";
 @import "font-awesome/path";
+@import "font-awesome/mixins";
+@import "font-awesome/core";
 @import "jquery-ui/autocomplete";
 @import "jquery-ui/datepicker";
 @import "jquery-ui/sortable";

--- a/app/assets/stylesheets/mixins/icons.scss
+++ b/app/assets/stylesheets/mixins/icons.scss
@@ -7,7 +7,7 @@
 %svg-icon {
   @supports (mask-image: url()) {
     background: currentcolor;
-    content: "";
+    content: "" !important;
     height: 1em;
     mask-repeat: no-repeat;
     mask-size: 100% 100%;

--- a/app/assets/stylesheets/mixins/icons.scss
+++ b/app/assets/stylesheets/mixins/icons.scss
@@ -1,5 +1,5 @@
 %font-icon {
-  display: inline-block;
+  @extend %fa-icon;
   font-family: "Font Awesome 5 Free";
   vertical-align: middle;
 }


### PR DESCRIPTION
## References

* The issue was introduced in pull request #4516

## Background

In commit 4d49ec8ef we replaced an `@extend .fa-` clause with a `content: fa-content()` clause.

With the `@extend` clause, the `content:` property appeared wherever the `.fa-` selector was defined, so we later overwrote it in our `%svg-icon` selector, which was defined later in the generated CSS.

Defining the property with `content: fa-content()`, on the other hand, caused the `content:` property to appear wherever we used the mixin with `@include has-fa-icon`. That meant our `%svg-icon` selector would appear before it, and would not overwrite it.

## Objectives

* Make sure SVG icons don't have an illegible character as content
* Fix a `line-height` issue with SVG icons
* Include font awesome mixins again so they're available to other Consul installations

## Visual changes

### Before these changes

![There's a blank space between the bottom of the admin menu and the bottom of the browser window](https://user-images.githubusercontent.com/35156/124305164-0232de00-db65-11eb-9151-c38ef4d0e96c.png)

### After these changes

![There's no blanck space between the bottom of the admin menu and the bottom of the browser window](https://user-images.githubusercontent.com/35156/124305179-07902880-db65-11eb-9803-6b3502a928cf.png)

## Notes

We could modify a few things and make the code more complicate in order to avoid that. In this case, however, it's easier to add an `!important` flag; after all, it is indeed important that SVG icons have no content so screen readers don't try to announce illegible characters.