### PR TITLE
Fix Rubocop convention offenses

### DIFF
--- a/spec/system/admin/budget_groups_spec.rb
+++ b/spec/system/admin/budget_groups_spec.rb
@@ -30,7 +30,6 @@ describe "Admin budget groups", :admin do
       1.times { create(:budget_heading, group: above) }
       2.times { create(:budget_heading, group: below) }
 
-
       visit admin_budget_path(budget)
 
       within "section", text: "Heading groups" do

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -326,7 +326,6 @@ describe "Budgets" do
 
   context "Show" do
     let!(:budget) { create(:budget, :selecting) }
-    let!(:group)  { create(:budget_group, budget: budget) }
 
     scenario "Take into account headings with the same name from a different budget" do
       group1 = create(:budget_group, budget: budget, name: "New York")


### PR DESCRIPTION
## References

* These offenses were introduced in commit 2b709f1a3 from pull request #4686 and commit 756a16f67 from pull request #4717

## Objectives

* Have zero reports about offenses when running `rubocop --fail-level convention --display-only-fail-level-offenses`
* Keep the code as clean and consistent as possible