### PR TITLE
Fix typo for "instagram"

### DIFF
--- a/app/components/layout/social_component.rb
+++ b/app/components/layout/social_component.rb
@@ -13,7 +13,7 @@ class Layout::SocialComponent < ApplicationComponent
         facebook: "https://www.facebook.com",
         youtube: "https://www.youtube.com",
         telegram: "https://www.telegram.me",
-        instragram: "https://www.instagram.com"
+        instagram: "https://www.instagram.com"
       }.select { |name, _| setting["#{name}_handle"].present? }
     end
 

--- a/spec/components/layout/social_component_spec.rb
+++ b/spec/components/layout/social_component_spec.rb
@@ -3,11 +3,21 @@ require "rails_helper"
 describe Layout::SocialComponent do
   describe "#render?" do
     it "renders when a social setting is present" do
-      Setting["twitter_handle"] = "myhandle"
+      Setting["twitter_handle"] = "my_twitter_handle"
+      Setting["facebook_handle"] = "my_facebook_handle"
+      Setting["youtube_handle"] = "my_youtube_handle"
+      Setting["telegram_handle"] = "my_telegram_handle"
+      Setting["instagram_handle"] = "my_instagram_handle"
+      Setting["org_name"] = "CONSUL"
 
       render_inline Layout::SocialComponent.new
 
       expect(page).to have_css "ul"
+      expect(page).to have_link "CONSUL Twitter", href: "https://twitter.com/my_twitter_handle"
+      expect(page).to have_link "CONSUL Facebook", href: "https://www.facebook.com/my_facebook_handle"
+      expect(page).to have_link "CONSUL YouTube", href: "https://www.youtube.com/my_youtube_handle"
+      expect(page).to have_link "CONSUL Telegram", href: "https://www.telegram.me/my_telegram_handle"
+      expect(page).to have_link "CONSUL Instagram", href: "https://www.instagram.com/my_instagram_handle"
     end
 
     it "renders when a content block is present" do


### PR DESCRIPTION
## Objectives
Fix a typo in Layout::SocialComponent and use "instagram" instead of "instragram".

This typo when defining the `sites` in the Layout::SocialComponent caused the icon with its link to instagram not to be rendered in the footer.

## Visual Changes
- Before
![The social component section in the footer did not shows the instagram icon](https://user-images.githubusercontent.com/16189/151540076-475c8c5d-afb3-48d3-b192-be4e142210f0.png)

- After
![The social component section in the footer shows the instagram icon](https://user-images.githubusercontent.com/16189/151540210-8ede6619-5dba-4790-85bc-06de8f40e4c7.png)



