### PR TITLE
Use telephone fields in phone number form controls

### DIFF
--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -24,7 +24,7 @@
                 <%= fo.text_field :name, autofocus: true, maxlength: Organization.name_max_length %>
                 <%= fo.text_field :responsible_name, autofocus: true, maxlength: Organization.responsible_name_max_length %>
               <% end %>
-              <%= f.text_field :phone_number %>
+              <%= f.phone_field :phone_number %>
 
             <% else %>
               <%= f.text_field :username, maxlength: User.username_max_length %>

--- a/app/views/organizations/registrations/new.html.erb
+++ b/app/views/organizations/registrations/new.html.erb
@@ -15,7 +15,7 @@
 
       <%= f.email_field :email %>
 
-      <%= f.text_field :phone_number %>
+      <%= f.phone_field :phone_number %>
 
       <%= f.invisible_captcha :address %>
 

--- a/app/views/verification/sms/new.html.erb
+++ b/app/views/verification/sms/new.html.erb
@@ -29,8 +29,8 @@
         <%= f.label :phone, t("verification.sms.new.phone"), class: "inline-block" %>
         <span class="inline-block"><%= sanitize(t("verification.sms.new.phone_format")) %></span>
         <p class="help-text" id="phone-text-help"><%= t("verification.sms.new.phone_note") %></p>
-        <%= f.text_field :phone, label: false,
-                                 aria: { describedby: "phone-help-text" } %>
+        <%= f.phone_field :phone, label: false,
+                                  aria: { describedby: "phone-help-text" } %>
       </div>
 
       <%= f.submit t("verification.sms.new.submit_button"), class: "button success" %>


### PR DESCRIPTION
## Objectives

Make it easier for mobile phone users to enter a phone number.

## Visual Changes

### Before these changes

Phone browsers shows a alphanumeric keyboard:
![By focusing on the input of the phone field on a mobile device we see an alphanumeric keyboard](https://user-images.githubusercontent.com/16189/146347746-c0d8dbb1-5327-41b2-b4de-45514e2d130d.png)

### After these changes

Phone browsers shows a numeric keyboard which makes it easy to enter phone numbers.
![By focusing on the input of the phone field on a mobile device we see an numeric keyboard which makes it easy to enter phone numbers](https://user-images.githubusercontent.com/16189/146347614-5e7b2907-1fd4-4249-a33c-f006ab311af3.png)
