### PR TITLE
Remove devise-async dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem "daemons", "~> 1.4.0"
 gem "dalli", "~> 2.7.11"
 gem "delayed_job_active_record", "~> 4.1.6"
 gem "devise", "~> 4.8.0"
-gem "devise-async", "~> 1.0.0"
 gem "devise-security", "~> 0.16.0"
 gem "font-awesome-sass", "~> 5.15.1" # Remember to update vendor/assets/images/fontawesome when updating this gem
 gem "foundation-rails", "~> 6.6.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,9 +172,6 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-async (1.0.0)
-      activejob (>= 5.0)
-      devise (>= 4.0)
     devise-security (0.16.0)
       devise (>= 4.3.0, < 5.0)
     diff-lcs (1.4.4)
@@ -717,7 +714,6 @@ DEPENDENCIES
   database_cleaner (~> 2.0.1)
   delayed_job_active_record (~> 4.1.6)
   devise (~> 4.8.0)
-  devise-async (~> 1.0.0)
   devise-security (~> 0.16.0)
   email_spec (~> 2.2.0)
   erb_lint (~> 0.0.37)


### PR DESCRIPTION
## References

* We don't use devise-async since commit 84338592d.

## Objectives

* Cleanup unused dependencies
* Remove unmaintained dependencies with no Rails 6 / Ruby 3 support