### PR TITLE
Add consistency between deploy-secrets and installer

### DIFF
--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -1,18 +1,18 @@
 staging:
-  deploy_to: "/var/www/consul"
+  deploy_to: "/home/deploy/consul"
   ssh_port: "21"
   server: "staging.consul.es"
-  user: "xxxxx"
+  user: "deploy"
 
 preproduction:
-  deploy_to: "/var/www/consul"
+  deploy_to: "/home/deploy/consul"
   ssh_port: "2222"
   server1: xxx.xxx.xxx.xxx
   server2: xxx.xxx.xxx.xxx
-  user: xxxxx
+  user: "deploy"
 
 production:
-  deploy_to: "/var/www/consul"
+  deploy_to: "/home/deploy/consul"
   ssh_port: "22"
   server1: xxx.xxx.xxx.xxx
   server2: xxx.xxx.xxx.xxx


### PR DESCRIPTION
## Objectives
Add the same path in the `deploy-secrets.yml.example` file where the default application is installed with the installer.

The installer creates the application in the following path:
`home_dir: "/home/{{{ deploy_user }}"`
We update the variable "deploy_to" in the deploy-secrets file to be consistent with the installer.
