### PR TITLE
Show answers with attachments in additional info

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -22,7 +22,7 @@ class PollsController < ApplicationController
     @questions = @poll.questions.for_render.sort_for_list
     @token = poll_voter_token(@poll, current_user)
     @poll_questions_answers = Poll::Question::Answer.where(question: @poll.questions)
-                                                    .where.not(description: "").order(:given_order)
+                                                    .with_content.order(:given_order)
 
     @answers_by_question_id = {}
     poll_answers = ::Poll::Answer.by_question(@poll.question_ids).by_author(current_user&.id)

--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -14,6 +14,14 @@ class Poll::Question::Answer < ApplicationRecord
   validates_translation :title, presence: true
   validates :given_order, presence: true, uniqueness: { scope: :question_id }
 
+  scope :with_content, -> { where.not(id: without_content) }
+  scope :without_content, -> do
+    where(description: "")
+      .left_joins(:images).where(images: { id: nil })
+      .left_joins(:documents).where(documents: { id: nil })
+      .left_joins(:videos).where(poll_question_answer_videos: { id: nil })
+  end
+
   def self.order_answers(ordered_array)
     ordered_array.each_with_index do |answer_id, order|
       find(answer_id).update_column(:given_order, (order + 1))

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -50,9 +50,7 @@
     <div class="row padding">
       <% @poll_questions_answers.each do |answer| %>
         <div class="small-12 medium-6 column end answer <%= cycle("first", "") %>" id="answer_<%= answer.id %>">
-          <% if answer.description.present? %>
-            <h3><%= answer.title %></h3>
-          <% end %>
+          <h3><%= answer.title %></h3>
 
           <% if answer.images.any? %>
             <%= render "gallery", answer: answer %>

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -73,6 +73,18 @@ FactoryBot.define do
     transient { poll { association(:poll) } }
 
     question { association(:poll_question, poll: poll) }
+
+    trait :with_image do
+      after(:create) { |answer| create(:image, imageable: answer) }
+    end
+
+    trait :with_document do
+      after(:create) { |answer| create(:document, documentable: answer) }
+    end
+
+    trait :with_video do
+      after(:create) { |answer| create(:poll_answer_video, answer: answer) }
+    end
   end
 
   factory :poll_answer_video, class: "Poll::Question::Answer::Video" do

--- a/spec/models/poll/question/answer_spec.rb
+++ b/spec/models/poll/question/answer_spec.rb
@@ -2,4 +2,36 @@ require "rails_helper"
 
 describe Poll::Question::Answer do
   it_behaves_like "globalizable", :poll_question_answer
+
+  describe "#with_content" do
+    it "returns answers with a description" do
+      answer = create(:poll_question_answer, description: "I've got a description")
+
+      expect(Poll::Question::Answer.with_content).to eq [answer]
+    end
+
+    it "returns answers with images and no description" do
+      answer = create(:poll_question_answer, :with_image, description: "")
+
+      expect(Poll::Question::Answer.with_content).to eq [answer]
+    end
+
+    it "returns answers with documents and no description" do
+      question = create(:poll_question_answer, :with_document, description: "")
+
+      expect(Poll::Question::Answer.with_content).to eq [question]
+    end
+
+    it "returns answers with videos and no description" do
+      question = create(:poll_question_answer, :with_video, description: "")
+
+      expect(Poll::Question::Answer.with_content).to eq [question]
+    end
+
+    it "does not return answers with no description and no images, documents nor videos" do
+      create(:poll_question_answer, description: "")
+
+      expect(Poll::Question::Answer.with_content).to be_empty
+    end
+  end
 end

--- a/spec/system/polls/questions_spec.rb
+++ b/spec/system/polls/questions_spec.rb
@@ -10,4 +10,17 @@ describe "Poll Questions" do
 
     expect(proposal_question.title).to appear_before(normal_question.title)
   end
+
+  scenario "shows answers with an image and no description" do
+    poll = create(:poll)
+    answer = create(:poll_question_answer, poll: poll, title: "Pedestrian road", description: "")
+    create(:image, imageable: answer, title: "Trees on both sides of the road")
+
+    visit poll_path(poll)
+
+    within "#poll_more_info_answers" do
+      expect(page).to have_content "Pedestrian road"
+      expect(page).to have_selector "img[alt='Trees on both sides of the road']"
+    end
+  end
 end


### PR DESCRIPTION
## Background

We weren't showing the details of answers without a description, even if they had images, videos or documents. Some users found that behavior unexpected since the description isn't a mandatory field and so they left it blank, but they added images to that answer and they didn't appear on the poll page.

## Objectives

* Show detailed information of answers with images, videos and/or documents in the poll page, even if they don't have a description