### PR TITLE
Fix outline position for header logo

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -625,6 +625,7 @@ body > header,
   }
 
   .top-bar-title {
+    display: flex;
     line-height: $line-height;
     margin-right: 0;
 


### PR DESCRIPTION
## Objectives

For accessibility issues when a link is in the focus state an outline is shown helping the user to know where he has clicked and also to help when navigating using the keyboard.

This PR fixes the alignment of the main CONSUL logo outline in the header.

## Visual Changes

### Before
<img width="537" alt="before" src="https://user-images.githubusercontent.com/631897/125639439-2ad5d680-81a2-46bf-9696-dd6ae3441548.png">

### After
<img width="502" alt="after" src="https://user-images.githubusercontent.com/631897/125639450-4a3a7691-f40c-4b22-a32d-f6c4ceffea53.png">
