### PR TITLE
Fix sending OAuth confirmation instructions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -348,7 +348,7 @@ class User < ApplicationRecord
   end
 
   def send_oauth_confirmation_instructions
-    if oauth_email != email
+    if oauth_email != email || confirmed_at.nil?
       update(confirmed_at: nil)
       send_confirmation_instructions
     end

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -324,7 +324,7 @@ describe "Users" do
         expect(page).to have_field "Email", with: user.email
       end
 
-      scenario "Try to register with the username of an already existing user" do
+      scenario "Try to register with verified email and with the username of an already existing user" do
         create(:user, username: "manuela", email: "manuela@consul.dev", password: "judgementday")
         OmniAuth.config.add_mock(:twitter, twitter_hash_with_verified_email)
 
@@ -345,6 +345,39 @@ describe "Users" do
 
         expect_to_be_signed_in
 
+        click_link "My account"
+        expect(page).to have_field "Username", with: "manuela2"
+
+        visit edit_user_registration_path
+        expect(page).to have_field "Email", with: "manuelacarmena@example.com"
+      end
+
+      scenario "Try to register with unverified email and with the username of an already existing user" do
+        create(:user, username: "manuela", email: "manuela@consul.dev", password: "judgementday")
+        OmniAuth.config.add_mock(:twitter, twitter_hash_with_email)
+
+        visit "/"
+        click_link "Register"
+        click_link "Sign up with Twitter"
+
+        expect(page).to have_current_path(finish_signup_path)
+        expect(page).to have_field "Username", with: "manuela"
+
+        click_button "Register"
+
+        expect(page).to have_current_path(do_finish_signup_path)
+
+        fill_in "Username", with: "manuela2"
+        click_button "Register"
+        confirm_email
+
+        expect(page).to have_content "Your account has been confirmed"
+
+        visit "/"
+        click_link "Sign in"
+        click_link "Sign in with Twitter"
+
+        within("#notice") { click_button "Close" }
         click_link "My account"
         expect(page).to have_field "Username", with: "manuela2"
 


### PR DESCRIPTION
## Objectives

When we try to register with omniauth and the email or username already exists,
we use the `finish_signup` and `do_finish_signup` actions to allow the user to choose
another `email` or `username`.

The `do_finish_signup` action of the registration controller calls the
`send_oauth_confirmation_instructions` method which is responsible for sending the
confirmation email.

In this method we were only validating the case that the email is duplicated. Now
we add one more condition that allows us to send the instructions for the case in
which we have had to change our username.
