### PR TITLE
Add sanitize to description on moderator activity

### DIFF
--- a/app/views/admin/activity/show.html.erb
+++ b/app/views/admin/activity/show.html.erb
@@ -42,7 +42,7 @@
             <% else %>
               <strong><%= activity.actionable.title %></strong>
               <br>
-              <%= activity.actionable.description %>
+              <%= sanitize(activity.actionable.description) %>
             <% end %>
           <td class="align-top">
             <%= activity.user.name %> (<%= activity.user.email %>)

--- a/spec/system/admin/activity_spec.rb
+++ b/spec/system/admin/activity_spec.rb
@@ -9,7 +9,7 @@ describe "Admin activity" do
 
   context "Proposals" do
     scenario "Shows moderation activity on proposals" do
-      proposal = create(:proposal)
+      proposal = create(:proposal, description: "<p>Description with html tag</p>")
 
       visit proposal_path(proposal)
 
@@ -24,6 +24,7 @@ describe "Admin activity" do
         expect(page).to have_content(proposal.title)
         expect(page).to have_content("Hidden")
         expect(page).to have_content(admin.user.username)
+        expect(page).to have_css("p", exact_text: "Description with html tag")
       end
     end
 


### PR DESCRIPTION
## Objectives
Currently html tags were being displayed in the description.
We used the sanitize method to not display them.

## Visual Changes
- Before
![Captura de pantalla 2021-09-21 a las 12 08 41](https://user-images.githubusercontent.com/16189/134153587-a0561cb3-8f38-492c-bc97-346c7299ed53.png)

- After
![Captura de pantalla 2021-09-21 a las 12 09 52](https://user-images.githubusercontent.com/16189/134153628-6702e4bb-04cf-444b-b6ef-15296d26864c.png)
