### PR TITLE
Include DelayedJob errors in Errbit exceptions

### DIFF
--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -1,3 +1,5 @@
+require "airbrake/delayed_job" if defined?(Delayed)
+
 Airbrake.configure do |config|
   config.host = Rails.application.secrets.errbit_host
   config.project_id = Rails.application.secrets.errbit_project_id


### PR DESCRIPTION
## References

* We added support for Airbrake/Errbit in pull request #3624 and we use Airbrake 7.4.0 since pull request #4646

## Background

The integration between Airbrake/Errbit and DelayedJob wasn't working because we require our dependencies in alphabetic order, and so by the time `airbrake` was required, `delayed_job` wasn't loaded.

## Objectives

* Make sure CONSUL installations using Airbrake/Errbit are notified when a delayed job fails