### PR TITLE
Make management and admin headers consistent

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -6,6 +6,8 @@ module AdminHelper
   def namespaced_header_title
     if namespace == "moderation/budgets"
       t("moderation.header.title")
+    elsif namespace == "management"
+      t("management.dashboard.index.title")
     else
       t("#{namespace}.header.title")
     end

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -34,15 +34,17 @@
         <% end %>
       </div>
 
-      <div id="responsive_menu">
-        <div class="top-bar-right">
-          <ul class="menu" data-responsive-menu="medium-dropdown">
-            <%= render "shared/admin_login_items" %>
-            <%= render "layouts/notification_item" %>
-            <%= render "devise/menu/login_items" %>
-          </ul>
+      <% if show_admin_menu?(current_user) || namespace != "management" %>
+        <div id="responsive_menu">
+          <div class="top-bar-right">
+            <ul class="menu" data-responsive-menu="medium-dropdown">
+              <%= render "shared/admin_login_items", current_user: current_user %>
+              <%= render "layouts/notification_item", current_user: current_user %>
+              <%= render "devise/menu/login_items", current_user: current_user %>
+            </ul>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </header>

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -8,41 +8,7 @@
   </head>
 
   <body class="admin">
-    <header class="header">
-      <div class="top-links">
-        <%= render "shared/locale_switcher" %>
-
-        <%= link_to root_path, class: "float-right" do %>
-          <%= t("admin.dashboard.index.back", org: setting["org_name"]) %>
-        <% end %>
-      </div>
-
-      <div class="expanded row admin-top-bar">
-        <div class="top-bar">
-          <div class="top-bar-left">
-            <h1>
-              <%= link_to management_root_path do %>
-                <%= setting["org_name"] %>
-                <br><small><%= t("management.dashboard.index.title") %></small>
-              <% end %>
-            </h1>
-          </div>
-          <% if show_admin_menu?(manager_logged_in) %>
-            <div id="responsive_menu">
-
-              <div class="top-bar-right">
-                <ul class="menu" data-responsive-menu="medium-dropdown">
-                  <%= render "shared/admin_login_items", current_user: manager_logged_in %>
-                  <%= render "layouts/notification_item", current_user: manager_logged_in %>
-                  <%= render "devise/menu/login_items", current_user: manager_logged_in %>
-                </ul>
-              </div>
-
-            </div>
-          <% end %>
-        </div>
-      </div>
-    </header>
+    <%= render "layouts/admin_header", current_user: manager_logged_in %>
 
     <div class="menu-and-content">
       <%= check_box_tag :show_menu, nil, false, role: "switch" %>

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -11,6 +11,10 @@
     <header class="header">
       <div class="top-links">
         <%= render "shared/locale_switcher" %>
+
+        <%= link_to root_path, class: "float-right" do %>
+          <%= t("admin.dashboard.index.back", org: setting["org_name"]) %>
+        <% end %>
       </div>
 
       <div class="expanded row admin-top-bar">
@@ -29,6 +33,7 @@
               <div class="top-bar-right">
                 <ul class="menu" data-responsive-menu="medium-dropdown">
                   <%= render "shared/admin_login_items", current_user: manager_logged_in %>
+                  <%= render "layouts/notification_item", current_user: manager_logged_in %>
                   <%= render "devise/menu/login_items", current_user: manager_logged_in %>
                 </ul>
               </div>

--- a/spec/system/management_spec.rb
+++ b/spec/system/management_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "Management" do
   let(:user) { create(:user) }
+  before { Setting["org_name"] = "CONSUL" }
 
   scenario "Should show admin menu if logged user is admin" do
     create(:administrator, user: user)
@@ -11,9 +12,12 @@ describe "Management" do
     click_link "Menu"
     click_link "Management"
 
-    expect(page).to have_content("My content")
-    expect(page).to have_content("My account")
-    expect(page).to have_content("Sign out")
+    expect(page).to have_link "Go back to CONSUL"
+
+    expect(page).to have_link "You don't have new notifications"
+    expect(page).to have_link "My content"
+    expect(page).to have_link "My account"
+    expect(page).to have_link "Sign out"
   end
 
   scenario "Should not show admin menu if logged user is manager" do
@@ -24,8 +28,11 @@ describe "Management" do
     click_link "Menu"
     click_link "Management"
 
-    expect(page).not_to have_content("My content")
-    expect(page).not_to have_content("My account")
-    expect(page).not_to have_content("Sign out")
+    expect(page).to have_link "Go back to CONSUL"
+
+    expect(page).not_to have_content "You don't have new notifications"
+    expect(page).not_to have_content "My content"
+    expect(page).not_to have_content "My account"
+    expect(page).not_to have_content "Sign out"
   end
 end


### PR DESCRIPTION
## References

* Work on this issue started in pull request #3680

## Background

We offer different sections for managers and administrators. This is great for institutions with a huge amount of activity where administrators can't do everything and have to delegate some tasks.

However, in many institutions administrators do the management themselves, and in this case it's strange to find a different header when browsing the management section.

## Objectives

* Add a "go back to CONSUL" link in the management section
* Make sure administrators  get the "notifications" link when browsing the management section
* Remove code duplication between the management and admin headers

## Visual Changes

### Before these changes

When signed in as an administrator:

![In the management header, there's neither a link to go back to CONSUL nor a link to see the notifications](https://user-images.githubusercontent.com/35156/141123294-ed146639-2c27-4096-997d-60de70e06d32.png)

### After these changes

When signed in as an administrator:

![In the management header, there's a link to go back to CONSUL and a link to see the notifications](https://user-images.githubusercontent.com/35156/141123304-f6cdc1ca-f604-4090-a2e5-5c6c88e577e8.png)