### PR TITLE
Translate budget and budget phase main link url

### DIFF
--- a/app/components/admin/budget_phases/form_component.html.erb
+++ b/app/components/admin/budget_phases/form_component.html.erb
@@ -49,11 +49,11 @@
       <p class="help-text"> <%= t("admin.budget_phases.edit.main_call_to_action_description") %></p>
       <%= translations_form.text_field :main_link_text %>
     </div>
-  <% end %>
 
-  <div class="small-12 column">
-    <%= f.text_field :main_link_url, placeholder: t("admin.shared.example_url") %>
-  </div>
+    <div class="small-12 column">
+      <%= translations_form.text_field :main_link_url, placeholder: t("admin.shared.example_url") %>
+    </div>
+  <% end %>
 
   <% if feature?(:allow_images) %>
     <div class="images small-12 column">

--- a/app/components/admin/budget_phases/form_component.html.erb
+++ b/app/components/admin/budget_phases/form_component.html.erb
@@ -51,7 +51,7 @@
     </div>
 
     <div class="small-12 column">
-      <%= translations_form.text_field :main_link_url, placeholder: t("admin.shared.example_url") %>
+      <%= translations_form.text_field :main_link_url, hint: t("admin.shared.example_url") %>
     </div>
   <% end %>
 

--- a/app/components/admin/budgets/form_component.html.erb
+++ b/app/components/admin/budgets/form_component.html.erb
@@ -21,13 +21,12 @@
           <%= translations_form.text_field :main_link_text %>
         </div>
       </div>
-    <% end %>
-
-    <div class="row expanded">
-      <div class="small-12 medium-9 large-6 column end">
-        <%= f.text_field :main_link_url, placeholder: t("admin.shared.example_url") %>
+      <div class="row expanded">
+        <div class="small-12 medium-9 large-6 column end">
+          <%= translations_form.text_field :main_link_url, placeholder: t("admin.shared.example_url") %>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <div class="row expanded">
       <div class="small-12 medium-4 column">

--- a/app/components/admin/budgets/form_component.html.erb
+++ b/app/components/admin/budgets/form_component.html.erb
@@ -21,9 +21,10 @@
           <%= translations_form.text_field :main_link_text %>
         </div>
       </div>
+
       <div class="row expanded">
         <div class="small-12 medium-9 large-6 column end">
-          <%= translations_form.text_field :main_link_url, placeholder: t("admin.shared.example_url") %>
+          <%= translations_form.text_field :main_link_url, hint: t("admin.shared.example_url") %>
         </div>
       </div>
     <% end %>

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -59,7 +59,6 @@ class Admin::BudgetsController < Admin::BaseController
       valid_attributes = [:phase,
                           :currency_symbol,
                           :voting_style,
-                          :main_link_url,
                           administrator_ids: [],
                           valuator_ids: [],
                           image_attributes: image_attributes

--- a/app/controllers/admin/budgets_wizard/budgets_controller.rb
+++ b/app/controllers/admin/budgets_wizard/budgets_controller.rb
@@ -37,7 +37,7 @@ class Admin::BudgetsWizard::BudgetsController < Admin::BudgetsWizard::BaseContro
     end
 
     def allowed_params
-      valid_attributes = [:currency_symbol, :voting_style, :main_link_url, administrator_ids: [],
+      valid_attributes = [:currency_symbol, :voting_style, administrator_ids: [],
                           valuator_ids: [], image_attributes: image_attributes]
 
       valid_attributes + [translation_params(Budget)]

--- a/app/controllers/concerns/admin/budget_phases_actions.rb
+++ b/app/controllers/concerns/admin/budget_phases_actions.rb
@@ -40,7 +40,7 @@ module Admin::BudgetPhasesActions
     end
 
     def budget_phase_params
-      valid_attributes = [:starts_at, :ends_at, :enabled, :main_link_url,
+      valid_attributes = [:starts_at, :ends_at, :enabled,
                           image_attributes: image_attributes]
       params.require(:budget_phase).permit(*valid_attributes, translation_params(Budget::Phase))
     end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -5,7 +5,7 @@ class Budget < ApplicationRecord
   include Reportable
   include Imageable
 
-  translates :name, :main_link_text, touch: true
+  translates :name, :main_link_text, :main_link_url, touch: true
   include Globalizable
 
   class Translation
@@ -24,11 +24,11 @@ class Budget < ApplicationRecord
   VOTING_STYLES = %w[knapsack approval].freeze
 
   validates_translation :name, presence: true
+  validates_translation :main_link_url, presence: true, unless: -> { main_link_text.blank? }
   validates :phase, inclusion: { in: Budget::Phase::PHASE_KINDS }
   validates :currency_symbol, presence: true
   validates :slug, presence: true, format: /\A[a-z0-9\-_]+\z/
   validates :voting_style, inclusion: { in: VOTING_STYLES }
-  validates :main_link_url, presence: true, if: -> { main_link_text.present? }
 
   has_many :investments, dependent: :destroy
   has_many :ballots, dependent: :destroy

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -9,6 +9,7 @@ class Budget
     translates :summary, touch: true
     translates :description, touch: true
     translates :main_link_text, touch: true
+    translates :main_link_url, touch: true
     include Globalizable
     include Sanitizable
     include Imageable
@@ -19,9 +20,9 @@ class Budget
 
     validates_translation :name, presence: true
     validates_translation :description, length: { maximum: DESCRIPTION_MAX_LENGTH }
+    validates_translation :main_link_url, presence: true, unless: -> { main_link_text.blank? }
     validates :budget, presence: true
     validates :kind, presence: true, uniqueness: { scope: :budget }, inclusion: { in: ->(*) { PHASE_KINDS }}
-    validates :main_link_url, presence: true, if: -> { main_link_text.present? }
     validate :invalid_dates_range?
     validate :prev_phase_dates_valid?
     validate :next_phase_dates_valid?

--- a/app/models/concerns/globalizable.rb
+++ b/app/models/concerns/globalizable.rb
@@ -32,14 +32,19 @@ module Globalizable
     private
 
       def required_attribute?(attribute)
-        presence_validators = [ActiveModel::Validations::PresenceValidator,
-          ActiveRecord::Validations::PresenceValidator]
-
-        attribute_validators(attribute).any? { |validator| presence_validators.include? validator }
+        self.class.validators_on(attribute).any? do |validator|
+          validator.kind == :presence && !conditional_validator?(validator)
+        end
       end
 
-      def attribute_validators(attribute)
-        self.class.validators_on(attribute).map(&:class)
+      def conditional_validator?(validator)
+        return false unless validator.options[:unless]
+
+        if validator.options[:unless].to_proc.arity.zero?
+          instance_exec(&validator.options[:unless])
+        else
+          validator.options[:unless].to_proc.call(self)
+        end
       end
 
       def check_translations_number

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -160,9 +160,9 @@ en:
         voting_style: "Final voting style"
         voting_style_knapsack: "Knapsack"
         voting_style_approval: "Approval"
-        main_link_url: "The link takes you to (add a link)"
       budget/translation:
         main_link_text: "Text on the link"
+        main_link_url: "The link takes you to (add a link)"
         name: "Name"
       budget/investment:
         heading_id: "Heading"
@@ -231,12 +231,12 @@ en:
         enabled: "Phase enabled"
         ends_at: "End date"
         starts_at: "Start date"
-        main_link_url: "The link takes you to (add a link)"
       budget/phase/translation:
         name: "Name"
         description: "Description"
         summary: "Summary"
         main_link_text: "Text on the link"
+        main_link_url: "The link takes you to (add a link)"
       comment:
         body: "Comment"
         user: "User"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1369,7 +1369,7 @@ en:
       show_results_and_stats: "Show results and stats"
       results_and_stats_reminder: "Marking these checkboxes the results and/or stats will be publicly available and every user will see them."
       close_modal: Close modal
-      example_url: "https://consulproject.org"
+      example_url: "For example, https://consulproject.org or /help"
     geozones:
       index:
         title: Geozone

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1366,7 +1366,6 @@ en:
       content: Content
       created_at: Created at
       color_help: Hexadecimal format
-      example_url: "https://consulproject.org"
       show_results_and_stats: "Show results and stats"
       results_and_stats_reminder: "Marking these checkboxes the results and/or stats will be publicly available and every user will see them."
       close_modal: Close modal

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -160,9 +160,9 @@ es:
         voting_style: "Estilo de la votación final"
         voting_style_knapsack: Bolsa de dinero
         voting_style_approval: Por aprobación
-        main_link_url: "El enlace te lleva a (añade un enlace)"
       budget/translation:
         main_link_text: "Texto del enlace"
+        main_link_url: "El enlace te lleva a (añade un enlace)"
         name: "Nombre"
       budget/investment:
         heading_id: "Partida presupuestaria"
@@ -231,12 +231,12 @@ es:
         enabled: "Fase habilitada"
         ends_at: "Fecha de fin"
         starts_at: "Fecha de inicio"
-        main_link_url: "El enlace te lleva a (añade un enlace)"
       budget/phase/translation:
         name: "Nombre"
         description: "Descripción"
         summary: "Resumen"
         main_link_text: "Texto del enlace"
+        main_link_url: "El enlace te lleva a (añade un enlace)"
       comment:
         body: "Comentario"
         user: "Usuario"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1365,7 +1365,6 @@ es:
       content: Contenido
       created_at: Fecha de creación
       color_help: Formato hexadecimal
-      example_url: "https://consulproject.org"
       show_results_and_stats: "Mostrar resultados y estadísticas"
       results_and_stats_reminder: "Si marcas estas casillas los resultados y/o estadísticas serán públicos y podrán verlos todos los usuarios."
       close_modal: Cerrar ventana emergente

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1368,7 +1368,7 @@ es:
       show_results_and_stats: "Mostrar resultados y estadísticas"
       results_and_stats_reminder: "Si marcas estas casillas los resultados y/o estadísticas serán públicos y podrán verlos todos los usuarios."
       close_modal: Cerrar ventana emergente
-      example_url: "https://consulproject.org"
+      example_url: "Por ejemplo, https://consulproject.org o /help"
     geozones:
       index:
         title: Zonas

--- a/db/migrate/20211103090940_translate_budget_main_link_url.rb
+++ b/db/migrate/20211103090940_translate_budget_main_link_url.rb
@@ -1,0 +1,6 @@
+class TranslateBudgetMainLinkUrl < ActiveRecord::Migration[5.2]
+  def change
+    add_column :budget_translations, :main_link_url, :string
+    remove_column :budgets, :main_link_url, :string
+  end
+end

--- a/db/migrate/20211103112944_translate_budget_phase_main_link_url.rb
+++ b/db/migrate/20211103112944_translate_budget_phase_main_link_url.rb
@@ -1,0 +1,6 @@
+class TranslateBudgetPhaseMainLinkUrl < ActiveRecord::Migration[5.2]
+  def change
+    add_column :budget_phase_translations, :main_link_url, :string
+    remove_column :budget_phases, :main_link_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_25_152739) do
+ActiveRecord::Schema.define(version: 2021_11_03_112944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -316,6 +316,7 @@ ActiveRecord::Schema.define(version: 2021_08_25_152739) do
     t.text "summary"
     t.string "name"
     t.string "main_link_text"
+    t.string "main_link_url"
     t.index ["budget_phase_id"], name: "index_budget_phase_translations_on_budget_phase_id"
     t.index ["locale"], name: "index_budget_phase_translations_on_locale"
   end
@@ -327,7 +328,6 @@ ActiveRecord::Schema.define(version: 2021_08_25_152739) do
     t.datetime "starts_at"
     t.datetime "ends_at"
     t.boolean "enabled", default: true
-    t.string "main_link_url"
     t.index ["ends_at"], name: "index_budget_phases_on_ends_at"
     t.index ["kind"], name: "index_budget_phases_on_kind"
     t.index ["next_phase_id"], name: "index_budget_phases_on_next_phase_id"
@@ -349,6 +349,7 @@ ActiveRecord::Schema.define(version: 2021_08_25_152739) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.string "main_link_text"
+    t.string "main_link_url"
     t.index ["budget_id"], name: "index_budget_translations_on_budget_id"
     t.index ["locale"], name: "index_budget_translations_on_locale"
   end
@@ -393,7 +394,6 @@ ActiveRecord::Schema.define(version: 2021_08_25_152739) do
     t.text "description_informing"
     t.string "voting_style", default: "knapsack"
     t.boolean "published"
-    t.string "main_link_url"
   end
 
   create_table "campaigns", id: :serial, force: :cascade do |t|

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -86,8 +86,6 @@ FactoryBot.define do
       evaluator.voters.each { |voter| create(:vote, votable: proposal, voter: voter) }
       evaluator.followers.each { |follower| create(:follow, followable: proposal, user: follower) }
     end
-
-    factory :retired_proposal, traits: [:retired]
   end
 
   factory :proposal_notification do

--- a/spec/models/concerns/globalizable.rb
+++ b/spec/models/concerns/globalizable.rb
@@ -13,9 +13,6 @@ shared_examples_for "globalizable" do |factory_name|
   let(:attribute) { required_fields.sample || fields.sample }
 
   before do
-    if factory_name == :budget || factory_name == :budget_phase
-      record.main_link_url = "https://consulproject.org"
-    end
     record.update!(attribute => "In English")
 
     I18n.with_locale(:es) do

--- a/spec/models/milestone_spec.rb
+++ b/spec/models/milestone_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe Milestone do
+  it_behaves_like "globalizable", :milestone
   it_behaves_like "globalizable", :milestone_with_description
 
   describe "Validations" do

--- a/spec/models/progress_bar_spec.rb
+++ b/spec/models/progress_bar_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe ProgressBar do
   let(:progress_bar) { build(:progress_bar) }
 
+  it_behaves_like "globalizable", :progress_bar
   it_behaves_like "globalizable", :secondary_progress_bar
 
   it "is valid" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -7,7 +7,7 @@ describe Proposal do
     it_behaves_like "has_public_author"
     it_behaves_like "notifiable"
     it_behaves_like "map validations"
-    it_behaves_like "globalizable", :retired_proposal
+    it_behaves_like "globalizable", :proposal
     it_behaves_like "sanitizable"
     it_behaves_like "acts as paranoid", :proposal
   end

--- a/spec/system/admin/translatable_spec.rb
+++ b/spec/system/admin/translatable_spec.rb
@@ -355,7 +355,9 @@ describe "Admin edit translatable records", :admin do
   context "Remove all translations" do
     let(:translatable) { create(:milestone) }
 
-    scenario "Shows an error message" do
+    scenario "Shows an error message when there's a mandatory translatable field" do
+      translatable.update!(status: nil)
+
       visit admin_polymorphic_path(translatable, action: :edit)
 
       click_link "Remove language"
@@ -364,6 +366,19 @@ describe "Admin edit translatable records", :admin do
       click_button "Update milestone"
 
       expect(page).to have_content "Is mandatory to provide one translation at least"
+    end
+
+    scenario "Is successful when there isn't a mandatory translatable field" do
+      translatable.update!(status: Milestone::Status.first)
+
+      visit admin_polymorphic_path(translatable, action: :edit)
+
+      click_link "Remove language"
+      click_link "Remove language"
+
+      click_button "Update milestone"
+
+      expect(page).to have_content "Milestone updated successfully"
     end
   end
 


### PR DESCRIPTION
## References

Related PR's: 
 * Improve budget header #4501
 * Improve budget phases #4510 

## Objectives

Make the `main_link_url` field translatable to store different destinations for each language, particularly useful when the destination page is available in many languages.

## Visual Changes

**Before: Budget edition page**
![Captura de pantalla 2021-11-03 a las 16 20 39-fullpage](https://user-images.githubusercontent.com/15726/140089722-2409997e-88a6-48f7-ace0-1f6a711f5665.png)

**Before: Budget phase edition page**
![Captura de pantalla 2021-11-03 a las 16 20 49-fullpage](https://user-images.githubusercontent.com/15726/140089749-03e066ff-3c50-4bae-8b99-ef916833a800.png)


**After: Budget edition page**
![Captura de pantalla 2021-11-04 a las 11 18 15-fullpage](https://user-images.githubusercontent.com/15726/140297200-5795ffc6-9786-452a-be3a-e77596c1bcf5.png)


**After: Budget phase edition page**
![Captura de pantalla 2021-11-04 a las 11 20 47-fullpage](https://user-images.githubusercontent.com/15726/140297279-8103c6ea-18bd-491f-b393-57ad2e8c396d.png)


## Notes

I omitted the data migration process from non-translatable fields to the new translatable ones because the related PR's were not released yet.
