### PR TITLE
Use a rake task to delete cached attachments

### DIFF
--- a/app/assets/javascripts/documentable.js
+++ b/app/assets/javascripts/documentable.js
@@ -115,7 +115,8 @@
       $("#max-documents-notice").removeClass("hide");
     },
     initializeRemoveCachedDocumentLinks: function() {
-      $("#nested-documents").on("ajax:complete", "a.remove-cached-attachment", function() {
+      $("#nested-documents").on("click", "a.remove-cached-attachment", function(event) {
+        event.preventDefault();
         App.Documentable.unlockUploads();
         $(this).closest(".direct-upload").remove();
       });

--- a/app/assets/javascripts/imageable.js
+++ b/app/assets/javascripts/imageable.js
@@ -119,7 +119,8 @@
       }
     },
     initializeRemoveCachedImageLinks: function() {
-      $("#nested-image").on("ajax:complete", "a.remove-cached-attachment", function() {
+      $("#nested-image").on("click", "a.remove-cached-attachment", function(event) {
+        event.preventDefault();
         $("#new_image_link").removeClass("hide");
         $(this).closest(".direct-upload").remove();
       });

--- a/app/components/documents/fields_component.rb
+++ b/app/components/documents/fields_component.rb
@@ -18,16 +18,7 @@ class Documents::FieldsComponent < ApplicationComponent
 
     def destroy_link
       if !document.persisted? && document.cached_attachment.present?
-        link_to t("documents.form.delete_button"),
-          direct_upload_destroy_path(
-            "direct_upload[resource_type]": document.documentable_type,
-            "direct_upload[resource_id]": document.documentable_id,
-            "direct_upload[resource_relation]": "documents",
-            "direct_upload[cached_attachment]": document.cached_attachment
-          ),
-          method: :delete,
-          remote: true,
-          class: "delete remove-cached-attachment"
+        link_to t("documents.form.delete_button"), "#", class: "delete remove-cached-attachment"
       else
         link_to_remove_association document.new_record? ? t("documents.form.cancel_button") : t("documents.form.delete_button"), f, class: "delete remove-document"
       end

--- a/app/components/images/fields_component.rb
+++ b/app/components/images/fields_component.rb
@@ -19,16 +19,7 @@ class Images::FieldsComponent < ApplicationComponent
 
     def destroy_link
       if !image.persisted? && image.cached_attachment.present?
-        link_to t("images.form.delete_button"),
-          direct_upload_destroy_path(
-            "direct_upload[resource_type]": image.imageable_type,
-            "direct_upload[resource_id]": image.imageable_id,
-            "direct_upload[resource_relation]": "image",
-            "direct_upload[cached_attachment]": image.cached_attachment
-          ),
-          method: :delete,
-          remote: true,
-          class: "delete remove-cached-attachment"
+        link_to t("images.form.delete_button"), "#", class: "delete remove-cached-attachment"
       else
         link_to_remove_association t("images.form.delete_button"), f, class: "delete remove-image"
       end

--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -20,20 +20,8 @@ class DirectUploadsController < ApplicationController
                      destroy_link: render_destroy_upload_link(@direct_upload),
                      attachment_url: @direct_upload.relation.attachment.url }
     else
-      @direct_upload.destroy_attachment
       render json: { errors: @direct_upload.errors[:attachment].join(", ") },
              status: 422
-    end
-  end
-
-  def destroy
-    @direct_upload = DirectUpload.new(direct_upload_params.merge(user: current_user))
-    @direct_upload.relation.set_attachment_from_cached_attachment
-
-    if @direct_upload.destroy_attachment
-      render json: :ok
-    else
-      render json: :error
     end
   end
 

--- a/app/helpers/direct_uploads_helper.rb
+++ b/app/helpers/direct_uploads_helper.rb
@@ -1,16 +1,6 @@
 module DirectUploadsHelper
   def render_destroy_upload_link(direct_upload)
     label = direct_upload.resource_relation == "image" ? "images" : "documents"
-    link_to t("#{label}.form.delete_button"),
-            direct_upload_destroy_path(
-              "direct_upload[resource_type]": direct_upload.resource_type,
-              "direct_upload[resource_id]": direct_upload.resource_id,
-              "direct_upload[resource_relation]": direct_upload.resource_relation,
-              "direct_upload[cached_attachment]": direct_upload.relation.cached_attachment,
-              format: :json
-            ),
-            method: :delete,
-            remote: true,
-            class: "delete remove-cached-attachment"
+    link_to t("#{label}.form.delete_button"), "#", class: "delete remove-cached-attachment"
   end
 end

--- a/app/models/direct_upload.rb
+++ b/app/models/direct_upload.rb
@@ -37,10 +37,6 @@ class DirectUpload
     @relation.attachment.save
   end
 
-  def destroy_attachment
-    @relation.attachment.destroy
-  end
-
   def persisted?
     false
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -30,7 +30,6 @@ class Image < ApplicationRecord
   validate :validate_image_dimensions, if: -> { attachment.present? && attachment.dirty? }
 
   before_save :set_attachment_from_cached_attachment, if: -> { cached_attachment.present? }
-  after_save :remove_cached_attachment,               if: -> { cached_attachment.present? }
 
   def set_cached_attachment_from_attachment
     self.cached_attachment = if Paperclip::Attachment.default_options[:storage] == :filesystem
@@ -119,13 +118,5 @@ class Image < ApplicationRecord
 
     def attachment_of_valid_content_type?
       attachment.present? && imageable_accepted_content_types.include?(attachment_content_type)
-    end
-
-    def remove_cached_attachment
-      image = Image.new(imageable: imageable,
-                        cached_attachment: cached_attachment,
-                        user: user)
-      image.set_attachment_from_cached_attachment
-      image.attachment.destroy
     end
 end

--- a/config/routes/direct_upload.rb
+++ b/config/routes/direct_upload.rb
@@ -1,2 +1,1 @@
 resources :direct_uploads, only: [:create]
-delete "direct_uploads/destroy", to: "direct_uploads#destroy", as: :direct_upload_destroy

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -36,6 +36,10 @@ end
 #   rake "dashboards:send_notifications"
 # end
 
+every 1.day, at: "1:00 am", roles: [:cron] do
+  rake "files:remove_old_cached_attachments"
+end
+
 every 1.day, at: "3:00 am", roles: [:cron] do
   rake "votes:reset_hot_score"
 end

--- a/lib/tasks/files.rake
+++ b/lib/tasks/files.rake
@@ -1,0 +1,18 @@
+namespace :files do
+  desc "Removes cached attachments which weren't deleted for some reason"
+  task remove_old_cached_attachments: :environment do
+    paths = Dir.glob(Rails.root.join("public/system/*/cached_attachments/**/*"))
+    logger = ApplicationLogger.new
+
+    paths.each do |path|
+      if File.file?(path)
+        if File.mtime(path) < 1.day.ago
+          File.delete(path)
+          logger.info "The file #{path} has been removed"
+        end
+      else
+        Dir.delete(path) if Dir.empty?(path)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/files_spec.rb
+++ b/spec/lib/tasks/files_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "files tasks" do
+  describe "remove_old_cached_attachments" do
+    let(:run_rake_task) do
+      Rake::Task["files:remove_old_cached_attachments"].reenable
+      Rake.application.invoke_task("files:remove_old_cached_attachments")
+    end
+
+    it "deletes old cached attachments" do
+      image = build(:image)
+      document = build(:document)
+
+      image.attachment.save
+      document.attachment.save
+
+      travel_to(2.days.from_now) { run_rake_task }
+
+      expect(File.exists?(image.attachment.path)).to be false
+      expect(File.exists?(document.attachment.path)).to be false
+    end
+
+    it "does not delete recent cached attachments" do
+      image = build(:image)
+      document = build(:document)
+
+      image.attachment.save
+      document.attachment.save
+
+      travel_to(2.minutes.from_now) { run_rake_task }
+
+      expect(File.exists?(image.attachment.path)).to be true
+      expect(File.exists?(document.attachment.path)).to be true
+    end
+
+    it "does not delete old regular attachments" do
+      image = create(:image)
+      document = create(:document)
+
+      travel_to(2.days.from_now) { run_rake_task }
+
+      expect(File.exists?(image.attachment.path)).to be true
+      expect(File.exists?(document.attachment.path)).to be true
+    end
+  end
+end

--- a/spec/models/direct_upload_spec.rb
+++ b/spec/models/direct_upload_spec.rb
@@ -43,16 +43,4 @@ describe DirectUpload do
       expect(proposal_document_direct_upload.relation.attachment.path).to include("cached_attachments")
     end
   end
-
-  context "destroy_attachment" do
-    it "removes uploaded file" do
-      proposal_document_direct_upload = build(:direct_upload, :proposal, :documents)
-
-      proposal_document_direct_upload.save_attachment
-      uploaded_path = proposal_document_direct_upload.relation.attachment.path
-      proposal_document_direct_upload.destroy_attachment
-
-      expect(File.exist?(uploaded_path)).to eq(false)
-    end
-  end
 end


### PR DESCRIPTION
## Background

Our previous system to delete cached attachments didn't work for documents because the `custom_hash_data` is different for files created from a file and files created from cached attachments.

When creating a document attachment, the name of the file is taken into account to calculate the hash. Let's say the original file name is "logo.pdf", and the generated hash is "123456". The cached attachment will be "123456.pdf", so the generated hash using the cached attachment will be something different, like "28af3". So the file that will be removed will be "28af3.pdf", and not "123456.pdf", which will still be present.

Furthermore, there are times where users choose a file and then they close the browser or go to a different page. In those cases, we weren't deleting the cached attachments either.

## Objectives

* Fix a bug where cached document attachments weren't correctly deleted
* Improve the user experience removing a cached attachment  by making it instantaneous

## Notes

There's related a bug in documents: when editing a record (for example, a proposal), if the title of the document changes, its hash
changes, and so it will be impossible to generate a link to that document. Changing the way this hash is generated is not an option because it would break links to existing files. We'll fix it when moving to Active Storage in pull request #4600.