### PR TITLE
Fix comment notifications on legislation proposals

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,10 +1,6 @@
 module MailerHelper
   def commentable_url(commentable)
-    return poll_url(commentable) if commentable.is_a?(Poll)
-    return debate_url(commentable) if commentable.is_a?(Debate)
-    return proposal_url(commentable) if commentable.is_a?(Proposal)
-    return community_topic_url(commentable.community_id, commentable) if commentable.is_a?(Topic)
-    return budget_investment_url(commentable.budget_id, commentable) if commentable.is_a?(Budget::Investment)
+    polymorphic_url(commentable)
   end
 
   def valuation_comments_url(commentable)

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -22,5 +22,11 @@ describe Mailer do
 
       expect(email).to deliver_from "New organization <new@consul.dev>"
     end
+
+    it "sends emails for comments on legislation proposals" do
+      email = Mailer.comment(create(:legislation_proposal_comment))
+
+      expect(email.subject).to include("commented on your proposal")
+    end
   end
 end


### PR DESCRIPTION
## Objectives

* Fix a bug which caused emails not to be sent when commenting on legislation proposals.