### PR TITLE
Remove official level filter from advanced search

### DIFF
--- a/app/assets/stylesheets/advanced_search.scss
+++ b/app/assets/stylesheets/advanced_search.scss
@@ -6,12 +6,12 @@
   @include breakpoint(large) {
     .filter {
       @include grid-column;
-      width: 25%;
+      width: 33%;
     }
 
     .date-filters {
       float: left;
-      width: 25%;
+      width: 33%;
 
       .filter {
         width: 100%;
@@ -23,7 +23,7 @@
     }
 
     .submit {
-      width: 25%;
+      width: 33%;
     }
   }
 

--- a/app/components/shared/advanced_search_component.html.erb
+++ b/app/components/shared/advanced_search_component.html.erb
@@ -40,12 +40,6 @@
       </div>
     </div>
 
-    <div class="filter">
-      <label for="advanced_search_official_level"><%= t("shared.advanced_search.author_type") %></label>
-      <%= select_tag("advanced_search[official_level]", official_level_search_options,
-                    include_blank: t("shared.advanced_search.author_type_blank")) %>
-    </div>
-
     <% if sdg? %>
       <div class="filter">
         <label for="advanced_search_goal"><%= t("shared.advanced_search.goal") %></label>

--- a/app/components/shared/advanced_search_component.html.erb
+++ b/app/components/shared/advanced_search_component.html.erb
@@ -8,8 +8,7 @@
       <label for="search">
         <%= t("shared.advanced_search.general") %>
       </label>
-      <%= text_field_tag "search", params[:search],
-                         placeholder: t("shared.advanced_search.general_placeholder") %>
+      <%= text_field_tag "search", params[:search] %>
     </div>
 
     <div class="date-filters">

--- a/app/components/shared/advanced_search_component.rb
+++ b/app/components/shared/advanced_search_component.rb
@@ -7,11 +7,6 @@ class Shared::AdvancedSearchComponent < ApplicationComponent
       params[:advanced_search] || {}
     end
 
-    def official_level_search_options
-      options_for_select((1..5).map { |i| [setting["official_level_#{i}_name"], i] },
-                         advanced_search[:official_level])
-    end
-
     def date_range_options
       options_for_select([
         [t("shared.advanced_search.date_1"), 1],

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -20,7 +20,7 @@ module Filterable
     def allowed_filter?(filter, value)
       return if value.blank?
 
-      ["official_level", "date_range", "goal", "target"].include?(filter)
+      ["date_range", "goal", "target"].include?(filter)
     end
   end
 end

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -673,8 +673,6 @@ en:
     "no": "No"
     search_results: "Search results"
     advanced_search:
-      author_type: "By author category"
-      author_type_blank: "Select a category"
       date: "By date"
       date_placeholder: "DD/MM/YYYY"
       date_range_blank: "Choose a date"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -683,7 +683,6 @@ en:
       date_5: "Customized"
       from: "From"
       general: "With the text"
-      general_placeholder: "Write the text"
       goal: "By SDG"
       goal_blank: "Select a goal"
       search: "Filter"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -683,7 +683,6 @@ es:
       date_5: "Personalizada"
       from: "Desde"
       general: "Con el texto"
-      general_placeholder: "Escribe el texto"
       goal: "Por ODS"
       goal_blank: "Elige un objetivo"
       search: "Filtrar"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -673,8 +673,6 @@ es:
     "no": "No"
     search_results: "Resultados de la búsqueda"
     advanced_search:
-      author_type: "Por categoría de autor"
-      author_type_blank: "Elige una categoría"
       date: "Por fecha"
       date_placeholder: "DD/MM/AAAA"
       date_range_blank: "Elige una fecha"

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -12,7 +12,7 @@ describe "Advanced search" do
     visit debates_path
 
     click_button "Advanced search"
-    fill_in "Write the text", with: "Schwifty"
+    fill_in "With the text", with: "Schwifty"
     click_button "Filter"
 
     expect(page).to have_content("There are 2 debates")
@@ -32,7 +32,7 @@ describe "Advanced search" do
     visit proposals_path
 
     click_button "Advanced search"
-    fill_in "Write the text", with: "Schwifty"
+    fill_in "With the text", with: "Schwifty"
     click_button "Filter"
 
     expect(page).to have_content("There are 2 citizen proposals")
@@ -52,7 +52,7 @@ describe "Advanced search" do
     visit budget_investments_path(budget)
 
     click_button "Advanced search"
-    fill_in "Write the text", with: "Schwifty"
+    fill_in "With the text", with: "Schwifty"
     click_button "Filter"
 
     expect(page).to have_content("There are 2 investments")
@@ -204,7 +204,7 @@ describe "Advanced search" do
       visit budget_investments_path(budget)
 
       click_button "Advanced search"
-      fill_in "Write the text", with: "Schwifty"
+      fill_in "With the text", with: "Schwifty"
       select "7. Affordable and Clean Energy", from: "By SDG"
       select "Last 24 hours", from: "js-advanced-search-date-min"
 
@@ -224,7 +224,7 @@ describe "Advanced search" do
       visit debates_path
       click_button "Advanced search"
 
-      fill_in "Write the text", with: "Schwifty"
+      fill_in "With the text", with: "Schwifty"
       select "7. Affordable and Clean Energy", from: "By SDG"
       select "Last 24 hours", from: "js-advanced-search-date-min"
 

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -64,222 +64,37 @@ describe "Advanced search" do
     end
   end
 
-  context "Search by author type" do
-    scenario "Public employee" do
-      Setting["official_level_1_name"] = "Official position 1"
-      ana = create :user, official_level: 1
-      john = create :user, official_level: 2
+  context "Search by date" do
+    context "Predefined date ranges" do
+      scenario "Last day" do
+        bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 1.minute.ago)
+        bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 1.hour.ago)
+        bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 2.days.ago)
 
-      debate1 = create(:debate, author: ana)
-      debate2 = create(:debate, author: ana)
-      debate3 = create(:debate, author: john)
+        visit budget_investments_path(budget)
 
-      visit debates_path
+        click_button "Advanced search"
+        select "Last 24 hours", from: "js-advanced-search-date-min"
+        click_button "Filter"
 
-      click_button "Advanced search"
-      select "Official position 1", from: "advanced_search_official_level"
-      click_button "Filter"
+        expect(page).to have_content("There are 2 investments")
 
-      expect(page).to have_content("There are 2 debates")
-
-      within("#debates") do
-        expect(page).to have_content(debate1.title)
-        expect(page).to have_content(debate2.title)
-        expect(page).not_to have_content(debate3.title)
-      end
-    end
-
-    scenario "Municipal Organization" do
-      Setting["official_level_2_name"] = "Official position 2"
-      ana = create :user, official_level: 2
-      john = create :user, official_level: 3
-
-      proposal1 = create(:proposal, author: ana)
-      proposal2 = create(:proposal, author: ana)
-      proposal3 = create(:proposal, author: john)
-
-      visit proposals_path
-
-      click_button "Advanced search"
-      select "Official position 2", from: "advanced_search_official_level"
-      click_button "Filter"
-
-      expect(page).to have_content("There are 2 citizen proposals")
-
-      within("#proposals") do
-        expect(page).to have_content(proposal1.title)
-        expect(page).to have_content(proposal2.title)
-        expect(page).not_to have_content(proposal3.title)
-      end
-    end
-
-    scenario "General director" do
-      Setting["official_level_3_name"] = "Official position 3"
-      ana = create :user, official_level: 3
-      john = create :user, official_level: 4
-
-      bdgt_invest1 = create(:budget_investment, heading: heading, author: ana)
-      bdgt_invest2 = create(:budget_investment, heading: heading, author: ana)
-      bdgt_invest3 = create(:budget_investment, heading: heading, author: john)
-
-      visit budget_investments_path(budget)
-
-      click_button "Advanced search"
-      select "Official position 3", from: "advanced_search_official_level"
-      click_button "Filter"
-
-      expect(page).to have_content("There are 2 investments")
-
-      within("#budget-investments") do
-        expect(page).to have_content(bdgt_invest1.title)
-        expect(page).to have_content(bdgt_invest2.title)
-        expect(page).not_to have_content(bdgt_invest3.title)
-      end
-    end
-
-    scenario "City councillor" do
-      Setting["official_level_4_name"] = "Official position 4"
-      ana = create :user, official_level: 4
-      john = create :user, official_level: 5
-
-      debate1 = create(:debate, author: ana)
-      debate2 = create(:debate, author: ana)
-      debate3 = create(:debate, author: john)
-
-      visit debates_path
-
-      click_button "Advanced search"
-      select "Official position 4", from: "advanced_search_official_level"
-      click_button "Filter"
-
-      expect(page).to have_content("There are 2 debates")
-
-      within("#debates") do
-        expect(page).to have_content(debate1.title)
-        expect(page).to have_content(debate2.title)
-        expect(page).not_to have_content(debate3.title)
-      end
-    end
-
-    scenario "Mayoress" do
-      Setting["official_level_5_name"] = "Official position 5"
-      ana = create :user, official_level: 5
-      john = create :user, official_level: 4
-
-      proposal1 = create(:proposal, author: ana)
-      proposal2 = create(:proposal, author: ana)
-      proposal3 = create(:proposal, author: john)
-
-      visit proposals_path
-
-      click_button "Advanced search"
-      select "Official position 5", from: "advanced_search_official_level"
-      click_button "Filter"
-
-      expect(page).to have_content("There are 2 citizen proposals")
-
-      within("#proposals") do
-        expect(page).to have_content(proposal1.title)
-        expect(page).to have_content(proposal2.title)
-        expect(page).not_to have_content(proposal3.title)
-      end
-    end
-
-    context "Search by date" do
-      context "Predefined date ranges" do
-        scenario "Last day" do
-          bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 1.minute.ago)
-          bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 1.hour.ago)
-          bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 2.days.ago)
-
-          visit budget_investments_path(budget)
-
-          click_button "Advanced search"
-          select "Last 24 hours", from: "js-advanced-search-date-min"
-          click_button "Filter"
-
-          expect(page).to have_content("There are 2 investments")
-
-          within("#budget-investments") do
-            expect(page).to have_content(bdgt_invest1.title)
-            expect(page).to have_content(bdgt_invest2.title)
-            expect(page).not_to have_content(bdgt_invest3.title)
-          end
-        end
-
-        scenario "Last week" do
-          debate1 = create(:debate, created_at: 1.day.ago)
-          debate2 = create(:debate, created_at: 5.days.ago)
-          debate3 = create(:debate, created_at: 8.days.ago)
-
-          visit debates_path
-
-          click_button "Advanced search"
-          select "Last week", from: "js-advanced-search-date-min"
-          click_button "Filter"
-
-          within("#debates") do
-            expect(page).to have_css(".debate", count: 2)
-
-            expect(page).to have_content(debate1.title)
-            expect(page).to have_content(debate2.title)
-            expect(page).not_to have_content(debate3.title)
-          end
-        end
-
-        scenario "Last month" do
-          proposal1 = create(:proposal, created_at: 10.days.ago)
-          proposal2 = create(:proposal, created_at: 20.days.ago)
-          proposal3 = create(:proposal, created_at: 33.days.ago)
-
-          visit proposals_path
-
-          click_button "Advanced search"
-          select "Last month", from: "js-advanced-search-date-min"
-          click_button "Filter"
-
-          expect(page).to have_content("There are 2 citizen proposals")
-
-          within("#proposals") do
-            expect(page).to have_content(proposal1.title)
-            expect(page).to have_content(proposal2.title)
-            expect(page).not_to have_content(proposal3.title)
-          end
-        end
-
-        scenario "Last year" do
-          bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 300.days.ago)
-          bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 350.days.ago)
-          bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 370.days.ago)
-
-          visit budget_investments_path(budget)
-
-          click_button "Advanced search"
-          select "Last year", from: "js-advanced-search-date-min"
-          click_button "Filter"
-
-          expect(page).to have_content("There are 2 investments")
-
-          within("#budget-investments") do
-            expect(page).to have_content(bdgt_invest1.title)
-            expect(page).to have_content(bdgt_invest2.title)
-            expect(page).not_to have_content(bdgt_invest3.title)
-          end
+        within("#budget-investments") do
+          expect(page).to have_content(bdgt_invest1.title)
+          expect(page).to have_content(bdgt_invest2.title)
+          expect(page).not_to have_content(bdgt_invest3.title)
         end
       end
 
-      scenario "Search by custom date range" do
-        debate1 = create(:debate, created_at: 2.days.ago)
-        debate2 = create(:debate, created_at: 3.days.ago)
-        debate3 = create(:debate, created_at: 9.days.ago)
+      scenario "Last week" do
+        debate1 = create(:debate, created_at: 1.day.ago)
+        debate2 = create(:debate, created_at: 5.days.ago)
+        debate3 = create(:debate, created_at: 8.days.ago)
 
         visit debates_path
 
         click_button "Advanced search"
-        select "Customized", from: "js-advanced-search-date-min"
-        fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
-        fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
-        find_field("With the text").click
+        select "Last week", from: "js-advanced-search-date-min"
         click_button "Filter"
 
         within("#debates") do
@@ -291,163 +106,226 @@ describe "Advanced search" do
         end
       end
 
-      scenario "Search by custom invalid date range" do
-        proposal1 = create(:proposal, created_at: 2.days.ago)
-        proposal2 = create(:proposal, created_at: 3.days.ago)
-        proposal3 = create(:proposal, created_at: 9.days.ago)
+      scenario "Last month" do
+        proposal1 = create(:proposal, created_at: 10.days.ago)
+        proposal2 = create(:proposal, created_at: 20.days.ago)
+        proposal3 = create(:proposal, created_at: 33.days.ago)
 
         visit proposals_path
 
         click_button "Advanced search"
-        select "Customized", from: "js-advanced-search-date-min"
-        fill_in "advanced_search_date_min", with: 4000.years.ago.strftime("%d/%m/%Y")
-        fill_in "advanced_search_date_max", with: "13/13/2199"
-        find_field("With the text").click
+        select "Last month", from: "js-advanced-search-date-min"
         click_button "Filter"
 
-        expect(page).to have_content("There are 3 citizen proposals")
+        expect(page).to have_content("There are 2 citizen proposals")
 
         within("#proposals") do
           expect(page).to have_content(proposal1.title)
           expect(page).to have_content(proposal2.title)
-          expect(page).to have_content(proposal3.title)
+          expect(page).not_to have_content(proposal3.title)
         end
       end
 
-      scenario "Search by multiple filters" do
-        Setting["official_level_1_name"] = "Official position 1"
-        ana = create :user, official_level: 1
-        john = create :user, official_level: 1
-
-        create(:budget_investment, heading: heading, title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
-        create(:budget_investment, heading: heading, title: "Hello Schwifty", author: john, created_at: 2.days.ago)
-        create(:budget_investment, heading: heading, title: "Save the forest")
+      scenario "Last year" do
+        bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 300.days.ago)
+        bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 350.days.ago)
+        bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 370.days.ago)
 
         visit budget_investments_path(budget)
 
         click_button "Advanced search"
-        fill_in "Write the text", with: "Schwifty"
-        select "Official position 1", from: "advanced_search_official_level"
-        select "Last 24 hours", from: "js-advanced-search-date-min"
-
+        select "Last year", from: "js-advanced-search-date-min"
         click_button "Filter"
 
-        expect(page).to have_content("There is 1 investment")
+        expect(page).to have_content("There are 2 investments")
 
         within("#budget-investments") do
-          expect(page).to have_content "Get Schwifty"
-        end
-      end
-
-      scenario "Maintain advanced search criteria" do
-        Setting["official_level_1_name"] = "Official position 1"
-
-        visit debates_path
-        click_button "Advanced search"
-
-        fill_in "Write the text", with: "Schwifty"
-        select "Official position 1", from: "advanced_search_official_level"
-        select "Last 24 hours", from: "js-advanced-search-date-min"
-
-        click_button "Filter"
-
-        within ".advanced-search-form" do
-          expect(page).to have_selector("input[name='search'][value='Schwifty']")
-          expect(page).to have_select("advanced_search[official_level]", selected: "Official position 1")
-          expect(page).to have_select("advanced_search[date_min]", selected: "Last 24 hours")
-        end
-      end
-
-      scenario "Maintain custom date search criteria" do
-        visit proposals_path
-        click_button "Advanced search"
-
-        select "Customized", from: "js-advanced-search-date-min"
-        fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
-        fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
-        find_field("With the text").click
-        click_button "Filter"
-
-        expect(page).to have_content("citizen proposals cannot be found")
-
-        within ".advanced-search-form" do
-          expect(page).to have_select("advanced_search[date_min]", selected: "Customized")
-          expect(page).to have_selector("input[name='advanced_search[date_min]'][value*='#{7.days.ago.strftime("%d/%m/%Y")}']")
-          expect(page).to have_selector("input[name='advanced_search[date_max]'][value*='#{1.day.ago.strftime("%d/%m/%Y")}']")
+          expect(page).to have_content(bdgt_invest1.title)
+          expect(page).to have_content(bdgt_invest2.title)
+          expect(page).not_to have_content(bdgt_invest3.title)
         end
       end
     end
 
-    describe "SDG" do
-      before do
-        Setting["feature.sdg"] = true
-        Setting["sdg.process.debates"] = true
-        Setting["sdg.process.proposals"] = true
-        Setting["sdg.process.budgets"] = true
+    scenario "Search by custom date range" do
+      debate1 = create(:debate, created_at: 2.days.ago)
+      debate2 = create(:debate, created_at: 3.days.ago)
+      debate3 = create(:debate, created_at: 9.days.ago)
+
+      visit debates_path
+
+      click_button "Advanced search"
+      select "Customized", from: "js-advanced-search-date-min"
+      fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
+      fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
+      find_field("With the text").click
+      click_button "Filter"
+
+      within("#debates") do
+        expect(page).to have_css(".debate", count: 2)
+
+        expect(page).to have_content(debate1.title)
+        expect(page).to have_content(debate2.title)
+        expect(page).not_to have_content(debate3.title)
+      end
+    end
+
+    scenario "Search by custom invalid date range" do
+      proposal1 = create(:proposal, created_at: 2.days.ago)
+      proposal2 = create(:proposal, created_at: 3.days.ago)
+      proposal3 = create(:proposal, created_at: 9.days.ago)
+
+      visit proposals_path
+
+      click_button "Advanced search"
+      select "Customized", from: "js-advanced-search-date-min"
+      fill_in "advanced_search_date_min", with: 4000.years.ago.strftime("%d/%m/%Y")
+      fill_in "advanced_search_date_max", with: "13/13/2199"
+      find_field("With the text").click
+      click_button "Filter"
+
+      expect(page).to have_content("There are 3 citizen proposals")
+
+      within("#proposals") do
+        expect(page).to have_content(proposal1.title)
+        expect(page).to have_content(proposal2.title)
+        expect(page).to have_content(proposal3.title)
+      end
+    end
+
+    scenario "Search by multiple filters" do
+      Setting["feature.sdg"] = true
+      Setting["sdg.process.budgets"] = true
+
+      create(:budget_investment, heading: heading, title: "Get Schwifty", sdg_goals: [SDG::Goal[7]], created_at: 1.minute.ago)
+      create(:budget_investment, heading: heading, title: "Hello Schwifty", sdg_goals: [SDG::Goal[7]], created_at: 2.days.ago)
+      create(:budget_investment, heading: heading, title: "Save the forest")
+
+      visit budget_investments_path(budget)
+
+      click_button "Advanced search"
+      fill_in "Write the text", with: "Schwifty"
+      select "7. Affordable and Clean Energy", from: "By SDG"
+      select "Last 24 hours", from: "js-advanced-search-date-min"
+
+      click_button "Filter"
+
+      expect(page).to have_content("There is 1 investment")
+
+      within("#budget-investments") do
+        expect(page).to have_content "Get Schwifty"
+      end
+    end
+
+    scenario "Maintain advanced search criteria" do
+      Setting["feature.sdg"] = true
+      Setting["sdg.process.debates"] = true
+
+      visit debates_path
+      click_button "Advanced search"
+
+      fill_in "Write the text", with: "Schwifty"
+      select "7. Affordable and Clean Energy", from: "By SDG"
+      select "Last 24 hours", from: "js-advanced-search-date-min"
+
+      click_button "Filter"
+
+      within ".advanced-search-form" do
+        expect(page).to have_selector("input[name='search'][value='Schwifty']")
+        expect(page).to have_select("By SDG", selected: "7. Affordable and Clean Energy")
+        expect(page).to have_select("advanced_search[date_min]", selected: "Last 24 hours")
+      end
+    end
+
+    scenario "Maintain custom date search criteria" do
+      visit proposals_path
+      click_button "Advanced search"
+
+      select "Customized", from: "js-advanced-search-date-min"
+      fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
+      fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
+      find_field("With the text").click
+      click_button "Filter"
+
+      expect(page).to have_content("citizen proposals cannot be found")
+
+      within ".advanced-search-form" do
+        expect(page).to have_select("advanced_search[date_min]", selected: "Customized")
+        expect(page).to have_selector("input[name='advanced_search[date_min]'][value*='#{7.days.ago.strftime("%d/%m/%Y")}']")
+        expect(page).to have_selector("input[name='advanced_search[date_max]'][value*='#{1.day.ago.strftime("%d/%m/%Y")}']")
+      end
+    end
+  end
+
+  describe "SDG" do
+    before do
+      Setting["feature.sdg"] = true
+      Setting["sdg.process.debates"] = true
+      Setting["sdg.process.proposals"] = true
+      Setting["sdg.process.budgets"] = true
+    end
+
+    scenario "Search by goal" do
+      create(:budget_investment, title: "Purifier", heading: heading, sdg_goals: [SDG::Goal[6]])
+      create(:budget_investment, title: "Hospital", heading: heading, sdg_goals: [SDG::Goal[3]])
+
+      visit budget_investments_path(budget)
+      click_button "Advanced search"
+      select "6. Clean Water and Sanitation", from: "By SDG"
+      click_button "Filter"
+
+      expect(page).to have_content("There is 1 investment")
+
+      within("#budget-investments") do
+        expect(page).to have_content "Purifier"
+        expect(page).not_to have_content "Hospital"
       end
 
-      scenario "Search by goal" do
-        create(:budget_investment, title: "Purifier", heading: heading, sdg_goals: [SDG::Goal[6]])
-        create(:budget_investment, title: "Hospital", heading: heading, sdg_goals: [SDG::Goal[3]])
+      expect(page).to have_select "By target",
+                                  selected: "Select a target",
+                                  enabled_options: ["Select a target"] + %w[6.1 6.2 6.3 6.4 6.5 6.6 6.A 6.B]
+    end
 
-        visit budget_investments_path(budget)
-        click_button "Advanced search"
-        select "6. Clean Water and Sanitation", from: "By SDG"
-        click_button "Filter"
+    scenario "Search by target" do
+      create(:debate, title: "Unrelated")
+      create(:debate, title: "High school", sdg_targets: [SDG::Target["4.1"]])
+      create(:debate, title: "Preschool", sdg_targets: [SDG::Target["4.2"]])
 
-        expect(page).to have_content("There is 1 investment")
+      visit debates_path
+      click_button "Advanced search"
+      select "4.2", from: "By target"
+      click_button "Filter"
 
-        within("#budget-investments") do
-          expect(page).to have_content "Purifier"
-          expect(page).not_to have_content "Hospital"
-        end
+      expect(page).to have_content("There is 1 debate")
 
-        expect(page).to have_select "By target",
-                                    selected: "Select a target",
-                                    enabled_options: ["Select a target"] + %w[6.1 6.2 6.3 6.4 6.5 6.6 6.A 6.B]
+      within("#debates") do
+        expect(page).to have_content("Preschool")
+        expect(page).not_to have_content("High school")
+        expect(page).not_to have_content("Unrelated")
       end
+    end
 
-      scenario "Search by target" do
-        create(:debate, title: "Unrelated")
-        create(:debate, title: "High school", sdg_targets: [SDG::Target["4.1"]])
-        create(:debate, title: "Preschool", sdg_targets: [SDG::Target["4.2"]])
+    scenario "Dynamic target options depending on the selected goal" do
+      visit proposals_path
 
-        visit debates_path
-        click_button "Advanced search"
-        select "4.2", from: "By target"
-        click_button "Filter"
+      click_button "Advanced search"
+      select "1. No Poverty", from: "By SDG"
 
-        expect(page).to have_content("There is 1 debate")
+      expect(page).to have_select "By target",
+                                  selected: "Select a target",
+                                  enabled_options: ["Select a target"] + %w[1.1 1.2 1.3 1.4 1.5 1.A 1.B]
 
-        within("#debates") do
-          expect(page).to have_content("Preschool")
-          expect(page).not_to have_content("High school")
-          expect(page).not_to have_content("Unrelated")
-        end
-      end
+      select "1.1", from: "By target"
+      select "13. Climate Action", from: "By SDG"
 
-      scenario "Dynamic target options depending on the selected goal" do
-        visit proposals_path
+      expect(page).to have_select "By target",
+                                  selected: "Select a target",
+                                  enabled_options: ["Select a target"] + %w[13.1 13.2 13.3 13.A 13.B]
 
-        click_button "Advanced search"
-        select "1. No Poverty", from: "By SDG"
+      select "13.1", from: "By target"
+      select "Select a goal", from: "By SDG"
 
-        expect(page).to have_select "By target",
-                                    selected: "Select a target",
-                                    enabled_options: ["Select a target"] + %w[1.1 1.2 1.3 1.4 1.5 1.A 1.B]
-
-        select "1.1", from: "By target"
-        select "13. Climate Action", from: "By SDG"
-
-        expect(page).to have_select "By target",
-                                    selected: "Select a target",
-                                    enabled_options: ["Select a target"] + %w[13.1 13.2 13.3 13.A 13.B]
-
-        select "13.1", from: "By target"
-        select "Select a goal", from: "By SDG"
-
-        expect(page).to have_select "By target", selected: "13.1", disabled_options: []
-      end
+      expect(page).to have_select "By target", selected: "13.1", disabled_options: []
     end
   end
 end


### PR DESCRIPTION
## Objectives

* Remove a confusing filter which isn't that useful in the advanced search
* Remove a useless placeholder in the advanced search

## Notes

User testing has shown this filter isn't really useful and sometimes makes users wonder what it's about. This is particularly true in CONSUL installations which don't change the default values (most of them), since users will see a filter with options like "Official position 1".

## Visual changes

### Before these changes

![There are four select fields in the advanced search form: date, author category, SDG and target](https://user-images.githubusercontent.com/35156/130702636-51617207-1262-4625-b1f5-54188006619a.png)

### After these changes

![There are three select fields in the advanced search form: date, SDG and target](https://user-images.githubusercontent.com/35156/130702650-5ad9c98b-6c49-4d8f-9666-d8ffca40da5e.png)
