### PR TITLE
Change the way we handle source strings updates

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -3,7 +3,7 @@ files:
     translation: /config/locales/%locale%/%original_file_name%
     ignore:
       - /config/locales/**/rails_date_order.yml
-    update_option: update_without_changes
+    update_option: update_as_unapproved
     languages_mapping:
       locale:
         ar: ar


### PR DESCRIPTION
## References

We changed a source string with interpolations in #4665. However, as we were using the Crowdin `update_option: update_as_unapproved`, the other languages previous translations of this string kept as approved, so Crowdin managers and translations did not realize about this change.

More precisely, we changed the source string from `Are you sure? This action will delete %{resource_name} '%{name}' and can't be undone.` to `Are you sure? This action will delete \"%{name}\" and can't be undone.` which only has one interpolation argument. As other languages keep having the old translation with two interpolations arguments, the application crashed when loading the translation.

This problem affects the following languages: German, Turkish, Italian, Romanian and Swedish.

## Objectives

Change the way we handle source strings updates, so the other languages translations approvals are removed, and we have a way to find them.

With the `update_without_changes`, previous translations are kept even when the source string changed utterly. Using this option caused some problems when updating source language strings, as the translators do not get any notification, and the old translation keeps approved, so translators do not have an easy way to find those strings in Crowdin.

With the `update_as_unapproved` option, we hope translators and Crowdin managers can find those translations that need to be updated by searching among not approved translations.

Quoting Crowdin's docs [1]:

> update_without_changes - preserve translations and validations of changed strings
> update_as_unapproved - preserve translations of changed strings and remove validations of those translations if they exist

[1] https://support.crowdin.com/configuration-file/#changed-strings-update
