### PR TITLE
Add setting to allow removing investments supports

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -593,13 +593,6 @@ code {
   }
 }
 
-.admin {
-
-  .investment-projects-list.medium-9 {
-    width: 100%;
-  }
-}
-
 .investment-projects-summary {
 
   th,

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -515,6 +515,10 @@
   @include breakpoint(medium) {
     min-height: $line-height * 15;
   }
+
+  .with-image > .row {
+    display: flex;
+  }
 }
 
 .budget-investments-list .budget-investment,
@@ -543,6 +547,7 @@
     }
 
     img {
+      height: 100%;
       max-width: 12rem;
     }
   }

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -503,7 +503,6 @@
 
 .debates-list,
 .proposals-list,
-.investment-projects-list,
 .budget-investments-list {
 
   @include breakpoint(medium) {
@@ -511,7 +510,6 @@
   }
 }
 
-.investment-projects-list,
 .budget-investments-list {
 
   @include breakpoint(medium) {

--- a/app/components/budgets/investments/votes_component.html.erb
+++ b/app/components/budgets/investments/votes_component.html.erb
@@ -11,11 +11,13 @@
           <div class="callout success">
             <%= t("budgets.investments.votes.already_supported") %>
           </div>
-          <%= button_to t("budgets.investments.votes.remove_support"), remove_support_path,
-              class: "button button-remove-support expanded",
-              method: "delete",
-              remote: true,
-              "aria-label": remove_support_aria_label %>
+          <% if feature?(:remove_investments_supports) %>
+            <%= button_to t("budgets.investments.votes.remove_support"), remove_support_path,
+                class: "button button-remove-support expanded",
+                method: "delete",
+                remote: true,
+                "aria-label": remove_support_aria_label %>
+          <% end %>
         </div>
       <% else %>
         <%= button_to t("budgets.investments.votes.support"), support_path,

--- a/app/controllers/budgets/investments/votes_controller.rb
+++ b/app/controllers/budgets/investments/votes_controller.rb
@@ -1,6 +1,9 @@
 module Budgets
   module Investments
     class VotesController < ApplicationController
+      include FeatureFlags
+      feature_flag :remove_investments_supports, only: :destroy
+
       load_and_authorize_resource :budget
       load_and_authorize_resource :investment, through: :budget, class: "Budget::Investment"
       load_and_authorize_resource through: :investment, through_association: :votes_for, only: :destroy

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -102,6 +102,7 @@ class Setting < ApplicationRecord
         "feature.graphql_api": true,
         "feature.sdg": true,
         "feature.machine_learning": false,
+        "feature.remove_investments_supports": false,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/app/views/budgets/investments/_investment.html.erb
+++ b/app/views/budgets/investments/_investment.html.erb
@@ -2,13 +2,10 @@
   <div class="panel <%= ("with-image" if feature?(:allow_images) && investment.image.present?) %>">
 
     <% if feature?(:allow_images) && investment.image.present? %>
-    <div class="row" data-equalizer>
+    <div class="row">
 
       <div class="small-12 medium-3 large-2 column text-center">
-        <div data-equalizer-watch>
-          <%= image_tag investment.image_url(:thumb),
-                        alt: investment.image.title.unicode_normalize %>
-        </div>
+        <%= image_tag investment.image_url(:thumb), alt: investment.image.title.unicode_normalize %>
       </div>
 
       <div class="small-12 medium-6 large-7 column">
@@ -36,14 +33,12 @@
 
         <% if investment.should_show_votes? %>
           <div id="<%= dom_id(investment) %>_votes"
-               class="small-12 medium-3 column text-center"
-               <%= "data-equalizer-watch" if feature?(:allow_images) && investment.image.present? %>>
+               class="small-12 medium-3 column text-center">
                <%= render Budgets::Investments::VotesComponent.new(investment) %>
           </div>
         <% elsif investment.should_show_vote_count? %>
           <div id="<%= dom_id(investment) %>_votes"
-               class="small-12 medium-3 column text-center"
-               <%= "data-equalizer-watch" if feature?(:allow_images) && investment.image.present? %>>
+               class="small-12 medium-3 column text-center">
             <div class="supports js-participation">
               <span class="total-supports no-button">
                 <%= t("budgets.investments.investment.supports",
@@ -53,8 +48,7 @@
           </div>
         <% elsif investment.should_show_ballots? && !management_controller? %>
           <div id="<%= dom_id(investment) %>_ballot"
-                class="small-12 medium-3 column text-center"
-                <%= "data-equalizer-watch" if feature?(:allow_images) && investment.image.present? %>>
+               class="small-12 medium-3 column text-center">
                 <%= render "/budgets/investments/ballot",
                   investment: investment,
                   investment_ids: investment_ids,
@@ -62,18 +56,14 @@
           </div>
         <% elsif investment.should_show_price? %>
           <div id="<%= dom_id(investment) %>_price"
-               class="supports small-12 medium-3 column text-center"
-               <%= "data-equalizer-watch" if feature?(:allow_images) && investment.image.present? %>>
+               class="supports small-12 medium-3 column text-center">
             <div class="supports">
               <span class="total-supports no-button">
                 <%= investment.formatted_price %>
               </span>
             </div>
           </div>
-        <% else %>
-          <div <%= "data-equalizer-watch" if feature?(:allow_images) && investment.image.present? %>></div>
         <% end %>
-
       <% end %>
     </div>
   </div>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -12,6 +12,7 @@
           investment.author,
           Flag.flagged?(current_user, investment),
           investment.followed_by?(current_user),
+          feature?(:remove_investments_supports),
           current_user&.voted_for?(investment)] do %>
   <section class="budget-investment-show" id="<%= dom_id(investment) %>">
 

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -132,6 +132,8 @@ en:
       dashboard:
         notification_emails: "Dashboard notification emails"
         notification_emails_description: "Enable sending dashboard notification emails to proposal's authors"
+      remove_investments_supports: "Allow removing supports on budget investments"
+      remove_investments_supports_description: "Allow users to remove supports on participatory budgets investments during the selecting projects phase."
       sdg: SDG
       sdg_description: Enable Sustainable Development Goals sections in the administration menu and in the Global Settings.
     remote_census:

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -132,6 +132,8 @@ es:
       dashboard:
         notification_emails: "Emails del panel de progreso"
         notification_emails_description: "Activar el envío de emails de notificaciones a los autores de las propuestas en la sección de panel de progreso"
+      remove_investments_supports: "Permitir retirar los apoyos en los proyectos de gasto"
+      remove_investments_supports_description: "Permite que los usuarios retiren su apoyo en los proyectos de gasto de los presupuestos participativos durante la fase de apoyos."
       sdg: ODS
       sdg_description: Habilitar secciones relacionadas con Objetivos de Desarrollo Sostenible en el menú de administración y en la sección de Configuración Global.
     remote_census:

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -5,6 +5,7 @@ section "Creating Settings" do
     "facebook_handle": "CONSUL",
     "feature.featured_proposals": "true",
     "feature.map": "true",
+    "feature.remove_investments_supports": true,
     "instagram_handle": "CONSUL",
     "mailer_from_address": "noreply@consul.dev",
     "mailer_from_name": "CONSUL",

--- a/spec/components/budgets/investments/votes_component_spec.rb
+++ b/spec/components/budgets/investments/votes_component_spec.rb
@@ -25,16 +25,31 @@ describe Budgets::Investments::VotesComponent do
         expect(page).to have_button "Support", disabled: true
       end
 
-      it "shows the button to remove support when users have supported the investment" do
-        user = create(:user)
-        user.up_votes(investment)
-        sign_in(user)
+      describe "button to remove support" do
+        let(:user) { create(:user) }
 
-        render_inline component
+        before do
+          user.up_votes(investment)
+          sign_in(user)
+        end
 
-        expect(page).to have_button count: 1, disabled: :all
-        expect(page).to have_button "Remove your support"
-        expect(page).to have_button "Remove your support to Renovate sidewalks in Main Street"
+        it "is shown when the setting is enabled" do
+          Setting["feature.remove_investments_supports"] = true
+
+          render_inline component
+
+          expect(page).to have_button count: 1, disabled: :all
+          expect(page).to have_button "Remove your support"
+          expect(page).to have_button "Remove your support to Renovate sidewalks in Main Street"
+        end
+
+        it "is not shown when the setting is disabled" do
+          Setting["feature.remove_investments_supports"] = false
+
+          render_inline component
+
+          expect(page).not_to have_button disabled: :all
+        end
       end
     end
   end

--- a/spec/controllers/budgets/investments/votes_controller_spec.rb
+++ b/spec/controllers/budgets/investments/votes_controller_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe Budgets::Investments::VotesController do
+  let(:user) { create(:user) }
+  let(:budget) { create(:budget, :selecting) }
+  let(:investment) { create(:budget_investment, budget: budget) }
+  let(:vote) { create(:vote, votable: investment, voter: user) }
+  before { sign_in user }
+
+  describe "DELETE destroy" do
+    it "raises an exception when the remove supports feature is disabled" do
+      Setting["feature.remove_investments_supports"] = false
+
+      expect do
+        delete :destroy, xhr: true, params: { budget_id: budget, investment_id: investment, id: vote }
+      end.to raise_exception(FeatureFlags::FeatureDisabled)
+    end
+  end
+
+  describe "POST create" do
+    it "is not affected by the remove supports feature" do
+      Setting["feature.remove_investments_supports"] = false
+
+      post :create, params: { budget_id: budget, investment_id: investment }
+
+      expect(response).to redirect_to budget_investments_path(heading_id: investment.heading.id)
+    end
+  end
+end

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -404,6 +404,7 @@ describe "Budgets" do
     end
 
     scenario "Show supports only if the support has not been removed" do
+      Setting["feature.remove_investments_supports"] = true
       voter = create(:user, :level_two)
       budget = create(:budget, phase: "selecting")
       investment = create(:budget_investment, :selected, budget: budget)

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1230,6 +1230,7 @@ describe "Budget Investments" do
     end
 
     scenario "Remove a support from show view" do
+      Setting["feature.remove_investments_supports"] = true
       investment = create(:budget_investment, budget: budget)
 
       login_as(author)
@@ -1251,6 +1252,7 @@ describe "Budget Investments" do
     end
 
     scenario "Remove a support from index view" do
+      Setting["feature.remove_investments_supports"] = true
       investment = create(:budget_investment, budget: budget)
 
       login_as(author)

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -334,6 +334,7 @@ describe "Budget Investments" do
     end
 
     scenario "Remove support on behalf of someone else in index view" do
+      Setting["feature.remove_investments_supports"] = true
       create(:budget_investment, heading: heading)
 
       login_managed_user(user)
@@ -354,6 +355,7 @@ describe "Budget Investments" do
     end
 
     scenario "Remove support on behalf of someone else in show view" do
+      Setting["feature.remove_investments_supports"] = true
       create(:budget_investment, heading: heading, title: "Don't support me!")
 
       login_managed_user(user)


### PR DESCRIPTION
## References

Allow users to remove their support on investments https://github.com/consul/consul/commit/a851048d56b05e6027deb1328f15754b96efcd1d.

## Objectives

This PR add a new setting to allow remove investments supports. Also, fix broken layout when interact with support/remove support button on investments list.

## Visual Changes

### New setting
<img width="1398" alt="new_setting" src="https://user-images.githubusercontent.com/631897/140559121-dd626280-b781-44b6-b618-5494abea0bea.png">

### Broken layout when interact with support/remove support button (BEFORE)
![supports](https://user-images.githubusercontent.com/631897/140578898-865fa1c5-f6a0-4d1a-8c52-cdfd0b13f203.png)

### Fixed layout
https://user-images.githubusercontent.com/631897/140559127-0c6f023c-b526-4b1b-a0b9-83cb0e2d780d.mov

## Notes

It's necessary to run `rake settings:add_new_settings` to include the new setting if you don't use Capistrano to deploy. 😌 