### PR TITLE
Improve accessibility in admin table actions

### DIFF
--- a/app/assets/stylesheets/admin/action.scss
+++ b/app/assets/stylesheets/admin/action.scss
@@ -1,0 +1,6 @@
+.admin .admin-action {
+
+  &[disabled] {
+    @include button-disabled;
+  }
+}

--- a/app/assets/stylesheets/admin/table_actions.scss
+++ b/app/assets/stylesheets/admin/table_actions.scss
@@ -1,4 +1,5 @@
 .admin .table-actions {
+  align-items: flex-start;
   display: flex;
 
   > :not(:first-child) {

--- a/app/assets/stylesheets/admin/table_actions.scss
+++ b/app/assets/stylesheets/admin/table_actions.scss
@@ -5,7 +5,8 @@
     margin-left: rem-calc(10);
   }
 
-  a {
+  a,
+  button {
     align-items: center;
     display: flex;
     flex-direction: column;
@@ -23,6 +24,10 @@
     &::before {
       font-size: 1.6em;
     }
+  }
+
+  button {
+    cursor: pointer;
   }
 
   .edit-link {
@@ -121,6 +126,7 @@
   .manage-link,
   .ballots-link {
     @include has-fa-icon(archive, solid);
+    color: $link;
   }
 
   .cards-link {

--- a/app/assets/stylesheets/admin/table_actions.scss
+++ b/app/assets/stylesheets/admin/table_actions.scss
@@ -19,6 +19,7 @@
     &:hover,
     &:focus {
       color: $link-hover;
+      text-decoration: none;
     }
 
     &::before {
@@ -77,7 +78,7 @@
   .investments-link {
     color: darken($warning-color, 20%);
 
-    &::before {
+    &:not(:hover, :focus)::before {
       color: $warning-color;
     }
   }

--- a/app/assets/stylesheets/admin/table_actions.scss
+++ b/app/assets/stylesheets/admin/table_actions.scss
@@ -14,7 +14,6 @@
     font-size: 0.9em;
     line-height: $global-lineheight;
     margin-right: 1em;
-    position: relative;
     text-align: center;
 
     &:hover,

--- a/app/components/admin/action_component.html.erb
+++ b/app/components/admin/action_component.html.erb
@@ -1,0 +1,1 @@
+<%= link_to text, path, html_options %>

--- a/app/components/admin/action_component.html.erb
+++ b/app/components/admin/action_component.html.erb
@@ -1,1 +1,5 @@
-<%= link_to text, path, html_options %>
+<% if options[:method] && options[:method] != :get %>
+  <%= button_to(path, html_options) { text } %>
+<% else %>
+  <%= link_to text, path, html_options %>
+<% end %>

--- a/app/components/admin/action_component.html.erb
+++ b/app/components/admin/action_component.html.erb
@@ -1,4 +1,4 @@
-<% if options[:method] && options[:method] != :get %>
+<% if button? %>
   <%= button_to(path, html_options) { text } %>
 <% else %>
   <%= link_to text, path, html_options %>

--- a/app/components/admin/action_component.rb
+++ b/app/components/admin/action_component.rb
@@ -21,12 +21,21 @@ class Admin::ActionComponent < ApplicationComponent
     def html_options
       {
         class: html_class,
+        "aria-label": label,
         data: { confirm: confirmation_text }
-      }.merge(options.except(:confirm, :path, :text))
+      }.merge(options.except(:"aria-label", :confirm, :path, :text))
     end
 
     def html_class
       "#{action.to_s.gsub("_", "-")}-link"
+    end
+
+    def label
+      if options[:"aria-label"] == true
+        t("admin.actions.label", action: text, name: record_name)
+      else
+        options[:"aria-label"]
+      end
     end
 
     def confirmation_text
@@ -34,6 +43,14 @@ class Admin::ActionComponent < ApplicationComponent
         t("admin.actions.confirm")
       else
         options[:confirm]
+      end
+    end
+
+    def record_name
+      if record.respond_to?(:human_name)
+        record.human_name
+      else
+        record.to_s.humanize
       end
     end
 

--- a/app/components/admin/action_component.rb
+++ b/app/components/admin/action_component.rb
@@ -40,7 +40,11 @@ class Admin::ActionComponent < ApplicationComponent
 
     def confirmation_text
       if options[:confirm] == true
-        t("admin.actions.confirm")
+        if action == :destroy
+          t("admin.actions.confirm_delete", name: record_name)
+        else
+          t("admin.actions.confirm_action", action: text, name: record_name)
+        end
       else
         options[:confirm]
       end

--- a/app/components/admin/action_component.rb
+++ b/app/components/admin/action_component.rb
@@ -1,0 +1,47 @@
+class Admin::ActionComponent < ApplicationComponent
+  include Admin::Namespace
+  attr_reader :action, :record, :options
+
+  def initialize(action, record, **options)
+    @action = action
+    @record = record
+    @options = options
+  end
+
+  private
+
+    def text
+      options[:text] || t("admin.actions.#{action}")
+    end
+
+    def path
+      options[:path] || default_path
+    end
+
+    def html_options
+      {
+        class: html_class,
+        data: { confirm: confirmation_text }
+      }.merge(options.except(:confirm, :path, :text))
+    end
+
+    def html_class
+      "#{action.to_s.gsub("_", "-")}-link"
+    end
+
+    def confirmation_text
+      if options[:confirm] == true
+        t("admin.actions.confirm")
+      else
+        options[:confirm]
+      end
+    end
+
+    def default_path
+      if %i[answers configure destroy preview show].include?(action.to_sym)
+        namespaced_polymorphic_path(namespace, record)
+      else
+        namespaced_polymorphic_path(namespace, record, { action: action }.merge(request.query_parameters))
+      end
+    end
+end

--- a/app/components/admin/action_component.rb
+++ b/app/components/admin/action_component.rb
@@ -10,6 +10,10 @@ class Admin::ActionComponent < ApplicationComponent
 
   private
 
+    def button?
+      options[:method] && options[:method] != :get
+    end
+
     def text
       options[:text] || t("admin.actions.#{action}")
     end
@@ -22,12 +26,15 @@ class Admin::ActionComponent < ApplicationComponent
       {
         class: html_class,
         "aria-label": label,
-        data: { confirm: confirmation_text }
-      }.merge(options.except(:"aria-label", :confirm, :path, :text))
+        data: {
+          confirm: confirmation_text,
+          disable_with: (text if button?)
+        }
+      }.merge(options.except(:"aria-label", :class, :confirm, :path, :text))
     end
 
     def html_class
-      "#{action.to_s.gsub("_", "-")}-link"
+      "admin-action #{options[:class] || "#{action.to_s.gsub("_", "-")}-link"}".strip
     end
 
     def label

--- a/app/components/admin/budget_groups/groups_component.html.erb
+++ b/app/components/admin/budget_groups/groups_component.html.erb
@@ -17,9 +17,9 @@
           <td><%= group.headings.count %></td>
           <td>
             <%= render Admin::TableActionsComponent.new(group) do |actions| %>
-              <%= actions.link_to t("admin.budget_groups.headings_manage"),
-                                  headings_path(actions, group),
-                                  class: "headings-link" %>
+              <%= actions.action(:headings,
+                                 text: t("admin.budget_groups.headings_manage"),
+                                 path: headings_path(group)) %>
             <% end %>
           </td>
         </tr>

--- a/app/components/admin/budget_groups/groups_component.rb
+++ b/app/components/admin/budget_groups/groups_component.rb
@@ -1,4 +1,5 @@
 class Admin::BudgetGroups::GroupsComponent < ApplicationComponent
+  include Admin::Namespace
   attr_reader :groups
 
   def initialize(groups)
@@ -11,7 +12,7 @@ class Admin::BudgetGroups::GroupsComponent < ApplicationComponent
       @budget ||= groups.first.budget
     end
 
-    def headings_path(table_actions_component, group)
-      send("#{table_actions_component.namespace}_budget_group_headings_path", group.budget, group)
+    def headings_path(group)
+      send("#{namespace}_budget_group_headings_path", group.budget, group)
     end
 end

--- a/app/components/admin/budgets/table_actions_component.html.erb
+++ b/app/components/admin/budgets/table_actions_component.html.erb
@@ -1,22 +1,25 @@
 <%= render Admin::TableActionsComponent.new(budget,
   destroy_confirmation: t("admin.actions.confirm_delete", resource_name: t("admin.budgets.shared.resource_name"),
                                                           name: budget.name)
-  ) do %>
-  <%= link_to t("admin.budgets.index.budget_investments"),
-                 admin_budget_budget_investments_path(budget_id: budget.id),
-                 class: "investments-link" %>
-  <%= link_to t("admin.budgets.index.edit_groups"),
-                 admin_budget_groups_path(budget),
-                 class: "groups-link" %>
+  ) do |actions| %>
+  <%= actions.action(:investments,
+                     text: t("admin.budgets.index.budget_investments"),
+                     path: admin_budget_budget_investments_path(budget_id: budget.id)) %>
+  <%= actions.action(:groups,
+                     text: t("admin.budgets.index.edit_groups"),
+                     path: admin_budget_groups_path(budget)) %>
   <% if budget.poll.present? %>
-    <%= link_to t("admin.budgets.index.admin_ballots"),
-                admin_poll_booth_assignments_path(budget.poll),
-                class: "ballots-link" %>
+    <%= actions.action(:ballots,
+                       text: t("admin.budgets.index.admin_ballots"),
+                       path: admin_poll_booth_assignments_path(budget.poll)) %>
   <% else %>
-    <%= link_to_create_budget_poll %>
+    <%= actions.action(:ballots,
+                       text: t("admin.budgets.index.admin_ballots"),
+                       path: create_budget_poll_path,
+                       method: :post) %>
   <% end %>
-  <%= link_to t("admin.budgets.actions.preview"),
-                 budget_path(budget),
-                 target: "_blank",
-                 class: "preview-link" %>
+  <%= actions.action(:preview,
+                     text: t("admin.budgets.actions.preview"),
+                     path: budget_path(budget),
+                     target: "_blank") %>
 <% end %>

--- a/app/components/admin/budgets/table_actions_component.html.erb
+++ b/app/components/admin/budgets/table_actions_component.html.erb
@@ -1,7 +1,4 @@
-<%= render Admin::TableActionsComponent.new(budget,
-  destroy_confirmation: t("admin.actions.confirm_delete", resource_name: t("admin.budgets.shared.resource_name"),
-                                                          name: budget.name)
-  ) do |actions| %>
+<%= render Admin::TableActionsComponent.new(budget) do |actions| %>
   <%= actions.action(:investments,
                      text: t("admin.budgets.index.budget_investments"),
                      path: admin_budget_budget_investments_path(budget_id: budget.id)) %>

--- a/app/components/admin/budgets/table_actions_component.rb
+++ b/app/components/admin/budgets/table_actions_component.rb
@@ -7,17 +7,14 @@ class Admin::Budgets::TableActionsComponent < ApplicationComponent
 
   private
 
-    def link_to_create_budget_poll
+    def create_budget_poll_path
       balloting_phase = budget.phases.find_by(kind: "balloting")
 
-      link_to t("admin.budgets.index.admin_ballots"),
-        admin_polls_path(poll: {
-          name:      budget.name,
-          budget_id: budget.id,
-          starts_at: balloting_phase.starts_at,
-          ends_at:   balloting_phase.ends_at
-        }),
-        class: "ballots-link",
-        method: :post
+      admin_polls_path(poll: {
+        name:      budget.name,
+        budget_id: budget.id,
+        starts_at: balloting_phase.starts_at,
+        ends_at:   balloting_phase.ends_at
+      })
     end
 end

--- a/app/components/admin/hidden_table_actions_component.html.erb
+++ b/app/components/admin/hidden_table_actions_component.html.erb
@@ -1,12 +1,14 @@
-<%= render Admin::TableActionsComponent.new(actions: []) do %>
-  <%= link_to restore_text, restore_path,
-    method: :put,
-    data: { confirm: t("admin.actions.confirm") },
-    class: "restore-link" %>
+<%= render Admin::TableActionsComponent.new(record, actions: []) do |actions| %>
+  <%= actions.action(:restore,
+                     text: restore_text,
+                     path: restore_path,
+                     method: :put,
+                     confirm: true) %>
 
   <% unless record.confirmed_hide? %>
-    <%= link_to confirm_hide_text, confirm_hide_path,
-      method: :put,
-      class: "confirm-hide-link" %>
+    <%= actions.action(:confirm_hide,
+                       text: confirm_hide_text,
+                       path: confirm_hide_path,
+                       method: :put) %>
   <% end %>
 <% end %>

--- a/app/components/admin/organizations/table_actions_component.html.erb
+++ b/app/components/admin/organizations/table_actions_component.html.erb
@@ -1,13 +1,13 @@
-<%= render Admin::TableActionsComponent.new(actions: []) do %>
+<%= render Admin::TableActionsComponent.new(organization, actions: []) do |actions| %>
   <% if can_verify? %>
-    <%= link_to t("admin.organizations.index.verify"),
-      verify_admin_organization_path(organization, request.query_parameters),
-      method: :put, class: "verify-link" %>
+    <%= actions.action(:verify,
+                       text: t("admin.organizations.index.verify"),
+                       method: :put) %>
   <% end %>
 
   <% if can_reject? %>
-    <%= link_to t("admin.organizations.index.reject"),
-      reject_admin_organization_path(organization, request.query_parameters),
-      method: :put, class: "reject-link" %>
+    <%= actions.action(:reject,
+                       text: t("admin.organizations.index.reject"),
+                       method: :put) %>
   <% end %>
 <% end %>

--- a/app/components/admin/poll/officers/officers_component.html.erb
+++ b/app/components/admin/poll/officers/officers_component.html.erb
@@ -23,11 +23,11 @@
               destroy_options: { class: "destroy-officer-link" }
             ) %>
           <% else %>
-            <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
-              <%= actions.link_to t("admin.poll_officers.officer.add"),
-                                  add_user_path(officer),
-                                  method: :post,
-                                  class: "create-officer-link" %>
+            <%= render Admin::TableActionsComponent.new(officer, actions: []) do |actions| %>
+              <%= actions.action(:create_officer,
+                                 text: t("admin.poll_officers.officer.add"),
+                                 path: add_user_path(officer),
+                                 method: :post) %>
             <% end %>
           <% end %>
         </td>

--- a/app/components/admin/roles/table_actions_component.html.erb
+++ b/app/components/admin/roles/table_actions_component.html.erb
@@ -4,7 +4,7 @@
     destroy_options: { class: "destroy-role-link" }
   ) %>
 <% else %>
-  <%= render Admin::TableActionsComponent.new(actions: []) do %>
-    <%= link_to add_user_text, add_user_path, method: :post, class: "create-role-link" %>
+  <%= render Admin::TableActionsComponent.new(record, actions: []) do |actions| %>
+    <%= actions.action(:create_role, text: add_user_text, path: add_user_path, method: :post) %>
   <% end %>
 <% end %>

--- a/app/components/admin/table_actions_component.html.erb
+++ b/app/components/admin/table_actions_component.html.erb
@@ -2,10 +2,10 @@
   <%= content %>
 
   <% if actions.include?(:edit) %>
-    <%= link_to edit_text, edit_path, edit_options %>
+    <%= action(:edit, edit_options.merge(text: edit_text, path: edit_path)) %>
   <% end %>
 
   <% if actions.include?(:destroy) %>
-    <%= link_to destroy_text, destroy_path, destroy_options %>
+    <%= action(:destroy, destroy_options.merge(text: destroy_text, path: destroy_path)) %>
   <% end %>
 </div>

--- a/app/components/admin/table_actions_component.rb
+++ b/app/components/admin/table_actions_component.rb
@@ -1,10 +1,13 @@
 class Admin::TableActionsComponent < ApplicationComponent
-  include Admin::Namespace
   attr_reader :record, :options
 
-  def initialize(record = nil, **options)
+  def initialize(record, **options)
     @record = record
     @options = options
+  end
+
+  def action(action_name, **args)
+    render Admin::ActionComponent.new(action_name, record, **args)
   end
 
   private
@@ -14,15 +17,15 @@ class Admin::TableActionsComponent < ApplicationComponent
     end
 
     def edit_text
-      options[:edit_text] || t("admin.actions.edit")
+      options[:edit_text]
     end
 
     def edit_path
-      options[:edit_path] || namespaced_polymorphic_path(namespace, record, action: :edit)
+      options[:edit_path]
     end
 
     def edit_options
-      { class: "edit-link" }.merge(options[:edit_options] || {})
+      options[:edit_options] || {}
     end
 
     def destroy_text
@@ -30,18 +33,13 @@ class Admin::TableActionsComponent < ApplicationComponent
     end
 
     def destroy_path
-      options[:destroy_path] || namespaced_polymorphic_path(namespace, record)
+      options[:destroy_path]
     end
 
     def destroy_options
       {
         method: :delete,
-        class: "destroy-link",
-        data: { confirm: destroy_confirmation }
+        confirm: options[:destroy_confirmation] || true
       }.merge(options[:destroy_options] || {})
-    end
-
-    def destroy_confirmation
-      options[:destroy_confirmation] || t("admin.actions.confirm")
     end
 end

--- a/app/components/admin/table_actions_component.rb
+++ b/app/components/admin/table_actions_component.rb
@@ -7,7 +7,7 @@ class Admin::TableActionsComponent < ApplicationComponent
   end
 
   def action(action_name, **args)
-    render Admin::ActionComponent.new(action_name, record, **args)
+    render Admin::ActionComponent.new(action_name, record, "aria-label": true, **args)
   end
 
   private

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
+  include HumanName
   self.abstract_class = true
 
   def self.sample(count = 1)

--- a/app/models/concerns/human_name.rb
+++ b/app/models/concerns/human_name.rb
@@ -1,0 +1,9 @@
+module HumanName
+  def human_name
+    %i[title name subject].each do |method|
+      return send(method) if respond_to?(method)
+    end
+
+    raise "Must implement a method defining a human name"
+  end
+end

--- a/app/models/dashboard/administrator_task.rb
+++ b/app/models/dashboard/administrator_task.rb
@@ -8,4 +8,8 @@ class Dashboard::AdministratorTask < ApplicationRecord
 
   scope :pending, -> { where(executed_at: nil) }
   scope :done, -> { where.not(executed_at: nil) }
+
+  def title
+    "#{source.proposal.title} #{source.action.title}"
+  end
 end

--- a/app/models/local_census_record.rb
+++ b/app/models/local_census_record.rb
@@ -10,6 +10,10 @@ class LocalCensusRecord < ApplicationRecord
 
   scope :search, ->(terms) { where("document_number ILIKE ?", "%#{terms}%") }
 
+  def title
+    "#{ApplicationController.helpers.humanize_document_type(document_type)} #{document_number}"
+  end
+
   private
 
     def sanitize

--- a/app/models/poll/booth_assignment.rb
+++ b/app/models/poll/booth_assignment.rb
@@ -3,6 +3,8 @@ class Poll
     belongs_to :booth
     belongs_to :poll
 
+    delegate :name, to: :booth
+
     before_destroy :destroy_poll_shifts, only: :destroy
 
     has_many :officer_assignments, dependent: :destroy

--- a/app/models/poll/shift.rb
+++ b/app/models/poll/shift.rb
@@ -16,6 +16,10 @@ class Poll
     after_create :create_officer_assignments
     before_destroy :destroy_officer_assignments
 
+    def title
+      "#{I18n.t("admin.poll_shifts.#{task}")} #{officer_name} #{I18n.l(date.to_date, format: :long)}"
+    end
+
     def persist_data
       self.officer_name = officer.name
       self.officer_email = officer.email

--- a/app/views/admin/admin_notifications/index.html.erb
+++ b/app/views/admin/admin_notifications/index.html.erb
@@ -31,15 +31,11 @@
         <td>
           <% if admin_notification.draft? %>
             <%= render Admin::TableActionsComponent.new(admin_notification) do |actions| %>
-              <%= actions.link_to t("admin.admin_notifications.index.preview"),
-                                  admin_admin_notification_path(admin_notification),
-                                  class: "preview-link" %>
+              <%= actions.action(:preview, text: t("admin.admin_notifications.index.preview")) %>
             <% end %>
           <% else %>
-            <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
-              <%= actions.link_to t("admin.admin_notifications.index.view"),
-                                  admin_admin_notification_path(admin_notification),
-                                  class: "show-link" %>
+            <%= render Admin::TableActionsComponent.new(admin_notification, actions: []) do |actions| %>
+              <%= actions.action(:show, text: t("admin.admin_notifications.index.view")) %>
             <% end %>
           <% end %>
         </td>

--- a/app/views/admin/audits/_audits.html.erb
+++ b/app/views/admin/audits/_audits.html.erb
@@ -34,10 +34,8 @@
               <%= audit.user&.name %>
             </td>
             <td>
-              <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
-                <%= actions.link_to t("shared.show"),
-                  admin_polymorphic_path(audit),
-                  class: "show-link" %>
+              <%= render Admin::TableActionsComponent.new(audit, actions: []) do |actions| %>
+                <%= actions.action(:show, text: t("shared.show")) %>
               <% end %>
             </td>
           </tr>

--- a/app/views/admin/dashboard/actions/_default_actions.html.erb
+++ b/app/views/admin/dashboard/actions/_default_actions.html.erb
@@ -6,6 +6,7 @@
     <td colspan="4">&nbsp;</td>
     <td>
       <%= render Admin::TableActionsComponent.new(
+        action,
         actions: [:edit],
         edit_path: admin_settings_path(anchor: "tab-proposals"),
       ) %>

--- a/app/views/admin/newsletters/index.html.erb
+++ b/app/views/admin/newsletters/index.html.erb
@@ -30,9 +30,7 @@
         </td>
         <td>
           <%= render Admin::TableActionsComponent.new(newsletter) do |actions| %>
-            <%= actions.link_to t("admin.newsletters.index.preview"),
-                                admin_newsletter_path(newsletter),
-                                class: "preview-link" %>
+            <%= actions.action :preview, text: t("admin.newsletters.index.preview") %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/officials/index.html.erb
+++ b/app/views/admin/officials/index.html.erb
@@ -27,6 +27,7 @@
           </td>
           <td>
             <%= render Admin::TableActionsComponent.new(
+              official,
               actions: [:edit],
               edit_path: edit_admin_official_path(official)
             ) %>

--- a/app/views/admin/officials/search.html.erb
+++ b/app/views/admin/officials/search.html.erb
@@ -33,6 +33,7 @@
           </td>
           <td>
             <%= render Admin::TableActionsComponent.new(
+              user,
               actions: [:edit],
               edit_path: edit_admin_official_path(user),
               edit_text: (t("admin.officials.search.make_official") unless user.official?)

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -26,12 +26,12 @@
   </td>
   <td>
     <% unless @poll.expired? %>
-      <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
-        <%= actions.link_to t("admin.booth_assignments.manage.actions.assign"),
-                            admin_poll_booth_assignments_path(@poll, booth_id: booth.id),
-                            method: :post,
-                            remote: true,
-                            class: "assign-booth-link" %>
+      <%= render Admin::TableActionsComponent.new(booth, actions: []) do |actions| %>
+        <%= actions.action(:assign_booth,
+                           text: t("admin.booth_assignments.manage.actions.assign"),
+                           path: admin_poll_booth_assignments_path(@poll, booth_id: booth.id),
+                           method: :post,
+                           remote: true) %>
       <% end %>
     <% end %>
   </td>

--- a/app/views/admin/poll/booths/_booth.html.erb
+++ b/app/views/admin/poll/booths/_booth.html.erb
@@ -7,10 +7,10 @@
   </td>
   <td>
     <% if controller_name == "shifts" || controller_name == "booths" && action_name == "available" %>
-      <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
-        <%= actions.link_to t("admin.booths.booth.shifts"),
-                            new_admin_booth_shift_path(booth),
-                            class: "shifts-link" %>
+      <%= render Admin::TableActionsComponent.new(booth, actions: []) do |actions| %>
+        <%= actions.action(:shifts,
+                           text: t("admin.booths.booth.shifts"),
+                           path: new_admin_booth_shift_path(booth)) %>
       <% end %>
     <% else %>
       <%= render Admin::TableActionsComponent.new(booth, actions: [:edit]) %>

--- a/app/views/admin/poll/polls/_poll.html.erb
+++ b/app/views/admin/poll/polls/_poll.html.erb
@@ -10,9 +10,7 @@
     <%= render Admin::TableActionsComponent.new(poll,
       destroy_confirmation: t("admin.polls.destroy.alert")
     ) do |actions| %>
-      <%= actions.link_to t("admin.actions.configure"),
-                          admin_poll_path(poll),
-                          class: "configure-link" %>
+      <%= actions.action(:configure) %>
     <% end %>
   </td>
 </tr>

--- a/app/views/admin/poll/polls/_questions.html.erb
+++ b/app/views/admin/poll/polls/_questions.html.erb
@@ -29,8 +29,7 @@
         </td>
         <td>
           <%= render Admin::TableActionsComponent.new(question) do |actions| %>
-            <%= actions.link_to t("admin.polls.show.edit_answers"), admin_question_path(question),
-                                                                    class: "answers-link" %>
+            <%= actions.action(:answers, text: t("admin.polls.show.edit_answers")) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/poll/polls/booth_assignments.html.erb
+++ b/app/views/admin/poll/polls/booth_assignments.html.erb
@@ -15,10 +15,10 @@
             <%= l poll.starts_at.to_date %> - <%= l poll.ends_at.to_date %>
           </td>
           <td>
-            <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
-              <%= actions.link_to t("admin.booth_assignments.manage_assignments"),
-                                  manage_admin_poll_booth_assignments_path(poll),
-                                  class: "manage-link" %>
+            <%= render Admin::TableActionsComponent.new(poll, actions: []) do |actions| %>
+              <%= actions.action(:manage,
+                                 text: t("admin.booth_assignments.manage_assignments"),
+                                 path: manage_admin_poll_booth_assignments_path(poll)) %>
             <% end %>
           </td>
         </tr>

--- a/app/views/admin/poll/questions/_questions.html.erb
+++ b/app/views/admin/poll/questions/_questions.html.erb
@@ -26,8 +26,7 @@
           </td>
           <td>
             <%= render Admin::TableActionsComponent.new(question) do |actions| %>
-              <%= actions.link_to t("admin.polls.show.edit_answers"), admin_question_path(question),
-                                                                      class: "answers-link" %>
+              <%= actions.action(:answers, text: t("admin.polls.show.edit_answers")) %>
             <% end %>
           </td>
         </tr>

--- a/app/views/admin/poll/questions/_successful_proposals.html.erb
+++ b/app/views/admin/poll/questions/_successful_proposals.html.erb
@@ -15,11 +15,11 @@
           </p>
         </td>
         <td>
-          <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
-            <%= actions.link_to t("admin.shared.view"), proposal_path(proposal), class: "show-link" %>
-            <%= actions.link_to t("admin.questions.index.create_question"),
-                  new_admin_question_path(proposal_id: proposal.id),
-                  class: "new-link" %>
+          <%= render Admin::TableActionsComponent.new(proposal, actions: []) do |actions| %>
+            <%= actions.action(:show, text: t("admin.shared.view"), path: proposal_path(proposal)) %>
+            <%= actions.action(:new,
+                               text: t("admin.questions.index.create_question"),
+                               path: new_admin_question_path(proposal_id: proposal.id)) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/poll/questions/answers/documents.html.erb
+++ b/app/views/admin/poll/questions/answers/documents.html.erb
@@ -40,11 +40,11 @@
               actions: [:destroy],
               destroy_path: document_path(document)
             ) do |actions| %>
-              <%= actions.link_to t("documents.buttons.download_document"),
-                                  document.attachment.url,
-                                  target: "_blank",
-                                  rel: "nofollow",
-                                  class: "download-link" %>
+              <%= actions.action(:download,
+                                 text: t("documents.buttons.download_document"),
+                                 path: document.attachment.url,
+                                 target: "_blank",
+                                 rel: "nofollow") %>
 
             <% end %>
           </td>

--- a/app/views/admin/poll/shifts/_search_officers_results.html.erb
+++ b/app/views/admin/poll/shifts/_search_officers_results.html.erb
@@ -24,6 +24,7 @@
         </td>
         <td>
           <%= render Admin::TableActionsComponent.new(
+            user,
             actions: [:edit],
             edit_text: t("admin.poll_shifts.new.edit_shifts"),
             edit_path: new_admin_booth_shift_path(officer_id: user.poll_officer.id)

--- a/app/views/admin/site_customization/content_blocks/index.html.erb
+++ b/app/views/admin/site_customization/content_blocks/index.html.erb
@@ -44,6 +44,7 @@
         <td><%= raw content_block.body %></td>
         <td>
           <%= render Admin::TableActionsComponent.new(
+            content_block,
             actions: [:destroy],
             destroy_path: admin_site_customization_delete_heading_content_block_path(content_block)
           ) %>

--- a/app/views/admin/site_customization/documents/index.html.erb
+++ b/app/views/admin/site_customization/documents/index.html.erb
@@ -27,6 +27,7 @@
           <td>
             <div class="small-12 medium-6 column">
               <%= render Admin::TableActionsComponent.new(
+                document,
                 actions: [:destroy],
                 destroy_path: admin_site_customization_document_path(document)
               ) %>

--- a/app/views/admin/site_customization/pages/index.html.erb
+++ b/app/views/admin/site_customization/pages/index.html.erb
@@ -29,15 +29,15 @@
         <td><%= t("admin.site_customization.pages.page.status_#{page.status}") %></td>
         <td>
           <%= render Admin::TableActionsComponent.new(page) do |actions| %>
-            <%= actions.link_to t("admin.site_customization.pages.page.see_cards"),
-                                admin_site_customization_page_widget_cards_path(page),
-                                class: "cards-link" %>
+            <%= actions.action(:cards,
+                               text: t("admin.site_customization.pages.page.see_cards"),
+                               path: admin_site_customization_page_widget_cards_path(page)) %>
 
             <% if page.status == "published" %>
-              <%= actions.link_to t("admin.site_customization.pages.index.see_page"),
-                                  page.url,
-                                  target: "_blank",
-                                  class: "show-link" %>
+              <%= actions.action(:show,
+                                 text: t("admin.site_customization.pages.index.see_page"),
+                                 path: page.url,
+                                 options: { target: "_blank" }) %>
             <% end %>
           <% end %>
         </td>

--- a/app/views/admin/system_emails/index.html.erb
+++ b/app/views/admin/system_emails/index.html.erb
@@ -18,21 +18,21 @@
         <%= t("admin.system_emails.#{system_email_title}.description") %>
       </td>
       <td>
-        <%= render Admin::TableActionsComponent.new(actions: []) do |actions| %>
+        <%= render Admin::TableActionsComponent.new(system_email_title, actions: []) do |actions| %>
           <% if system_email_actions.include?("view") %>
-            <%= actions.link_to t("admin.shared.view"),
-                                admin_system_email_view_path(system_email_title),
-                                class: "show-link" %>
+            <%= actions.action(:show,
+                               text: t("admin.shared.view"),
+                               path: admin_system_email_view_path(system_email_title)) %>
           <% end %>
 
           <% if system_email_actions.include?("preview_pending") %>
-            <%= actions.link_to t("admin.system_emails.preview_pending.action"),
-                                admin_system_email_preview_pending_path(system_email_title),
-                                class: "preview-pending-link" %>
-            <%= actions.link_to t("admin.system_emails.preview_pending.send_pending"),
-                                admin_system_email_send_pending_path(system_email_title),
-                                class: "send-pending-link",
-                                method: :put %>
+            <%= actions.action(:preview_pending,
+                               text: t("admin.system_emails.preview_pending.action"),
+                               path: admin_system_email_preview_pending_path(system_email_title)) %>
+             <%= actions.action(:send_pending,
+                                text: t("admin.system_emails.preview_pending.send_pending"),
+                                path: admin_system_email_send_pending_path(system_email_title),
+                                method: :put) %>
           <% end %>
 
           <% if system_email_actions.include?("edit_info") %>

--- a/app/views/admin/valuators/_valuator_row.html.erb
+++ b/app/views/admin/valuators/_valuator_row.html.erb
@@ -20,9 +20,7 @@
   </td>
   <td>
     <%= render Admin::TableActionsComponent.new(valuator) do |actions| %>
-      <%= actions.link_to t("admin.shared.view"),
-        admin_valuator_path(valuator),
-        class: "show-link" %>
+      <%= actions.action(:show, text: t("admin.shared.view")) %>
     <% end %>
   </td>
 </tr>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -5,7 +5,10 @@ en:
     actions:
       actions: Actions
       confirm: Are you sure?
+      confirm_action: "Are you sure? %{action} \"%{name}\""
+      confirm_delete: "Are you sure? This action will delete \"%{name}\" and can't be undone."
       confirm_hide: Confirm moderation
+      delete: "Delete"
       hide: Hide
       hide_author: Hide author
       label: "%{action} %{name}"
@@ -14,8 +17,6 @@ en:
       unmark_featured: Unmark featured
       edit: Edit
       configure: Configure
-      delete: Delete
-      confirm_delete: "Are you sure? This action will delete %{resource_name} '%{name}' and can't be undone."
     officing_booth:
       title: "You are officing the booth located at %{booth}. If this is not correct, do not continue and call the help phone number. Thank you."
     banners:
@@ -148,8 +149,6 @@ en:
         calculate: Calculate Winner Investments
         calculated: Winners being calculated, it may take a minute.
         recalculate: Recalculate Winner Investments
-      shared:
-        resource_name: "the budget"
     budget_groups:
       name: "Name"
       headings_name: "Headings"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -8,6 +8,7 @@ en:
       confirm_hide: Confirm moderation
       hide: Hide
       hide_author: Hide author
+      label: "%{action} %{name}"
       restore: Restore
       mark_featured: Featured
       unmark_featured: Unmark featured

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -5,7 +5,10 @@ es:
     actions:
       actions: Acciones
       confirm: '¿Estás seguro?'
+      confirm_action: "¿Estás seguro? %{action} \"%{name}\""
+      confirm_delete: "¿Estás seguro? Esta acción borrará \"%{name}\" y no se puede deshacer."
       confirm_hide: Confirmar moderación
+      delete: Borrar
       hide: Ocultar
       hide_author: Bloquear al autor
       label: "%{action} %{name}"
@@ -14,8 +17,6 @@ es:
       unmark_featured: Quitar destacado
       edit: Editar
       configure: Configurar
-      confirm_delete: "¿Estás seguro? Esta acción borrará %{resource_name} '%{name}' y no se puede deshacer."
-      delete: Borrar
     officing_booth:
       title: "Estás ahora mismo en la mesa ubicada en %{booth}. Si esto no es correcto no sigas adelante y llama al teléfono de incidencias. Gracias."
     banners:
@@ -148,8 +149,6 @@ es:
         calculate: Calcular proyectos ganadores
         calculated: Calculando ganadores, puede tardar un minuto.
         recalculate: Recalcular proyectos ganadores
-      shared:
-        resource_name: "el presupuesto"
     budget_groups:
       name: "Nombre"
       headings_name: "Partidas"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -8,6 +8,7 @@ es:
       confirm_hide: Confirmar moderación
       hide: Ocultar
       hide_author: Bloquear al autor
+      label: "%{action} %{name}"
       restore: Volver a mostrar
       mark_featured: Destacar
       unmark_featured: Quitar destacado

--- a/spec/components/admin/action_component_spec.rb
+++ b/spec/components/admin/action_component_spec.rb
@@ -60,4 +60,49 @@ describe Admin::ActionComponent do
       end
     end
   end
+
+  describe "data-confirm attribute" do
+    it "is not rendered by default" do
+      render_inline Admin::ActionComponent.new(:edit, double, path: "/")
+
+      expect(page).to have_link count: 1
+      expect(page).not_to have_css "[data-confirm]"
+    end
+
+    it "is not rendered when confirm is nil" do
+      render_inline Admin::ActionComponent.new(:edit, double, path: "/", confirm: nil)
+
+      expect(page).to have_link count: 1
+      expect(page).not_to have_css "[data-confirm]"
+    end
+
+    it "renders with the given value" do
+      render_inline Admin::ActionComponent.new(:edit, double, path: "/", confirm: "Really?")
+
+      expect(page).to have_link count: 1
+      expect(page).to have_css "[data-confirm='Really?']"
+    end
+
+    context "when confirm is true" do
+      it "uses the human name as default" do
+        record = double(human_name: "Everywhere and nowhere")
+        text = 'Are you sure? Edit "Everywhere and nowhere"'
+
+        render_inline Admin::ActionComponent.new(:edit, record, path: "/", confirm: true)
+
+        expect(page).to have_link count: 1
+        expect(page).to have_css "[data-confirm='#{text}']"
+      end
+
+      it "includes a more detailed message for the destroy action" do
+        record = double(human_name: "Participatory Budget 2015")
+        text = 'Are you sure? This action will delete "Participatory Budget 2015" and can\\\'t be undone.'
+
+        render_inline Admin::ActionComponent.new(:destroy, record, path: "/", confirm: true)
+
+        expect(page).to have_link count: 1
+        expect(page).to have_css "[data-confirm='#{text}']"
+      end
+    end
+  end
 end

--- a/spec/components/admin/action_component_spec.rb
+++ b/spec/components/admin/action_component_spec.rb
@@ -1,10 +1,19 @@
 require "rails_helper"
 
 describe Admin::ActionComponent do
-  it "includes an HTML class for the action" do
-    render_inline Admin::ActionComponent.new(:edit, double, path: "/")
+  describe "HTML class" do
+    it "includes an HTML class for the action by default" do
+      render_inline Admin::ActionComponent.new(:edit, double, path: "/")
 
-    expect(page).to have_css "a.edit-link"
+      expect(page).to have_css "a.edit-link.admin-action"
+    end
+
+    it "keeps the admin-action class when the class is overwritten" do
+      render_inline Admin::ActionComponent.new(:edit, double, path: "/", class: "modify-link")
+
+      expect(page).to have_css "a.modify-link.admin-action"
+      expect(page).not_to have_css ".edit-link"
+    end
   end
 
   describe "aria-label attribute" do
@@ -103,6 +112,20 @@ describe Admin::ActionComponent do
         expect(page).to have_link count: 1
         expect(page).to have_css "[data-confirm='#{text}']"
       end
+    end
+  end
+
+  describe "data-disable-with attribute" do
+    it "is not rendered for links" do
+      render_inline Admin::ActionComponent.new(:edit, double, path: "/")
+
+      expect(page).not_to have_css "[data-disable-with]"
+    end
+
+    it "is rendered for buttons" do
+      render_inline Admin::ActionComponent.new(:hide, double, path: "/", method: :delete)
+
+      expect(page).to have_css "button[data-disable-with='Hide']"
     end
   end
 end

--- a/spec/components/admin/action_component_spec.rb
+++ b/spec/components/admin/action_component_spec.rb
@@ -6,4 +6,58 @@ describe Admin::ActionComponent do
 
     expect(page).to have_css "a.edit-link"
   end
+
+  describe "aria-label attribute" do
+    it "is not rendered by default" do
+      record = double(human_name: "Stay home")
+
+      render_inline Admin::ActionComponent.new(:edit, record, path: "/")
+
+      expect(page).to have_link count: 1
+      expect(page).not_to have_css "[aria-label]"
+    end
+
+    it "is not rendered when aria-label is nil" do
+      render_inline Admin::ActionComponent.new(:edit, double, path: "/", "aria-label": nil)
+
+      expect(page).to have_link count: 1
+      expect(page).not_to have_css "[aria-label]"
+    end
+
+    it "renders with the given value" do
+      render_inline Admin::ActionComponent.new(:edit, double, path: "/", "aria-label": "Modify")
+
+      expect(page).to have_link count: 1
+      expect(page).to have_css "[aria-label='Modify']"
+    end
+
+    context "when aria-label is true" do
+      it "includes the action and the human_name of the record" do
+        record = double(human_name: "Stay home")
+
+        render_inline Admin::ActionComponent.new(:edit, record, path: "/", "aria-label": true)
+
+        expect(page).to have_link count: 1
+        expect(page).to have_css "a[aria-label='Edit Stay home']", exact_text: "Edit"
+      end
+
+      it "uses the to_s method when there's no human_name" do
+        record = double(to_s: "do_not_go_out")
+
+        render_inline Admin::ActionComponent.new(:edit, record, path: "/", "aria-label": true)
+
+        expect(page).to have_link count: 1
+        expect(page).to have_css "a[aria-label='Edit Do not go out']", exact_text: "Edit"
+      end
+
+      it "uses the human_name when there are both human_name and to_s" do
+        record = double(human_name: "Stay home", to_s: "do_not_go_out")
+
+        render_inline Admin::ActionComponent.new(:edit, record, path: "/", "aria-label": true)
+
+        expect(page).to have_link count: 1
+        expect(page).to have_css "a[aria-label='Edit Stay home']", exact_text: "Edit"
+      end
+    end
+  end
 end

--- a/spec/components/admin/action_component_spec.rb
+++ b/spec/components/admin/action_component_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+describe Admin::ActionComponent do
+  it "includes an HTML class for the action" do
+    render_inline Admin::ActionComponent.new(:edit, double, path: "/")
+
+    expect(page).to have_css "a.edit-link"
+  end
+end

--- a/spec/components/admin/budgets/table_actions_component_spec.rb
+++ b/spec/components/admin/budgets/table_actions_component_spec.rb
@@ -4,22 +4,24 @@ describe Admin::Budgets::TableActionsComponent, controller: Admin::BaseControlle
   let(:budget) { create(:budget) }
   let(:component) { Admin::Budgets::TableActionsComponent.new(budget) }
 
-  it "renders links to edit and delete budget, manage investments and edit groups and manage ballots" do
+  it "renders actions to edit and delete budget, manage investments and edit groups and manage ballots" do
     render_inline component
 
-    expect(page).to have_css "a", count: 6
+    expect(page).to have_link count: 4
     expect(page).to have_link "Investment projects", href: /investments/
     expect(page).to have_link "Heading groups", href: /groups/
     expect(page).to have_link "Edit", href: /edit/
-    expect(page).to have_link "Ballots"
     expect(page).to have_link "Preview", href: /budgets/
-    expect(page).to have_link "Delete", href: /budgets/
+
+    expect(page).to have_button count: 2
+    expect(page).to have_css "form[action*='budgets']", exact_text: "Delete"
+    expect(page).to have_button "Ballots"
   end
 
-  it "renders link to create new poll for budgets without polls" do
+  it "renders button to create new poll for budgets without polls" do
     render_inline component
 
-    expect(page).to have_css "a[href*='polls'][data-method='post']", text: "Ballots"
+    expect(page).to have_css "form[action*='polls'][method='post']", exact_text: "Ballots"
   end
 
   it "renders link to manage ballots for budgets with polls" do

--- a/spec/components/admin/hidden_table_actions_component_spec.rb
+++ b/spec/components/admin/hidden_table_actions_component_spec.rb
@@ -4,11 +4,12 @@ describe Admin::HiddenTableActionsComponent do
   let(:record) { create(:user) }
   let(:component) { Admin::HiddenTableActionsComponent.new(record) }
 
-  it "renders links to restore and confirm hide" do
+  it "renders buttons to restore and confirm hide" do
     render_inline component
 
-    expect(page).to have_css "a", count: 2
-    expect(page).to have_css "a[href*='restore'][data-method='put']", text: "Restore"
-    expect(page).to have_css "a[href*='confirm_hide'][data-method='put']", text: "Confirm moderation"
+    expect(page).to have_button count: 2
+    expect(page).to have_css "form[action*='restore']", exact_text: "Restore"
+    expect(page).to have_css "form[action*='confirm_hide']", exact_text: "Confirm moderation"
+    expect(page).to have_css "input[name='_method'][value='put']", visible: :hidden, count: 2
   end
 end

--- a/spec/components/admin/organizations/table_actions_component_spec.rb
+++ b/spec/components/admin/organizations/table_actions_component_spec.rb
@@ -4,35 +4,36 @@ describe Admin::Organizations::TableActionsComponent, controller: Admin::Organiz
   let(:organization) { create(:organization) }
   let(:component) { Admin::Organizations::TableActionsComponent.new(organization) }
 
-  it "renders links to verify and reject when it can" do
+  it "renders buttons to verify and reject when it can" do
     allow(component).to receive(:can_verify?).and_return(true)
     allow(component).to receive(:can_reject?).and_return(true)
 
     render_inline component
 
-    expect(page).to have_css "a", count: 2
-    expect(page).to have_css "a[href*='verify'][data-method='put']", text: "Verify"
-    expect(page).to have_css "a[href*='reject'][data-method='put']", text: "Reject"
+    expect(page).to have_button count: 2
+    expect(page).to have_css "form[action*='verify']", exact_text: "Verify"
+    expect(page).to have_css "form[action*='reject']", exact_text: "Reject"
+    expect(page).to have_css "input[name='_method'][value='put']", visible: :hidden, count: 2
   end
 
-  it "renders link to verify when it cannot reject" do
+  it "renders button to verify when it cannot reject" do
     allow(component).to receive(:can_verify?).and_return(true)
     allow(component).to receive(:can_reject?).and_return(false)
 
     render_inline component
 
-    expect(page).to have_css "a", count: 1
-    expect(page).to have_link "Verify"
+    expect(page).to have_button count: 1
+    expect(page).to have_button "Verify"
   end
 
-  it "renders link to reject when it cannot verify" do
+  it "renders button to reject when it cannot verify" do
     allow(component).to receive(:can_verify?).and_return(false)
     allow(component).to receive(:can_reject?).and_return(true)
 
     render_inline component
 
-    expect(page).to have_css "a", count: 1
-    expect(page).to have_link "Reject"
+    expect(page).to have_button count: 1
+    expect(page).to have_button "Reject"
   end
 
   it "does not render any actions when it cannot verify nor reject" do
@@ -41,6 +42,6 @@ describe Admin::Organizations::TableActionsComponent, controller: Admin::Organiz
 
     render_inline component
 
-    expect(page).not_to have_css "a"
+    expect(page).not_to have_button
   end
 end

--- a/spec/components/admin/organizations/table_actions_component_spec.rb
+++ b/spec/components/admin/organizations/table_actions_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Organizations::TableActionsComponent do
+describe Admin::Organizations::TableActionsComponent, controller: Admin::OrganizationsController do
   let(:organization) { create(:organization) }
   let(:component) { Admin::Organizations::TableActionsComponent.new(organization) }
 

--- a/spec/components/admin/poll/officers/officers_component_spec.rb
+++ b/spec/components/admin/poll/officers/officers_component_spec.rb
@@ -12,21 +12,24 @@ describe Admin::Poll::Officers::OfficersComponent, controller: Admin::BaseContro
     tbody = page.find("tbody")
 
     expect(tbody).to have_css "tr", count: 2
-    expect(tbody).to have_css "a", count: 2
+    expect(tbody).to have_button count: 2
   end
 
-  it "renders link to destroy for existing officers" do
+  it "renders button to destroy for existing officers" do
     render_inline component
     row = page.find("tr", text: "Old officer")
 
-    expect(row).to have_css "a[data-method='delete']", text: "Delete"
+    expect(row).to have_button "Delete position"
+    expect(row).to have_css "input[name='_method'][value='delete']", visible: :hidden
   end
 
-  it "renders link to add for new officers" do
+  it "renders button to add for new officers" do
     render_inline component
     row = page.find("tr", text: "New officer")
 
-    expect(row).to have_css "a[data-method='post']", text: "Add"
+    expect(row).to have_button "Add"
+    expect(row).to have_css "form[method='post']"
+    expect(row).not_to have_css "input[name='_method']", visible: :all
   end
 
   it "accepts table options" do

--- a/spec/components/admin/roles/table_actions_component_spec.rb
+++ b/spec/components/admin/roles/table_actions_component_spec.rb
@@ -3,15 +3,17 @@ require "rails_helper"
 describe Admin::Roles::TableActionsComponent, controller: Admin::BaseController do
   let(:user) { create(:user) }
 
-  it "renders link to add the role for new records" do
+  it "renders button to add the role for new records" do
     render_inline Admin::Roles::TableActionsComponent.new(user.build_manager)
 
-    expect(page).to have_css "a[data-method='post']", text: "Add"
+    expect(page).to have_css "form[method='post']", exact_text: "Add"
+    expect(page).not_to have_css "input[name='_method']", visible: :all
   end
 
-  it "renders link to remove the role for existing records" do
+  it "renders button to remove the role for existing records" do
     render_inline Admin::Roles::TableActionsComponent.new(create(:manager, user: user))
 
-    expect(page).to have_css "a[data-method='delete']", text: "Delete"
+    expect(page).to have_css "form[method='post']", exact_text: "Delete"
+    expect(page).to have_css "input[name='_method'][value='delete']", visible: :hidden
   end
 end

--- a/spec/components/admin/table_actions_component_spec.rb
+++ b/spec/components/admin/table_actions_component_spec.rb
@@ -1,14 +1,16 @@
 require "rails_helper"
 
 describe Admin::TableActionsComponent, controller: Admin::BaseController do
-  let(:record) { create(:banner) }
+  let(:record) { create(:banner, title: "Important!") }
 
   it "renders links to edit and destroy a record by default" do
     render_inline Admin::TableActionsComponent.new(record)
 
     expect(page).to have_css "a", count: 2
-    expect(page).to have_css "a[href*='edit']", text: "Edit"
-    expect(page).to have_css "a[data-method='delete']", text: "Delete"
+    expect(page).to have_css "a[href*='edit']", exact_text: "Edit"
+    expect(page).to have_css "a[aria-label='Edit Important!']", exact_text: "Edit"
+    expect(page).to have_css "a[data-method='delete']", exact_text: "Delete"
+    expect(page).to have_css "a[aria-label='Delete Important!']", exact_text: "Delete"
   end
 
   context "actions parameter is passed" do

--- a/spec/components/admin/table_actions_component_spec.rb
+++ b/spec/components/admin/table_actions_component_spec.rb
@@ -37,7 +37,7 @@ describe Admin::TableActionsComponent, controller: Admin::BaseController do
   end
 
   it "allows custom URLs" do
-    render_inline Admin::TableActionsComponent.new(edit_path: "/myedit", destroy_path: "/mydestroy")
+    render_inline Admin::TableActionsComponent.new(nil, edit_path: "/myedit", destroy_path: "/mydestroy")
 
     expect(page).to have_link "Edit", href: "/myedit"
     expect(page).to have_link "Delete", href: "/mydestroy"

--- a/spec/components/admin/table_actions_component_spec.rb
+++ b/spec/components/admin/table_actions_component_spec.rb
@@ -3,14 +3,16 @@ require "rails_helper"
 describe Admin::TableActionsComponent, controller: Admin::BaseController do
   let(:record) { create(:banner, title: "Important!") }
 
-  it "renders links to edit and destroy a record by default" do
+  it "renders edit and destroy actions by default" do
     render_inline Admin::TableActionsComponent.new(record)
 
-    expect(page).to have_css "a", count: 2
+    expect(page).to have_link count: 1
     expect(page).to have_css "a[href*='edit']", exact_text: "Edit"
-    expect(page).to have_css "a[aria-label='Edit Important!']", exact_text: "Edit"
-    expect(page).to have_css "a[data-method='delete']", exact_text: "Delete"
-    expect(page).to have_css "a[aria-label='Delete Important!']", exact_text: "Delete"
+    expect(page).to have_css "a[aria-label='Edit Important!']"
+
+    expect(page).to have_button count: 1
+    expect(page).to have_css "button[aria-label='Delete Important!']", exact_text: "Delete"
+    expect(page).to have_css "input[name='_method'][value='delete']", visible: :hidden
   end
 
   context "actions parameter is passed" do
@@ -18,13 +20,13 @@ describe Admin::TableActionsComponent, controller: Admin::BaseController do
       render_inline Admin::TableActionsComponent.new(record, actions: [:edit])
 
       expect(page).to have_link "Edit"
-      expect(page).not_to have_link "Delete"
+      expect(page).not_to have_button "Delete"
     end
 
-    it "renders a link to destroy a record if passed" do
+    it "renders a button to destroy a record if passed" do
       render_inline Admin::TableActionsComponent.new(record, actions: [:destroy])
 
-      expect(page).to have_link "Delete"
+      expect(page).to have_button "Delete"
       expect(page).not_to have_link "Edit"
     end
   end
@@ -32,9 +34,9 @@ describe Admin::TableActionsComponent, controller: Admin::BaseController do
   it "allows custom texts for actions" do
     render_inline Admin::TableActionsComponent.new(record, edit_text: "change", destroy_text: "annihilate")
 
-    expect(page).to have_link "annihilate"
+    expect(page).to have_button "annihilate"
     expect(page).to have_link "change"
-    expect(page).not_to have_link "Delete"
+    expect(page).not_to have_button "Delete"
     expect(page).not_to have_link "Edit"
   end
 
@@ -42,13 +44,13 @@ describe Admin::TableActionsComponent, controller: Admin::BaseController do
     render_inline Admin::TableActionsComponent.new(record, edit_path: "/myedit", destroy_path: "/mydestroy")
 
     expect(page).to have_link "Edit", href: "/myedit"
-    expect(page).to have_link "Delete", href: "/mydestroy"
+    expect(page).to have_css "form[action='/mydestroy']", exact_text: "Delete"
   end
 
   it "allows custom confirmation text" do
     render_inline Admin::TableActionsComponent.new(record, destroy_confirmation: "Are you mad? Be careful!")
 
-    expect(page).to have_css "a[data-confirm='Are you mad? Be careful!']"
+    expect(page).to have_css "button[data-confirm='Are you mad? Be careful!']"
   end
 
   it "allows custom options" do
@@ -62,19 +64,23 @@ describe Admin::TableActionsComponent, controller: Admin::BaseController do
       "<a href='/'>Main</a>".html_safe
     end
 
-    expect(page).to have_css "a", count: 3
+    expect(page).to have_css "a", count: 2
     expect(page).to have_link "Main", href: "/"
     expect(page).to have_link "Edit"
-    expect(page).to have_link "Delete"
+
+    expect(page).to have_button count: 1
+    expect(page).to have_button "Delete"
   end
 
   context "different namespace" do
-    it "generates links to different namespaces", controller: SDGManagement::BaseController do
+    it "generates actions to different namespaces", controller: SDGManagement::BaseController do
       render_inline Admin::TableActionsComponent.new(create(:sdg_local_target))
 
-      expect(page).to have_css "a", count: 2
-      expect(page).to have_css "a[href^='/sdg_management/'][href*='edit']", text: "Edit"
-      expect(page).to have_css "a[href^='/sdg_management/'][data-method='delete']", text: "Delete"
+      expect(page).to have_link count: 1
+      expect(page).to have_css "a[href^='/sdg_management/'][href*='edit']", exact_text: "Edit"
+
+      expect(page).to have_button count: 1
+      expect(page).to have_css "form[action^='/sdg_management/']", exact_text: "Delete"
     end
   end
 end

--- a/spec/components/admin/table_actions_component_spec.rb
+++ b/spec/components/admin/table_actions_component_spec.rb
@@ -39,7 +39,7 @@ describe Admin::TableActionsComponent, controller: Admin::BaseController do
   end
 
   it "allows custom URLs" do
-    render_inline Admin::TableActionsComponent.new(nil, edit_path: "/myedit", destroy_path: "/mydestroy")
+    render_inline Admin::TableActionsComponent.new(record, edit_path: "/myedit", destroy_path: "/mydestroy")
 
     expect(page).to have_link "Edit", href: "/myedit"
     expect(page).to have_link "Delete", href: "/mydestroy"

--- a/spec/models/human_name_spec.rb
+++ b/spec/models/human_name_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+describe HumanName do
+  describe "#human_name" do
+    it "uses the title when available" do
+      model = Class.new do
+        include HumanName
+
+        def title
+          "I am fire"
+        end
+      end
+
+      expect(model.new.human_name).to eq "I am fire"
+    end
+
+    it "uses the name when available" do
+      model = Class.new do
+        include HumanName
+
+        def name
+          "Be like water"
+        end
+      end
+
+      expect(model.new.human_name).to eq "Be like water"
+    end
+
+    it "uses the subject when available" do
+      model = Class.new do
+        include HumanName
+
+        def subject
+          "20% off on fire and water"
+        end
+      end
+
+      expect(model.new.human_name).to eq "20% off on fire and water"
+    end
+
+    it "prioritizes title over name and subject" do
+      model = Class.new do
+        include HumanName
+
+        def title
+          "I am fire"
+        end
+
+        def name
+          "Be like water"
+        end
+
+        def subject
+          "20% off on fire and water"
+        end
+      end
+
+      expect(model.new.human_name).to eq "I am fire"
+    end
+
+    it "prioritizes name over subject" do
+      model = Class.new do
+        include HumanName
+
+        def name
+          "Be like water"
+        end
+
+        def subject
+          "20% off on fire and water"
+        end
+      end
+
+      expect(model.new.human_name).to eq "Be like water"
+    end
+
+    it "raises an exception when no methods are defined" do
+      model = Class.new do
+        include HumanName
+      end
+
+      expect { model.new.human_name }.to raise_error RuntimeError
+    end
+  end
+end

--- a/spec/shared/system/admin_milestoneable.rb
+++ b/spec/shared/system/admin_milestoneable.rb
@@ -113,7 +113,7 @@ shared_examples "admin_milestoneable" do |factory_name, path_name|
 
         visit path
 
-        accept_confirm { click_link "Delete" }
+        accept_confirm { click_button "Delete" }
 
         expect(page).not_to have_content "Title will it remove"
       end

--- a/spec/shared/system/admin_progressable.rb
+++ b/spec/shared/system/admin_progressable.rb
@@ -112,7 +112,7 @@ shared_examples "admin_progressable" do |factory_name, path_name|
         bar = create(:progress_bar, progressable: progressable, percentage: 34)
 
         visit path
-        within("#progress_bar_#{bar.id}") { accept_confirm { click_link "Delete" } }
+        within("#progress_bar_#{bar.id}") { accept_confirm { click_button "Delete" } }
 
         expect(page).to have_content "Progress bar deleted successfully"
         expect(page).not_to have_content "34%"

--- a/spec/system/admin/activity_spec.rb
+++ b/spec/system/admin/activity_spec.rb
@@ -59,7 +59,7 @@ describe "Admin activity" do
       visit admin_hidden_proposals_path
 
       within("#proposal_#{proposal.id}") do
-        accept_confirm { click_link "Restore" }
+        accept_confirm { click_button "Restore" }
       end
 
       expect(page).to have_content "There are no hidden proposals"
@@ -126,7 +126,7 @@ describe "Admin activity" do
       visit admin_hidden_debates_path
 
       within("#debate_#{debate.id}") do
-        accept_confirm { click_link "Restore" }
+        accept_confirm { click_button "Restore" }
       end
 
       expect(page).to have_content "There are no hidden debates"
@@ -194,7 +194,7 @@ describe "Admin activity" do
       visit admin_hidden_comments_path
 
       within("#comment_#{comment.id}") do
-        accept_confirm { click_link "Restore" }
+        accept_confirm { click_button "Restore" }
       end
 
       expect(page).to have_content "There are no hidden comments"
@@ -340,7 +340,7 @@ describe "Admin activity" do
       visit admin_hidden_users_path
 
       within("#user_#{user.id}") do
-        accept_confirm { click_link "Restore" }
+        accept_confirm { click_button "Restore" }
       end
 
       expect(page).to have_content "There are no hidden users"

--- a/spec/system/admin/admin_notifications_spec.rb
+++ b/spec/system/admin/admin_notifications_spec.rb
@@ -118,7 +118,7 @@ describe "Admin Notifications", :admin do
 
       visit admin_admin_notifications_path
       within("#admin_notification_#{notification.id}") do
-        accept_confirm { click_link "Delete" }
+        accept_confirm { click_button "Delete" }
       end
 
       expect(page).to have_content "Notification deleted successfully"
@@ -129,8 +129,9 @@ describe "Admin Notifications", :admin do
       notification = create(:admin_notification, :sent)
 
       visit admin_admin_notifications_path
+
       within("#admin_notification_#{notification.id}") do
-        expect(page).not_to have_link("Delete")
+        expect(page).not_to have_button "Delete"
       end
     end
   end

--- a/spec/system/admin/administrators_spec.rb
+++ b/spec/system/admin/administrators_spec.rb
@@ -24,7 +24,9 @@ describe "Admin administrators" do
     click_button "Search"
 
     expect(page).to have_content user.name
-    click_link "Add"
+
+    click_button "Add"
+
     within("#administrators") do
       expect(page).to have_content user.name
     end
@@ -34,7 +36,7 @@ describe "Admin administrators" do
     visit admin_administrators_path
 
     within "#administrator_#{user_administrator.id}" do
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
     end
 
     within("#administrators") do
@@ -46,7 +48,7 @@ describe "Admin administrators" do
     visit admin_administrators_path
 
     within "#administrator_#{admin.id}" do
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
     end
 
     within("#error") do
@@ -110,7 +112,7 @@ describe "Admin administrators" do
       fill_in "Search user by name or email", with: administrator2.email
       click_button "Search"
 
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
 
       expect(page).to have_content(administrator1.email)
       expect(page).not_to have_content(administrator2.email)

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -173,7 +173,7 @@ describe "Admin banners magement", :admin do
 
     expect(page).to have_content "Ugly banner"
 
-    accept_confirm { click_link "Delete" }
+    accept_confirm { click_button "Delete" }
 
     visit admin_root_path
     expect(page).not_to have_content "Ugly banner"

--- a/spec/system/admin/budget_groups_spec.rb
+++ b/spec/system/admin/budget_groups_spec.rb
@@ -59,7 +59,7 @@ describe "Admin budget groups", :admin do
       group = create(:budget_group, budget: budget)
 
       visit admin_budget_groups_path(budget)
-      within("#budget_group_#{group.id}") { accept_confirm { click_link "Delete" } }
+      within("#budget_group_#{group.id}") { accept_confirm { click_button "Delete" } }
 
       expect(page).to have_content "Group deleted successfully"
       expect(page).not_to have_selector "#budget_group_#{group.id}"
@@ -70,7 +70,7 @@ describe "Admin budget groups", :admin do
       create(:budget_heading, group: group)
 
       visit admin_budget_groups_path(budget)
-      within("#budget_group_#{group.id}") { accept_confirm { click_link "Delete" } }
+      within("#budget_group_#{group.id}") { accept_confirm { click_button "Delete" } }
 
       expect(page).to have_content "You cannot delete a Group that has associated headings"
       expect(page).to have_selector "#budget_group_#{group.id}"

--- a/spec/system/admin/budget_headings_spec.rb
+++ b/spec/system/admin/budget_headings_spec.rb
@@ -38,7 +38,7 @@ describe "Admin budget headings", :admin do
         expect(page).not_to have_content "10000"
         expect(page).to have_content "Yes"
         expect(page).to have_link "Edit"
-        expect(page).to have_link "Delete"
+        expect(page).to have_button "Delete"
       end
 
       within "#budget_heading_#{heading2.id}" do
@@ -47,7 +47,7 @@ describe "Admin budget headings", :admin do
         expect(page).to have_content "10000"
         expect(page).to have_content "No"
         expect(page).to have_link "Edit"
-        expect(page).to have_link "Delete"
+        expect(page).to have_button "Delete"
       end
 
       within "#budget_heading_#{heading3.id}" do
@@ -56,7 +56,7 @@ describe "Admin budget headings", :admin do
         expect(page).to have_content "10000"
         expect(page).to have_content "No"
         expect(page).to have_link "Edit"
-        expect(page).to have_link "Delete"
+        expect(page).to have_button "Delete"
       end
     end
 
@@ -64,7 +64,7 @@ describe "Admin budget headings", :admin do
       heading = create(:budget_heading, group: group)
 
       visit admin_budget_group_headings_path(budget, group)
-      within("#budget_heading_#{heading.id}") { accept_confirm { click_link "Delete" } }
+      within("#budget_heading_#{heading.id}") { accept_confirm { click_button "Delete" } }
 
       expect(page).to have_content "Heading deleted successfully"
       expect(page).not_to have_selector "#budget_heading_#{heading.id}"
@@ -75,7 +75,7 @@ describe "Admin budget headings", :admin do
       create(:budget_investment, heading: heading)
 
       visit admin_budget_group_headings_path(budget, group)
-      within(".heading", text: "Atlantis") { accept_confirm { click_link "Delete" } }
+      within(".heading", text: "Atlantis") { accept_confirm { click_button "Delete" } }
 
       expect(page).to have_content "You cannot delete a Heading that has associated investments"
       expect(page).to have_content "Atlantis"

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -99,7 +99,7 @@ describe "Admin budgets", :admin do
       visit admin_budgets_path
 
       within "tr", text: "To be deleted" do
-        message = "Are you sure? This action will delete the budget 'To be deleted' and can't be undone."
+        message = "Are you sure? This action will delete \"To be deleted\" and can't be undone."
 
         accept_confirm(message) { click_link "Delete" }
       end

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -101,7 +101,7 @@ describe "Admin budgets", :admin do
       within "tr", text: "To be deleted" do
         message = "Are you sure? This action will delete \"To be deleted\" and can't be undone."
 
-        accept_confirm(message) { click_link "Delete" }
+        accept_confirm(message) { click_button "Delete" }
       end
 
       expect(page).to have_content("Budget deleted successfully")

--- a/spec/system/admin/budgets_wizard/groups_spec.rb
+++ b/spec/system/admin/budgets_wizard/groups_spec.rb
@@ -124,7 +124,7 @@ describe "Budgets wizard, groups step", :admin do
       create(:budget_group, budget: budget, name: "Delete me!")
 
       visit admin_budgets_wizard_budget_groups_path(budget)
-      within("tr", text: "Delete me!") { accept_confirm { click_link "Delete" } }
+      within("tr", text: "Delete me!") { accept_confirm { click_button "Delete" } }
 
       expect(page).to have_content "Group deleted successfully"
       expect(page).not_to have_content "Delete me!"
@@ -137,7 +137,7 @@ describe "Budgets wizard, groups step", :admin do
 
       visit admin_budgets_wizard_budget_groups_path(budget)
 
-      within("tr", text: "Don't delete me!") { accept_confirm { click_link "Delete" } }
+      within("tr", text: "Don't delete me!") { accept_confirm { click_button "Delete" } }
 
       expect(page).to have_content "You cannot delete a Group that has associated headings"
       expect(page).to have_content "Don't delete me!"

--- a/spec/system/admin/budgets_wizard/headings_spec.rb
+++ b/spec/system/admin/budgets_wizard/headings_spec.rb
@@ -148,7 +148,7 @@ describe "Budgets wizard, headings step", :admin do
       create(:budget_heading, group: group, name: "Delete me!")
 
       visit admin_budgets_wizard_budget_group_headings_path(budget, group)
-      within("tr", text: "Delete me!") { accept_confirm { click_link "Delete" } }
+      within("tr", text: "Delete me!") { accept_confirm { click_button "Delete" } }
 
       expect(page).to have_content "Heading deleted successfully"
       expect(page).not_to have_content "Delete me!"
@@ -161,7 +161,7 @@ describe "Budgets wizard, headings step", :admin do
 
       visit admin_budgets_wizard_budget_group_headings_path(budget, group)
 
-      within("tr", text: "Don't delete me!") { accept_confirm { click_link "Delete" } }
+      within("tr", text: "Don't delete me!") { accept_confirm { click_button "Delete" } }
 
       expect(page).to have_content "You cannot delete a Heading that has associated investments"
       expect(page).to have_content "Don't delete me!"

--- a/spec/system/admin/dashboard/actions_spec.rb
+++ b/spec/system/admin/dashboard/actions_spec.rb
@@ -94,9 +94,7 @@ describe "Admin dashboard actions", :admin do
     end
 
     scenario "deletes the action" do
-      page.accept_confirm do
-        click_link "Delete"
-      end
+      accept_confirm { click_button "Delete" }
 
       expect(page).not_to have_content(action.title)
     end
@@ -104,9 +102,7 @@ describe "Admin dashboard actions", :admin do
     scenario "can not delete actions that have been executed" do
       _executed_action = create(:dashboard_executed_action, action: action)
 
-      page.accept_confirm do
-        click_link "Delete"
-      end
+      accept_confirm { click_button "Delete" }
 
       expect(page).to have_content("Cannot delete record because dependent executed actions exist")
     end

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -103,7 +103,7 @@ describe "Admin newsletter emails", :admin do
 
     visit admin_newsletters_path
     within("#newsletter_#{newsletter.id}") do
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
     end
 
     expect(page).to have_content "Newsletter deleted successfully"

--- a/spec/system/admin/geozones_spec.rb
+++ b/spec/system/admin/geozones_spec.rb
@@ -74,7 +74,7 @@ describe "Admin geozones", :admin do
 
     visit admin_geozones_path
 
-    within("#geozone_#{geozone.id}") { accept_confirm { click_link "Delete" } }
+    within("#geozone_#{geozone.id}") { accept_confirm { click_button "Delete" } }
 
     expect(page).to have_content "Geozone successfully deleted"
     expect(page).not_to have_content("Delete me!")
@@ -86,7 +86,7 @@ describe "Admin geozones", :admin do
 
     visit admin_geozones_path
 
-    within("#geozone_#{geozone.id}") { accept_confirm { click_link "Delete" } }
+    within("#geozone_#{geozone.id}") { accept_confirm { click_button "Delete" } }
 
     expect(page).to have_content "This geozone can't be deleted since there are elements attached to it"
 

--- a/spec/system/admin/hidden_budget_investments_spec.rb
+++ b/spec/system/admin/hidden_budget_investments_spec.rb
@@ -18,7 +18,7 @@ describe "Admin hidden budget investments", :admin do
 
     visit admin_hidden_budget_investments_path
 
-    accept_confirm { click_link "Restore" }
+    accept_confirm { click_button "Restore" }
 
     expect(page).not_to have_content(investment.title)
 
@@ -36,7 +36,7 @@ describe "Admin hidden budget investments", :admin do
     expect(page).not_to have_link "Pending"
     expect(page).to have_content(investment.title)
 
-    click_link "Confirm moderation"
+    click_button "Confirm moderation"
 
     expect(page).not_to have_content(investment.title)
 
@@ -84,7 +84,7 @@ describe "Admin hidden budget investments", :admin do
 
     visit admin_hidden_budget_investments_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_link "Restore", match: :first, exact: true }
+    accept_confirm { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_comments_spec.rb
+++ b/spec/system/admin/hidden_comments_spec.rb
@@ -67,7 +67,7 @@ describe "Admin hidden comments", :admin do
     comment = create(:comment, :hidden, body: "Not really SPAM")
     visit admin_hidden_comments_path
 
-    accept_confirm { click_link "Restore" }
+    accept_confirm { click_button "Restore" }
 
     expect(page).not_to have_content(comment.body)
 
@@ -80,7 +80,7 @@ describe "Admin hidden comments", :admin do
     comment = create(:comment, :hidden, body: "SPAM")
     visit admin_hidden_comments_path
 
-    click_link "Confirm moderation"
+    click_button "Confirm moderation"
 
     expect(page).not_to have_content(comment.body)
     click_link("Confirmed")
@@ -128,7 +128,7 @@ describe "Admin hidden comments", :admin do
 
     visit admin_hidden_comments_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_link "Restore", match: :first, exact: true }
+    accept_confirm { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_debates_spec.rb
+++ b/spec/system/admin/hidden_debates_spec.rb
@@ -5,7 +5,7 @@ describe "Admin hidden debates", :admin do
     debate = create(:debate, :hidden)
     visit admin_hidden_debates_path
 
-    accept_confirm { click_link "Restore" }
+    accept_confirm { click_button "Restore" }
 
     expect(page).not_to have_content(debate.title)
 
@@ -18,7 +18,7 @@ describe "Admin hidden debates", :admin do
     debate = create(:debate, :hidden)
     visit admin_hidden_debates_path
 
-    click_link "Confirm moderation"
+    click_button "Confirm moderation"
 
     expect(page).not_to have_content(debate.title)
     click_link("Confirmed")
@@ -70,7 +70,7 @@ describe "Admin hidden debates", :admin do
 
     visit admin_hidden_debates_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_link "Restore", match: :first, exact: true }
+    accept_confirm { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_proposals_spec.rb
+++ b/spec/system/admin/hidden_proposals_spec.rb
@@ -18,7 +18,7 @@ describe "Admin hidden proposals", :admin do
     proposal = create(:proposal, :hidden)
     visit admin_hidden_proposals_path
 
-    accept_confirm { click_link "Restore" }
+    accept_confirm { click_button "Restore" }
 
     expect(page).not_to have_content(proposal.title)
 
@@ -31,7 +31,7 @@ describe "Admin hidden proposals", :admin do
     proposal = create(:proposal, :hidden)
     visit admin_hidden_proposals_path
 
-    click_link "Confirm moderation"
+    click_button "Confirm moderation"
 
     expect(page).not_to have_content(proposal.title)
     click_link("Confirmed")
@@ -83,7 +83,7 @@ describe "Admin hidden proposals", :admin do
 
     visit admin_hidden_proposals_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_link "Restore", match: :first, exact: true }
+    accept_confirm { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/hidden_users_spec.rb
+++ b/spec/system/admin/hidden_users_spec.rb
@@ -21,7 +21,7 @@ describe "Admin hidden users", :admin do
     user = create(:user, :hidden)
     visit admin_hidden_users_path
 
-    accept_confirm { click_link "Restore" }
+    accept_confirm { click_button "Restore" }
 
     expect(page).not_to have_content(user.username)
 
@@ -34,7 +34,7 @@ describe "Admin hidden users", :admin do
     user = create(:user, :hidden)
     visit admin_hidden_users_path
 
-    click_link "Confirm moderation"
+    click_button "Confirm moderation"
 
     expect(page).not_to have_content(user.username)
     click_link("Confirmed")
@@ -82,7 +82,7 @@ describe "Admin hidden users", :admin do
 
     visit admin_hidden_users_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_link "Restore", match: :first, exact: true }
+    accept_confirm { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/local_census_records_spec.rb
+++ b/spec/system/admin/local_census_records_spec.rb
@@ -25,7 +25,7 @@ describe "Admin local census records", :admin do
 
       within "#local_census_record_#{local_census_record.id}" do
         expect(page).to have_link "Edit"
-        expect(page).to have_link "Delete"
+        expect(page).to have_button "Delete"
       end
     end
 

--- a/spec/system/admin/managers_spec.rb
+++ b/spec/system/admin/managers_spec.rb
@@ -19,7 +19,9 @@ describe "Admin managers", :admin do
     click_button "Search"
 
     expect(page).to have_content user.name
-    click_link "Add"
+
+    click_button "Add"
+
     within("#managers") do
       expect(page).to have_content user.name
     end
@@ -28,7 +30,7 @@ describe "Admin managers", :admin do
   scenario "Delete Manager" do
     visit admin_managers_path
 
-    accept_confirm { click_link "Delete" }
+    accept_confirm { click_button "Delete" }
 
     within("#managers") do
       expect(page).not_to have_content manager.name
@@ -88,7 +90,7 @@ describe "Admin managers", :admin do
       fill_in "Search user by name or email", with: manager2.email
       click_button "Search"
 
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
 
       expect(page).to have_content(manager1.email)
       expect(page).not_to have_content(manager2.email)

--- a/spec/system/admin/milestone_statuses_spec.rb
+++ b/spec/system/admin/milestone_statuses_spec.rb
@@ -78,7 +78,7 @@ describe "Admin milestone statuses", :admin do
       visit admin_milestone_statuses_path
 
       within("#milestone_status_#{status.id}") do
-        accept_confirm { click_link "Delete" }
+        accept_confirm { click_button "Delete" }
       end
 
       expect(page).not_to have_content status.name

--- a/spec/system/admin/moderators_spec.rb
+++ b/spec/system/admin/moderators_spec.rb
@@ -19,7 +19,9 @@ describe "Admin moderators", :admin do
     click_button "Search"
 
     expect(page).to have_content user.name
-    click_link "Add"
+
+    click_button "Add"
+
     within("#moderators") do
       expect(page).to have_content user.name
     end
@@ -28,7 +30,7 @@ describe "Admin moderators", :admin do
   scenario "Delete Moderator" do
     visit admin_moderators_path
 
-    accept_confirm { click_link "Delete" }
+    accept_confirm { click_button "Delete" }
 
     within("#moderators") do
       expect(page).not_to have_content moderator.name
@@ -88,7 +90,7 @@ describe "Admin moderators", :admin do
       fill_in "Search user by name or email", with: moderator2.email
       click_button "Search"
 
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
 
       expect(page).to have_content(moderator1.email)
       expect(page).not_to have_content(moderator2.email)

--- a/spec/system/admin/organizations_spec.rb
+++ b/spec/system/admin/organizations_spec.rb
@@ -88,10 +88,10 @@ describe "Admin::Organizations" do
     visit admin_organizations_path
     within("#organization_#{organization.id}") do
       expect(page).to have_current_path(admin_organizations_path, ignore_query: true)
-      expect(page).to have_link("Verify")
-      expect(page).to have_link("Reject")
+      expect(page).to have_button "Verify"
+      expect(page).to have_button "Reject"
 
-      click_on "Verify"
+      click_button "Verify"
     end
     expect(page).to have_current_path(admin_organizations_path, ignore_query: true)
 
@@ -111,10 +111,10 @@ describe "Admin::Organizations" do
 
     within("#organization_#{organization.id}") do
       expect(page).to have_content "Verified"
-      expect(page).not_to have_link("Verify")
-      expect(page).to have_link("Reject")
+      expect(page).to have_button "Reject"
+      expect(page).not_to have_button "Verify"
 
-      click_on "Reject"
+      click_button "Reject"
     end
     expect(page).to have_current_path(admin_organizations_path, ignore_query: true)
     expect(page).not_to have_content organization.name
@@ -133,10 +133,10 @@ describe "Admin::Organizations" do
     click_on "Rejected"
 
     within("#organization_#{organization.id}") do
-      expect(page).to have_link("Verify")
-      expect(page).not_to have_link("Reject", exact: true)
+      expect(page).to have_button "Verify"
+      expect(page).not_to have_button "Reject"
 
-      click_on "Verify"
+      click_button "Verify"
     end
     expect(page).to have_current_path(admin_organizations_path, ignore_query: true)
     expect(page).not_to have_content organization.name
@@ -211,7 +211,7 @@ describe "Admin::Organizations" do
 
     visit admin_organizations_path(filter: "pending", page: 2)
 
-    click_on("Verify", match: :first)
+    click_button "Verify", match: :first
 
     expect(page).to have_current_path(/filter=pending/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/poll/booth_assigments_spec.rb
+++ b/spec/system/admin/poll/booth_assigments_spec.rb
@@ -61,11 +61,11 @@ describe "Admin booths assignments", :admin do
         expect(page).to have_content(booth.name)
         expect(page).to have_content "Unassigned"
 
-        click_link "Assign booth"
+        click_button "Assign booth"
 
         expect(page).not_to have_content "Unassigned"
         expect(page).to have_content "Assigned"
-        expect(page).to have_link "Unassign booth"
+        expect(page).to have_button "Unassign booth"
       end
 
       visit admin_poll_path(poll)
@@ -100,11 +100,11 @@ describe "Admin booths assignments", :admin do
         expect(page).to have_content(booth.name)
         expect(page).to have_content "Assigned"
 
-        click_link "Unassign booth"
+        click_button "Unassign booth"
 
         expect(page).to have_content "Unassigned"
         expect(page).not_to have_content "Assigned"
-        expect(page).to have_link "Assign booth"
+        expect(page).to have_button "Assign booth"
       end
 
       visit admin_poll_path(poll)
@@ -127,11 +127,11 @@ describe "Admin booths assignments", :admin do
         expect(page).to have_content(booth.name)
         expect(page).to have_content "Assigned"
 
-        accept_confirm { click_link "Unassign booth" }
+        accept_confirm { click_button "Unassign booth" }
 
         expect(page).to have_content "Unassigned"
         expect(page).not_to have_content "Assigned"
-        expect(page).to have_link "Assign booth"
+        expect(page).to have_button "Assign booth"
       end
     end
 
@@ -143,8 +143,7 @@ describe "Admin booths assignments", :admin do
       within("#poll_booth_#{booth.id}") do
         expect(page).to have_content(booth.name)
         expect(page).to have_content "Assigned"
-
-        expect(page).not_to have_link "Unassign booth"
+        expect(page).not_to have_button "Unassign booth"
       end
     end
   end

--- a/spec/system/admin/poll/officers_spec.rb
+++ b/spec/system/admin/poll/officers_spec.rb
@@ -19,14 +19,16 @@ describe "Admin poll officers", :admin do
     click_button "Search"
 
     expect(page).to have_content user.name
-    click_link "Add"
+
+    click_button "Add"
+
     within("#officers") do
       expect(page).to have_content user.name
     end
   end
 
   scenario "Delete" do
-    accept_confirm { click_link "Delete position" }
+    accept_confirm { click_button "Delete position" }
 
     expect(page).not_to have_css "#officers"
   end

--- a/spec/system/admin/poll/polls_spec.rb
+++ b/spec/system/admin/poll/polls_spec.rb
@@ -119,7 +119,7 @@ describe "Admin polls", :admin do
       visit admin_polls_path
 
       within("#poll_#{poll.id}") do
-        accept_confirm { click_link "Delete" }
+        accept_confirm { click_button "Delete" }
       end
 
       expect(page).to have_content("Poll deleted successfully")
@@ -133,7 +133,7 @@ describe "Admin polls", :admin do
       visit admin_polls_path
 
       within(".poll", text: "Do you support CONSUL?") do
-        accept_confirm { click_link "Delete" }
+        accept_confirm { click_button "Delete" }
       end
 
       expect(page).to     have_content("Poll deleted successfully")
@@ -150,7 +150,7 @@ describe "Admin polls", :admin do
       visit admin_polls_path
 
       within(".poll", text: "Do you support CONSUL?") do
-        accept_confirm { click_link "Delete" }
+        accept_confirm { click_button "Delete" }
       end
 
       expect(page).to have_content "Poll deleted successfully"
@@ -164,7 +164,7 @@ describe "Admin polls", :admin do
       visit admin_polls_path
 
       within("#poll_#{poll.id}") do
-        accept_confirm { click_link "Delete" }
+        accept_confirm { click_button "Delete" }
       end
 
       expect(page).to have_content("You cannot delete a poll that has votes")

--- a/spec/system/admin/poll/questions/answers/documents/documents_spec.rb
+++ b/spec/system/admin/poll/questions/answers/documents/documents_spec.rb
@@ -28,7 +28,7 @@ describe "Documents", :admin do
     visit admin_answer_documents_path(answer)
     expect(page).to have_content(document.title)
 
-    accept_confirm { click_link "Delete" }
+    accept_confirm { click_button "Delete" }
 
     expect(page).not_to have_content(document.title)
   end

--- a/spec/system/admin/poll/questions_spec.rb
+++ b/spec/system/admin/poll/questions_spec.rb
@@ -17,7 +17,7 @@ describe "Admin poll questions", :admin do
       expect(page).to have_content(question1.title)
       expect(page).to have_link "Edit answers"
       expect(page).to have_link "Edit"
-      expect(page).to have_link "Delete"
+      expect(page).to have_button "Delete"
     end
 
     visit admin_poll_path(poll2)
@@ -27,7 +27,7 @@ describe "Admin poll questions", :admin do
       expect(page).to have_content question2.title
       expect(page).to have_link "Edit answers"
       expect(page).to have_link "Edit"
-      expect(page).to have_link "Delete"
+      expect(page).to have_button "Delete"
     end
 
     visit admin_poll_path(poll3)
@@ -38,7 +38,7 @@ describe "Admin poll questions", :admin do
       expect(page).to have_link "(See proposal)", href: proposal_path(question3.proposal)
       expect(page).to have_link "Edit answers"
       expect(page).to have_link "Edit"
-      expect(page).to have_link "Delete"
+      expect(page).to have_button "Delete"
     end
   end
 
@@ -142,7 +142,7 @@ describe "Admin poll questions", :admin do
     visit admin_poll_path(poll)
 
     within("#poll_question_#{question1.id}") do
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
     end
 
     expect(page).not_to have_content(question1.title)

--- a/spec/system/admin/poll/shifts_spec.rb
+++ b/spec/system/admin/poll/shifts_spec.rb
@@ -174,7 +174,7 @@ describe "Admin shifts", :admin do
 
     expect(page).to have_css(".shift", count: 1)
     within("#shift_#{shift.id}") do
-      accept_confirm { click_link "Remove" }
+      accept_confirm { click_button "Remove" }
     end
 
     expect(page).to have_content "Shift removed"
@@ -198,7 +198,7 @@ describe "Admin shifts", :admin do
 
     expect(page).to have_css(".shift", count: 1)
     within("#shift_#{shift.id}") do
-      accept_confirm { click_link "Remove" }
+      accept_confirm { click_button "Remove" }
     end
 
     expect(page).not_to have_content "Shift removed"
@@ -225,7 +225,7 @@ describe "Admin shifts", :admin do
 
     expect(page).to have_css(".shift", count: 1)
     within("#shift_#{shift.id}") do
-      accept_confirm { click_link "Remove" }
+      accept_confirm { click_button "Remove" }
     end
 
     expect(page).not_to have_content "Shift removed"

--- a/spec/system/admin/proposal_notifications_spec.rb
+++ b/spec/system/admin/proposal_notifications_spec.rb
@@ -13,7 +13,7 @@ describe "Admin proposal notifications", :admin do
     proposal_notification = create(:proposal_notification, :hidden, created_at: Date.current - 5.days)
     visit admin_hidden_proposal_notifications_path
 
-    accept_confirm { click_link "Restore" }
+    accept_confirm { click_button "Restore" }
 
     expect(page).not_to have_content(proposal_notification.title)
 
@@ -28,7 +28,7 @@ describe "Admin proposal notifications", :admin do
     proposal_notification = create(:proposal_notification, :hidden, created_at: Date.current - 5.days)
     visit admin_hidden_proposal_notifications_path
 
-    click_link "Confirm moderation"
+    click_button "Confirm moderation"
 
     expect(page).not_to have_content(proposal_notification.title)
     click_link("Confirmed")
@@ -80,7 +80,7 @@ describe "Admin proposal notifications", :admin do
 
     visit admin_hidden_proposal_notifications_path(filter: "with_confirmed_hide", page: 2)
 
-    accept_confirm { click_link "Restore", match: :first, exact: true }
+    accept_confirm { click_button "Restore", match: :first, exact: true }
 
     expect(page).to have_current_path(/filter=with_confirmed_hide/)
     expect(page).to have_current_path(/page=2/)

--- a/spec/system/admin/sdg/managers_spec.rb
+++ b/spec/system/admin/sdg/managers_spec.rb
@@ -22,7 +22,7 @@ describe "Admin SDG managers" do
 
     expect(page).to have_content user.name
 
-    click_link "Add"
+    click_button "Add"
 
     within("#sdg_managers") do
       expect(page).to have_content user.name
@@ -32,7 +32,7 @@ describe "Admin SDG managers" do
   scenario "Delete SDG Manager" do
     visit admin_sdg_managers_path
 
-    accept_confirm { click_link "Delete" }
+    accept_confirm { click_button "Delete" }
 
     within("#sdg_managers") do
       expect(page).not_to have_content sdg_manager.name
@@ -90,7 +90,7 @@ describe "Admin SDG managers" do
       fill_in "Search user by name or email", with: sdg_manager2.email
       click_button "Search"
 
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
 
       expect(page).to have_content(sdg_manager1.email)
       expect(page).not_to have_content(sdg_manager2.email)

--- a/spec/system/admin/site_customization/content_blocks_spec.rb
+++ b/spec/system/admin/site_customization/content_blocks_spec.rb
@@ -91,7 +91,7 @@ describe "Admin custom content blocks", :admin do
       expect(page).to have_content("#{block.name} (#{block.locale})")
       expect(page).to have_content(block.body)
 
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
 
       expect(page).not_to have_content("#{block.name} (#{block.locale})")
       expect(page).not_to have_content(block.body)

--- a/spec/system/admin/site_customization/documents_spec.rb
+++ b/spec/system/admin/site_customization/documents_spec.rb
@@ -75,7 +75,7 @@ describe "Documents", :admin do
     visit admin_site_customization_documents_path
 
     within("#document_#{document.id}") do
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
     end
 
     expect(page).to have_content "Document deleted succesfully"

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -36,8 +36,10 @@ describe "System Emails" do
           within("##{email_id}") do
             expect(page).to have_link("Preview Pending",
                                       href: admin_system_email_preview_pending_path(email_id))
-            expect(page).to have_link("Send pending",
-                                      href: admin_system_email_send_pending_path(email_id))
+
+            within "form[action='#{admin_system_email_send_pending_path(email_id)}']" do
+              expect(page).to have_button "Send pending"
+            end
 
             expect(page).not_to have_content "You can edit this email in"
             expect(page).not_to have_content "app/views/mailer/#{email_id}.html.erb"
@@ -57,7 +59,7 @@ describe "System Emails" do
             expect(page).to have_content "app/views/mailer/#{email_id}.html.erb"
 
             expect(page).not_to have_link "Preview Pending"
-            expect(page).not_to have_link "Send pending"
+            expect(page).not_to have_button "Send pending"
           end
         end
       end
@@ -327,7 +329,7 @@ describe "System Emails" do
 
       visit admin_system_emails_path
 
-      click_on "Send pending"
+      click_button "Send pending"
 
       email = open_last_email
       expect(email).to deliver_to(voter)

--- a/spec/system/admin/tags_spec.rb
+++ b/spec/system/admin/tags_spec.rb
@@ -39,7 +39,7 @@ describe "Admin tags", :admin do
     expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
     end
 
     expect(page).not_to have_content "bad tag"
@@ -57,7 +57,7 @@ describe "Admin tags", :admin do
     expect(page).to have_content "bad tag"
 
     within("#tag_#{tag2.id}") do
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
     end
 
     expect(page).not_to have_content "bad tag"

--- a/spec/system/admin/valuator_groups_spec.rb
+++ b/spec/system/admin/valuator_groups_spec.rb
@@ -67,7 +67,7 @@ describe "Valuator groups", :admin do
     create(:valuator_group)
 
     visit admin_valuator_groups_path
-    accept_confirm { click_link "Delete" }
+    accept_confirm { click_button "Delete" }
 
     expect(page).to have_content "Valuator group deleted successfully"
     expect(page).to have_content "There are no valuator groups"

--- a/spec/system/admin/valuators_spec.rb
+++ b/spec/system/admin/valuators_spec.rb
@@ -55,7 +55,7 @@ describe "Admin valuators", :admin do
   scenario "Destroy" do
     visit admin_valuators_path
 
-    accept_confirm { click_link "Delete" }
+    accept_confirm { click_button "Delete" }
 
     within("#valuators") do
       expect(page).not_to have_content(valuator.name)

--- a/spec/system/admin/widgets/cards_spec.rb
+++ b/spec/system/admin/widgets/cards_spec.rb
@@ -110,9 +110,7 @@ describe "Cards", :admin do
     visit admin_homepage_path
 
     within("#widget_card_#{card.id}") do
-      accept_confirm do
-        click_link "Delete"
-      end
+      accept_confirm { click_button "Delete" }
     end
 
     expect(page).to have_content "Card removed successfully"
@@ -238,9 +236,7 @@ describe "Cards", :admin do
 
         expect(page).to have_content("Card title")
 
-        accept_confirm do
-          click_link "Delete"
-        end
+        accept_confirm { click_button "Delete" }
 
         expect(page).to have_current_path admin_site_customization_page_widget_cards_path(custom_page)
         expect(page).not_to have_content "Card title"

--- a/spec/system/budget_polls/budgets_spec.rb
+++ b/spec/system/budget_polls/budgets_spec.rb
@@ -8,7 +8,7 @@ describe "Admin Budgets", :admin do
 
       visit admin_budgets_path
 
-      click_link "Ballots"
+      click_button "Ballots"
 
       expect(page).to have_current_path(/admin\/polls\/\d+/)
       expect(page).to have_content(budget.name)
@@ -24,7 +24,7 @@ describe "Admin Budgets", :admin do
       visit admin_budgets_path
       select "Français", from: "Language:"
 
-      click_link "Bulletins de l’admin"
+      click_button "Bulletins de l’admin"
 
       expect(page).to have_current_path(/admin\/polls\/\d+/)
       expect(page).to have_content("Budget pour le changement climatique")

--- a/spec/system/sdg_management/homepage_spec.rb
+++ b/spec/system/sdg_management/homepage_spec.rb
@@ -82,7 +82,7 @@ describe "SDG homepage configuration" do
       visit sdg_management_homepage_path
 
       within ".sdg-header" do
-        accept_confirm { click_link "Delete" }
+        accept_confirm { click_button "Delete" }
       end
 
       expect(page).not_to have_content "SDG Header"

--- a/spec/system/sdg_management/local_targets_spec.rb
+++ b/spec/system/sdg_management/local_targets_spec.rb
@@ -16,7 +16,7 @@ describe "Local Targets" do
       expect(page).to have_title "SDG content - Local Targets"
       within("table tr", text: "Affordable food") do
         expect(page).to have_link "Edit"
-        expect(page).to have_link "Delete"
+        expect(page).to have_button "Delete"
       end
       expect(page).to have_link "Create local target"
     end
@@ -91,7 +91,7 @@ describe "Local Targets" do
       create(:sdg_local_target, code: "1.1.1")
       visit sdg_management_local_targets_path
 
-      accept_confirm { click_link "Delete" }
+      accept_confirm { click_button "Delete" }
 
       expect(page).to have_content("Local target deleted successfully")
       expect(page).not_to have_content("1.1.1")


### PR DESCRIPTION
## References

* Part of this pull request deals with the admin part of issue #4015

## Objectives

* Give more information to screen reader users when focusing on an action in admin tables
* Avoid the disadvantages of using links to generate POST/PUT/DELETE requests by using buttons
* Add a more detailed confirmation message for admin actions requiring confirmation