### PR TITLE
Fix "Add image" button styles in budget phases

### DIFF
--- a/app/assets/stylesheets/admin/budget_phases/form.scss
+++ b/app/assets/stylesheets/admin/budget_phases/form.scss
@@ -1,6 +1,6 @@
 .admin .budget-phases-form {
 
-  fieldset {
+  > fieldset {
     margin-top: $line-height;
 
     > * {


### PR DESCRIPTION
## References

* It was broken since we fixed issues with other image fields in commit 394a94cbf from pull request #4586

## Visual Changes

### Before these changes

![The button to add image to a phase fills in the whole screen width](https://user-images.githubusercontent.com/35156/131768212-877b4fb9-10d5-439d-93b6-bf3e6b5901d5.png)

### After these changes

![The button to add image to a phase fills is as wide as its text](https://user-images.githubusercontent.com/35156/131768222-85013ce4-4ee4-428d-81a9-1324eb9d54dd.png)