### PR TITLE
Add missing expectations in investments test

### DIFF
--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1128,7 +1128,12 @@ describe "Budget Investments" do
         accept_confirm { click_link("Delete") }
       end
 
+      expect(page).to have_content "Investment project deleted succesfully"
+
       visit user_path(user, tab: :budget_investments)
+
+      expect(page).to have_content "User has no public activity"
+      expect(page).not_to have_content investment1.title
     end
   end
 


### PR DESCRIPTION
## References

* This test was hanging forever in our [test run #2790, job 1](https://github.com/consul/consul/runs/3687898744)

## Objectives

* Reduce the number of tests which hang forever and cause CI failures