### PR TITLE
Display delete action buttom for sent notification

### DIFF
--- a/app/views/admin/admin_notifications/index.html.erb
+++ b/app/views/admin/admin_notifications/index.html.erb
@@ -34,7 +34,7 @@
               <%= actions.action(:preview, text: t("admin.admin_notifications.index.preview")) %>
             <% end %>
           <% else %>
-            <%= render Admin::TableActionsComponent.new(admin_notification, actions: []) do |actions| %>
+            <%= render Admin::TableActionsComponent.new(admin_notification, actions: [:destroy]) do |actions| %>
               <%= actions.action(:show, text: t("admin.admin_notifications.index.view")) %>
             <% end %>
           <% end %>


### PR DESCRIPTION
## References

-  Closes #2476.

## Objectives

Allow administrators to delete notifications already sent.

## Visual Changes

Before

![image](https://user-images.githubusercontent.com/95383700/146607300-34751ca1-0107-4fde-a108-f5f1ef633176.png)

After 

![image](https://user-images.githubusercontent.com/95383700/146607318-19f07985-8eb9-412c-a3b4-b0400b9eee52.png)
