### PR TITLE
Fix social share image URL with external storage

### DIFF
--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -5,7 +5,7 @@ module ImagesHelper
     if Paperclip::Attachment.default_options[:storage] == :filesystem
       URI(request.url) + image.attachment.url(version)
     else
-      investment.image_url(version)
+      image.attachment.url(version)
     end
   end
 


### PR DESCRIPTION
## References

* Closes #2850

## Objectives

* Fix a bug causing a 500 error when storing images using external service and rendering the link to share an investment with an image in social media