### PR TITLE
Fix rubocop convention offenses

### DIFF
--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -316,7 +316,7 @@ describe "Advanced search" do
 
       scenario "Search by multiple filters" do
         Setting["official_level_1_name"] = "Official position 1"
-        ana  = create :user, official_level: 1
+        ana = create :user, official_level: 1
         john = create :user, official_level: 1
 
         create(:budget_investment, heading: heading, title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -531,7 +531,7 @@ describe "Budget Investments" do
 
       fill_in "Title", with: "I am a bot"
       fill_in_ckeditor "Description", with: "This is the description"
-      check   "budget_investment_terms_of_service"
+      check "budget_investment_terms_of_service"
 
       click_button "Create Investment"
 

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -342,9 +342,9 @@ describe "Emails" do
   end
 
   context "Budgets" do
-    let(:author)   { create(:user, :level_two) }
-    let(:budget)   { create(:budget) }
-    let!(:heading) { create(:budget_heading, name: "More hospitals", budget: budget) }
+    let(:author) { create(:user, :level_two) }
+    let(:budget) { create(:budget) }
+    before { create(:budget_heading, name: "More hospitals", budget: budget) }
 
     scenario "Investment created" do
       login_as(author)
@@ -352,7 +352,7 @@ describe "Emails" do
 
       fill_in "Title", with: "Build a hospital"
       fill_in_ckeditor "Description", with: "We have lots of people that require medical attention"
-      check   "budget_investment_terms_of_service"
+      check "budget_investment_terms_of_service"
 
       click_button "Create Investment"
       expect(page).to have_content "Investment created successfully"


### PR DESCRIPTION
## References

* These offenses were introduced in commits 0488b3735, 287c48873 and 8d38ed58c

## Background

While we use Pronto to detect offenses in the lines changed in our pull requests, sometimes our changes introduce offenses in other lines, and we don't detect them.

## Objectives

* Make the code consistent with our conventions