### PR TITLE
Fix Sass deprecation warning

### DIFF
--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -49,7 +49,7 @@ $show-header-for-stacked: true !default;
 // --------------------
 
 $body-margin: calc(50vw - #{$global-width / 2}) !default;
-$full-width-margin: #{$global-width / 2} - 50vw !default;
+$full-width-margin: unquote("#{$global-width / 2} - 50vw") !default;
 
 $base-font-size:      rem-calc(17) !default;
 $base-line:           rem-calc(26) !default;


### PR DESCRIPTION
## References

* We introduced the code causing this warning in commit 701378d02c from pull request #4582

## Background

When running `scss-lint`, we were getting the following message:

DEPRECATION WARNING: #{} interpolation near operators will be simplified in a future version of Sass. To preserve the current behavior, use quotes:

```scss
  unquote("#{$global-width / 2} - 50vw")
```

## Objectives

* Avoid deprecation warnings