### PR TITLE
Improve styles for long admin menu items

### DIFF
--- a/app/assets/stylesheets/admin/menu.scss
+++ b/app/assets/stylesheets/admin/menu.scss
@@ -7,12 +7,19 @@
   ul {
     list-style-type: none;
     margin-bottom: 0;
-    margin-left: 0;
+    margin-#{$global-left}: 0;
     padding: 0;
   }
 
   > ul > li a {
+    display: flex;
     font-weight: bold;
+
+    &::before,
+    &::after {
+      flex: 1em 0 0;
+      margin-top: 0.1em;
+    }
 
     @mixin icon($name, $style) {
       @include has-fa-icon($name, $style);
@@ -20,15 +27,6 @@
       &::before {
         @extend %admin-menu-icon;
       }
-    }
-
-    [class^="icon-"] {
-      display: inline-block;
-      font-size: rem-calc(20);
-      line-height: $line-height;
-      text-align: center;
-      vertical-align: middle;
-      width: $line-height * 1.5;
     }
 
     &.booths-link {
@@ -142,7 +140,7 @@
   li a {
     color: inherit;
     display: block;
-    padding: $line-height / 2 $line-height / 4;
+    padding: $line-height / 2;
     vertical-align: top;
 
     &:hover {
@@ -154,15 +152,13 @@
 
   .is-accordion-submenu-parent {
 
-    > a::after {
-      border: 0;
-      content: "\f078";
-      font-family: "Font Awesome 5 Free";
-      font-weight: bold;
-      height: auto;
-      position: absolute;
-      right: 24px;
-      transition: 0.25s;
+    > a {
+      @include has-fa-icon(chevron-down, solid, after);
+
+      &::after {
+        margin-#{$global-left}: auto;
+        transition: 0.25s;
+      }
     }
   }
 

--- a/app/assets/stylesheets/admin/menu.scss
+++ b/app/assets/stylesheets/admin/menu.scss
@@ -176,6 +176,7 @@
 
     a {
       font-weight: normal;
+      margin-#{$global-right}: 0;
     }
 
     .is-active {

--- a/app/assets/stylesheets/admin/menu.scss
+++ b/app/assets/stylesheets/admin/menu.scss
@@ -142,8 +142,7 @@
   li a {
     color: inherit;
     display: block;
-    line-height: $line-height * 2;
-    padding-left: $line-height / 4;
+    padding: $line-height / 2 $line-height / 4;
     vertical-align: top;
 
     &:hover {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -460,6 +460,7 @@ button,
     > nav {
       flex: 20%;
       min-width: $side-menu-min-width;
+      max-width: max-content;
 
       + * {
         flex: 80%;

--- a/app/assets/stylesheets/mixins/icons.scss
+++ b/app/assets/stylesheets/mixins/icons.scss
@@ -17,8 +17,7 @@
 
 %admin-menu-icon {
   font-size: rem-calc(20);
-  margin-left: rem-calc(8);
-  margin-right: rem-calc(10);
+  margin-#{$global-right}: rem-calc(10);
 }
 
 $font-awesome-icons: (


### PR DESCRIPTION
## Objectives

* Make it easier to differentiate submenu items expanding over several lines
* Fix overlap between the icon to open/close a submenu and the text associated to it
* Fix icon to open/close a submenu in languages written from right to left
* Reduce blank space in the admin menu on large screens
* Improve admin menu in RTL languages

## Visual Changes

### Before these changes

Admin section in German:

![Spacing between lines of submenu items makes it hard to see when an element starts and ends, and the icon to open a submenu overlaps with the text](https://user-images.githubusercontent.com/35156/131050584-7b523277-1a1c-4046-8c5c-02138b878e20.png)

Admin menu on large screens in English:

![The menu is wider than its contents and there's a lot of blank space between a menu item and the icon to open/close its submenu](https://user-images.githubusercontent.com/35156/131050587-cae243f2-e4d1-4581-a2be-2a6ca2995dd1.png)

### After these changes

Admin section in German:

![It's easy to see when an element starts and ends, and the icon to open a submenu doesn't overlap with the text](https://user-images.githubusercontent.com/35156/131051261-a58584d0-0e31-48de-a744-cd800a085eaa.png)

Admin menu on large screens in English:

![The menu is as wide as its contents](https://user-images.githubusercontent.com/35156/131050594-a3edc0e3-2e10-4bae-bc61-b4ba1432f9a3.png)
