### PR TITLE
Fix typo in Spanish translation for "yes"

### DIFF
--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -294,7 +294,7 @@ es:
           title: Selección
         winner:
           title: Ganador
-          "true": "Si"
+          "true": "Sí"
           "false": "No"
         valuator_groups: "Grupos de evaluadores"
         preview: Vista previa

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -669,7 +669,7 @@ es:
     filter: "Filtrar"
     save: "Guardar"
     delete: "Borrar"
-    "yes": "Si"
+    "yes": "Sí"
     "no": "No"
     search_results: "Resultados de la búsqueda"
     advanced_search:


### PR DESCRIPTION
## Objectives

* Fix a typo and use "sí" instead of "si" to mean "yes"