### PR TITLE
Fix investment list layout on small/medium screens

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -514,10 +514,10 @@
 
   @include breakpoint(medium) {
     min-height: $line-height * 15;
-  }
 
-  .with-image > .row {
-    display: flex;
+    .with-image > .row {
+      display: flex;
+    }
   }
 }
 

--- a/app/components/budgets/investments/votes_component.html.erb
+++ b/app/components/budgets/investments/votes_component.html.erb
@@ -12,11 +12,13 @@
             <%= t("budgets.investments.votes.already_supported") %>
           </div>
           <% if feature?(:remove_investments_supports) %>
-            <%= button_to t("budgets.investments.votes.remove_support"), remove_support_path,
+            <%= button_to remove_support_path,
                 class: "button button-remove-support expanded",
                 method: "delete",
                 remote: true,
-                "aria-label": remove_support_aria_label %>
+                "aria-label": remove_support_aria_label do %>
+              <%= t("budgets.investments.votes.remove_support") %>
+            <% end %>
           <% end %>
         </div>
       <% else %>

--- a/app/views/management/budgets/investments/index.html.erb
+++ b/app/views/management/budgets/investments/index.html.erb
@@ -4,7 +4,7 @@
   </span>
 
   <div class="wrap row">
-    <div id="budget-investments" class="budget-investments-list small-12 medium-9 column">
+    <div id="budget-investments" class="budget-investments-list small-12 column">
 
       <div class="small-12 search-results">
         <%= tag.h2 t("management.budget_investments.filters.unfeasible") if params[:unfeasible].present? %>


### PR DESCRIPTION
## References

* This bug for small screens was introduced in pull request #4730
* The button didn't look so well for medium screen since it was added in pull request #4504

## Objectives

* Use a vertical layout on small screens
* Make sure the text of the buttons is displayed properly when there isn't much space
* Use all available space for the investments list in the management section

## Visual Changes

### Before these changes

On medium-sized screens:

![The text on the button is on one line, but since there isn't much space, only the beginning can be read](https://user-images.githubusercontent.com/35156/140921173-fb8377f6-f347-44df-848c-a6d425f5f0b3.png)

On small-sized screens:

![The image is barely visible and there isn't much space for the description](https://user-images.githubusercontent.com/35156/140830270-9bb399ef-7e5c-4ee9-a9df-83e3ddb19d69.png)

Management portal on medium-sized screens:

![The investments list only uses 75% of the available space, so there's barely enough space for its elements](https://user-images.githubusercontent.com/35156/140920401-9b30b36d-ae98-43a9-a231-100aac9d7168.png)

### After these changes

On medium-sized screens:

![The text on the button spans over multiple lines and so the whole text can be read](https://user-images.githubusercontent.com/35156/140919125-2449e2ad-6104-4f22-840d-a43e28c22418.png)

On small-sized screens:

![The image is fully visible and the description is below it, taking all the available space](https://user-images.githubusercontent.com/35156/140920746-add20153-e267-4175-8fc0-d839f72632f5.png)

Management portal on medium-sized screens:

![The investments list uses 100% of the available space, so there's more space for its elements](https://user-images.githubusercontent.com/35156/140920442-9bb889b3-26d3-4fc4-8850-4e659c3c4a6a.png)
