### PR TITLE
Fix newsletter actions

### DIFF
--- a/app/helpers/newsletter_helper.rb
+++ b/app/helpers/newsletter_helper.rb
@@ -1,0 +1,9 @@
+module NewsletterHelper
+  def available_actions(newsletter)
+    if newsletter.draft? 
+      { actions: [:edit, :destroy] }
+    else
+      { actions: [:destroy] }
+    end
+  end
+end

--- a/app/views/admin/newsletters/index.html.erb
+++ b/app/views/admin/newsletters/index.html.erb
@@ -29,7 +29,7 @@
           <% end %>
         </td>
         <td>
-          <%= render Admin::TableActionsComponent.new(newsletter) do |actions| %>
+          <%= render Admin::TableActionsComponent.new(newsletter, available_actions(newsletter)) do |actions| %>
             <%= actions.action :preview, text: t("admin.newsletters.index.preview") %>
           <% end %>
         </td>

--- a/spec/factories/emails.rb
+++ b/spec/factories/emails.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     segment_recipient  { UserSegments::SEGMENTS.sample }
     sequence(:from)    { |n| "noreply#{n}@consul.dev" }
     sequence(:body)    { |n| "Body #{n}" }
+
+    trait :sent do
+      sent_at { Time.current }
+    end
   end
 end

--- a/spec/helpers/newsletter_helper_spec.rb
+++ b/spec/helpers/newsletter_helper_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe NewsletterHelper do
+  describe "#available_actions" do
+    context "when the newsletter has not yet been sent" do
+      let(:newsletter) { build(:newsletter) }
+
+      it "returns a hash containing an array of default actions" do
+        expect(available_actions(newsletter)).to eq({
+          actions: [:edit, :destroy]
+        })
+      end
+    end
+    context "when the newsletter has already been sent" do
+      let(:newsletter) { build(:newsletter, sent_at: Date.today) }
+
+      it "returns a hash containing an array that includes only :destroy action" do
+        expect(available_actions(newsletter)).to eq({ actions: [:destroy] })
+      end
+    end
+  end
+end

--- a/spec/helpers/newsletter_helper_spec.rb
+++ b/spec/helpers/newsletter_helper_spec.rb
@@ -12,7 +12,7 @@ describe NewsletterHelper do
       end
     end
     context "when the newsletter has already been sent" do
-      let(:newsletter) { build(:newsletter, sent_at: Date.today) }
+      let(:newsletter) { build(:newsletter, :sent) }
 
       it "returns a hash containing an array that includes only :destroy action" do
         expect(available_actions(newsletter)).to eq({ actions: [:destroy] })

--- a/spec/system/admin/emails/newsletters_spec.rb
+++ b/spec/system/admin/emails/newsletters_spec.rb
@@ -76,26 +76,37 @@ describe "Admin newsletter emails", :admin do
     expect(page).to have_content "This is a body"
   end
 
-  scenario "Update" do
-    newsletter = create(:newsletter)
+  context "Update" do
+    scenario "A draft newsletter can be updated" do
+      newsletter = create(:newsletter)
 
-    visit admin_newsletters_path
-    within("#newsletter_#{newsletter.id}") do
-      click_link "Edit"
+      visit admin_newsletters_path
+      within("#newsletter_#{newsletter.id}") do
+        click_link "Edit"
+      end
+
+      expect(page).to have_link "Go back", href: admin_newsletters_path
+
+      fill_in_newsletter_form(subject: "This is a subject",
+                              segment_recipient: "Investment authors in the current budget",
+                              body: "This is a body")
+      click_button "Update Newsletter"
+
+      expect(page).to have_content "Newsletter updated successfully"
+      expect(page).to have_content "This is a subject"
+      expect(page).to have_content "Investment authors in the current budget"
+      expect(page).to have_content "no-reply@consul.dev"
+      expect(page).to have_content "This is a body"
     end
 
-    expect(page).to have_link "Go back", href: admin_newsletters_path
+    scenario "A sent newsletter can not be updated" do
+      newsletter = create(:newsletter, :sent)
 
-    fill_in_newsletter_form(subject: "This is a subject",
-                            segment_recipient: "Investment authors in the current budget",
-                            body: "This is a body")
-    click_button "Update Newsletter"
-
-    expect(page).to have_content "Newsletter updated successfully"
-    expect(page).to have_content "This is a subject"
-    expect(page).to have_content "Investment authors in the current budget"
-    expect(page).to have_content "no-reply@consul.dev"
-    expect(page).to have_content "This is a body"
+      visit admin_newsletters_path
+      within("#newsletter_#{newsletter.id}") do
+        expect(page).not_to have_link "Edit"
+      end
+    end
   end
 
   scenario "Destroy" do


### PR DESCRIPTION
## References

- Closes #2481

## Objectives

Since the newsletter has already been sent and cannot be resent, there is no reason for the edit button to be displayed.

## Visual Changes
![image](https://user-images.githubusercontent.com/95383700/146443509-e28e0d2b-b750-4b8f-93cf-ed0e8135a1c2.png)

