### PR TITLE
Fix flaky spec in campaign-tracking tests

### DIFF
--- a/spec/system/campaigns_spec.rb
+++ b/spec/system/campaigns_spec.rb
@@ -24,12 +24,12 @@ describe "Email campaigns", :admin do
     visit root_path(track_id: Campaign.last.id + 1)
 
     visit admin_stats_path
+
+    expect(page).to have_content campaign1.name
+    expect(page).not_to have_content campaign2.name
+
     click_link campaign1.name
 
     expect(page).to have_content "#{campaign1.name} (1)"
-
-    click_link "Go back"
-
-    expect(page).not_to have_content campaign2.name.to_s
   end
 end


### PR DESCRIPTION
## References

* A test failed in our [test run ##3091, build 4](https://github.com/consul/consul/runs/4189454984)

## Objective
As the failing test is correct, we are fixing the test executed just before it in the referenced build.

The last expectation we were using in this test is satisfied before going back to the admin stats page, as the campaing2 name is not present before clicking the `Go back` link. Because of this, the test could end while the request thrown by clicking on the `Go back` link is not completed yet, which can collide with the following test and cause a flake spec.

## Failures

```
  1) Email campaigns Track email templates
     Failure/Error: ds.add params[:event].titleize, Ahoy::Event.where(name: params[:event]).group_by_day(:time).count

     ActiveRecord::StatementInvalid:
       PG::ProtocolViolation: ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 1
       : SELECT COUNT(*) AS count_all, DATE_TRUNC('day', "ahoy_events"."time"::timestamptz AT TIME ZONE 'Europe/Madrid') AT TIME ZONE 'Europe/Madrid' AS date_trunc_day_ahoy_events_time_timestamptz_at_time_zone_europe FROM "ahoy_events" WHERE "ahoy_events"."name" = $1 AND ("ahoy_events"."time" IS NOT NULL) GROUP BY DATE_TRUNC('day', "ahoy_events"."time"::timestamptz AT TIME ZONE 'Europe/Madrid') AT TIME ZONE 'Europe/Madrid'

     [Screenshot]: tmp/screenshots/failures_r_spec_example_groups_email_campaigns_track_email_templates_888.png

     # ./app/controllers/admin/api/stats_controller.rb:13:in `show'
     # ------------------
     # --- Caused by: ---
     # PG::ProtocolViolation:
     #   ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 1
     #   ./app/controllers/admin/api/stats_controller.rb:13:in `show'
```
