### PR TITLE
Fix inconsistent order in system email preview

### DIFF
--- a/app/controllers/admin/system_emails_controller.rb
+++ b/app/controllers/admin/system_emails_controller.rb
@@ -43,6 +43,7 @@ class Admin::SystemEmailsController < Admin::BaseController
     case @system_email
     when "proposal_notification_digest"
       @previews = ProposalNotification.where(id: unsent_proposal_notifications_ids)
+                                      .order(:id)
                                       .page(params[:page])
     end
   end

--- a/app/views/admin/system_emails/preview_pending/_proposal_notification_digest.html.erb
+++ b/app/views/admin/system_emails/preview_pending/_proposal_notification_digest.html.erb
@@ -24,7 +24,7 @@
     <div class="row">
       <div class="column">
         <strong><%= t("admin.shared.content") %></strong>
-        <p id="phase-description-help-text">
+        <p>
           <%= preview.body %>
         </p>
       </div>


### PR DESCRIPTION
## References

* This bug caused a test to fail sometimes; for example in our [test run 1879, job 3](https://github.com/consul/consul/runs/2954630259) or our [test run 2207, job 1](https://github.com/consul/consul/runs/3290963815)

## Objectives

* Fix inconsistent order in system email preview
* Fix invalid HTML in system email preview