### PR TITLE
Expire cache when adding documents and images

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -7,7 +7,7 @@ class Document < ApplicationRecord
                                  hash_secret: Rails.application.secrets.secret_key_base
 
   belongs_to :user
-  belongs_to :documentable, polymorphic: true
+  belongs_to :documentable, polymorphic: true, touch: true
 
   validates :title, presence: true
   validates :user_id, presence: true

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -12,7 +12,7 @@ class Image < ApplicationRecord
                                  hash_secret: Rails.application.secrets.secret_key_base
 
   belongs_to :user
-  belongs_to :imageable, polymorphic: true
+  belongs_to :imageable, polymorphic: true, touch: true
 
   validates :title, presence: true
   validate :validate_title_length

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -9,7 +9,6 @@
 
 <% cache [locale_and_user_status(investment),
           investment,
-          investment.image,
           investment.author,
           Flag.flagged?(current_user, investment),
           investment.followed_by?(current_user),

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -400,6 +400,14 @@ describe Proposal do
       expect { proposal.update(tag_list: "new tag") }.to change { proposal.cache_version }
     end
 
+    it "expires cache when it has a new image" do
+      expect { create(:image, imageable: proposal) }.to change { proposal.cache_version }
+    end
+
+    it "expires cache when it has a new document" do
+      expect { create(:document, documentable: proposal) }.to change { proposal.cache_version }
+    end
+
     it "expires cache when hidden" do
       expect { proposal.hide }.to change { proposal.cache_version }
     end


### PR DESCRIPTION
Proposals and budget investments were not correctly updated when adding,
removing or modifying their documents and images.

## Objectives

* Make sure proposals, invetments, and other models with images/documents are correctly displayed after changing their images/documents