### PR TITLE
Wait for suggestions to finish loading in tests

### DIFF
--- a/app/assets/javascripts/suggest.js
+++ b/app/assets/javascripts/suggest.js
@@ -6,6 +6,14 @@
         var $this, callback, timer;
         $this = $(this);
         callback = function() {
+          var js_suggest_selector, locale;
+          js_suggest_selector = $this.data("js-suggest");
+
+          if (js_suggest_selector.startsWith(".")) {
+            locale = $this.closest(".translatable-fields").data("locale");
+            js_suggest_selector += "[data-locale=" + locale + "]";
+          }
+
           $.ajax({
             url: $this.data("js-url"),
             data: {
@@ -13,15 +21,12 @@
             },
             type: "GET",
             dataType: "html",
+            beforeSend: function() {
+              $(js_suggest_selector).removeClass("suggest-success").addClass("suggest-loading");
+            },
             success: function(stHtml) {
-              var js_suggest_selector, locale;
-              js_suggest_selector = $this.data("js-suggest");
-
-              if (js_suggest_selector.startsWith(".")) {
-                locale = $this.closest(".translatable-fields").data("locale");
-                js_suggest_selector += "[data-locale=" + locale + "]";
-              }
               $(js_suggest_selector).html(stHtml);
+              $(js_suggest_selector).removeClass("suggest-loading").addClass("suggest-success");
             }
           });
         };

--- a/spec/shared/system/mappable.rb
+++ b/spec/shared/system/mappable.rb
@@ -298,7 +298,7 @@ def do_login_for(user)
 end
 
 def fill_in_proposal_form
-  fill_in "Proposal title", with: "Help refugees"
+  fill_in_new_proposal_title with: "Help refugees"
   fill_in "Proposal summary", with: "In summary, what we want is..."
 end
 
@@ -319,7 +319,7 @@ def validate_latitude_longitude(mappable_factory_name)
 end
 
 def fill_in_budget_investment_form
-  fill_in "Title", with: "Budget investment title"
+  fill_in_new_investment_title with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
   check :budget_investment_terms_of_service
 end

--- a/spec/shared/system/nested_documentable.rb
+++ b/spec/shared/system/nested_documentable.rb
@@ -339,7 +339,7 @@ def expect_document_has_cached_attachment(index, extension)
 end
 
 def documentable_fill_new_valid_proposal
-  fill_in "Proposal title", with: "Proposal title #{rand(9999)}"
+  fill_in_new_proposal_title with: "Proposal title #{rand(9999)}"
   fill_in "Proposal summary", with: "Proposal summary"
   check :proposal_terms_of_service
 end
@@ -350,7 +350,7 @@ def documentable_fill_new_valid_dashboard_action
 end
 
 def documentable_fill_new_valid_budget_investment
-  fill_in "Title", with: "Budget investment title"
+  fill_in_new_investment_title with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
   check :budget_investment_terms_of_service
 end

--- a/spec/shared/system/nested_imageable.rb
+++ b/spec/shared/system/nested_imageable.rb
@@ -271,7 +271,7 @@ def imageable_attach_new_file(_imageable_factory_name, path, success = true)
 end
 
 def imageable_fill_new_valid_proposal
-  fill_in "Proposal title", with: "Proposal title"
+  fill_in_new_proposal_title with: "Proposal title"
   fill_in "Proposal summary", with: "Proposal summary"
   check :proposal_terms_of_service
 end
@@ -281,7 +281,7 @@ def imageable_fill_new_valid_budget
 end
 
 def imageable_fill_new_valid_budget_investment
-  fill_in "Title", with: "Budget investment title"
+  fill_in_new_investment_title with: "Budget investment title"
   fill_in_ckeditor "Description", with: "Budget investment description"
   check :budget_investment_terms_of_service
 end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -33,12 +33,30 @@ module CommonActions
   end
 
   def fill_in_proposal
-    fill_in "Proposal title", with: "Help refugees"
+    fill_in_new_proposal_title with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in_ckeditor "Proposal text", with: "This is very important because..."
     fill_in "External video URL", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
     fill_in "Full name of the person submitting the proposal", with: "Isabel Garcia"
     check "I agree to the Privacy Policy and the Terms and conditions of use"
+  end
+
+  def fill_in_new_proposal_title(with:)
+    fill_in "Proposal title", with: with
+
+    expect(page).to have_css ".suggest-success"
+  end
+
+  def fill_in_new_debate_title(with:)
+    fill_in "Debate title", with: with
+
+    expect(page).to have_css ".suggest-success"
+  end
+
+  def fill_in_new_investment_title(with:)
+    fill_in "Title", with: with
+
+    expect(page).to have_css ".suggest-success"
   end
 
   def set_officing_booth(booth = nil)

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -567,7 +567,7 @@ describe "Budget Investments" do
       login_as(author)
       visit new_budget_investment_path(budget)
 
-      fill_in "Title", with: "I am a bot"
+      fill_in_new_investment_title with: "I am a bot"
       fill_in_ckeditor "Description", with: "This is the description"
       check "budget_investment_terms_of_service"
 
@@ -585,7 +585,7 @@ describe "Budget Investments" do
       expect(page).not_to have_field "budget_investment_heading_id"
       expect(page).to have_content("#{heading.name} (#{budget.formatted_heading_price(heading)})")
 
-      fill_in "Title", with: "Build a skyscraper"
+      fill_in_new_investment_title with: "Build a skyscraper"
       fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
       fill_in "Location additional info", with: "City center"
       fill_in "If you are proposing in the name of a collective/organization, "\
@@ -637,7 +637,7 @@ describe "Budget Investments" do
 
       select "Health: Medical supplies", from: "Heading"
 
-      fill_in "Title", with: "Build a skyscraper"
+      fill_in_new_investment_title with: "Build a skyscraper"
       fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
       fill_in "Location additional info", with: "City center"
       fill_in "If you are proposing in the name of a collective/organization, "\
@@ -1700,7 +1700,7 @@ describe "Budget Investments" do
     scenario "create budget investment with sdg related list" do
       login_as(author)
       visit new_budget_investment_path(budget)
-      fill_in "Title", with: "A title for a budget investment related with SDG related content"
+      fill_in_new_investment_title with: "A title for a budget investment related with SDG related content"
       fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
       click_sdg_goal(1)
       check "budget_investment_terms_of_service"

--- a/spec/system/debates_spec.rb
+++ b/spec/system/debates_spec.rb
@@ -190,7 +190,7 @@ describe "Debates" do
     login_as(author)
 
     visit new_debate_path
-    fill_in "Debate title", with: "A title for a debate"
+    fill_in_new_debate_title with: "A title for a debate"
     fill_in_ckeditor "Initial debate text", with: "This is very important because..."
     check "debate_terms_of_service"
 
@@ -227,7 +227,7 @@ describe "Debates" do
     login_as(author)
 
     visit new_debate_path
-    fill_in "Debate title", with: "I am a bot"
+    fill_in_new_debate_title with: "I am a bot"
     fill_in_ckeditor "Initial debate text", with: "This is the description"
     check "debate_terms_of_service"
 
@@ -270,7 +270,7 @@ describe "Debates" do
     login_as(author)
 
     visit new_debate_path
-    fill_in "Debate title", with: "Testing auto link"
+    fill_in_new_debate_title with: "Testing auto link"
     fill_in_ckeditor "Initial debate text", with: "This is a link www.example.org"
     check "debate_terms_of_service"
 
@@ -839,7 +839,7 @@ describe "Debates" do
     scenario "create debate with sdg related list" do
       login_as(user)
       visit new_debate_path
-      fill_in "Debate title", with: "A title for a debate related with SDG related content"
+      fill_in_new_debate_title with: "A title for a debate related with SDG related content"
       fill_in_ckeditor "Initial debate text", with: "This is very important because..."
       click_sdg_goal(1)
       check "debate_terms_of_service"

--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -349,7 +349,7 @@ describe "Emails" do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
-      fill_in "Title", with: "Build a hospital"
+      fill_in_new_investment_title with: "Build a hospital"
       fill_in_ckeditor "Description", with: "We have lots of people that require medical attention"
       check "budget_investment_terms_of_service"
 

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -65,7 +65,7 @@ describe "Budget Investments" do
         expect(page).to have_content user.document_number
       end
 
-      fill_in "Title", with: "Build a park in my neighborhood"
+      fill_in_new_investment_title with: "Build a park in my neighborhood"
       fill_in_ckeditor "Description", with: "There is no parks here..."
       fill_in "budget_investment_location", with: "City center"
       fill_in "budget_investment_organization_name", with: "T.I.A."

--- a/spec/system/management/proposals_spec.rb
+++ b/spec/system/management/proposals_spec.rb
@@ -16,7 +16,7 @@ describe "Proposals" do
         expect(page).to have_content user.document_number.to_s
       end
 
-      fill_in "Proposal title", with: "Help refugees"
+      fill_in_new_proposal_title with: "Help refugees"
       fill_in "Proposal summary", with: "In summary, what we want is..."
       fill_in_ckeditor "Proposal text", with: "This is very important because..."
       fill_in "External video URL", with: "https://www.youtube.com/watch?v=yRYFKcMa_Ek"

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -335,7 +335,7 @@ describe "Proposals" do
 
     visit new_proposal_path
 
-    fill_in "Proposal title", with: "Help refugees"
+    fill_in_new_proposal_title with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in_ckeditor "Proposal text", with: "This is very important because..."
     fill_in "External video URL", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
@@ -390,7 +390,7 @@ describe "Proposals" do
     login_as(author)
 
     visit new_proposal_path
-    fill_in "Proposal title", with: "I am a bot"
+    fill_in_new_proposal_title with: "I am a bot"
     fill_in "Proposal summary", with: "This is the summary"
     fill_in_ckeditor "Proposal text", with: "This is the description"
     fill_in "Full name of the person submitting the proposal", with: "Some other robot"
@@ -408,7 +408,7 @@ describe "Proposals" do
     login_as(author)
 
     visit new_proposal_path
-    fill_in "Proposal title", with: "Help refugees"
+    fill_in_new_proposal_title with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in_ckeditor "Proposal text", with: "This is very important because..."
     fill_in "Full name of the person submitting the proposal", with: "Isabel Garcia"
@@ -436,7 +436,7 @@ describe "Proposals" do
 
     expect(page).not_to have_field "Full name of the person submitting the proposal"
 
-    fill_in "Proposal title", with: "Help refugees"
+    fill_in_new_proposal_title with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in_ckeditor "Proposal text", with: "This is very important because..."
     check "I agree to the Privacy Policy and the Terms and conditions of use"
@@ -487,7 +487,7 @@ describe "Proposals" do
     login_as(author)
 
     visit new_proposal_path
-    fill_in "Proposal title", with: "Testing auto link"
+    fill_in_new_proposal_title with: "Testing auto link"
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in_ckeditor "Proposal text", with: "This is a link www.example.org"
     fill_in "Full name of the person submitting the proposal", with: "Isabel Garcia"
@@ -565,7 +565,7 @@ describe "Proposals" do
 
       visit new_proposal_path
 
-      fill_in "Proposal title", with: "Help refugees"
+      fill_in_new_proposal_title with: "Help refugees"
       fill_in "Proposal summary", with: "In summary, what we want is..."
       fill_in_ckeditor "Proposal text", with: "This is very important because..."
       fill_in "External video URL", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
@@ -1600,7 +1600,7 @@ describe "Successful proposals" do
 
       expect(page).to have_current_path(new_proposal_path)
 
-      fill_in "Proposal title", with: "Help refugees"
+      fill_in_new_proposal_title with: "Help refugees"
       fill_in "Proposal summary", with: "In summary what we want is..."
       fill_in_ckeditor "Proposal text", with: "This is very important because..."
       fill_in "External video URL", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
@@ -1624,7 +1624,7 @@ describe "Successful proposals" do
     scenario "create proposal with sdg related list" do
       login_as(user)
       visit new_proposal_path
-      fill_in "Proposal title", with: "A title for a proposal related with SDG related content"
+      fill_in_new_proposal_title with: "A title for a proposal related with SDG related content"
       fill_in "Proposal summary", with: "In summary, what we want is..."
       fill_in "Full name of the person submitting the proposal", with: "Isabel Garcia"
       click_sdg_goal(1)

--- a/spec/system/tags/budget_investments_spec.rb
+++ b/spec/system/tags/budget_investments_spec.rb
@@ -66,7 +66,7 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    fill_in "Title", with: "Build a skyscraper"
+    fill_in_new_investment_title with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
 
@@ -84,7 +84,7 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    fill_in "Title", with: "Build a skyscraper"
+    fill_in_new_investment_title with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
     check "budget_investment_terms_of_service"
 
@@ -108,7 +108,7 @@ describe "Tags" do
     visit budget_path(budget)
     click_link "Create a budget investment"
 
-    fill_in "Title", with: "Build a skyscraper"
+    fill_in_new_investment_title with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
     check "budget_investment_terms_of_service"
 
@@ -132,7 +132,7 @@ describe "Tags" do
     visit budget_investments_path(budget, heading_id: heading.id)
     click_link "Create a budget investment"
 
-    fill_in "Title", with: "Build a skyscraper"
+    fill_in_new_investment_title with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "If I had a gym near my place I could go do Zumba"
     check "budget_investment_terms_of_service"
 
@@ -153,7 +153,7 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    fill_in "Title", with: "Build a skyscraper"
+    fill_in_new_investment_title with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
 
@@ -170,7 +170,7 @@ describe "Tags" do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    fill_in "Title", with: "Build a skyscraper"
+    fill_in_new_investment_title with: "Build a skyscraper"
     fill_in_ckeditor "Description", with: "I want to live in a high tower over the clouds"
     check   "budget_investment_terms_of_service"
 

--- a/spec/system/tags/debates_spec.rb
+++ b/spec/system/tags/debates_spec.rb
@@ -65,7 +65,7 @@ describe "Tags" do
     login_as(user)
 
     visit new_debate_path
-    fill_in "Debate title", with: "Title"
+    fill_in_new_debate_title with: "Title"
     fill_in_ckeditor "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
@@ -84,7 +84,7 @@ describe "Tags" do
     login_as(user)
 
     visit new_debate_path
-    fill_in "Debate title", with: "Title"
+    fill_in_new_debate_title with: "Title"
     fill_in_ckeditor "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
@@ -102,7 +102,7 @@ describe "Tags" do
 
     visit new_debate_path
 
-    fill_in "Debate title", with: "A test of dangerous strings"
+    fill_in_new_debate_title with: "A test of dangerous strings"
     fill_in_ckeditor "Initial debate text", with: "A description suitable for this test"
     check "debate_terms_of_service"
 

--- a/spec/system/tags/proposals_spec.rb
+++ b/spec/system/tags/proposals_spec.rb
@@ -64,7 +64,7 @@ describe "Tags" do
     login_as(user)
 
     visit new_proposal_path
-    fill_in "Proposal title", with: "Help refugees"
+    fill_in_new_proposal_title with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in_ckeditor "Proposal text", with: "This is very important because..."
     fill_in "Full name of the person submitting the proposal", with: "Isabel Garcia"
@@ -88,7 +88,7 @@ describe "Tags" do
     login_as(create(:user))
     visit new_proposal_path
 
-    fill_in "Proposal title", with: "Help refugees"
+    fill_in_new_proposal_title with: "Help refugees"
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in_ckeditor "Proposal text", with: "A description with enough characters"
     fill_in "External video URL", with: "https://www.youtube.com/watch?v=Ae6gQmhaMn4"
@@ -115,7 +115,7 @@ describe "Tags" do
     login_as(user)
 
     visit new_proposal_path
-    fill_in "Proposal title", with: "Title"
+    fill_in_new_proposal_title with: "Title"
     fill_in_ckeditor "Proposal text", with: "Description"
     check "I agree to the Privacy Policy and the Terms and conditions of use"
 
@@ -133,7 +133,7 @@ describe "Tags" do
 
     visit new_proposal_path
 
-    fill_in "Proposal title", with: "A test of dangerous strings"
+    fill_in_new_proposal_title with: "A test of dangerous strings"
     fill_in "Proposal summary", with: "In summary, what we want is..."
     fill_in_ckeditor "Proposal text", with: "A description suitable for this test"
     fill_in "Full name of the person submitting the proposal", with: "Isabel Garcia"

--- a/spec/system/tags_spec.rb
+++ b/spec/system/tags_spec.rb
@@ -58,7 +58,7 @@ describe "Tags" do
     login_as(user)
 
     visit new_debate_path
-    fill_in "Debate title", with: "Title"
+    fill_in_new_debate_title with: "Title"
     fill_in_ckeditor "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 
@@ -77,7 +77,7 @@ describe "Tags" do
     login_as(user)
 
     visit new_debate_path
-    fill_in "Debate title", with: "Title"
+    fill_in_new_debate_title with: "Title"
     fill_in_ckeditor "Initial debate text", with: "Description"
     check "debate_terms_of_service"
 

--- a/spec/system/translatable_spec.rb
+++ b/spec/system/translatable_spec.rb
@@ -12,7 +12,7 @@ describe "Public area translatable records" do
     scenario "Add only single translation at once" do
       visit new_debate_path
 
-      fill_in "Debate title", with: "Who won the debate?"
+      fill_in_new_debate_title with: "Who won the debate?"
       fill_in_ckeditor "Initial debate text", with: "And who will win this debate?"
       check "debate_terms_of_service"
       click_button "Start a debate"
@@ -23,7 +23,7 @@ describe "Public area translatable records" do
     scenario "Add single translation maintains introduced field values" do
       visit new_proposal_path
 
-      fill_in "Proposal title", with: "Olympic Games in Melbourne"
+      fill_in_new_proposal_title with: "Olympic Games in Melbourne"
       fill_in "Proposal summary", with: "Full proposal for our candidature"
       fill_in_ckeditor "Proposal text", with: "2032 will make Australia famous again"
       check "proposal_terms_of_service"
@@ -40,11 +40,11 @@ describe "Public area translatable records" do
 
       visit new_budget_investment_path(budget)
 
-      fill_in "Title", with: "My awesome project"
+      fill_in_new_investment_title with: "My awesome project"
       fill_in_ckeditor "Description", with: "Everything is awesome!"
 
       select "Français", from: :add_language
-      fill_in "Title", with: "Titre en Français"
+      fill_in_new_investment_title with: "Titre en Français"
       fill_in_ckeditor "Description", with: "Contenu en Français"
 
       check "budget_investment_terms_of_service"
@@ -58,7 +58,7 @@ describe "Public area translatable records" do
       click_link "Remove language"
       select "Français", from: :add_language
 
-      fill_in "Proposal title", with: "Titre en Français"
+      fill_in_new_proposal_title with: "Titre en Français"
       fill_in "Proposal summary", with: "Résumé en Français"
       check "proposal_terms_of_service"
       click_button "Create proposal"
@@ -72,7 +72,7 @@ describe "Public area translatable records" do
       visit new_budget_investment_path(budget)
       click_link "Remove language"
       select "Português brasileiro", from: :add_language
-      fill_in "Title", with: "Titre en Français"
+      fill_in_new_investment_title with: "Titre en Français"
       fill_in_ckeditor "Description", with: "Contenu en Français"
 
       check "budget_investment_terms_of_service"


### PR DESCRIPTION
## References

* Some tests were hanging indefinitely in pull request #4598
* There were some timeouts in Github Actions due to this, like [test run #2741, build 3](https://github.com/consul/consul/runs/3656948132), [test run #2752, build 1](https://github.com/consul/consul/runs/3664024045), [test run #2754, build 3](https://github.com/consul/consul/runs/3668786453), [test run #2755, build 1](https://github.com/consul/consul/runs/3668791332) or [test run #2756, build 1](https://github.com/consul/consul/runs/3669379951).

## Background

Sometimes tests were hanging indefinitely. Debugging shows that in some cases it's due to submitting a form before the AJAX request to get proposals, debates or investments suggestions is finished, since having an AJAX and a non-AJAX request at the same time when running the tests sometimes leads to unexpected results.

In our case, we were having many timeouts in Github Actions in the branches where we use both ActiveStorage and Paperclip to store files (based on pull request #4598). I can reproduce it in those branches running the following test ("Should show new image after successful creation with one uploaded file"), although only when my laptop isn't plugged (!!):

```
rspec './spec/system/proposals_spec.rb[1:33:1:14]'
```

## Objectives

* Avoid having one AJAX and one regular request in tests at the same time, which might cause the test to hang forever