### PR TITLE
Fix flaky legislation draft version spec

### DIFF
--- a/spec/system/admin/legislation/draft_versions_spec.rb
+++ b/spec/system/admin/legislation/draft_versions_spec.rb
@@ -27,7 +27,6 @@ describe "Admin legislation draft versions", :admin do
         click_link "Collaborative Legislation"
       end
 
-      click_link "All"
       within("tr", text: "An example legislation process") { click_link "Edit" }
       click_link "Drafting"
 


### PR DESCRIPTION
## References

* This test failed in our [test run #2524, build 2](https://github.com/consul/consul/runs/3452325004)

## Failure

```
1) Admin legislation draft versions Create Valid legislation draft version
   Failure/Error: click_link "Drafting"

   Capybara::ElementNotFound:
     Unable to find link "Drafting"
```

## Objectives

* Make the test pass 100% of the time

## Notes

The test was failing sometimes, probably because the "Edit" link within the "An example legislation process" row is already present before clicking the "All" link. This can lead to simultaneous requests.

Just removing the unnecessary click on the "All" link solves the issue.