### PR TITLE
Make it easier to define custom settings

### DIFF
--- a/app/models/custom/setting.rb
+++ b/app/models/custom/setting.rb
@@ -1,0 +1,31 @@
+require_dependency Rails.root.join("app", "models", "setting").to_s
+
+class Setting
+  class << self
+    alias_method :consul_defaults, :defaults
+
+    # Change this code when you'd like to add settings that aren't
+    # already present in the database. These settings will be added when
+    # first installing CONSUL, when deploying code with Capistrano, or
+    # when manually executing the `settings:add_new_settings` task.
+    #
+    # If a setting already exists in the database, changing its value in
+    # this file will have no effect unless the task `rake db:seed` is
+    # invoked or the method `Setting.reset_defaults` is executed. Doing
+    # so will overwrite the values of all existing settings in the
+    # database, so use with care.
+    #
+    # The tests in the spec/ folder rely on CONSUL's default settings, so
+    # it's recommended not to change the default settings in the test
+    # environment.
+    def defaults
+      if Rails.env.test?
+        consul_defaults
+      else
+        consul_defaults.merge({
+          # Overwrite default CONSUL settings or add new settings here
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Objectives

* Make it easier to define custom settings
* Make it easier to change the default settings without breaking the tests
* Make it easier to use the same default settings in several CONSUL installations or (when we implement multitentancy) in new tenants
* Provide an example of how to write custom models
* Provide documentation about how to change the default settings