### PR TITLE
Enable SDG content by default

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -100,7 +100,7 @@ class Setting < ApplicationRecord
         "feature.remote_census": nil,
         "feature.valuation_comment_notification": true,
         "feature.graphql_api": true,
-        "feature.sdg": false,
+        "feature.sdg": true,
         "feature.machine_learning": false,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -5,7 +5,6 @@ section "Creating Settings" do
     "facebook_handle": "CONSUL",
     "feature.featured_proposals": "true",
     "feature.map": "true",
-    "feature.sdg": "true",
     "instagram_handle": "CONSUL",
     "mailer_from_address": "noreply@consul.dev",
     "mailer_from_name": "CONSUL",


### PR DESCRIPTION
## References

* We introduced the SDG content in pull request #4251

## Objectives

* Enable by defaut content many CONSUL installations are interested in

## Notes

We didn't enable SDG by default in pull request #4251 so existing installations didn't suddenly get a new section without expecting it.

But since the setting already exists for installations using version CONSUL 1.3, now it will only be enabled for new installations.