### PR TITLE
Render investments list when budget has multiple headings

### DIFF
--- a/app/assets/stylesheets/budgets/ballot/show.scss
+++ b/app/assets/stylesheets/budgets/ballot/show.scss
@@ -1,0 +1,8 @@
+.budget-ballot-show {
+
+  > header {
+    @extend %budget-header;
+    @include grid-column-gutter;
+    padding-bottom: $line-height;
+  }
+}

--- a/app/assets/stylesheets/budgets/groups/index.scss
+++ b/app/assets/stylesheets/budgets/groups/index.scss
@@ -1,0 +1,7 @@
+.budget-groups-index {
+
+  > header {
+    @extend %budget-header;
+    @include full-width-background($adjust-padding: true);
+  }
+}

--- a/app/assets/stylesheets/budgets/groups/show.scss
+++ b/app/assets/stylesheets/budgets/groups/show.scss
@@ -1,0 +1,7 @@
+.budget-group-show {
+
+  > header {
+    @extend %budget-header;
+    @include grid-column-gutter;
+  }
+}

--- a/app/assets/stylesheets/budgets/index.scss
+++ b/app/assets/stylesheets/budgets/index.scss
@@ -1,0 +1,8 @@
+.budgets-index {
+
+  > header {
+    @extend %budget-header;
+    @include grid-column-gutter;
+    margin-bottom: $line-height;
+  }
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -67,6 +67,7 @@ body {
 main {
   display: block;
 
+  &.budget-groups-index,
   &.budget-investment-new,
   &.debate-new,
   &.proposal-new,

--- a/app/assets/stylesheets/mixins/budgets.scss
+++ b/app/assets/stylesheets/mixins/budgets.scss
@@ -1,0 +1,26 @@
+@import "mixins/buttons";
+@import "mixins/layouts";
+
+%budget-header {
+  @extend %brand-background;
+  @include full-width-background;
+
+  h1 {
+    font-size: rem-calc(60);
+    padding: $line-height * 2 0 $line-height;
+  }
+
+  h1,
+  h2,
+  p,
+  a,
+  .back,
+  .icon-angle-left,
+  .description {
+    color: inherit;
+  }
+
+  a {
+    text-decoration: underline;
+  }
+}

--- a/app/assets/stylesheets/mixins/budgets.scss
+++ b/app/assets/stylesheets/mixins/budgets.scss
@@ -7,7 +7,7 @@
 
   h1 {
     font-size: rem-calc(60);
-    padding: $line-height * 2 0 $line-height;
+    padding: $line-height 0;
   }
 
   h1,

--- a/app/assets/stylesheets/mixins/buttons.scss
+++ b/app/assets/stylesheets/mixins/buttons.scss
@@ -1,3 +1,5 @@
+@import "mixins/colors";
+
 @mixin base-button {
   font-size: $base-font-size;
 

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1095,8 +1095,8 @@
 // -----------
 
 .budget-header {
-  @extend %brand-background;
-  @include full-width-background;
+  @extend %budget-header;
+
   margin-top: -$line-height;
   min-height: $line-height * 25;
   padding-bottom: $line-height;
@@ -1120,25 +1120,6 @@
       display: block;
       width: 20%;
     }
-  }
-
-  h1 {
-    font-size: rem-calc(60);
-    padding: $line-height * 2 0 $line-height;
-  }
-
-  h1,
-  h2,
-  p,
-  a,
-  .back,
-  .icon-angle-left,
-  .description {
-    color: inherit;
-  }
-
-  a {
-    text-decoration: underline;
   }
 
   .confirmed {

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1108,6 +1108,10 @@
     background-size: cover;
   }
 
+  h1 {
+    padding-top: $line-height * 2;
+  }
+
   .budget-title {
     font-weight: bold;
     text-transform: uppercase;

--- a/app/components/budgets/groups/index_component.html.erb
+++ b/app/components/budgets/groups/index_component.html.erb
@@ -1,0 +1,8 @@
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: budget_groups_url %>
+<% end %>
+
+<main class="budget-groups-index">
+  <%= header(before: back_link_to(budget_path(budget))) %>
+  <%= render Budgets::GroupsAndHeadingsComponent.new(budget) %>
+</main>

--- a/app/components/budgets/groups/index_component.rb
+++ b/app/components/budgets/groups/index_component.rb
@@ -1,0 +1,12 @@
+class Budgets::Groups::IndexComponent < ApplicationComponent
+  include Header
+  attr_reader :budget
+
+  def initialize(budget)
+    @budget = budget
+  end
+
+  def title
+    t("budgets.groups.show.title")
+  end
+end

--- a/app/components/budgets/investments_list_component.html.erb
+++ b/app/components/budgets/investments_list_component.html.erb
@@ -14,7 +14,7 @@
   <div class="row margin-top">
     <div class="small-12 medium-6 large-4 small-centered column margin-top">
       <%= link_to t("budgets.investments_list.see_all"),
-                  budget_investments_path(budget),
+                  see_all_path,
                   class: "button expanded" %>
     </div>
   </div>

--- a/app/components/budgets/investments_list_component.html.erb
+++ b/app/components/budgets/investments_list_component.html.erb
@@ -10,7 +10,7 @@
   </section>
 <% end %>
 
-<% unless budget.informing? %>
+<% if budget.single_heading? && !budget.informing? || investments.any? %>
   <div class="row margin-top">
     <div class="small-12 medium-6 large-4 small-centered column margin-top">
       <%= link_to t("budgets.investments_list.see_all"),

--- a/app/components/budgets/investments_list_component.rb
+++ b/app/components/budgets/investments_list_component.rb
@@ -17,4 +17,12 @@ class Budgets::InvestmentsListComponent < ApplicationComponent
       budget.investments.none
     end
   end
+
+  def see_all_path
+    if budget.single_heading?
+      budget_investments_path(budget)
+    else
+      budget_groups_path(budget)
+    end
+  end
 end

--- a/app/components/budgets/investments_list_component.rb
+++ b/app/components/budgets/investments_list_component.rb
@@ -5,10 +5,6 @@ class Budgets::InvestmentsListComponent < ApplicationComponent
     @budget = budget
   end
 
-  def render?
-    budget.single_heading?
-  end
-
   def investments(limit: 9)
     case budget.phase
     when "accepting", "reviewing"

--- a/app/components/budgets/supports_info_component.html.erb
+++ b/app/components/budgets/supports_info_component.html.erb
@@ -18,12 +18,10 @@
 
     <p><%= t("budgets.supports_info.share") %></p>
 
-    <% if budget.single_heading? %>
-      <p>
-        <a href="#investments_list" class="keep-scrolling" data-smooth-scroll>
-          <%= t("budgets.supports_info.scrolling") %><br>
-        </a>
-      </p>
-    <% end %>
+    <p>
+      <a href="#investments_list" class="keep-scrolling" data-smooth-scroll>
+        <%= t("budgets.supports_info.scrolling") %><br>
+      </a>
+    </p>
   </section>
 </aside>

--- a/app/components/concerns/header.rb
+++ b/app/components/concerns/header.rb
@@ -1,7 +1,7 @@
 module Header
   extend ActiveSupport::Concern
 
-  def header(&block)
+  def header(before: nil, &block)
     provide(:title) do
       [
         t("#{namespace}.header.title", default: ""),
@@ -17,11 +17,7 @@ module Header
                   end
 
     tag.header do
-      if block_given?
-        content_tag(heading_tag, title) + capture(&block)
-      else
-        content_tag(heading_tag, title)
-      end
+      safe_join([before, content_tag(heading_tag, title), (capture(&block) if block_given?)].compact)
     end
   end
 

--- a/app/controllers/budgets/groups_controller.rb
+++ b/app/controllers/budgets/groups_controller.rb
@@ -5,7 +5,7 @@ module Budgets
     feature_flag :budgets
 
     before_action :load_budget
-    before_action :load_group
+    before_action :load_group, only: [:show]
     authorize_resource :budget
     authorize_resource :group, class: "Budget::Group"
 
@@ -13,6 +13,9 @@ module Budgets
     has_filters investment_filters, only: [:show]
 
     def show
+    end
+
+    def index
     end
 
     private

--- a/app/views/budgets/ballot/_ballot.html.erb
+++ b/app/views/budgets/ballot/_ballot.html.erb
@@ -1,20 +1,18 @@
-<div class="budget-header">
-  <div class="row">
-    <%= back_link_to session[:ballot_referer] %>
+<header>
+  <%= back_link_to session[:ballot_referer] %>
 
-    <h1 class="text-center"><%= t("budgets.ballots.show.title") %></h1>
+  <h1 class="text-center"><%= t("budgets.ballots.show.title") %></h1>
 
-    <div class="small-12 medium-8 column small-centered text-center">
-      <h2>
-        <%= sanitize(t("budgets.ballots.show.voted", count: @ballot.investments.count)) %>
-      </h2>
-      <p class="confirmed">
-        <%= t("budgets.ballots.show.voted_info") %>
-      <p>
-      <p><%= t("budgets.ballots.show.voted_info_2") %></p>
-    </div>
+  <div class="small-12 medium-8 column small-centered text-center">
+    <h2>
+      <%= sanitize(t("budgets.ballots.show.voted", count: @ballot.investments.count)) %>
+    </h2>
+    <p class="confirmed">
+      <%= t("budgets.ballots.show.voted_info") %>
+    <p>
+    <p><%= t("budgets.ballots.show.voted_info_2") %></p>
   </div>
-</div>
+</header>
 
 <div class="row ballot">
   <% ballot_groups = @ballot.groups.sort_by_name %>

--- a/app/views/budgets/ballot/show.html.erb
+++ b/app/views/budgets/ballot/show.html.erb
@@ -1,3 +1,3 @@
-<div id="ballot">
+<main id="ballot" class="budget-ballot-show">
   <%= render "budgets/ballot/ballot" %>
-</div>
+</main>

--- a/app/views/budgets/groups/index.html.erb
+++ b/app/views/budgets/groups/index.html.erb
@@ -1,0 +1,1 @@
+<%= render Budgets::Groups::IndexComponent.new(@budget) %>

--- a/app/views/budgets/groups/show.html.erb
+++ b/app/views/budgets/groups/show.html.erb
@@ -2,72 +2,70 @@
   <%= render "shared/canonical", href: budget_group_url(filter: @current_filter) %>
 <% end %>
 
-<div class="budget-header">
-  <div class="row">
-    <div class="small-12 medium-9 column">
-      <%= back_link_to budget_path(@budget) %>
-      <h2><%= t("budgets.groups.show.title") %></h2>
-    </div>
-  </div>
-</div>
+<main class="budget-group-show">
+  <header>
+    <%= back_link_to budget_path(@budget) %>
+    <h1><%= t("budgets.groups.show.title") %></h1>
+  </header>
 
-<% if @current_filter == "unfeasible" %>
-  <div class="row margin-top">
-    <div class="small-12 column">
-      <h3><%= t("budgets.groups.show.unfeasible_title") %></h3>
+  <% if @current_filter == "unfeasible" %>
+    <div class="row margin-top">
+      <div class="small-12 column">
+        <h3><%= t("budgets.groups.show.unfeasible_title") %></h3>
+      </div>
     </div>
-  </div>
-<% elsif @current_filter == "unselected" %>
-  <div class="row margin-top">
-    <div class="small-12 column">
-      <h3><%= t("budgets.groups.show.unselected_title") %></h3>
+  <% elsif @current_filter == "unselected" %>
+    <div class="row margin-top">
+      <div class="small-12 column">
+        <h3><%= t("budgets.groups.show.unselected_title") %></h3>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
 
-<div class="row margin">
-  <div id="headings" class="small-12 medium-7 column select-district">
-    <div class="row">
-      <% @group.headings.sort_by_name.each_slice(7) do |slice| %>
-        <div class="small-6 medium-4 column end">
-          <% slice.each do |heading| %>
-            <span id="<%= dom_id(heading) %>"
-                  class="<%= css_for_ballot_heading(heading) %>">
-              <%= link_to heading.name,
-                          budget_investments_path(heading_id: heading.id,
-                                                  filter: @current_filter) %><br>
-            </span>
-          <% end %>
+  <div class="row margin">
+    <div id="headings" class="small-12 medium-7 column select-district">
+      <div class="row">
+        <% @group.headings.sort_by_name.each_slice(7) do |slice| %>
+          <div class="small-6 medium-4 column end">
+            <% slice.each do |heading| %>
+              <span id="<%= dom_id(heading) %>"
+                    class="<%= css_for_ballot_heading(heading) %>">
+                <%= link_to heading.name,
+                            budget_investments_path(heading_id: heading.id,
+                                                    filter: @current_filter) %><br>
+              </span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="medium-5 column show-for-medium text-center">
+      <%= image_tag(image_path_for("map.jpg")) %>
+    </div>
+  </div>
+
+  <% if @budget.balloting_or_later? %>
+    <% unless @current_filter == "unfeasible" %>
+      <div class="row">
+        <div class="small-12 column">
+          <small>
+            <%= link_to t("budgets.groups.show.unfeasible"),
+                        budget_group_path(@budget, @group, filter: "unfeasible") %>
+          </small>
         </div>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="medium-5 column show-for-medium text-center">
-    <%= image_tag(image_path_for("map.jpg")) %>
-  </div>
-</div>
-
-<% if @budget.balloting_or_later? %>
-  <% unless @current_filter == "unfeasible" %>
-    <div class="row">
-      <div class="small-12 column">
-        <small>
-          <%= link_to t("budgets.groups.show.unfeasible"),
-                      budget_group_path(@budget, @group, filter: "unfeasible") %>
-        </small>
       </div>
-    </div>
-  <% end %>
+    <% end %>
 
-  <% unless @current_filter == "unselected" %>
-    <div class="row">
-      <div class="small-12 column">
-        <small>
-          <%= link_to t("budgets.groups.show.unselected"),
-                      budget_group_path(@budget, @group, filter: "unselected") %>
-        </small>
+    <% unless @current_filter == "unselected" %>
+      <div class="row">
+        <div class="small-12 column">
+          <small>
+            <%= link_to t("budgets.groups.show.unselected"),
+                        budget_group_path(@budget, @group, filter: "unselected") %>
+          </small>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
-<% end %>
+</main>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -6,28 +6,26 @@
   <%= render "shared/canonical", href: budgets_url %>
 <% end %>
 
-<% if @budget.present? %>
-  <%= render Budgets::BudgetComponent.new(@budget) %>
+<main class="budgets-index">
+  <% if @budget.present? %>
+    <%= render Budgets::BudgetComponent.new(@budget) %>
 
-  <% if @finished_budgets.present? %>
-    <%= render "finished", budgets: @finished_budgets %>
-  <% end %>
-<% else %>
-  <div class="budget-header margin-bottom">
+    <% if @finished_budgets.present? %>
+      <%= render "finished", budgets: @finished_budgets %>
+    <% end %>
+  <% else %>
+    <header>
+      <h1><%= t("budgets.index.title") %></h1>
+    </header>
+
     <div class="row">
-      <div class="small-12 medium-9 column">
-          <h1><%= t("budgets.index.title") %></h1>
+      <div class="small-12 column">
+        <div class="callout primary">
+          <%= t("budgets.index.empty_budgets") %>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 
-  <div class="row">
-    <div class="small-12 column">
-      <div class="callout primary">
-        <%= t("budgets.index.empty_budgets") %>
-      </div>
-    </div>
-  </div>
-<% end %>
-
-<%= render Budgets::FooterComponent.new %>
+  <%= render Budgets::FooterComponent.new %>
+</main>

--- a/config/routes/budget.rb
+++ b/config/routes/budget.rb
@@ -1,5 +1,5 @@
 resources :budgets, only: [:show, :index] do
-  resources :groups, controller: "budgets/groups", only: [:show]
+  resources :groups, controller: "budgets/groups", only: [:show, :index]
   resources :investments, controller: "budgets/investments" do
     member do
       put :flag

--- a/spec/components/budgets/investments_list_component_spec.rb
+++ b/spec/components/budgets/investments_list_component_spec.rb
@@ -170,7 +170,7 @@ describe Budgets::InvestmentsListComponent, type: :component do
           render_inline Budgets::InvestmentsListComponent.new(budget)
 
           expect(page).to have_link "See all investments",
-                                    href: budget_investments_path(budget)
+                                    href: budget_groups_path(budget)
         end
       end
     end

--- a/spec/components/budgets/investments_list_component_spec.rb
+++ b/spec/components/budgets/investments_list_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Budgets::InvestmentsListComponent, type: :component do
-  describe "#investments_preview_list" do
+  describe "#investments" do
     let(:budget)    { create(:budget, :accepting) }
     let(:group)     { create(:budget_group, budget: budget) }
     let(:heading)   { create(:budget_heading, group: group) }

--- a/spec/components/budgets/investments_list_component_spec.rb
+++ b/spec/components/budgets/investments_list_component_spec.rb
@@ -115,15 +115,15 @@ describe Budgets::InvestmentsListComponent, type: :component do
       end
     end
 
-    it "is not rendered for budgets with multiple headings" do
+    it "is rendered for budgets with multiple headings" do
       create(:budget_heading, budget: budget)
 
-      Budget::Phase::PHASE_KINDS.each do |phase_name|
+      (Budget::Phase::PHASE_KINDS - %w[informing finished]).each do |phase_name|
         budget.phase = phase_name
 
         render_inline Budgets::InvestmentsListComponent.new(budget)
 
-        expect(page.native.inner_html).to be_empty
+        expect(page).to have_content "List of investments"
       end
     end
   end
@@ -147,6 +147,31 @@ describe Budgets::InvestmentsListComponent, type: :component do
 
         expect(page).to have_link "See all investments",
                                   href: budget_investments_path(budget)
+      end
+    end
+
+    context "budget with multiple headings" do
+      before { create(:budget_heading, budget: budget) }
+
+      it "is not shown in the informing or finished phases" do
+        %w[informing finished].each do |phase_name|
+          budget.phase = phase_name
+
+          render_inline Budgets::InvestmentsListComponent.new(budget)
+
+          expect(page).not_to have_link "See all investments"
+        end
+      end
+
+      it "is shown in all other phases" do
+        (Budget::Phase::PHASE_KINDS - %w[informing finished]).each do |phase_name|
+          budget.phase = phase_name
+
+          render_inline Budgets::InvestmentsListComponent.new(budget)
+
+          expect(page).to have_link "See all investments",
+                                    href: budget_investments_path(budget)
+        end
       end
     end
   end

--- a/spec/components/budgets/supports_info_component_spec.rb
+++ b/spec/components/budgets/supports_info_component_spec.rb
@@ -16,12 +16,12 @@ describe Budgets::SupportsInfoComponent, type: :component do
     expect(page).to have_link "Keep scrolling to see all ideas"
   end
 
-  it "when budget has multiple headings the link to see all ideas is not rendered" do
+  it "renders the link to see all ideas when there are multiple headings" do
     create_list(:budget_heading, 2, group: group)
 
     render_inline component
 
-    expect(page).not_to have_link "Keep scrolling to see all ideas"
+    expect(page).to have_link "Keep scrolling to see all ideas"
   end
 
   it "does not render anything when the budget is not selecting" do

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -319,7 +319,7 @@ describe "Budgets" do
                                 href: budget_investments_path(budget)
     end
 
-    scenario "Do not show investments list when budget has multiple headings" do
+    scenario "Show investments list when budget has multiple headings" do
       budget = create(:budget, phase: "accepting")
       group = create(:budget_group, budget: budget)
       heading_1 = create(:budget_heading, group: group)
@@ -329,7 +329,7 @@ describe "Budgets" do
 
       visit budget_path(budget)
 
-      expect(page).not_to have_css ".investments-list"
+      expect(page).to have_css ".investments-list"
     end
 
     scenario "Show supports info on selecting phase" do

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -313,27 +313,13 @@ describe "Budgets" do
       visit budget_path(budget)
       expect(page).not_to have_link "See all investments"
 
-      %w[accepting reviewing selecting valuating].each do |phase_name|
+      (Budget::Phase::PHASE_KINDS - ["informing"]).each do |phase_name|
         budget.update!(phase: phase_name)
 
         visit budget_path(budget)
         expect(page).to have_link "See all investments",
                                   href: budget_investments_path(budget)
       end
-
-      %w[publishing_prices balloting reviewing_ballots].each do |phase_name|
-        budget.update!(phase: phase_name)
-
-        visit budget_path(budget)
-        expect(page).to have_link "See all investments",
-                                  href: budget_investments_path(budget)
-      end
-
-      budget.update!(phase: "finished")
-
-      visit budget_path(budget)
-      expect(page).to have_link "See all investments",
-                                  href: budget_investments_path(budget)
     end
 
     scenario "Show investments list" do

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -301,107 +301,35 @@ describe "Budgets" do
       expect(page).to have_link "See results"
     end
 
-    scenario "Show link to see all investments" do
-      budget = create(:budget)
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
-
-      create_list(:budget_investment, 3, :selected, heading: heading, price: 999)
-
-      budget.update!(phase: "informing")
-
-      visit budget_path(budget)
-      expect(page).not_to have_link "See all investments"
-
-      (Budget::Phase::PHASE_KINDS - ["informing"]).each do |phase_name|
-        budget.update!(phase: phase_name)
-
-        visit budget_path(budget)
-        expect(page).to have_link "See all investments",
-                                  href: budget_investments_path(budget)
-      end
-    end
-
     scenario "Show investments list" do
-      budget = create(:budget)
+      budget = create(:budget, phase: "balloting")
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group)
 
       create_list(:budget_investment, 3, :selected, heading: heading, price: 999)
-
-      %w[informing finished].each do |phase_name|
-        budget.update!(phase: phase_name)
-
-        visit budget_path(budget)
-
-        expect(page).not_to have_content "List of investments"
-        expect(page).not_to have_css ".investments-list"
-        expect(page).not_to have_css ".budget-investment"
-      end
-
-      %w[accepting reviewing selecting].each do |phase_name|
-        budget.update!(phase: phase_name)
-
-        visit budget_path(budget)
-
-        within(".investments-list") do
-          expect(page).to have_content "List of investments"
-          expect(page).not_to have_content "SUPPORTS"
-          expect(page).not_to have_content "PRICE"
-        end
-      end
-
-      budget.update!(phase: "valuating")
 
       visit budget_path(budget)
 
       within(".investments-list") do
         expect(page).to have_content "List of investments"
-        expect(page).to have_content("SUPPORTS", count: 3)
-        expect(page).not_to have_content "PRICE"
+        expect(page).to have_content "PRICE", count: 3
       end
 
-      %w[publishing_prices balloting reviewing_ballots].each do |phase_name|
-        budget.update!(phase: phase_name)
-
-        visit budget_path(budget)
-
-        within(".investments-list") do
-          expect(page).to have_content "List of investments"
-          expect(page).to have_content("PRICE", count: 3)
-        end
-      end
+      expect(page).to have_link "See all investments",
+                                href: budget_investments_path(budget)
     end
 
     scenario "Do not show investments list when budget has multiple headings" do
-      budget = create(:budget)
+      budget = create(:budget, phase: "accepting")
       group = create(:budget_group, budget: budget)
       heading_1 = create(:budget_heading, group: group)
       create(:budget_heading, group: group)
 
       create_list(:budget_investment, 3, :selected, heading: heading_1, price: 999)
 
-      %w[accepting reviewing selecting].each do |phase_name|
-        budget.update!(phase: phase_name)
-
-        visit budget_path(budget)
-
-        expect(page).not_to have_css ".investments-list"
-      end
-
-      budget.update!(phase: "valuating")
-
       visit budget_path(budget)
 
       expect(page).not_to have_css ".investments-list"
-
-      %w[publishing_prices balloting reviewing_ballots].each do |phase_name|
-        budget.update!(phase: phase_name)
-
-        visit budget_path(budget)
-
-        expect(page).not_to have_css ".investments-list"
-      end
     end
 
     scenario "Show supports info on selecting phase" do

--- a/spec/system/budgets/groups_spec.rb
+++ b/spec/system/budgets/groups_spec.rb
@@ -53,4 +53,16 @@ describe "Budget Groups" do
       expect(page).to have_current_path budget_path(budget)
     end
   end
+
+  context "Index" do
+    scenario "Render headings" do
+      create(:budget_heading, group: group, name: "New heading name")
+
+      visit budget_groups_path(budget)
+
+      expect(page).to have_content "Select a heading"
+      expect(page).to have_link "New heading name"
+      expect(page).to have_link "Go back", href: budget_path(budget)
+    end
+  end
 end


### PR DESCRIPTION
## References
Related PR's: #4198 #4507 

## Objectives
Render investments list component in all budgets types:
- We make this change to unify the index/show budget pages. This way both single and multiple budgets will render the investments list component.
- When budget has multiple headings, the link "see all investments" we redirect to budget groups index page

## Visual Changes
![Budget groups index page](https://user-images.githubusercontent.com/16189/127130146-1a25d9b3-294f-4cfb-a5ed-8737d47193bd.png)

