### PR TITLE
Remove a potentially pre-existing server.pid in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,10 @@ services:
   app:
 
     # use the Dockerfile next to this file
+    # Remove a potentially pre-existing server.pid for Rails
     build: .
     entrypoint: /usr/local/bin/entrypoint.sh
-    command: bundle exec rails s -p 3000 -b "0.0.0.0"
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     working_dir: /var/www/consul
 
     # rely on the RAILS_ENV value of the host machine


### PR DESCRIPTION
This command will tigger the script in the entrypoint.sh to remove a potentially pre-existing server.pid for Rails. With this change the ops does not have to manually [rm tmp/pids/server.pid] remove the server.pid file when the container is restarted.
