### PR TITLE
Don't render empty SDG tag list div

### DIFF
--- a/app/components/sdg/tag_list_component.rb
+++ b/app/components/sdg/tag_list_component.rb
@@ -7,6 +7,10 @@ class SDG::TagListComponent < ApplicationComponent
     @linkable = linkable
   end
 
+  def render?
+    record.sdg_goals.any? || record.sdg_targets.any?
+  end
+
   private
 
     def goals_list

--- a/spec/components/sdg/tag_list_component_spec.rb
+++ b/spec/components/sdg/tag_list_component_spec.rb
@@ -22,6 +22,14 @@ describe SDG::TagListComponent do
     expect(page).to have_link "target 3.2.1"
   end
 
+  it "does not render when there are no tags" do
+    record = build(:debate, sdg_goals: [], sdg_targets: [])
+
+    render_inline SDG::TagListComponent.new(record)
+
+    expect(page.native.inner_html).to be_empty
+  end
+
   context "when linkable is false" do
     let(:component) { SDG::TagListComponent.new(debate, linkable: false) }
 


### PR DESCRIPTION
## References

* We don't render empty regular tags since commit 4d27bbeba

## Objectives

* Avoid adding an empty `<div class="sdg-tag-list">` tag, which might have associated styles (in custom CONSUL installation styles, for instance) and thus break the layout