### PR TITLE
Fix user edit page title

### DIFF
--- a/config/locales/es/devise_views.yml
+++ b/config/locales/es/devise_views.yml
@@ -87,7 +87,7 @@ es:
           title: Darme de baja
         edit:
           current_password_label: Contraseña actual
-          edit: Editar propuesta
+          edit: Editar
           email_label: Email
           leave_blank: Dejar en blanco si no deseas cambiarla
           need_current: Necesitamos tu contraseña actual para confirmar los cambios


### PR DESCRIPTION
## References

This text was changed through #1891 a long time ago.

## Objectives

Fix user edit page title.

## Visual Changes

**Before**
<img width="733" alt="before-fix" src="https://user-images.githubusercontent.com/15726/143058761-001a88ba-0b9d-4a19-9b60-8776a0db4f7c.png">

**After**
<img width="760" alt="after-fix" src="https://user-images.githubusercontent.com/15726/143058778-4d237648-3392-464e-afc6-ad866c303f39.png">

