### PR TITLE
Add offline ballot sheet votes to the total vote count

### DIFF
--- a/app/models/poll/ballot_sheet.rb
+++ b/app/models/poll/ballot_sheet.rb
@@ -7,6 +7,8 @@ class Poll::BallotSheet < ApplicationRecord
   validates :poll_id, presence: true
   validates :officer_assignment_id, presence: true
 
+  after_create :verify_ballots
+
   def author
     officer_assignment.officer.name
   end

--- a/app/views/officing/ballot_sheets/new.html.erb
+++ b/app/views/officing/ballot_sheets/new.html.erb
@@ -2,12 +2,12 @@
   <h2><%= t("officing.poll_budgets.new.title", poll_budget: @poll.name) %></h2>
 
   <%= form_tag(officing_poll_ballot_sheets_path(@poll)) do %>
-    <label><%= t("officing.poll_budgets.new.booth") %></label>
+    <%= label_tag :officer_assignment_id, t("officing.poll_budgets.new.booth") %>
     <%= select_tag :officer_assignment_id,
                     booths_for_officer_select_options(@officer_assignments),
                     { prompt: t("officing.poll_budgets.new.select_booth") } %>
 
-    <label><%= t("officing.poll_budgets.new.csv_data") %></label>
+    <%= label_tag :data, t("officing.poll_budgets.new.csv_data") %>
     <%= text_area_tag :data, nil, rows: 10 %>
 
     <%= submit_tag t("officing.poll_budgets.new.submit"), class: "button" %>

--- a/spec/models/poll/ballot_sheet_spec.rb
+++ b/spec/models/poll/ballot_sheet_spec.rb
@@ -2,9 +2,12 @@ require "rails_helper"
 
 describe Poll::BallotSheet do
   let(:ballot_sheet) do
-    build(:poll_ballot_sheet, poll: create(:poll),
+    budget = create(:budget)
+    investment1 = create(:budget_investment, budget: budget)
+    investment2 = create(:budget_investment, budget: budget)
+    build(:poll_ballot_sheet, poll: create(:poll, budget: budget),
           officer_assignment: create(:poll_officer_assignment),
-          data: "1234;5678")
+          data: "#{investment1.id};#{investment2.id}")
   end
 
   context "Validations" do
@@ -36,9 +39,7 @@ describe Poll::BallotSheet do
 
   describe "#verify_ballots" do
     it "creates ballots for each document number" do
-      poll = create(:poll, :for_budget)
-      poll_ballot = create(:poll_ballot_sheet, poll: poll, data: "1,2,3;4,5,6")
-      poll_ballot.verify_ballots
+      create(:poll_ballot_sheet, poll: create(:poll, :for_budget), data: "1,2,3;4,5,6")
 
       expect(Poll::Ballot.count).to eq(2)
       expect(Budget::Ballot.count).to eq(2)

--- a/spec/system/officing/ballot_sheets_spec.rb
+++ b/spec/system/officing/ballot_sheets_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "Officing ballot sheets" do
+  let(:budget) { create(:budget, :reviewing_ballots) }
+  let(:heading) { create(:budget_heading, budget: budget, price: 300) }
+  let(:poll) { create(:poll, name: "Latest budget poll", budget: budget, ends_at: Date.current) }
+  let(:booth) { create(:poll_booth, name: "The only booth") }
+  let(:officer) { create(:poll_officer) }
+  let!(:admin) { create(:administrator).user }
+
+  scenario "Create a ballot sheet for a budget poll" do
+    create(:poll_officer_assignment, officer: officer, poll: poll, booth: booth)
+    create(:poll_shift, :recount_scrutiny_task, officer: officer, booth: booth, date: Date.current)
+
+    titles = %w[First Second Third Fourth]
+    investments = 4.times.map do |n|
+      create(:budget_investment, :selected, title: titles[n], heading: heading, price: 100)
+    end
+
+    login_as(officer.user)
+    visit officing_root_path
+    click_link "Total recounts and results"
+    within("tr", text: "Latest budget poll") { click_link "Add results" }
+
+    select "The only booth", from: "Booth"
+    fill_in "CSV data", with: "#{investments[0..1].map(&:id).join(",")};#{investments[1..2].map(&:id).join(",")}"
+    click_button "Save"
+
+    expect(page).to have_content "Creation date"
+    expect(page).to have_content "CSV data"
+
+    logout
+    login_as(admin)
+    visit admin_budget_path(budget)
+    click_button "Calculate Winner Investments"
+
+    expect(page).to have_content "Winners being calculated"
+
+    visit budget_results_path(budget)
+
+    within("tr", text: "Second") { expect(page).to have_content("2") }
+    within("tr", text: "First") { expect(page).to have_content("1") }
+    within("tr", text: "Third") { expect(page).to have_content("1") }
+    expect(page).not_to have_content "Fourth"
+  end
+end


### PR DESCRIPTION
## References

A few days ago I was trying the [offline votes upload form (ballot sheet)](https://github.com/consul/consul/issues/4774), and noticed that the votes were not being included into the total vote count of the budget investments showed in the results page. I thought this could possible be a bug.

## Objectives

Add the ballot sheet votes to the total vote count of participatory budgeting investments.

### Context

_Note: Please let me know if I'm missing something, I'm pretty new to Consul, and I'm a RAILS newbie as well._

If I understood properly, offline votes of participatory budgeting must be uploaded via the [ballot sheet CSV data form](https://github.com/consul/consul/blob/ccf8d3a8e2c6369c0d7b416313feffb2bcbb00ef/app/views/officing/polls/ballot_sheets/new.html.erb#L12). I tried this form on my local installation, and the ballot sheet was uploaded, but **the votes were not added to the total count of the investments votes** showed in the results page.

[`Poll::BallotSheet.verify_ballots`](https://github.com/consul/consul/blob/aeb84108bcc2dd50204c67751d7ec58a9b3af272c4/app/models/poll/ballot_sheet.rb#L14-L19) is the method that takes care of registering the votes for a given ballot sheet. After [searching the code](https://github.com/consul/consul/search?q=verify_ballots), the only reference I found to this method was in its [spec](https://github.com/consul/consul/blob/416eac284aef211bde44eb2454694bef3bf20889/spec/models/poll/ballot_sheet_spec.rb#L41), where it was being called explicitely.

Now, I'm not aware of any RAILS API making implicit calls to this method (with my little RAILS ecosystem knowledge). If neither the app code or the 3rd party libraries are calling it, then how are these votes being counted in?

### Implementation details

- Added the `Poll::BallotSheet.verify_ballots` to the [Active Record `after_create` callback](https://api.rubyonrails.org/v5.2/classes/ActiveRecord/Callbacks.html), so the votes are added right after ballot sheet creation.
- Removed the explicit call to `Poll::BallotSheet.verify_ballots` from the spec.

## Visual Changes

None

## Notes

None
