### PR TITLE
Remove broken technical assistance text in footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -9,7 +9,6 @@
         <%= sanitize(t("layouts.footer.description",
           open_source: link_to(t("layouts.footer.open_source"), t("layouts.footer.open_source_url"), target: "blank", rel: "nofollow"),
           consul:  link_to(t("layouts.footer.consul"), t("layouts.footer.consul_url"), target: "blank", rel: "nofollow"))) %>
-        <%= t("layouts.footer.contact_us") %>
       </p>
     </div>
 

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -213,7 +213,6 @@ en:
       conditions: Terms and conditions of use
       consul: CONSUL application
       consul_url: https://github.com/consul/consul
-      contact_us: For technical assistance visit
       copyright: CONSUL, %{year}
       description: This portal uses the %{consul} which is %{open_source}.
       open_source: open-source software

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -213,7 +213,6 @@ es:
       conditions: Condiciones de uso
       consul: aplicación CONSUL
       consul_url: https://github.com/consul/consul
-      contact_us: Para asistencia técnica entra en
       copyright: CONSUL, %{year}
       description: Este portal usa la %{consul} que es %{open_source}.
       open_source: software de código abierto


### PR DESCRIPTION
## References

* Closes #3125
* The text was incomplete since commit e14b7b67fb

## Objectives

Remove a text which was intended to be used with a link that has been removed since then.