### PR TITLE
Fix generating dashboard poster on production

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -9,6 +9,7 @@
 //= link ckeditor/config.js
 //= link stat_graphs.js
 //= link dashboard_graphs.js
+//= link dashboard_poster.css
 //= link print.css
 //= link pdf_fonts.css
 //= link_tree ../../../vendor/assets/images

--- a/app/assets/stylesheets/dashboard_poster.scss
+++ b/app/assets/stylesheets/dashboard_poster.scss
@@ -1,0 +1,6 @@
+@import "font-awesome/variables";
+@import "font-awesome/mixins";
+@import "font-awesome/core";
+@import "foundation_and_overrides";
+@import "mixins/*";
+@import "dashboard";

--- a/app/views/dashboard/poster/index.pdf.erb
+++ b/app/views/dashboard/poster/index.pdf.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <%= wicked_pdf_stylesheet_link_tag "application" -%>
+  <%= wicked_pdf_stylesheet_link_tag "dashboard_poster" -%>
   <%= wicked_pdf_stylesheet_link_tag "pdf_fonts" -%>
 </head>
 <body class="dashboard-poster-pdf">


### PR DESCRIPTION
## References

* We introduced this bug in commit 905ac48bb from pull request #4141

## Objectives

Fix a bug which made it impossible to generate the proposals dashboard poster on production environments.

## Notes

We aren't adding a test case because this bug is only present on production environments when assets have been precompiled.