### PR TITLE
Explicitely use Debian Buster in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.8
+FROM ruby:2.6.8-buster
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
## References

* The Ruby Docker images use Debian Bullseye docker-library/ruby#357
* Our continuous integration failed after the upgrade in our [Docker run #1157](https://github.com/consul/consul/runs/3350324089)

## Background

Debian Bullseye was released two days ago, and is now the defaultdistribution for the Docker image.

Our image isn't compatible with Debian Bullseye right now, and we haven't done any testing with it.

## Objectives

* Make sure our Docker image uses a compatible distribution