### PR TITLE
Use a more precise required/optional fields legend

### DIFF
--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -769,8 +769,8 @@ en:
         zero: "0 languages in use"
         one: "1 language in use"
         other: "%{count} languages in use"
-    optional: "Optional"
-    required: "Required"
+    optional: "Optional fields"
+    required: "Required fields"
   social:
     facebook: "%{org} Facebook"
     twitter: "%{org} Twitter"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -769,8 +769,8 @@ es:
         zero: "0 idiomas en uso"
         one: "1 idioma en uso"
         other: "%{count} idiomas en uso"
-    optional: "Opcional"
-    required: "Obligatorio"
+    optional: "Campos opcionales"
+    required: "Campos obligatorios"
   social:
     facebook: "Facebook de %{org}"
     twitter: "Twitter de %{org}"


### PR DESCRIPTION
## References

* The styles for public forms was changed in pull requests #4580 and #4225

## Background

Usability tests showed some users were struggling when seeing the word "Required" as a legend (it's actually styled as a title), since this isn't a common pattern when filling in forms. They were expecting something like "Fields with * are required", and so the "Required" text alone made them feel the sentence wasn't complete.

We could also add an "*" to required fields in addition to the "Required" text. In this case, however, some users wondered what the asterisk was about: "It can't mean 'required' because they've already said these fields are required".

## Objectives

* Make it easier for citizens to know which fields are required

## Visual Changes

### Before these changes

![Fieldset legends are "Required" and "Optional"](https://user-images.githubusercontent.com/35156/138708767-d44eeb88-8dac-4650-a0d5-01ac7670c3c8.png)

### After these changes

![Fieldset legends are "Required fields" and "Optional fields"](https://user-images.githubusercontent.com/35156/138708787-4d1efd6c-c69d-469b-95ec-2ba798e92cd4.png)

## Notes

We'll probably have to revisit required and optional fields again. For now, we're just doing a small improvement.