### PR TITLE
Remove unused attachments code

### DIFF
--- a/app/models/concerns/galleryable.rb
+++ b/app/models/concerns/galleryable.rb
@@ -4,9 +4,5 @@ module Galleryable
   included do
     has_many :images, as: :imageable, inverse_of: :imageable, dependent: :destroy
     accepts_nested_attributes_for :images, allow_destroy: true, update_only: true
-
-    def image_url(style)
-      image&.attachment&.url(style) || ""
-    end
   end
 end

--- a/app/views/dashboard/mailing/index.html.erb
+++ b/app/views/dashboard/mailing/index.html.erb
@@ -9,11 +9,7 @@
     </div>
 
     <div class="margin-bottom">
-      <% if proposal.image.present? %>
-        <%= image_tag proposal.image.attachment.url(:large) %>
-      <% else %>
-        <%= image_tag "default_mailing.jpg" %>
-      <% end %>
+      <%= image_tag(proposal.image_url(:large).presence || "default_mailing.jpg") %>
     </div>
 
     <div class="mail-body">

--- a/spec/shared/models/acts_as_imageable.rb
+++ b/spec/shared/models/acts_as_imageable.rb
@@ -58,12 +58,4 @@ shared_examples "acts as imageable" do |imageable_factory|
       expect(image).not_to be_valid
     end
   end
-
-  it "image destroy should remove image from file storage" do
-    image.save!
-    image_url = image.attachment.url
-    new_url = "/attachments/original/missing.png"
-
-    expect { image.attachment.destroy }.to change { image.attachment.url }.from(image_url).to(new_url)
-  end
 end

--- a/spec/shared/system/nested_imageable.rb
+++ b/spec/shared/system/nested_imageable.rb
@@ -47,10 +47,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       do_login_for user
       visit send(path, arguments)
 
-      imageable_attach_new_file(
-        imageable_factory_name,
-        Rails.root.join("spec/fixtures/files/clippy.jpg")
-      )
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
 
       expect_image_has_title("clippy.jpg")
     end
@@ -75,10 +72,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       do_login_for user
       visit send(path, arguments)
 
-      imageable_attach_new_file(
-        imageable_factory_name,
-        Rails.root.join("spec/fixtures/files/clippy.jpg")
-      )
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
 
       expect(page).to have_selector ".loading-bar.complete"
     end
@@ -87,11 +81,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       do_login_for user
       visit send(path, arguments)
 
-      imageable_attach_new_file(
-        imageable_factory_name,
-        Rails.root.join("spec/fixtures/files/logo_header.png"),
-        false
-      )
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/logo_header.png"), false)
 
       expect(page).to have_selector ".loading-bar.errors"
     end
@@ -100,10 +90,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       do_login_for user
       visit send(path, arguments)
 
-      imageable_attach_new_file(
-        imageable_factory_name,
-        Rails.root.join("spec/fixtures/files/clippy.jpg")
-      )
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
 
       expect_image_has_cached_attachment(".jpg")
     end
@@ -112,11 +99,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       do_login_for user
       visit send(path, arguments)
 
-      imageable_attach_new_file(
-        imageable_factory_name,
-        Rails.root.join("spec/fixtures/files/logo_header.png"),
-        false
-      )
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/logo_header.png"), false)
 
       expect_image_has_cached_attachment("")
     end
@@ -141,10 +124,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       do_login_for user
       visit send(path, arguments)
 
-      imageable_attach_new_file(
-        imageable_factory_name,
-        Rails.root.join("spec/fixtures/files/clippy.jpg")
-      )
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
 
       within "#nested-image .image" do
         click_link "Remove image"
@@ -171,10 +151,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
 
-      imageable_attach_new_file(
-        imageable_factory_name,
-        Rails.root.join("spec/fixtures/files/clippy.jpg")
-      )
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
 
       expect(page).to have_selector ".loading-bar.complete"
 
@@ -188,10 +165,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       visit send(path, arguments)
       send(fill_resource_method_name) if fill_resource_method_name
 
-      imageable_attach_new_file(
-        imageable_factory_name,
-        Rails.root.join("spec/fixtures/files/clippy.jpg")
-      )
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
 
       expect(page).to have_selector ".loading-bar.complete"
 
@@ -255,7 +229,7 @@ def imageable_redirected_to_resource_show_or_navigate_to
   end
 end
 
-def imageable_attach_new_file(_imageable_factory_name, path, success = true)
+def imageable_attach_new_file(path, success = true)
   click_link "Add image"
   within "#nested-image" do
     image = find(".image")

--- a/spec/system/admin/budget_phases_spec.rb
+++ b/spec/system/admin/budget_phases_spec.rb
@@ -46,10 +46,7 @@ describe "Admin budget phases" do
     scenario "shows successful notice when updating the phase with a valid image" do
       visit edit_admin_budget_budget_phase_path(budget, budget.current_phase)
 
-      imageable_attach_new_file(
-        "budget_phase_image",
-        Rails.root.join("spec/fixtures/files/clippy.jpg")
-      )
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
 
       click_on "Save changes"
 

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -175,7 +175,7 @@ describe "Admin collaborative legislation", :admin do
         fill_in "End", with: base_date + 5.days
       end
 
-      imageable_attach_new_file(create(:image), Rails.root.join("spec/fixtures/files/clippy.jpg"))
+      imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
 
       click_button "Create process"
 

--- a/spec/system/admin/poll/questions/answers/images/images_spec.rb
+++ b/spec/system/admin/poll/questions/answers/images/images_spec.rb
@@ -32,14 +32,13 @@ describe "Images", :admin do
 
   scenario "Add image to answer" do
     answer = create(:poll_question_answer)
-    image = create(:image)
 
     visit admin_answer_images_path(answer)
     expect(page).not_to have_css("img[title='clippy.jpg']")
     expect(page).not_to have_content("clippy.jpg")
 
     visit new_admin_answer_image_path(answer)
-    imageable_attach_new_file(image, Rails.root.join("spec/fixtures/files/clippy.jpg"))
+    imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
     click_button "Save image"
 
     expect(page).to have_css("img[title='clippy.jpg']")

--- a/spec/system/admin/site_customization/documents_spec.rb
+++ b/spec/system/admin/site_customization/documents_spec.rb
@@ -58,7 +58,7 @@ describe "Documents", :admin do
     click_button "Upload"
 
     expect(page).to have_content "Document uploaded succesfully"
-    expect(page).to have_link "logo.pdf", href: Document.last.attachment.url
+    expect(page).to have_link "logo.pdf"
   end
 
   scenario "Errors on create" do

--- a/spec/system/admin/widgets/cards_spec.rb
+++ b/spec/system/admin/widgets/cards_spec.rb
@@ -40,19 +40,18 @@ describe "Cards", :admin do
   end
 
   scenario "Index" do
-    3.times { create(:widget_card) }
+    cards = Array.new(3) { create(:widget_card) }
 
     visit admin_homepage_path
 
     expect(page).to have_css(".homepage-card", count: 3)
 
-    cards = Widget::Card.all
     cards.each do |card|
       expect(page).to have_content card.title
       expect(page).to have_content card.description
       expect(page).to have_content card.link_text
       expect(page).to have_content card.link_url
-      expect(page).to have_link("Show image", href: card.image_url(:large))
+      expect(page).to have_link "Show image"
     end
   end
 

--- a/spec/system/legislation/proposals_spec.rb
+++ b/spec/system/legislation/proposals_spec.rb
@@ -146,7 +146,7 @@ describe "Legislation Proposals" do
 
     fill_in "Proposal title", with: "Legislation proposal with image"
     fill_in "Proposal summary", with: "Including an image on a legislation proposal"
-    imageable_attach_new_file(create(:image), Rails.root.join("spec/fixtures/files/clippy.jpg"))
+    imageable_attach_new_file(Rails.root.join("spec/fixtures/files/clippy.jpg"))
     check "legislation_proposal_terms_of_service"
     click_button "Create proposal"
 


### PR DESCRIPTION
## References

* Depends on pull request #4598

## Objectives

* Make it easier to migrate to Active Storage
* Remove unused code