### PR TITLE
Remove ES6-specific syntax in amsify suggestags

### DIFF
--- a/vendor/assets/javascripts/jquery.amsify.suggestags.js
+++ b/vendor/assets/javascripts/jquery.amsify.suggestags.js
@@ -506,7 +506,11 @@ var AmsifySuggestags;
 			return listHTML;
 		},
 
-		addTag : function(value, animate=true) {
+		addTag : function(value, animate) {
+			if(animate === undefined) {
+				animate = true;
+			}
+
 			if(!value) {
                 return;
 			}
@@ -624,7 +628,11 @@ var AmsifySuggestags;
             }
 		},
 
-		removeTag: function(value, animate=true) {
+		removeTag: function(value, animate) {
+			if(animate === undefined) {
+				animate = true;
+			}
+
 			var _self = this;
 			$findTags = $(this.selectors.inputArea).find('[data-val="'+value+'"]');
 			if($findTags.length) {


### PR DESCRIPTION
## References

* We added amsify suggestags in pull request #4315

## Objectives

* Make sure JavaScript loads in old browsers which don't support the ES6 syntax.

## Notes

We don't officially guarantee all JavaScript will work on old browsers, but we do our best to make the page usable to a reasonable degree on them because the main goal of CONSUL is to help organizing participatory processes where all citizens can participate.

We're getting warnings from ESLint. However, we're ignoring them since this is a vendor file and follows its own conventions.