### PR TITLE
Display delete button for sent notification

### DIFF
--- a/app/views/admin/admin_notifications/index.html.erb
+++ b/app/views/admin/admin_notifications/index.html.erb
@@ -34,7 +34,7 @@
               <%= actions.action(:preview, text: t("admin.admin_notifications.index.preview")) %>
             <% end %>
           <% else %>
-            <%= render Admin::TableActionsComponent.new(admin_notification, actions: []) do |actions| %>
+            <%= render Admin::TableActionsComponent.new(admin_notification, actions: [:destroy]) do |actions| %>
               <%= actions.action(:show, text: t("admin.admin_notifications.index.view")) %>
             <% end %>
           <% end %>

--- a/spec/system/admin/admin_notifications_spec.rb
+++ b/spec/system/admin/admin_notifications_spec.rb
@@ -125,14 +125,16 @@ describe "Admin Notifications", :admin do
       expect(page).to have_css(".notification", count: 0)
     end
 
-    scenario "Sent notification can not be destroyed" do
+    scenario "Sent notification can be destroyed" do
       notification = create(:admin_notification, :sent)
 
       visit admin_admin_notifications_path
-
       within("#admin_notification_#{notification.id}") do
-        expect(page).not_to have_button "Delete"
+        accept_confirm { click_button "Delete" }
       end
+
+      expect(page).to have_content "Notification deleted successfully"
+      expect(page).to have_css(".notification", count: 0)
     end
   end
 


### PR DESCRIPTION
## References

-  Closes #2476.

## Objectives

Allow administrators to delete sent notifications.

## Visual Changes

Before

![image](https://user-images.githubusercontent.com/95383700/146607300-34751ca1-0107-4fde-a108-f5f1ef633176.png)

After 

![image](https://user-images.githubusercontent.com/95383700/146607318-19f07985-8eb9-412c-a3b4-b0400b9eee52.png)

## Notes

Reopening pull request with correct branch name.