### PR TITLE
Fix budget mode selection in Internet Explorer 11

### DIFF
--- a/app/assets/stylesheets/admin/budgets/heading_mode.scss
+++ b/app/assets/stylesheets/admin/budgets/heading_mode.scss
@@ -56,7 +56,7 @@
   p {
     font-size: $small-font-size;
     font-style: italic;
-    flex: 1;
+    flex-grow: 1;
   }
 
   a {


### PR DESCRIPTION
## References

* A similar Internet Explorer issue was addressed in pull request #4561

## Visual changes

These screenshots were taken on Internet Explorer 11.

### Before these changes

![One mode is shown below the other one, and the links to create a budget overlap with their description](https://user-images.githubusercontent.com/35156/132034418-a7c68d6f-7d5f-416b-b737-5a05118de3c7.png)

### After these changes

![One mode is shown on the left and the other one on the right, and the links to create a budget are shown below their description](https://user-images.githubusercontent.com/35156/132034433-de5d9be8-c35c-4b4c-abd1-1efdee082020.png)

## Notes

We don't officially guarantee the page will look properly in Internet Explorer, but we try to support as many browsers as possible when it's easy to do so.