### PR TITLE
Add default focus outline to buttons

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -978,17 +978,6 @@ table {
     }
   }
 
-  .legislation-draft-version-body {
-    font-family: $font-family-serif;
-    background: #f5f5f5;
-    height: 16em;
-
-    &:focus {
-      border: 1px solid #cacaca;
-      box-shadow: inset 0 1px 2px rgba(34, 34, 34, 0.1);
-    }
-  }
-
   .markdown-preview {
     font-family: $font-family-serif;
     border: 1px solid #cacaca;
@@ -1032,11 +1021,14 @@ table {
 
     .legislation-draft-version-body {
       border-radius: 0;
-      padding: 1rem;
-      border: 0;
 
       @include breakpoint(medium) {
-        padding: 1rem 2rem;
+        padding-left: 2rem;
+        padding-right: 2rem;
+      }
+
+      &:focus {
+        box-shadow: inset 0 1px 2px rgba(34, 34, 34, 0.1);
       }
     }
 
@@ -1048,12 +1040,6 @@ table {
         padding: 1rem 2rem;
       }
     }
-  }
-}
-
-.legislation-draft-version-body {
-  &:focus {
-    border: 0;
   }
 }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -274,6 +274,10 @@ $table-header:   #ecf1f6;
       border: $admin-border;
       border-radius: rem-calc(6);
       box-shadow: none;
+
+      &:focus {
+        border: $input-border-focus;
+      }
     }
   }
 

--- a/app/assets/stylesheets/admin/machine_learning/scripts.scss
+++ b/app/assets/stylesheets/admin/machine_learning/scripts.scss
@@ -49,10 +49,6 @@
     margin-bottom: 0;
     margin-top: $line-height;
 
-    &:focus {
-      outline: $outline-focus;
-    }
-
     &.cancel {
       @include hollow-button($alert-color);
     }

--- a/app/assets/stylesheets/admin/machine_learning/setting.scss
+++ b/app/assets/stylesheets/admin/machine_learning/setting.scss
@@ -16,10 +16,6 @@
     min-width: rem-calc(100);
     position: relative;
 
-    &:focus {
-      outline: $outline-focus;
-    }
-
     &::after {
       background: $white;
       border-radius: 100%;

--- a/app/assets/stylesheets/advanced_search.scss
+++ b/app/assets/stylesheets/advanced_search.scss
@@ -40,10 +40,6 @@
       margin-bottom: 0;
       margin-top: $line-height / 4;
     }
-
-    &:focus {
-      outline: $outline-focus;
-    }
   }
 
   .general-search,

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -116,6 +116,19 @@ button,
   &:focus {
     outline: $outline-focus;
   }
+
+  &:focus-visible {
+    outline: $outline-focus;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  &:active,
+  &:focus:active {
+    outline: $outline-focus;
+  }
 }
 
 .button {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -106,6 +106,14 @@ a {
 
   &:focus {
     color: $link-hover;
+  }
+}
+
+a,
+button,
+[type="button"],
+[type="submit"] {
+  &:focus {
     outline: $outline-focus;
   }
 }
@@ -2399,10 +2407,6 @@ table {
 
   @include breakpoint(medium) {
     float: right;
-  }
-
-  &:focus {
-    outline: $outline-focus;
   }
 
   &[aria-expanded="false"] + form {

--- a/app/assets/stylesheets/layout/locale_switcher.scss
+++ b/app/assets/stylesheets/layout/locale_switcher.scss
@@ -39,6 +39,7 @@
       width: auto;
 
       &:focus {
+        border: 0;
         outline: $outline-focus;
       }
 

--- a/app/assets/stylesheets/mixins/buttons.scss
+++ b/app/assets/stylesheets/mixins/buttons.scss
@@ -39,8 +39,4 @@
     color: $link-hover;
     text-decoration: underline;
   }
-
-  &:focus {
-    outline: $outline-focus;
-  }
 }

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -772,10 +772,6 @@
         cursor: pointer;
       }
 
-      &:focus {
-        outline: $outline-focus;
-      }
-
       &:active {
         opacity: 0.75;
       }

--- a/app/assets/stylesheets/sdg/related_list_selector.scss
+++ b/app/assets/stylesheets/sdg/related_list_selector.scss
@@ -73,10 +73,6 @@
 
   .remove-tag {
     color: $white;
-
-    &:focus {
-      outline: $outline-focus;
-    }
   }
 
   h3 {

--- a/app/views/admin/legislation/draft_versions/_form.html.erb
+++ b/app/views/admin/legislation/draft_versions/_form.html.erb
@@ -50,7 +50,8 @@
         </div>
 
         <div class="small-12 medium-6 column markdown-area">
-          <%= translations_form.text_area :body, label: false, rows: 10 %>
+          <%= translations_form.text_area :body, label: false, rows: 10,
+                                          class: "legislation-draft-version-body" %>
         </div>
 
         <div class="small-12 medium-6 column markdown-preview">


### PR DESCRIPTION
## References

* We lost focus styles on some elements in commit 4dad04ae3, since we added a border with a rule which had more precedence than the rule of border on focus

## Objectives

* Make it easier for keyboard users to know which control they're interacting with

## Visual Changes

### Before these changes

![Focus on buttons is very noticeable, with a thin dotted outline](https://user-images.githubusercontent.com/35156/132688026-74a3b28c-0050-4f2a-af0b-f574159b898d.png)

![Focus on form controls in the admin section is not shown in any way](https://user-images.githubusercontent.com/35156/132687430-1bf74da4-1a97-4823-9b66-c16243c119ba.png)

### After these changes

![Focus on buttons is obvious, using the same outline as links](https://user-images.githubusercontent.com/35156/132688043-3a2934ac-7a98-43e3-8a57-2a1739995e98.png)

![Focus on form controls in the admin section is shown with a different border, like in the public section](https://user-images.githubusercontent.com/35156/132687460-8083e177-4e54-4882-ad39-4e4ef0bbd479.png)