### PR TITLE
Fix flaky investments order spec

### DIFF
--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -297,7 +297,12 @@ describe "Budget Investments" do
       expect(order).not_to be_empty
 
       click_link "highest rated"
+
+      expect(page).to have_css "h2", exact_text: "highest rated"
+
       click_link "random"
+
+      expect(page).to have_css "h2", exact_text: "random"
 
       visit budget_investments_path(budget, heading_id: heading.id)
       new_order = all(".budget-investment h3").map(&:text)


### PR DESCRIPTION
## References

* This test failed in our [test run #2238, build 2](https://github.com/consul/consul/runs/3295502777)

## Failure message

```
1) Budget Investments Orders Random order after another order
     Failure/Error: tags.sort { |a, b| b.taggings_count <=> a.taggings_count }[0, limit]

     ActionView::Template::Error:
       PG::ProtocolViolation: ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 3
       : SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2 AND "taggings"."context" = $3

     # ./app/models/concerns/taggable.rb:12:in `sort'
     # ./app/models/concerns/taggable.rb:12:in `tag_list_with_limit'
     # ./app/components/shared/tag_list_component.rb:17:in `tag_links'
     # ./app/components/shared/tag_list_component.rb:13:in `links'
     # ./app/components/shared/tag_list_component.html.erb:1:in `call'
     # ./app/views/shared/_tags.html.erb:4:in `_app_views_shared__tags_html_erb__1786540979487546022_69985865643240'
     # ./app/views/budgets/investments/_investment.html.erb:30:in `block in _app_views_budgets_investments__investment_html_erb___3127551676118346414_46974811334080'
     # ./app/views/budgets/investments/_investment.html.erb:21:in `_app_views_budgets_investments__investment_html_erb___3127551676118346414_46974811334080'
     # ./app/views/budgets/investments/index.html.erb:78:in `block in _app_views_budgets_investments_index_html_erb__4007896506534525799_46974861443540'
     # ./app/views/budgets/investments/index.html.erb:77:in `_app_views_budgets_investments_index_html_erb__4007896506534525799_46974861443540'
     # ./config/initializers/wicked_pdf.rb:10:in `render'
     # ------------------
     # --- Caused by: ---
     # PG::ProtocolViolation:
     #   ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 3
     #   ./app/models/concerns/taggable.rb:12:in `sort'
```

## Notes

The test probably failed due to simultaneous requests:

* We were clicking on a link and then clicking on another link (which was already on the page) before checking the first request had finished
* We were then visiting a page after clicking the second link, without checking the second request had finished