### PR TITLE
Remove URL methods in models

### DIFF
--- a/app/components/relationable/related_list_component.html.erb
+++ b/app/components/relationable/related_list_component.html.erb
@@ -6,7 +6,7 @@
       <div>
         <span class="related-content-title"><%= t("related_content.content_title.#{related.model_name.singular}") %></span><br>
         <h3 class="inline-block">
-          <%= link_to related.title, related.url %>
+          <%= link_to related.title, polymorphic_path(related) %>
         </h3>
       </div>
       <% if current_user && related_content.author != current_user && !related_content.scored_by_user?(current_user) %>

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -2,7 +2,6 @@ class Budget
   class Investment < ApplicationRecord
     SORTING_OPTIONS = { id: "id", supports: "cached_votes_up" }.freeze
 
-    include Rails.application.routes.url_helpers
     include Measurable
     include Sanitizable
     include Taggable
@@ -121,10 +120,6 @@ class Budget
 
     def comments_count
       comments.count
-    end
-
-    def url
-      budget_investment_path(budget, self)
     end
 
     def self.sort_by_title

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -1,7 +1,6 @@
 require "numeric"
 
 class Debate < ApplicationRecord
-  include Rails.application.routes.url_helpers
   include Flaggable
   include Taggable
   include Conflictable
@@ -52,10 +51,6 @@ class Debate < ApplicationRecord
   visitable class_name: "Visit"
 
   attr_accessor :link_required
-
-  def url
-    debate_path(self)
-  end
 
   def self.recommendations(user)
     tagged_with(user.interests, any: true).where.not(author_id: user.id)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -1,5 +1,4 @@
 class Proposal < ApplicationRecord
-  include Rails.application.routes.url_helpers
   include Flaggable
   include Taggable
   include Conflictable
@@ -87,10 +86,6 @@ class Proposal < ApplicationRecord
   scope :published,                -> { where.not(published_at: nil) }
   scope :draft,                    -> { where(published_at: nil) }
   scope :created_by,               ->(author) { where(author: author) }
-
-  def url
-    proposal_path(self)
-  end
 
   def publish
     update!(published_at: Time.current)

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -8,25 +8,25 @@ shared_examples "relationable" do |relationable_model_name|
   scenario "related contents are listed" do
     create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
-    visit relationable.url
+    visit polymorphic_path(relationable)
     within("#related-content-list") do
       expect(page).to have_content related1.title
     end
 
-    visit related1.url
+    visit polymorphic_path(related1)
     within("#related-content-list") do
       expect(page).to have_content relationable.title
     end
   end
 
   scenario "related contents list is not rendered if there are no relations" do
-    visit relationable.url
+    visit polymorphic_path(relationable)
     expect(page).not_to have_css "#related-content-list"
   end
 
   scenario "related contents can be added" do
     login_as(user)
-    visit relationable.url
+    visit polymorphic_path(relationable)
 
     expect(page).not_to have_css "#related_content"
     expect(page).to have_css ".add-related-content[aria-expanded='false']"
@@ -36,7 +36,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(page).to have_css ".add-related-content[aria-expanded='true']"
 
     within("#related_content") do
-      fill_in "Link to related content", with: "#{url}#{related1.url}"
+      fill_in "Link to related content", with: "#{url}#{polymorphic_path(related1)}"
       click_button "Add"
     end
 
@@ -44,7 +44,7 @@ shared_examples "relationable" do |relationable_model_name|
       expect(page).to have_content related1.title
     end
 
-    visit related1.url
+    visit polymorphic_path(related1)
 
     within("#related-content-list") do
       expect(page).to have_content relationable.title
@@ -53,7 +53,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "Link to related content", with: "#{url}#{related2.url}"
+      fill_in "Link to related content", with: "#{url}#{polymorphic_path(related2)}"
       click_button "Add"
     end
 
@@ -64,7 +64,7 @@ shared_examples "relationable" do |relationable_model_name|
 
   scenario "if related content URL is invalid returns error" do
     login_as(user)
-    visit relationable.url
+    visit polymorphic_path(relationable)
 
     click_button "Add related content"
 
@@ -78,12 +78,12 @@ shared_examples "relationable" do |relationable_model_name|
 
   scenario "returns error when relating content URL to itself" do
     login_as(user)
-    visit relationable.url
+    visit polymorphic_path(relationable)
 
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "Link to related content", with: url + relationable.url.to_s
+      fill_in "Link to related content", with: url + polymorphic_path(relationable)
       click_button "Add"
     end
 
@@ -102,7 +102,7 @@ shared_examples "relationable" do |relationable_model_name|
       related = create(:debate, title: "My path is the only one I've walked")
 
       login_as(user)
-      visit relationable.url
+      visit polymorphic_path(relationable)
 
       click_button "Add related content"
 
@@ -120,12 +120,12 @@ shared_examples "relationable" do |relationable_model_name|
   scenario "returns an error when the related content already exists" do
     create(:related_content, parent_relationable: relationable, child_relationable: related1)
     login_as(user)
-    visit relationable.url
+    visit polymorphic_path(relationable)
 
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "url", with: url + related1.url.to_s
+      fill_in "url", with: url + polymorphic_path(related1)
       click_button "Add"
     end
 
@@ -136,7 +136,7 @@ shared_examples "relationable" do |relationable_model_name|
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     login_as(user)
-    visit relationable.url
+    visit polymorphic_path(relationable)
 
     within("#related-content-list") do
       click_link "Yes"
@@ -153,7 +153,7 @@ shared_examples "relationable" do |relationable_model_name|
     related_content = create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
 
     login_as(user)
-    visit relationable.url
+    visit polymorphic_path(relationable)
 
     within("#related-content-list") do
       click_link "No"
@@ -179,7 +179,7 @@ shared_examples "relationable" do |relationable_model_name|
 
     login_as(user)
 
-    visit relationable.url
+    visit polymorphic_path(relationable)
 
     expect(page).not_to have_css "#related-content-list"
   end

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -3,7 +3,7 @@ shared_examples "relationable" do |relationable_model_name|
   let(:related1) { create([:proposal, :debate, :budget_investment].sample) }
   let(:related2) { create([:proposal, :debate, :budget_investment].sample) }
   let(:user) { create(:user) }
-  let!(:url) { Setting["url"] }
+  before { Setting["url"] = Capybara.app_host }
 
   scenario "related contents are listed" do
     create(:related_content, parent_relationable: relationable, child_relationable: related1, author: build(:user))
@@ -36,7 +36,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(page).to have_css ".add-related-content[aria-expanded='true']"
 
     within("#related_content") do
-      fill_in "Link to related content", with: "#{url}#{polymorphic_path(related1)}"
+      fill_in "Link to related content", with: polymorphic_url(related1)
       click_button "Add"
     end
 
@@ -53,7 +53,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "Link to related content", with: "#{url}#{polymorphic_path(related2)}"
+      fill_in "Link to related content", with: polymorphic_url(related2)
       click_button "Add"
     end
 
@@ -73,7 +73,7 @@ shared_examples "relationable" do |relationable_model_name|
       click_button "Add"
     end
 
-    expect(page).to have_content "Link not valid. Remember to start with #{url}."
+    expect(page).to have_content "Link not valid. Remember to start with #{Capybara.app_host}."
   end
 
   scenario "returns error when relating content URL to itself" do
@@ -83,7 +83,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "Link to related content", with: url + polymorphic_path(relationable)
+      fill_in "Link to related content", with: polymorphic_url(relationable)
       click_button "Add"
     end
 
@@ -107,7 +107,7 @@ shared_examples "relationable" do |relationable_model_name|
       click_button "Add related content"
 
       within("#related_content") do
-        fill_in "Link to related content", with: "#{url}/mypath/#{related.id}"
+        fill_in "Link to related content", with: "#{Capybara.app_host}/mypath/#{related.id}"
         click_button "Add"
       end
 
@@ -125,7 +125,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "url", with: url + polymorphic_path(related1)
+      fill_in "url", with: polymorphic_url(related1)
       click_button "Add"
     end
 


### PR DESCRIPTION
## References

* Closes #2313
* We can use `polymorphic_path` for pretty much every record since pull request  #3952

## Objectives

* Remove legacy methods to get URLs in the models
* Simplify tests dealing with related content
