### PR TITLE
Add short titles to SDG targets

### DIFF
--- a/app/assets/javascripts/sdg/related_list_selector.js
+++ b/app/assets/javascripts/sdg/related_list_selector.js
@@ -89,6 +89,12 @@
       suggestions_input[0].id = original_input[0].id + "_suggestions";
 
       $("[for='" + original_input[0].id + "']").attr("for", suggestions_input[0].id);
+
+      suggestions_input.attr("aria-describedby", original_input.attr("aria-describedby"));
+
+      if ($(original_input).attr("placeholder") === undefined) {
+        suggestions_input.removeAttr("placeholder");
+      }
     }
   };
 }).call(this);

--- a/app/components/concerns/sdg/options_for_select.rb
+++ b/app/components/concerns/sdg/options_for_select.rb
@@ -8,6 +8,6 @@ module SDG::OptionsForSelect
   def target_options(selected_code = nil)
     targets = SDG::Target.all + SDG::LocalTarget.all
 
-    options_from_collection_for_select(targets.sort, :code, :code, selected_code)
+    options_from_collection_for_select(targets.sort, :code, :code_and_title, selected_code)
   end
 end

--- a/app/components/sdg/goals/targets_component.html.erb
+++ b/app/components/sdg/goals/targets_component.html.erb
@@ -18,7 +18,7 @@
           <dl>
             <% targets.sort.each do |target| %>
               <dt><%= target.code %><dt>
-              <dd><%= target.title %><dd>
+              <dd><%= target.long_title %><dd>
             <% end %>
           </dl>
         <% end %>

--- a/app/components/sdg/related_list_selector_component.html.erb
+++ b/app/components/sdg/related_list_selector_component.html.erb
@@ -13,7 +13,6 @@
 
     <%= f.text_field :related_sdg_list,
                       class: "input",
-                      placeholder: t("sdg.related_list_selector.placeholder"),
                       hint: sanitize(t("sdg.related_list_selector.hint",
                                       link: link_to(t("sdg.related_list_selector.help.text"),
                                                       sdg_help_path,

--- a/app/components/sdg/related_list_selector_component.rb
+++ b/app/components/sdg/related_list_selector_component.rb
@@ -20,7 +20,7 @@ class SDG::RelatedListSelectorComponent < ApplicationComponent
     {
       tag: goal_or_target.code_and_title.gsub(",", ""),
       display_text: text_for(goal_or_target),
-      title: goal_or_target.title,
+      title: goal_or_target.long_title,
       value: goal_or_target.code
     }
   end

--- a/app/components/sdg/related_list_selector_component.rb
+++ b/app/components/sdg/related_list_selector_component.rb
@@ -18,7 +18,7 @@ class SDG::RelatedListSelectorComponent < ApplicationComponent
 
   def suggestion_tag_for(goal_or_target)
     {
-      tag: "#{goal_or_target.code}. #{goal_or_target.title.gsub(",", "")}",
+      tag: goal_or_target.code_and_title.gsub(",", ""),
       display_text: text_for(goal_or_target),
       title: goal_or_target.title,
       value: goal_or_target.code

--- a/app/components/sdg_management/local_targets/form_component.rb
+++ b/app/components/sdg_management/local_targets/form_component.rb
@@ -30,14 +30,10 @@ class SDGManagement::LocalTargets::FormComponent < ApplicationComponent
     def target_options
       grouped_targets = SDG::Goal.order(:code).map do |goal|
         [
-          code_and_title(goal),
-          goal.targets.sort.map { |target| [code_and_title(target), target.id] }
+          goal.code_and_title,
+          goal.targets.sort.map { |target| [target.code_and_title, target.id] }
         ]
       end
       grouped_options_for_select(grouped_targets, local_target.target_id)
-    end
-
-    def code_and_title(resource)
-      "#{resource.code} #{resource.title}"
     end
 end

--- a/app/components/sdg_management/local_targets/index_component.html.erb
+++ b/app/components/sdg_management/local_targets/index_component.html.erb
@@ -18,7 +18,7 @@
       <% local_targets.group_by(&:target).map do |target, local_targets| %>
         <tr class="target-header">
           <th id="<%= header_id(target) %>" colspan="3" scope="colgroup">
-            <%= target.code %> <%= target.title %>
+            <%= target.code_and_title %>
           </th>
         </tr>
 

--- a/app/components/sdg_management/targets/index_component.html.erb
+++ b/app/components/sdg_management/targets/index_component.html.erb
@@ -23,7 +23,7 @@
               <%= target.code %>
             </th>
             <td headers="<%= header_id(goal) %> <%= header_id(target) %> target-title">
-              <%= target.title %>
+              <%= target.long_title %>
             </td>
           </tr>
         <% end %>

--- a/app/models/concerns/sdg/related.rb
+++ b/app/models/concerns/sdg/related.rb
@@ -41,4 +41,8 @@ module SDG::Related
       end
     end
   end
+
+  def code_and_title
+    "#{code}. #{title}"
+  end
 end

--- a/app/models/sdg/goal.rb
+++ b/app/models/sdg/goal.rb
@@ -9,6 +9,7 @@ class SDG::Goal < ApplicationRecord
   def title
     I18n.t("sdg.goals.goal_#{code}.title")
   end
+  alias_method :long_title, :title
 
   def title_in_two_lines
     I18n.t("sdg.goals.goal_#{code}.title_in_two_lines")

--- a/app/models/sdg/goal.rb
+++ b/app/models/sdg/goal.rb
@@ -21,8 +21,4 @@ class SDG::Goal < ApplicationRecord
   def self.[](code)
     find_by!(code: code)
   end
-
-  def code_and_title
-    "#{code}. #{title}"
-  end
 end

--- a/app/models/sdg/local_target.rb
+++ b/app/models/sdg/local_target.rb
@@ -18,6 +18,8 @@ class SDG::LocalTarget < ApplicationRecord
 
   before_validation :set_related_goal
 
+  alias_method :long_title, :title
+
   def self.[](code)
     find_by!(code: code)
   end

--- a/app/models/sdg/target.rb
+++ b/app/models/sdg/target.rb
@@ -8,7 +8,11 @@ class SDG::Target < ApplicationRecord
   has_many :local_targets, dependent: :destroy
 
   def title
-    I18n.t("sdg.goals.goal_#{goal.code}.targets.target_#{code_key}.title")
+    I18n.t("#{i18n_key}.short_title", default: long_title, fallback: nil)
+  end
+
+  def long_title
+    I18n.t("#{i18n_key}.long_title")
   end
 
   def self.[](code)
@@ -16,6 +20,10 @@ class SDG::Target < ApplicationRecord
   end
 
   private
+
+    def i18n_key
+      "sdg.goals.goal_#{goal.code}.targets.target_#{code_key}"
+    end
 
     def code_key
       code.gsub(".", "_").upcase

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -8,19 +8,26 @@ en:
         long_description: '<p>Globally, the number of people living in extreme poverty declined from 36 per cent in 1990 to 10 per cent in 2015. But the pace of change is decelerating and the COVID-19 crisis <a href="https://www.un.org/sites/un2.un.org/files/sg_report_socio-economic_impact_of_covid19.pdf">risks reversing decades of progress</a> in the fight against poverty. <a href="https://www.wider.unu.edu/node/237051">New research</a> published by the UNU World Institute for Development Economics Research warns that the economic fallout from <a href="https://www.wider.unu.edu/publication/estimates-impact-covid-19-global-poverty">the global pandemic could increase global poverty by as much as half a billion people</a>, or 8% of the total human population. This would be the first time that poverty has increased globally in thirty years, since 1990.</p> <p>More than <a href="http://www.worldbank.org/en/news/press-release/2018/09/19/decline-of-global-extreme-poverty-continues-but-has-slowed-world-bank">700 million people</a>, or 10 per cent of the world population, still live in extreme poverty today, struggling to fulfil the most basic needs like health, education, and access to water and sanitation, to name a few. The majority of people living on less than $1.90 a day live in sub-Saharan Africa. Worldwide, the <a href="https://unstats.un.org/sdgs/report/2019/goal-01/">poverty rate in rural areas is 17.2 per cent</a>—more than three times higher than in urban areas.&nbsp;</p> <p>For those who work, having a job does not guarantee a decent living. In fact, <a href="https://unstats.un.org/sdgs/report/2019/goal-01/">8 per cent</a> of employed workers and their families worldwide lived in extreme poverty in 2018. One out of five children live in extreme poverty. Ensuring social protection for all children and other vulnerable groups is critical to reduce poverty.</p>'
         targets:
           target_1_1:
-            title: "By 2030, eradicate extreme poverty for all people everywhere, currently measured as people living on less than $1.25 a day"
+            long_title: "By 2030, eradicate extreme poverty for all people everywhere, currently measured as people living on less than $1.25 a day"
+            short_title: "Eradicate Extreme Poverty"
           target_1_2:
-            title: "By 2030, reduce at least by half the proportion of men, women and children of all ages living in poverty in all its dimensions according to national definitions"
+            long_title: "By 2030, reduce at least by half the proportion of men, women and children of all ages living in poverty in all its dimensions according to national definitions"
+            short_title: "Reduce Poverty by at Least 50%"
           target_1_3:
-            title: "Implement nationally appropriate social protection systems and measures for all, including floors, and by 2030 achieve substantial coverage of the poor and the vulnerable"
+            long_title: "Implement nationally appropriate social protection systems and measures for all, including floors, and by 2030 achieve substantial coverage of the poor and the vulnerable"
+            short_title: "Implement Social Protection Systems"
           target_1_4:
-            title: "By 2030, ensure that all men and women, in particular the poor and the vulnerable, have equal rights to economic resources, as well as access to basic services, ownership and control over land and other forms of property, inheritance, natural resources, appropriate new technology and financial services, including microfinance"
+            long_title: "By 2030, ensure that all men and women, in particular the poor and the vulnerable, have equal rights to economic resources, as well as access to basic services, ownership and control over land and other forms of property, inheritance, natural resources, appropriate new technology and financial services, including microfinance"
+            short_title: "Equal Rights to Ownership, Basic Services, Technology and Economic Resources"
           target_1_5:
-            title: "By 2030, build the resilience of the poor and those in vulnerable situations and reduce their exposure and vulnerability to climate-related extreme events and other economic, social and environmental shocks and disasters"
+            long_title: "By 2030, build the resilience of the poor and those in vulnerable situations and reduce their exposure and vulnerability to climate-related extreme events and other economic, social and environmental shocks and disasters"
+            short_title: "Build Resilience to Environmental, Economic and Social Disasters"
           target_1_A:
-            title: "Ensure significant mobilization of resources from a variety of sources, including through enhanced development cooperation, in order to provide adequate and predictable means for developing countries, in particular least developed countries, to implement programmes and policies to end poverty in all its dimensions"
+            long_title: "Ensure significant mobilization of resources from a variety of sources, including through enhanced development cooperation, in order to provide adequate and predictable means for developing countries, in particular least developed countries, to implement programmes and policies to end poverty in all its dimensions"
+            short_title: "Mobilize Resources to Implement Policies to End Poverty"
           target_1_B:
-            title: "Create sound policy frameworks at the national, regional and international levels, based on pro-poor and gender-sensitive development strategies, to support accelerated investment in poverty eradication actions"
+            long_title: "Create sound policy frameworks at the national, regional and international levels, based on pro-poor and gender-sensitive development strategies, to support accelerated investment in poverty eradication actions"
+            short_title: "Create pro-poor and gender-sensitive policy frameworks"
       goal_2:
         title: "Zero Hunger"
         title_in_two_lines: "Zero\nHunger"
@@ -28,21 +35,29 @@ en:
         long_description: '<p>After decades of steady decline, the number of people who suffer from hunger – as measured by the prevalence of undernourishment – began to slowly increase again in 2015. Current estimates show that <a href="http://www.fao.org/publications/sofi/2020/en/">nearly 690 million people are hungry, or 8.9 percent of the world population</a> – up by 10 million people in one year and by nearly 60 million in five years.</p> <p>The world is not on track to achieve Zero Hunger by 2030. If recent trends continue, the number of people affected by hunger would surpass 840 million by 2030.</p> <p>According to the World Food Programme, <a href="https://www.wfp.org/publications/2020-global-report-food-crises">135 million suffer from acute hunger</a> largely due to man-made conflicts, climate change and economic downturns. The COVID-19 pandemic could now double that number, putting an additional 130 million people at risk of suffering acute hunger by the end of 2020.</p> <p>With more than <a href="https://insight.wfp.org/covid-19-will-almost-double-people-in-acute-hunger-by-end-of-2020-59df0c4a8072">a quarter of a billion people potentially at the brink of starvation</a>, swift action needs to be taken to provide food and humanitarian relief to the most at-risk regions.</p> <p>At the same time,&nbsp;a profound change of the global food and agriculture system is needed if we are to nourish the more than 690 million people who are hungry today – and the&nbsp;<a href="https://www.un.org/development/desa/en/news/population/world-population-prospects-2019.html">additional 2 billion people</a>&nbsp;the world will have by 2050. Increasing agricultural productivity and sustainable food production are crucial to help alleviate the perils of hunger.</p>'
         targets:
           target_2_1:
-            title: "By 2030, end hunger and ensure access by all people, in particular the poor and people in vulnerable situations, including infants, to safe, nutritious and sufficient food all year round."
+            long_title: "By 2030, end hunger and ensure access by all people, in particular the poor and people in vulnerable situations, including infants, to safe, nutritious and sufficient food all year round."
+            short_title: "Universal Access to Safe and Nutritious Food"
           target_2_2:
-            title: "By 2030, end all forms of malnutrition, including achieving, by 2025, the internationally agreed targets on stunting and wasting in children under 5 years of age, and address the nutritional needs of adolescent girls, pregnant and lactating women and older persons."
+            long_title: "By 2030, end all forms of malnutrition, including achieving, by 2025, the internationally agreed targets on stunting and wasting in children under 5 years of age, and address the nutritional needs of adolescent girls, pregnant and lactating women and older persons."
+            short_title: "End All Forms of Malnutrition"
           target_2_3:
-            title: "By 2030, double the agricultural productivity and incomes of small-scale food producers, in particular women, indigenous peoples, family farmers, pastoralists and fishers, including through secure and equal access to land, other productive resources and inputs, knowledge, financial services, markets and opportunities for value addition and non-farm employment."
+            long_title: "By 2030, double the agricultural productivity and incomes of small-scale food producers, in particular women, indigenous peoples, family farmers, pastoralists and fishers, including through secure and equal access to land, other productive resources and inputs, knowledge, financial services, markets and opportunities for value addition and non-farm employment."
+            short_title: "Double the Productivity and Incomes of Small-Scale Food Producers"
           target_2_4:
-            title: "By 2030, ensure sustainable food production systems and implement resilient agricultural practices that increase productivity and production, that help maintain ecosystems, that strengthen capacity for adaptation to climate change, extreme weather, drought, flooding and other disasters and that progressively improve land and soil quality."
+            long_title: "By 2030, ensure sustainable food production systems and implement resilient agricultural practices that increase productivity and production, that help maintain ecosystems, that strengthen capacity for adaptation to climate change, extreme weather, drought, flooding and other disasters and that progressively improve land and soil quality."
+            short_title: "Sustainable Food Production and Resilient Agricultural Practices"
           target_2_5:
-            title: "By 2020, maintain the genetic diversity of seeds, cultivated plants and farmed and domesticated animals and their related wild species, including through soundly managed and diversified seed and plant banks at the national, regional and international levels, and promote access to and fair and equitable sharing of benefits arising from the utilization of genetic resources and associated traditional knowledge, as internationally agreed."
+            long_title: "By 2020, maintain the genetic diversity of seeds, cultivated plants and farmed and domesticated animals and their related wild species, including through soundly managed and diversified seed and plant banks at the national, regional and international levels, and promote access to and fair and equitable sharing of benefits arising from the utilization of genetic resources and associated traditional knowledge, as internationally agreed."
+            short_title: "Maintain the Genetic Diversity in Food Production"
           target_2_A:
-            title: "Increase investment, including through enhanced international cooperation, in rural infrastructure, agricultural research and extension services, technology development and plant and livestock gene banks in order to enhance agricultural productive capacity in developing countries, in particular least developed countries."
+            long_title: "Increase investment, including through enhanced international cooperation, in rural infrastructure, agricultural research and extension services, technology development and plant and livestock gene banks in order to enhance agricultural productive capacity in developing countries, in particular least developed countries."
+            short_title: "Invest in Rural Infrastructure, Agricultural Research, Technology and Gene Banks"
           target_2_B:
-            title: "Correct and prevent trade restrictions and distortions in world agricultural markets, including through the parallel elimination of all forms of agricultural export subsidies and all export measures with equivalent effect, in accordance with the mandate of the Doha Development Round."
+            long_title: "Correct and prevent trade restrictions and distortions in world agricultural markets, including through the parallel elimination of all forms of agricultural export subsidies and all export measures with equivalent effect, in accordance with the mandate of the Doha Development Round."
+            short_title: "Prevent Agricultural Trade Restrictions, Market Distortions and Export Subsidies"
           target_2_C:
-            title: "Adopt measures to ensure the proper functioning of food commodity markets and their derivatives and facilitate timely access to market information, including on food reserves, in order to help limit extreme food price volatility."
+            long_title: "Adopt measures to ensure the proper functioning of food commodity markets and their derivatives and facilitate timely access to market information, including on food reserves, in order to help limit extreme food price volatility."
+            short_title: "Ensure Stable Food Commodity Markets and Timely Access to Information"
       goal_3:
         title: "Good Health and Well-Being"
         title_in_two_lines: "Good Health\nand Well-Being"
@@ -50,31 +65,44 @@ en:
         long_description: '<p>Ensuring healthy lives and promoting well-being at all ages is essential to sustainable development. Currently, the world is facing a <a href="https://www.un.org/coronavirus">global health crisis</a> unlike any other — COVID-19 is spreading human suffering, destabilizing the global economy and upending the lives of billions of people around the globe.&nbsp;</p> <p>Before the pandemic, major progress was made in <a href="https://unstats.un.org/sdgs/report/2019/goal-03/">improving the health of millions of people</a>. Significant strides were made in increasing life expectancy and reducing some of the common killers associated with child and maternal mortality. But more efforts are needed to fully eradicate a wide range of diseases and address many different persistent and emerging health issues. By focusing on providing more efficient funding of health systems, improved sanitation and hygiene, and increased access to physicians, significant progress can be made in helping to save the lives of millions.</p> <p>Health emergencies such as COVID-19 pose a global risk and have shown the critical need for preparedness. The United Nations Development Programme highlighted huge disparities in <a href="https://www.undp.org/content/undp/en/home/news-centre/news/2020/COVID19_UNDP_data_dashboards_reveal_disparities_among_countries_to_cope_and_recover.html">countries’ abilities to cope with and recover from the COVID-19 crisis</a>. The pandemic provides a watershed moment for health emergency preparedness and for investment in critical 21st century public services.&nbsp;</p>'
         targets:
           target_3_1:
-            title: "By 2030, reduce the global maternal mortality ratio to less than 70 per 100,000 live births."
+            long_title: "By 2030, reduce the global maternal mortality ratio to less than 70 per 100,000 live births."
+            short_title: "Reduce Maternal Mortality"
           target_3_2:
-            title: "By 2030, end preventable deaths of newborns and children under 5 years of age, with all countries aiming to reduce neonatal mortality to at least as low as 12 per 1,000 live births and under-5 mortality to at least as low as 25 per 1,000 live births."
+            long_title: "By 2030, end preventable deaths of newborns and children under 5 years of age, with all countries aiming to reduce neonatal mortality to at least as low as 12 per 1,000 live births and under-5 mortality to at least as low as 25 per 1,000 live births."
+            short_title: "End All Preventable Deaths Under 5 Years of Age"
           target_3_3:
-            title: "By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical diseases and combat hepatitis, water-borne diseases and other communicable diseases."
+            long_title: "By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical diseases and combat hepatitis, water-borne diseases and other communicable diseases."
+            short_title: "Fight Communicable Diseases"
           target_3_4:
-            title: "By 2030, reduce by one third premature mortality from non-communicable diseases through prevention and treatment and promote mental health and well-being."
+            long_title: "By 2030, reduce by one third premature mortality from non-communicable diseases through prevention and treatment and promote mental health and well-being."
+            short_title: "Reduce Mortality from Non-Communicable Diseases and Promote Mental Health"
           target_3_5:
-            title: "Strengthen the prevention and treatment of substance abuse, including narcotic drug abuse and harmful use of alcohol."
+            long_title: "Strengthen the prevention and treatment of substance abuse, including narcotic drug abuse and harmful use of alcohol."
+            short_title: "Prevent and Treat Substance Abuse"
           target_3_6:
-            title: "By 2020, halve the number of global deaths and injuries from road traffic accidents."
+            long_title: "By 2020, halve the number of global deaths and injuries from road traffic accidents."
+            short_title: "Reduce Road Injuries and Deaths"
           target_3_7:
-            title: "By 2030, ensure universal access to sexual and reproductive health-care services, including for family planning, information and education, and the integration of reproductive health into national strategies and programmes."
+            long_title: "By 2030, ensure universal access to sexual and reproductive health-care services, including for family planning, information and education, and the integration of reproductive health into national strategies and programmes."
+            short_title: "Universal Access to Sexual and Reproductive Care, Family Planning and Education"
           target_3_8:
-            title: "Achieve universal health coverage, including financial risk protection, access to quality essential health-care services and access to safe, effective, quality and affordable essential medicines and vaccines for all."
+            long_title: "Achieve universal health coverage, including financial risk protection, access to quality essential health-care services and access to safe, effective, quality and affordable essential medicines and vaccines for all."
+            short_title: "Achieve Universal Health Coverage"
           target_3_9:
-            title: "By 2030, substantially reduce the number of deaths and illnesses from hazardous chemicals and air, water and soil pollution and contamination."
+            long_title: "By 2030, substantially reduce the number of deaths and illnesses from hazardous chemicals and air, water and soil pollution and contamination."
+            short_title: "Reduce Illnesses and Death from Hazardous Chemicals and Pollution"
           target_3_A:
-            title: "Strengthen the implementation of the World Health Organization Framework Convention on Tobacco Control in all countries, as appropriate."
+            long_title: "Strengthen the implementation of the World Health Organization Framework Convention on Tobacco Control in all countries, as appropriate."
+            short_title: "Implement the WHO Framework Convention on Tobacco Control"
           target_3_B:
-            title: "Support the research and development of vaccines and medicines for the communicable and noncommunicable diseases that primarily affect developing countries, provide access to affordable essential medicines and vaccines, in accordance with the Doha Declaration on the TRIPS Agreement and Public Health, which affirms the right of developing countries to use to the full the provisions in the Agreement on Trade Related Aspects of Intellectual Property Rights regarding flexibilities to protect public health, and, in particular, provide access to medicines for all."
+            long_title: "Support the research and development of vaccines and medicines for the communicable and noncommunicable diseases that primarily affect developing countries, provide access to affordable essential medicines and vaccines, in accordance with the Doha Declaration on the TRIPS Agreement and Public Health, which affirms the right of developing countries to use to the full the provisions in the Agreement on Trade Related Aspects of Intellectual Property Rights regarding flexibilities to protect public health, and, in particular, provide access to medicines for all."
+            short_title: "Support Research, Development and Universal Access to Affordable Vaccines and Medicines"
           target_3_C:
-            title: "Substantially increase health financing and the recruitment, development, training and retention of the health workforce in developing countries, especially in least developed countries and small island developing States."
+            long_title: "Substantially increase health financing and the recruitment, development, training and retention of the health workforce in developing countries, especially in least developed countries and small island developing States."
+            short_title: "Increase Health Financing and Support Health Workforce in Developing Countries"
           target_3_D:
-            title: "Strengthen the capacity of all countries, in particular developing countries, for early warning, risk reduction and management of national and global health risks."
+            long_title: "Strengthen the capacity of all countries, in particular developing countries, for early warning, risk reduction and management of national and global health risks."
+            short_title: "Improve Early Warning Systems for Global Health Risks"
       goal_4:
         title: "Quality Education"
         title_in_two_lines: "Quality\nEducation"
@@ -82,25 +110,35 @@ en:
         long_description: '<p>Education enables upward socioeconomic mobility and is a key to escaping poverty. Over the past decade, major progress was made towards increasing access to education and school enrollment rates at all levels, particularly for girls. Nevertheless, <a href="http://uis.unesco.org/en/topic/out-school-children-and-youth">about 260 million children were still out of school</a> in 2018 — nearly one fifth of the global population in that age group. And more than half of all children and adolescents worldwide are <a href="https://unstats.un.org/sdgs/report/2019/goal-04/">not meeting minimum proficiency standards</a> in reading and mathematics.&nbsp;</p> <p>In 2020, as the COVID-19 pandemic spread across the globe, a majority of countries announced the temporary closure of schools, impacting more than 91 per cent of students worldwide. By April 2020, close to <a href="https://en.unesco.org/covid19/educationresponse">1.6 billion children and youth were out of school</a>. And nearly <a href="https://www.un.org/sites/un2.un.org/files/policy_brief_on_covid_impact_on_children_16_april_2020.pdf">369 million children who rely on school meals</a> needed to look to other sources for daily nutrition.&nbsp;</p> <p>Never before have so many children been out of school at the same time, disrupting learning and upending lives, especially the most vulnerable and marginalised. The global pandemic has far-reaching consequences that may jeopardize hard won gains made in improving global education.</p>'
         targets:
           target_4_1:
-            title: "By 2030, ensure that all girls and boys complete free, equitable and quality primary and secondary education leading to relevant and Goal-4 effective learning outcomes."
+            long_title: "By 2030, ensure that all girls and boys complete free, equitable and quality primary and secondary education leading to relevant and Goal-4 effective learning outcomes."
+            short_title: "Free Primary and Secondary Education"
           target_4_2:
-            title: "By 2030, ensure that all girls and boys have access to quality early childhood development, care and preprimary education so that they are ready for primary education."
+            long_title: "By 2030, ensure that all girls and boys have access to quality early childhood development, care and preprimary education so that they are ready for primary education."
+            short_title: "Equal Access to Quality Pre-Primary Education"
           target_4_3:
-            title: "By 2030, ensure equal access for all women and men to affordable and quality technical, vocational and tertiary education, including university."
+            long_title: "By 2030, ensure equal access for all women and men to affordable and quality technical, vocational and tertiary education, including university."
+            short_title: "Equal Access to Affordable Technical, Vocational and Higher Education"
           target_4_4:
-            title: "By 2030, substantially increase the number of youth and adults who have relevant skills, including technical and vocational skills, for employment, decent jobs and entrepreneurship."
+            long_title: "By 2030, substantially increase the number of youth and adults who have relevant skills, including technical and vocational skills, for employment, decent jobs and entrepreneurship."
+            short_title: "Increase the Number of People with Relevant Skills for Financial Success"
           target_4_5:
-            title: "By 2030, eliminate gender disparities in education and ensure equal access to all levels of education and vocational training for the vulnerable, including persons with disabilities, indigenous peoples and children in vulnerable situations."
+            long_title: "By 2030, eliminate gender disparities in education and ensure equal access to all levels of education and vocational training for the vulnerable, including persons with disabilities, indigenous peoples and children in vulnerable situations."
+            short_title: "Eliminate All Discrimination in Education"
           target_4_6:
-            title: "By 2030, ensure that all youth and a substantial proportion of adults, both men and women, achieve literacy and numeracy."
+            long_title: "By 2030, ensure that all youth and a substantial proportion of adults, both men and women, achieve literacy and numeracy."
+            short_title: "Universal Literacy and Numeracy"
           target_4_7:
-            title: "By 2030, ensure that all learners acquire the knowledge and skills needed to promote sustainable development, including, among others, through education for sustainable development and sustainable lifestyles, human rights, gender equality, promotion of a culture of peace and non-violence, global citizenship and appreciation of cultural diversity and of culture’s contribution to sustainable development."
+            long_title: "By 2030, ensure that all learners acquire the knowledge and skills needed to promote sustainable development, including, among others, through education for sustainable development and sustainable lifestyles, human rights, gender equality, promotion of a culture of peace and non-violence, global citizenship and appreciation of cultural diversity and of culture’s contribution to sustainable development."
+            short_title: "Education for Sustainable Development and Global Citizenship"
           target_4_A:
-            title: "Build and upgrade education facilities that are child, disability and gender sensitive and provide safe, nonviolent, inclusive and effective learning environments for all."
+            long_title: "Build and upgrade education facilities that are child, disability and gender sensitive and provide safe, nonviolent, inclusive and effective learning environments for all."
+            short_title: "Build and Upgrade Inclusive and Safe Schools"
           target_4_B:
-            title: "By 2020, substantially expand globally the number of scholarships available to developing countries, in particular least developed countries, small island developing States and African countries, for enrolment in higher education, including vocational training and information and communications technology, technical, engineering and scientific programmes, in developed countries and other developing countries."
+            long_title: "By 2020, substantially expand globally the number of scholarships available to developing countries, in particular least developed countries, small island developing States and African countries, for enrolment in higher education, including vocational training and information and communications technology, technical, engineering and scientific programmes, in developed countries and other developing countries."
+            short_title: "Expand Higher Education Scholarships for Developing Countries"
           target_4_C:
-            title: "By 2030, substantially increase the supply of qualified teachers, including through international cooperation for teacher training in developing countries, especially least developed countries and small island developing states."
+            long_title: "By 2030, substantially increase the supply of qualified teachers, including through international cooperation for teacher training in developing countries, especially least developed countries and small island developing states."
+            short_title: "Increase the supply of qualified teachers In Developing Countries"
       goal_5:
         title: "Gender Equality"
         title_in_two_lines: "Gender\nEquality"
@@ -108,23 +146,32 @@ en:
         long_description: '<p>Gender equality is not only a fundamental human right, but a necessary foundation for a peaceful, prosperous and sustainable world.&nbsp;</p> <p>There has been <a href="https://www.unwomen.org/-/media/headquarters/attachments/sections/library/publications/2020/gender-equality-womens-rights-in-review-key-facts-and-figures-en.pdf?la=en&amp;vs=935">progress</a> over the last decades: More girls are going to school, fewer girls are forced into early marriage, more women are serving in parliament and positions of leadership, and laws are being reformed to advance gender equality.&nbsp;</p> <p>Despite these gains, many <a href="https://www.unwomen.org/-/media/headquarters/attachments/sections/library/publications/2020/gender-equality-womens-rights-in-review-key-facts-and-figures-en.pdf?la=en&amp;vs=935">challenges</a> remain: discriminatory laws and social norms remain pervasive, women continue to be underrepresented at all levels of political leadership, and 1 in 5 women and girls between the ages of 15 and 49 report experiencing physical or sexual violence by an intimate partner within a 12-month period.</p> <p>The effects of <a href="https://www.un.org/sites/un2.un.org/files/policy_brief_on_covid_impact_on_women_9_apr_2020_updated.pdf">the COVID-19 pandemic could reverse the limited progress</a> that has been made on gender equality and women’s rights.&nbsp; The coronavirus outbreak <a href="https://www.unfpa.org/sites/default/files/resource-pdf/COVID-19_A_Gender_Lens_Guidance_Note.pdf">exacerbates existing inequalities</a> for women and girls across every sphere – from health and the economy, to security and social protection.&nbsp;</p> <p>Women play a disproportionate role in responding to the virus, including as frontline healthcare workers and carers at home. Women’s unpaid care work has increased significantly as a result of school closures and the increased needs of older people. Women are also harder hit by the economic impacts of COVID-19, as they disproportionately work in insecure labour markets. Nearly 60 per cent of women work in the informal economy, which puts them at greater risk of falling into poverty.&nbsp;</p> <p>The pandemic has also led to a steep increase in <a href="https://www.unwomen.org/-/media/headquarters/attachments/sections/library/publications/2020/issue-brief-covid-19-and-ending-violence-against-women-and-girls-en.pdf?la=en&amp;vs=5006">violence against women and girls</a>. With lockdown measures in place, many women are trapped at home with their abusers, struggling to access services that are suffering from cuts and restrictions. Emerging data shows that, since the outbreak of the pandemic, violence against women and girls – and particularly domestic violence – has intensified.</p>'
         targets:
           target_5_1:
-            title: "End all forms of discrimination against all women and girls everywhere."
+            long_title: "End all forms of discrimination against all women and girls everywhere."
+            short_title: "End Discrimination Against Women and Girls"
           target_5_2:
-            title: "Eliminate all forms of violence against all women and girls in the public and private spheres, including trafficking and sexual and other types of exploitation."
+            long_title: "Eliminate all forms of violence against all women and girls in the public and private spheres, including trafficking and sexual and other types of exploitation."
+            short_title: "End All Violence Against and Exploitation of Women and Girls"
           target_5_3:
-            title: "Eliminate all harmful practices, such as child, early and forced marriage and female genital mutilation."
+            long_title: "Eliminate all harmful practices, such as child, early and forced marriage and female genital mutilation."
+            short_title: "Eliminate Forced Marriages and Genital Mutilation"
           target_5_4:
-            title: "Recognize and value unpaid care and domestic work through the provision of public services, infrastructure and social protection policies and the promotion of shared responsibility within the household and the family as nationally appropriate."
+            long_title: "Recognize and value unpaid care and domestic work through the provision of public services, infrastructure and social protection policies and the promotion of shared responsibility within the household and the family as nationally appropriate."
+            short_title: "Value Unpaid Care and Promote Shared Domestic Responsibilities"
           target_5_5:
-            title: "Ensure women’s full and effective participation and equal opportunities for leadership at all levels of decisionmaking in political, economic and public life."
+            long_title: "Ensure women’s full and effective participation and equal opportunities for leadership at all levels of decisionmaking in political, economic and public life."
+            short_title: "Ensure Full Participation in Leadership and Decision-Making"
           target_5_6:
-            title: "Ensure universal access to sexual and reproductive health and reproductive rights as agreed in accordance with the Programme of Action of the International Conference on Population and Development and the Beijing Platform for Action and the outcome documents of their review conferences."
+            long_title: "Ensure universal access to sexual and reproductive health and reproductive rights as agreed in accordance with the Programme of Action of the International Conference on Population and Development and the Beijing Platform for Action and the outcome documents of their review conferences."
+            short_title: "Universal Access to Reproductive Health and Rights"
           target_5_A:
-            title: "Undertake reforms to give women equal rights to economic resources, as well as access to ownership and control over land and other forms of property, financial services, inheritance and natural resources, in accordance with national laws."
+            long_title: "Undertake reforms to give women equal rights to economic resources, as well as access to ownership and control over land and other forms of property, financial services, inheritance and natural resources, in accordance with national laws."
+            short_title: "Equal Rights to Economic Resources, Property Ownership and Financial Services"
           target_5_B:
-            title: "Enhance the use of enabling technology, in particular information and communications technology, to promote the empowerment of women."
+            long_title: "Enhance the use of enabling technology, in particular information and communications technology, to promote the empowerment of women."
+            short_title: "Promote Empowerment of Women through Technology"
           target_5_C:
-            title: "Adopt and strengthen sound policies and enforceable legislation for the promotion of gender equality and the empowerment of all women and girls at all levels."
+            long_title: "Adopt and strengthen sound policies and enforceable legislation for the promotion of gender equality and the empowerment of all women and girls at all levels."
+            short_title: "Adopt and Strengthen Policies and Enforceable Legislation for Gender Equality"
       goal_6:
         title: "Clean Water and Sanitation"
         title_in_two_lines: "Clean Water\nand Sanitation"
@@ -132,21 +179,29 @@ en:
         long_description: '<p>While substantial progress has been made in increasing access to clean drinking water and sanitation, billions of people—mostly in rural areas—still lack these basic services. Worldwide, <a href="https://www.who.int/news-room/detail/18-06-2019-1-in-3-people-globally-do-not-have-access-to-safe-drinking-water-unicef-who">one in three people do not have access to safe drinking water</a>, <a href="https://www.unwater.org/water-facts/water-sanitation-and-hygiene/">two out of five people do not have a basic hand-washing facility</a> with soap and water, and more than <a href="https://news.un.org/en/story/2019/11/1051561">673 million people still practice open defecation</a>.</p> <p>The COVID-19 pandemic has demonstrated the critical importance of sanitation, hygiene and adequate access to clean water for preventing and containing diseases. <a href="https://www.unwater.org/water-facts/handhygiene/">Hand hygiene saves lives</a>. According to the World Health Organization, <a href="https://www.who.int/news-room/events/detail/2020/05/05/default-calendar/hand-hygiene-day">handwashing is one of the most effective actions you can take</a> to reduce the spread of pathogens and prevent infections, including the COVID-19 virus. Yet billions of people still lack safe water sanitation, and funding is inadequate.</p>'
         targets:
           target_6_1:
-            title: "By 2030, achieve universal and equitable access to safe and affordable drinking water for all."
+            long_title: "By 2030, achieve universal and equitable access to safe and affordable drinking water for all."
+            short_title: "Safe and Affordable Drinking Water"
           target_6_2:
-            title: "By 2030, achieve access to adequate and equitable sanitation and hygiene for all and end open defecation, paying special attention to the needs of women and girls and those in vulnerable situations."
+            long_title: "By 2030, achieve access to adequate and equitable sanitation and hygiene for all and end open defecation, paying special attention to the needs of women and girls and those in vulnerable situations."
+            short_title: "End Open Defecation and Provide Access to Sanitation and Hygiene"
           target_6_3:
-            title: "By 2030, improve water quality by reducing pollution, eliminating dumping and minimizing release of hazardous chemicals and materials, halving the proportion of untreated wastewater and substantially increasing recycling and safe reuse globally."
+            long_title: "By 2030, improve water quality by reducing pollution, eliminating dumping and minimizing release of hazardous chemicals and materials, halving the proportion of untreated wastewater and substantially increasing recycling and safe reuse globally."
+            short_title: "Improve Water Quality, Wastewater Treatment and Safe Reuse"
           target_6_4:
-            title: "By 2030, substantially increase water-use efficiency across all sectors and ensure sustainable withdrawals and supply of freshwater to address water scarcity and substantially reduce the number of people suffering from water scarcity."
+            long_title: "By 2030, substantially increase water-use efficiency across all sectors and ensure sustainable withdrawals and supply of freshwater to address water scarcity and substantially reduce the number of people suffering from water scarcity."
+            short_title: "Increase Water-Use Efficiency and Ensure Freshwater Supplies"
           target_6_5:
-            title: "By 2030, implement integrated water resources management at all levels, including through transboundary cooperation as appropriate."
+            long_title: "By 2030, implement integrated water resources management at all levels, including through transboundary cooperation as appropriate."
+            short_title: "Implement Integrated Water Resources Management"
           target_6_6:
-            title: "By 2020, protect and restore water-related ecosystems, including mountains, forests, wetlands, rivers, aquifers and lakes."
+            long_title: "By 2020, protect and restore water-related ecosystems, including mountains, forests, wetlands, rivers, aquifers and lakes."
+            short_title: "Protect and Restore Water-Related Ecosystems"
           target_6_A:
-            title: "By 2030, expand international cooperation and capacity-building support to developing countries in water- and sanitation-related activities and programmes, including water harvesting, desalination, water efficiency, wastewater treatment, recycling and reuse technologies."
+            long_title: "By 2030, expand international cooperation and capacity-building support to developing countries in water- and sanitation-related activities and programmes, including water harvesting, desalination, water efficiency, wastewater treatment, recycling and reuse technologies."
+            short_title: "Expand Water and Sanitation Support to Developing Countries"
           target_6_B:
-            title: "Support and strengthen the participation of local communities in improving water and sanitation management."
+            long_title: "Support and strengthen the participation of local communities in improving water and sanitation management."
+            short_title: "Support Local Engagement in Water and Sanitation Management"
       goal_7:
         title: "Affordable and Clean Energy"
         title_in_two_lines: "Affordable and\nClean Energy"
@@ -154,15 +209,20 @@ en:
         long_description: '<p>The world is making <a href="https://unstats.un.org/sdgs/report/2019/goal-07/">progress towards Goal 7</a>, with encouraging signs that energy is becoming more sustainable and widely available. Access to electricity in poorer countries has begun to accelerate, energy efficiency continues to improve, and renewable energy is making impressive gains in the electricity sector.&nbsp;</p> <p>Nevertheless, more focused attention is needed to improve access to clean and safe cooking fuels and technologies for 3 billion people, to expand the use of renewable energy beyond the electricity sector, and to increase electrification in sub-Saharan Africa.</p> <p>The <a href="https://trackingsdg7.esmap.org/">Energy Progress Report</a> provides global dashboard to register progress on energy access, energy efficiency and renewable energy. It assesses the progress made by each country on these three pillars and provides a snapshot of how far we are from achieving the 2030 Sustainable Development Goals targets.</p>'
         targets:
           target_7_1:
-            title: "By 2030, ensure universal access to affordable, reliable and modern energy services."
+            long_title: "By 2030, ensure universal access to affordable, reliable and modern energy services."
+            short_title: "Universal Access to Modern Energy"
           target_7_2:
-            title: "By 2030, increase substantially the share of renewable energy in the global energy mix."
+            long_title: "By 2030, increase substantially the share of renewable energy in the global energy mix."
+            short_title: "Increase Global Percentage of Renewable Energy"
           target_7_3:
-            title: "By 2030, double the global rate of improvement in energy efficiency."
+            long_title: "By 2030, double the global rate of improvement in energy efficiency."
+            short_title: "Double the Improvement in Energy Efficiency"
           target_7_A:
-            title: "By 2030, enhance international cooperation to facilitate access to clean energy research and technology, including renewable energy, energy efficiency and advanced and cleaner fossil-fuel technology, and promote investment in energy infrastructure and clean energy technology."
+            long_title: "By 2030, enhance international cooperation to facilitate access to clean energy research and technology, including renewable energy, energy efficiency and advanced and cleaner fossil-fuel technology, and promote investment in energy infrastructure and clean energy technology."
+            short_title: "Promote Access to Research, Technology and Investments in Clean Energy "
           target_7_B:
-            title: "By 2030, expand infrastructure and upgrade technology for supplying modern and sustainable energy services for all in developing countries, in particular least developed countries, small island developing States, and land-locked developing countries, in accordance with their respective programmes of support."
+            long_title: "By 2030, expand infrastructure and upgrade technology for supplying modern and sustainable energy services for all in developing countries, in particular least developed countries, small island developing States, and land-locked developing countries, in accordance with their respective programmes of support."
+            short_title: "Expand and Upgrade Energy Services for Developing Countries"
       goal_8:
         title: "Decent Work and Economic Growth"
         title_in_two_lines: "Decent Work and\nEconomic Growth"
@@ -170,29 +230,41 @@ en:
         long_description: '<p>Sustained and inclusive economic growth can drive progress, create decent jobs for all and improve living standards.&nbsp;</p> <p>COVID-19 has <a href="https://www.un.org/sites/un2.un.org/files/sg_report_socio-economic_impact_of_covid19.pdf">disrupted billions of lives</a> and endangered the global economy. The International Monetary Fund (IMF) expects a <a href="https://blogs.imf.org/2020/04/14/the-great-lockdown-worst-economic-downturn-since-the-great-depression/">global recession</a> as bad as or worse than in 2009. As job losses escalate, the International Labor Organization estimates that <a href="https://www.ilo.org/global/about-the-ilo/newsroom/news/WCMS_743036/lang--en/index.htm">nearly half of the global workforce is at risk</a> of losing their livelihoods.</p> <p><a href="https://developmentfinance.un.org/press-release-financing-sustainable-development-report-2020">Even before the outbreak of COVID-19</a>, one in five countries – home to billions of people living in poverty – were likely to see per capita incomes stagnate or decline in 2020. Now, the<a href="https://developmentfinance.un.org/press-release-financing-sustainable-development-report-2020"> economic and financial shocks</a> associated with COVID-19—such as disruptions to industrial production, falling commodity prices, financial market volatility, and rising insecurity—are derailing the already tepid economic growth and compounding heightened risks from other factors.&nbsp;&nbsp;</p>'
         targets:
           target_8_1:
-            title: "Sustain per capita economic growth in accordance with national circumstances and, in particular, at least 7 per cent gross domestic product growth per annum in the least developed countries."
+            long_title: "Sustain per capita economic growth in accordance with national circumstances and, in particular, at least 7 per cent gross domestic product growth per annum in the least developed countries."
+            short_title: "Sustainable Economic Growth"
           target_8_2:
-            title: "Achieve higher levels of economic productivity through diversification, technological upgrading and innovation, including through a focus on high-value added and labour-intensive sectors."
+            long_title: "Achieve higher levels of economic productivity through diversification, technological upgrading and innovation, including through a focus on high-value added and labour-intensive sectors."
+            short_title: "Diversify, Innovate and Upgrade for Economic Productivity"
           target_8_3:
-            title: "Promote development-oriented policies that support productive activities, decent job creation, entrepreneurship, creativity and innovation, and encourage the formalization and growth of micro-, small- and medium-sized enterprises, including through access to financial services."
+            long_title: "Promote development-oriented policies that support productive activities, decent job creation, entrepreneurship, creativity and innovation, and encourage the formalization and growth of micro-, small- and medium-sized enterprises, including through access to financial services."
+            short_title: "Promote Policies to Support Job Creation and Growing Enterprises"
           target_8_4:
-            title: "Improve progressively, through 2030, global resource efficiency in consumption and production and endeavour to decouple economic growth from environmental degradation, in accordance with the 10-year framework of programmes on sustainable consumption and production, with developed countries taking the lead."
+            long_title: "Improve progressively, through 2030, global resource efficiency in consumption and production and endeavour to decouple economic growth from environmental degradation, in accordance with the 10-year framework of programmes on sustainable consumption and production, with developed countries taking the lead."
+            short_title: "Improve Resource Efficiency in Consumption and Production"
           target_8_5:
-            title: "By 2030, achieve full and productive employment and decent work for all women and men, including for young people and persons with disabilities, and equal pay for work of equal value."
+            long_title: "By 2030, achieve full and productive employment and decent work for all women and men, including for young people and persons with disabilities, and equal pay for work of equal value."
+            short_title: "Full Employment and Decent Work with Equal Pay"
           target_8_6:
-            title: "By 2020, substantially reduce the proportion of youth not in employment, education or training."
+            long_title: "By 2020, substantially reduce the proportion of youth not in employment, education or training."
+            short_title: "Promote Youth Employment, Education and Training"
           target_8_7:
-            title: "Take immediate and effective measures to eradicate forced labour, end modern slavery and human trafficking and secure the prohibition and elimination of the worst forms of child labour, including recruitment and use of child soldiers, and by 2025 end child labour in all its forms."
+            long_title: "Take immediate and effective measures to eradicate forced labour, end modern slavery and human trafficking and secure the prohibition and elimination of the worst forms of child labour, including recruitment and use of child soldiers, and by 2025 end child labour in all its forms."
+            short_title: "End Modern Slavery, Trafficking and Child Labour"
           target_8_8:
-            title: "Protect labour rights and promote safe and secure working environments for all workers, including migrant workers, in particular women migrants, and those in precarious employment."
+            long_title: "Protect labour rights and promote safe and secure working environments for all workers, including migrant workers, in particular women migrants, and those in precarious employment."
+            short_title: "Protect Labour Rights and Promote Safe Working Environments"
           target_8_9:
-            title: "By 2030, devise and implement policies to promote sustainable tourism that creates jobs and promotes local culture and products"
+            long_title: "By 2030, devise and implement policies to promote sustainable tourism that creates jobs and promotes local culture and products"
+            short_title: "Promote Beneficial and Sustainable Tourism"
           target_8_10:
-            title: "Strengthen the capacity of domestic financial institutions to encourage and expand access to banking, insurance and financial services for all."
+            long_title: "Strengthen the capacity of domestic financial institutions to encourage and expand access to banking, insurance and financial services for all."
+            short_title: "Universal Access to Banking, Insurance and Financial Services"
           target_8_A:
-            title: "Increase Aid for Trade support for developing countries, in particular least developed countries, including through the Enhanced Integrated Framework for Trade-Related Technical Assistance to Least Developed Countries."
+            long_title: "Increase Aid for Trade support for developing countries, in particular least developed countries, including through the Enhanced Integrated Framework for Trade-Related Technical Assistance to Least Developed Countries."
+            short_title: "Increase Aid for Trade Support"
           target_8_B:
-            title: "By 2020, develop and operationalize a global strategy for youth employment and implement the Global Jobs Pact of the International Labour Organization."
+            long_title: "By 2020, develop and operationalize a global strategy for youth employment and implement the Global Jobs Pact of the International Labour Organization."
+            short_title: "Develop a Global Youth Employment Strategy"
       goal_9:
         title: "Industry, Innovation and Infrastructure"
         title_in_two_lines: "Industry, Innovation\nand Infrastructure"
@@ -200,21 +272,29 @@ en:
         long_description: '<p>Inclusive and sustainable industrialization, together with <a href="https://unstats.un.org/sdgs/report/2019/goal-09/">innovation and infrastructure</a>, can unleash dynamic and competitive economic forces that generate employment and income. They play a key role in introducing and promoting new technologies, facilitating international trade and enabling the efficient use of resources.&nbsp;</p> <p>However, the world still has a long way to go to fully tap this potential. Least developed countries, in particular, need to accelerate the development of their manufacturing sector if they are to meet the 2030 target, and scale up investment in scientific research and innovation.&nbsp;</p> <p>Global manufacturing growth has been steadily declining, even before the outbreak of the COVID-19 pandemic. The pandemic is <a href="https://unctad.org/en/pages/newsdetails.aspx?OriginalVersionID=2297">hitting manufacturing industries</a> hard and causing disruptions in global value chains and the supply of products.&nbsp;</p> <p>Innovation and technological progress are key to finding lasting solutions to both economic and environmental challenges, such as increased resource and energy-efficiency. Globally, <a href="https://sustainabledevelopment.un.org/content/documents/26158Final_SG_SDG_Progress_Report_14052020.pdf">investment in research and development</a> (R&amp;D) as a proportion of GDP increased from 1.5 per cent in 2000 to 1.7 per cent in 2015 and remained almost unchanged in 2017, but was only less than 1 per cent&nbsp; in developing regions.</p> <p>In terms of communications infrastructure, more than half of the world’s population is now online and almost the entire world population lives in an area covered by a mobile network. It is estimated that in 2019, <a href="https://sustainabledevelopment.un.org/content/documents/26158Final_SG_SDG_Progress_Report_14052020.pdf">96.5 per cent were covered by at least a 2G network</a>.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p> <p>The coronavirus pandemic has revealed the urgent <a href="https://www.unescap.org/blog/covid-19-reveals-urgent-need-resilient-infrastructure">need for resilient infrastructure</a>. The Asian Development Bank notes that critical infrastructure in the region remains far from adequate in many countries, despite the rapid economic growth and development the region has experienced over the past decade. The <a href="https://www.unescap.org/publications/economic-and-social-survey-asia-and-pacific-2019-ambitions-beyond-growth">Economic and Social Survey of Asia and the Pacific</a> highlights that making infrastructure resilient to disasters and climate change will require an additional investment of $434 billion per year. This sum may need to be even greater in some subregions, such as the Pacific small island developing states.&nbsp; &nbsp; &nbsp; </p>'
         targets:
           target_9_1:
-            title: "Develop quality, reliable, sustainable and resilient infrastructure, including regional and transborder infrastructure, to support economic development and human well-being, with a focus on affordable and equitable access for all."
+            long_title: "Develop quality, reliable, sustainable and resilient infrastructure, including regional and transborder infrastructure, to support economic development and human well-being, with a focus on affordable and equitable access for all."
+            short_title: "Develop Sustainable, Resilient and Inclusive Infrastructures"
           target_9_2:
-            title: "Promote inclusive and sustainable industrialization and, by 2030, significantly raise industry’s share of employment and gross domestic product, in line with national circumstances, and double its share in least developed countries."
+            long_title: "Promote inclusive and sustainable industrialization and, by 2030, significantly raise industry’s share of employment and gross domestic product, in line with national circumstances, and double its share in least developed countries."
+            short_title: "Promote Inclusive and Sustainable Industrialization"
           target_9_3:
-            title: "Increase the access of small-scale industrial and other enterprises, in particular in developing countries, to financial services, including affordable credit, and their integration into value chains and markets."
+            long_title: "Increase the access of small-scale industrial and other enterprises, in particular in developing countries, to financial services, including affordable credit, and their integration into value chains and markets."
+            short_title: "Increase Access to Financial Services and Markets"
           target_9_4:
-            title: "By 2030, upgrade infrastructure and retrofit industries to make them sustainable, with increased resource-use efficiency and greater adoption of clean and environmentally sound technologies and industrial processes, with all countries taking action in accordance with their respective capabilities."
+            long_title: "By 2030, upgrade infrastructure and retrofit industries to make them sustainable, with increased resource-use efficiency and greater adoption of clean and environmentally sound technologies and industrial processes, with all countries taking action in accordance with their respective capabilities."
+            short_title: "Upgrade All Industries and Infrastructures for Sustainability"
           target_9_5:
-            title: "Enhance scientific research, upgrade the technological capabilities of industrial sectors in all countries, in particular developing countries, including, by 2030, encouraging innovation and substantially increasing the number of research and development workers per 1 million people and public and private research and development spending."
+            long_title: "Enhance scientific research, upgrade the technological capabilities of industrial sectors in all countries, in particular developing countries, including, by 2030, encouraging innovation and substantially increasing the number of research and development workers per 1 million people and public and private research and development spending."
+            short_title: "Enhance Research and Upgrade Industrial Technologies "
           target_9_A:
-            title: "Facilitate sustainable and resilient infrastructure development in developing countries through enhanced financial, technological and technical support to African countries, least developed countries, landlocked developing countries and small island developing States 18."
+            long_title: "Facilitate sustainable and resilient infrastructure development in developing countries through enhanced financial, technological and technical support to African countries, least developed countries, landlocked developing countries and small island developing States 18."
+            short_title: "Facilitate Sustainable Infrastructure Development for Developing Countries"
           target_9_B:
-            title: "Support domestic technology development, research and innovation in developing countries, including by ensuring a conducive policy environment for, inter alia, industrial diversification and value addition to commodities."
+            long_title: "Support domestic technology development, research and innovation in developing countries, including by ensuring a conducive policy environment for, inter alia, industrial diversification and value addition to commodities."
+            short_title: "Support Domestic Technology Development and Industrial Diversification"
           target_9_C:
-            title: "Significantly increase access to information and communications technology and strive to provide universal and affordable access to the Internet in least developed countries by 2020."
+            long_title: "Significantly increase access to information and communications technology and strive to provide universal and affordable access to the Internet in least developed countries by 2020."
+            short_title: "Universal Access to Information and Communications Technology"
       goal_10:
         title: "Reduced Inequalities"
         title_in_two_lines: "Reduced\nInequalities"
@@ -222,25 +302,35 @@ en:
         long_description: '<p>Reducing inequalities and ensuring no one is left behind are integral to achieving the Sustainable Development Goals.&nbsp;</p> <p>Inequality within and among countries is a persistent cause for concern. Despite some positive signs toward reducing inequality in some dimensions, such as reducing relative income inequality in some countries and preferential trade status benefiting lower-income countries, <a href="https://unstats.un.org/sdgs/report/2019/goal-10/">inequality still persists</a>.</p> <p><a href="https://www.un.org/sustainabledevelopment/goal-of-the-month-may-2020">COVID-19 has deepened existing inequalities</a>, hitting the poorest and most vulnerable communities the hardest. It has put a spotlight on economic inequalities and fragile social safety nets that leave vulnerable communities to bear the brunt of the crisis.&nbsp; At the same time, social, political and economic inequalities have amplified the impacts of the pandemic.</p> <p>On the economic front, the COVID-19 pandemic has significantly increased global <a href="https://www.ilo.org/global/about-the-ilo/newsroom/news/WCMS_743036/lang--en/index.htm">unemployment</a> and dramatically slashed workers’ incomes.</p> <p>COVID-19 also puts at risk the limited progress that has been made on <a href="https://data.unwomen.org/resources/covid-19-emerging-gender-data-and-why-it-matters">gender equality</a> and women’s rights over the past decades. Across every sphere, from health to the economy, security to social protection, the impacts of COVID-19 are exacerbated for women and girls simply by virtue of their sex.</p> <p>Inequalities are also deepening for <a href="https://www.un.org/sites/un2.un.org/files/un_policy_brief_on_human_rights_and_covid_23_april_2020.pdf">vulnerable populations</a> in countries with weaker health systems and those facing existing humanitarian crises. Refugees and migrants, as well as indigenous peoples, older persons, people with disabilities and children are particularly at risk of being left behind. And <a href="https://www.un.org/en/coronavirus/covid-19-un-counters-pandemic-related-hate-and-xenophobia">hate speech</a> targeting vulnerable groups is rising.</p>'
         targets:
           target_10_1:
-            title: "By 2030, progressively achieve and sustain income growth of the bottom 40 per cent of the population at a rate higher than the national average."
+            long_title: "By 2030, progressively achieve and sustain income growth of the bottom 40 per cent of the population at a rate higher than the national average."
+            short_title: "Reduce Income Inequalities"
           target_10_2:
-            title: "By 2030, empower and promote the social, economic and political inclusion of all, irrespective of age, sex, disability, race, ethnicity, origin, religion or economic or other status."
+            long_title: "By 2030, empower and promote the social, economic and political inclusion of all, irrespective of age, sex, disability, race, ethnicity, origin, religion or economic or other status."
+            short_title: "Promote Universal Social, Economic and Political Inclusion"
           target_10_3:
-            title: "Ensure equal opportunity and reduce inequalities of outcome, including by eliminating discriminatory laws, policies and practices and promoting appropriate legislation, policies and action in this regard."
+            long_title: "Ensure equal opportunity and reduce inequalities of outcome, including by eliminating discriminatory laws, policies and practices and promoting appropriate legislation, policies and action in this regard."
+            short_title: "Ensure Equal Opportunities and End Discrimination"
           target_10_4:
-            title: "Adopt policies, especially fiscal, wage and social protection policies, and progressively achieve greater equality."
+            long_title: "Adopt policies, especially fiscal, wage and social protection policies, and progressively achieve greater equality."
+            short_title: "Adopt Fiscal and Social Policies that Promote Equality"
           target_10_5:
-            title: "Improve the regulation and monitoring of global financial markets and institutions and strengthen the implementation of such regulations."
+            long_title: "Improve the regulation and monitoring of global financial markets and institutions and strengthen the implementation of such regulations."
+            short_title: "Improved Regulation of Global Financial Markets and Institutions"
           target_10_6:
-            title: "Ensure enhanced representation and voice for developing countries in decision-making in global international economic and financial institutions in order to deliver more effective, credible, accountable and legitimate institutions."
+            long_title: "Ensure enhanced representation and voice for developing countries in decision-making in global international economic and financial institutions in order to deliver more effective, credible, accountable and legitimate institutions."
+            short_title: "Enhanced Representation for Developing Countries in Financial Institutions"
           target_10_7:
-            title: "Facilitate orderly, safe, regular and responsible migration and mobility of people, including through the implementation of planned and well-managed migration policies."
+            long_title: "Facilitate orderly, safe, regular and responsible migration and mobility of people, including through the implementation of planned and well-managed migration policies."
+            short_title: "Responsible and Well-Managed Migration Policies"
           target_10_A:
-            title: "Implement the principle of special and differential treatment for developing countries, in particular least developed countries, in accordance with World Trade Organization agreements."
+            long_title: "Implement the principle of special and differential treatment for developing countries, in particular least developed countries, in accordance with World Trade Organization agreements."
+            short_title: "Special and Differential Treatment for Developing Countries"
           target_10_B:
-            title: "Encourage official development assistance and financial flows, including foreign direct investment, to States where the need is greatest, in particular least developed countries, African countries, small island developing States and landlocked developing countries, in accordance with their national plans and programmes."
+            long_title: "Encourage official development assistance and financial flows, including foreign direct investment, to States where the need is greatest, in particular least developed countries, African countries, small island developing States and landlocked developing countries, in accordance with their national plans and programmes."
+            short_title: "Encourage Development Assistance and Investment in Least Developed Countries"
           target_10_C:
-            title: "By 2030, reduce to less than 3 per cent the transaction costs of migrant remittances and eliminate remittance corridors with costs higher than 5 per cent."
+            long_title: "By 2030, reduce to less than 3 per cent the transaction costs of migrant remittances and eliminate remittance corridors with costs higher than 5 per cent."
+            short_title: "Reduce Transaction Costs for Migrant Remittances"
       goal_11:
         title: "Sustainable Cities and Communities"
         title_in_two_lines: "Sustainable Cities\nand Communities"
@@ -248,25 +338,35 @@ en:
         long_description: '<p>The world is becoming increasingly urbanized. Since 2007, <a href="https://unstats.un.org/sdgs/report/2019/goal-11/">more than half the world’s population has been living in cities</a>, and that share is projected to rise to 60 per cent by 2030.&nbsp;</p> <p>Cities and metropolitan areas are powerhouses of economic growth—contributing about 60 per cent of global GDP. However, they also account for about 70 per cent of global carbon emissions and over 60 per cent of resource use.&nbsp;</p> <p>Rapid urbanization is resulting in a growing number of slum dwellers, inadequate and overburdened infrastructure and services (such as waste collection and water and sanitation systems, roads and transport), worsening air pollution and unplanned urban sprawl.&nbsp;</p> <p><a href="https://unhabitat.org/coronavirus-will-travel-incredibly-fast-in-africas-slums-un-habitat-chief-warns">The impact of COVID-19</a> will be most devastating in poor and densely populated urban areas, especially for the one billion people living in informal settlements and slums worldwide, where overcrowding also makes it difficult to follow recommended measures such as social distancing and self-isolation.&nbsp;</p> <p>The UN food agency, FAO, warned that hunger and fatalities could rise significantly in urban areas, without measures to ensure that poor and vulnerable residents have <a href="https://news.un.org/en/story/2020/05/1063622">access to food</a>.&nbsp;</p>'
         targets:
           target_11_1:
-            title: "By 2030, ensure access for all to adequate, safe and affordable housing and basic services and upgrade slums."
+            long_title: "By 2030, ensure access for all to adequate, safe and affordable housing and basic services and upgrade slums."
+            short_title: "Safe and Affordable Housing"
           target_11_2:
-            title: "By 2030, provide access to safe, affordable, accessible and sustainable transport systems for all, improving road safety, notably by expanding public transport, with special attention to the needs of those in vulnerable situations, women, children, persons with disabilities and older persons."
+            long_title: "By 2030, provide access to safe, affordable, accessible and sustainable transport systems for all, improving road safety, notably by expanding public transport, with special attention to the needs of those in vulnerable situations, women, children, persons with disabilities and older persons."
+            short_title: "Affordable and Sustainable Transport Systems"
           target_11_3:
-            title: "By 2030, enhance inclusive and sustainable urbanization and capacity for participatory, integrated and sustainable human settlement planning and management in all countries."
+            long_title: "By 2030, enhance inclusive and sustainable urbanization and capacity for participatory, integrated and sustainable human settlement planning and management in all countries."
+            short_title: "Inclusive and Sustainable Urbanization"
           target_11_4:
-            title: "Strengthen efforts to protect and safeguard the world’s cultural and natural heritage."
+            long_title: "Strengthen efforts to protect and safeguard the world’s cultural and natural heritage."
+            short_title: "Protect the World’s Cultural and Natural Heritage"
           target_11_5:
-            title: "By 2030, significantly reduce the number of deaths and the number of people affected and substantially decrease the direct economic losses relative to global gross domestic product caused by disasters, including water-related disasters, with a focus on protecting the poor and people in vulnerable situations."
+            long_title: "By 2030, significantly reduce the number of deaths and the number of people affected and substantially decrease the direct economic losses relative to global gross domestic product caused by disasters, including water-related disasters, with a focus on protecting the poor and people in vulnerable situations."
+            short_title: "Reduce the Adverse Effects of Natural Disasters"
           target_11_6:
-            title: "By 2030, reduce the adverse per capita environmental impact of cities, including by paying special attention to air quality and municipal and other waste management."
+            long_title: "By 2030, reduce the adverse per capita environmental impact of cities, including by paying special attention to air quality and municipal and other waste management."
+            short_title: "Reduce the Environmental Impact of Cities"
           target_11_7:
-            title: "By 2030, provide universal access to safe, inclusive and accessible, green and public spaces, in particular for women and children, older persons and persons with disabilities."
+            long_title: "By 2030, provide universal access to safe, inclusive and accessible, green and public spaces, in particular for women and children, older persons and persons with disabilities."
+            short_title: "Provide Access to Safe and Inclusive Green and Public Spaces"
           target_11_A:
-            title: "Support positive economic, social and environmental links between urban, peri-urban and rural areas by strengthening national and regional development planning."
+            long_title: "Support positive economic, social and environmental links between urban, peri-urban and rural areas by strengthening national and regional development planning."
+            short_title: "Strong National and Regional Development Planning"
           target_11_B:
-            title: "By 2020, substantially increase the number of cities and human settlements adopting and implementing integrated policies and plans towards inclusion, resource efficiency, mitigation and adaptation to climate change, resilience to disasters, and develop and implement, in line with the Sendai Framework for Disaster Risk Reduction 2015-2030, holistic disaster risk management at all levels."
+            long_title: "By 2020, substantially increase the number of cities and human settlements adopting and implementing integrated policies and plans towards inclusion, resource efficiency, mitigation and adaptation to climate change, resilience to disasters, and develop and implement, in line with the Sendai Framework for Disaster Risk Reduction 2015-2030, holistic disaster risk management at all levels."
+            short_title: "Implement Policies for Inclusion, Resource Efficiency and Disaster Risk Reduction"
           target_11_C:
-            title: "Support least developed countries, including through financial and technical assistance, in building sustainable and resilient buildings utilizing local materials."
+            long_title: "Support least developed countries, including through financial and technical assistance, in building sustainable and resilient buildings utilizing local materials."
+            short_title: "Support Least Developed Countries in Sustainable and Resilient Building"
       goal_12:
         title: "Responsible Consumption and Production"
         title_in_two_lines: "Responsible Consumption\nand Production"
@@ -274,27 +374,38 @@ en:
         long_description: '<p>Worldwide consumption and production — a driving force of the global economy — rest on the use of the natural environment and resources in a way that continues to have destructive impacts on the planet.&nbsp;</p> <p>Economic and social progress over the last century has been accompanied by environmental degradation that is endangering the very systems on which our future development — indeed, our very survival — depends.&nbsp;</p> <p>A few <a href="https://www.unenvironment.org/explore-topics/sustainable-development-goals/why-do-sustainable-development-goals-matter/goal-12">facts and figures</a>:</p> <ul> <li style="font-weight: 400">Each year, an estimated one third of all food produced – equivalent to 1.3 billion tonnes worth around $1 trillion – ends up rotting in the bins of consumers and retailers, or spoiling due to poor transportation and harvesting practices.</li> <li style="font-weight: 400">If people worldwide switched to energy efficient light bulbs the world would save US$120 billion annually.</li> <li style="font-weight: 400">Should the global population reach 9.6 billion by 2050, the equivalent of almost three planets could be required to provide the natural resources needed to sustain current lifestyles.</li> </ul> <p>The COVID-19 pandemic offers countries an opportunity to build recovery plans that will reverse current trends and change our consumption and production patterns towards a more sustainable future.</p> <p><a href="https://www.unenvironment.org/explore-topics/resource-efficiency/what-we-do/sustainable-consumption-and-production-policies">Sustainable consumption and production</a> is about doing more and better with less. It is also about decoupling economic growth from environmental degradation, increasing resource efficiency and promoting sustainable lifestyles.</p> <p>Sustainable consumption and production can also contribute substantially to poverty alleviation and the transition towards low-carbon and green economies.</p>'
         targets:
           target_12_1:
-            title: "Implement the 10-year framework of programmes on sustainable consumption and production, all countries taking action, with developed countries taking the lead, taking into account the development and capabilities of developing countries."
+            long_title: "Implement the 10-year framework of programmes on sustainable consumption and production, all countries taking action, with developed countries taking the lead, taking into account the development and capabilities of developing countries."
+            short_title: "Implement the 10-Year Sustainable Consumption and Production Framework"
           target_12_2:
-            title: "By 2030, achieve the sustainable management and efficient use of natural resources."
+            long_title: "By 2030, achieve the sustainable management and efficient use of natural resources."
+            short_title: "Sustainable Management and Use of Natural Resources"
           target_12_3:
-            title: "By 2030, halve per capita global food waste at the retail and consumer levels and reduce food losses along production and supply chains, including post-harvest losses."
+            long_title: "By 2030, halve per capita global food waste at the retail and consumer levels and reduce food losses along production and supply chains, including post-harvest losses."
+            short_title: "Halve Global Per Capita Food Waste"
           target_12_4:
-            title: "By 2020, achieve the environmentally sound management of chemicals and all wastes throughout their life cycle, in accordance with agreed international frameworks, and significantly reduce their release to air, water and soil in order to minimize their adverse impacts on human health and the environment."
+            long_title: "By 2020, achieve the environmentally sound management of chemicals and all wastes throughout their life cycle, in accordance with agreed international frameworks, and significantly reduce their release to air, water and soil in order to minimize their adverse impacts on human health and the environment."
+            short_title: "Responsible Management of Chemicals and Waste"
           target_12_5:
-            title: "By 2030, substantially reduce waste generation through prevention, reduction, recycling and reuse."
+            long_title: "By 2030, substantially reduce waste generation through prevention, reduction, recycling and reuse."
+            short_title: "Substantially Reduce Waste Generation"
           target_12_6:
-            title: "Encourage companies, especially large and transnational companies, to adopt sustainable practices and to integrate sustainability information into their reporting cycle."
+            long_title: "Encourage companies, especially large and transnational companies, to adopt sustainable practices and to integrate sustainability information into their reporting cycle."
+            short_title: "Encourage Companies to Adopt Sustainable Practices and Sustainability Reporting"
           target_12_7:
-            title: "Promote public procurement practices that are sustainable, in accordance with national policies and priorities."
+            long_title: "Promote public procurement practices that are sustainable, in accordance with national policies and priorities."
+            short_title: "Promote Sustainable Public Procurement Practices "
           target_12_8:
-            title: "By 2030, ensure that people everywhere have the relevant information and awareness for sustainable development and lifestyles in harmony with nature."
+            long_title: "By 2030, ensure that people everywhere have the relevant information and awareness for sustainable development and lifestyles in harmony with nature."
+            short_title: "Promote Universal Understanding of Sustainable Lifestyles"
           target_12_A:
-            title: "Support developing countries to strengthen their scientific and technological capacity to move towards more sustainable patterns of consumption and production."
+            long_title: "Support developing countries to strengthen their scientific and technological capacity to move towards more sustainable patterns of consumption and production."
+            short_title: "Support Developing Countries' Scientific and Technological Capacity for Sustainable Consumption and Production"
           target_12_B:
-            title: "Develop and implement tools to monitor sustainable development impacts for sustainable tourism that creates jobs and promotes local culture and products."
+            long_title: "Develop and implement tools to monitor sustainable development impacts for sustainable tourism that creates jobs and promotes local culture and products."
+            short_title: "Develop and Implement Tools to Monitor Sustainable Tourism"
           target_12_C:
-            title: "Rationalize inefficient fossil-fuel subsidies that encourage wasteful consumption by removing market distortions, in accordance with national circumstances, including by restructuring taxation and phasing out those harmful subsidies, where they exist, to reflect their environmental impacts, taking fully into account the specific needs and conditions of developing countries and minimizing the possible adverse impacts on their development in a manner that protects the poor and the affected communities."
+            long_title: "Rationalize inefficient fossil-fuel subsidies that encourage wasteful consumption by removing market distortions, in accordance with national circumstances, including by restructuring taxation and phasing out those harmful subsidies, where they exist, to reflect their environmental impacts, taking fully into account the specific needs and conditions of developing countries and minimizing the possible adverse impacts on their development in a manner that protects the poor and the affected communities."
+            short_title: "Remove Market Distortions that Encourage Wasteful Consumption"
       goal_13:
         title: "Climate Action"
         title_in_two_lines: "Climate\nAction"
@@ -302,15 +413,20 @@ en:
         long_description: '<p>2019 was the <a href="https://news.un.org/en/story/2020/03/1059061">second warmest year on record</a> and the end of the warmest decade (2010- 2019) ever recorded.&nbsp;&nbsp;</p> <p>Carbon dioxide (CO2) levels and other <a href="https://news.un.org/en/story/2020/04/1062332">greenhouse gases in the atmosphere</a> rose to new records in 2019.&nbsp;</p> <p>Climate change is affecting every country on every continent. It is disrupting national economies and affecting lives. Weather patterns are changing, sea levels are rising, and weather events are becoming more extreme.</p> <p>Although greenhouse gas emissions are projected to drop about 6 per cent in 2020 due to travel bans and economic slowdowns resulting from the COVID-19 pandemic, this improvement is only temporary. <a href="https://news.un.org/en/story/2020/04/1062332">Climate change is not on pause</a>. Once the global economy begins to recover from the pandemic, emissions are expected to return to higher levels.</p> <p>Saving lives and livelihoods requires urgent action to address both the pandemic and the climate emergency.</p> <p>The <a href="https://unfccc.int/process-and-meetings/the-paris-agreement/the-paris-agreement">Paris Agreement</a>, adopted in 2015, aims to strengthen the global response to the threat of climate change by keeping a global temperature rise this century well below 2 degrees Celsius above pre-industrial levels. The agreement also aims to strengthen the ability of countries to deal with the impacts of climate change, through appropriate financial flows, a new technology framework and an enhanced capacity building framework.</p>'
         targets:
           target_13_1:
-            title: "Strengthen resilience and adaptive capacity to climate-related hazards and natural disasters in all countries."
+            long_title: "Strengthen resilience and adaptive capacity to climate-related hazards and natural disasters in all countries."
+            short_title: "Strengthen resilience and Adaptive Capacity to Climate Related Disasters"
           target_13_2:
-            title: "Integrate climate change measures into national policies, strategies and planning."
+            long_title: "Integrate climate change measures into national policies, strategies and planning."
+            short_title: "Integrate Climate Change Measures into Policies and Planning"
           target_13_3:
-            title: "Improve education, awareness-raising and human and institutional capacity on climate change mitigation, adaptation, impact reduction and early warning."
+            long_title: "Improve education, awareness-raising and human and institutional capacity on climate change mitigation, adaptation, impact reduction and early warning."
+            short_title: "Build Knowledge and Capacity to Meet Climate Change"
           target_13_A:
-            title: "Implement the commitment undertaken by developed-country parties to the United Nations Framework Convention on Climate Change to a goal of mobilizing jointly $100 billion annually by 2020 from all sources to address the needs of developing countries in the context of meaningful mitigation actions and transparency on implementation and fully operationalize the Green Climate Fund through its capitalization as soon as possible."
+            long_title: "Implement the commitment undertaken by developed-country parties to the United Nations Framework Convention on Climate Change to a goal of mobilizing jointly $100 billion annually by 2020 from all sources to address the needs of developing countries in the context of meaningful mitigation actions and transparency on implementation and fully operationalize the Green Climate Fund through its capitalization as soon as possible."
+            short_title: "Implement the UN Framework Convention on Climate Change"
           target_13_B:
-            title: "Promote mechanisms for raising capacity for effective climate change-related planning and management in least developed countries and small island developing States, including focusing on women, youth and local and marginalized communities."
+            long_title: "Promote mechanisms for raising capacity for effective climate change-related planning and management in least developed countries and small island developing States, including focusing on women, youth and local and marginalized communities."
+            short_title: "Promote Mechanisms to Raise Capacity for Planning and Management"
       goal_14:
         title: "Life Below Water"
         title_in_two_lines: "Life Below\nWater"
@@ -318,25 +434,35 @@ en:
         long_description: '<p>The ocean drives global systems that make the Earth habitable for humankind. Our rainwater, drinking water, weather, climate, coastlines, much of our food, and even the oxygen in the air we breathe, are all ultimately provided and regulated by the sea.&nbsp;</p> <p>Careful management of this <a href="https://www.unenvironment.org/explore-topics/oceans-seas/why-do-oceans-and-seas-matter">essential global resource</a> is a key feature of a sustainable future. However, at the current time, there is a continuous deterioration of coastal waters owing to pollution, and ocean acidification is having an adversarial effect on the functioning of ecosystems and biodiversity. This is also negatively impacting small scale fisheries.&nbsp;</p> <p>Saving our ocean must remain a priority. Marine biodiversity is critical to the health of people and our planet. Marine protected areas need to be effectively managed and well-resourced and regulations need to be put in place to reduce overfishing, marine pollution and ocean acidification.</p>'
         targets:
           target_14_1:
-            title: "By 2025, prevent and significantly reduce marine pollution of all kinds, in particular from land-based activities, including marine debris and nutrient pollution."
+            long_title: "By 2025, prevent and significantly reduce marine pollution of all kinds, in particular from land-based activities, including marine debris and nutrient pollution."
+            short_title: "Reduce Marine Pollution"
           target_14_2:
-            title: "By 2020, sustainably manage and protect marine and coastal ecosystems to avoid significant adverse impacts, including by strengthening their resilience, and take action for their restoration in order to achieve healthy and productive oceans."
+            long_title: "By 2020, sustainably manage and protect marine and coastal ecosystems to avoid significant adverse impacts, including by strengthening their resilience, and take action for their restoration in order to achieve healthy and productive oceans."
+            short_title: "Protect and Restore Ecosystems"
           target_14_3:
-            title: "Minimize and address the impacts of ocean acidification, including through enhanced scientific cooperation at all levels."
+            long_title: "Minimize and address the impacts of ocean acidification, including through enhanced scientific cooperation at all levels."
+            short_title: "Reduce Ocean Acidification"
           target_14_4:
-            title: "By 2020, effectively regulate harvesting and end overfishing, illegal, unreported and unregulated fishing and destructive fishing practices and implement science-based management plans, in order to restore fish stocks in the shortest time feasible, at least to levels that can produce maximum sustainable yield as determined by their biological characteristics."
+            long_title: "By 2020, effectively regulate harvesting and end overfishing, illegal, unreported and unregulated fishing and destructive fishing practices and implement science-based management plans, in order to restore fish stocks in the shortest time feasible, at least to levels that can produce maximum sustainable yield as determined by their biological characteristics."
+            short_title: "Sustainable Fishing"
           target_14_5:
-            title: "By 2020, conserve at least 10 per cent of coastal and marine areas, consistent with national and international law and based on the best available scientific information."
+            long_title: "By 2020, conserve at least 10 per cent of coastal and marine areas, consistent with national and international law and based on the best available scientific information."
+            short_title: "Conserve Coastal and Marine Areas"
           target_14_6:
-            title: "By 2020, prohibit certain forms of fisheries subsidies which contribute to overcapacity and overfishing, eliminate subsidies that contribute to illegal, unreported and unregulated fishing and refrain from introducing new such subsidies, recognizing that appropriate and effective special and differential treatment for developing and least developed countries should be an integral part of the World Trade Organization fisheries subsidies negotiation."
+            long_title: "By 2020, prohibit certain forms of fisheries subsidies which contribute to overcapacity and overfishing, eliminate subsidies that contribute to illegal, unreported and unregulated fishing and refrain from introducing new such subsidies, recognizing that appropriate and effective special and differential treatment for developing and least developed countries should be an integral part of the World Trade Organization fisheries subsidies negotiation."
+            short_title: "End Subsidies Contributing to Overfishing"
           target_14_7:
-            title: "By 2030, increase the economic benefits to Small Island developing States and least developed countries from the sustainable use of marine resources, including through sustainable management of fisheries, aquaculture and tourism."
+            long_title: "By 2030, increase the economic benefits to Small Island developing States and least developed countries from the sustainable use of marine resources, including through sustainable management of fisheries, aquaculture and tourism."
+            short_title: "Increase the Economic Benefits from Sustainable Use of Marine Resources"
           target_14_A:
-            title: "Increase scientific knowledge, develop research capacity and transfer marine technology, taking into account the Intergovernmental Oceanographic Commission Criteria and Guidelines on the Transfer of Marine Technology, in order to improve ocean health and to enhance the contribution of marine biodiversity to the development of developing countries, in particular small island developing States and least developed countries."
+            long_title: "Increase scientific knowledge, develop research capacity and transfer marine technology, taking into account the Intergovernmental Oceanographic Commission Criteria and Guidelines on the Transfer of Marine Technology, in order to improve ocean health and to enhance the contribution of marine biodiversity to the development of developing countries, in particular small island developing States and least developed countries."
+            short_title: "Increase Scientific Knowledge, Research and Technology for Ocean Health"
           target_14_B:
-            title: "Provide access for small-scale artisanal fishers to marine resources and markets."
+            long_title: "Provide access for small-scale artisanal fishers to marine resources and markets."
+            short_title: "Support Small Scale Fishers"
           target_14_C:
-            title: "Enhance the conservation and sustainable use of oceans and their resources by implementing international law as reflected in UNCLOS, which provides the legal framework for the conservation and sustainable use of oceans and their resources, as recalled in paragraph 158 of The Future We Want."
+            long_title: "Enhance the conservation and sustainable use of oceans and their resources by implementing international law as reflected in UNCLOS, which provides the legal framework for the conservation and sustainable use of oceans and their resources, as recalled in paragraph 158 of The Future We Want."
+            short_title: "Implement and Enforce International Sea Law"
       goal_15:
         title: "Life on Land"
         title_in_two_lines: "Life on\nLand"
@@ -344,29 +470,41 @@ en:
         long_description: '<p>Nature is critical to our survival: nature provides us with our oxygen, regulates our weather patterns, pollinates our crops, produces our food, feed and fibre. But it is under increasing stress. <a href="https://news.un.org/en/story/2020/04/1061082">Human activity has altered almost 75 per cent of the earth’s surface</a>, squeezing wildlife and nature into an ever-smaller corner of the planet.</p> <p>Around <a href="https://ipbes.net/sites/default/files/2020-02/ipbes_global_assessment_report_summary_for_policymakers_en.pdf">1 million animal and plant species are threatened with extinction</a> – many within decades – according to the 2019 Global Assessment Report on Biodiversity and Ecosystem Service. The report called for transformative changes to restore and protect nature. It found that the health of ecosystems on which we and all other species depend is deteriorating more rapidly than ever, affecting&nbsp; the very foundations of our economies, livelihoods, food security, health and quality of life worldwide.&nbsp;</p> <p>Deforestation and desertification – caused by human activities and climate change – pose major challenges to sustainable development and have affected the lives and livelihoods of millions of people. <a href="https://news.un.org/en/story/2019/05/1038291">Forests are vitally important </a>for sustaining life on Earth, and play a major role in the fight against climate change. And investing in <a href="https://news.un.org/en/story/2019/09/1045802">land restoration</a> is critical for improving livelihoods, reducing vulnerabilities, and reducing risks for the economy.</p> <p>The health of our planet also plays an important role in <a href="https://www.unenvironment.org/resources/emerging-zoonotic-diseases-and-links-ecosystem-health-unep-frontiers-2016-chapter">the emergence of zoonotic diseases</a>, i.e. diseases that are transmissible between animals and humans. As we continue to encroach on fragile ecosystems, we bring humans into ever-greater contact with wildlife, enabling pathogens in wildlife to spill over to livestock and humans, increasing the risk of disease emergence and amplification.</p>'
         targets:
           target_15_1:
-            title: "By 2020, ensure the conservation, restoration and sustainable use of terrestrial and inland freshwater ecosystems and their services, in particular forests, wetlands, mountains and drylands, in line with obligations under international agreements."
+            long_title: "By 2020, ensure the conservation, restoration and sustainable use of terrestrial and inland freshwater ecosystems and their services, in particular forests, wetlands, mountains and drylands, in line with obligations under international agreements."
+            short_title: "Conserve and Restore Terrestrial and Freshwater Ecosystems"
           target_15_2:
-            title: "By 2020, promote the implementation of sustainable management of all types of forests, halt deforestation, restore degraded forests and substantially increase afforestation and reforestation globally."
+            long_title: "By 2020, promote the implementation of sustainable management of all types of forests, halt deforestation, restore degraded forests and substantially increase afforestation and reforestation globally."
+            short_title: "End Deforestation and Restore Degraded Forests"
           target_15_3:
-            title: "By 2030, combat desertification, restore degraded land and soil, including land affected by desertification, drought and floods, and strive to achieve a land degradation-neutral world."
+            long_title: "By 2030, combat desertification, restore degraded land and soil, including land affected by desertification, drought and floods, and strive to achieve a land degradation-neutral world."
+            short_title: "End Desertification and Restore Degraded Land"
           target_15_4:
-            title: "By 2030, ensure the conservation of mountain ecosystems, including their biodiversity, in order to enhance their capacity to provide benefits that are essential for sustainable development."
+            long_title: "By 2030, ensure the conservation of mountain ecosystems, including their biodiversity, in order to enhance their capacity to provide benefits that are essential for sustainable development."
+            short_title: "Ensure Conservation of Mountain Ecosystems"
           target_15_5:
-            title: "Take urgent and significant action to reduce the degradation of natural habitats, halt the loss of biodiversity and, by 2020, protect and prevent the extinction of threatened species."
+            long_title: "Take urgent and significant action to reduce the degradation of natural habitats, halt the loss of biodiversity and, by 2020, protect and prevent the extinction of threatened species."
+            short_title: "Protect Biodiversity and Natural Habitats"
           target_15_6:
-            title: "Promote fair and equitable sharing of the benefits arising from the utilization of genetic resources and promote appropriate access to such resources, as internationally agreed."
+            long_title: "Promote fair and equitable sharing of the benefits arising from the utilization of genetic resources and promote appropriate access to such resources, as internationally agreed."
+            short_title: "Promote Access to Genetic Resources and Fair Sharing of the Benefits"
           target_15_7:
-            title: "Take urgent action to end poaching and trafficking of protected species of flora and fauna and address both demand and supply of illegal wildlife products."
+            long_title: "Take urgent action to end poaching and trafficking of protected species of flora and fauna and address both demand and supply of illegal wildlife products."
+            short_title: "Eliminate Poaching and Trafficking of Protected Species"
           target_15_8:
-            title: "By 2020, introduce measures to prevent the introduction and significantly reduce the impact of invasive alien species on land and water ecosystems and control or eradicate the priority species."
+            long_title: "By 2020, introduce measures to prevent the introduction and significantly reduce the impact of invasive alien species on land and water ecosystems and control or eradicate the priority species."
+            short_title: "Prevent Invasive Alien Species on Land and in Water Ecosystems"
           target_15_9:
-            title: "By 2020, integrate ecosystem and biodiversity values into national and local planning, development processes, poverty reduction strategies and accounts."
+            long_title: "By 2020, integrate ecosystem and biodiversity values into national and local planning, development processes, poverty reduction strategies and accounts."
+            short_title: "Integrate Ecosystem and Biodiversity in Governmental Planning"
           target_15_A:
-            title: "Mobilize and significantly increase financial resources from all sources to conserve and sustainably use biodiversity and ecosystems."
+            long_title: "Mobilize and significantly increase financial resources from all sources to conserve and sustainably use biodiversity and ecosystems."
+            short_title: "Increase Financial Resources to Conserve and Sustainably Use Ecosystem and Biodiversity"
           target_15_B:
-            title: "Mobilize significant resources from all sources and at all levels to finance sustainable forest management and provide adequate incentives to developing countries to advance such management, including for conservation and reforestation."
+            long_title: "Mobilize significant resources from all sources and at all levels to finance sustainable forest management and provide adequate incentives to developing countries to advance such management, including for conservation and reforestation."
+            short_title: "Finance and Incentivize Sustainable Forest Management"
           target_15_C:
-            title: "Enhance global support for efforts to combat poaching and trafficking of protected species, including by increasing the capacity of local communities to pursue sustainable livelihood opportunities."
+            long_title: "Enhance global support for efforts to combat poaching and trafficking of protected species, including by increasing the capacity of local communities to pursue sustainable livelihood opportunities."
+            short_title: "Combat Global Poaching and Trafficking"
       goal_16:
         title: "Peace, Justice and Strong Institutions"
         title_in_two_lines: "Peace, Justice and\nStrong Institutions"
@@ -374,29 +512,41 @@ en:
         long_description: '<p>Conflict, insecurity, weak institutions and limited access to justice remain a great threat to sustainable development.&nbsp;</p> <p>The number of <a href="https://www.unhcr.org/en-us/news/press/2019/6/5d03b22b4/worldwide-displacement-tops-70-million-un-refugee-chief-urges-greater-solidarity.html">people fleeing war, persecution and conflict exceeded 70 million</a> in 2018, the highest level recorded by the UN refugee agency (UNHCR) in almost 70 years.&nbsp;</p> <p>In 2019, the United Nations tracked <a href="https://sustainabledevelopment.un.org/content/documents/26158Final_SG_SDG_Progress_Report_14052020.pdf">357 killings and 30 enforced disappearances</a> of human rights defenders, journalists and trade unionists in 47 countries.</p> <p>And the births of around <a href="https://data.unicef.org/topic/child-protection/birth-registration/">one in four children</a> under age 5 worldwide are never officially recorded, depriving them of a proof of legal identity crucial for the protection of their rights and for access to justice and social services.</p>'
         targets:
           target_16_1:
-            title: "Significantly reduce all forms of violence and related death rates everywhere."
+            long_title: "Significantly reduce all forms of violence and related death rates everywhere."
+            short_title: "Reduce Violence Everywhere"
           target_16_2:
-            title: "End abuse, exploitation, trafficking and all forms of violence against and torture of children."
+            long_title: "End abuse, exploitation, trafficking and all forms of violence against and torture of children."
+            short_title: "Protect Children from Abuse, Exploitation, Trafficking and Violence"
           target_16_3:
-            title: "Promote the rule of law at the national and international levels and ensure equal access to justice for all."
+            long_title: "Promote the rule of law at the national and international levels and ensure equal access to justice for all."
+            short_title: "Promote the Rule of Law And Ensure Equal Access to Justice"
           target_16_4:
-            title: "By 2030, significantly reduce illicit financial and arms flows, strengthen the recovery and return of stolen assets and combat all forms of organized crime."
+            long_title: "By 2030, significantly reduce illicit financial and arms flows, strengthen the recovery and return of stolen assets and combat all forms of organized crime."
+            short_title: "Combat Organized Crime and Illicit Financial and Arms Flows"
           target_16_5:
-            title: "Substantially reduce corruption and bribery in all their forms."
+            long_title: "Substantially reduce corruption and bribery in all their forms."
+            short_title: "Substantially Reduce Corruption and Bribery"
           target_16_6:
-            title: "Develop effective, accountable and transparent institutions at all levels."
+            long_title: "Develop effective, accountable and transparent institutions at all levels."
+            short_title: "Develop Effective, Accountable and Transparent Institutions"
           target_16_7:
-            title: "Ensure responsive, inclusive, participatory and representative decision-making at all levels."
+            long_title: "Ensure responsive, inclusive, participatory and representative decision-making at all levels."
+            short_title: "Ensure Responsive, Inclusive and Representative Decision-Making"
           target_16_8:
-            title: "Broaden and strengthen the participation of developing countries in the institutions of global governance."
+            long_title: "Broaden and strengthen the participation of developing countries in the institutions of global governance."
+            short_title: "Strengthen the Participation in Global Governance"
           target_16_9:
-            title: "By 2030, provide legal identity for all, including birth registration."
+            long_title: "By 2030, provide legal identity for all, including birth registration."
+            short_title: "Provide Universal Legal Identity"
           target_16_10:
-            title: "Ensure public access to information and protect fundamental freedoms, in accordance with national legislation and international agreements."
+            long_title: "Ensure public access to information and protect fundamental freedoms, in accordance with national legislation and international agreements."
+            short_title: "Ensure Public Access to Information and Protect Fundamental Freedoms"
           target_16_A:
-            title: "Strengthen relevant national institutions, including through international cooperation, for building capacity at all levels, in particular in developing countries, to prevent violence and combat terrorism and crime."
+            long_title: "Strengthen relevant national institutions, including through international cooperation, for building capacity at all levels, in particular in developing countries, to prevent violence and combat terrorism and crime."
+            short_title: "Strengthen National Institutions to Prevent Violence and Combat Terrorism and Crime"
           target_16_B:
-            title: "Promote and enforce non-discriminatory laws and policies for sustainable development."
+            long_title: "Promote and enforce non-discriminatory laws and policies for sustainable development."
+            short_title: "Promote and Enforce Non-Discriminatory Laws and Policies"
       goal_17:
         title: "Partnerships For the Goals"
         title_in_two_lines: "Partnerships\nFor the Goals"
@@ -404,43 +554,62 @@ en:
         long_description: '<p>The SDGs can only be realized with strong global partnerships and cooperation.</p> <p>A successful development agenda requires inclusive partnerships — at the global, regional, national and local levels — built upon principles and values, and upon a shared vision and shared goals placing people and the planet at the centre.</p> <p>Many countries require Official Development Assistance to encourage growth and trade. Yet, <a href="https://www.un.org/press/en/2019/ga12191.doc.htm">aid levels are falling</a> and donor countries have not lived up to their pledge to ramp up development finance.</p> <p>Due to the COVID-19 pandemic, the <a href="https://www.imf.org/en/Publications/WEO/Issues/2020/04/14/weo-april-2020">global economy</a> is projected to contract sharply, by 3 per cent, in 2020, experiencing its worst recession since the Great Depression.</p> <p>Strong international cooperation is needed now more than ever to ensure that countries have the means to recover from the pandemic, build back better and achieve the Sustainable Development Goals.</p>'
         targets:
           target_17_1:
-            title: "Strengthen domestic resource mobilization, including through international support to developing countries, to improve domestic capacity for tax and other revenue collection."
+            long_title: "Strengthen domestic resource mobilization, including through international support to developing countries, to improve domestic capacity for tax and other revenue collection."
+            short_title: "Mobilize Resources to Improve Domestic Revenue Collection "
           target_17_2:
-            title: "Developed countries to implement fully their official development assistance commitments, including the commitment by many developed countries to achieve the target of 0.7 per cent of ODA/GNI to developing countries and 0.15 to 0.20 per cent of ODA/GNI to least developed countries ODA providers are encouraged to consider setting a target to provide at least 0.20 per cent of ODA/GNI to least developed countries."
+            long_title: "Developed countries to implement fully their official development assistance commitments, including the commitment by many developed countries to achieve the target of 0.7 per cent of ODA/GNI to developing countries and 0.15 to 0.20 per cent of ODA/GNI to least developed countries ODA providers are encouraged to consider setting a target to provide at least 0.20 per cent of ODA/GNI to least developed countries."
+            short_title: "Implement All Development Assistance Commitments"
           target_17_3:
-            title: "Mobilize additional financial resources for developing countries from multiple sources."
+            long_title: "Mobilize additional financial resources for developing countries from multiple sources."
+            short_title: "Mobilize Financial Resources for Developing Countries"
           target_17_4:
-            title: "Assist developing countries in attaining long-term debt sustainability through coordinated policies aimed at fostering debt financing, debt relief and debt restructuring, as appropriate, and address the external debt of highly indebted poor countries to reduce debt distress."
+            long_title: "Assist developing countries in attaining long-term debt sustainability through coordinated policies aimed at fostering debt financing, debt relief and debt restructuring, as appropriate, and address the external debt of highly indebted poor countries to reduce debt distress."
+            short_title: "Assist Developing Countries in Attaining Debt Sustainability"
           target_17_5:
-            title: "Adopt and implement investment promotion regimes for least developed countries."
+            long_title: "Adopt and implement investment promotion regimes for least developed countries."
+            short_title: "Invest in Least Developed Countries"
           target_17_6:
-            title: "Enhance North-South, South-South and triangular regional and international cooperation on and access to science, technology and innovation and enhance knowledge sharing on mutually agreed terms, including through improved coordination among existing mechanisms, in particular at the United Nations level, and through a global technology facilitation mechanism."
+            long_title: "Enhance North-South, South-South and triangular regional and international cooperation on and access to science, technology and innovation and enhance knowledge sharing on mutually agreed terms, including through improved coordination among existing mechanisms, in particular at the United Nations level, and through a global technology facilitation mechanism."
+            short_title: "Knowledge Sharing and Cooperation for Access to Science, Technology and Innovation"
           target_17_7:
-            title: "Promote the development, transfer, dissemination and diffusion of environmentally sound technologies to developing countries on favourable terms, including on concessional and preferential terms, as mutually agreed."
+            long_title: "Promote the development, transfer, dissemination and diffusion of environmentally sound technologies to developing countries on favourable terms, including on concessional and preferential terms, as mutually agreed."
+            short_title: "Promote Sustainable Technologies to Developing Countries"
           target_17_8:
-            title: "Fully operationalize the technology bank and science, technology and innovation capacity-building mechanism for least developed countries by 2017 and enhance the use of enabling technology, in particular information and communications technology."
+            long_title: "Fully operationalize the technology bank and science, technology and innovation capacity-building mechanism for least developed countries by 2017 and enhance the use of enabling technology, in particular information and communications technology."
+            short_title: "Strengthen the Science, Technology and Innovation Capacity for Least Developed Countries"
           target_17_9:
-            title: "Enhance international support for implementing effective and targeted capacity-building in developing countries to support national plans to implement all the sustainable development goals, including through North-South, South-South and triangular cooperation."
+            long_title: "Enhance international support for implementing effective and targeted capacity-building in developing countries to support national plans to implement all the sustainable development goals, including through North-South, South-South and triangular cooperation."
+            short_title: "Enhance SDG Capacity in Developing Countries "
           target_17_10:
-            title: "Promote a universal, rules-based, open, non-discriminatory and equitable multilateral trading system under the World Trade Organization, including through the conclusion of negotiations under its Doha Development Agenda."
+            long_title: "Promote a universal, rules-based, open, non-discriminatory and equitable multilateral trading system under the World Trade Organization, including through the conclusion of negotiations under its Doha Development Agenda."
+            short_title: "Promote a Universal Trading System under the WTO"
           target_17_11:
-            title: "Significantly increase the exports of developing countries, in particular with a view to doubling the least developed countries’ share of global exports by 2020."
+            long_title: "Significantly increase the exports of developing countries, in particular with a view to doubling the least developed countries’ share of global exports by 2020."
+            short_title: "Increase the Exports of Developing Countries"
           target_17_12:
-            title: "Realize timely implementation of duty-free and quota-free market access on a lasting basis for all least developed countries, consistent with World Trade Organization decisions, including by ensuring that preferential rules of origin applicable to imports from least developed countries are transparent and simple, and contribute to facilitating market access."
+            long_title: "Realize timely implementation of duty-free and quota-free market access on a lasting basis for all least developed countries, consistent with World Trade Organization decisions, including by ensuring that preferential rules of origin applicable to imports from least developed countries are transparent and simple, and contribute to facilitating market access."
+            short_title: "Remove Trade Barriers for Least Developed Countries"
           target_17_13:
-            title: "Enhance global macroeconomic stability, including through policy coordination and policy coherence."
+            long_title: "Enhance global macroeconomic stability, including through policy coordination and policy coherence."
+            short_title: "Enhance Global Macroeconomic Stability"
           target_17_14:
-            title: "Enhance policy coherence for sustainable development."
+            long_title: "Enhance policy coherence for sustainable development."
+            short_title: "Enhance Policy Coherence for Sustainable Development"
           target_17_15:
-            title: "Respect each country’s policy space and leadership to establish and implement policies for poverty eradication and sustainable development."
+            long_title: "Respect each country’s policy space and leadership to establish and implement policies for poverty eradication and sustainable development."
+            short_title: "Respect National Leadership to Implement Policies for the Sustainable Development Goals"
           target_17_16:
-            title: "Enhance the global partnership for sustainable development, complemented by multi-stakeholder partnerships that mobilize and share knowledge, expertise, technology and financial resources, to support the achievement of the sustainable development goals in all countries, in particular developing countries."
+            long_title: "Enhance the global partnership for sustainable development, complemented by multi-stakeholder partnerships that mobilize and share knowledge, expertise, technology and financial resources, to support the achievement of the sustainable development goals in all countries, in particular developing countries."
+            short_title: "Enhance the Global Partnership for Sustainable Development"
           target_17_17:
-            title: "Encourage and promote effective public, public-private and civil society partnerships, building on the experience and resourcing strategies of partnerships."
+            long_title: "Encourage and promote effective public, public-private and civil society partnerships, building on the experience and resourcing strategies of partnerships."
+            short_title: "Encourage Effective Partnerships"
           target_17_18:
-            title: "By 2020, enhance capacity-building support to developing countries, including for least developed countries and small island developing States, to increase significantly the availability of high-quality, timely and reliable data disaggregated by income, gender, age, race, ethnicity, migratory status, disability, geographic location and other characteristics relevant in national contexts."
+            long_title: "By 2020, enhance capacity-building support to developing countries, including for least developed countries and small island developing States, to increase significantly the availability of high-quality, timely and reliable data disaggregated by income, gender, age, race, ethnicity, migratory status, disability, geographic location and other characteristics relevant in national contexts."
+            short_title: "Enhance Availability of Reliable Data"
           target_17_19:
-            title: "By 2030, build on existing initiatives to develop measurements of progress on sustainable development that complement gross domestic product, and support statistical capacity-building in developing countries."
+            long_title: "By 2030, build on existing initiatives to develop measurements of progress on sustainable development that complement gross domestic product, and support statistical capacity-building in developing countries."
+            short_title: "Further Develop Measurements of Progress"
       help:
         title: "Sustainable Development Goals help"
         description: "You can align your contributions to the community (debates, citizen proposals and investment projects) with the Sustaniable Development Goals 2030 Agenda, this will allow us to have an overview of our contribution to each of the Sustainable Development Goals. Below you can find out about all the goals, their targets and localized targets."

--- a/config/locales/en/sdg.yml
+++ b/config/locales/en/sdg.yml
@@ -632,7 +632,6 @@ en:
         title: "Which SDGs and targets are aligned with my %{record}?"
         text: "SDG help page"
       hint: You can introduce the code of a specific goal/target or a text to find one. For more information visit the %{link}.
-      placeholder: "Write a goal or target code or description"
       remove_tag: "Remove"
       title: "Sustainable Development Goals and Targets"
     targets:

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -8,19 +8,26 @@ es:
         long_description: '<p>A nivel mundial, el número de personas que viven en situación de extrema pobreza disminuyó desde un 36&nbsp;% en 1990 hasta un 10&nbsp;% en 2015. No obstante, el ritmo al que se produce este cambio está disminuyendo, y la crisis de la COVID-19 <a href="https://www.un.org/sites/un2.un.org/files/sg_report_socio-economic_impact_of_covid19.pdf">pone en riesgo décadas de progreso</a> en la lucha contra la pobreza. <a href="https://www.wider.unu.edu/node/237051">Una nueva investigación</a> publicada por el Instituto Mundial de Investigaciones de Economía del Desarrollo de la Universidad de las Naciones Unidas advierte de que las consecuencias económicas de <a href="https://www.wider.unu.edu/publication/estimates-impact-covid-19-global-poverty">la pandemia mundial podrían incrementar la pobreza en todo el mundo hasta llegar a afectar a 500&nbsp;millones de personas más</a>, o lo que es lo mismo, a un 8&nbsp;% más de la población total mundial. Esta sería la primera vez que la pobreza aumente en todo el mundo en 30&nbsp;años, desde 1990.</p> <p>Más de <a href="http://www.worldbank.org/en/news/press-release/2018/09/19/decline-of-global-extreme-poverty-continues-but-has-slowed-world-bank">700&nbsp;millones de personas</a>, o el 10&nbsp;% de la población mundial, aún vive en situación de extrema pobreza a día de hoy, con dificultades para satisfacer las necesidades más básicas, como la salud, la educación y el acceso a agua y saneamiento, por nombrar algunas. La mayoría de las personas que viven con menos de 1,90&nbsp;dólares al día viven en el África subsahariana. En todo el mundo, los <a href="https://unstats.un.org/sdgs/report/2019/goal-01/">índices de pobreza en las áreas rurales son del 17,2&nbsp;%</a>; más del triple de los mismos índices para las áreas urbanas.</p> <p>Para los que trabajan, su puesto de trabajo no les garantiza una vida digna. De hecho, <a href="https://unstats.un.org/sdgs/report/2019/goal-01/">el 8&nbsp;%</a> de los trabajadores de todo el mundo, y sus familias, vivían en situación de extrema pobreza en 2018. Uno de cada cinco niños vive en situación de extrema pobreza. Garantizar la protección social de todos los niños y otros grupos vulnerables resulta crucial para reducir la pobreza.</p>'
         targets:
           target_1_1:
-            title: "Para 2030, erradicar la pobreza extrema para todas las personas en el mundo, actualmente medida por un ingreso por persona inferior a 1,25 dólares al día."
+            long_title: "Para 2030, erradicar la pobreza extrema para todas las personas en el mundo, actualmente medida por un ingreso por persona inferior a 1,25 dólares al día."
+            short_title: "Erradicación de la pobreza extrema"
           target_1_2:
-            title: "Para 2030, reducir al menos a la mitad la proporción de hombres, mujeres y niños y niñas de todas las edades que viven en la pobreza en todas sus dimensiones con arreglo a las definiciones nacionales."
+            long_title: "Para 2030, reducir al menos a la mitad la proporción de hombres, mujeres y niños y niñas de todas las edades que viven en la pobreza en todas sus dimensiones con arreglo a las definiciones nacionales."
+            short_title: "Reducción de la pobreza relativa en todas sus dimensiones"
           target_1_3:
-            title: "Poner en práctica a nivel nacional sistemas y medidas apropiadas de protección social para todos y, para 2030, lograr una amplia cobertura de los pobres y los más vulnerables."
+            long_title: "Poner en práctica a nivel nacional sistemas y medidas apropiadas de protección social para todos y, para 2030, lograr una amplia cobertura de los pobres y los más vulnerables."
+            short_title: "Implantación de sistemas de protección social"
           target_1_4:
-            title: "Para 2030, garantizar que todos los hombres y mujeres, en particular los pobres y los más vulnerables, tengan los mismos derechos a los recursos económicos, así como acceso a los servicios básicos, la propiedad y el control de las tierras y otros bienes, la herencia, los recursos naturales, las nuevas tecnologías y los servicios económicos, incluida la microfinanciación."
+            long_title: "Para 2030, garantizar que todos los hombres y mujeres, en particular los pobres y los más vulnerables, tengan los mismos derechos a los recursos económicos, así como acceso a los servicios básicos, la propiedad y el control de las tierras y otros bienes, la herencia, los recursos naturales, las nuevas tecnologías y los servicios económicos, incluida la microfinanciación."
+            short_title: "Garantía de acceso a servicios básicos y recursos financieros"
           target_1_5:
-            title: "Para 2030, fomentar la resiliencia de los pobres y las personas que se encuentran en situaciones vulnerables y reducir su exposición y vulnerabilidad a los fenómenos extremos relacionados con el clima y a otros desastres económicos, sociales y ambientales."
+            long_title: "Para 2030, fomentar la resiliencia de los pobres y las personas que se encuentran en situaciones vulnerables y reducir su exposición y vulnerabilidad a los fenómenos extremos relacionados con el clima y a otros desastres económicos, sociales y ambientales."
+            short_title: "Resiliencia a desastres ambientales, económicos y sociales"
           target_1_A:
-            title: "Garantizar una movilización importante de recursos procedentes de diversas fuentes, incluso mediante la mejora de la cooperación para el desarrollo, a fin de proporcionar medios suficientes y previsibles para los países en desarrollo, en particular los países menos adelantados, para poner en práctica programas y políticas encaminados a poner fin a la pobreza en todas sus dimensiones."
+            long_title: "Garantizar una movilización importante de recursos procedentes de diversas fuentes, incluso mediante la mejora de la cooperación para el desarrollo, a fin de proporcionar medios suficientes y previsibles para los países en desarrollo, en particular los países menos adelantados, para poner en práctica programas y políticas encaminados a poner fin a la pobreza en todas sus dimensiones."
+            short_title: "Fomentar la resiliencia a los desastres ambientales, económicos y sociales"
           target_1_B:
-            title: "Crear marcos normativos sólidos en el ámbito nacional, regional e internacional, sobre la base de estrategias de desarrollo en favor de los pobres que tengan en cuenta las cuestiones de género, a fin de apoyar la inversión acelerada en medidas para erradicar la pobreza."
+            long_title: "Crear marcos normativos sólidos en el ámbito nacional, regional e internacional, sobre la base de estrategias de desarrollo en favor de los pobres que tengan en cuenta las cuestiones de género, a fin de apoyar la inversión acelerada en medidas para erradicar la pobreza."
+            short_title: "Creación de marcos normativos para erradicar la pobreza"
       goal_2:
         title: "Hambre Cero"
         title_in_two_lines: "Hambre\nCero"
@@ -28,21 +35,29 @@ es:
         long_description: '<p>Tras décadas de una disminución constante, el número de personas que padecen hambre (medido por la prevalencia de desnutrición) comenzó a aumentar lentamente de nuevo en 2015. Las estimaciones actuales indican que cerca de <a href="http://www.fao.org/3/ca9699es/CA9699ES.pdf">690 millones de personas en el mundo padecen hambre</a>, es decir, el 8,9 por ciento de la población mundial, lo que supone un aumento de unos 10 millones de personas en un año y de unos 60 millones en cinco años.</p> <p>El mundo no está bien encaminado para alcanzar el objetivo de hambre cero para 2030. Si continúan las tendencias recientes, el número de personas afectadas por el hambre superará los 840 millones de personas para 2030.</p> <p>Según el Programa Mundial de Alimentos, alrededor de <a href="https://www.wfp.org/publications/2020-global-report-food-crises">135&nbsp;millones de personas padecen hambre severa</a> <img src="https://www.un.org/common/images/icons/ico_en.gif" alt="Disponible en inglés" width="14" height="14" style="border:none">, debido principalmente a los conflictos causados por los seres humanos, el cambio climático y las recesiones económicas. La pandemia de COVID-19 podría duplicar ahora esa cifra y sumar unos 130&nbsp;millones de personas más que estarían en riesgo de padecer hambre severa a finales de 2020.</p> <p>Con más de <a href="https://insight.wfp.org/covid-19-will-almost-double-people-in-acute-hunger-by-end-of-2020-59df0c4a8072">250&nbsp;millones de personas que podrían encontrarse al borde de la hambruna</a> <img src="https://www.un.org/common/images/icons/ico_en.gif" alt="Disponible en inglés" width="14" height="14" style="border:none">, es necesario actuar rápidamente para proporcionar alimentos y ayuda humanitaria a las regiones que corren más riesgos.</p> <p>Al mismo tiempo, es necesario llevar a cabo un cambio profundo en el sistema agroalimentario mundial si queremos alimentar a más de 820&nbsp;millones de personas que padecen hambre y a los <a href="https://www.un.org/development/desa/en/news/population/world-population-prospects-2019.html">2000&nbsp;millones de personas más</a> que vivirán en el mundo en 2050. El aumento de la productividad agrícola y la producción alimentaria sostenible son cruciales para ayudar a aliviar los riesgos del hambre.</p>'
         targets:
           target_2_1:
-            title: "Para 2030, poner fin al hambre y asegurar el acceso de todas las personas, en particular los pobres y las personas en situaciones vulnerables, incluidos los lactantes, a una alimentación sana, nutritiva y suficiente durante todo el año."
+            long_title: "Para 2030, poner fin al hambre y asegurar el acceso de todas las personas, en particular los pobres y las personas en situaciones vulnerables, incluidos los lactantes, a una alimentación sana, nutritiva y suficiente durante todo el año."
+            short_title: "Poner fin al hambre"
           target_2_2:
-            title: "Para 2030, poner fin a todas las formas de malnutrición, incluso logrando, a más tardar en 2025, las metas convenidas internacionalmente sobre el retraso del crecimiento y la emaciación de los niños menores de 5 años, y abordar las necesidades de nutrición de las adolescentes, las mujeres embarazadas y lactantes y las personas de edad."
+            long_title: "Para 2030, poner fin a todas las formas de malnutrición, incluso logrando, a más tardar en 2025, las metas convenidas internacionalmente sobre el retraso del crecimiento y la emaciación de los niños menores de 5 años, y abordar las necesidades de nutrición de las adolescentes, las mujeres embarazadas y lactantes y las personas de edad."
+            short_title: "Poner fin a todas las formas de malnutrición"
           target_2_3:
-            title: "Para 2030, duplicar la productividad agrícola y los ingresos de los productores de alimentos en pequeña escala, en particular las mujeres, los pueblos indígenas, los agricultores familiares, los pastores y los pescadores, entre otras cosas mediante un acceso seguro y equitativo a las tierras, a otros recursos de producción e insumos, conocimientos, servicios financieros, mercados y oportunidades para la generación de valor añadido y empleos no agrícolas."
+            long_title: "Para 2030, duplicar la productividad agrícola y los ingresos de los productores de alimentos en pequeña escala, en particular las mujeres, los pueblos indígenas, los agricultores familiares, los pastores y los pescadores, entre otras cosas mediante un acceso seguro y equitativo a las tierras, a otros recursos de producción e insumos, conocimientos, servicios financieros, mercados y oportunidades para la generación de valor añadido y empleos no agrícolas."
+            short_title: "Duplicación de productividad e ingresos agrícolas a pequeña escala"
           target_2_4:
-            title: "Para 2030, asegurar la sostenibilidad de los sistemas de producción de alimentos y aplicar prácticas agrícolas resilientes que aumenten la productividad y la producción, contribuyan al mantenimiento de los ecosistemas, fortalezcan la capacidad de adaptación al cambio climático, los fenómenos meteorológicos extremos, las sequías, las inundaciones y otros desastres, y mejoren progresivamente la calidad del suelo y la tierra."
+            long_title: "Para 2030, asegurar la sostenibilidad de los sistemas de producción de alimentos y aplicar prácticas agrícolas resilientes que aumenten la productividad y la producción, contribuyan al mantenimiento de los ecosistemas, fortalezcan la capacidad de adaptación al cambio climático, los fenómenos meteorológicos extremos, las sequías, las inundaciones y otros desastres, y mejoren progresivamente la calidad del suelo y la tierra."
+            short_title: "Prácticas agrícolas sostenibles y resilientes"
           target_2_5:
-            title: "Para 2020, mantener la diversidad genética de las semillas, las plantas cultivadas y los animales de granja y domesticados y sus especies silvestres conexas, entre otras cosas mediante una buena gestión y diversificación de los bancos de semillas y plantas a nivel nacional, regional e internacional, y promover el acceso a los beneficios que se deriven de la utilización de los recursos genéticos y los conocimientos tradicionales y su distribución justa y equitativa, como se ha convenido internacionalmente."
+            long_title: "Para 2020, mantener la diversidad genética de las semillas, las plantas cultivadas y los animales de granja y domesticados y sus especies silvestres conexas, entre otras cosas mediante una buena gestión y diversificación de los bancos de semillas y plantas a nivel nacional, regional e internacional, y promover el acceso a los beneficios que se deriven de la utilización de los recursos genéticos y los conocimientos tradicionales y su distribución justa y equitativa, como se ha convenido internacionalmente."
+            short_title: "Mantenimiento de la diversidad genética de semillas"
           target_2_A:
-            title: "Aumentar las inversiones, incluso mediante una mayor cooperación internacional, en la infraestructura rural, la investigación agrícola y los servicios de extensión, el desarrollo tecnológico y los bancos de genes de plantas y ganado a fin de mejorar la capacidad de producción agrícola en los países en desarrollo, en particular en los países menos adelantados."
+            long_title: "Aumentar las inversiones, incluso mediante una mayor cooperación internacional, en la infraestructura rural, la investigación agrícola y los servicios de extensión, el desarrollo tecnológico y los bancos de genes de plantas y ganado a fin de mejorar la capacidad de producción agrícola en los países en desarrollo, en particular en los países menos adelantados."
+            short_title: "Aumento de inversiones en agricultura"
           target_2_B:
-            title: "Corregir y prevenir las restricciones y distorsiones comerciales en los mercados agropecuarios mundiales, entre otras cosas mediante la eliminación paralela de todas las formas de subvenciones a las exportaciones agrícolas y todas las medidas de exportación con efectos equivalentes, de conformidad con el mandato de la Ronda de Doha para el Desarrollo."
+            long_title: "Corregir y prevenir las restricciones y distorsiones comerciales en los mercados agropecuarios mundiales, entre otras cosas mediante la eliminación paralela de todas las formas de subvenciones a las exportaciones agrícolas y todas las medidas de exportación con efectos equivalentes, de conformidad con el mandato de la Ronda de Doha para el Desarrollo."
+            short_title: "Estabilidad mercados agropecuarios mundiales"
           target_2_C:
-            title: "Adoptar medidas para asegurar el buen funcionamiento de los mercados de productos básicos alimentarios y sus derivados y facilitar el acceso oportuno a información sobre los mercados, en particular sobre las reservas de alimentos, a fin de ayudar a limitar la extrema volatilidad de los precios de los alimentos."
+            long_title: "Adoptar medidas para asegurar el buen funcionamiento de los mercados de productos básicos alimentarios y sus derivados y facilitar el acceso oportuno a información sobre los mercados, en particular sobre las reservas de alimentos, a fin de ayudar a limitar la extrema volatilidad de los precios de los alimentos."
+            short_title: "Control de la volatilidad de precios de los alimentos"
       goal_3:
         title: "Salud y Bienestar"
         title_in_two_lines: "Salud\ny Bienestar"
@@ -50,31 +65,44 @@ es:
         long_description: '<p>Garantizar una vida sana y promover el bienestar en todas las edades es esencial para el desarrollo sostenible.</p> <p>Actualmente, el mundo se enfrenta a una <a href="https://www.un.org/coronavirus">crisis sanitaria mundial</a> sin precedentes; la COVID-19 está propagando el sufrimiento humano, desestabilizando la economía mundial y cambiando drásticamente las vidas de miles de millones de personas en todo el mundo.</p> <p>Antes de la pandemia, se consiguieron grandes avances en <a href="https://unstats.un.org/sdgs/report/2019/goal-03/">la mejora de la salud de millones de personas</a>. En concreto, estos grandes avances se alcanzaron al aumentar la esperanza de vida y reducir algunas de las causas de muerte comunes asociadas con la mortalidad infantil y materna. Sin embargo, se necesitan más esfuerzos para erradicar por completo una gran variedad de enfermedades y abordar un gran número de problemas de salud, tanto constantes como emergentes. A través de una financiación más eficiente de los sistemas sanitarios, un mayor saneamiento e higiene, y un mayor acceso al personal médico, se podrán conseguir avances significativos a la hora de ayudar a salvar las vidas de millones de personas.</p> <p>Las emergencias sanitarias, como la derivada de la COVID-19, suponen un riesgo mundial y han demostrado que la preparación es vital. El Programa de las Naciones Unidas para el Desarrollo señaló las grandes diferencias relativas a las <a href="https://www.undp.org/content/undp/en/home/news-centre/news/2020/COVID19_UNDP_data_dashboards_reveal_disparities_among_countries_to_cope_and_recover.html">capacidades de los países para lidiar con la crisis de la COVID-19 y recuperarse de ella</a>. La pandemia constituye un punto de inflexión en lo referente a la preparación para las emergencias sanitarias y la inversión en servicios públicos vitales del siglo XXI.</p>'
         targets:
           target_3_1:
-            title: "Para 2030, reducir la tasa mundial de mortalidad materna a menos de 70 por cada 100.000 nacidos vivos."
+            long_title: "Para 2030, reducir la tasa mundial de mortalidad materna a menos de 70 por cada 100.000 nacidos vivos."
+            short_title: "Reducción de la tasa de mortalidad materna"
           target_3_2:
-            title: "Para 2030, poner fin a las muertes evitables de recién nacidos y de niños menores de 5 años, logrando que todos los países intenten reducir la mortalidad neonatal al menos hasta 12 por cada 1.000 nacidos vivos, y la mortalidad de niños menores de 5 años al menos hasta 25 por cada 1.000 nacidos vivos."
+            long_title: "Para 2030, poner fin a las muertes evitables de recién nacidos y de niños menores de 5 años, logrando que todos los países intenten reducir la mortalidad neonatal al menos hasta 12 por cada 1.000 nacidos vivos, y la mortalidad de niños menores de 5 años al menos hasta 25 por cada 1.000 nacidos vivos."
+            short_title: "Eliminar la mortalidad infantil"
           target_3_3:
-            title: "Para 2030, poner fin a las epidemias del SIDA, la tuberculosis, la malaria y las enfermedades tropicales desatendidas y combatir la hepatitis, las enfermedades transmitidas por el agua y otras enfermedades transmisibles."
+            long_title: "Para 2030, poner fin a las epidemias del SIDA, la tuberculosis, la malaria y las enfermedades tropicales desatendidas y combatir la hepatitis, las enfermedades transmitidas por el agua y otras enfermedades transmisibles."
+            short_title: "Poner fin a las enfermedades transmisibles"
           target_3_4:
-            title: "Para 2030, reducir en un tercio la mortalidad prematura por enfermedades no transmisibles mediante la prevención y el tratamiento y promover la salud mental y el bienestar."
+            long_title: "Para 2030, reducir en un tercio la mortalidad prematura por enfermedades no transmisibles mediante la prevención y el tratamiento y promover la salud mental y el bienestar."
+            short_title: "Reducción de las enfermedades no transmisibles y salud mental"
           target_3_5:
-            title: "Fortalecer la prevención y el tratamiento del abuso de sustancias adictivas, incluido el uso indebido de estupefacientes y el consumo nocivo de alcohol."
+            long_title: "Fortalecer la prevención y el tratamiento del abuso de sustancias adictivas, incluido el uso indebido de estupefacientes y el consumo nocivo de alcohol."
+            short_title: "Prevención y tratamiento de abusos de drogas y alcohol"
           target_3_6:
-            title: "Para 2020, reducir a la mitad el número de muertes y lesiones causadas por accidentes de tráfico en el mundo."
+            long_title: "Para 2020, reducir a la mitad el número de muertes y lesiones causadas por accidentes de tráfico en el mundo."
+            short_title: "Reducción de accidentes de tráfico"
           target_3_7:
-            title: "Para 2030, garantizar el acceso universal a los servicios de salud sexual y reproductiva, incluidos los de planificación de la familia, información y educación, y la integración de la salud reproductiva en las estrategias y los programas nacionales."
+            long_title: "Para 2030, garantizar el acceso universal a los servicios de salud sexual y reproductiva, incluidos los de planificación de la familia, información y educación, y la integración de la salud reproductiva en las estrategias y los programas nacionales."
+            short_title: "Garantía de acceso a la salud Sexual y reproductiva, y a la planificación familiar"
           target_3_8:
-            title: "Lograr la cobertura sanitaria universal, en particular la protección contra los riesgos financieros, el acceso a servicios de salud esenciales de calidad y el acceso a medicamentos y vacunas seguros, eficaces, asequibles y de calidad para todos."
+            long_title: "Lograr la cobertura sanitaria universal, en particular la protección contra los riesgos financieros, el acceso a servicios de salud esenciales de calidad y el acceso a medicamentos y vacunas seguros, eficaces, asequibles y de calidad para todos."
+            short_title: "Lograr la cobertura universal y acceso medicamentos"
           target_3_9:
-            title: "Para 2030, reducir sustancialmente el número de muertes y enfermedades producidas por productos químicos peligrosos y la contaminación del aire, el agua y el suelo."
+            long_title: "Para 2030, reducir sustancialmente el número de muertes y enfermedades producidas por productos químicos peligrosos y la contaminación del aire, el agua y el suelo."
+            short_title: "Reducción de muertes por contaminación química y polución"
           target_3_A:
-            title: "Fortalecer la aplicación del Convenio Marco de la Organización Mundial de la Salud para el Control del Tabaco en todos los países, según proceda."
+            long_title: "Fortalecer la aplicación del Convenio Marco de la Organización Mundial de la Salud para el Control del Tabaco en todos los países, según proceda."
+            short_title: "Control del tabaco"
           target_3_B:
-            title: "Apoyar las actividades de investigación y desarrollo de vacunas y medicamentos para las enfermedades transmisibles y no transmisibles que afectan primordialmente a los países en desarrollo y facilitar el acceso a medicamentos y vacunas esenciales asequibles de conformidad con la Declaración de Doha relativa al Acuerdo sobre los ADPIC y la Salud Pública, en la que se afirma el derecho de los países en desarrollo a utilizar al máximo las disposiciones del Acuerdo sobre los Aspectos de los Derechos de Propiedad Intelectual Relacionados con el Comercio en lo relativo a la flexibilidad para proteger la salud pública y, en particular, proporcionar acceso a los medicamentos para todos."
+            long_title: "Apoyar las actividades de investigación y desarrollo de vacunas y medicamentos para las enfermedades transmisibles y no transmisibles que afectan primordialmente a los países en desarrollo y facilitar el acceso a medicamentos y vacunas esenciales asequibles de conformidad con la Declaración de Doha relativa al Acuerdo sobre los ADPIC y la Salud Pública, en la que se afirma el derecho de los países en desarrollo a utilizar al máximo las disposiciones del Acuerdo sobre los Aspectos de los Derechos de Propiedad Intelectual Relacionados con el Comercio en lo relativo a la flexibilidad para proteger la salud pública y, en particular, proporcionar acceso a los medicamentos para todos."
+            short_title: "Apoyo a la I+D de vacunas y medicamentos esenciales"
           target_3_C:
-            title: "Aumentar sustancialmente la financiación de la salud y la contratación, el desarrollo, la capacitación y la retención del personal sanitario en los países en desarrollo, especialmente en los países menos adelantados y los pequeños Estados insulares en desarrollo."
+            long_title: "Aumentar sustancialmente la financiación de la salud y la contratación, el desarrollo, la capacitación y la retención del personal sanitario en los países en desarrollo, especialmente en los países menos adelantados y los pequeños Estados insulares en desarrollo."
+            short_title: "Aumento de la financiación del sistema sanitario"
           target_3_D:
-            title: "Reforzar la capacidad de todos los países, en particular los países en desarrollo, en materia de alerta temprana, reducción de riesgos y gestión de los riesgos para la salud nacional y mundial."
+            long_title: "Reforzar la capacidad de todos los países, en particular los países en desarrollo, en materia de alerta temprana, reducción de riesgos y gestión de los riesgos para la salud nacional y mundial."
+            short_title: "Refuerzo en la gestión de riesgos sanitarios"
       goal_4:
         title: "Educación de Calidad"
         title_in_two_lines: "Educación\nde Calidad"
@@ -82,25 +110,35 @@ es:
         long_description: '<p>La educación permite la movilidad socioeconómica ascendente y es clave para salir de la pobreza. Durante la última década, se consiguieron grandes avances a la hora de ampliar el acceso a la educación y las tasas de matriculación en las escuelas en todos los niveles, especialmente para las niñas. No obstante, <a href="http://uis.unesco.org/en/topic/out-school-children-and-youth">alrededor de 260&nbsp;millones de niños aún estaban fuera de la escuela</a> en 2018; cerca de una quinta parte de la población mundial de ese grupo de edad. Además, más de la mitad de todos los niños y adolescentes de todo el mundo <a href="https://unstats.un.org/sdgs/report/2019/goal-04/">no están alcanzando los estándares mínimos de competencia</a> en lectura y matemáticas.</p> <p>En 2020, a medida que la pandemia de la COVID-19 se propagaba por todo el planeta, la mayor parte de los países anunciaron el cierre temporal de las escuelas, lo que afectó a más del 91&nbsp;% de los estudiantes en todo el mundo. En abril de 2020, cerca de <a href="https://en.unesco.org/covid19/educationresponse">1600&nbsp;millones de niños y jóvenes estaban fuera de la escuela</a>. Igualmente, cerca de <a href="https://www.un.org/sites/un2.un.org/files/policy_brief_on_covid_impact_on_children_16_april_2020.pdf">369&nbsp;millones de niños que dependen de los comedores escolares</a> tuvieron que buscar otras fuentes de nutrición diaria.</p> <p>Nunca antes habían estado tantos niños fuera de la escuela al mismo tiempo, lo que altera su aprendizaje y cambia drásticamente sus vidas, especialmente las de los niños más vulnerables y marginados. La pandemia mundial tiene graves consecuencias que pueden poner en peligro los avances que tanto costaron conseguir a la hora de mejorar la educación a nivel mundial.</p>'
         targets:
           target_4_1:
-            title: "De aquí a 2030, asegurar que todas las niñas y todos los niños terminen la enseñanza primaria y secundaria, que ha de ser gratuita, equitativa y de calidad y producir resultados de aprendizaje pertinentes y efectivos."
+            long_title: "De aquí a 2030, asegurar que todas las niñas y todos los niños terminen la enseñanza primaria y secundaria, que ha de ser gratuita, equitativa y de calidad y producir resultados de aprendizaje pertinentes y efectivos."
+            short_title: "Asegurar la calidad de la educación primaria y secundaria"
           target_4_2:
-            title: "De aquí a 2030, asegurar que todas las niñas y todos los niños tengan acceso a servicios de atención y desarrollo en la primera infancia y educación preescolar de calidad, a fin de que estén preparados para la enseñanza primaria."
+            long_title: "De aquí a 2030, asegurar que todas las niñas y todos los niños tengan acceso a servicios de atención y desarrollo en la primera infancia y educación preescolar de calidad, a fin de que estén preparados para la enseñanza primaria."
+            short_title: "Asegurar el acceso y calidad de la educación Pre-escolar"
           target_4_3:
-            title: "De aquí a 2030, asegurar el acceso igualitario de todos los hombres y las mujeres a una formación técnica, profesional y superior de calidad, incluida la enseñanza universitaria."
+            long_title: "De aquí a 2030, asegurar el acceso igualitario de todos los hombres y las mujeres a una formación técnica, profesional y superior de calidad, incluida la enseñanza universitaria."
+            short_title: "Asegurar el acceso igualitario a la formación superior"
           target_4_4:
-            title: "De aquí a 2030, aumentar considerablemente el número de jóvenes y adultos que tienen las competencias necesarias, en particular técnicas y profesionales, para acceder al empleo, el trabajo decente y el emprendimiento."
+            long_title: "De aquí a 2030, aumentar considerablemente el número de jóvenes y adultos que tienen las competencias necesarias, en particular técnicas y profesionales, para acceder al empleo, el trabajo decente y el emprendimiento."
+            short_title: "Aumento de las competencias para acceder al empleo"
           target_4_5:
-            title: "De aquí a 2030, eliminar las disparidades de género en la educación y asegurar el acceso igualitario a todos los niveles de la enseñanza y la formación profesional para las personas vulnerables, incluidas las personas con discapacidad, los pueblos indígenas y los niños en situaciones de vulnerabilidad."
+            long_title: "De aquí a 2030, eliminar las disparidades de género en la educación y asegurar el acceso igualitario a todos los niveles de la enseñanza y la formación profesional para las personas vulnerables, incluidas las personas con discapacidad, los pueblos indígenas y los niños en situaciones de vulnerabilidad."
+            short_title: "Eliminación Disparidad de género y colectivos vulnerables"
           target_4_6:
-            title: "De aquí a 2030, asegurar que todos los jóvenes y una proporción considerable de los adultos, tanto hombres como mujeres, estén alfabetizados y tengan nociones elementales de aritmética."
+            long_title: "De aquí a 2030, asegurar que todos los jóvenes y una proporción considerable de los adultos, tanto hombres como mujeres, estén alfabetizados y tengan nociones elementales de aritmética."
+            short_title: "Asegurar la alfabetización y conocimiento de aritmética"
           target_4_7:
-            title: "De aquí a 2030, asegurar que todos los alumnos adquieran los conocimientos teóricos y prácticos necesarios para promover el desarrollo sostenible, entre otras cosas mediante la educación para el desarrollo sostenible y los estilos de vida sostenibles, los derechos humanos, la igualdad de género, la promoción de una cultura de paz y no violencia, la ciudadanía mundial y la valoración de la diversidad cultural y la contribución de la cultura al desarrollo sostenible."
+            long_title: "De aquí a 2030, asegurar que todos los alumnos adquieran los conocimientos teóricos y prácticos necesarios para promover el desarrollo sostenible, entre otras cosas mediante la educación para el desarrollo sostenible y los estilos de vida sostenibles, los derechos humanos, la igualdad de género, la promoción de una cultura de paz y no violencia, la ciudadanía mundial y la valoración de la diversidad cultural y la contribución de la cultura al desarrollo sostenible."
+            short_title: "Fomentar la educación Global para el Desarrollo Sostenible"
           target_4_A:
-            title: "Construir y adecuar instalaciones educativas que tengan en cuenta las necesidades de los niños y las personas con discapacidad y las diferencias de género, y que ofrezcan entornos de aprendizaje seguros, no violentos, inclusivos y eficaces para todos."
+            long_title: "Construir y adecuar instalaciones educativas que tengan en cuenta las necesidades de los niños y las personas con discapacidad y las diferencias de género, y que ofrezcan entornos de aprendizaje seguros, no violentos, inclusivos y eficaces para todos."
+            short_title: "Mejora de instalaciones educativas inclusivas y seguras"
           target_4_B:
-            title: "De aquí a 2020, aumentar considerablemente a nivel mundial el número de becas disponibles para los países en desarrollo, en particular los países menos adelantados, los pequeños Estados insulares en desarrollo y los países africanos, a fin de que sus estudiantes puedan matricularse en programas de enseñanza superior, incluidos programas de formación profesional y programas técnicos, científicos, de ingeniería y de tecnología de la información y las comunicaciones, de países desarrollados y otros países en desarrollo."
+            long_title: "De aquí a 2020, aumentar considerablemente a nivel mundial el número de becas disponibles para los países en desarrollo, en particular los países menos adelantados, los pequeños Estados insulares en desarrollo y los países africanos, a fin de que sus estudiantes puedan matricularse en programas de enseñanza superior, incluidos programas de formación profesional y programas técnicos, científicos, de ingeniería y de tecnología de la información y las comunicaciones, de países desarrollados y otros países en desarrollo."
+            short_title: "Aumento de becas para enseñanza superior"
           target_4_C:
-            title: "De aquí a 2030, aumentar considerablemente la oferta de docentes calificados, incluso mediante la cooperación internacional para la formación de docentes en los países en desarrollo, especialmente los países menos adelantados y los pequeños Estados insulares en desarrollo."
+            long_title: "De aquí a 2030, aumentar considerablemente la oferta de docentes calificados, incluso mediante la cooperación internacional para la formación de docentes en los países en desarrollo, especialmente los países menos adelantados y los pequeños Estados insulares en desarrollo."
+            short_title: "Mejorar la cualificación de docentes"
       goal_5:
         title: "Igualdad de Género"
         title_in_two_lines: "Igualdad\nde Género"
@@ -108,23 +146,32 @@ es:
         long_description: '<p>La igualdad de género no solo es un derecho humano fundamental, sino que es uno de los fundamentos esenciales para construir un mundo pacífico, próspero y sostenible.</p> <p>Se han conseguido algunos <a href="https://www.unwomen.org/-/media/headquarters/attachments/sections/library/publications/2020/gender-equality-womens-rights-in-review-key-facts-and-figures-en.pdf?la=en&amp;vs=935">avances</a> durante las últimas décadas: más niñas están escolarizadas, y se obliga a menos niñas al matrimonio precoz; hay más mujeres con cargos en parlamentos y en posiciones de liderazgo, y las leyes se están reformando para fomentar la igualdad de género.</p> <p>A pesar de estos logros, todavía existen muchas <a href="https://www.unwomen.org/-/media/headquarters/attachments/sections/library/publications/2020/gender-equality-womens-rights-in-review-key-facts-and-figures-en.pdf?la=en&amp;vs=935">dificultades</a>: las leyes y las normas sociales discriminatorias continúan siendo generalizadas, las mujeres siguen estando infrarrepresentadas a todos los niveles de liderazgo político, y 1 de cada 5&nbsp;mujeres y niñas de entre 15 y 49&nbsp;años afirma haber sufrido violencia sexual o física a manos de una pareja íntima en un período de 12&nbsp;meses.</p> <p>Los efectos de <a href="https://www.un.org/sites/un2.un.org/files/policy_brief_on_covid_impact_on_women_9_apr_2020_updated.pdf">la pandemia de la COVID-19 podrían revertir los escasos logros</a> que se han alcanzado en materia de igualdad de género y derechos de las mujeres.&nbsp; El brote de coronavirus <a href="https://www.unfpa.org/sites/default/files/resource-pdf/COVID-19_A_Gender_Lens_Guidance_Note.pdf">agrava las desigualdades existentes</a> para las mujeres y niñas a nivel mundial; desde la salud y la economía, hasta la seguridad y la protección social.</p> <p>Las mujeres desempeñan un papel desproporcionado en la respuesta al virus, incluso como trabajadoras sanitarias en primera línea y como cuidadoras en el hogar. El trabajo de cuidados no remunerado de las mujeres ha aumentado de manera significativa como consecuencia del cierre de las escuelas y el aumento de las necesidades de los ancianos. Las mujeres también se ven más afectadas por los efectos económicos de la COVID-19, ya que trabajan, de manera desproporcionada, en mercados laborales inseguros. Cerca del 60&nbsp;% de las mujeres trabaja en la economía informal, lo que las expone aún más a caer en la pobreza.</p> <p>La pandemia también ha conducido a un fuerte aumento de la <a href="https://www.unwomen.org/-/media/headquarters/attachments/sections/library/publications/2020/issue-brief-covid-19-and-ending-violence-against-women-and-girls-en.pdf?la=en&amp;vs=5006">violencia contra las mujeres y las niñas</a>. Con las medidas de confinamiento en vigor, muchas mujeres se encuentran atrapadas en casa con sus abusadores, con dificultades para acceder a servicios que están padeciendo recortes y restricciones. Los nuevos datos muestran que, desde el brote de la pandemia, la violencia contra las mujeres y las niñas (y, especialmente, la violencia doméstica) se ha intensificado.</p>'
         targets:
           target_5_1:
-            title: "Poner fin a todas las formas de discriminación contra todas las mujeres y las niñas en todo el mundo."
+            long_title: "Poner fin a todas las formas de discriminación contra todas las mujeres y las niñas en todo el mundo."
+            short_title: "Poner fin a la discriminación"
           target_5_2:
-            title: "Eliminar todas las formas de violencia contra todas las mujeres y las niñas en los ámbitos público y privado, incluidas la trata y la explotación sexual y otros tipos de explotación."
+            long_title: "Eliminar todas las formas de violencia contra todas las mujeres y las niñas en los ámbitos público y privado, incluidas la trata y la explotación sexual y otros tipos de explotación."
+            short_title: "Eliminar todas las formas de violencia de género"
           target_5_3:
-            title: "Eliminar todas las prácticas nocivas, como el matrimonio infantil, precoz y forzado y la mutilación genital femenina."
+            long_title: "Eliminar todas las prácticas nocivas, como el matrimonio infantil, precoz y forzado y la mutilación genital femenina."
+            short_title: "Eliminar matrimonio infantil y mutilación genital femenina"
           target_5_4:
-            title: "Reconocer y valorar los cuidados y el trabajo doméstico no remunerados mediante servicios públicos, infraestructuras y políticas de protección social, y promoviendo la responsabilidad compartida en el hogar y la familia, según proceda en cada país."
+            long_title: "Reconocer y valorar los cuidados y el trabajo doméstico no remunerados mediante servicios públicos, infraestructuras y políticas de protección social, y promoviendo la responsabilidad compartida en el hogar y la familia, según proceda en cada país."
+            short_title: "Reconocer el trabajo de cuidados y doméstico"
           target_5_5:
-            title: "Asegurar la participación plena y efectiva de las mujeres y la igualdad de oportunidades de liderazgo a todos los niveles decisorios en la vida política, económica y pública."
+            long_title: "Asegurar la participación plena y efectiva de las mujeres y la igualdad de oportunidades de liderazgo a todos los niveles decisorios en la vida política, económica y pública."
+            short_title: "Asegurar la participación plena de la mujer e igualdad oportunidades"
           target_5_6:
-            title: "Asegurar el acceso universal a la salud sexual y reproductiva y los derechos reproductivos según lo acordado de conformidad con el Programa de Acción de la Conferencia Internacional sobre la Población y el Desarrollo, la Plataforma de Acción de Beijing y los documentos finales de sus conferencias de examen."
+            long_title: "Asegurar el acceso universal a la salud sexual y reproductiva y los derechos reproductivos según lo acordado de conformidad con el Programa de Acción de la Conferencia Internacional sobre la Población y el Desarrollo, la Plataforma de Acción de Beijing y los documentos finales de sus conferencias de examen."
+            short_title: "Asegurar el acceso salud sexual y reproductiva y derechos reproductivos"
           target_5_A:
-            title: "Emprender reformas que otorguen a las mujeres igualdad de derechos a los recursos económicos, así como acceso a la propiedad y al control de la tierra y otros tipos de bienes, los servicios financieros, la herencia y los recursos naturales, de conformidad con las leyes nacionales."
+            long_title: "Emprender reformas que otorguen a las mujeres igualdad de derechos a los recursos económicos, así como acceso a la propiedad y al control de la tierra y otros tipos de bienes, los servicios financieros, la herencia y los recursos naturales, de conformidad con las leyes nacionales."
+            short_title: "Asegurar la igualdad de derechos a los recursos económicos"
           target_5_B:
-            title: "Mejorar el uso de la tecnología instrumental, en particular la tecnología de la información y las comunicaciones, para promover el empoderamiento de las mujeres."
+            long_title: "Mejorar el uso de la tecnología instrumental, en particular la tecnología de la información y las comunicaciones, para promover el empoderamiento de las mujeres."
+            short_title: "Mejorar el uso de tecnología y TIC"
           target_5_C:
-            title: "Aprobar y fortalecer políticas acertadas y leyes aplicables para promover la igualdad de género y el empoderamiento de todas las mujeres y las niñas a todos los niveles."
+            long_title: "Aprobar y fortalecer políticas acertadas y leyes aplicables para promover la igualdad de género y el empoderamiento de todas las mujeres y las niñas a todos los niveles."
+            short_title: "Aprobar políticas y leyes para la igualdad y el empoderamiento"
       goal_6:
         title: "Agua Limpia y Saneamiento"
         title_in_two_lines: "Agua Limpia\ny Saneamiento"
@@ -132,21 +179,29 @@ es:
         long_description: '<p>Si bien se ha conseguido progresar de manera sustancial a la hora de ampliar el acceso a agua potable y saneamiento, existen miles de millones de personas (principalmente en áreas rurales) que aún carecen de estos servicios básicos. En todo el mundo, <a href="https://www.who.int/news-room/detail/18-06-2019-1-in-3-people-globally-do-not-have-access-to-safe-drinking-water-unicef-who">una de cada tres personas no tiene acceso a agua potable salubre</a>, <a href="https://www.unwater.org/water-facts/water-sanitation-and-hygiene/">dos de cada cinco personas no disponen de una instalación básica destinada a lavarse las manos</a> con agua y jabón, y más de <a href="https://news.un.org/en/story/2019/11/1051561">673&nbsp;millones de personas aún defecan al aire libre</a>.</p> <p>La pandemia de la COVID-19 ha puesto de manifiesto la importancia vital del saneamiento, la higiene y un acceso adecuado a agua limpia para prevenir y contener las enfermedades. <a href="https://www.unwater.org/water-facts/handhygiene/">La higiene de manos salva vidas</a>. De acuerdo con la Organización Mundial de la Salud, <a href="https://www.who.int/news-room/events/detail/2020/05/05/default-calendar/hand-hygiene-day">el lavado de manos es una de las acciones más efectivas que se pueden llevar a cabo</a> para reducir la propagación de patógenos y prevenir infecciones, incluido el virus de la COVID-19. Aun así, hay miles de millones de personas que carecen de acceso a agua salubre y saneamiento, y los fondos son insuficientes.</p>'
         targets:
           target_6_1:
-            title: "De aquí a 2030, lograr el acceso universal y equitativo al agua potable a un precio asequible para todos."
+            long_title: "De aquí a 2030, lograr el acceso universal y equitativo al agua potable a un precio asequible para todos."
+            short_title: "Lograr el acceso a agua potable"
           target_6_2:
-            title: "De aquí a 2030, lograr el acceso a servicios de saneamiento e higiene adecuados y equitativos para todos y poner fin a la defecación al aire libre, prestando especial atención a las necesidades de las mujeres y las niñas y las personas en situaciones de vulnerabilidad."
+            long_title: "De aquí a 2030, lograr el acceso a servicios de saneamiento e higiene adecuados y equitativos para todos y poner fin a la defecación al aire libre, prestando especial atención a las necesidades de las mujeres y las niñas y las personas en situaciones de vulnerabilidad."
+            short_title: "Lograr el acceso a servicios de saneamiento e higiene"
           target_6_3:
-            title: "De aquí a 2030, mejorar la calidad del agua reduciendo la contaminación, eliminando el vertimiento y minimizando la emisión de productos químicos y materiales peligrosos, reduciendo a la mitad el porcentaje de aguas residuales sin tratar y aumentando considerablemente el reciclado y la reutilización sin riesgos a nivel mundial."
+            long_title: "De aquí a 2030, mejorar la calidad del agua reduciendo la contaminación, eliminando el vertimiento y minimizando la emisión de productos químicos y materiales peligrosos, reduciendo a la mitad el porcentaje de aguas residuales sin tratar y aumentando considerablemente el reciclado y la reutilización sin riesgos a nivel mundial."
+            short_title: "Mejorar la calidad de agua. Reducir la contaminación y aguas residuales"
           target_6_4:
-            title: "De aquí a 2030, aumentar considerablemente el uso eficiente de los recursos hídricos en todos los sectores y asegurar la sostenibilidad de la extracción y el abastecimiento de agua dulce para hacer frente a la escasez de agua y reducir considerablemente el número de personas que sufren falta de agua."
+            long_title: "De aquí a 2030, aumentar considerablemente el uso eficiente de los recursos hídricos en todos los sectores y asegurar la sostenibilidad de la extracción y el abastecimiento de agua dulce para hacer frente a la escasez de agua y reducir considerablemente el número de personas que sufren falta de agua."
+            short_title: "Aumentar el uso eficiente de recursos hídricos (extracción de agua dulce)"
           target_6_5:
-            title: "De aquí a 2030, implementar la gestión integrada de los recursos hídricos a todos los niveles, incluso mediante la cooperación transfronteriza, según proceda."
+            long_title: "De aquí a 2030, implementar la gestión integrada de los recursos hídricos a todos los niveles, incluso mediante la cooperación transfronteriza, según proceda."
+            short_title: "Implementar la gestión integral de recursos hídricos"
           target_6_6:
-            title: "De aquí a 2020, proteger y restablecer los ecosistemas relacionados con el agua, incluidos los bosques, las montañas, los humedales, los ríos, los acuíferos y los lagos."
+            long_title: "De aquí a 2020, proteger y restablecer los ecosistemas relacionados con el agua, incluidos los bosques, las montañas, los humedales, los ríos, los acuíferos y los lagos."
+            short_title: "Protección de los ecosistemas relacionados con agua"
           target_6_A:
-            title: "De aquí a 2030, ampliar la cooperación internacional y el apoyo prestado a los países en desarrollo para la creación de capacidad en actividades y programas relativos al agua y el saneamiento, como los de captación de agua, desalinización, uso eficiente de los recursos hídricos, tratamiento de aguas residuales, reciclado y tecnologías de reutilización."
+            long_title: "De aquí a 2030, ampliar la cooperación internacional y el apoyo prestado a los países en desarrollo para la creación de capacidad en actividades y programas relativos al agua y el saneamiento, como los de captación de agua, desalinización, uso eficiente de los recursos hídricos, tratamiento de aguas residuales, reciclado y tecnologías de reutilización."
+            short_title: "Fomentar la creación de capacidades de gestión"
           target_6_B:
-            title: "Apoyar y fortalecer la participación de las comunidades locales en la mejora de la gestión del agua y el saneamiento."
+            long_title: "Apoyar y fortalecer la participación de las comunidades locales en la mejora de la gestión del agua y el saneamiento."
+            short_title: "Apoyar la participación de las comunidades locales"
       goal_7:
         title: "Energía Asequible y No Contaminante"
         title_in_two_lines: "Energía Sostenible\ny No Contaminante"
@@ -154,15 +209,20 @@ es:
         long_description: '<p>El mundo está <a href="https://unstats.un.org/sdgs/report/2019/goal-07/">avanzando hacia la consecución del Objetivo 7</a> con indicios alentadores de que la energía se está volviendo más sostenible y ampliamente disponible. El acceso a la electricidad en los países más pobres ha comenzado a acelerarse, la eficiencia energética continúa mejorando y la energía renovable está logrando resultados excelentes en el sector eléctrico.</p> <p>A pesar de ello, es necesario prestar una mayor atención a las mejoras para el acceso a combustibles de cocina limpios y seguros, y a tecnologías para 3000&nbsp;millones de personas, para expandir el uso de la energía renovable más allá del sector eléctrico e incrementar la electrificación en el África subsahariana.</p> <p>El <a href="https://trackingsdg7.esmap.org/">informe de progreso en materia de energía</a> proporciona un registro mundial del progreso relativo al acceso a la energía, la eficiencia energética y la energía renovable. Evalúa el progreso conseguido por cada país en estos tres pilares y ofrece una panorámica del camino que nos queda por recorrer para conseguir las metas de los Objetivos de Desarrollo Sostenible 2030.</p>'
         targets:
           target_7_1:
-            title: "De aquí a 2030, garantizar el acceso universal a servicios energéticos asequibles, fiables y modernos."
+            long_title: "De aquí a 2030, garantizar el acceso universal a servicios energéticos asequibles, fiables y modernos."
+            short_title: "Garantizar acceso universal a energía"
           target_7_2:
-            title: "De aquí a 2030, aumentar considerablemente la proporción de energía renovable en el conjunto de fuentes energéticas."
+            long_title: "De aquí a 2030, aumentar considerablemente la proporción de energía renovable en el conjunto de fuentes energéticas."
+            short_title: "Aumento de las energías renovables"
           target_7_3:
-            title: "De aquí a 2030, duplicar la tasa mundial de mejora de la eficiencia energética."
+            long_title: "De aquí a 2030, duplicar la tasa mundial de mejora de la eficiencia energética."
+            short_title: "Duplicar la tasa de eficiencia energética"
           target_7_A:
-            title: "De aquí a 2030, aumentar la cooperación internacional para facilitar el acceso a la investigación y la tecnología relativas a la energía limpia, incluidas las fuentes renovables, la eficiencia energética y las tecnologías avanzadas y menos contaminantes de combustibles fósiles, y promover la inversión en infraestructura energética y tecnologías limpias."
+            long_title: "De aquí a 2030, aumentar la cooperación internacional para facilitar el acceso a la investigación y la tecnología relativas a la energía limpia, incluidas las fuentes renovables, la eficiencia energética y las tecnologías avanzadas y menos contaminantes de combustibles fósiles, y promover la inversión en infraestructura energética y tecnologías limpias."
+            short_title: "Aumento de la investigación e inversión en energías limpias"
           target_7_B:
-            title: "De aquí a 2030, ampliar la infraestructura y mejorar la tecnología para prestar servicios energéticos modernos y sostenibles para todos en los países en desarrollo, en particular los países menos adelantados, los pequeños Estados insulares en desarrollo y los países en desarrollo sin litoral, en consonancia con sus respectivos programas de apoyo."
+            long_title: "De aquí a 2030, ampliar la infraestructura y mejorar la tecnología para prestar servicios energéticos modernos y sostenibles para todos en los países en desarrollo, en particular los países menos adelantados, los pequeños Estados insulares en desarrollo y los países en desarrollo sin litoral, en consonancia con sus respectivos programas de apoyo."
+            short_title: "Ampliar la infraestructura y tecnología en países en desarrollo"
       goal_8:
         title: "Trabajo Decente y Crecimiento Económico"
         title_in_two_lines: "Trabajo Decente\ny Crecimiento Económico"
@@ -170,29 +230,41 @@ es:
         long_description: '<p>Un crecimiento económico inclusivo y sostenido puede impulsar el progreso, crear empleos decentes para todos y mejorar los estándares de vida.</p> <p>La COVID-19 ha <a href="https://www.un.org/sites/un2.un.org/files/sg_report_socio-economic_impact_of_covid19.pdf">alterado miles de millones de vidas</a> y ha puesto en peligro la economía mundial. El Fondo Monetario Internacional (FMI) prevé una <a href="https://blogs.imf.org/2020/04/14/the-great-lockdown-worst-economic-downturn-since-the-great-depression/">recesión mundial</a> tan mala o peor que la de 2009. A medida que se intensifica la pérdida de empleo, la Organización Internacional del Trabajo estima que <a href="https://www.ilo.org/global/about-the-ilo/newsroom/news/WCMS_743036/lang--en/index.htm">cerca de la mitad de todos los trabajadores a nivel mundial se encuentra en riesgo</a> de perder sus medios de subsistencia.</p> <p><a href="https://developmentfinance.un.org/press-release-financing-sustainable-development-report-2020">Incluso antes del brote de la COVID-19</a>, era probable que uno de cada cinco países (en donde habitan miles de millones de personas que viven en situación de pobreza) vieran sus ingresos per cápita estancarse o reducirse en 2020. A día de hoy, las <a href="https://developmentfinance.un.org/press-release-financing-sustainable-development-report-2020">perturbaciones económicas y financieras</a> derivadas de la COVID-19 (como las alteraciones en la producción industrial, la caída de los precios de los productos básicos, la volatilidad del mercado financiero y el aumento de la inseguridad) están desbaratando el ya de por sí tibio crecimiento económico y empeorando los riesgos acentuados de otros factores.</p>'
         targets:
           target_8_1:
-            title: "Mantener el crecimiento económico per capita de conformidad con las circunstancias nacionales y, en particular, un crecimiento del producto interno bruto de al menos el 7% anual en los países menos adelantados."
+            long_title: "Mantener el crecimiento económico per capita de conformidad con las circunstancias nacionales y, en particular, un crecimiento del producto interno bruto de al menos el 7% anual en los países menos adelantados."
+            short_title: "Mantenimiento del crecimiento económico"
           target_8_2:
-            title: "Lograr niveles más elevados de productividad económica mediante la diversificación, la modernización tecnológica y la innovación, entre otras cosas centrándose en los sectores con gran valor añadido y un uso intensivo de la mano de obra."
+            long_title: "Lograr niveles más elevados de productividad económica mediante la diversificación, la modernización tecnológica y la innovación, entre otras cosas centrándose en los sectores con gran valor añadido y un uso intensivo de la mano de obra."
+            short_title: "Elevar la productividad a través de la diversificación, tecnología e innovación"
           target_8_3:
-            title: "Promover políticas orientadas al desarrollo que apoyen las actividades productivas, la creación de puestos de trabajo decentes, el emprendimiento, la creatividad y la innovación, y fomentar la formalización y el crecimiento de las microempresas y las pequeñas y medianas empresas, incluso mediante el acceso a servicios financieros."
+            long_title: "Promover políticas orientadas al desarrollo que apoyen las actividades productivas, la creación de puestos de trabajo decentes, el emprendimiento, la creatividad y la innovación, y fomentar la formalización y el crecimiento de las microempresas y las pequeñas y medianas empresas, incluso mediante el acceso a servicios financieros."
+            short_title: "Fomento de pequeña y mediana empresa"
           target_8_4:
-            title: "Mejorar progresivamente, de aquí a 2030, la producción y el consumo eficientes de los recursos mundiales y procurar desvincular el crecimiento económico de la degradación del medio ambiente, conforme al Marco Decenal de Programas sobre modalidades de Consumo y Producción Sostenibles, empezando por los países desarrollados."
+            long_title: "Mejorar progresivamente, de aquí a 2030, la producción y el consumo eficientes de los recursos mundiales y procurar desvincular el crecimiento económico de la degradación del medio ambiente, conforme al Marco Decenal de Programas sobre modalidades de Consumo y Producción Sostenibles, empezando por los países desarrollados."
+            short_title: "Mejora de la producción y consumo eficiente y respetuoso"
           target_8_5:
-            title: "De aquí a 2030, lograr el empleo pleno y productivo y el trabajo decente para todas las mujeres y los hombres, incluidos los jóvenes y las personas con discapacidad, así como la igualdad de remuneración por trabajo de igual valor."
+            long_title: "De aquí a 2030, lograr el empleo pleno y productivo y el trabajo decente para todas las mujeres y los hombres, incluidos los jóvenes y las personas con discapacidad, así como la igualdad de remuneración por trabajo de igual valor."
+            short_title: "Lograr el pleno empleo y trabajo decente"
           target_8_6:
-            title: "De aquí a 2020, reducir considerablemente la proporción de jóvenes que no están empleados y no cursan estudios ni reciben capacitación."
+            long_title: "De aquí a 2020, reducir considerablemente la proporción de jóvenes que no están empleados y no cursan estudios ni reciben capacitación."
+            short_title: "Reducción de los jóvenes sin trabajo ni estudios"
           target_8_7:
-            title: "Adoptar medidas inmediatas y eficaces para erradicar el trabajo forzoso, poner fin a las formas contemporáneas de esclavitud y la trata de personas y asegurar la prohibición y eliminación de las peores formas de trabajo infantil, incluidos el reclutamiento y la utilización de niños soldados, y, de aquí a 2025, poner fin al trabajo infantil en todas sus formas."
+            long_title: "Adoptar medidas inmediatas y eficaces para erradicar el trabajo forzoso, poner fin a las formas contemporáneas de esclavitud y la trata de personas y asegurar la prohibición y eliminación de las peores formas de trabajo infantil, incluidos el reclutamiento y la utilización de niños soldados, y, de aquí a 2025, poner fin al trabajo infantil en todas sus formas."
+            short_title: "Erradicación la esclavitud, trata y trabajo infantil"
           target_8_8:
-            title: "Proteger los derechos laborales y promover un entorno de trabajo seguro y sin riesgos para todos los trabajadores, incluidos los trabajadores migrantes, en particular las mujeres migrantes y las personas con empleos precarios."
+            long_title: "Proteger los derechos laborales y promover un entorno de trabajo seguro y sin riesgos para todos los trabajadores, incluidos los trabajadores migrantes, en particular las mujeres migrantes y las personas con empleos precarios."
+            short_title: "Protección de los derechos laborales y trabajo seguro"
           target_8_9:
-            title: "De aquí a 2030, elaborar y poner en práctica políticas encaminadas a promover un turismo sostenible que cree puestos de trabajo y promueva la cultura y los productos locales."
+            long_title: "De aquí a 2030, elaborar y poner en práctica políticas encaminadas a promover un turismo sostenible que cree puestos de trabajo y promueva la cultura y los productos locales."
+            short_title: "Promoción el turismo sostenible"
           target_8_10:
-            title: "Fortalecer la capacidad de las instituciones financieras nacionales para fomentar y ampliar el acceso a los servicios bancarios, financieros y de seguros para todos."
+            long_title: "Fortalecer la capacidad de las instituciones financieras nacionales para fomentar y ampliar el acceso a los servicios bancarios, financieros y de seguros para todos."
+            short_title: "Fortalecimiento la capacidad de las instituciones financieras"
           target_8_A:
-            title: "Aumentar el apoyo a la iniciativa de ayuda para el comercio en los países en desarrollo, en particular los países menos adelantados, incluso mediante el Marco Integrado Mejorado para la Asistencia Técnica a los Países Menos Adelantados en Materia de Comercio."
+            long_title: "Aumentar el apoyo a la iniciativa de ayuda para el comercio en los países en desarrollo, en particular los países menos adelantados, incluso mediante el Marco Integrado Mejorado para la Asistencia Técnica a los Países Menos Adelantados en Materia de Comercio."
+            short_title: "Aumento ayuda para el comercio en países en desarrollo"
           target_8_B:
-            title: "De aquí a 2020, desarrollar y poner en marcha una estrategia mundial para el empleo de los jóvenes y aplicar el Pacto Mundial para el Empleo de la Organización Internacional del Trabajo."
+            long_title: "De aquí a 2020, desarrollar y poner en marcha una estrategia mundial para el empleo de los jóvenes y aplicar el Pacto Mundial para el Empleo de la Organización Internacional del Trabajo."
+            short_title: "Desarrollo de la estrategia mundial para empleo juvenil"
       goal_9:
         title: "Industria, Innovación e Infraestructuras"
         title_in_two_lines: "Industria, Innovación\ne Infraestructuras"
@@ -200,21 +272,29 @@ es:
         long_description: '<p>La industrialización inclusiva y sostenible, junto con la <a href="https://unstats.un.org/sdgs/report/2019/goal-09/">innovación y la infraestructura</a>, pueden dar rienda suelta a las fuerzas económicas dinámicas y competitivas que generan el empleo y los ingresos. Estas desempeñan un papel clave a la hora de introducir y promover nuevas tecnologías, facilitar el comercio internacional y permitir el uso eficiente de los recursos.</p> <p>Sin embargo, todavía queda un largo camino que recorrer para que el mundo pueda aprovechar al máximo este potencial. En especial, los países menos desarrollados necesitan acelerar el desarrollo de sus sectores manufactureros si desean conseguir la meta de 2030 y aumentar la inversión en investigación e innovación científicas.</p> <p>El crecimiento del sector manufacturero a nivel mundial ha ido disminuyendo constantemente, incluso antes del brote de la pandemia de la COVID-19. La pandemia está <a href="https://unctad.org/en/pages/newsdetails.aspx?OriginalVersionID=2297">afectando gravemente a las industrias manufactureras</a> y está provocando alteraciones en las cadenas de valor mundiales y en el suministro de productos.</p> <p>La innovación y el progreso tecnológico son claves para descubrir soluciones duraderas para los desafíos económicos y medioambientales, como el aumento de la eficiencia energética y de recursos. A nivel mundial, <a href="https://sustainabledevelopment.un.org/content/documents/26158Final_SG_SDG_Progress_Report_14052020.pdf">la inversión en investigación y desarrollo</a> (I+D), como porcentaje del PIB, aumentó de un 1,5&nbsp;% en el 2000 a un 1,7&nbsp;% en el 2015, y continuó casi en el mismo nivel en el 2017. Sin embargo, en las regiones en desarrollo fue inferior al 1&nbsp;%.</p> <p>En términos de infraestructura de comunicaciones, más de la mitad de la población mundial está ahora conectada y casi toda la población global vive en un área con cobertura de red móvil. Se estima que, en 2019, <a href="https://sustainabledevelopment.un.org/content/documents/26158Final_SG_SDG_Progress_Report_14052020.pdf">el 96,5&nbsp;% de la población tenía cobertura de red, como mínimo, 2G</a>.</p>'
         targets:
           target_9_1:
-            title: "Desarrollar infraestructuras fiables, sostenibles, resilientes y de calidad, incluidas infraestructuras regionales y transfronterizas, para apoyar el desarrollo económico y el bienestar humano, haciendo especial hincapié en el acceso asequible y equitativo para todos."
+            long_title: "Desarrollar infraestructuras fiables, sostenibles, resilientes y de calidad, incluidas infraestructuras regionales y transfronterizas, para apoyar el desarrollo económico y el bienestar humano, haciendo especial hincapié en el acceso asequible y equitativo para todos."
+            short_title: "Desarrollo de Infraestructura sostenible"
           target_9_2:
-            title: "Promover una industrialización inclusiva y sostenible y, de aquí a 2030, aumentar significativamente la contribución de la industria al empleo y al producto interno bruto, de acuerdo con las circunstancias nacionales, y duplicar esa contribución en los países menos adelantados."
+            long_title: "Promover una industrialización inclusiva y sostenible y, de aquí a 2030, aumentar significativamente la contribución de la industria al empleo y al producto interno bruto, de acuerdo con las circunstancias nacionales, y duplicar esa contribución en los países menos adelantados."
+            short_title: "Promoción de industria inclusiva y sostenible"
           target_9_3:
-            title: "Aumentar el acceso de las pequeñas industrias y otras empresas, particularmente en los países en desarrollo, a los servicios financieros, incluidos créditos asequibles, y su integración en las cadenas de valor y los mercados."
+            long_title: "Aumentar el acceso de las pequeñas industrias y otras empresas, particularmente en los países en desarrollo, a los servicios financieros, incluidos créditos asequibles, y su integración en las cadenas de valor y los mercados."
+            short_title: "Aumento del acceso PYMES a servicios financieros y cadenas de valor"
           target_9_4:
-            title: "De aquí a 2030, modernizar la infraestructura y reconvertir las industrias para que sean sostenibles, utilizando los recursos con mayor eficacia y promoviendo la adopción de tecnologías y procesos industriales limpios y ambientalmente racionales, y logrando que todos los países tomen medidas de acuerdo con sus capacidades respectivas."
+            long_title: "De aquí a 2030, modernizar la infraestructura y reconvertir las industrias para que sean sostenibles, utilizando los recursos con mayor eficacia y promoviendo la adopción de tecnologías y procesos industriales limpios y ambientalmente racionales, y logrando que todos los países tomen medidas de acuerdo con sus capacidades respectivas."
+            short_title: "Modernización de la infraestructura, tecnología limpia"
           target_9_5:
-            title: "Aumentar la investigación científica y mejorar la capacidad tecnológica de los sectores industriales de todos los países, en particular los países en desarrollo, entre otras cosas fomentando la innovación y aumentando considerablemente, de aquí a 2030, el número de personas que trabajan en investigación y desarrollo por millón de habitantes y los gastos de los sectores público y privado en investigación y desarrollo."
+            long_title: "Aumentar la investigación científica y mejorar la capacidad tecnológica de los sectores industriales de todos los países, en particular los países en desarrollo, entre otras cosas fomentando la innovación y aumentando considerablemente, de aquí a 2030, el número de personas que trabajan en investigación y desarrollo por millón de habitantes y los gastos de los sectores público y privado en investigación y desarrollo."
+            short_title: "Aumento de la investigación científica, capacidad tecnológica"
           target_9_A:
-            title: "Facilitar el desarrollo de infraestructuras sostenibles y resilientes en los países en desarrollo mediante un mayor apoyo financiero, tecnológico y técnico a los países africanos, los países menos adelantados, los países en desarrollo sin litoral y los pequeños Estados insulares en desarrollo."
+            long_title: "Facilitar el desarrollo de infraestructuras sostenibles y resilientes en los países en desarrollo mediante un mayor apoyo financiero, tecnológico y técnico a los países africanos, los países menos adelantados, los países en desarrollo sin litoral y los pequeños Estados insulares en desarrollo."
+            short_title: "Apoyo a infraestructuras sostenibles y resilientes"
           target_9_B:
-            title: "Apoyar el desarrollo de tecnologías, la investigación y la innovación nacionales en los países en desarrollo, incluso garantizando un entorno normativo propicio a la diversificación industrial y la adición de valor a los productos básicos, entre otras cosas."
+            long_title: "Apoyar el desarrollo de tecnologías, la investigación y la innovación nacionales en los países en desarrollo, incluso garantizando un entorno normativo propicio a la diversificación industrial y la adición de valor a los productos básicos, entre otras cosas."
+            short_title: "Desarrollo de la tecnología, investigación e innovación"
           target_9_C:
-            title: "Aumentar significativamente el acceso a la tecnología de la información y las comunicaciones y esforzarse por proporcionar acceso universal y asequible a Internet en los países menos adelantados de aquí a 2020."
+            long_title: "Aumentar significativamente el acceso a la tecnología de la información y las comunicaciones y esforzarse por proporcionar acceso universal y asequible a Internet en los países menos adelantados de aquí a 2020."
+            short_title: "Aumento del acceso a TIC e Internet"
       goal_10:
         title: "Reducción de las Desigualdades"
         title_in_two_lines: "Reducción de las\nDesigualdades"
@@ -222,25 +302,35 @@ es:
         long_description: '<p>Reducir las desigualdades y garantizar que nadie se queda atrás forma parte integral de la consecución de los Objetivos de Desarrollo Sostenible.</p> <p>La desigualdad dentro de los países y entre estos es un continuo motivo de preocupación. A pesar de la existencia de algunos indicios positivos hacia la reducción de la desigualdad en algunas dimensiones, como la reducción de la desigualdad de ingresos en algunos países y el estatus comercial preferente que beneficia a los países de bajos ingresos, <a href="https://unstats.un.org/sdgs/report/2019/goal-10/">la desigualdad aún continúa</a>.</p> <p><a href="https://www.un.org/sustainabledevelopment/goal-of-the-month-may-2020">La COVID-19 ha intensificado las desigualdades existentes</a> y ha afectado más que nadie a los pobres y las comunidades más vulnerables. Ha sacado a la luz las desigualdades económicas y las frágiles redes de seguridad social que hacen que las comunidades vulnerables tengan que sufrir las consecuencias de la crisis.&nbsp; Al mismo tiempo, las desigualdades sociales, políticas y económicas han amplificado los efectos de la pandemia.</p> <p>En el frente económico, la pandemia de la COVID-19 ha aumentado significativamente el <a href="https://www.ilo.org/global/about-the-ilo/newsroom/news/WCMS_743036/lang--en/index.htm">desempleo</a> mundial y ha recortado drásticamente los ingresos de los trabajadores.</p> <p>La COVID-19 también pone en riesgo los escasos avances que se han conseguido <a href="https://data.unwomen.org/resources/covid-19-emerging-gender-data-and-why-it-matters">en materia de igualdad de género</a> y derechos de las mujeres durante las últimas décadas. Prácticamente en todos los ámbitos, desde la salud hasta la economía, desde la seguridad hasta la protección social, los efectos de la COVID-19 han agravado la situación de las mujeres y las niñas simplemente como consecuencia de su sexo.</p> <p>Las desigualdades también están aumentando para las <a href="https://www.un.org/sites/un2.un.org/files/un_policy_brief_on_human_rights_and_covid_23_april_2020.pdf">poblaciones vulnerables</a> en países con sistemas sanitarios más deficientes y en países que se enfrentan a crisis humanitarias existentes. Los refugiados y los migrantes, así como los pueblos indígenas, los ancianos, las personas con discapacidad y los niños se encuentran especialmente en riesgo de ser excluidos. Además, el <a href="https://www.un.org/en/coronavirus/covid-19-un-counters-pandemic-related-hate-and-xenophobia">discurso de odio</a> dirigido a los grupos vulnerables está en aumento.</p>'
         targets:
           target_10_1:
-            title: "De aquí a 2030, lograr progresivamente y mantener el crecimiento de los ingresos del 40% más pobre de la población a una tasa superior a la media nacional."
+            long_title: "De aquí a 2030, lograr progresivamente y mantener el crecimiento de los ingresos del 40% más pobre de la población a una tasa superior a la media nacional."
+            short_title: "Crecimiento de Ingresos del 40% población pobre"
           target_10_2:
-            title: "De aquí a 2030, potenciar y promover la inclusión social, económica y política de todas las personas, independientemente de su edad, sexo, discapacidad, raza, etnia, origen, religión o situación económica u otra condición."
+            long_title: "De aquí a 2030, potenciar y promover la inclusión social, económica y política de todas las personas, independientemente de su edad, sexo, discapacidad, raza, etnia, origen, religión o situación económica u otra condición."
+            short_title: "Promoción de la Inclusión social, económica y política"
           target_10_3:
-            title: "Garantizar la igualdad de oportunidades y reducir la desigualdad de resultados, incluso eliminando las leyes, políticas y prácticas discriminatorias y promoviendo legislaciones, políticas y medidas adecuadas a ese respecto."
+            long_title: "Garantizar la igualdad de oportunidades y reducir la desigualdad de resultados, incluso eliminando las leyes, políticas y prácticas discriminatorias y promoviendo legislaciones, políticas y medidas adecuadas a ese respecto."
+            short_title: "Garantizar la igualdad de oportunidades"
           target_10_4:
-            title: "Adoptar políticas, especialmente fiscales, salariales y de protección social, y lograr progresivamente una mayor igualdad."
+            long_title: "Adoptar políticas, especialmente fiscales, salariales y de protección social, y lograr progresivamente una mayor igualdad."
+            short_title: "Adopción de políticas fiscales, salariales y de protección social"
           target_10_5:
-            title: "Mejorar la reglamentación y vigilancia de las instituciones y los mercados financieros mundiales y fortalecer la aplicación de esos reglamentos."
+            long_title: "Mejorar la reglamentación y vigilancia de las instituciones y los mercados financieros mundiales y fortalecer la aplicación de esos reglamentos."
+            short_title: "Mejorar de la regulación de los mercados financieros mundiales"
           target_10_6:
-            title: "Asegurar una mayor representación e intervención de los países en desarrollo en las decisiones adoptadas por las instituciones económicas y financieras internacionales para aumentar la eficacia, fiabilidad, rendición de cuentas y legitimidad de esas instituciones."
+            long_title: "Asegurar una mayor representación e intervención de los países en desarrollo en las decisiones adoptadas por las instituciones económicas y financieras internacionales para aumentar la eficacia, fiabilidad, rendición de cuentas y legitimidad de esas instituciones."
+            short_title: "Participación de países en desarrollo en IFIs y OOII"
           target_10_7:
-            title: "Facilitar la migración y la movilidad ordenadas, seguras, regulares y responsables de las personas, incluso mediante la aplicación de políticas migratorias planificadas y bien gestionadas."
+            long_title: "Facilitar la migración y la movilidad ordenadas, seguras, regulares y responsables de las personas, incluso mediante la aplicación de políticas migratorias planificadas y bien gestionadas."
+            short_title: "Facilitar la migración y políticas migratorias ordenadas"
           target_10_A:
-            title: "Aplicar el principio del trato especial y diferenciado para los países en desarrollo, en particular los países menos adelantados, de conformidad con los acuerdos de la Organización Mundial del Comercio."
+            long_title: "Aplicar el principio del trato especial y diferenciado para los países en desarrollo, en particular los países menos adelantados, de conformidad con los acuerdos de la Organización Mundial del Comercio."
+            short_title: "Aplicación del principio del trato especial y diferenciado (OMC)"
           target_10_B:
-            title: "Fomentar la asistencia oficial para el desarrollo y las corrientes financieras, incluida la inversión extranjera directa, para los Estados con mayores necesidades, en particular los países menos adelantados, los países africanos, los pequeños Estados insulares en desarrollo y los países en desarrollo sin litoral, en consonancia con sus planes y programas nacionales."
+            long_title: "Fomentar la asistencia oficial para el desarrollo y las corrientes financieras, incluida la inversión extranjera directa, para los Estados con mayores necesidades, en particular los países menos adelantados, los países africanos, los pequeños Estados insulares en desarrollo y los países en desarrollo sin litoral, en consonancia con sus planes y programas nacionales."
+            short_title: "Fomento de corrientes financieras para países en desarrollo"
           target_10_C:
-            title: "De aquí a 2030, reducir a menos del 3% los costos de transacción de las remesas de los migrantes y eliminar los corredores de remesas con un costo superior al 5%."
+            long_title: "De aquí a 2030, reducir a menos del 3% los costos de transacción de las remesas de los migrantes y eliminar los corredores de remesas con un costo superior al 5%."
+            short_title: "Reducción de costes de Remesas"
       goal_11:
         title: "Ciudades y Comunidades Sostenibles"
         title_in_two_lines: "Ciudades y Comunidades\nSostenibles"
@@ -248,25 +338,35 @@ es:
         long_description: '<p>El mundo cada vez está más urbanizado. Desde 2007, <a href="https://unstats.un.org/sdgs/report/2019/goal-11/">más de la mitad de la población mundial ha estado viviendo en ciudades</a>, y se espera que dicha cantidad aumente hasta el 60&nbsp;% para 2030.</p> <p>Las ciudades y las áreas metropolitanas son centros neurálgicos del crecimiento económico, ya que contribuyen al 60&nbsp;% aproximadamente del PIB mundial. Sin embargo, también representan alrededor del 70&nbsp;% de las emisiones de carbono mundiales y más del 60&nbsp;% del uso de recursos.</p> <p>La rápida urbanización está dando como resultado un número creciente de habitantes en barrios pobres, infraestructuras y servicios inadecuados y sobrecargados (como la recogida de residuos y los sistemas de agua y saneamiento, carreteras y transporte), lo cual está empeorando la contaminación del aire y el crecimiento urbano incontrolado.</p> <p><a href="https://unhabitat.org/coronavirus-will-travel-incredibly-fast-in-africas-slums-un-habitat-chief-warns">El impacto de la COVID-19</a> será más devastador en las zonas urbanas pobres y densamente pobladas, especialmente para el mil millón de personas que vive en asentamientos informales y en barrios marginales en todo el mundo, donde el hacinamiento también dificulta cumplir con las medidas recomendadas, como el distanciamiento social y el autoaislamiento.</p> <p>El organismo de las Naciones Unidas para los alimentos, la FAO, advirtió de que el hambre y las muertes podrían aumentar de manera significativa en las zonas urbanas que no cuentan con medidas para garantizar que los residentes pobres y vulnerables tengan <a href="https://news.un.org/en/story/2020/05/1063622">acceso a alimentos</a>.</p>'
         targets:
           target_11_1:
-            title: "De aquí a 2030, asegurar el acceso de todas las personas a viviendas y servicios básicos adecuados, seguros y asequibles y mejorar los barrios marginales."
+            long_title: "De aquí a 2030, asegurar el acceso de todas las personas a viviendas y servicios básicos adecuados, seguros y asequibles y mejorar los barrios marginales."
+            short_title: "Asegurar el acceso a la vivienda"
           target_11_2:
-            title: "De aquí a 2030, proporcionar acceso a sistemas de transporte seguros, asequibles, accesibles y sostenibles para todos y mejorar la seguridad vial, en particular mediante la ampliación del transporte público, prestando especial atención a las necesidades de las personas en situación de vulnerabilidad, las mujeres, los niños, las personas con discapacidad y las personas de edad."
+            long_title: "De aquí a 2030, proporcionar acceso a sistemas de transporte seguros, asequibles, accesibles y sostenibles para todos y mejorar la seguridad vial, en particular mediante la ampliación del transporte público, prestando especial atención a las necesidades de las personas en situación de vulnerabilidad, las mujeres, los niños, las personas con discapacidad y las personas de edad."
+            short_title: "Proporcionar el acceso a transporte público"
           target_11_3:
-            title: "De aquí a 2030, aumentar la urbanización inclusiva y sostenible y la capacidad para la planificación y la gestión participativas, integradas y sostenibles de los asentamientos humanos en todos los países."
+            long_title: "De aquí a 2030, aumentar la urbanización inclusiva y sostenible y la capacidad para la planificación y la gestión participativas, integradas y sostenibles de los asentamientos humanos en todos los países."
+            short_title: "Aumento de la urbanización inclusiva y sostenible"
           target_11_4:
-            title: "Redoblar los esfuerzos para proteger y salvaguardar el patrimonio cultural y natural del mundo."
+            long_title: "Redoblar los esfuerzos para proteger y salvaguardar el patrimonio cultural y natural del mundo."
+            short_title: "Protección del patrimonio cultural y natural"
           target_11_5:
-            title: "De aquí a 2030, reducir significativamente el número de muertes causadas por los desastres, incluidos los relacionados con el agua, y de personas afectadas por ellos, y reducir considerablemente las pérdidas económicas directas provocadas por los desastres en comparación con el producto interno bruto mundial, haciendo especial hincapié en la protección de los pobres y las personas en situaciones de vulnerabilidad."
+            long_title: "De aquí a 2030, reducir significativamente el número de muertes causadas por los desastres, incluidos los relacionados con el agua, y de personas afectadas por ellos, y reducir considerablemente las pérdidas económicas directas provocadas por los desastres en comparación con el producto interno bruto mundial, haciendo especial hincapié en la protección de los pobres y las personas en situaciones de vulnerabilidad."
+            short_title: "Reducción del número de muertes por desastres y reducción de vulnerabilidad"
           target_11_6:
-            title: "De aquí a 2030, reducir el impacto ambiental negativo per capita de las ciudades, incluso prestando especial atención a la calidad del aire y la gestión de los desechos municipales y de otro tipo."
+            long_title: "De aquí a 2030, reducir el impacto ambiental negativo per capita de las ciudades, incluso prestando especial atención a la calidad del aire y la gestión de los desechos municipales y de otro tipo."
+            short_title: "Reducción del impacto ambiental en ciudades"
           target_11_7:
-            title: "De aquí a 2030, proporcionar acceso universal a zonas verdes y espacios públicos seguros, inclusivos y accesibles, en particular para las mujeres y los niños, las personas de edad y las personas con discapacidad."
+            long_title: "De aquí a 2030, proporcionar acceso universal a zonas verdes y espacios públicos seguros, inclusivos y accesibles, en particular para las mujeres y los niños, las personas de edad y las personas con discapacidad."
+            short_title: "Proporcionar el acceso a zonas verdes y espacios públicos seguros"
           target_11_A:
-            title: "Apoyar los vínculos económicos, sociales y ambientales positivos entre las zonas urbanas, periurbanas y rurales fortaleciendo la planificación del desarrollo nacional y regional."
+            long_title: "Apoyar los vínculos económicos, sociales y ambientales positivos entre las zonas urbanas, periurbanas y rurales fortaleciendo la planificación del desarrollo nacional y regional."
+            short_title: "Apoyo a vínculos zonas urbanas, periurbanas y rurales"
           target_11_B:
-            title: "De aquí a 2020, aumentar considerablemente el número de ciudades y asentamientos humanos que adoptan e implementan políticas y planes integrados para promover la inclusión, el uso eficiente de los recursos, la mitigación del cambio climático y la adaptación a él y la resiliencia ante los desastres, y desarrollar y poner en práctica, en consonancia con el Marco de Sendai para la Reducción del Riesgo de Desastres 2015-2030, la gestión integral de los riesgos de desastre a todos los niveles."
+            long_title: "De aquí a 2020, aumentar considerablemente el número de ciudades y asentamientos humanos que adoptan e implementan políticas y planes integrados para promover la inclusión, el uso eficiente de los recursos, la mitigación del cambio climático y la adaptación a él y la resiliencia ante los desastres, y desarrollar y poner en práctica, en consonancia con el Marco de Sendai para la Reducción del Riesgo de Desastres 2015-2030, la gestión integral de los riesgos de desastre a todos los niveles."
+            short_title: "Aumento de la reducción de riesgos de desastres en ciudades"
           target_11_C:
-            title: "Proporcionar apoyo a los países menos adelantados, incluso mediante asistencia financiera y técnica, para que puedan construir edificios sostenibles y resilientes utilizando materiales locales."
+            long_title: "Proporcionar apoyo a los países menos adelantados, incluso mediante asistencia financiera y técnica, para que puedan construir edificios sostenibles y resilientes utilizando materiales locales."
+            short_title: "Apoyo a la construcción de edificios sostenibles y resilientes en PMAs"
       goal_12:
         title: "Producción y Consumo Responsables"
         title_in_two_lines: "Producción y Consumo\nResponsables"
@@ -274,27 +374,38 @@ es:
         long_description: '<p>El consumo y la producción mundiales (fuerzas impulsoras de la economía mundial) dependen del uso del medio ambiente natural y de los recursos de una manera que continúa teniendo efectos destructivos sobre el planeta.</p> <p>El progreso económico y social conseguido durante el último siglo ha estado acompañado de una degradación medioambiental que está poniendo en peligro los mismos sistemas de los que depende nuestro desarrollo futuro (y ciertamente, nuestra supervivencia).</p> <p>Estos son algunos <a href="https://www.unenvironment.org/explore-topics/sustainable-development-goals/why-do-sustainable-development-goals-matter/goal-12">hechos y cifras</a>:</p> <ul> <li>Cada año, se estima que un tercio de toda la comida producida (el equivalente a 1300&nbsp;millones de toneladas con un valor cercano al billón de dólares) acaba pudriéndose en los cubos de basura de los consumidores y minoristas, o estropeándose debido a un transporte y unas prácticas de recolección deficientes.</li> <li>Si todo el mundo cambiase sus bombillas por unas energéticamente eficientes, se ahorrarían 120&nbsp;000&nbsp;millones de dólares estadounidenses al año.</li> <li>En caso de que la población mundial alcance los 9600&nbsp;millones de personas en 2050, se podría necesitar el equivalente a casi tres planetas para proporcionar los recursos naturales necesarios para mantener los estilos de vida actuales.</li> </ul> <p>La pandemia de la COVID-19 ofrece a los países la oportunidad de elaborar planes de recuperación que reviertan las tendencias actuales y cambien nuestros patrones de consumo y producción hacia un futuro más sostenible.</p> <p><a href="https://www.unenvironment.org/explore-topics/resource-efficiency/what-we-do/sustainable-consumption-and-production-policies">El consumo y la producción sostenibles </a>consisten en hacer más y mejor con menos. También se trata de desvincular el crecimiento económico de la degradación medioambiental, aumentar la eficiencia de recursos y promover estilos de vida sostenibles.</p> <p>El consumo y la producción sostenibles también pueden contribuir de manera sustancial a la mitigación de la pobreza y a la transición hacia economías verdes y con bajas emisiones de carbono.</p>'
         targets:
           target_12_1:
-            title: "Aplicar el Marco Decenal de Programas sobre Modalidades de Consumo y Producción Sostenibles, con la participación de todos los países y bajo el liderazgo de los países desarrollados, teniendo en cuenta el grado de desarrollo y las capacidades de los países en desarrollo."
+            long_title: "Aplicar el Marco Decenal de Programas sobre Modalidades de Consumo y Producción Sostenibles, con la participación de todos los países y bajo el liderazgo de los países desarrollados, teniendo en cuenta el grado de desarrollo y las capacidades de los países en desarrollo."
+            short_title: "Aplicación marco de consumo y producción sostenibles"
           target_12_2:
-            title: "De aquí a 2030, lograr la gestión sostenible y el uso eficiente de los recursos naturales."
+            long_title: "De aquí a 2030, lograr la gestión sostenible y el uso eficiente de los recursos naturales."
+            short_title: "Lograr el uso eficiente de recursos naturales"
           target_12_3:
-            title: "De aquí a 2030, reducir a la mitad el desperdicio de alimentos per capita mundial en la venta al por menor y a nivel de los consumidores y reducir las pérdidas de alimentos en las cadenas de producción y suministro, incluidas las pérdidas posteriores a la cosecha."
+            long_title: "De aquí a 2030, reducir a la mitad el desperdicio de alimentos per capita mundial en la venta al por menor y a nivel de los consumidores y reducir las pérdidas de alimentos en las cadenas de producción y suministro, incluidas las pérdidas posteriores a la cosecha."
+            short_title: "Reducción del desperdicio de alimentos"
           target_12_4:
-            title: "De aquí a 2020, lograr la gestión ecológicamente racional de los productos químicos y de todos los desechos a lo largo de su ciclo de vida, de conformidad con los marcos internacionales convenidos, y reducir significativamente su liberación a la atmósfera, el agua y el suelo a fin de minimizar sus efectos adversos en la salud humana y el medio ambiente."
+            long_title: "De aquí a 2020, lograr la gestión ecológicamente racional de los productos químicos y de todos los desechos a lo largo de su ciclo de vida, de conformidad con los marcos internacionales convenidos, y reducir significativamente su liberación a la atmósfera, el agua y el suelo a fin de minimizar sus efectos adversos en la salud humana y el medio ambiente."
+            short_title: "Gestión de desechos y productos químicos"
           target_12_5:
-            title: "De aquí a 2030, reducir considerablemente la generación de desechos mediante actividades de prevención, reducción, reciclado y reutilización."
+            long_title: "De aquí a 2030, reducir considerablemente la generación de desechos mediante actividades de prevención, reducción, reciclado y reutilización."
+            short_title: "Prevención, reducción, reciclado y reutilización de desechos"
           target_12_6:
-            title: "Alentar a las empresas, en especial las grandes empresas y las empresas transnacionales, a que adopten prácticas sostenibles e incorporen información sobre la sostenibilidad en su ciclo de presentación de informes."
+            long_title: "Alentar a las empresas, en especial las grandes empresas y las empresas transnacionales, a que adopten prácticas sostenibles e incorporen información sobre la sostenibilidad en su ciclo de presentación de informes."
+            short_title: "Adopción de prácticas sostenibles en empresas"
           target_12_7:
-            title: "Promover prácticas de adquisición pública que sean sostenibles, de conformidad con las políticas y prioridades nacionales."
+            long_title: "Promover prácticas de adquisición pública que sean sostenibles, de conformidad con las políticas y prioridades nacionales."
+            short_title: "Adquisiciones públicas sostenibles"
           target_12_8:
-            title: "De aquí a 2030, asegurar que las personas de todo el mundo tengan la información y los conocimientos pertinentes para el desarrollo sostenible y los estilos de vida en armonía con la naturaleza."
+            long_title: "De aquí a 2030, asegurar que las personas de todo el mundo tengan la información y los conocimientos pertinentes para el desarrollo sostenible y los estilos de vida en armonía con la naturaleza."
+            short_title: "Asegurar la educación para el Desarrollo Sostenible"
           target_12_A:
-            title: "Ayudar a los países en desarrollo a fortalecer su capacidad científica y tecnológica para avanzar hacia modalidades de consumo y producción más sostenibles."
+            long_title: "Ayudar a los países en desarrollo a fortalecer su capacidad científica y tecnológica para avanzar hacia modalidades de consumo y producción más sostenibles."
+            short_title: "Fortalecimiento de ciencia y tecnología para sostenibilidad"
           target_12_B:
-            title: "Elaborar y aplicar instrumentos para vigilar los efectos en el desarrollo sostenible, a fin de lograr un turismo sostenible que cree puestos de trabajo y promueva la cultura y los productos locales."
+            long_title: "Elaborar y aplicar instrumentos para vigilar los efectos en el desarrollo sostenible, a fin de lograr un turismo sostenible que cree puestos de trabajo y promueva la cultura y los productos locales."
+            short_title: "Lograr turismo sostenible"
           target_12_C:
-            title: "Racionalizar los subsidios ineficientes a los combustibles fósiles que fomentan el consumo antieconómico eliminando las distorsiones del mercado, de acuerdo con las circunstancias nacionales, incluso mediante la reestructuración de los sistemas tributarios y la eliminación gradual de los subsidios perjudiciales, cuando existan, para reflejar su impacto ambiental, teniendo plenamente en cuenta las necesidades y condiciones específicas de los países en desarrollo y minimizando los posibles efectos adversos en su desarrollo, de manera que se proteja a los pobres y a las comunidades afectadas."
+            long_title: "Racionalizar los subsidios ineficientes a los combustibles fósiles que fomentan el consumo antieconómico eliminando las distorsiones del mercado, de acuerdo con las circunstancias nacionales, incluso mediante la reestructuración de los sistemas tributarios y la eliminación gradual de los subsidios perjudiciales, cuando existan, para reflejar su impacto ambiental, teniendo plenamente en cuenta las necesidades y condiciones específicas de los países en desarrollo y minimizando los posibles efectos adversos en su desarrollo, de manera que se proteja a los pobres y a las comunidades afectadas."
+            short_title: "Regulación de subsidios a combustibles fósiles"
       goal_13:
         title: "Acción Por el Clima"
         title_in_two_lines: "Acción\nPor el Clima"
@@ -302,15 +413,20 @@ es:
         long_description: '<p>El 2019 fue el <a href="https://news.un.org/en/story/2020/03/1059061">segundo año más caluroso de todos los tiempos</a> y marcó el final de la década más calurosa (2010-2019) que se haya registrado jamás.</p> <p>Los niveles de dióxido de carbono (CO2) y de otros <a href="https://news.un.org/en/story/2020/04/1062332">gases de efecto invernadero en la atmósfera</a> aumentaron hasta niveles récord en 2019.</p> <p>El cambio climático está afectando a todos los países de todos los continentes. Está alterando las economías nacionales y afectando a distintas vidas. Los sistemas meteorológicos están cambiando, los niveles del mar están subiendo y los fenómenos meteorológicos son cada vez más extremos.</p> <p>A pesar de que se estima que las emisiones de gases de efecto invernadero caigan alrededor de un 6&nbsp;% en 2020 debido a las restricciones de movimiento y las recesiones económicas derivadas de la pandemia de la COVID-19, esta mejora es solo temporal. <a href="https://news.un.org/en/story/2020/04/1062332">El cambio climático no se va a pausar</a>. Una vez que la economía mundial comience a recuperarse de la pandemia, se espera que las emisiones vuelvan a niveles mayores.</p> <p>Es necesario tomar medidas urgentes para abordar tanto la pandemia como la emergencia climática con el fin de salvar vidas y medios de subsistencia.</p> <p>El <a href="https://unfccc.int/process-and-meetings/the-paris-agreement/the-paris-agreement">Acuerdo de París</a>, aprobado en 2015, aspira a reforzar la respuesta mundial a la amenaza del cambio climático manteniendo el aumento global de la temperatura durante este siglo muy por debajo de 2&nbsp;grados Celsius con respecto a los niveles preindustriales. El acuerdo también aspira a reforzar la capacidad de los países para lidiar con los efectos del cambio climático mediante flujos financieros apropiados, un nuevo marco tecnológico y un marco de desarrollo de la capacidad mejorado.</p>'
         targets:
           target_13_1:
-            title: "Fortalecer la resiliencia y la capacidad de adaptación a los riesgos relacionados con el clima y los desastres naturales en todos los países."
+            long_title: "Fortalecer la resiliencia y la capacidad de adaptación a los riesgos relacionados con el clima y los desastres naturales en todos los países."
+            short_title: "Fortalecimiento de la resiliencia y adaptación"
           target_13_2:
-            title: "Incorporar medidas relativas al cambio climático en las políticas, estrategias y planes nacionales."
+            long_title: "Incorporar medidas relativas al cambio climático en las políticas, estrategias y planes nacionales."
+            short_title: "Incorporación del cambio climático en políticas, estrategias y planes nacionales"
           target_13_3:
-            title: "Mejorar la educación, la sensibilización y la capacidad humana e institucional respecto de la mitigación del cambio climático, la adaptación a él, la reducción de sus efectos y la alerta temprana."
+            long_title: "Mejorar la educación, la sensibilización y la capacidad humana e institucional respecto de la mitigación del cambio climático, la adaptación a él, la reducción de sus efectos y la alerta temprana."
+            short_title: "Mejora de la Educación y sensibilización medioambiental"
           target_13_A:
-            title: "Cumplir el compromiso de los países desarrollados que son partes en la Convención Marco de las Naciones Unidas sobre el Cambio Climático de lograr para el año 2020 el objetivo de movilizar conjuntamente 100.000 millones de dólares anuales procedentes de todas las fuentes a fin de atender las necesidades de los países en desarrollo respecto de la adopción de medidas concretas de mitigación y la transparencia de su aplicación, y poner en pleno funcionamiento el Fondo Verde para el Clima capitalizándolo lo antes posible."
+            long_title: "Cumplir el compromiso de los países desarrollados que son partes en la Convención Marco de las Naciones Unidas sobre el Cambio Climático de lograr para el año 2020 el objetivo de movilizar conjuntamente 100.000 millones de dólares anuales procedentes de todas las fuentes a fin de atender las necesidades de los países en desarrollo respecto de la adopción de medidas concretas de mitigación y la transparencia de su aplicación, y poner en pleno funcionamiento el Fondo Verde para el Clima capitalizándolo lo antes posible."
+            short_title: "Movilización de recursos económicos"
           target_13_B:
-            title: "Promover mecanismos para aumentar la capacidad para la planificación y gestión eficaces en relación con el cambio climático en los países menos adelantados y los pequeños Estados insulares en desarrollo, haciendo particular hincapié en las mujeres, los jóvenes y las comunidades locales y marginadas."
+            long_title: "Promover mecanismos para aumentar la capacidad para la planificación y gestión eficaces en relación con el cambio climático en los países menos adelantados y los pequeños Estados insulares en desarrollo, haciendo particular hincapié en las mujeres, los jóvenes y las comunidades locales y marginadas."
+            short_title: "Gestión cambio climático en los países menos avanzados"
       goal_14:
         title: "Vida Submarina"
         title_in_two_lines: "Vida\nSubmarina"
@@ -318,25 +434,35 @@ es:
         long_description: '<p>El océano impulsa los sistemas mundiales que hacen de la Tierra un lugar habitable para el ser humano. Nuestra lluvia, el agua potable, el tiempo, el clima, los litorales, gran parte de nuestra comida e incluso el oxígeno del aire que respiramos los proporciona y regula el mar.</p> <p>Una gestión cuidadosa de este <a href="https://www.unenvironment.org/explore-topics/oceans-seas/why-do-oceans-and-seas-matter">recurso mundial esencial</a> es una característica clave de un futuro sostenible. No obstante, en la actualidad, existe un deterioro continuo de las aguas costeras debido a la contaminación y a la acidificación de los océanos que está teniendo un efecto adverso sobre el funcionamiento de los ecosistemas y la biodiversidad. Asimismo, también está teniendo un impacto perjudicial sobre las pesquerías de pequeña escala.</p> <p>Proteger nuestros océanos debe seguir siendo una prioridad. La biodiversidad marina es vital para la salud de las personas y de nuestro planeta. Las áreas marinas protegidas se deben gestionar de manera efectiva, al igual que sus recursos, y se deben poner en marcha reglamentos que reduzcan la sobrepesca, la contaminación marina y la acidificación de los océanos.</p>'
         targets:
           target_14_1:
-            title: "De aquí a 2025, prevenir y reducir significativamente la contaminación marina de todo tipo, en particular la producida por actividades realizadas en tierra, incluidos los detritos marinos y la polución por nutrientes."
+            long_title: "De aquí a 2025, prevenir y reducir significativamente la contaminación marina de todo tipo, en particular la producida por actividades realizadas en tierra, incluidos los detritos marinos y la polución por nutrientes."
+            short_title: "Prevención y reducción de la contaminación marina"
           target_14_2:
-            title: "De aquí a 2020, gestionar y proteger sosteniblemente los ecosistemas marinos y costeros para evitar efectos adversos importantes, incluso fortaleciendo su resiliencia, y adoptar medidas para restaurarlos a fin de restablecer la salud y la productividad de los océanos."
+            long_title: "De aquí a 2020, gestionar y proteger sosteniblemente los ecosistemas marinos y costeros para evitar efectos adversos importantes, incluso fortaleciendo su resiliencia, y adoptar medidas para restaurarlos a fin de restablecer la salud y la productividad de los océanos."
+            short_title: "Gestión ecosistemas marinos y costeros"
           target_14_3:
-            title: "Minimizar y abordar los efectos de la acidificación de los océanos, incluso mediante una mayor cooperación científica a todos los niveles."
+            long_title: "Minimizar y abordar los efectos de la acidificación de los océanos, incluso mediante una mayor cooperación científica a todos los niveles."
+            short_title: "Minimización de la acidificación de océanos"
           target_14_4:
-            title: "De aquí a 2020, reglamentar eficazmente la explotación pesquera y poner fin a la pesca excesiva, la pesca ilegal, no declarada y no reglamentada y las prácticas pesqueras destructivas, y aplicar planes de gestión con fundamento científico a fin de restablecer las poblaciones de peces en el plazo más breve posible, al menos alcanzando niveles que puedan producir el máximo rendimiento sostenible de acuerdo con sus características biológicas."
+            long_title: "De aquí a 2020, reglamentar eficazmente la explotación pesquera y poner fin a la pesca excesiva, la pesca ilegal, no declarada y no reglamentada y las prácticas pesqueras destructivas, y aplicar planes de gestión con fundamento científico a fin de restablecer las poblaciones de peces en el plazo más breve posible, al menos alcanzando niveles que puedan producir el máximo rendimiento sostenible de acuerdo con sus características biológicas."
+            short_title: "Regulación de la explotación pesquera sostenible"
           target_14_5:
-            title: "De aquí a 2020, conservar al menos el 10% de las zonas costeras y marinas, de conformidad con las leyes nacionales y el derecho internacional y sobre la base de la mejor información científica disponible."
+            long_title: "De aquí a 2020, conservar al menos el 10% de las zonas costeras y marinas, de conformidad con las leyes nacionales y el derecho internacional y sobre la base de la mejor información científica disponible."
+            short_title: "Conservación zonas costeras y marinas"
           target_14_6:
-            title: "De aquí a 2020, prohibir ciertas formas de subvenciones a la pesca que contribuyen a la sobrecapacidad y la pesca excesiva, eliminar las subvenciones que contribuyen a la pesca ilegal, no declarada y no reglamentada y abstenerse de introducir nuevas subvenciones de esa índole, reconociendo que la negociación sobre las subvenciones a la pesca en el marco de la Organización Mundial del Comercio debe incluir un trato especial y diferenciado, apropiado y efectivo para los países en desarrollo y los países menos adelantados ¹ (¹ Teniendo en cuenta las negociaciones en curso de la Organización Mundial del Comercio, el Programa de Doha para el Desarrollo y el mandato de la Declaración Ministerial de Hong Kong)."
+            long_title: "De aquí a 2020, prohibir ciertas formas de subvenciones a la pesca que contribuyen a la sobrecapacidad y la pesca excesiva, eliminar las subvenciones que contribuyen a la pesca ilegal, no declarada y no reglamentada y abstenerse de introducir nuevas subvenciones de esa índole, reconociendo que la negociación sobre las subvenciones a la pesca en el marco de la Organización Mundial del Comercio debe incluir un trato especial y diferenciado, apropiado y efectivo para los países en desarrollo y los países menos adelantados ¹ (¹ Teniendo en cuenta las negociaciones en curso de la Organización Mundial del Comercio, el Programa de Doha para el Desarrollo y el mandato de la Declaración Ministerial de Hong Kong)."
+            short_title: "Combatir la pesca ilegal y excesiva"
           target_14_7:
-            title: "De aquí a 2030, aumentar los beneficios económicos que los pequeños Estados insulares en desarrollo y los países menos adelantados obtienen del uso sostenible de los recursos marinos, en particular mediante la gestión sostenible de la pesca, la acuicultura y el turismo."
+            long_title: "De aquí a 2030, aumentar los beneficios económicos que los pequeños Estados insulares en desarrollo y los países menos adelantados obtienen del uso sostenible de los recursos marinos, en particular mediante la gestión sostenible de la pesca, la acuicultura y el turismo."
+            short_title: "Aumento de los beneficios económicos de la pesca sostenible"
           target_14_A:
-            title: "Aumentar los conocimientos científicos, desarrollar la capacidad de investigación y transferir tecnología marina, teniendo en cuenta los Criterios y Directrices para la Transferencia de Tecnología Marina de la Comisión Oceanográfica Intergubernamental, a fin de mejorar la salud de los océanos y potenciar la contribución de la biodiversidad marina al desarrollo de los países en desarrollo, en particular los pequeños Estados insulares en desarrollo y los países menos adelantados."
+            long_title: "Aumentar los conocimientos científicos, desarrollar la capacidad de investigación y transferir tecnología marina, teniendo en cuenta los Criterios y Directrices para la Transferencia de Tecnología Marina de la Comisión Oceanográfica Intergubernamental, a fin de mejorar la salud de los océanos y potenciar la contribución de la biodiversidad marina al desarrollo de los países en desarrollo, en particular los pequeños Estados insulares en desarrollo y los países menos adelantados."
+            short_title: "Apoyo a la investigación y tecnología marina"
           target_14_B:
-            title: "Facilitar el acceso de los pescadores artesanales a los recursos marinos y los mercados."
+            long_title: "Facilitar el acceso de los pescadores artesanales a los recursos marinos y los mercados."
+            short_title: "Fomento de la pesca a pequeña escala y artesanal"
           target_14_C:
-            title: "Mejorar la conservación y el uso sostenible de los océanos y sus recursos aplicando el derecho internacional reflejado en la Convención de las Naciones Unidas sobre el Derecho del Mar, que constituye el marco jurídico para la conservación y la utilización sostenible de los océanos y sus recursos, como se recuerda en el párrafo 158 del documento “El futuro que queremos”."
+            long_title: "Mejorar la conservación y el uso sostenible de los océanos y sus recursos aplicando el derecho internacional reflejado en la Convención de las Naciones Unidas sobre el Derecho del Mar, que constituye el marco jurídico para la conservación y la utilización sostenible de los océanos y sus recursos, como se recuerda en el párrafo 158 del documento “El futuro que queremos”."
+            short_title: "Aplicación Convención de NNUU sobre el Derecho del Mar"
       goal_15:
         title: "Vida de Ecosistemas Terrestres"
         title_in_two_lines: "Vida de Ecosistemas\nTerrestres"
@@ -344,29 +470,41 @@ es:
         long_description: '<p>El brote de la COVID-19 resalta la necesidad de <a href="https://www.unenvironment.org/news-and-stories/story/coronavirus-outbreak-highlights-need-address-threats-ecosystems-and-wildlife">abordar las amenazas a las que se enfrentan las especies silvestres y los ecosistemas</a>.</p> <p>En 2016, el Programa de las Naciones Unidas para el Medio Ambiente (PNUMA) alertó de que un aumento mundial de las <a href="https://www.unenvironment.org/resources/emerging-zoonotic-diseases-and-links-ecosystem-health-unep-frontiers-2016-chapter">epidemias zoonóticas</a> era motivo de preocupación. En concreto, señaló que el 75&nbsp;% de todas las enfermedades infecciosas nuevas en humanos son zoonóticas y que dichas enfermedades están estrechamente relacionadas con la salud de los ecosistemas.</p> <p>«Con la COVID-19, el planeta ha enviado su mayor alerta hasta la fecha indicando que la humanidad debe cambiar», <a href="https://www.unenvironment.org/news-and-stories/press-release/unep-steps-work-zoonotics-protecting-environment-reduce-pandemic">ha explicado la Directora Ejecutiva del PNUMA, Inger Andersen</a>.</p> <p>En <a href="https://wedocs.unep.org/bitstream/handle/20.500.11822/32218/UNEP_COVID.pdf?sequence=1&amp;isAllowed=y"><em>Trabajar con el medio ambiente para proteger a las personas</em></a>, el PNUMA detalla cómo «reconstruir mejor», mediante una base científica más sólida, políticas que contribuyan a un planeta más sano y más inversiones verdes.</p> <p>La respuesta del PNUMA se ocupa de cuatro áreas:</p> <ol> <li>Ayudar a las naciones a gestionar los desechos médicos de la COVID-19.</li> <li>Producir un cambio transformativo para la naturaleza y las personas.</li> <li>Trabajar para garantizar que los paquetes de recuperación económica creen resiliencia para crisis futuras.</li> <li>Modernizar la gobernanza ambiental a nivel mundial.</li> </ol> <p>Para prevenir, detener y revertir la degradación de los ecosistemas de todo el mundo, las Naciones Unidas han declarado la <a href="http://www.decadeonrestoration.org/">Década para la Restauración de los Ecosistemas (2021-2030)</a>. Esta respuesta coordinada a nivel mundial ante la pérdida y degradación de los hábitats se centrará en desarrollar la voluntad y la capacidad políticas para restaurar la relación de los seres humanos con la naturaleza. Asimismo, se trata de una respuesta directa al aviso de la ciencia, tal y como se expresa en el <a href="https://www.ipcc.ch/srccl/">Informe especial sobre cambio climático y tierra</a> del Grupo Intergubernamental de Expertos sobre el Cambio Climático, a las decisiones adoptadas por todos los Estados Miembros de las Naciones Unidas en las convenciones de Río sobre <a href="https://unfccc.int/resource/docs/convkp/conveng.pdf">cambio climático</a> y <a href="https://www.cbd.int/">biodiversidad</a> y a la <a href="https://www.unccd.int/sites/default/files/relevant-links/2017-01/English_0.pdf">Convención de las Naciones Unidas para la Lucha contra la Desertificación</a>.</p> <p>Se sigue trabajando en un nuevo y ambicioso <a href="https://www.cbd.int/conferences/post2020">Marco mundial de diversidad biológica posterior a 2020</a>.</p> <p>Mientras el mundo responde a la actual pandemia y se recupera de ella, necesitará un plan sólido destinado a la protección de la naturaleza, de manera que la naturaleza pueda proteger a la humanidad.</p>'
         targets:
           target_15_1:
-            title: "Para 2020, velar por la conservación, el restablecimiento y el uso sostenible de los ecosistemas terrestres y los ecosistemas interiores de agua dulce y los servicios que proporcionan, en particular los bosques, los humedales, las montañas y las zonas áridas, en consonancia con las obligaciones contraídas en virtud de acuerdos internacionales."
+            long_title: "Para 2020, velar por la conservación, el restablecimiento y el uso sostenible de los ecosistemas terrestres y los ecosistemas interiores de agua dulce y los servicios que proporcionan, en particular los bosques, los humedales, las montañas y las zonas áridas, en consonancia con las obligaciones contraídas en virtud de acuerdos internacionales."
+            short_title: "Asegurar la Conservación y uso sostenibles de los ecosistemas"
           target_15_2:
-            title: "Para 2020, promover la gestión sostenible de todos los tipos de bosques, poner fin a la deforestación, recuperar los bosques degradados e incrementar la forestación y la reforestación a nivel mundial."
+            long_title: "Para 2020, promover la gestión sostenible de todos los tipos de bosques, poner fin a la deforestación, recuperar los bosques degradados e incrementar la forestación y la reforestación a nivel mundial."
+            short_title: "Gestión sostenibles de bosques"
           target_15_3:
-            title: "By 2030, combat desertification, restore degraded land and soil, including land affected by desertification, drought and floods, and strive to achieve a land degradation-neutral world."
+            long_title: "By 2030, combat desertification, restore degraded land and soil, including land affected by desertification, drought and floods, and strive to achieve a land degradation-neutral world."
+            short_title: "Lucha contra la desertificación"
           target_15_4:
-            title: "Para 2030, velar por la conservación de los ecosistemas montañosos, incluida su diversidad biológica, a fin de mejorar su capacidad de proporcionar beneficios esenciales para el desarrollo sostenible."
+            long_title: "Para 2030, velar por la conservación de los ecosistemas montañosos, incluida su diversidad biológica, a fin de mejorar su capacidad de proporcionar beneficios esenciales para el desarrollo sostenible."
+            short_title: "Asegurar la conservación ecosistemas montañosos"
           target_15_5:
-            title: "Adoptar medidas urgentes y significativas para reducir la degradación de los hábitats naturales, detener la pérdida de la diversidad biológica y, para 2020, proteger las especies amenazadas y evitar su extinción."
+            long_title: "Adoptar medidas urgentes y significativas para reducir la degradación de los hábitats naturales, detener la pérdida de la diversidad biológica y, para 2020, proteger las especies amenazadas y evitar su extinción."
+            short_title: "Medidas contra la degradación y pérdida de biodiversidad"
           target_15_6:
-            title: "Promover la participación justa y equitativa en los beneficios que se deriven de la utilización de los recursos genéticos y promover el acceso adecuado a esos recursos, como se ha convenido internacionalmente."
+            long_title: "Promover la participación justa y equitativa en los beneficios que se deriven de la utilización de los recursos genéticos y promover el acceso adecuado a esos recursos, como se ha convenido internacionalmente."
+            short_title: "Acceso y uso adecuado de los recursos genéticos"
           target_15_7:
-            title: "Adoptar medidas urgentes para poner fin a la caza furtiva y el tráfico de especies protegidas de flora y fauna y abordar la demanda y la oferta ilegales de productos silvestres."
+            long_title: "Adoptar medidas urgentes para poner fin a la caza furtiva y el tráfico de especies protegidas de flora y fauna y abordar la demanda y la oferta ilegales de productos silvestres."
+            short_title: "Combatir la caza furtiva y especies protegidas"
           target_15_8:
-            title: "Para 2020, adoptar medidas para prevenir la introducción de especies exóticas invasoras y reducir de forma significativa sus efectos en los ecosistemas terrestres y acuáticos y controlar o erradicar las especies prioritarias."
+            long_title: "Para 2020, adoptar medidas para prevenir la introducción de especies exóticas invasoras y reducir de forma significativa sus efectos en los ecosistemas terrestres y acuáticos y controlar o erradicar las especies prioritarias."
+            short_title: "Prevención de especies invasoras"
           target_15_9:
-            title: "Para 2020, integrar los valores de los ecosistemas y la diversidad biológica en la planificación nacional y local, los procesos de desarrollo, las estrategias de reducción de la pobreza y la contabilidad."
+            long_title: "Para 2020, integrar los valores de los ecosistemas y la diversidad biológica en la planificación nacional y local, los procesos de desarrollo, las estrategias de reducción de la pobreza y la contabilidad."
+            short_title: "Integración de planes sensibles a medioambiente"
           target_15_A:
-            title: "Movilizar y aumentar de manera significativa los recursos financieros procedentes de todas las fuentes para conservar y utilizar de forma sostenible la diversidad biológica y los ecosistemas."
+            long_title: "Movilizar y aumentar de manera significativa los recursos financieros procedentes de todas las fuentes para conservar y utilizar de forma sostenible la diversidad biológica y los ecosistemas."
+            short_title: "Movilización y aumento de los recursos financieros"
           target_15_B:
-            title: "Movilizar un volumen apreciable de recursos procedentes de todas las fuentes y a todos los niveles para financiar la gestión forestal sostenible y proporcionar incentivos adecuados a los países en desarrollo para que promuevan dicha gestión, en particular con miras a la conservación y la reforestación."
+            long_title: "Movilizar un volumen apreciable de recursos procedentes de todas las fuentes y a todos los niveles para financiar la gestión forestal sostenible y proporcionar incentivos adecuados a los países en desarrollo para que promuevan dicha gestión, en particular con miras a la conservación y la reforestación."
+            short_title: "Aumento de recursos para gestión forestal"
           target_15_C:
-            title: "Aumentar el apoyo mundial a la lucha contra la caza furtiva y el tráfico de especies protegidas, en particular aumentando la capacidad de las comunidades locales para promover oportunidades de subsistencia sostenibles."
+            long_title: "Aumentar el apoyo mundial a la lucha contra la caza furtiva y el tráfico de especies protegidas, en particular aumentando la capacidad de las comunidades locales para promover oportunidades de subsistencia sostenibles."
+            short_title: "Apoyar la lucha contra caza furtiva"
       goal_16:
         title: "Paz, Justicia e Instituciones Sólidas"
         title_in_two_lines: "Paz, Justicia e\nInstituciones Sólidas"
@@ -374,29 +512,41 @@ es:
         long_description: '<p>Los conflictos, la inseguridad, las instituciones débiles y el acceso limitado a la justicia continúan suponiendo una grave amenaza para el desarrollo sostenible.</p> <p>El número de <a href="https://www.unhcr.org/en-us/news/press/2019/6/5d03b22b4/worldwide-displacement-tops-70-million-un-refugee-chief-urges-greater-solidarity.html">personas que huyen de las guerras, las persecuciones y los conflictos superó los 70&nbsp;millones</a> en 2018, la cifra más alta registrada por la Oficina del Alto Comisionado de las Naciones Unidas para los Refugiados (ACNUR) en casi 70&nbsp;años.</p> <p>En 2019, las Naciones Unidas registraron <a href="https://sustainabledevelopment.un.org/content/documents/26158Final_SG_SDG_Progress_Report_14052020.pdf">357&nbsp;asesinatos y 30&nbsp;desapariciones forzadas</a> de defensores de los derechos humanos, periodistas y sindicalistas en 47&nbsp;países.</p> <p>Por otro lado, los nacimientos de alrededor de <a href="https://data.unicef.org/topic/child-protection/birth-registration/">uno de cada cuatro niños</a> en todo el mundo con menos de 5&nbsp;años nunca se registran de manera oficial, lo que les priva de una prueba de identidad legal, que es crucial para la protección de sus derechos y para el acceso a la justicia y a los servicios sociales.</p>'
         targets:
           target_16_1:
-            title: "Reducir significativamente todas las formas de violencia y las correspondientes tasas de mortalidad en todo el mundo."
+            long_title: "Reducir significativamente todas las formas de violencia y las correspondientes tasas de mortalidad en todo el mundo."
+            short_title: "Reducción de todas las formas de violencia"
           target_16_2:
-            title: "Poner fin al maltrato, la explotación, la trata y todas las formas de violencia y tortura contra los niños."
+            long_title: "Poner fin al maltrato, la explotación, la trata y todas las formas de violencia y tortura contra los niños."
+            short_title: "Erradicación del maltrato, trata y explotación infantil"
           target_16_3:
-            title: "Promover el estado de derecho en los planos nacional e internacional y garantizar la igualdad de acceso a la justicia para todos."
+            long_title: "Promover el estado de derecho en los planos nacional e internacional y garantizar la igualdad de acceso a la justicia para todos."
+            short_title: "Promoción del Estado de Derecho, acceso a justicia"
           target_16_4:
-            title: "By 2030, significantly reduce illicit financial and arms flows, strengthen the recovery and return of stolen assets and combat all forms of organized crime."
+            long_title: "By 2030, significantly reduce illicit financial and arms flows, strengthen the recovery and return of stolen assets and combat all forms of organized crime."
+            short_title: "Reducción de las Corrientes financieras y de armas ilícitas"
           target_16_5:
-            title: "Reducir considerablemente la corrupción y el soborno en todas sus formas."
+            long_title: "Reducir considerablemente la corrupción y el soborno en todas sus formas."
+            short_title: "Reducción de la corrupción y soborno"
           target_16_6:
-            title: "Crear a todos los niveles instituciones eficaces y transparentes que rindan cuentas."
+            long_title: "Crear a todos los niveles instituciones eficaces y transparentes que rindan cuentas."
+            short_title: "Creación de instituciones eficaces y transparentes"
           target_16_7:
-            title: "Garantizar la adopción en todos los niveles de decisiones inclusivas, participativas y representativas que respondan a las necesidades."
+            long_title: "Garantizar la adopción en todos los niveles de decisiones inclusivas, participativas y representativas que respondan a las necesidades."
+            short_title: "Fomento de la participación ciudadana"
           target_16_8:
-            title: "Ampliar y fortalecer la participación de los países en desarrollo en las instituciones de gobernanza mundial."
+            long_title: "Ampliar y fortalecer la participación de los países en desarrollo en las instituciones de gobernanza mundial."
+            short_title: "Fortalecimiento de la participación países en desarrollo en OOII"
           target_16_9:
-            title: "By 2030, provide legal identity for all, including birth registration."
+            long_title: "By 2030, provide legal identity for all, including birth registration."
+            short_title: "Proporción de identidad jurídica y registro de nacimientos"
           target_16_10:
-            title: "Garantizar el acceso público a la información y proteger las libertades fundamentales, de conformidad con las leyes nacionales y los acuerdos internacionales."
+            long_title: "Garantizar el acceso público a la información y proteger las libertades fundamentales, de conformidad con las leyes nacionales y los acuerdos internacionales."
+            short_title: "Acceso a información y libertades fundamentales"
           target_16_A:
-            title: "Fortalecer las instituciones nacionales pertinentes, incluso mediante la cooperación internacional, para crear a todos los niveles, particularmente en los países en desarrollo, la capacidad de prevenir la violencia y combatir el terrorismo y la delincuencia."
+            long_title: "Fortalecer las instituciones nacionales pertinentes, incluso mediante la cooperación internacional, para crear a todos los niveles, particularmente en los países en desarrollo, la capacidad de prevenir la violencia y combatir el terrorismo y la delincuencia."
+            short_title: "Fortalecimiento instituciones en prevención de la violencia"
           target_16_B:
-            title: "Promover y aplicar leyes y políticas no discriminatorias en favor del desarrollo sostenible."
+            long_title: "Promover y aplicar leyes y políticas no discriminatorias en favor del desarrollo sostenible."
+            short_title: "Promoción y aplicación de leyes y políticas (DDHH)"
       goal_17:
         title: "Alianzas para Lograr los Objetivos"
         title_in_two_lines: "Alianzas para\nLograr los Objetivos"
@@ -404,43 +554,62 @@ es:
         long_description: '<p>Los ODS solo se pueden conseguir con asociaciones mundiales sólidas y cooperación.</p> <p>Para que un programa de desarrollo se cumpla satisfactoriamente, es necesario establecer asociaciones inclusivas (a nivel mundial, regional, nacional y local) sobre principios y valores, así como sobre una visión y unos objetivos compartidos que se centren primero en las personas y el planeta.</p> <p>Muchos países requieren asistencia oficial para el desarrollo con el fin de fomentar el crecimiento y el comercio. Aun así, <a href="https://www.un.org/press/en/2019/ga12191.doc.htm">los niveles de ayuda están disminuyendo</a> y los países donantes no han respetado su compromiso de aumentar la financiación para el desarrollo.</p> <p>Debido a la pandemia de la COVID-19, se espera que la <a href="https://www.imf.org/en/Publications/WEO/Issues/2020/04/14/weo-april-2020">economía mundial</a> se contraiga fuertemente, en un 3&nbsp;%, en 2020, lo que constituiría su peor recesión desde la Gran Depresión.</p> <p>Ahora más que nunca es necesaria una sólida cooperación internacional con el fin de garantizar que los países que poseen los medios para recuperarse de la pandemia reconstruyan mejor y consigan los Objetivos de Desarrollo Sostenible.</p>'
         targets:
           target_17_1:
-            title: "Fortalecer la movilización de recursos internos, incluso mediante la prestación de apoyo internacional a los países en desarrollo, con el fin de mejorar la capacidad nacional para recaudar ingresos fiscales y de otra índole."
+            long_title: "Fortalecer la movilización de recursos internos, incluso mediante la prestación de apoyo internacional a los países en desarrollo, con el fin de mejorar la capacidad nacional para recaudar ingresos fiscales y de otra índole."
+            short_title: "Movilización de recursos domésticos para recaudación fiscal"
           target_17_2:
-            title: "Velar por que los países desarrollados cumplan plenamente sus compromisos en relación con la asistencia oficial para el desarrollo, incluido el compromiso de numerosos países desarrollados de alcanzar el objetivo de destinar el 0,7% del ingreso nacional bruto a la asistencia oficial para el desarrollo de los países en desarrollo y entre el 0,15% y el 0,20% del ingreso nacional bruto a la asistencia oficial para el desarrollo de los países menos adelantados; se alienta a los proveedores de asistencia oficial para el desarrollo a que consideren la posibilidad de fijar una meta para destinar al menos el 0,20% del ingreso nacional bruto a la asistencia oficial para el desarrollo de los países menos adelantados."
+            long_title: "Velar por que los países desarrollados cumplan plenamente sus compromisos en relación con la asistencia oficial para el desarrollo, incluido el compromiso de numerosos países desarrollados de alcanzar el objetivo de destinar el 0,7% del ingreso nacional bruto a la asistencia oficial para el desarrollo de los países en desarrollo y entre el 0,15% y el 0,20% del ingreso nacional bruto a la asistencia oficial para el desarrollo de los países menos adelantados; se alienta a los proveedores de asistencia oficial para el desarrollo a que consideren la posibilidad de fijar una meta para destinar al menos el 0,20% del ingreso nacional bruto a la asistencia oficial para el desarrollo de los países menos adelantados."
+            short_title: "Cumplimiento del 0,7% AOD"
           target_17_3:
-            title: "Movilizar recursos financieros adicionales de múltiples fuentes para los países en desarrollo."
+            long_title: "Movilizar recursos financieros adicionales de múltiples fuentes para los países en desarrollo."
+            short_title: "Movilización de recursos financieros adicionales"
           target_17_4:
-            title: "Ayudar a los países en desarrollo a lograr la sostenibilidad de la deuda a largo plazo con políticas coordinadas orientadas a fomentar la financiación, el alivio y la reestructuración de la deuda, según proceda, y hacer frente a la deuda externa de los países pobres muy endeudados a fin de reducir el endeudamiento excesivo."
+            long_title: "Ayudar a los países en desarrollo a lograr la sostenibilidad de la deuda a largo plazo con políticas coordinadas orientadas a fomentar la financiación, el alivio y la reestructuración de la deuda, según proceda, y hacer frente a la deuda externa de los países pobres muy endeudados a fin de reducir el endeudamiento excesivo."
+            short_title: "Reestructuración de la Deuda"
           target_17_5:
-            title: "Adoptar y aplicar sistemas de promoción de las inversiones en favor de los países menos adelantados."
+            long_title: "Adoptar y aplicar sistemas de promoción de las inversiones en favor de los países menos adelantados."
+            short_title: "Promoción de inversiones en países menos adelantados"
           target_17_6:
-            title: "Mejorar la cooperación regional e internacional Norte-Sur, Sur-Sur y triangular en materia de ciencia, tecnología e innovación y el acceso a estas, y aumentar el intercambio de conocimientos en condiciones mutuamente convenidas, incluso mejorando la coordinación entre los mecanismos existentes, en particular a nivel de las Naciones Unidas, y mediante un mecanismo mundial de facilitación de la tecnología."
+            long_title: "Mejorar la cooperación regional e internacional Norte-Sur, Sur-Sur y triangular en materia de ciencia, tecnología e innovación y el acceso a estas, y aumentar el intercambio de conocimientos en condiciones mutuamente convenidas, incluso mejorando la coordinación entre los mecanismos existentes, en particular a nivel de las Naciones Unidas, y mediante un mecanismo mundial de facilitación de la tecnología."
+            short_title: "Mejora del traspaso de tecnología"
           target_17_7:
-            title: "Promover el desarrollo de tecnologías ecológicamente racionales y su transferencia, divulgación y difusión a los países en desarrollo en condiciones favorables, incluso en condiciones concesionarias y preferenciales, según lo convenido de mutuo acuerdo."
+            long_title: "Promover el desarrollo de tecnologías ecológicamente racionales y su transferencia, divulgación y difusión a los países en desarrollo en condiciones favorables, incluso en condiciones concesionarias y preferenciales, según lo convenido de mutuo acuerdo."
+            short_title: "Promoción de tecnologías ecológicamente racionales"
           target_17_8:
-            title: "Poner en pleno funcionamiento, a más tardar en 2017, el banco de tecnología y el mecanismo de apoyo a la creación de capacidad en materia de ciencia, tecnología e innovación para los países menos adelantados y aumentar la utilización de tecnologías instrumentales, en particular la tecnología de la información y las comunicaciones."
+            long_title: "Poner en pleno funcionamiento, a más tardar en 2017, el banco de tecnología y el mecanismo de apoyo a la creación de capacidad en materia de ciencia, tecnología e innovación para los países menos adelantados y aumentar la utilización de tecnologías instrumentales, en particular la tecnología de la información y las comunicaciones."
+            short_title: "Creación de banco de tecnología"
           target_17_9:
-            title: "Aumentar el apoyo internacional para realizar actividades de creación de capacidad eficaces y específicas en los países en desarrollo a fin de respaldar los planes nacionales de implementación de todos los Objetivos de Desarrollo Sostenible, incluso mediante la cooperación Norte-Sur, Sur-Sur y triangular."
+            long_title: "Aumentar el apoyo internacional para realizar actividades de creación de capacidad eficaces y específicas en los países en desarrollo a fin de respaldar los planes nacionales de implementación de todos los Objetivos de Desarrollo Sostenible, incluso mediante la cooperación Norte-Sur, Sur-Sur y triangular."
+            short_title: "Refuerzo de capacidades de implementación ODS"
           target_17_10:
-            title: "Promover un sistema de comercio multilateral universal, basado en normas, abierto, no discriminatorio y equitativo en el marco de la Organización Mundial del Comercio, incluso mediante la conclusión de las negociaciones en el marco del Programa de Doha para el Desarrollo."
+            long_title: "Promover un sistema de comercio multilateral universal, basado en normas, abierto, no discriminatorio y equitativo en el marco de la Organización Mundial del Comercio, incluso mediante la conclusión de las negociaciones en el marco del Programa de Doha para el Desarrollo."
+            short_title: "Promoción de comercio multilateral universal"
           target_17_11:
-            title: "Aumentar significativamente las exportaciones de los países en desarrollo, en particular con miras a duplicar la participación de los países menos adelantados en las exportaciones mundiales de aquí a 2020."
+            long_title: "Aumentar significativamente las exportaciones de los países en desarrollo, en particular con miras a duplicar la participación de los países menos adelantados en las exportaciones mundiales de aquí a 2020."
+            short_title: "Aumento de las exportaciones de países en desarrollo"
           target_17_12:
-            title: "Lograr la consecución oportuna del acceso a los mercados libre de derechos y contingentes de manera duradera para todos los países menos adelantados, conforme a las decisiones de la Organización Mundial del Comercio, incluso velando por que las normas de origen preferenciales aplicables a las importaciones de los países menos adelantados sean transparentes y sencillas y contribuyan a facilitar el acceso a los mercados."
+            long_title: "Lograr la consecución oportuna del acceso a los mercados libre de derechos y contingentes de manera duradera para todos los países menos adelantados, conforme a las decisiones de la Organización Mundial del Comercio, incluso velando por que las normas de origen preferenciales aplicables a las importaciones de los países menos adelantados sean transparentes y sencillas y contribuyan a facilitar el acceso a los mercados."
+            short_title: "Acceso a mercado para países en desarrollo"
           target_17_13:
-            title: "Aumentar la estabilidad macroeconómica mundial, incluso mediante la coordinación y coherencia de las políticas."
+            long_title: "Aumentar la estabilidad macroeconómica mundial, incluso mediante la coordinación y coherencia de las políticas."
+            short_title: "Aumento de la estabilidad macroeconómica mundial"
           target_17_14:
-            title: "Mejorar la coherencia de las políticas para el desarrollo sostenible."
+            long_title: "Mejorar la coherencia de las políticas para el desarrollo sostenible."
+            short_title: "Mejora de la coherencia de políticas"
           target_17_15:
-            title: "Respetar el margen normativo y el liderazgo de cada país para establecer y aplicar políticas de erradicación de la pobreza y desarrollo sostenible."
+            long_title: "Respetar el margen normativo y el liderazgo de cada país para establecer y aplicar políticas de erradicación de la pobreza y desarrollo sostenible."
+            short_title: "Respeto a la Soberanía nacional"
           target_17_16:
-            title: "Mejorar la Alianza Mundial para el Desarrollo Sostenible, complementada por alianzas entre múltiples interesados que movilicen e intercambien conocimientos, especialización, tecnología y recursos financieros, a fin de apoyar el logro de los Objetivos de Desarrollo Sostenible en todos los países, particularmente los países en desarrollo."
+            long_title: "Mejorar la Alianza Mundial para el Desarrollo Sostenible, complementada por alianzas entre múltiples interesados que movilicen e intercambien conocimientos, especialización, tecnología y recursos financieros, a fin de apoyar el logro de los Objetivos de Desarrollo Sostenible en todos los países, particularmente los países en desarrollo."
+            short_title: "Mejorar la Alianza Mundial para el desarrollo sostenible"
           target_17_17:
-            title: "Fomentar y promover la constitución de alianzas eficaces en las esferas pública, público-privada y de la sociedad civil, aprovechando la experiencia y las estrategias de obtención de recursos de las alianzas."
+            long_title: "Fomentar y promover la constitución de alianzas eficaces en las esferas pública, público-privada y de la sociedad civil, aprovechando la experiencia y las estrategias de obtención de recursos de las alianzas."
+            short_title: "Fomento de alianzas público-privadas"
           target_17_18:
-            title: "De aquí a 2020, mejorar el apoyo a la creación de capacidad prestado a los países en desarrollo, incluidos los países menos adelantados y los pequeños Estados insulares en desarrollo, para aumentar significativamente la disponibilidad de datos oportunos, fiables y de gran calidad desglosados por ingresos, sexo, edad, raza, origen étnico, estatus migratorio, discapacidad, ubicación geográfica y otras características pertinentes en los contextos nacionales."
+            long_title: "De aquí a 2020, mejorar el apoyo a la creación de capacidad prestado a los países en desarrollo, incluidos los países menos adelantados y los pequeños Estados insulares en desarrollo, para aumentar significativamente la disponibilidad de datos oportunos, fiables y de gran calidad desglosados por ingresos, sexo, edad, raza, origen étnico, estatus migratorio, discapacidad, ubicación geográfica y otras características pertinentes en los contextos nacionales."
+            short_title: "Creación de capacidad estadística"
           target_17_19:
-            title: "De aquí a 2030, aprovechar las iniciativas existentes para elaborar indicadores que permitan medir los progresos en materia de desarrollo sostenible y complementen el producto interno bruto, y apoyar la creación de capacidad estadística en los países en desarrollo."
+            long_title: "De aquí a 2030, aprovechar las iniciativas existentes para elaborar indicadores que permitan medir los progresos en materia de desarrollo sostenible y complementen el producto interno bruto, y apoyar la creación de capacidad estadística en los países en desarrollo."
+            short_title: "Promoción de indicadores que vayan más allá del PIB"
       help:
         title: "Ayuda Objetivos de Desarrollo Sostenible"
         description: "Puedes alinear tus aportaciones a la comunidad (debates, propuestas ciudadanas y proyectos de inversión) con los Objetivos de Desarrollo Sostenible de la Agenda 2030, esto nos permitirá tener una visión general de nuestra aportación en cada uno de los objetivos de desarrollo sostenible. A continuación puedes informarte de todos los objetivos, sus metas y las metas localizadas."

--- a/config/locales/es/sdg.yml
+++ b/config/locales/es/sdg.yml
@@ -632,7 +632,6 @@ es:
         title: "¿Qué ODS y metas se alinean con mi %{record}?"
         text: "página de ayuda de ODS"
       hint: Puedes introducir el código de un objetivo/meta específico o un texto para encontrar uno. Para más información visita la %{link}.
-      placeholder: "Escribe las etiquetas que desees"
       remove_tag: "Eliminar"
       title: "Objetivos de Desarrollo Sostenible y Metas"
     targets:

--- a/spec/components/sdg/related_list_selector_component_spec.rb
+++ b/spec/components/sdg/related_list_selector_component_spec.rb
@@ -62,7 +62,7 @@ describe SDG::RelatedListSelectorComponent do
       suggestion = component.suggestion_tag_for(SDG::Target[1.1])
 
       expect(suggestion).to eq({
-        tag: "1.1. By 2030 eradicate extreme poverty for all people everywhere currently measured as people living on less than $1.25 a day",
+        tag: "1.1. Eradicate Extreme Poverty",
         display_text: "1.1",
         title: "By 2030, eradicate extreme poverty for all people everywhere, currently measured as people living on less than $1.25 a day",
         value: "1.1"

--- a/spec/models/sdg/goal_spec.rb
+++ b/spec/models/sdg/goal_spec.rb
@@ -78,4 +78,10 @@ describe SDG::Goal do
       expect(goal.description).to eq "Poner fin a la pobreza en todas sus formas en todo el mundo."
     end
   end
+
+  describe "#long_title" do
+    it "returns the title" do
+      expect(SDG::Goal[1].long_title).to eq "No Poverty"
+    end
+  end
 end

--- a/spec/models/sdg/local_target_spec.rb
+++ b/spec/models/sdg/local_target_spec.rb
@@ -119,4 +119,12 @@ describe SDG::LocalTarget do
       expect { SDG::LocalTarget["1.1.99"] }.to raise_exception ActiveRecord::RecordNotFound
     end
   end
+
+  describe "#long_title" do
+    it "returns the title" do
+      target = build(:sdg_local_target, title: "Improve local water transport system")
+
+      expect(target.long_title).to eq "Improve local water transport system"
+    end
+  end
 end

--- a/spec/models/sdg/local_target_spec.rb
+++ b/spec/models/sdg/local_target_spec.rb
@@ -47,6 +47,14 @@ describe SDG::LocalTarget do
     expect(build(:sdg_local_target, target: nil)).not_to be_valid
   end
 
+  describe "#code_and_title" do
+    it "returns the code and the title" do
+      target = build(:sdg_local_target, code: "4.4.1", title: "Build a university")
+
+      expect(target.code_and_title).to eq "4.4.1. Build a university"
+    end
+  end
+
   describe "#set_related_goal" do
     it "before validation set related goal" do
       local_target = build(:sdg_local_target, code: "1.1.1", target: SDG::Target["1.1"], goal: nil)

--- a/spec/models/sdg/target_spec.rb
+++ b/spec/models/sdg/target_spec.rb
@@ -24,29 +24,51 @@ describe SDG::Target do
     expect(target.errors.full_messages).to include "Code has already been taken"
   end
 
-  it "translates title" do
-    target = SDG::Target["1.1"]
+  describe "#long_title" do
+    it "returns the official title in the desired language" do
+      target = SDG::Target["1.1"]
 
-    expect(target.title).to start_with "By 2030, eradicate extreme poverty"
+      expect(target.long_title).to start_with "By 2030, eradicate extreme poverty"
 
-    I18n.with_locale(:es) do
-      expect(target.title).to start_with "Para 2030, erradicar la pobreza extrema"
+      I18n.with_locale(:es) do
+        expect(target.long_title).to start_with "Para 2030, erradicar la pobreza extrema"
+      end
+
+      target = SDG::Target["17.11"]
+
+      expect(target.long_title).to start_with "Significantly increase the exports of developing countries"
+
+      I18n.with_locale(:es) do
+        expect(target.long_title).to start_with "Aumentar significativamente las exportaciones de los países"
+      end
+    end
+  end
+
+  describe "#title" do
+    let(:target) { SDG::Target["1.1"] }
+
+    it "returns the abbreviated title" do
+      expect(target.title).to eq "Eradicate Extreme Poverty"
     end
 
-    target = SDG::Target["17.11"]
+    context "translation unavailable" do
+      after { I18n.backend.reload! }
 
-    expect(target.title).to start_with "Significantly increase the exports of developing countries"
+      it "returns the official title when the abbreviated title isn't available" do
+        keys = { goals: { goal_1: { targets: { target_1_1: { short_title: nil }}}}}
 
-    I18n.with_locale(:es) do
-      expect(target.title).to start_with "Aumentar significativamente las exportaciones de los países"
+        I18n.backend.store_translations(:en, { sdg: keys })
+
+        expect(target.title).to start_with "By 2030, eradicate extreme poverty"
+      end
     end
   end
 
   describe "#code_and_title" do
-    it "returns the code and the title" do
+    it "returns the code and the abbreviated title" do
       target = SDG::Target["8.A"]
 
-      expect(target.code_and_title).to start_with "8.A. Increase Aid for Trade support for developing"
+      expect(target.code_and_title).to eq "8.A. Increase Aid for Trade Support"
     end
   end
 

--- a/spec/models/sdg/target_spec.rb
+++ b/spec/models/sdg/target_spec.rb
@@ -42,6 +42,14 @@ describe SDG::Target do
     end
   end
 
+  describe "#code_and_title" do
+    it "returns the code and the title" do
+      target = SDG::Target["8.A"]
+
+      expect(target.code_and_title).to start_with "8.A. Increase Aid for Trade support for developing"
+    end
+  end
+
   describe "#<=>" do
     let(:goal)   { build(:sdg_goal, code: 10) }
     let(:target) { build(:sdg_target, code: "10.19", goal: goal) }

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -269,6 +269,17 @@ describe "Advanced search" do
       create(:budget_investment, title: "Purifier", heading: heading, sdg_goals: [SDG::Goal[6]])
       create(:budget_investment, title: "Hospital", heading: heading, sdg_goals: [SDG::Goal[3]])
 
+      goal_6_targets = [
+        "6.1. Safe and Affordable Drinking Water",
+        "6.2. End Open Defecation and Provide Access to Sanitation and Hygiene",
+        "6.3. Improve Water Quality, Wastewater Treatment and Safe Reuse",
+        "6.4. Increase Water-Use Efficiency and Ensure Freshwater Supplies",
+        "6.5. Implement Integrated Water Resources Management",
+        "6.6. Protect and Restore Water-Related Ecosystems",
+        "6.A. Expand Water and Sanitation Support to Developing Countries",
+        "6.B. Support Local Engagement in Water and Sanitation Management"
+      ]
+
       visit budget_investments_path(budget)
       click_button "Advanced search"
       select "6. Clean Water and Sanitation", from: "By SDG"
@@ -283,7 +294,7 @@ describe "Advanced search" do
 
       expect(page).to have_select "By target",
                                   selected: "Select a target",
-                                  enabled_options: ["Select a target"] + %w[6.1 6.2 6.3 6.4 6.5 6.6 6.A 6.B]
+                                  enabled_options: ["Select a target"] + goal_6_targets
     end
 
     scenario "Search by target" do
@@ -293,7 +304,7 @@ describe "Advanced search" do
 
       visit debates_path
       click_button "Advanced search"
-      select "4.2", from: "By target"
+      select "4.2. Equal Access to Quality Pre-Primary Education", from: "By target"
       click_button "Filter"
 
       expect(page).to have_content("There is 1 debate")
@@ -306,6 +317,24 @@ describe "Advanced search" do
     end
 
     scenario "Dynamic target options depending on the selected goal" do
+      goal_1_targets = [
+        "1.1. Eradicate Extreme Poverty",
+        "1.2. Reduce Poverty by at Least 50%",
+        "1.3. Implement Social Protection Systems",
+        "1.4. Equal Rights to Ownership, Basic Services, Technology and Economic Resources",
+        "1.5. Build Resilience to Environmental, Economic and Social Disasters",
+        "1.A. Mobilize Resources to Implement Policies to End Poverty",
+        "1.B. Create pro-poor and gender-sensitive policy frameworks"
+      ]
+
+      goal_13_targets = [
+        "13.1. Strengthen resilience and Adaptive Capacity to Climate Related Disasters",
+        "13.2. Integrate Climate Change Measures into Policies and Planning",
+        "13.3. Build Knowledge and Capacity to Meet Climate Change",
+        "13.A. Implement the UN Framework Convention on Climate Change",
+        "13.B. Promote Mechanisms to Raise Capacity for Planning and Management"
+      ]
+
       visit proposals_path
 
       click_button "Advanced search"
@@ -313,19 +342,21 @@ describe "Advanced search" do
 
       expect(page).to have_select "By target",
                                   selected: "Select a target",
-                                  enabled_options: ["Select a target"] + %w[1.1 1.2 1.3 1.4 1.5 1.A 1.B]
+                                  enabled_options: ["Select a target"] + goal_1_targets
 
-      select "1.1", from: "By target"
+      select "1.1. Eradicate Extreme Poverty", from: "By target"
       select "13. Climate Action", from: "By SDG"
 
       expect(page).to have_select "By target",
                                   selected: "Select a target",
-                                  enabled_options: ["Select a target"] + %w[13.1 13.2 13.3 13.A 13.B]
+                                  enabled_options: ["Select a target"] + goal_13_targets
 
-      select "13.1", from: "By target"
+      select "13.3. Build Knowledge and Capacity to Meet Climate Change", from: "By target"
       select "Select a goal", from: "By SDG"
 
-      expect(page).to have_select "By target", selected: "13.1", disabled_options: []
+      expect(page).to have_select "By target",
+                                  selected: "13.3. Build Knowledge and Capacity to Meet Climate Change",
+                                  disabled_options: []
     end
   end
 end

--- a/spec/system/sdg_management/local_targets_spec.rb
+++ b/spec/system/sdg_management/local_targets_spec.rb
@@ -39,8 +39,7 @@ describe "Local Targets" do
     scenario "Shows succesful notice when form is fullfilled correctly" do
       visit new_sdg_management_local_target_path
 
-      target = SDG::Target["1.1"]
-      select "1.1. #{target.title}", from: "Target"
+      select "1.1. Eradicate Extreme Poverty", from: "Target"
       fill_in "Code", with: "1.1.1"
       fill_in "Title", with: "Local target title"
       fill_in "Description", with: "Local target description"
@@ -53,8 +52,7 @@ describe "Local Targets" do
     scenario "Shows form errors when not valid" do
       visit new_sdg_management_local_target_path
 
-      target = SDG::Target["2.3"]
-      code_and_title = "2.3. #{target.title}"
+      code_and_title = "2.3. Double the Productivity and Incomes of Small-Scale Food Producers"
       select code_and_title, from: "Target"
       click_button "Create local target"
 

--- a/spec/system/sdg_management/local_targets_spec.rb
+++ b/spec/system/sdg_management/local_targets_spec.rb
@@ -40,7 +40,7 @@ describe "Local Targets" do
       visit new_sdg_management_local_target_path
 
       target = SDG::Target["1.1"]
-      select "#{target.code} #{target.title}", from: "Target"
+      select "1.1. #{target.title}", from: "Target"
       fill_in "Code", with: "1.1.1"
       fill_in "Title", with: "Local target title"
       fill_in "Description", with: "Local target description"
@@ -54,7 +54,7 @@ describe "Local Targets" do
       visit new_sdg_management_local_target_path
 
       target = SDG::Target["2.3"]
-      code_and_title = "#{target.code} #{target.title}"
+      code_and_title = "2.3. #{target.title}"
       select code_and_title, from: "Target"
       click_button "Create local target"
 

--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -151,6 +151,19 @@ describe "SDG Relations" do
         create(:budget_investment, title: "School", sdg_goals: [SDG::Goal[4]])
         create(:budget_investment, title: "Hospital", sdg_goals: [SDG::Goal[3]])
 
+        goal_4_targets = [
+          "4.1. Free Primary and Secondary Education",
+          "4.2. Equal Access to Quality Pre-Primary Education",
+          "4.3. Equal Access to Affordable Technical, Vocational and Higher Education",
+          "4.4. Increase the Number of People with Relevant Skills for Financial Success",
+          "4.5. Eliminate All Discrimination in Education",
+          "4.6. Universal Literacy and Numeracy",
+          "4.7. Education for Sustainable Development and Global Citizenship",
+          "4.A. Build and Upgrade Inclusive and Safe Schools",
+          "4.B. Expand Higher Education Scholarships for Developing Countries",
+          "4.C. Increase the supply of qualified teachers In Developing Countries"
+        ]
+
         visit sdg_management_budget_investments_path
         select "4. Quality Education", from: "goal_code"
         click_button "Search"
@@ -161,7 +174,7 @@ describe "SDG Relations" do
 
         expect(page).to have_select "By target",
                                     selected: "All targets",
-                                    enabled_options: ["All targets"] + %w[4.1 4.2 4.3 4.4 4.5 4.6 4.7 4.A 4.B 4.C]
+                                    enabled_options: ["All targets"] + goal_4_targets
       end
 
       scenario "target filter" do
@@ -169,7 +182,7 @@ describe "SDG Relations" do
         create(:budget_investment, title: "Preschool", sdg_targets: [SDG::Target[4.2]])
 
         visit sdg_management_budget_investments_path
-        select "4.1", from: "target_code"
+        select "4.1. Free Primary and Secondary Education", from: "target_code"
         click_button "Search"
 
         expect(page).to have_content "School"
@@ -178,13 +191,13 @@ describe "SDG Relations" do
       end
 
       scenario "local target filter" do
-        create(:sdg_local_target, code: "4.1.1")
-        create(:sdg_local_target, code: "4.1.2")
+        create(:sdg_local_target, code: "4.1.1", title: "Improve local schools")
+        create(:sdg_local_target, code: "4.1.2", title: "Increase the teacher per student rate")
         create(:debate, title: "Rebuild local schools", sdg_local_targets: [SDG::LocalTarget["4.1.1"]])
         create(:debate, title: "Hire teachers", sdg_local_targets: [SDG::LocalTarget["4.1.2"]])
 
         visit sdg_management_debates_path
-        select "4.1.1", from: "target_code"
+        select "4.1.1. Improve local schools", from: "target_code"
         click_button "Search"
 
         expect(page).to have_content "Rebuild local schools"
@@ -212,25 +225,45 @@ describe "SDG Relations" do
       end
 
       scenario "dynamic target options depending on the selected goal" do
+        goal_1_targets = [
+          "1.1. Eradicate Extreme Poverty",
+          "1.2. Reduce Poverty by at Least 50%",
+          "1.3. Implement Social Protection Systems",
+          "1.4. Equal Rights to Ownership, Basic Services, Technology and Economic Resources",
+          "1.5. Build Resilience to Environmental, Economic and Social Disasters",
+          "1.A. Mobilize Resources to Implement Policies to End Poverty",
+          "1.B. Create pro-poor and gender-sensitive policy frameworks"
+        ]
+
+        goal_13_targets = [
+          "13.1. Strengthen resilience and Adaptive Capacity to Climate Related Disasters",
+          "13.2. Integrate Climate Change Measures into Policies and Planning",
+          "13.3. Build Knowledge and Capacity to Meet Climate Change",
+          "13.A. Implement the UN Framework Convention on Climate Change",
+          "13.B. Promote Mechanisms to Raise Capacity for Planning and Management"
+        ]
+
         visit sdg_management_polls_path
 
         select "1. No Poverty", from: "By goal"
 
         expect(page).to have_select "By target",
                                     selected: "All targets",
-                                    enabled_options: ["All targets"] + %w[1.1 1.2 1.3 1.4 1.5 1.A 1.B]
+                                    enabled_options: ["All targets"] + goal_1_targets
 
-        select "1.1", from: "By target"
+        select "1.1. Eradicate Extreme Poverty", from: "By target"
         select "13. Climate Action", from: "By goal"
 
         expect(page).to have_select "By target",
                                     selected: "All targets",
-                                    enabled_options: ["All targets"] + %w[13.1 13.2 13.3 13.A 13.B]
+                                    enabled_options: ["All targets"] + goal_13_targets
 
-        select "13.1", from: "By target"
+        select "13.3. Build Knowledge and Capacity to Meet Climate Change", from: "By target"
         select "All goals", from: "By goal"
 
-        expect(page).to have_select "By target", selected: "13.1", disabled_options: []
+        expect(page).to have_select "By target",
+                                    selected: "13.3. Build Knowledge and Capacity to Meet Climate Change",
+                                    disabled_options: []
       end
     end
   end

--- a/spec/system/sdg_management/targets_spec.rb
+++ b/spec/system/sdg_management/targets_spec.rb
@@ -25,11 +25,11 @@ describe "Targets" do
 
       visit sdg_management_targets_path
 
-      expect(goal_8.title).to appear_before(goal_8_target_2.title)
-      expect(goal_8_target_2.title).to appear_before(goal_8_target_10.title)
-      expect(goal_8_target_10.title).to appear_before(goal_16.title)
-      expect(goal_16.title).to appear_before(goal_16_target_10.title)
-      expect(goal_16_target_10.title).to appear_before(goal_16_target_a.title)
+      expect(goal_8.title).to appear_before(goal_8_target_2.long_title)
+      expect(goal_8_target_2.long_title).to appear_before(goal_8_target_10.long_title)
+      expect(goal_8_target_10.long_title).to appear_before(goal_16.title)
+      expect(goal_16.title).to appear_before(goal_16_target_10.long_title)
+      expect(goal_16_target_10.long_title).to appear_before(goal_16_target_a.long_title)
     end
   end
 end


### PR DESCRIPTION
## References

* These titles come from [The Global Goals](https://www.globalgoals.org/)
* Remove a distracting placeholder in the goals and targets selector

## Objectives

* Make forms allowing users to select targets more usable

## Visual Changes

### Before these changes

Advanced search:

![In the advanced search filter, targets are represented by their code](https://user-images.githubusercontent.com/35156/130866522-7d1099d1-3774-409b-9817-edb45b710fbf.png)

Goals and targets selector:

![Searching for a target in the new investment form returns results with very long descriptions](https://user-images.githubusercontent.com/35156/130866524-6994b5f2-df42-49c0-abe9-4853ba062d6f.png)

### After these changes

Advanced search:

![In the advanced search filter, targets are represented by their code and title](https://user-images.githubusercontent.com/35156/130866542-5f17bfd7-07ea-42b4-8db0-c5319c8a379e.png)

Goals and targets selector:

![Searching for a target in the new investment form returns results with concise titles](https://user-images.githubusercontent.com/35156/130866545-d8620d9e-a9fd-405d-9644-49e0ea83cd20.png)

## Notes

It would be great if we could find a way to rename the translation keys in Crowdin; right now we use `summary` for the short title and `title` for the full description, which isn't ideal.