### PR TITLE
Simplify type and current user in component tests

### DIFF
--- a/spec/components/admin/budgets/duration_component_spec.rb
+++ b/spec/components/admin/budgets/duration_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Budgets::DurationComponent, type: :component do
+describe Admin::Budgets::DurationComponent do
   describe "#dates" do
     it "shows both dates when both are defined" do
       durable = double(

--- a/spec/components/admin/budgets/form_component_spec.rb
+++ b/spec/components/admin/budgets/form_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Budgets::FormComponent, type: :component do
+describe Admin::Budgets::FormComponent do
   describe "#voting_styles_select_options" do
     it "provides vote kinds" do
       types = [["Knapsack", "knapsack"], ["Approval", "approval"]]

--- a/spec/components/admin/budgets/index_component_spec.rb
+++ b/spec/components/admin/budgets/index_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Budgets::IndexComponent, type: :component, controller: Admin::BudgetsController do
+describe Admin::Budgets::IndexComponent, controller: Admin::BudgetsController do
   before do
     allow_any_instance_of(Admin::BudgetsController).to receive(:valid_filters).and_return(["all"])
     allow_any_instance_of(Admin::BudgetsController).to receive(:current_filter).and_return("all")

--- a/spec/components/admin/budgets/table_actions_component_spec.rb
+++ b/spec/components/admin/budgets/table_actions_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Budgets::TableActionsComponent, type: :component, controller: Admin::BaseController do
+describe Admin::Budgets::TableActionsComponent, controller: Admin::BaseController do
   let(:budget) { create(:budget) }
   let(:component) { Admin::Budgets::TableActionsComponent.new(budget) }
 

--- a/spec/components/admin/budgets_wizard/headings/group_switcher_component_spec.rb
+++ b/spec/components/admin/budgets_wizard/headings/group_switcher_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::BudgetsWizard::Headings::GroupSwitcherComponent, type: :component do
+describe Admin::BudgetsWizard::Headings::GroupSwitcherComponent do
   it "is not rendered for budgets with one group" do
     group = create(:budget_group, budget: create(:budget))
 

--- a/spec/components/admin/hidden_table_actions_component_spec.rb
+++ b/spec/components/admin/hidden_table_actions_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::HiddenTableActionsComponent, type: :component do
+describe Admin::HiddenTableActionsComponent do
   let(:record) { create(:user) }
   let(:component) { Admin::HiddenTableActionsComponent.new(record) }
 

--- a/spec/components/admin/organizations/table_actions_component_spec.rb
+++ b/spec/components/admin/organizations/table_actions_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Organizations::TableActionsComponent, type: :component do
+describe Admin::Organizations::TableActionsComponent do
   let(:organization) { create(:organization) }
   let(:component) { Admin::Organizations::TableActionsComponent.new(organization) }
 

--- a/spec/components/admin/poll/officers/officers_component_spec.rb
+++ b/spec/components/admin/poll/officers/officers_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Poll::Officers::OfficersComponent, type: :component, controller: Admin::BaseController do
+describe Admin::Poll::Officers::OfficersComponent, controller: Admin::BaseController do
   let(:existing_officer) { create(:poll_officer, name: "Old officer") }
   let(:new_officer) { build(:poll_officer, name: "New officer") }
   let(:officers) { [existing_officer, new_officer] }

--- a/spec/components/admin/poll/questions/filter_component_spec.rb
+++ b/spec/components/admin/poll/questions/filter_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Poll::Questions::FilterComponent, type: :component do
+describe Admin::Poll::Questions::FilterComponent do
   it "renders a button to submit the form" do
     render_inline Admin::Poll::Questions::FilterComponent.new([])
 

--- a/spec/components/admin/roles/table_actions_component_spec.rb
+++ b/spec/components/admin/roles/table_actions_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Roles::TableActionsComponent, type: :component, controller: Admin::BaseController do
+describe Admin::Roles::TableActionsComponent, controller: Admin::BaseController do
   let(:user) { create(:user) }
 
   it "renders link to add the role for new records" do

--- a/spec/components/admin/stats/sdg/goal_component_spec.rb
+++ b/spec/components/admin/stats/sdg/goal_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::Stats::SDG::GoalComponent, type: :component do
+describe Admin::Stats::SDG::GoalComponent do
   let(:component) { Admin::Stats::SDG::GoalComponent.new(goal: goal) }
   let(:goal) { SDG::Goal.sample }
 

--- a/spec/components/admin/table_actions_component_spec.rb
+++ b/spec/components/admin/table_actions_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Admin::TableActionsComponent, type: :component, controller: Admin::BaseController do
+describe Admin::TableActionsComponent, controller: Admin::BaseController do
   let(:record) { create(:banner) }
 
   it "renders links to edit and destroy a record by default" do

--- a/spec/components/budgets/budget_component_spec.rb
+++ b/spec/components/budgets/budget_component_spec.rb
@@ -5,9 +5,7 @@ describe Budgets::BudgetComponent do
   let(:heading) { create(:budget_heading, budget: budget) }
   let(:user) { create(:user) }
 
-  before do
-    allow(controller).to receive(:current_user).and_return(user)
-  end
+  before { sign_in(user) }
 
   describe "budget header" do
     it "shows budget name and link to help" do

--- a/spec/components/budgets/budget_component_spec.rb
+++ b/spec/components/budgets/budget_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Budgets::BudgetComponent, type: :component do
+describe Budgets::BudgetComponent do
   let(:budget) { create(:budget) }
   let(:heading) { create(:budget_heading, budget: budget) }
   let(:user) { create(:user) }

--- a/spec/components/budgets/investment_component_spec.rb
+++ b/spec/components/budgets/investment_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Budgets::InvestmentComponent, type: :component do
+describe Budgets::InvestmentComponent do
   let(:user) { create(:user) }
 
   before do

--- a/spec/components/budgets/investment_component_spec.rb
+++ b/spec/components/budgets/investment_component_spec.rb
@@ -1,11 +1,7 @@
 require "rails_helper"
 
 describe Budgets::InvestmentComponent do
-  let(:user) { create(:user) }
-
-  before do
-    allow(controller).to receive(:current_user).and_return(user)
-  end
+  before { sign_in(create(:user)) }
 
   it "shows the investment image when defined" do
     investment = create(:budget_investment, :with_image)

--- a/spec/components/budgets/investments/form_component_spec.rb
+++ b/spec/components/budgets/investments/form_component_spec.rb
@@ -4,10 +4,7 @@ describe Budgets::Investments::FormComponent do
   include Rails.application.routes.url_helpers
 
   let(:budget) { create(:budget) }
-
-  before do
-    allow(controller).to receive(:current_user).and_return(create(:user))
-  end
+  before { sign_in(create(:user)) }
 
   around do |example|
     with_request_url(new_budget_investment_path(budget)) { example.run }

--- a/spec/components/budgets/investments/form_component_spec.rb
+++ b/spec/components/budgets/investments/form_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Budgets::Investments::FormComponent, type: :component do
+describe Budgets::Investments::FormComponent do
   include Rails.application.routes.url_helpers
 
   let(:budget) { create(:budget) }

--- a/spec/components/budgets/investments/votes_component_spec.rb
+++ b/spec/components/budgets/investments/votes_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Budgets::Investments::VotesComponent, type: :component do
+describe Budgets::Investments::VotesComponent do
   describe "vote link" do
     context "when investment shows votes" do
       let(:investment) { create(:budget_investment, title: "Renovate sidewalks in Main Street") }

--- a/spec/components/budgets/investments/votes_component_spec.rb
+++ b/spec/components/budgets/investments/votes_component_spec.rb
@@ -19,8 +19,6 @@ describe Budgets::Investments::VotesComponent do
       end
 
       it "disables the button to support the investment to unidentified users" do
-        sign_in(nil)
-
         render_inline component
 
         expect(page).to have_button count: 1, disabled: :all

--- a/spec/components/budgets/investments/votes_component_spec.rb
+++ b/spec/components/budgets/investments/votes_component_spec.rb
@@ -9,7 +9,7 @@ describe Budgets::Investments::VotesComponent do
       before { allow(investment).to receive(:should_show_votes?).and_return(true) }
 
       it "displays a button to support the investment to identified users" do
-        allow(controller).to receive(:current_user).and_return(create(:user))
+        sign_in(create(:user))
 
         render_inline component
 
@@ -19,7 +19,7 @@ describe Budgets::Investments::VotesComponent do
       end
 
       it "disables the button to support the investment to unidentified users" do
-        allow(controller).to receive(:current_user).and_return(nil)
+        sign_in(nil)
 
         render_inline component
 
@@ -30,7 +30,7 @@ describe Budgets::Investments::VotesComponent do
       it "shows the button to remove support when users have supported the investment" do
         user = create(:user)
         user.up_votes(investment)
-        allow(controller).to receive(:current_user).and_return(user)
+        sign_in(user)
 
         render_inline component
 

--- a/spec/components/budgets/investments_list_component_spec.rb
+++ b/spec/components/budgets/investments_list_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Budgets::InvestmentsListComponent, type: :component do
+describe Budgets::InvestmentsListComponent do
   include Rails.application.routes.url_helpers
 
   let(:budget)    { create(:budget, :accepting) }

--- a/spec/components/budgets/investments_list_component_spec.rb
+++ b/spec/components/budgets/investments_list_component_spec.rb
@@ -7,7 +7,7 @@ describe Budgets::InvestmentsListComponent do
   let(:group)     { create(:budget_group, budget: budget) }
   let(:heading)   { create(:budget_heading, group: group) }
 
-  before { allow(controller).to receive(:current_user).and_return(nil) }
+  before { sign_in(nil) }
 
   describe "#investments" do
     let(:component) { Budgets::InvestmentsListComponent.new(budget) }

--- a/spec/components/budgets/investments_list_component_spec.rb
+++ b/spec/components/budgets/investments_list_component_spec.rb
@@ -7,8 +7,6 @@ describe Budgets::InvestmentsListComponent do
   let(:group)     { create(:budget_group, budget: budget) }
   let(:heading)   { create(:budget_heading, group: group) }
 
-  before { sign_in(nil) }
-
   describe "#investments" do
     let(:component) { Budgets::InvestmentsListComponent.new(budget) }
 

--- a/spec/components/budgets/phases_component_spec.rb
+++ b/spec/components/budgets/phases_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Budgets::PhasesComponent, type: :component do
+describe Budgets::PhasesComponent do
   let(:budget) { create(:budget) }
 
   it "shows budget current phase main link when defined" do

--- a/spec/components/budgets/subheader_component_spec.rb
+++ b/spec/components/budgets/subheader_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Budgets::SubheaderComponent, type: :component do
+describe Budgets::SubheaderComponent do
   it "shows budget current phase name" do
     allow(controller).to receive(:current_user).and_return(create(:user))
     budget = create(:budget, :informing)

--- a/spec/components/budgets/subheader_component_spec.rb
+++ b/spec/components/budgets/subheader_component_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Budgets::SubheaderComponent do
   it "shows budget current phase name" do
-    allow(controller).to receive(:current_user).and_return(create(:user))
+    sign_in(create(:user))
     budget = create(:budget, :informing)
 
     render_inline Budgets::SubheaderComponent.new(budget)
@@ -17,7 +17,7 @@ describe Budgets::SubheaderComponent do
     let(:budget) { create(:budget, :accepting) }
 
     it "and user is level_two_or_three_verified shows a link to create a new investment" do
-      allow(controller).to receive(:current_user).and_return(create(:user, :level_two))
+      sign_in(create(:user, :level_two))
 
       render_inline Budgets::SubheaderComponent.new(budget)
 
@@ -34,7 +34,7 @@ describe Budgets::SubheaderComponent do
     end
 
     it "and user is not verified shows a link to account verification" do
-      allow(controller).to receive(:current_user).and_return(create(:user))
+      sign_in(create(:user))
 
       render_inline Budgets::SubheaderComponent.new(budget)
 
@@ -53,7 +53,7 @@ describe Budgets::SubheaderComponent do
     end
 
     it "and user is not logged in shows links to sign in and sign up" do
-      allow(controller).to receive(:current_user).and_return(nil)
+      sign_in(nil)
 
       render_inline Budgets::SubheaderComponent.new(budget)
 
@@ -77,12 +77,12 @@ describe Budgets::SubheaderComponent do
   describe "See results link" do
     it "is showed when budget is finished and results are enabled for all users" do
       budget = create(:budget, :finished)
-      allow(controller).to receive(:current_user).and_return(create(:user))
+      sign_in(create(:user))
       render_inline Budgets::SubheaderComponent.new(budget)
 
       expect(page).to have_link "See results"
 
-      allow(controller).to receive(:current_user).and_return(create(:administrator).user)
+      sign_in(create(:administrator).user)
       render_inline Budgets::SubheaderComponent.new(budget)
 
       expect(page).to have_link "See results"
@@ -90,12 +90,12 @@ describe Budgets::SubheaderComponent do
 
     it "is not showed when budget is finished or results are disabled for all users" do
       budget = create(:budget, :balloting, results_enabled: true)
-      allow(controller).to receive(:current_user).and_return(create(:user))
+      sign_in(create(:user))
       render_inline Budgets::SubheaderComponent.new(budget)
 
       expect(page).not_to have_link "See results"
 
-      allow(controller).to receive(:current_user).and_return(create(:administrator).user)
+      sign_in(create(:administrator).user)
       render_inline Budgets::SubheaderComponent.new(budget)
 
       expect(page).not_to have_link "See results"

--- a/spec/components/budgets/subheader_component_spec.rb
+++ b/spec/components/budgets/subheader_component_spec.rb
@@ -53,8 +53,6 @@ describe Budgets::SubheaderComponent do
     end
 
     it "and user is not logged in shows links to sign in and sign up" do
-      sign_in(nil)
-
       render_inline Budgets::SubheaderComponent.new(budget)
 
       expect(page).to have_content "To create a new budget investment you must"

--- a/spec/components/budgets/supports_info_component_spec.rb
+++ b/spec/components/budgets/supports_info_component_spec.rb
@@ -4,7 +4,7 @@ describe Budgets::SupportsInfoComponent do
   let(:budget) { create(:budget, :selecting) }
   let(:group) { create(:budget_group, budget: budget) }
   let(:component) { Budgets::SupportsInfoComponent.new(budget) }
-  before { allow(component).to receive(:current_user).and_return(nil) }
+  before { sign_in(nil) }
 
   it "renders when the budget is selecting" do
     create(:budget_heading, group: group)
@@ -42,7 +42,7 @@ describe Budgets::SupportsInfoComponent do
 
     context "logged users" do
       let(:user) { create(:user, :level_two) }
-      before { allow(component).to receive(:current_user).and_return(user) }
+      before { sign_in(user) }
 
       it "shows supported investments" do
         heading = create(:budget_heading, budget: budget)
@@ -67,14 +67,14 @@ describe Budgets::SupportsInfoComponent do
       it "does not show supports for another budget" do
         second_budget = create(:budget, phase: "selecting")
         second_component = Budgets::SupportsInfoComponent.new(second_budget)
-        allow(second_component).to receive(:current_user).and_return(user)
-
         create_list(:budget_investment, 2, :selected, budget: budget, voters: [user])
         create_list(:budget_investment, 3, :selected, budget: second_budget, voters: [user])
 
         render_inline component
 
         expect(page).to have_content "So far you've supported 2 projects."
+
+        sign_in(user)
 
         render_inline second_component
 

--- a/spec/components/budgets/supports_info_component_spec.rb
+++ b/spec/components/budgets/supports_info_component_spec.rb
@@ -4,7 +4,6 @@ describe Budgets::SupportsInfoComponent do
   let(:budget) { create(:budget, :selecting) }
   let(:group) { create(:budget_group, budget: budget) }
   let(:component) { Budgets::SupportsInfoComponent.new(budget) }
-  before { sign_in(nil) }
 
   it "renders when the budget is selecting" do
     create(:budget_heading, group: group)

--- a/spec/components/budgets/supports_info_component_spec.rb
+++ b/spec/components/budgets/supports_info_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Budgets::SupportsInfoComponent, type: :component do
+describe Budgets::SupportsInfoComponent do
   let(:budget) { create(:budget, :selecting) }
   let(:group) { create(:budget_group, budget: budget) }
   let(:component) { Budgets::SupportsInfoComponent.new(budget) }

--- a/spec/components/layout/locale_switcher_component_spec.rb
+++ b/spec/components/layout/locale_switcher_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Layout::LocaleSwitcherComponent, type: :component do
+describe Layout::LocaleSwitcherComponent do
   let(:component) { Layout::LocaleSwitcherComponent.new }
 
   around do |example|

--- a/spec/components/layout/social_component_spec.rb
+++ b/spec/components/layout/social_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Layout::SocialComponent, type: :component do
+describe Layout::SocialComponent do
   describe "#render?" do
     it "renders when a social setting is present" do
       Setting["twitter_handle"] = "myhandle"

--- a/spec/components/layout/top_links_component_spec.rb
+++ b/spec/components/layout/top_links_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Layout::TopLinksComponent, type: :component do
+describe Layout::TopLinksComponent do
   describe "#render?" do
     it "renders when a content block is defined" do
       create(:site_customization_content_block, name: "top_links")

--- a/spec/components/machine_learning/comments_summary_component_spec.rb
+++ b/spec/components/machine_learning/comments_summary_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe MachineLearning::CommentsSummaryComponent, type: :component do
+describe MachineLearning::CommentsSummaryComponent do
   let(:commentable) { double(summary_comment: double(body: "There's a general agreement")) }
   let(:component) { MachineLearning::CommentsSummaryComponent.new(commentable) }
 

--- a/spec/components/machine_learning/comments_summary_component_spec.rb
+++ b/spec/components/machine_learning/comments_summary_component_spec.rb
@@ -7,7 +7,6 @@ describe MachineLearning::CommentsSummaryComponent do
   before do
     Setting["feature.machine_learning"] = true
     Setting["machine_learning.comments_summary"] = true
-    sign_in(nil)
   end
 
   it "is displayed when the setting is enabled" do

--- a/spec/components/machine_learning/comments_summary_component_spec.rb
+++ b/spec/components/machine_learning/comments_summary_component_spec.rb
@@ -7,7 +7,7 @@ describe MachineLearning::CommentsSummaryComponent do
   before do
     Setting["feature.machine_learning"] = true
     Setting["machine_learning.comments_summary"] = true
-    allow(controller).to receive(:current_user).and_return(nil)
+    sign_in(nil)
   end
 
   it "is displayed when the setting is enabled" do

--- a/spec/components/pages/help/section_component_spec.rb
+++ b/spec/components/pages/help/section_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Pages::Help::SectionComponent, type: :component do
+describe Pages::Help::SectionComponent do
   describe "#image_path" do
     it "returns the image for the first fallback language with an image" do
       allow(I18n).to receive(:fallbacks).and_return({ en: [:es, :de] })

--- a/spec/components/relationable/related_list_component_spec.rb
+++ b/spec/components/relationable/related_list_component_spec.rb
@@ -14,8 +14,6 @@ describe Relationable::RelatedListComponent do
     create(:related_content, parent_relationable: proposal,
            child_relationable: machine_proposal,
            machine_learning: true)
-
-    sign_in(nil)
   end
 
   it "displays machine learning and user content when machine learning is enabled" do

--- a/spec/components/relationable/related_list_component_spec.rb
+++ b/spec/components/relationable/related_list_component_spec.rb
@@ -15,7 +15,7 @@ describe Relationable::RelatedListComponent do
            child_relationable: machine_proposal,
            machine_learning: true)
 
-    allow(controller).to receive(:current_user).and_return(nil)
+    sign_in(nil)
   end
 
   it "displays machine learning and user content when machine learning is enabled" do

--- a/spec/components/relationable/related_list_component_spec.rb
+++ b/spec/components/relationable/related_list_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Relationable::RelatedListComponent, type: :component do
+describe Relationable::RelatedListComponent do
   let(:proposal) { create(:proposal) }
   let(:user_proposal) { create(:proposal, title: "I am user related") }
   let(:machine_proposal) { create(:proposal, title: "I am machine related") }

--- a/spec/components/sdg/goals/help_page_component_spec.rb
+++ b/spec/components/sdg/goals/help_page_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::Goals::HelpPageComponent, type: :component do
+describe SDG::Goals::HelpPageComponent do
   let(:goals) { SDG::Goal.all }
   let(:component) { SDG::Goals::HelpPageComponent.new(goals) }
 

--- a/spec/components/sdg/goals/index_component_spec.rb
+++ b/spec/components/sdg/goals/index_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::Goals::IndexComponent, type: :component do
+describe SDG::Goals::IndexComponent do
   let!(:goals) { SDG::Goal.all }
   let!(:phases) { SDG::Phase.all }
   let!(:component) { SDG::Goals::IndexComponent.new(goals, header: nil, phases: phases) }

--- a/spec/components/sdg/goals/plain_tag_list_component_spec.rb
+++ b/spec/components/sdg/goals/plain_tag_list_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::Goals::PlainTagListComponent, type: :component do
+describe SDG::Goals::PlainTagListComponent do
   let(:debate) { create(:debate, sdg_goals: [SDG::Goal[1], SDG::Goal[3]]) }
   let(:component) { SDG::Goals::PlainTagListComponent.new(debate) }
 

--- a/spec/components/sdg/goals/show_component_spec.rb
+++ b/spec/components/sdg/goals/show_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::Goals::ShowComponent, type: :component do
+describe SDG::Goals::ShowComponent do
   let!(:goal_1) { SDG::Goal[1] }
 
   before do

--- a/spec/components/sdg/goals/tag_cloud_component_spec.rb
+++ b/spec/components/sdg/goals/tag_cloud_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::Goals::TagCloudComponent, type: :component do
+describe SDG::Goals::TagCloudComponent do
   before do
     Setting["feature.sdg"] = true
     Setting["sdg.process.debates"] = true

--- a/spec/components/sdg/goals/tag_list_component_spec.rb
+++ b/spec/components/sdg/goals/tag_list_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::Goals::TagListComponent, type: :component do
+describe SDG::Goals::TagListComponent do
   let(:debate) { create(:debate, sdg_goals: [SDG::Goal[1], SDG::Goal[3]]) }
   let(:component) { SDG::Goals::TagListComponent.new(debate) }
 

--- a/spec/components/sdg/goals/targets_component_spec.rb
+++ b/spec/components/sdg/goals/targets_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::Goals::TargetsComponent, type: :component do
+describe SDG::Goals::TargetsComponent do
   let(:goal) { SDG::Goal[1] }
   let(:component) { SDG::Goals::TargetsComponent.new(goal) }
 

--- a/spec/components/sdg/related_list_selector_component_spec.rb
+++ b/spec/components/sdg/related_list_selector_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::RelatedListSelectorComponent, type: :component do
+describe SDG::RelatedListSelectorComponent do
   let(:debate) { create(:debate) }
   let(:form) { ConsulFormBuilder.new(:debate, debate, ActionView::Base.new, {}) }
   let(:component) { SDG::RelatedListSelectorComponent.new(form) }

--- a/spec/components/sdg/tag_list_component_spec.rb
+++ b/spec/components/sdg/tag_list_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::TagListComponent, type: :component do
+describe SDG::TagListComponent do
   let(:debate) do
     create(:debate,
             sdg_goals: [SDG::Goal[3]],

--- a/spec/components/sdg/targets/plain_tag_list_component_spec.rb
+++ b/spec/components/sdg/targets/plain_tag_list_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::Targets::PlainTagListComponent, type: :component do
+describe SDG::Targets::PlainTagListComponent do
   let(:debate) do
     create(:debate,
            sdg_targets: [SDG::Target[1.1], SDG::Target[3.2], create(:sdg_local_target, code: "3.2.1")]

--- a/spec/components/sdg/targets/tag_list_component_spec.rb
+++ b/spec/components/sdg/targets/tag_list_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDG::Targets::TagListComponent, type: :component do
+describe SDG::Targets::TagListComponent do
   let(:debate) do
     create(:debate,
            sdg_targets: [SDG::Target[1.1], SDG::Target[3.2], create(:sdg_local_target, code: "3.2.1")]

--- a/spec/components/sdg_management/menu_component_spec.rb
+++ b/spec/components/sdg_management/menu_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDGManagement::MenuComponent, type: :component do
+describe SDGManagement::MenuComponent do
   let(:component) { SDGManagement::MenuComponent.new }
 
   before do

--- a/spec/components/sdg_management/relations/index_component_spec.rb
+++ b/spec/components/sdg_management/relations/index_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDGManagement::Relations::IndexComponent, type: :component, controller: SDGManagement::RelationsController do
+describe SDGManagement::Relations::IndexComponent, controller: SDGManagement::RelationsController do
   before do
     allow_any_instance_of(SDGManagement::RelationsController).to receive(:valid_filters)
       .and_return(SDGManagement::RelationsController::FILTERS)

--- a/spec/components/sdg_management/relations/search_component_spec.rb
+++ b/spec/components/sdg_management/relations/search_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDGManagement::Relations::SearchComponent, type: :component do
+describe SDGManagement::Relations::SearchComponent do
   describe "#goal_options" do
     it "orders goals by code in the select" do
       component = SDGManagement::Relations::SearchComponent.new(label: "Search proposals")

--- a/spec/components/sdg_management/subnavigation_component_spec.rb
+++ b/spec/components/sdg_management/subnavigation_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SDGManagement::SubnavigationComponent, type: :component do
+describe SDGManagement::SubnavigationComponent do
   let(:component) do
     SDGManagement::SubnavigationComponent.new(current: :goals) do
       "Tab content"

--- a/spec/components/shared/advanced_search_component_spec.rb
+++ b/spec/components/shared/advanced_search_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Shared::AdvancedSearchComponent, type: :component do
+describe Shared::AdvancedSearchComponent do
   let(:component) { Shared::AdvancedSearchComponent.new }
 
   context "JavaScript disabled" do

--- a/spec/components/shared/banner_component_spec.rb
+++ b/spec/components/shared/banner_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Shared::BannerComponent, type: :component do
+describe Shared::BannerComponent do
   it "renders given a banner" do
     banner = create(:banner,
                     title: "Vote now!",

--- a/spec/components/shared/filter_selector_component_spec.rb
+++ b/spec/components/shared/filter_selector_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Shared::FilterSelectorComponent, type: :component do
+describe Shared::FilterSelectorComponent do
   it "renders a form with a select" do
     component = Shared::FilterSelectorComponent.new(i18n_namespace: "budgets.investments.index")
     allow(component).to receive(:valid_filters).and_return(["unfeasible", "winners"])

--- a/spec/components/shared/link_list_component_spec.rb
+++ b/spec/components/shared/link_list_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Shared::LinkListComponent, type: :component do
+describe Shared::LinkListComponent do
   it "renders nothing with an empty list" do
     render_inline Shared::LinkListComponent.new
 

--- a/spec/components/shared/tag_list_component_spec.rb
+++ b/spec/components/shared/tag_list_component_spec.rb
@@ -9,7 +9,7 @@ describe Shared::TagListComponent do
   before do
     Setting["feature.machine_learning"] = true
     Setting["machine_learning.tags"] = true
-    allow(controller).to receive(:current_user).and_return(create(:administrator).user)
+    sign_in(create(:administrator).user)
   end
 
   it "displays machine learning tags when machine learning is enabled" do

--- a/spec/components/shared/tag_list_component_spec.rb
+++ b/spec/components/shared/tag_list_component_spec.rb
@@ -9,7 +9,6 @@ describe Shared::TagListComponent do
   before do
     Setting["feature.machine_learning"] = true
     Setting["machine_learning.tags"] = true
-    sign_in(create(:administrator).user)
   end
 
   it "displays machine learning tags when machine learning is enabled" do

--- a/spec/components/shared/tag_list_component_spec.rb
+++ b/spec/components/shared/tag_list_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Shared::TagListComponent, type: :component do
+describe Shared::TagListComponent do
   let(:user_tag) { create(:tag, name: "user tag") }
   let(:ml_tag) { create(:tag, name: "machine learning tag") }
   let(:proposal) { create(:proposal, tag_list: [user_tag], ml_tag_list: [ml_tag]) }

--- a/spec/components/widget/feeds/debate_component_spec.rb
+++ b/spec/components/widget/feeds/debate_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Widget::Feeds::DebateComponent, type: :component do
+describe Widget::Feeds::DebateComponent do
   let(:debate) { create(:debate, sdg_goals: [SDG::Goal[1]]) }
   let(:component) { Widget::Feeds::DebateComponent.new(debate) }
 

--- a/spec/components/widget/feeds/feed_component_spec.rb
+++ b/spec/components/widget/feeds/feed_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Widget::Feeds::FeedComponent, type: :component do
+describe Widget::Feeds::FeedComponent do
   it "renders a message when there are no items" do
     feed = double(kind: "debates", items: [])
     component = Widget::Feeds::FeedComponent.new(feed)

--- a/spec/components/widget/feeds/process_component_spec.rb
+++ b/spec/components/widget/feeds/process_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Widget::Feeds::ProcessComponent, type: :component do
+describe Widget::Feeds::ProcessComponent do
   let(:process) { create(:legislation_process, sdg_goals: [SDG::Goal[1]]) }
   let(:component) { Widget::Feeds::ProcessComponent.new(process) }
 

--- a/spec/components/widget/feeds/proposal_component_spec.rb
+++ b/spec/components/widget/feeds/proposal_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Widget::Feeds::ProposalComponent, type: :component do
+describe Widget::Feeds::ProposalComponent do
   let(:proposal) { create(:proposal, sdg_goals: [SDG::Goal[1]]) }
   let(:component) { Widget::Feeds::ProposalComponent.new(proposal) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,14 @@ require "capybara/rspec"
 require "selenium/webdriver"
 require "view_component/test_helpers"
 
+module ViewComponent
+  module TestHelpers
+    def sign_in(user)
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+  end
+end
+
 RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,10 @@ RSpec.configure do |config|
     sign_in(create(:administrator).user)
   end
 
+  config.before(:each, type: :component) do
+    sign_in(nil)
+  end
+
   config.around(:each, :controller, type: :component) do |example|
     with_controller_class(example.metadata[:controller]) { example.run }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ RSpec.configure do |config|
   config.include(CommonActions)
   config.include(ActiveSupport::Testing::TimeHelpers)
 
+  config.define_derived_metadata(file_path: Regexp.new("/spec/components/")) do |metadata|
+    metadata[:type] = :component
+  end
+
   config.before(:suite) do
     Rails.application.load_seed
   end


### PR DESCRIPTION
## Objectives

* Use component test helper methods in all tests under `spec/components/` without having to define `type: :component`
* Simplify stubbing the `current_user` method in component tests