### PR TITLE
Fix typos in proposals dashboard and budgets admin

### DIFF
--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -76,7 +76,7 @@ en:
         descriptions:
           ballots: "This will let you manage physical ballots. Only use this option if you're going to use physical booths to collect ballots during the final voting phase."
           calculate_winners: 'After calculating the results, only administrators will be able to access them. They will be public when the project reaches the "%{phase}" phase <strong>if the option "Show results" is enabled</strong> when editing the budget.'
-          destroy: "This will delete the budget and all its associated groups and headers. This action cannot be undone."
+          destroy: "This will delete the budget and all its associated groups and headings. This action cannot be undone."
         edit: "Edit budget"
         preview: "Preview"
         preview_results: "Preview results"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -471,7 +471,7 @@ en:
       group_by_month: Monthly
       group_by_week: Weekly
       group_by_date: Daily
-      progress: Acumulated progress
+      progress: Accumulated progress
       supports: Supports
       success: Ideal progress
       new_action: New


### PR DESCRIPTION
## References

Typos were introduced in: 
  * #4686 
  * #2773
  
[Crowdin consul project.](https://crowdin.com/project/consul)

## Objectives

Fix some English language typos.

## Notes
Thanks to the translators [Mortenwithana](https://crowdin.com/profile/Mortenwithana) and [chkoun](https://crowdin.com/profile/chkoun) for warning us 🙏🏼 .

**We have to add a reference to this PR to the 1.4 release CHANGELOG.**