### PR TITLE
Issue#4013 lenghth validations

### DIFF
--- a/app/components/debates/form_component.html.erb
+++ b/app/components/debates/form_component.html.erb
@@ -18,6 +18,11 @@
         <%= translations_form.text_area :description,
               maxlength: Debate.description_max_length,
               class: "html-area" %>
+        <% if @debate.errors.present? && locale == translations_form.locale %>
+          <div class="form-error is-visible html-area ">
+            <%= @debate.errors[:description][0] %>
+          </div>
+        <% end %>
       </div>
     <% end %>
   </fieldset>

--- a/app/models/concerns/measurable.rb
+++ b/app/models/concerns/measurable.rb
@@ -21,6 +21,5 @@ module Measurable
     def description_min_length
       10
     end
-
   end
 end

--- a/app/models/concerns/measurable.rb
+++ b/app/models/concerns/measurable.rb
@@ -17,5 +17,10 @@ module Measurable
     def description_max_length
       6000
     end
+
+    def description_min_length
+      10
+    end
+
   end
 end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -166,7 +166,7 @@ class Debate < ApplicationRecord
 
   def description_sanitized
     real_description_length = ActionView::Base.full_sanitizer.sanitize("#{description}").squish.length
-    if real_description_length <  Debate.description_min_length
+    if real_description_length < Debate.description_min_length
       errors.add(:description, :too_short, count: Debate.description_min_length)
     end
     if real_description_length > Debate.description_max_length

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -29,7 +29,8 @@ class Debate < ApplicationRecord
   has_many :comments, as: :commentable, inverse_of: :commentable
 
   validates_translation :title, presence: true, length: { in: 4..Debate.title_max_length }
-  validates_translation :description, presence: true, length: { in: 10..Debate.description_max_length }
+  validates_translation :description, presence: true
+  validate :description_sanitized
   validates :author, presence: true
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
@@ -161,5 +162,15 @@ class Debate < ApplicationRecord
     orders = %w[hot_score confidence_score created_at relevance]
     orders << "recommendations" if Setting["feature.user.recommendations_on_debates"] && user&.recommended_debates
     orders
+  end
+
+  def description_sanitized
+    real_description_length = ActionView::Base.full_sanitizer.sanitize("#{description}").squish.length
+    if real_description_length <  Debate.description_min_length
+      errors.add(:description, :too_short, count: Debate.description_min_length)
+    end
+    if real_description_length > Debate.description_max_length
+      errors.add(:description, :too_long, count: Debate.description_max_length)
+    end
   end
 end

--- a/spec/models/concerns/globalizable.rb
+++ b/spec/models/concerns/globalizable.rb
@@ -66,7 +66,7 @@ shared_examples_for "globalizable" do |factory_name|
       record.reload
 
       record.update!(translations_attributes: [
-        { locale: :de }.merge(fields.map { |field| [field, "Deutsch"] }.to_h)
+        { locale: :de }.merge(fields.map { |field| [field, "Deutsche Sprache"] }.to_h)
       ])
 
       record.reload
@@ -105,7 +105,7 @@ shared_examples_for "globalizable" do |factory_name|
       record.reload
 
       record.update!(translations_attributes: [
-        { id: record.translations.first.id }.merge(fields.map { |field| [field, "Cambiado"] }.to_h)
+        { id: record.translations.first.id }.merge(fields.map { |field| [field, "Actualizado"] }.to_h)
       ])
 
       record.reload
@@ -158,8 +158,8 @@ shared_examples_for "globalizable" do |factory_name|
   describe "Fallbacks" do
     before do
       I18n.with_locale(:de) do
-        record.update!(required_fields.map { |field| [field, "Deutsch"] }.to_h)
-        record.update!(attribute => "Deutsch")
+        record.update!(required_fields.map { |field| [field, "Deutsche Sprache"] }.to_h)
+        record.update!(attribute => "Deutsche Sprache")
       end
     end
 
@@ -177,7 +177,7 @@ shared_examples_for "globalizable" do |factory_name|
       Globalize.set_fallbacks_to_all_available_locales
 
       I18n.with_locale(:fr) do
-        expect(record.send(attribute)).to eq "Deutsch"
+        expect(record.send(attribute)).to eq "Deutsche Sprache"
       end
     end
 
@@ -188,7 +188,7 @@ shared_examples_for "globalizable" do |factory_name|
         { id: record.translations.find_by(locale: :en).id, _destroy: true }
       ])
 
-      expect(record.send(attribute)).to eq "Deutsch"
+      expect(record.send(attribute)).to eq "Deutsche Sprache"
     end
   end
 end

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -45,8 +45,13 @@ describe Debate do
     end
 
     it "is not valid when very short" do
-      debate.description = "abc"
+      debate.description = "<a><h1><u>abc</u></h1></a>"
       expect(debate).not_to be_valid
+    end
+
+    it "is valid when very long and sanitized" do
+      debate.description = "<a><h1>a</h1></a>" * 6000
+      expect(debate).to be_valid
     end
 
     it "is not valid when very long" do

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -259,14 +259,14 @@ describe "Debates" do
 
     visit new_debate_path
     fill_in "Debate title", with: "Testing an attack"
-    fill_in "Initial debate text", with: "<p>This is <script>alert('an attack');</script></p>"
+    fill_in "Initial debate text", with: "<p>This is a JS <script>alert('an attack');</script></p>"
     check "debate_terms_of_service"
 
     click_button "Start a debate"
 
     expect(page).to have_content "Debate created successfully."
     expect(page).to have_content "Testing an attack"
-    expect(page.html).to include "<p>This is alert('an attack');</p>"
+    expect(page.html).to include "<p>This is a JS alert('an attack');</p>"
     expect(page.html).not_to include "<script>alert('an attack');</script>"
     expect(page.html).not_to include "&lt;p&gt;This is"
   end


### PR DESCRIPTION
## References
Fixes issue #4013

## Objectives
Changes the method of validating the debate description field. Now the input is sanitized of the html tags before validating.

* With nil description:
![Screenshot from 2021-08-26 11-46-06](https://user-images.githubusercontent.com/61836657/130984745-bbe1a265-82a7-43a5-8e31-0375ddb91626.png)

* With too short description:
![Screenshot from 2021-08-26 11-46-27](https://user-images.githubusercontent.com/61836657/130984827-190c6194-0684-4e46-9740-1cda09e0d565.png)

* With too long description:
![Screenshot from 2021-08-26 11-47-42](https://user-images.githubusercontent.com/61836657/130984899-2e054dda-61ac-496c-ae81-1d9e393a585e.png)

## Visual Changes

* Now the short/long length description error message  is below the "can't be blank" message.
![Screenshot from 2021-08-26 11-46-06](https://user-images.githubusercontent.com/61836657/130985323-0647a273-8a2e-43a8-aa69-d9558bd39e4e.png)


## Notes
This PR is a rebased version of #4437 
