### PR TITLE
Remove a potentially pre-existing server.pid in entrypoint.sh

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -15,3 +15,6 @@ chgrp -R -h "$USER_GID" "$BUNDLE_PATH"
 
 /usr/bin/sudo -EH -u consul "$@"
 
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /var/www/consul/tmp/pids/server.pid
+

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -16,5 +16,12 @@ chgrp -R -h "$USER_GID" "$BUNDLE_PATH"
 /usr/bin/sudo -EH -u consul "$@"
 
 # Remove a potentially pre-existing server.pid for Rails.
-rm -f /var/www/consul/tmp/pids/server.pid
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -13,8 +13,6 @@ usermod -g "$USER_GID" consul 2> /dev/null
 chown -R -h "$USER_UID" "$BUNDLE_PATH"
 chgrp -R -h "$USER_GID" "$BUNDLE_PATH"
 
-/usr/bin/sudo -EH -u consul "$@"
-
 # Remove a potentially pre-existing server.pid for Rails.
 set -e
 
@@ -23,5 +21,5 @@ if [ -f tmp/pids/server.pid ]; then
 fi
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
-exec "$@"
+/usr/bin/sudo -EH -u consul "$@"
 


### PR DESCRIPTION
This command will tigger the script to remove a potentially pre-existing server.pid for Rails. With this change the ops does not have to manually `rm tmp/pids/server.pid` remove the server.pid file.
