### PR TITLE
Increase login links touch area on small screens

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -111,10 +111,6 @@ $table-header:   #ecf1f6;
     [class^="icon-"] {
       font-size: $base-font-size;
     }
-  }
-
-  .menu .menu-text {
-    padding: 0;
 
     h1 {
       margin-top: $line-height / 2;
@@ -128,14 +124,15 @@ $table-header:   #ecf1f6;
         color: inherit;
         text-transform: uppercase;
       }
-    }
 
-    a {
-      display: inline-block;
-      font-family: "Lato" !important;
-      font-size: rem-calc(24);
-      font-weight: lighter;
-      padding: 0;
+      a {
+        color: inherit;
+        display: inline-block;
+        font-family: "Lato" !important;
+        font-size: rem-calc(24);
+        font-weight: lighter;
+        line-height: 1;
+      }
     }
   }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -83,15 +83,8 @@ $table-header:   #ecf1f6;
 
         .submenu {
           border: 0;
-          display: block;
           margin-top: 0;
           position: initial;
-          width: 100%;
-        }
-
-        .is-active {
-          font-weight: normal;
-          text-decoration: none;
         }
 
         .is-submenu-item {
@@ -99,7 +92,7 @@ $table-header:   #ecf1f6;
         }
 
         a {
-          font-weight: normal !important;
+          font-weight: normal;
         }
       }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -81,14 +81,14 @@ $table-header:   #ecf1f6;
 
       .top-bar-right {
 
-        .submenu {
-          border: 0;
-          margin-top: 0;
-          position: initial;
+        > ul {
+          border-bottom: 0;
+          padding-bottom: 0;
+          margin-bottom: 0;
         }
 
-        .is-submenu-item {
-          padding: $line-height / 2 0;
+        .submenu {
+          position: initial;
         }
 
         a {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -744,7 +744,8 @@ body > header,
   a {
     color: inherit;
     display: inline-block;
-    line-height: $line-height * 2;
+    padding-bottom: $line-height / 2;
+    padding-top: $line-height / 2;
     position: relative;
     text-align: left;
     width: 100%;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -610,6 +610,17 @@ body > header,
 
   .menu {
 
+    @include breakpoint(small only) {
+      border-bottom: 1px solid $border;
+      margin-bottom: $line-height;
+      margin-top: $line-height / 2;
+      padding-bottom: $line-height;
+
+      .submenu {
+        margin-top: 0;
+      }
+    }
+
     &.is-dropdown-submenu {
       background: $body-background;
       color: $text;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -580,11 +580,12 @@ body > header,
 
     a {
       color: inherit;
+      line-height: inherit;
       padding-left: 0;
 
       @include breakpoint(medium) {
         font-size: $small-font-size;
-        padding: rem-calc(11) rem-calc(16);
+        padding: rem-calc(8) rem-calc(16);
       }
     }
 

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -40,7 +40,7 @@
 
       <div id="responsive_menu">
         <div class="top-bar-right">
-          <ul class="dropdown menu" data-dropdown-menu>
+          <ul class="menu" data-responsive-menu="medium-dropdown">
             <%= render "shared/admin_login_items" %>
             <%= render "layouts/notification_item" %>
             <%= render "devise/menu/login_items" %>

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -17,25 +17,21 @@
 
     <div class="top-bar">
       <div class="top-bar-left">
-        <ul class="menu">
-          <li class="menu-text">
-            <% if namespace == "officing" %>
-              <h1>
-                <%= link_to "#" do %>
-                  <%= setting["org_name"] %>
-                  <br><small><%= namespaced_header_title %></small>
-                <% end %>
-              </h1>
-            <% else %>
-              <h1>
-                <%= link_to namespaced_root_path do %>
-                  <%= setting["org_name"] %>
-                  <br><small><%= namespaced_header_title %></small>
-                <% end %>
-              </h1>
+        <% if namespace == "officing" %>
+          <h1>
+            <%= link_to "#" do %>
+              <%= setting["org_name"] %>
+              <br><small><%= namespaced_header_title %></small>
             <% end %>
-          </li>
-        </ul>
+          </h1>
+        <% else %>
+          <h1>
+            <%= link_to namespaced_root_path do %>
+              <%= setting["org_name"] %>
+              <br><small><%= namespaced_header_title %></small>
+            <% end %>
+          </h1>
+        <% end %>
       </div>
 
       <div id="responsive_menu">

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -16,16 +16,12 @@
       <div class="expanded row admin-top-bar">
         <div class="top-bar">
           <div class="top-bar-left">
-            <ul class="menu">
-              <li class="menu-text">
-                <h1>
-                  <%= link_to management_root_path do %>
-                    <%= setting["org_name"] %>
-                    <br><small><%= t("management.dashboard.index.title") %></small>
-                  <% end %>
-                </h1>
-              </li>
-            </ul>
+            <h1>
+              <%= link_to management_root_path do %>
+                <%= setting["org_name"] %>
+                <br><small><%= t("management.dashboard.index.title") %></small>
+              <% end %>
+            </h1>
           </div>
           <% if show_admin_menu?(manager_logged_in) %>
             <div id="responsive_menu">

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -1,7 +1,7 @@
 <% if show_admin_menu?(current_user) %>
   <li class="has-submenu">
     <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
-    <ul class="submenu menu vertical" data-submenu>
+    <ul class="submenu menu" data-submenu>
       <% if current_user.administrator? %>
         <li>
           <%= link_to t("layouts.header.administration"), admin_root_path %>


### PR DESCRIPTION
## Objectives

* Make it easier to click/touch the "Sign in", "Register", "My content", "My account" and "Sign out" links on small screens
* Make it easier to read menu items spanning over several lines
* Make it obvious on small screens that "my content" links are not part of the site navigation

## Visual Changes

### Before these changes

![On small screens there's barely any vertical space between the "My content" and "My account links"](https://user-images.githubusercontent.com/35156/131195381-33588775-15cf-478b-8e53-e1aa042dd553.png)

![The space between the lines of a navigation element is the same as the space between elements](https://user-images.githubusercontent.com/35156/131195379-05f85046-095c-4c61-82c5-b5c4a9154288.png)

![The space between the lines of a menu element is very small](https://user-images.githubusercontent.com/35156/131195380-ec0e30f9-36af-409b-a27e-79ec2e133816.png)

### After these changes

![On small screens there's plenty of vertical space between the "My content" and "My account links"](https://user-images.githubusercontent.com/35156/131195402-a9edce72-9fb9-4ac9-811c-92b504ba8d98.png)

![The space between the lines of a navigation element is smaller than the space between elements](https://user-images.githubusercontent.com/35156/131196268-4da113c3-57af-49bd-8b42-ad5831ecf235.png)

![The space between the lines of a menu element is the standard space between lines used everywhere else](https://user-images.githubusercontent.com/35156/131196107-618d8fa1-d7ea-4691-951d-3810c92cab5c.png)
