### PR TITLE
Improve support for RTL languages

### DIFF
--- a/app/assets/stylesheets/application-rtl.scss
+++ b/app/assets/stylesheets/application-rtl.scss
@@ -1,0 +1,3 @@
+$global-text-direction: rtl;
+
+@import "application";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,10 @@ module ApplicationHelper
     url_for(request.query_parameters.merge(query_parameters).merge(only_path: true))
   end
 
+  def rtl?
+    %i[ar fa he].include?(I18n.locale)
+  end
+
   def markdown(text)
     return text if text.blank?
 

--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -2,7 +2,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <title><%= content_for?(:title) ? yield(:title) : default_title %></title>
-<%= stylesheet_link_tag "application" %>
+<% if rtl? %>
+  <%= stylesheet_link_tag "application-rtl" %>
+<% else %>
+  <%= stylesheet_link_tag "application" %>
+<% end %>
 <%= javascript_include_tag "application", "data-turbolinks-track" => "reload" %>
 <%= csrf_meta_tags %>
 <%= favicon_link_tag "favicon.ico" %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html <%= "dir=rtl" if rtl? %> lang="<%= I18n.locale %>">
 
   <head>
     <%= render "layouts/common_head", default_title: "Admin" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>" data-current-user-id="<%= current_user&.id %>">
+<html <%= "dir=rtl" if rtl? %> lang="<%= I18n.locale %>" data-current-user-id="<%= current_user&.id %>">
   <head>
     <%= render "layouts/common_head", default_title: setting["org_name"] %>
     <%= render "layouts/tracking_data" %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html <%= "dir=rtl" if rtl? %> lang="<%= I18n.locale %>">
   <head>
     <%= render "layouts/common_head", default_title: setting["org_name"] %>
     <%= render "layouts/meta_tags" %>

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html <%= "dir=rtl" if rtl? %> lang="<%= I18n.locale %>">
 
   <head>
     <%= render "layouts/common_head", default_title: "Management" %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,6 +12,7 @@ Rails.application.config.assets.version = "1.0"
 Rails.application.config.assets.precompile += %w[ckeditor/config.js]
 Rails.application.config.assets.precompile += %w[stat_graphs.js]
 Rails.application.config.assets.precompile += %w[dashboard_graphs.js]
+Rails.application.config.assets.precompile += %w[application-rtl.css]
 Rails.application.config.assets.precompile += %w[print.css]
 Rails.application.config.assets.precompile += %w[pdf_fonts.css]
 Rails.application.config.assets.precompile += %w[sdg/*.png]


### PR DESCRIPTION
## Objectives

* Improve the page layout for languages which are read from right lo left

## Visual Changes

### Before these changes

![In Arabic, the navigation elements are in the same order as in English and are aligned to the left, just like the logo](https://user-images.githubusercontent.com/35156/129236204-1b401b4f-8b9e-4cb7-a21c-dac3ee0c8c01.png)

### After these changes

![In Arabic, the navigation elements are aligned to the right, just like the logo, with the first one being on the right](https://user-images.githubusercontent.com/35156/129236228-a769e486-9012-495e-9536-9631ee4d410c.png)

## Notes

To offer full support for RTL languages, we need to change every single reference to `float: left`, `float: right`, `text-align: left`, and possibly adjust other properties like `left`, `margin-left`, `padding-left` or `border-left`. In the meantime, we at least partially support these languages.
    
Replacing `float` with `flex` when possible would also improve RTL support.