### PR TITLE
Make investment filters less prominent

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -198,10 +198,12 @@ class Budget < ApplicationRecord
 
   def investments_filters
     [
-      (%w[not_unfeasible feasible unfeasible] if valuating_or_later?),
-      (%w[selected unselected] if publishing_prices_or_later?),
-      ("winners" if finished?)
-    ].compact.flatten
+      ("winners" if finished?),
+      ("selected" if publishing_prices_or_later? && !finished?),
+      ("unselected" if publishing_prices_or_later?),
+      ("not_unfeasible" if valuating?),
+      ("unfeasible" if valuating_or_later?)
+    ].compact
   end
 
   def email_selected

--- a/app/views/budgets/investments/_sidebar.html.erb
+++ b/app/views/budgets/investments/_sidebar.html.erb
@@ -59,8 +59,6 @@
   </div>
 <% end %>
 
-<%= render Budgets::Investments::FiltersComponent.new %>
-
 <% if @heading && !@heading.content_blocks.where(locale: I18n.locale).empty? %>
   <%= render "budgets/investments/content_blocks" %>
 <% end %>
@@ -70,3 +68,4 @@
 <% end %>
 <%= render "shared/tag_cloud", taggable: "Budget::Investment" %>
 <%= render "budgets/investments/categories" %>
+<%= render Budgets::Investments::FiltersComponent.new %>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -117,11 +117,10 @@ en:
           not_logged_in: "To create a new budget investment you must %{sign_in} or %{sign_up}."
         filter: "Filtering projects by"
         filters:
-          feasible: "Feasible"
-          not_unfeasible: "Feasible or with undecided feasibility"
-          selected: "Selected"
+          not_unfeasible: "Active"
+          selected: "Active"
           unfeasible: "Unfeasible"
-          unselected: "Unselected"
+          unselected: "Not selected for the final voting"
           winners: "Winners"
         orders:
           random: random

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -117,11 +117,10 @@ es:
           not_logged_in: "Para crear un nuevo proyecto de gasto debes %{sign_in} o %{sign_up}."
         filter: "Filtrando proyectos"
         filters:
-          feasible: "Viables"
-          not_unfeasible: "Viables o con viabilidad por decidir"
-          selected: "Seleccionados"
+          not_unfeasible: "Activos"
+          selected: "Activos"
           unfeasible: "Inviables"
-          unselected: "No seleccionados"
+          unselected: "No seleccionados para votación"
           winners: "Ganadores"
         orders:
           random: Aleatorios

--- a/spec/components/budgets/investments/filters_component_spec.rb
+++ b/spec/components/budgets/investments/filters_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe Budgets::Investments::FiltersComponent do
   let(:budget) { create(:budget) }
+  before { allow(controller).to receive(:valid_filters) { budget.investments_filters } }
 
   around do |example|
     with_request_url(Rails.application.routes.url_helpers.budget_investments_path(budget)) do
@@ -12,7 +13,6 @@ describe Budgets::Investments::FiltersComponent do
   it "is not displayed before valuation" do
     %w[informing accepting reviewing selecting].each do |phase|
       budget.update!(phase: phase)
-      allow(controller).to receive(:valid_filters).and_return(budget.investments_filters)
 
       render_inline Budgets::Investments::FiltersComponent.new
 
@@ -20,14 +20,35 @@ describe Budgets::Investments::FiltersComponent do
     end
   end
 
-  it "is displayed during and after valuation" do
-    Budget::Phase::kind_or_later("valuating").each do |phase|
-      budget.update!(phase: phase)
-      allow(controller).to receive(:valid_filters).and_return(budget.investments_filters)
+  it "shows the active and unfeasible investments during the valuation phase" do
+    budget.update!(phase: "valuating")
 
-      render_inline Budgets::Investments::FiltersComponent.new
+    render_inline Budgets::Investments::FiltersComponent.new
 
-      expect(page).to have_content "Filtering projects by"
-    end
+    expect(page).to have_link count: 2
+    expect(page).to have_link "Active"
+    expect(page).to have_link "Unfeasible"
+  end
+
+  it "shows the active, unselected and unfeasible filters during the final voting" do
+    budget.update!(phase: "balloting")
+
+    render_inline Budgets::Investments::FiltersComponent.new
+
+    expect(page).to have_link count: 3
+    expect(page).to have_link "Active"
+    expect(page).to have_link "Not selected for the final voting"
+    expect(page).to have_link "Unfeasible"
+  end
+
+  it "shows the winners, unselected and unfeasible investments when the budget is finished" do
+    budget.update!(phase: "finished")
+
+    render_inline Budgets::Investments::FiltersComponent.new
+
+    expect(page).to have_link count: 3
+    expect(page).to have_link "Winners"
+    expect(page).to have_link "Not selected for the final voting"
+    expect(page).to have_link "Unfeasible"
   end
 end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -297,21 +297,21 @@ describe Budget do
     it "returns feasibility filters during valuation" do
       budget.phase = "valuating"
 
-      expect(budget.investments_filters).to eq(%w[not_unfeasible feasible unfeasible])
+      expect(budget.investments_filters).to eq(%w[not_unfeasible unfeasible])
     end
 
     it "returns feasibility and selection filters during the final voting phases" do
       %w[publishing_prices balloting reviewing_ballots].each do |phase|
         budget.phase = phase
 
-        expect(budget.investments_filters).to eq(%w[not_unfeasible feasible unfeasible selected unselected])
+        expect(budget.investments_filters).to eq(%w[selected unselected unfeasible])
       end
     end
 
-    it "returns all filters after the budget has finished" do
+    it "returns winners, unfeasible and unselected when the budget has finished" do
       budget.phase = "finished"
 
-      expect(budget.investments_filters).to eq(%w[not_unfeasible feasible unfeasible selected unselected winners])
+      expect(budget.investments_filters).to eq(%w[winners unselected unfeasible])
     end
   end
 

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -144,41 +144,21 @@ describe "Budget Investments" do
 
     expect(page).to have_content "FILTERING PROJECTS BY"
 
-    click_link "Feasible"
-
-    expect(page).to have_css ".budget-investment", count: 1
-    expect(page).to have_content "Feasible investment"
-
     click_link "Unfeasible"
 
     expect(page).to have_content "Unfeasible investment"
     expect(page).to have_css ".budget-investment", count: 1
 
-    click_link "Unselected"
+    click_link "Not selected for the final voting"
 
     expect(page).to have_css ".budget-investment", count: 3
     expect(page).to have_content "Unselected investment"
     expect(page).to have_content "Unclassified investment"
     expect(page).to have_content "Feasible investment"
 
-    click_link "Selected"
-
-    expect(page).to have_css ".budget-investment", count: 2
-    expect(page).to have_content "Selected investment"
-    expect(page).to have_content "Winner investment"
-
     click_link "Winners"
 
     expect(page).to have_css ".budget-investment", count: 1
-    expect(page).to have_content "Winner investment"
-
-    click_link "Feasible or with undecided feasibility"
-
-    expect(page).to have_css ".budget-investment", count: 5
-    expect(page).to have_content "Selected investment"
-    expect(page).to have_content "Unselected investment"
-    expect(page).to have_content "Feasible investment"
-    expect(page).to have_content "Unclassified investment"
     expect(page).to have_content "Winner investment"
   end
 


### PR DESCRIPTION
## References

* We moved the investments filters to the sidebar in pull request #4717

## Objectives

* Make investment filters less prominent on large screens
* Make investment filters easier to understand

## Visual Changes

### Before these changes

During the valuation phase:

![The filters "Feasible or with undecided feasibility" and "Unfeasible" are shown at the top of the sidebar](https://user-images.githubusercontent.com/35156/141843437-b60fa37b-f056-4f53-ad69-bb177040e62a.png)

During the final voting:

![The filters "Feasible/undecided", "Unfeasible", "Selected" and "Unselected" are shown right after the "My ballot" section in the sidebar](https://user-images.githubusercontent.com/35156/141843453-e344a25c-bd34-4b79-a5d6-161fce4d0131.png)

### After these changes

During the valuation phase:

![The filters "Active" and "Unfeasible" are shown at the bottom of the sidebar](https://user-images.githubusercontent.com/35156/141843534-f074a9dd-a500-4297-a70d-7cb4e20a24ce.png)

During the final voting:

![The filters "Selected for the final voting", "Not selected for the final voting" and "Unfeasible" are shown at the bottom of the sidebar](https://user-images.githubusercontent.com/35156/141843561-4dc6aff3-a8af-467d-a040-1604f223f53a.png)