### PR TITLE
Do not show unpublished proposals on the homepage

### DIFF
--- a/app/models/widget/feed.rb
+++ b/app/models/widget/feed.rb
@@ -21,7 +21,7 @@ class Widget::Feed < ApplicationRecord
   end
 
   def proposals
-    Proposal.sort_by_hot_score.limit(limit)
+    Proposal.published.sort_by_hot_score.limit(limit)
   end
 
   def debates

--- a/spec/models/widget/feed_spec.rb
+++ b/spec/models/widget/feed_spec.rb
@@ -28,6 +28,14 @@ describe Widget::Feed do
 
         expect(feed.proposals).to eq([best_proposal, medium_proposal, worst_proposal])
       end
+
+      it "does not return unpublished proposals" do
+        create(:proposal, :draft, title: "Draft proposal")
+
+        feed = build(:widget_feed, kind: "proposals")
+
+        expect(feed.proposals).to be_empty
+      end
     end
 
     describe "#debates" do


### PR DESCRIPTION
## Objectives

* Make sure new sites don't display unpublished proposals on their homepage

## Notes

The chances of an unpublished proposal appearing on the homepage was very low because only the proposals with the most votes appear there and unpublished proposals don't have any votes. However, it was technically possible on new sites where only a few proposals had been created.