### PR TITLE
Store files with both Paperclip and ActiveStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ public/assets/
 public/machine_learning/data/
 public/system/
 /public/ckeditor_assets/
+storage/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
   DisplayStyleGuide: true
   Exclude:
     - "db/schema.rb"
+    - "lib/ckeditor/backend/active_storage.rb"
   DisabledByDefault: true
 
 Bundler/DuplicatedGem:

--- a/app/controllers/admin/site_customization/images_controller.rb
+++ b/app/controllers/admin/site_customization/images_controller.rb
@@ -26,8 +26,7 @@ class Admin::SiteCustomization::ImagesController < Admin::SiteCustomization::Bas
   end
 
   def destroy
-    @image.image = nil
-    if @image.save
+    if @image.update(image: nil)
       notice = t("admin.site_customization.images.destroy.notice")
     else
       notice = t("admin.site_customization.images.destroy.error")

--- a/app/models/ckeditor/asset.rb
+++ b/app/models/ckeditor/asset.rb
@@ -1,4 +1,5 @@
 class Ckeditor::Asset < ApplicationRecord
   include Ckeditor::Orm::ActiveRecord::AssetBase
+  include Ckeditor::Backend::ActiveStorage
   include Ckeditor::Backend::Paperclip
 end

--- a/app/models/ckeditor/picture.rb
+++ b/app/models/ckeditor/picture.rb
@@ -1,8 +1,10 @@
 class Ckeditor::Picture < Ckeditor::Asset
-  has_attached_file :data,
-                    url: "/ckeditor_assets/pictures/:id/:style_:basename.:extension",
-                    path: ":rails_root/public/ckeditor_assets/pictures/:id/:style_:basename.:extension",
-                    styles: { content: "800>", thumb: "118x100#" }
+  include HasAttachment
+
+  has_attachment :data,
+                 url: "/ckeditor_assets/pictures/:id/:style_:basename.:extension",
+                 path: ":rails_root/public/ckeditor_assets/pictures/:id/:style_:basename.:extension",
+                 styles: { content: "800>", thumb: "118x100#" }
 
   validates_attachment_presence :data
   validates_attachment_size :data, less_than: 2.megabytes

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -1,4 +1,5 @@
 module Attachable
+  include HasAttachment
   extend ActiveSupport::Concern
 
   included do
@@ -33,11 +34,11 @@ module Attachable
   end
 
   def set_attachment_from_cached_attachment
-    self.attachment = if Paperclip::Attachment.default_options[:storage] == :filesystem
-                        File.open(cached_attachment)
-                      else
-                        URI.parse(cached_attachment)
-                      end
+    if Paperclip::Attachment.default_options[:storage] == :filesystem
+      File.open(cached_attachment) { |file| self.attachment = file }
+    else
+      self.attachment = URI.parse(cached_attachment)
+    end
   end
 
   def prefix(attachment, _style)

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -37,7 +37,7 @@ module Attachable
     if Paperclip::Attachment.default_options[:storage] == :filesystem
       File.open(cached_attachment) { |file| self.attachment = file }
     else
-      self.attachment = URI.parse(cached_attachment)
+      self.attachment = URI.open(cached_attachment)
     end
   end
 

--- a/app/models/concerns/has_attachment.rb
+++ b/app/models/concerns/has_attachment.rb
@@ -1,0 +1,24 @@
+module HasAttachment
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def has_attachment(attribute, paperclip_options = {})
+      has_one_attached :"storage_#{attribute}"
+
+      has_attached_file attribute, paperclip_options
+      alias_method :"paperclip_#{attribute}=", :"#{attribute}="
+
+      define_method :"#{attribute}=" do |file|
+        if file.is_a?(IO)
+          send(:"storage_#{attribute}").attach(io: file, filename: File.basename(file.path))
+        elsif file.nil?
+          send(:"storage_#{attribute}").detach
+        else
+          send(:"storage_#{attribute}").attach(file)
+        end
+
+        send(:"paperclip_#{attribute}=", file)
+      end
+    end
+  end
+end

--- a/app/models/concerns/has_attachment.rb
+++ b/app/models/concerns/has_attachment.rb
@@ -9,7 +9,7 @@ module HasAttachment
       alias_method :"paperclip_#{attribute}=", :"#{attribute}="
 
       define_method :"#{attribute}=" do |file|
-        if file.is_a?(IO)
+        if file.is_a?(IO) || file.is_a?(Tempfile) && !file.is_a?(Ckeditor::Http::QqFile)
           send(:"storage_#{attribute}").attach(io: file, filename: File.basename(file.path))
         elsif file.nil?
           send(:"storage_#{attribute}").detach

--- a/app/models/direct_upload.rb
+++ b/app/models/direct_upload.rb
@@ -53,7 +53,7 @@ class DirectUpload
 
     def relation_attributtes
       {
-        attachment: @attachment,
+        paperclip_attachment: @attachment,
         cached_attachment: @cached_attachment,
         user: @user
       }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,10 +1,10 @@
 class Document < ApplicationRecord
   include Attachable
 
-  has_attached_file :attachment, url: "/system/:class/:prefix/:style/:hash.:extension",
-                                 hash_data: ":class/:style/:custom_hash_data",
-                                 use_timestamp: false,
-                                 hash_secret: Rails.application.secrets.secret_key_base
+  has_attachment :attachment, url: "/system/:class/:prefix/:style/:hash.:extension",
+                              hash_data: ":class/:style/:custom_hash_data",
+                              use_timestamp: false,
+                              hash_secret: Rails.application.secrets.secret_key_base
 
   belongs_to :user
   belongs_to :documentable, polymorphic: true, touch: true

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,15 +1,15 @@
 class Image < ApplicationRecord
   include Attachable
 
-  has_attached_file :attachment, styles: {
-                                   large: "x#{Setting["uploads.images.min_height"]}",
-                                   medium: "300x300#",
-                                   thumb: "140x245#"
-                                 },
-                                 url: "/system/:class/:prefix/:style/:hash.:extension",
-                                 hash_data: ":class/:style",
-                                 use_timestamp: false,
-                                 hash_secret: Rails.application.secrets.secret_key_base
+  has_attachment :attachment, styles: {
+                                large: "x#{Setting["uploads.images.min_height"]}",
+                                medium: "300x300#",
+                                thumb: "140x245#"
+                              },
+                              url: "/system/:class/:prefix/:style/:hash.:extension",
+                              hash_data: ":class/:style",
+                              use_timestamp: false,
+                              hash_secret: Rails.application.secrets.secret_key_base
 
   belongs_to :user
   belongs_to :imageable, polymorphic: true, touch: true

--- a/app/models/site_customization/image.rb
+++ b/app/models/site_customization/image.rb
@@ -1,4 +1,6 @@
 class SiteCustomization::Image < ApplicationRecord
+  include HasAttachment
+
   VALID_IMAGES = {
     "logo_header" => [260, 80],
     "social_media_icon" => [470, 246],
@@ -9,7 +11,7 @@ class SiteCustomization::Image < ApplicationRecord
     "logo_email" => [400, 80]
   }.freeze
 
-  has_attached_file :image
+  has_attachment :image
 
   validates :name, presence: true, uniqueness: true, inclusion: { in: VALID_IMAGES.keys }
   validates_attachment_content_type :image, content_type: ["image/png", "image/jpeg"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,17 +1,6 @@
 require_relative "boot"
 
-require "rails"
-# Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-# require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_view/railtie"
-require "action_cable/engine"
-require "sprockets/railtie"
-require "rails/test_unit/railtie"
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,9 @@ module Consul
     # Handle custom exceptions
     config.action_dispatch.rescue_responses["FeatureFlags::FeatureDisabled"] = :forbidden
 
+    # Store files locally.
+    config.active_storage.service = :local
+
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,7 +22,7 @@ set :pty, true
 set :use_sudo, false
 
 set :linked_files, %w[config/database.yml config/secrets.yml]
-set :linked_dirs, %w[.bundle log tmp public/system public/assets public/ckeditor_assets public/machine_learning/data]
+set :linked_dirs, %w[.bundle log tmp public/system public/assets public/ckeditor_assets public/machine_learning/data storage]
 
 set :keep_releases, 5
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,6 +47,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Store files in tmp folders.
+  config.active_storage.service = :test
+
   config.cache_store = :null_store
 
   config.after_initialize do

--- a/config/initializers/disable_active_storage_uploads.rb
+++ b/config/initializers/disable_active_storage_uploads.rb
@@ -1,0 +1,11 @@
+ActiveStorage::DirectUploadsController.class_eval do
+  def create
+    head :unauthorized
+  end
+end
+
+ActiveStorage::DiskController.class_eval do
+  def update
+    head :unauthorized
+  end
+end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,7 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,3 +5,28 @@ local:
 test:
   service: Disk
   root: <%= Rails.root.join("tmp/storage") %>
+
+# s3:
+#   service: S3
+#   access_key_id: <%= Rails.application.secrets.dig(:s3, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.secrets.dig(:s3, :secret_access_key) %>
+#   region: <%= Rails.application.secrets.dig(:s3, :region) %>
+#   bucket: <%= Rails.application.secrets.dig(:s3, :bucket) %>
+
+# Remember not to checkin your GCS keyfile to a repository
+# gcs:
+#   service: GCS
+#   project: <%= Rails.application.secrets.dig(:gcs, :project) %>
+#   credentials: <%= Rails.root.join(Rails.application.secrets.dig(:gcs, :credentials).to_s) %>
+#   bucket: <%= Rails.application.secrets.dig(:gcs, :bucket) %>
+
+# azure:
+#   service: AzureStorage
+#   storage_account_name: <%= Rails.application.secrets.dig(:azure, :storage_account_name) %>
+#   storage_access_key: <%= Rails.application.secrets.dig(:azure, :storage_access_key) %>
+#   container: <%= Rails.application.secrets.dig(:azure, :container) %>
+
+# mirror:
+#   service: Mirror
+#   primary: local
+#   mirrors: [ s3, gcs, azure ]

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -6,21 +6,23 @@ INVESTMENT_IMAGE_FILES = %w[
   olesya-grichina-218176-unsplash_713x475.jpg
   sole-d-alessandro-340443-unsplash_713x475.jpg
 ].map do |filename|
-  File.new(Rails.root.join("db",
-                           "dev_seeds",
-                           "images",
-                           "budget",
-                           "investments", filename))
+  Rails.root.join("db",
+                  "dev_seeds",
+                  "images",
+                  "budget",
+                  "investments", filename)
 end
 
 def add_image_to(imageable)
   # imageable should respond to #title & #author
-  imageable.image = Image.create!({
-    imageable: imageable,
-    title: imageable.title,
-    attachment: INVESTMENT_IMAGE_FILES.sample,
-    user: imageable.author
-  })
+  File.open(INVESTMENT_IMAGE_FILES.sample) do |file|
+    imageable.image = Image.create!({
+      imageable: imageable,
+      title: imageable.title,
+      attachment: file,
+      user: imageable.author
+    })
+  end
   imageable.save!
 end
 

--- a/db/dev_seeds/proposals.rb
+++ b/db/dev_seeds/proposals.rb
@@ -4,20 +4,22 @@ IMAGE_FILES = %w[
   steve-harvey-597760-unsplash_713x475.jpg
   tim-mossholder-302931-unsplash_713x475.jpg
 ].map do |filename|
-  File.new(Rails.root.join("db",
-                           "dev_seeds",
-                           "images",
-                           "proposals", filename))
+  Rails.root.join("db",
+                  "dev_seeds",
+                  "images",
+                  "proposals", filename)
 end
 
 def add_image_to(imageable)
   # imageable should respond to #title & #author
-  imageable.image = Image.create!({
-    imageable: imageable,
-    title: imageable.title,
-    attachment: IMAGE_FILES.sample,
-    user: imageable.author
-  })
+  File.open(IMAGE_FILES.sample) do |file|
+    imageable.image = Image.create!({
+      imageable: imageable,
+      title: imageable.title,
+      attachment: file,
+      user: imageable.author
+    })
+  end
   imageable.save!
 end
 

--- a/db/migrate/20210619201902_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210619201902_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:record_type, :record_id, :name, :blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,27 @@ ActiveRecord::Schema.define(version: 2021_08_11_195800) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
   create_table "activities", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.string "action"
@@ -1726,6 +1747,7 @@ ActiveRecord::Schema.define(version: 2021_08_11_195800) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "administrators", "users"
   add_foreign_key "budget_administrators", "administrators"
   add_foreign_key "budget_administrators", "budgets"

--- a/lib/ckeditor/backend/active_storage.rb
+++ b/lib/ckeditor/backend/active_storage.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Code copied from the ckeditor gem:
+# https://github.com/galetahub/ckeditor/pull/853
+module Ckeditor
+  module Backend
+    module ActiveStorage
+      def self.included(base)
+        base.send(:include, Rails.application.routes.url_helpers)
+        base.send(:include, InstanceMethods)
+        base.send(:extend, ClassMethods)
+      end
+
+      module ClassMethods
+        def self.extended(base)
+          base.class_eval do
+            before_save :apply_data
+            validate do
+              if data.nil? || file.nil?
+                errors.add(:data, :not_data_present, message: "data must be present")
+              end
+            end
+          end
+        end
+      end
+
+      module InstanceMethods
+        def url
+          rails_blob_path(self.storage_data, only_path: true)
+        end
+
+        def path
+          rails_blob_path(self.storage_data, only_path: true)
+        end
+
+        def styles
+        end
+
+        def content_type
+          self.storage_data.content_type
+        end
+
+        def content_type=(_content_type)
+          self.storage_data.content_type = _content_type
+        end
+
+        protected
+
+          def file
+            @file ||= storage_data
+          end
+
+          def blob
+            @blob ||= ::ActiveStorage::Blob.find(file.attachment.blob_id)
+          end
+
+          def apply_data
+            if data.is_a?(Ckeditor::Http::QqFile)
+              storage_data.attach(io: data, filename: data.original_filename)
+            else
+              storage_data.attach(data)
+            end
+
+            self.data_file_name = storage_data.blob.filename
+            self.data_content_type = storage_data.blob.content_type
+            self.data_file_size = storage_data.blob.byte_size
+          end
+      end
+    end
+
+    autoload :ActiveStorage, "ckeditor/backend/active_storage"
+  end
+end

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -1,0 +1,78 @@
+# This code is based on Thoughtbot's guide to migrating from Paperclip
+# to Active Storage:
+# https://github.com/thoughtbot/paperclip/blob/master/MIGRATING.md
+namespace :active_storage do
+  desc "Copy paperclip's attachment database columns to active storage"
+  task migrate_from_paperclip: :environment do
+    logger = ApplicationLogger.new
+    get_blob_id = "LASTVAL()"
+
+    ActiveRecord::Base.connection.raw_connection.prepare("active_storage_blob_statement", <<-SQL)
+    INSERT INTO active_storage_blobs (
+      key, filename, content_type, metadata, byte_size, checksum, created_at
+    ) VALUES ($1, $2, $3, '{}', $4, $5, $6)
+    SQL
+
+    ActiveRecord::Base.connection.raw_connection.prepare("active_storage_attachment_statement", <<-SQL)
+    INSERT INTO active_storage_attachments (
+      name, record_type, record_id, blob_id, created_at
+    ) VALUES ($1, $2, $3, #{get_blob_id}, $4)
+    SQL
+
+    Rails.application.eager_load!
+    models = ActiveRecord::Base.descendants.reject(&:abstract_class?)
+
+    ActiveRecord::Base.transaction do
+      models.each do |model|
+        attachments = model.column_names.map do |c|
+          if c =~ /(.+)_file_name$/
+            $1
+          end
+        end.compact
+
+        if attachments.blank?
+          next
+        end
+
+        model.find_each.each do |instance|
+          attachments.each do |attachment|
+            next if instance.send(attachment).path.blank?
+
+            ActiveRecord::Base.connection.raw_connection.exec_prepared(
+              "active_storage_blob_statement", [
+                SecureRandom.uuid, # Alternatively instance.send("#{attachment}_file_name"),
+                instance.send("#{attachment}_file_name"),
+                instance.send("#{attachment}_content_type"),
+                instance.send("#{attachment}_file_size"),
+                Digest::MD5.base64digest(File.read(instance.send(attachment).path)),
+                instance.updated_at.iso8601
+              ])
+
+            ActiveRecord::Base.connection.raw_connection.exec_prepared(
+              "active_storage_attachment_statement", [
+                attachment,
+                model.name,
+                instance.id,
+                instance.updated_at.iso8601
+              ])
+          end
+        end
+      end
+    end
+
+    ActiveStorage::Attachment.find_each do |attachment|
+      name = attachment.name
+      source = attachment.record.send(name).path
+
+      dest_dir = File.join(
+        "storage",
+        attachment.blob.key.first(2),
+        attachment.blob.key.first(4).last(2))
+      dest = File.join(dest_dir, attachment.blob.key)
+
+      FileUtils.mkdir_p(dest_dir)
+      logger.info "Copying #{source} to #{dest}"
+      FileUtils.cp(source, dest)
+    end
+  end
+end

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -24,6 +24,8 @@ namespace :active_storage do
 
     ActiveRecord::Base.transaction do
       models.each do |model|
+        next if model.name == "OldPassword" && !model.table_exists?
+
         attachments = model.column_names.map do |c|
           if c =~ /(.+)_file_name$/
             $1

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -46,7 +46,7 @@ namespace :active_storage do
                 instance.send("#{attachment}_file_size"),
                 Digest::MD5.base64digest(File.read(instance.send(attachment).path)),
                 instance.updated_at.iso8601,
-                attachment,
+                "storage_#{attachment}",
                 model.name,
                 instance.id,
                 instance.updated_at.iso8601
@@ -58,7 +58,7 @@ namespace :active_storage do
 
     ActiveStorage::Attachment.find_each do |attachment|
       dest = ActiveStorage::Blob.service.path_for(attachment.blob.key)
-      name = attachment.name
+      name = attachment.name.delete_prefix("storage_")
       source = attachment.record.send(name).path
 
       FileUtils.mkdir_p(File.dirname(dest))

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -40,6 +40,8 @@ namespace :active_storage do
 
         model.find_each.each do |instance|
           attachments.each do |attachment|
+            next if instance.send(:"storage_#{attachment}").attached?
+
             source = instance.send(attachment).path
 
             next if source.blank?
@@ -66,6 +68,9 @@ namespace :active_storage do
 
     ActiveStorage::Attachment.find_each do |attachment|
       dest = ActiveStorage::Blob.service.path_for(attachment.blob.key)
+
+      next if File.exist?(dest)
+
       name = attachment.name.delete_prefix("storage_")
       source = attachment.record.send(name).path
 

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -69,7 +69,7 @@ namespace :active_storage do
     ActiveStorage::Attachment.find_each do |attachment|
       dest = ActiveStorage::Blob.service.path_for(attachment.blob.key)
 
-      next if File.exist?(dest)
+      next if File.exist?(dest) || !attachment.record
 
       name = attachment.name.delete_prefix("storage_")
       source = attachment.record.send(name).path

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -40,7 +40,11 @@ namespace :active_storage do
 
         model.find_each.each do |instance|
           attachments.each do |attachment|
-            next if instance.send(attachment).path.blank?
+            source = instance.send(attachment).path
+
+            next if source.blank?
+
+            file = File.read(source) if File.exist?(source)
 
             connection.exec_prepared(
               statement_name, [
@@ -48,7 +52,7 @@ namespace :active_storage do
                 instance.send("#{attachment}_file_name"),
                 instance.send("#{attachment}_content_type"),
                 instance.send("#{attachment}_file_size"),
-                Digest::MD5.base64digest(File.read(instance.send(attachment).path)),
+                file && Digest::MD5.base64digest(file) || SecureRandom.hex(32),
                 instance.updated_at.iso8601,
                 "storage_#{attachment}",
                 model.name,
@@ -65,9 +69,11 @@ namespace :active_storage do
       name = attachment.name.delete_prefix("storage_")
       source = attachment.record.send(name).path
 
-      FileUtils.mkdir_p(File.dirname(dest))
-      logger.info "Copying #{source} to #{dest}"
-      FileUtils.cp(source, dest)
+      if source && File.exist?(source)
+        FileUtils.mkdir_p(File.dirname(dest))
+        logger.info "Copying #{source} to #{dest}"
+        FileUtils.cp(source, dest)
+      end
     end
   end
 end

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -61,16 +61,11 @@ namespace :active_storage do
     end
 
     ActiveStorage::Attachment.find_each do |attachment|
+      dest = ActiveStorage::Blob.service.path_for(attachment.blob.key)
       name = attachment.name
       source = attachment.record.send(name).path
 
-      dest_dir = File.join(
-        "storage",
-        attachment.blob.key.first(2),
-        attachment.blob.key.first(4).last(2))
-      dest = File.join(dest_dir, attachment.blob.key)
-
-      FileUtils.mkdir_p(dest_dir)
+      FileUtils.mkdir_p(File.dirname(dest))
       logger.info "Copying #{source} to #{dest}"
       FileUtils.cp(source, dest)
     end

--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -1,7 +1,13 @@
 namespace :consul do
   desc "Runs tasks needed to upgrade to the latest version"
   task execute_release_tasks: ["settings:rename_setting_keys",
-                               "settings:add_new_settings"]
+                               "settings:add_new_settings",
+                               "execute_release_1.4.0_tasks"]
+
+  desc "Runs tasks needed to upgrade from 1.3.0 to 1.4.0"
+  task "execute_release_1.4.0_tasks": [
+    "active_storage:migrate_from_paperclip"
+  ]
 
   desc "Runs tasks needed to upgrade from 1.2.0 to 1.3.0"
   task "execute_release_1.3.0_tasks": [

--- a/spec/controllers/active_storage/direct_uploads_controller_spec.rb
+++ b/spec/controllers/active_storage/direct_uploads_controller_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe ActiveStorage::DirectUploadsController do
+  describe "POST create" do
+    it "doesn't allow anonymous users to upload files" do
+      blob_attributes = { filename: "logo.pdf", byte_size: 30000, checksum: SecureRandom.hex(32) }
+
+      post :create, params: { blob: blob_attributes }
+
+      expect(ActiveStorage::Blob.count).to eq 0
+      expect(response).to be_unauthorized
+    end
+  end
+end

--- a/spec/controllers/active_storage/disk_controller_spec.rb
+++ b/spec/controllers/active_storage/disk_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe ActiveStorage::DiskController do
+  describe "PUT update" do
+    it "doesn't allow anonymous users to upload files" do
+      blob = create(:active_storage_blob)
+
+      put :update, params: { encoded_token: blob.signed_id }
+
+      expect(response).to be_unauthorized
+    end
+  end
+end

--- a/spec/factories/files.rb
+++ b/spec/factories/files.rb
@@ -55,4 +55,10 @@ FactoryBot.define do
     end
     initialize_with { new(attributes) }
   end
+
+  factory :active_storage_blob, class: "ActiveStorage::Blob" do
+    filename { "sample.pdf" }
+    byte_size { 3000 }
+    checksum { SecureRandom.hex(32) }
+  end
 end

--- a/spec/lib/tasks/active_storage_spec.rb
+++ b/spec/lib/tasks/active_storage_spec.rb
@@ -64,6 +64,19 @@ describe "active storage tasks" do
       expect(test_storage_file_paths.first).to eq migrated_file
     end
 
+    it "does not migrate files for deleted records" do
+      document = create(:document, attachment: File.new("spec/fixtures/files/clippy.pdf"))
+      FileUtils.rm storage_file_path(document)
+      Document.delete_all
+
+      run_rake_task
+
+      expect(ActiveStorage::Attachment.count).to eq 1
+      expect(ActiveStorage::Blob.count).to eq 1
+      expect(document.storage_attachment.filename).to eq "clippy.pdf"
+      expect(test_storage_file_paths.count).to eq 0
+    end
+
     def test_storage_file_paths
       Dir.glob("#{storage_root}/**/*").select { |file_or_folder| File.file?(file_or_folder) }
     end

--- a/spec/lib/tasks/active_storage_spec.rb
+++ b/spec/lib/tasks/active_storage_spec.rb
@@ -29,6 +29,21 @@ describe "active storage tasks" do
       expect(storage_file_path(document)).to eq test_storage_file_paths.first
     end
 
+    it "migrates records with deleted files ignoring the files" do
+      document = create(:document,
+                        attachment: nil,
+                        paperclip_attachment: File.new("spec/fixtures/files/clippy.pdf"))
+      FileUtils.rm(document.attachment.path)
+
+      run_rake_task
+      document.reload
+
+      expect(ActiveStorage::Attachment.count).to eq 1
+      expect(ActiveStorage::Blob.count).to eq 1
+      expect(document.storage_attachment.filename).to eq "clippy.pdf"
+      expect(test_storage_file_paths.count).to eq 0
+    end
+
     def test_storage_file_paths
       Dir.glob("#{storage_root}/**/*").select { |file_or_folder| File.file?(file_or_folder) }
     end

--- a/spec/lib/tasks/active_storage_spec.rb
+++ b/spec/lib/tasks/active_storage_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe "active storage tasks" do
+  describe "migrate_from_paperclip" do
+    let(:run_rake_task) do
+      Rake::Task["active_storage:migrate_from_paperclip"].reenable
+      Rake.application.invoke_task("active_storage:migrate_from_paperclip")
+    end
+
+    let(:storage_root) { ActiveStorage::Blob.service.root }
+    before { FileUtils.rm_rf storage_root }
+
+    it "migrates records and attachments" do
+      document = create(:document,
+                        attachment: nil,
+                        paperclip_attachment: File.new("spec/fixtures/files/clippy.pdf"))
+
+      expect(ActiveStorage::Attachment.count).to eq 0
+      expect(ActiveStorage::Blob.count).to eq 0
+      expect(test_storage_file_paths.count).to eq 0
+
+      run_rake_task
+      document.reload
+
+      expect(ActiveStorage::Attachment.count).to eq 1
+      expect(ActiveStorage::Blob.count).to eq 1
+      expect(document.storage_attachment.filename).to eq "clippy.pdf"
+      expect(test_storage_file_paths.count).to eq 1
+      expect(storage_file_path(document)).to eq test_storage_file_paths.first
+    end
+
+    def test_storage_file_paths
+      Dir.glob("#{storage_root}/**/*").select { |file_or_folder| File.file?(file_or_folder) }
+    end
+
+    def storage_file_path(record)
+      ActiveStorage::Blob.service.path_for(record.storage_attachment.blob.key)
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -4,6 +4,16 @@ describe Document do
   it_behaves_like "document validations", "budget_investment_document"
   it_behaves_like "document validations", "proposal_document"
 
+  it "stores attachments with both Paperclip and Active Storage" do
+    document = create(:document, attachment: File.new("spec/fixtures/files/clippy.pdf"))
+
+    expect(document.attachment).to exist
+    expect(document.attachment_file_name).to eq "clippy.pdf"
+
+    expect(document.storage_attachment).to be_attached
+    expect(document.storage_attachment.filename).to eq "clippy.pdf"
+  end
+
   context "scopes" do
     describe "#admin" do
       it "returns admin documents" do

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -3,4 +3,14 @@ require "rails_helper"
 describe Image do
   it_behaves_like "image validations", "budget_investment_image"
   it_behaves_like "image validations", "proposal_image"
+
+  it "stores attachments with both Paperclip and Active Storage" do
+    image = create(:image, attachment: File.new("spec/fixtures/files/clippy.jpg"))
+
+    expect(image.attachment).to exist
+    expect(image.attachment_file_name).to eq "clippy.jpg"
+
+    expect(image.storage_attachment).to be_attached
+    expect(image.storage_attachment.filename).to eq "clippy.jpg"
+  end
 end

--- a/spec/models/site_customization/image_spec.rb
+++ b/spec/models/site_customization/image_spec.rb
@@ -1,6 +1,17 @@
 require "rails_helper"
 
 describe SiteCustomization::Image do
+  it "stores images with both Paperclip and Active Storage" do
+    image = create(:site_customization_image, name: "map",
+                   image: File.new("spec/fixtures/files/custom_map.jpg"))
+
+    expect(image.image).to exist
+    expect(image.image_file_name).to eq "custom_map.jpg"
+
+    expect(image.storage_image).to be_attached
+    expect(image.storage_image.filename).to eq "custom_map.jpg"
+  end
+
   describe "logo" do
     it "is valid with a 260x80 image" do
       image = build(:site_customization_image,


### PR DESCRIPTION
## References

* [Paperclip has been deprecated for 3 years](https://thoughtbot.com/blog/closing-the-trombone)
* [Paperclip to Active Storage migration guide](https://github.com/thoughtbot/paperclip/blob/master/MIGRATING.md)
* [How to migrate to Active Storage without losing your mind](https://www.youtube.com/watch?v=tZ_WNUytO9o)
* This pull request implements the first step required to solve issue #2629 

## Objectives

* Make it possible to replace Paperclip with Active Storage in the future

## Notes

In order to migrate existing files from Paperclip to ActiveStorage, we need Paperclip to find out the files associated to existing database records. So we can't simply replace Paperclip with ActiveStorage.

That's why it's usually recommended to first run the migration and then replace Paperclip with ActiveStorage using two consecutive deployments.

However, in our case we can't rely on two consecutive deployments because we have to make an easy process so existing CONSUL installations don't run into any issues. We can't just release version 1.4.0 and 1.5.0 the same day and ask everyone to upgrade twice in a row.

Instead, we're following a different plan:

* We provide a Rake task (which will require Paperclip) to migrate existing files
* We still use Paperclip to generate link and image tags
* New files are handled using both Paperclip and ActiveStorage; that way, when we make the switch, we won't have to migrate them, and in the meantime they'll be accessible thanks to Paperclip
* After we make the switch (which will happen after releasing version 1.4.0), we'll update the `name` column in the active storage attachments tables in order to remove the `storage_` prefix

### Testing this pull request

Before merging this pull request, we need to test this scenario:

* Make sure we've got records with attachmets for all models handling attachments
* Run the `migrate_from_paperclip` task
* Attach files to both new and existing records from all models handling attachments
* Apply the changes in #4600 and run the `remove_paperclip_compatibility_in_existing_attachments` task
* Check images and documents attached before and after running the `migrate_from_paperclip` are correctly displayed

We need to do so with both a local storage and a remote storage.

## Release Notes

:warning: If you've added custom attachments, make sure to change these attachments so they use  with `has_attachment` instead of `has_attached_file`. Otherwise you might run into missing files when upgrading to version 1.5.0.

In version 1.5.0 we'll change the way we store attachments from Paperclip to Active Storage. In order to make the migration painless, version 1.4.0 stores new files using both systems. If you've changed anything related to the way attachments are handled, there's a chance you might run into some issues when executing `consul:execute_release_tasks` (which includes a task to copy existing files to Active Storage). In version 1.5.0 we'll drop Paperclip and use just Active Storage, so make sure to fix the issues or report them; otherwise you might run into missing files when upgrading to version 1.5.0.

After copying the existing files to Active Storage, **keep both the Active Storage files and the Paperclip files**. The Paperclip files are needed in version 1.4.0, and the Active Storage files will be needed in version 1.5.0.

If you're storing files using an external service (such as S3), make sure to edit the `config/storage.yml` file and configure the service. Sample configurations are provided for S3, GCS and Azure; uncomment them where appropriate and then edit your `config/secrets.yml` file with your credentials.