### PR TITLE
Fix investments list images width in Chrome 93+

### DIFF
--- a/app/assets/stylesheets/budgets/investments-list.scss
+++ b/app/assets/stylesheets/budgets/investments-list.scss
@@ -28,7 +28,6 @@
       border-top-left-radius: rem-calc(6);
       border-top-right-radius: rem-calc(6);
       height: $line-height * 10;
-      width: fit-content;
       object-fit: cover;
 
       @include breakpoint(medium only) {


### PR DESCRIPTION
## References

* The list of investments was added in pull request #4507
* Closes #4697 

## Objectives

Display the images correctly in budget investments list in Chrome 93 or later.

## Visual Changes

- Before
In budget investments list, there is blank space between the image and the border containing the image:
![](https://user-images.githubusercontent.com/16189/139089635-6d3cd810-91dd-46b6-8f18-2b28bbc1c496.png)

- After
In budget investments list, the image fills the full width of the border containing it:
![](https://user-images.githubusercontent.com/16189/139088292-9bc4ae08-1dea-4c5f-ba87-c6e42ae2e85f.png)

