### PR TITLE
Do not show confirm message if user can vote in all headings

### DIFF
--- a/app/components/budgets/investments/votes_component.rb
+++ b/app/components/budgets/investments/votes_component.rb
@@ -45,7 +45,7 @@ class Budgets::Investments::VotesComponent < ApplicationComponent
     def display_support_alert?
       current_user &&
         !current_user.voted_in_group?(investment.group) &&
-        investment.group.headings.count > 1
+        investment.group.headings.count > investment.group.max_votable_headings
     end
 
     def confirm_vote_message

--- a/spec/system/budgets/votes_spec.rb
+++ b/spec/system/budgets/votes_spec.rb
@@ -198,6 +198,16 @@ describe "Votes" do
 
         expect(page.driver.send(:find_modal).text).to match "You can only support investments in 2 districts."
       end
+
+      scenario "Do not show confirm message if user can vote in all headings" do
+        group.update!(max_votable_headings: group.headings.count)
+
+        visit budget_investments_path(budget, heading_id: new_york.id)
+        click_button "Support"
+
+        expect(page).to have_content "1 support"
+        expect(page).to have_content "You have already supported this investment project. Share it!"
+      end
     end
   end
 


### PR DESCRIPTION
## Objectives

In the Participatory Budgets during the "Selecting projects" phase, an alert appears warning the user of the number of headings in which he can support projects. The problem is that this message appears whenever there is more than 1 heading, although the user can select projects in all headings.

<img width="440" alt="support_alert" src="https://user-images.githubusercontent.com/631897/125637593-fbb400df-8005-4024-9ebb-9822105f4906.png">

This PR changes that the message only appears when the user can select in less headings than the maximum number of headings. 

For a group of 4 headings, if the Maximum number of headings in which a user can select projects:

`= 4: the message don't appear.`
`< 4: the message appears.`

