### PR TITLE
Make dev seeds independent on available locales

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -47,6 +47,7 @@ data:
     - config/locales/%{locale}/milestones.yml
     - config/locales/%{locale}/sdg.yml
     - config/locales/%{locale}/sdg_management.yml
+    - config/locales/%{locale}/seeds.yml
     - config/locales/%{locale}/stats.yml
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
@@ -79,6 +80,7 @@ search:
   paths:
    - app/
    - db/pages/
+   - db/dev_seeds/
 
   ## Root directories for relative keys resolution.
   # relative_roots:
@@ -122,7 +124,6 @@ ignore_missing:
   - "devise.failure.invalid"
   - "devise.registrations.destroyed"
   - "devise.password_expired.*"
-  - "seeds.settings.*"
 
 ## Consider these keys used:
 ignore_unused:
@@ -215,7 +216,6 @@ ignore_unused:
   - admin.stats.polls.expired
   - "stats.polls.*_percentage"
   - landings.cambia_tu_ciudad.*
-  - "seeds.settings.*"
   - "dashboard.polls.*.submit"
   - "related_content.content_title.*"
   - "sdg.goals.goal_*"

--- a/config/locales/en/seeds.yml
+++ b/config/locales/en/seeds.yml
@@ -73,11 +73,6 @@ en:
       phases:
         description: "Description in %{language}"
         summary: "Summary in %{language}"
-      valuator_groups:
-        culture_and_sports: Culture & Sports
-        gender_and_diversity: Gender & Diversity Policies
-        urban_development: Sustainable Urban Development
-        equity_and_employment: Equity & Employment
       statuses:
         studying_project: Studying the project
         bidding: Bidding

--- a/config/locales/en/seeds.yml
+++ b/config/locales/en/seeds.yml
@@ -2,17 +2,17 @@ en:
   seeds:
     admin_notifications:
       budget:
-        title: "We are closing the Participatory Budget!!"
-        body: "Hurry up and create a last proposal before it ends next in few days!"
+        title: "We are closing the Participatory Budget!"
+        body: "Hurry up and create a proposal before it ends in the next few days!"
       help:
         title: "Help us translate consul"
-        body: "If you are proficient in a language, please help us translate consul!."
+        body: "If you are proficient in a language, please help us translate consul!"
       map:
-        title: "You can now geolocate proposals & investments"
+        title: "You can now geolocate proposals and investments"
         body: "When you create a proposal or investment you now can specify a point on a map."
       proposal:
         title: "Do you have a proposal?"
-        body: "Remember you can create a proposal with your ideas and people will discuss & support it."
+        body: "Remember you can create a proposal with your ideas and people will discuss and support it."
     settings:
       official_level_1_name: Official position 1
       official_level_2_name: Official position 2
@@ -91,5 +91,5 @@ en:
       current_poll: "Current Poll"
       current_poll_geozone_restricted: "Current Poll Geozone Restricted"
       recounting_poll: "Recounting Poll"
-      expired_poll_without_stats: "Expired Poll without Stats & Results"
-      expired_poll_with_stats: "Expired Poll with Stats & Results"
+      expired_poll_without_stats: "Expired Poll without Stats and Results"
+      expired_poll_with_stats: "Expired Poll with Stats and Results"

--- a/config/locales/en/seeds.yml
+++ b/config/locales/en/seeds.yml
@@ -1,5 +1,18 @@
 en:
   seeds:
+    admin_notifications:
+      budget:
+        title: "We are closing the Participatory Budget!!"
+        body: "Hurry up and create a last proposal before it ends next in few days!"
+      help:
+        title: "Help us translate consul"
+        body: "If you are proficient in a language, please help us translate consul!."
+      map:
+        title: "You can now geolocate proposals & investments"
+        body: "When you create a proposal or investment you now can specify a point on a map."
+      proposal:
+        title: "Do you have a proposal?"
+        body: "Remember you can create a proposal with your ideas and people will discuss & support it."
     settings:
       official_level_1_name: Official position 1
       official_level_2_name: Official position 2
@@ -14,6 +27,27 @@ en:
     organizations:
       human_rights: Human Rights
       neighborhood_association: Neighborhood Association
+    cards:
+      budget:
+        title: "How do participatory budgets work?"
+        description: "Participatory budgets allow citizens to propose and decide directly how to spend part of the budget, with monitoring and rigorous evaluation of proposals by the institution. Maximum effectiveness and control with satisfaction for everyone."
+        link_text: "More about Participatory budgets"
+        label: "Participatory budgets"
+      debate:
+        title: "How do debates work?"
+        description: "Anyone can open threads on any subject, creating separate spaces where people can discuss the proposed topic. Debates are valued by everybody, to highlight the most important issues."
+        link_text: "More about debates"
+        label: "Debates"
+      header:
+        title: "CONSUL"
+        description: "Free software for citizen participation."
+        link_text: "More information"
+        label: "Welcome to"
+      proposal:
+        title: "How do citizen proposals work?"
+        description: "A space for everyone to create a citizen's proposal and seek supports. Proposals which reach to enough supports will be voted and so, together we can decide the issues that matter to us."
+        link_text: "More about proposals"
+        label: "Citizen proposals"
     categories:
       associations: Associations
       culture: Culture
@@ -36,6 +70,9 @@ en:
       groups:
         all_city: All City
         districts: Districts
+      phases:
+        description: "Description in %{language}"
+        summary: "Summary in %{language}"
       valuator_groups:
         culture_and_sports: Culture & Sports
         gender_and_diversity: Gender & Diversity Policies
@@ -46,6 +83,10 @@ en:
         bidding: Bidding
         executing_project: Executing the project
         executed: Executed
+    legislation:
+      draft_versions:
+        title: "Version %{number}"
+        body: "Draft version in %{language}"
     polls:
       current_poll: "Current Poll"
       current_poll_geozone_restricted: "Current Poll Geozone Restricted"

--- a/config/locales/es/seeds.yml
+++ b/config/locales/es/seeds.yml
@@ -73,11 +73,6 @@ es:
       phases:
         description: "Descripción en %{language}"
         summary: "Resumen en %{language}"
-      valuator_groups:
-        culture_and_sports: Cultura y Deportes
-        gender_and_diversity: Políticas de Género y Diversidad
-        urban_development: Desarrollo Urbano Sostenible
-        equity_and_employment: Equidad y Empleo
       statuses:
         studying_project: Estudiando el proyecto
         bidding: Licitación

--- a/config/locales/es/seeds.yml
+++ b/config/locales/es/seeds.yml
@@ -3,7 +3,7 @@ es:
     admin_notifications:
       budget:
         title: "Últimos días para crear proyectos de Presupuestos Participativos"
-        body: "Quedan pocos dias para que se cierre el plazo de presentación de proyectos de inversión para los presupuestos participativos!"
+        body: "¡Quedan pocos días para que se cierre el plazo de presentación de proyectos de inversión para los presupuestos participativos!"
       help:
         title: "Ayúdanos a traducir CONSUL"
         body: "Si dominas un idioma, ayúdanos a completar su traducción en CONSUL."
@@ -11,7 +11,7 @@ es:
         title: "Ahora puedes geolocalizar propuestas y proyectos de inversión"
         body: "Cuando crees una propuesta o proyecto de inversión podrás especificar su localización en el mapa"
       proposal:
-        title: "Tienes una propuesta?"
+        title: "¿Tienes una propuesta?"
         body: "Recuerda que puedes crear propuestas y los ciudadanos las debatirán y apoyarán."
     settings:
       official_level_1_name: Cargo oficial 1
@@ -29,8 +29,8 @@ es:
       neighborhood_association: Asociación Vecinal
     cards:
       budget:
-        title: "¿Cómo funcionan los propuestos participativos?"
-        description: "Los presupuestos participativos permiten que los ciudadanos propongan y decidan directamente cómo gastar parte del presupuesto, con la supervisión y valoración de la institución. Máxima eficacia y control para la satisfacción de todos"
+        title: "¿Cómo funcionan los presupuestos participativos?"
+        description: "Los presupuestos participativos permiten que los ciudadanos propongan y decidan directamente cómo gastar parte del presupuesto, con la supervisión y valoración de la institución. Máxima eficacia y control para la satisfacción de todos."
         link_text: "Más sobre presupuestos participativos"
         label: "Presupuestos participativos"
       debate:

--- a/config/locales/es/seeds.yml
+++ b/config/locales/es/seeds.yml
@@ -1,5 +1,18 @@
 es:
   seeds:
+    admin_notifications:
+      budget:
+        title: "Últimos días para crear proyectos de Presupuestos Participativos"
+        body: "Quedan pocos dias para que se cierre el plazo de presentación de proyectos de inversión para los presupuestos participativos!"
+      help:
+        title: "Ayúdanos a traducir CONSUL"
+        body: "Si dominas un idioma, ayúdanos a completar su traducción en CONSUL."
+      map:
+        title: "Ahora puedes geolocalizar propuestas y proyectos de inversión"
+        body: "Cuando crees una propuesta o proyecto de inversión podrás especificar su localización en el mapa"
+      proposal:
+        title: "Tienes una propuesta?"
+        body: "Recuerda que puedes crear propuestas y los ciudadanos las debatirán y apoyarán."
     settings:
       official_level_1_name: Cargo oficial 1
       official_level_2_name: Cargo oficial 2
@@ -14,6 +27,27 @@ es:
     organizations:
       human_rights: Derechos Humanos
       neighborhood_association: Asociación Vecinal
+    cards:
+      budget:
+        title: "¿Cómo funcionan los propuestos participativos?"
+        description: "Los presupuestos participativos permiten que los ciudadanos propongan y decidan directamente cómo gastar parte del presupuesto, con la supervisión y valoración de la institución. Máxima eficacia y control para la satisfacción de todos"
+        link_text: "Más sobre presupuestos participativos"
+        label: "Presupuestos participativos"
+      debate:
+        title: "¿Cómo funcionan los debates?"
+        description: "Cualquiera puede iniciar un debate sobre cualquier tema, creando un espacio separado donde compartir puntos de vista con otras personas. Los debates son valorados por todos para destacar los temas más importantes."
+        link_text: "Más sobre debates"
+        label: "Debates"
+      header:
+        title: "CONSUL"
+        description: "Software libre para la participación ciudadana."
+        link_text: "Más información"
+        label: "Bienvenido a"
+      proposal:
+        title: "¿Cómo funcionan las propuestas ciudadanas?"
+        description: "Un espacio para que el ciudadano cree una propuesta y busque apoyo. Las propuestas que obtengan el apoyo necesario serán votadas. Así juntos podemos decidir sobre los temas que nos importan."
+        link_text: "Más sobre propuestas"
+        label: "Propuestas ciudadanas"
     categories:
       associations: Asociaciones
       culture: Cultura
@@ -36,6 +70,9 @@ es:
       groups:
         all_city: Toda la Ciudad
         districts: Distritos
+      phases:
+        description: "Descripción en %{language}"
+        summary: "Resumen en %{language}"
       valuator_groups:
         culture_and_sports: Cultura y Deportes
         gender_and_diversity: Políticas de Género y Diversidad
@@ -46,6 +83,10 @@ es:
         bidding: Licitación
         executing_project: Ejecutando el proyecto
         executed: Ejecutado
+    legislation:
+      draft_versions:
+        title: "Versión %{number}"
+        body: "Borrador en %{language}"
     polls:
       current_poll: "Votación Abierta"
       current_poll_geozone_restricted: "Votación Abierta restringida por geozona"

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -18,7 +18,7 @@ def log(msg)
 end
 
 def random_locales
-  [I18n.default_locale, *I18n.available_locales.sample(4)].uniq
+  [I18n.default_locale, *(I18n.available_locales & %i[en es]), *I18n.available_locales.sample(4)].uniq.take(5)
 end
 
 require_relative "dev_seeds/settings"

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -21,6 +21,16 @@ def random_locales
   [I18n.default_locale, *(I18n.available_locales & %i[en es]), *I18n.available_locales.sample(4)].uniq.take(5)
 end
 
+def random_locales_attributes(**attribute_names_with_values)
+  random_locales.each_with_object({}) do |locale, attributes|
+    I18n.with_locale(locale) do
+      attribute_names_with_values.each do |attribute_name, value_proc|
+        attributes["#{attribute_name}_#{locale.to_s.underscore}"] = value_proc.call
+      end
+    end
+  end
+end
+
 require_relative "dev_seeds/settings"
 require_relative "dev_seeds/geozones"
 require_relative "dev_seeds/users"

--- a/db/dev_seeds/admin_notifications.rb
+++ b/db/dev_seeds/admin_notifications.rb
@@ -1,47 +1,33 @@
 section "Creating Admin Notifications & Templates" do
   AdminNotification.create!(
-    title_en: "Do you have a proposal?",
-    title_es: "Tienes una propuesta?",
-
-    body_en: "Remember you can create a proposal with your ideas and "\
-             "people will discuss & support it.",
-    body_es: "Recuerda que puedes crear propuestas y los ciudadanos las debatirán y apoyarán.",
-
-    link: "#{Setting["url"]}/proposals",
-    segment_recipient: "administrators"
+    random_locales_attributes(
+      %i[title body].map do |attribute|
+        [attribute, -> { I18n.t("seeds.admin_notifications.proposal.#{attribute}") }]
+      end.to_h
+    ).merge(link: "#{Setting["url"]}/proposals", segment_recipient: "administrators")
   ).deliver
 
   AdminNotification.create!(
-    title_en: "Help us translate consul",
-    title_es: "Ayúdanos a traducir CONSUL",
-
-    body_en: "If you are proficient in a language, please help us translate consul!.",
-    body_es: "Si dominas un idioma, ayúdanos a completar su traducción en CONSUL.",
-
-    link: "https://crwd.in/consul",
-    segment_recipient: "administrators"
+    random_locales_attributes(
+      %i[title body].map do |attribute|
+        [attribute, -> { I18n.t("seeds.admin_notifications.help.#{attribute}") }]
+      end.to_h
+    ).merge(link: "https://crwd.in/consul", segment_recipient: "administrators")
   ).deliver
 
   AdminNotification.create!(
-    title_en: "You can now geolocate proposals & investments",
-    title_es: "Ahora puedes geolocalizar propuestas y proyectos de inversión",
-
-    body_en: "When you create a proposal or investment you now can specify a point on a map",
-    body_es: "Cuando crees una propuesta o proyecto de inversión podrás especificar "\
-            "su localización en el mapa",
-
-    segment_recipient: "administrators"
+    random_locales_attributes(
+      %i[title body].map do |attribute|
+        [attribute, -> { I18n.t("seeds.admin_notifications.map.#{attribute}") }]
+      end.to_h
+    ).merge(segment_recipient: "administrators")
   ).deliver
 
   AdminNotification.create!(
-    title_en: "We are closing the Participatory Budget!!",
-    title_es: "Últimos días para crear proyectos de Presupuestos Participativos",
-
-    body_en: "Hurry up and create a last proposal before it ends next in few days!",
-    body_es: "Quedan pocos dias para que se cierre el plazo de presentación de proyectos de "\
-             "inversión para los presupuestos participativos!",
-
-    segment_recipient: "administrators",
-    sent_at: nil
+    random_locales_attributes(
+      %i[title body].map do |attribute|
+        [attribute, -> { I18n.t("seeds.admin_notifications.budget.#{attribute}") }]
+      end.to_h
+    ).merge(segment_recipient: "administrators", sent_at: nil)
   )
 end

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -28,75 +28,68 @@ end
 
 section "Creating Budgets" do
   Budget.create!(
-    name_en: "#{I18n.t("seeds.budgets.budget", locale: :en)} #{Date.current.year - 1}",
-    name_es: "#{I18n.t("seeds.budgets.budget", locale: :es)} #{Date.current.year - 1}",
-    currency_symbol: I18n.t("seeds.budgets.currency"),
-    phase: "finished",
-    published: true
+    {
+      currency_symbol: I18n.t("seeds.budgets.currency"),
+      phase: "finished",
+      published: true
+    }.merge(
+      random_locales_attributes(name: -> { "#{I18n.t("seeds.budgets.budget")} #{Date.current.year - 1}" })
+    )
   )
 
   Budget.create!(
-    name_en: "#{I18n.t("seeds.budgets.budget", locale: :en)} #{Date.current.year}",
-    name_es: "#{I18n.t("seeds.budgets.budget", locale: :es)} #{Date.current.year}",
-    currency_symbol: I18n.t("seeds.budgets.currency"),
-    phase: "accepting",
-    published: true
+    {
+      currency_symbol: I18n.t("seeds.budgets.currency"),
+      phase: "accepting",
+      published: true
+    }.merge(
+      random_locales_attributes(name: -> { "#{I18n.t("seeds.budgets.budget")} #{Date.current.year}" })
+    )
   )
 
   Budget.find_each do |budget|
     budget.phases.each do |phase|
-      random_locales.map do |locale|
-        Globalize.with_locale(locale) do
-          phase.name = I18n.t("budgets.phase.#{phase.kind}")
-          phase.description = "Description for locale #{locale}"
-          phase.summary = "Summary for locale #{locale}"
-          phase.save!
-        end
-      end
+      phase.update!(random_locales_attributes(
+        name: -> { I18n.t("budgets.phase.#{phase.kind}") },
+        summary: -> { I18n.t("seeds.budgets.phases.summary", language: I18n.t("i18n.language.name")) },
+        description: -> { I18n.t("seeds.budgets.phases.description", language: I18n.t("i18n.language.name")) }
+      ))
     end
   end
 
   Budget.all.each do |budget|
     city_group = budget.groups.create!(
-      name_en: I18n.t("seeds.budgets.groups.all_city", locale: :en),
-      name_es: I18n.t("seeds.budgets.groups.all_city", locale: :es)
+      random_locales_attributes(name: -> { I18n.t("seeds.budgets.groups.all_city") })
     )
 
     city_group.headings.create!(
-      name_en: I18n.t("seeds.budgets.groups.all_city", locale: :en),
-      name_es: I18n.t("seeds.budgets.groups.all_city", locale: :es),
-      price: 1000000,
-      population: 1000000,
-      latitude: "40.416775",
-      longitude: "-3.703790"
+      {
+        price: 1000000,
+        population: 1000000,
+        latitude: "40.416775",
+        longitude: "-3.703790"
+      }.merge(
+        random_locales_attributes(name: -> { I18n.t("seeds.budgets.groups.all_city") })
+      )
     )
 
     districts_group = budget.groups.create!(
-      name_en: I18n.t("seeds.budgets.groups.districts", locale: :en),
-      name_es: I18n.t("seeds.budgets.groups.districts", locale: :es)
+      random_locales_attributes(name: -> { I18n.t("seeds.budgets.groups.districts") })
     )
 
     [
-      {
-        name_en: I18n.t("seeds.geozones.north_district", locale: :en),
-        name_es: I18n.t("seeds.geozones.north_district", locale: :es),
+      random_locales_attributes(name: -> { I18n.t("seeds.geozones.north_district") }).merge(
         population: 350000
-      },
-      {
-        name_en: I18n.t("seeds.geozones.west_district", locale: :en),
-        name_es: I18n.t("seeds.geozones.west_district", locale: :es),
-        population: 300000,
-      },
-      {
-        name_en: I18n.t("seeds.geozones.east_district", locale: :en),
-        name_es: I18n.t("seeds.geozones.east_district", locale: :es),
-        population: 200000,
-      },
-      {
-        name_en: I18n.t("seeds.geozones.central_district", locale: :en),
-        name_es: I18n.t("seeds.geozones.central_district", locale: :es),
-        population: 150000,
-      }
+      ),
+      random_locales_attributes(name: -> { I18n.t("seeds.geozones.west_district") }).merge(
+        population: 300000
+      ),
+      random_locales_attributes(name: -> { I18n.t("seeds.geozones.east_district") }).merge(
+        population: 200000
+      ),
+      random_locales_attributes(name: -> { I18n.t("seeds.geozones.central_district") }).merge(
+        population: 150000
+      )
     ].each do |heading_params|
       districts_group.headings.create!(heading_params.merge(
         price: rand(5..10) * 100000,

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -47,7 +47,7 @@ section "Creating Budgets" do
     budget.phases.each do |phase|
       random_locales.map do |locale|
         Globalize.with_locale(locale) do
-          phase.name = "Name for locale #{locale}"
+          phase.name = I18n.t("budgets.phase.#{phase.kind}")
           phase.description = "Description for locale #{locale}"
           phase.summary = "Summary for locale #{locale}"
           phase.save!

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -57,67 +57,53 @@ section "Creating Budgets" do
   end
 
   Budget.all.each do |budget|
-    city_group_params = {
+    city_group = budget.groups.create!(
       name_en: I18n.t("seeds.budgets.groups.all_city", locale: :en),
       name_es: I18n.t("seeds.budgets.groups.all_city", locale: :es)
-    }
-    city_group = budget.groups.create!(city_group_params)
+    )
 
-    city_heading_params = {
+    city_group.headings.create!(
       name_en: I18n.t("seeds.budgets.groups.all_city", locale: :en),
       name_es: I18n.t("seeds.budgets.groups.all_city", locale: :es),
       price: 1000000,
       population: 1000000,
       latitude: "40.416775",
       longitude: "-3.703790"
-    }
-    city_group.headings.create!(city_heading_params)
+    )
 
-    districts_group_params = {
+    districts_group = budget.groups.create!(
       name_en: I18n.t("seeds.budgets.groups.districts", locale: :en),
       name_es: I18n.t("seeds.budgets.groups.districts", locale: :es)
-    }
-    districts_group = budget.groups.create!(districts_group_params)
+    )
 
-    north_heading_params = {
-      name_en: I18n.t("seeds.geozones.north_district", locale: :en),
-      name_es: I18n.t("seeds.geozones.north_district", locale: :es),
-      price: rand(5..10) * 100000,
-      population: 350000,
-      latitude: "40.416775",
-      longitude: "-3.703790"
-    }
-    districts_group.headings.create!(north_heading_params)
-
-    west_heading_params = {
-      name_en: I18n.t("seeds.geozones.west_district", locale: :en),
-      name_es: I18n.t("seeds.geozones.west_district", locale: :es),
-      price: rand(5..10) * 100000,
-      population: 300000,
-      latitude: "40.416775",
-      longitude: "-3.703790"
-    }
-    districts_group.headings.create!(west_heading_params)
-
-    east_heading_params = {
-      name_en: I18n.t("seeds.geozones.east_district", locale: :en),
-      name_es: I18n.t("seeds.geozones.east_district", locale: :es),
-      price: rand(5..10) * 100000,
-      population: 200000,
-      latitude: "40.416775",
-      longitude: "-3.703790"
-    }
-    districts_group.headings.create!(east_heading_params)
-
-    central_heading_params = {
-      name_en: I18n.t("seeds.geozones.central_district", locale: :en),
-      name_es: I18n.t("seeds.geozones.central_district", locale: :es),
-      price: rand(5..10) * 100000,
-      population: 150000,
-      latitude: "40.416775",
-      longitude: "-3.703790"
-    }
-    districts_group.headings.create!(central_heading_params)
+    [
+      {
+        name_en: I18n.t("seeds.geozones.north_district", locale: :en),
+        name_es: I18n.t("seeds.geozones.north_district", locale: :es),
+        population: 350000
+      },
+      {
+        name_en: I18n.t("seeds.geozones.west_district", locale: :en),
+        name_es: I18n.t("seeds.geozones.west_district", locale: :es),
+        population: 300000,
+      },
+      {
+        name_en: I18n.t("seeds.geozones.east_district", locale: :en),
+        name_es: I18n.t("seeds.geozones.east_district", locale: :es),
+        population: 200000,
+      },
+      {
+        name_en: I18n.t("seeds.geozones.central_district", locale: :en),
+        name_es: I18n.t("seeds.geozones.central_district", locale: :es),
+        population: 150000,
+      }
+    ].each do |heading_params|
+      districts_group.headings.create!(heading_params.merge(
+        price: rand(5..10) * 100000,
+        latitude: "40.416775",
+        longitude: "-3.703790"
+      ))
+    end
   end
 end
 

--- a/db/dev_seeds/legislation_processes.rb
+++ b/db/dev_seeds/legislation_processes.rb
@@ -25,12 +25,15 @@ section "Creating collaborative legislation" do
 
   Legislation::Process.find_each do |process|
     (1..3).each do |i|
-      process.draft_versions.create!(title_en: "Version #{i}",
-                                     title_es: "Versión #{i}",
-                                     body_en: ["Draft version in English",
-                                               *Faker::Lorem.paragraphs].join("\n\n"),
-                                     body_es: ["Versión borrador en Español",
-                                               *Faker::Lorem.paragraphs].join("\n\n"))
+      process.draft_versions.create!(random_locales_attributes(
+        title: -> { I18n.t("seeds.legislation.draft_versions.title", number: i) },
+        body: -> do
+          [
+            I18n.t("seeds.legislation.draft_versions.body", language: I18n.t("i18n.language.name")),
+            *Faker::Lorem.paragraphs
+          ].join("\n\n")
+        end
+      ))
     end
   end
 end

--- a/db/dev_seeds/widgets.rb
+++ b/db/dev_seeds/widgets.rb
@@ -8,88 +8,50 @@ section "Creating header and cards for the homepage" do
   end
 
   Widget::Card.create!(
-    title_en: "CONSUL",
-    title_es: "CONSUL",
-
-    description_en: "Free software for citizen participation.",
-    description_es: "Software libre para la participación ciudadana.",
-
-    link_text_en: "More information",
-    link_text_es: "Más información",
-
-    label_en: "Welcome to",
-    label_es: "Bienvenido a",
-
-    link_url: "http://consulproject.org/",
-    header: true,
-    image_attributes: create_image_attachment("header")
+    random_locales_attributes(
+      %i[title description link_text label].map do |attribute|
+        [attribute, -> { I18n.t("seeds.cards.header.#{attribute}") }]
+      end.to_h
+    ).merge(
+      link_url: "http://consulproject.org/",
+      header: true,
+      image_attributes: create_image_attachment("header")
+    )
   )
 
   Widget::Card.create!(
-    title_en: "How do debates work?",
-    title_es: "¿Cómo funcionan los debates?",
-
-    description_en: "Anyone can open threads on any subject, creating separate spaces "\
-                    "where people can discuss the proposed topic. Debates are valued by "\
-                    "everybody, to highlight the most important issues.",
-    description_es: "Cualquiera puede iniciar un debate sobre cualquier tema, creando un espacio "\
-                    "separado donde compartir puntos de vista con otras personas. Los debates son "\
-                    "valorados por todos para destacar los temas más importantes.",
-
-    link_text_en: "More about debates",
-    link_text_es: "Más sobre debates",
-
-    label_en: "Debates",
-    label_es: "Debates",
-
-    link_url: "https://youtu.be/zU_0UN4VajY",
-    header: false,
-    image_attributes: create_image_attachment("debate")
+    random_locales_attributes(
+      %i[title description link_text label].map do |attribute|
+        [attribute, -> { I18n.t("seeds.cards.debate.#{attribute}") }]
+      end.to_h
+    ).merge(
+      link_url: "https://youtu.be/zU_0UN4VajY",
+      header: false,
+      image_attributes: create_image_attachment("debate")
+    )
   )
 
   Widget::Card.create!(
-    title_en: "How do citizen proposals work?",
-    title_es: "¿Cómo funcionan las propuestas ciudadanas?",
-
-    description_en: "A space for everyone to create a citizen's proposal and seek supports. "\
-                    "Proposals which reach to enough supports will be voted and so, together we "\
-                    "can decide the issues that matter to us.",
-    description_es: "Un espacio para que el ciudadano cree una propuesta y busque apoyo. "\
-                    "Las propuestas que obtengan el apoyo necesario serán votadas. Así juntos "\
-                    "podemos decidir sobre los temas que nos importan.",
-
-    link_text_en: "More about proposals",
-    link_text_es: "Más sobre propuestas",
-
-    label_en: "Citizen proposals",
-    label_es: "Propuestas ciudadanas",
-
-    link_url: "https://youtu.be/ZHqBpT4uCoM",
-    header: false,
-    image_attributes: create_image_attachment("proposal")
+    random_locales_attributes(
+      %i[title description link_text label].map do |attribute|
+        [attribute, -> { I18n.t("seeds.cards.proposal.#{attribute}") }]
+      end.to_h
+    ).merge(
+      link_url: "https://youtu.be/ZHqBpT4uCoM",
+      header: false,
+      image_attributes: create_image_attachment("proposal")
+    )
   )
 
   Widget::Card.create!(
-    title_en: "How do participatory budgets work?",
-    title_es: "¿Cómo funcionan los propuestos participativos?",
-
-    description_en: "Participatory budgets allow citizens to propose and decide directly "\
-                    "how to spend part of the budget, with monitoring and rigorous evaluation "\
-                    "of proposals by the institution. Maximum effectiveness and control with "\
-                    "satisfaction for everyone.",
-    description_es: "Los presupuestos participativos permiten que los ciudadanos propongan y  "\
-                    "decidan directamente cómo gastar parte del presupuesto, con la supervisión "\
-                    "y valoración de la institución. Máxima eficacia y control para la "\
-                    "satisfacción de todos",
-
-    link_text_en: "More about Participatory budgets",
-    link_text_es: "Más sobre presupuestos participativos",
-
-    label_en: "Participatory budgets",
-    label_es: "Presupuestos participativos",
-
-    link_url: "https://youtu.be/igQ8KGZdk9c",
-    header: false,
-    image_attributes: create_image_attachment("budget")
+    random_locales_attributes(
+      %i[title description link_text label].map do |attribute|
+        [attribute, -> { I18n.t("seeds.cards.budget.#{attribute}") }]
+      end.to_h
+    ).merge(
+      link_url: "https://youtu.be/igQ8KGZdk9c",
+      header: false,
+      image_attributes: create_image_attachment("budget")
+    )
   )
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -2,6 +2,7 @@ namespace :db do
   desc "Resets the database and loads it from db/dev_seeds.rb"
   task :dev_seed, [:print_log] => [:environment] do |t, args|
     @avoid_log = args[:print_log] == "avoid_log"
+    I18n.enforce_available_locales = false
     load(Rails.root.join("db", "dev_seeds.rb"))
   end
 end


### PR DESCRIPTION
## References

* Closes #3835

## Objectives

* Make it possible to run the `db:dev_seed` task on CONSUL installations using languages which don't include English and Spanish
* Use default budget phases names in dev seeds