### PR TITLE
Make buttons to vote more accessible

### DIFF
--- a/app/assets/stylesheets/in_favor_against.scss
+++ b/app/assets/stylesheets/in_favor_against.scss
@@ -1,4 +1,9 @@
 .in-favor-against {
+  @include flex-with-gap($line-height / 4);
+
+  @include breakpoint(medium) {
+    @include flex-with-gap($line-height * 3 / 4);
+  }
 
   &,
   .in-favor,
@@ -83,13 +88,5 @@
 
   .no-voted {
     opacity: 0.3;
-  }
-
-  .against {
-    margin-left: $line-height / 4;
-  }
-
-  .divider {
-    margin: 0 rem-calc(6);
   }
 }

--- a/app/assets/stylesheets/in_favor_against.scss
+++ b/app/assets/stylesheets/in_favor_against.scss
@@ -7,8 +7,7 @@
     display: inline-block;
   }
 
-  .icon-like,
-  .icon-unlike {
+  button {
     background: #fff;
     border: 2px solid;
     border-radius: rem-calc(3);
@@ -16,7 +15,7 @@
     display: inline-block;
     font-size: rem-calc(30);
     line-height: rem-calc(30);
-    padding: rem-calc(3) rem-calc(6);
+    padding: rem-calc(3) rem-calc(6) rem-calc(6);
     position: relative;
 
     &:hover,
@@ -27,7 +26,8 @@
     }
   }
 
-  .icon-like {
+  .in-favor button {
+    @include has-fa-icon(thumbs-up, solid);
 
     &:hover,
     &:active {
@@ -36,7 +36,8 @@
     }
   }
 
-  .icon-unlike {
+  .against button {
+    @include has-fa-icon(thumbs-down, solid);
 
     &:hover,
     &:active {
@@ -67,29 +68,21 @@
   }
 
   .voted {
+    color: #fff;
+  }
 
-    .icon-like,
-    .icon-unlike {
-      color: #fff;
-    }
+  .in-favor .voted {
+    background: $like;
+    border: 2px solid $like;
+  }
 
-    .icon-like {
-      background: $like;
-      border: 2px solid $like;
-    }
-
-    .icon-unlike {
-      background: $unlike;
-      border: 2px solid $unlike;
-    }
+  .against .voted {
+    background: $unlike;
+    border: 2px solid $unlike;
   }
 
   .no-voted {
-
-    .icon-like,
-    .icon-unlike {
-      opacity: 0.3;
-    }
+    opacity: 0.3;
   }
 
   .against {

--- a/app/assets/stylesheets/in_favor_against.scss
+++ b/app/assets/stylesheets/in_favor_against.scss
@@ -1,5 +1,11 @@
 .in-favor-against {
-  display: inline-block;
+
+  &,
+  .in-favor,
+  .against,
+  form {
+    display: inline-block;
+  }
 
   .icon-like,
   .icon-unlike {
@@ -41,23 +47,22 @@
 
   .like,
   .unlike {
-    line-height: rem-calc(48);
     vertical-align: super;
     text-decoration: none;
+  }
 
-    .percentage {
-      color: $text;
-      display: inline-block;
-      font-size: $small-font-size;
-      line-height: $line-height * 2;
-      padding-right: $line-height / 2;
-      vertical-align: top;
+  .percentage {
+    color: $text;
+    display: inline-block;
+    font-size: $small-font-size;
+    line-height: $line-height * 2;
+    padding-right: $line-height / 2;
+    vertical-align: top;
 
-      @include breakpoint(medium) {
-        display: block;
-        line-height: $line-height;
-        padding-right: 0;
-      }
+    @include breakpoint(medium) {
+      display: block;
+      line-height: $line-height;
+      padding-right: 0;
     }
   }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1887,7 +1887,7 @@ table {
       display: inline-block;
     }
 
-    form {
+    .comment-form form {
       margin-top: $line-height / 2;
     }
   }
@@ -2004,17 +2004,18 @@ table {
 
 .comment-votes {
 
-  a,
+  button,
+  form {
+    display: inline-block;
+  }
+
   .icon-like,
   .icon-unlike {
     color: $text-light;
-    display: inline-block;
-    vertical-align: top;
   }
 
-  a:hover {
-    color: $text-medium;
-    text-decoration: none;
+  button:hover {
+    cursor: pointer;
 
     .icon-like {
       color: $like;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2006,22 +2006,30 @@ table {
 
   button,
   form {
+    color: $text-light;
     display: inline-block;
   }
 
-  .icon-like,
-  .icon-unlike {
-    color: $text-light;
+  button {
+    font-size: $base-font-size;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
-  button:hover {
-    cursor: pointer;
+  .in-favor button {
+    @include has-fa-icon(thumbs-up, solid);
 
-    .icon-like {
+    &:hover {
       color: $like;
     }
+  }
 
-    .icon-unlike {
+  .against button {
+    @include has-fa-icon(thumbs-down, solid);
+
+    &:hover {
       color: $unlike;
     }
   }

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -746,22 +746,6 @@
                   content: "|";
                 }
               }
-
-              .icon-like,
-              .icon-unlike {
-                cursor: pointer;
-                color: #c7c7c7;
-
-                &:hover,
-                &:active,
-                &:focus {
-                  color: #838383;
-                }
-              }
-
-              .icon-like {
-                margin-right: rem-calc(4);
-              }
             }
           }
         }

--- a/app/components/budgets/investments/ballot_component.html.erb
+++ b/app/components/budgets/investments/ballot_component.html.erb
@@ -14,7 +14,8 @@
                                             investments_ids: investment_ids),
                     class: "button button-remove-support expanded",
                     method: :delete,
-                    remote: true %>
+                    remote: true,
+                    "aria-label": remove_vote_aria_label %>
       <% end %>
     </div>
   <% else %>
@@ -30,7 +31,8 @@
                     class: "button button-support expanded",
                     title: t("budgets.investments.investment.support_title"),
                     method: :post,
-                    remote: true %>
+                    remote: true,
+                    "aria-label": vote_aria_label %>
       <% end %>
     </div>
   <% end %>

--- a/app/components/budgets/investments/ballot_component.html.erb
+++ b/app/components/budgets/investments/ballot_component.html.erb
@@ -8,14 +8,15 @@
         <%= investment.formatted_price %>
       </p>
       <% if investment.should_show_ballots? %>
-        <%= link_to t("budgets.ballots.show.remove"),
-                    budget_ballot_line_path(id: investment.id,
-                                            budget_id: investment.budget_id,
-                                            investments_ids: investment_ids),
-                    class: "button button-remove-support expanded",
-                    method: :delete,
-                    remote: true,
-                    "aria-label": remove_vote_aria_label %>
+        <%= button_to budget_ballot_line_path(id: investment.id,
+                                              budget_id: investment.budget_id,
+                                              investments_ids: investment_ids),
+                      class: "button button-remove-support expanded",
+                      method: :delete,
+                      remote: true,
+                      "aria-label": remove_vote_aria_label do %>
+          <%= t("budgets.ballots.show.remove") %>
+        <% end %>
       <% end %>
     </div>
   <% else %>
@@ -24,30 +25,34 @@
         <%= investment.formatted_price %>
       </p>
       <% if investment.should_show_ballots? %>
-        <%= link_to t("budgets.investments.investment.add"),
-                    budget_ballot_lines_path(investment_id: investment.id,
-                                             budget_id: investment.budget_id,
-                                             investments_ids: investment_ids),
-                    class: "button button-support expanded",
-                    title: t("budgets.investments.investment.support_title"),
-                    method: :post,
-                    remote: true,
-                    "aria-label": vote_aria_label %>
+        <%= button_to budget_ballot_lines_path(investment_id: investment.id,
+                                               budget_id: investment.budget_id,
+                                               investments_ids: investment_ids),
+                      class: "button button-support expanded",
+                      title: t("budgets.investments.investment.support_title"),
+                      method: :post,
+                      remote: true,
+                      disabled: reason.present?,
+                      "aria-label": vote_aria_label do %>
+          <%= t("budgets.investments.investment.add") %>
+        <% end %>
       <% end %>
     </div>
   <% end %>
 
   <% if reason.present? && !voted? %>
-    <div class="participation-not-allowed" style="display:none">
-      <p>
-        <small>
-          <%= sanitize(t("budgets.ballots.reasons_for_not_balloting.#{reason}",
-                verify_account: link_to_verify_account, signin: link_to_signin,
-                signup: link_to_signup, my_heading: link_to_my_heading,
-                change_ballot: link_to_change_ballot,
-                heading_link: heading_link(assigned_heading, budget))) %>
-        </small>
-      </p>
+    <div tabindex="0">
+      <div class="participation-not-allowed" style="display:none">
+        <p>
+          <small>
+            <%= sanitize(t("budgets.ballots.reasons_for_not_balloting.#{reason}",
+                  verify_account: link_to_verify_account, signin: link_to_signin,
+                  signup: link_to_signup, my_heading: link_to_my_heading,
+                  change_ballot: link_to_change_ballot,
+                  heading_link: heading_link(assigned_heading, budget))) %>
+          </small>
+        </p>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/components/budgets/investments/ballot_component.rb
+++ b/app/components/budgets/investments/ballot_component.rb
@@ -24,6 +24,14 @@ class Budgets::Investments::BallotComponent < ApplicationComponent
       @reason ||= investment.reason_for_not_being_ballotable_by(current_user, ballot)
     end
 
+    def vote_aria_label
+      t("budgets.investments.investment.add_label", investment: investment.title)
+    end
+
+    def remove_vote_aria_label
+      t("budgets.ballots.show.remove_label", investment: investment.title)
+    end
+
     def link_to_my_heading
       link_to(investment.heading.name,
               budget_investments_path(budget_id: investment.budget_id,

--- a/app/components/comments/votes_component.html.erb
+++ b/app/components/comments/votes_component.html.erb
@@ -3,14 +3,11 @@
   &nbsp;|&nbsp;
 
   <span class="in_favor">
-    <% if can?(:vote, comment) %>
-      <%= link_to vote_comment_path(comment, value: "yes"),
-          method: "post", remote: true, title: t("votes.agree") do %>
-          <span class="icon-like">
-            <span class="show-for-sr"><%= t("votes.agree") %></span>
-          </span>
-      <% end %>
-    <% else %>
+    <%= button_to vote_comment_path(comment, value: "yes"),
+        method: "post",
+        remote: true,
+        title: t("votes.agree"),
+        disabled: !can?(:vote, comment) do %>
       <span class="icon-like">
         <span class="show-for-sr"><%= t("votes.agree") %></span>
       </span>
@@ -19,14 +16,11 @@
   </span>
 
   <span class="against">
-    <% if can?(:vote, comment) %>
-      <%= link_to vote_comment_path(comment, value: "no"),
-          method: "post", remote: true, title: t("votes.disagree") do %>
-          <span class="icon-unlike">
-            <span class="show-for-sr"><%= t("votes.disagree") %></span>
-          </span>
-      <% end %>
-    <% else %>
+    <%= button_to vote_comment_path(comment, value: "no"),
+        method: "post",
+        remote: true,
+        title: t("votes.disagree"),
+        disabled: !can?(:vote, comment) do %>
       <span class="icon-unlike">
         <span class="show-for-sr"><%= t("votes.disagree") %></span>
       </span>

--- a/app/components/comments/votes_component.html.erb
+++ b/app/components/comments/votes_component.html.erb
@@ -2,15 +2,13 @@
   <%= t("comments.comment.votes", count: comment.total_votes) %>
   &nbsp;|&nbsp;
 
-  <span class="in_favor">
+  <span class="in-favor">
     <%= button_to vote_comment_path(comment, value: "yes"),
         method: "post",
         remote: true,
         title: t("votes.agree"),
         disabled: !can?(:vote, comment) do %>
-      <span class="icon-like">
-        <span class="show-for-sr"><%= t("votes.agree") %></span>
-      </span>
+      <span class="show-for-sr"><%= t("votes.agree") %></span>
     <% end %>
     <%= comment.total_likes %>
   </span>
@@ -21,9 +19,7 @@
         remote: true,
         title: t("votes.disagree"),
         disabled: !can?(:vote, comment) do %>
-      <span class="icon-unlike">
-        <span class="show-for-sr"><%= t("votes.disagree") %></span>
-      </span>
+      <span class="show-for-sr"><%= t("votes.disagree") %></span>
     <% end %>
     <%= comment.total_dislikes %>
   </span>

--- a/app/components/proposals/votes_component.html.erb
+++ b/app/components/proposals/votes_component.html.erb
@@ -11,7 +11,8 @@
           class: "button button-support small expanded",
           title: t("proposals.proposal.support_title"),
           method: "post",
-          remote: true %>
+          remote: true,
+          "aria-label": support_aria_label%>
     <% else %>
       <div class="button button-support small expanded">
         <%= t("proposals.proposal.support") %>

--- a/app/components/proposals/votes_component.html.erb
+++ b/app/components/proposals/votes_component.html.erb
@@ -6,17 +6,16 @@
       <div class="supported callout success">
         <%= t("proposals.proposal.already_supported") %>
       </div>
-    <% elsif can_vote? %>
-      <%= link_to t("proposals.proposal.support"), vote_url,
+    <% else %>
+      <%= button_to vote_url,
           class: "button button-support small expanded",
           title: t("proposals.proposal.support_title"),
           method: "post",
           remote: true,
-          "aria-label": support_aria_label%>
-    <% else %>
-      <div class="button button-support small expanded">
+          disabled: !can_vote?,
+          "aria-label": support_aria_label do %>
         <%= t("proposals.proposal.support") %>
-      </div>
+      <% end %>
     <% end %>
   </div>
 

--- a/app/components/proposals/votes_component.rb
+++ b/app/components/proposals/votes_component.rb
@@ -21,6 +21,10 @@ class Proposals::VotesComponent < ApplicationComponent
       proposal.votable_by?(current_user)
     end
 
+    def support_aria_label
+      t("proposals.proposal.support_label", proposal: proposal.title)
+    end
+
     def organization?
       current_user&.organization?
     end

--- a/app/components/shared/in_favor_against_component.html.erb
+++ b/app/components/shared/in_favor_against_component.html.erb
@@ -7,9 +7,7 @@
         method: "post",
         remote: true,
         disabled: !current_user do %>
-      <span class="icon-like">
-        <span class="show-for-sr"><%= t("votes.agree") %></span>
-      </span>
+      <span class="show-for-sr"><%= t("votes.agree") %></span>
     <% end %>
     <span class="percentage"><%= votes_percentage("likes", votable) %></span>
   </div>
@@ -24,9 +22,7 @@
         method: "post",
         remote: true,
         disabled: !current_user do %>
-      <span class="icon-unlike">
-        <span class="show-for-sr"><%= t("votes.disagree") %></span>
-      </span>
+      <span class="show-for-sr"><%= t("votes.disagree") %></span>
     <% end %>
     <span class="percentage"><%= votes_percentage("dislikes", votable) %></span>
   </div>

--- a/app/components/shared/in_favor_against_component.html.erb
+++ b/app/components/shared/in_favor_against_component.html.erb
@@ -12,8 +12,6 @@
     <span class="percentage"><%= votes_percentage("likes", votable) %></span>
   </div>
 
-  <span class="divider"></span>
-
   <div class="against">
     <%= button_to polymorphic_path(votable, action: :vote, value: "no"),
         class: "unlike #{voted_classes[:against]}",

--- a/app/components/shared/in_favor_against_component.html.erb
+++ b/app/components/shared/in_favor_against_component.html.erb
@@ -1,49 +1,33 @@
 <div class="in-favor-against">
   <div class="in-favor inline-block">
-    <% if current_user %>
-      <%= link_to polymorphic_path(votable, action: :vote, value: "yes"),
-          class: "like #{voted_classes[:in_favor]}",
-          title: t("votes.agree"),
-          "aria-label": agree_aria_label,
-          method: "post",
-          remote: true do %>
-        <span class="icon-like">
-          <span class="show-for-sr"><%= t("votes.agree") %></span>
-        </span>
-        <span class="percentage"><%= votes_percentage("likes", votable) %></span>
-      <% end %>
-    <% else %>
-      <div class="like">
-        <span class="icon-like">
-          <span class="show-for-sr"><%= t("votes.agree") %></span>
-        </span>
-        <span class="percentage"><%= votes_percentage("likes", votable) %></span>
-      </div>
+    <%= button_to polymorphic_path(votable, action: :vote, value: "yes"),
+        class: "like #{voted_classes[:in_favor]}",
+        title: t("votes.agree"),
+        "aria-label": agree_aria_label,
+        method: "post",
+        remote: true,
+        disabled: !current_user do %>
+      <span class="icon-like">
+        <span class="show-for-sr"><%= t("votes.agree") %></span>
+      </span>
+      <span class="percentage"><%= votes_percentage("likes", votable) %></span>
     <% end %>
   </div>
 
   <span class="divider"></span>
 
   <div class="against inline-block">
-    <% if current_user %>
-      <%= link_to polymorphic_path(votable, action: :vote, value: "no"),
-          class: "unlike #{voted_classes[:against]}",
-          title: t("votes.disagree"),
-          "aria-label": disagree_aria_label,
-          method: "post",
-          remote: true do %>
-        <span class="icon-unlike">
-          <span class="show-for-sr"><%= t("votes.disagree") %></span>
-        </span>
-        <span class="percentage"><%= votes_percentage("dislikes", votable) %></span>
-      <% end %>
-    <% else %>
-      <div class="unlike">
-        <span class="icon-unlike">
-          <span class="show-for-sr"><%= t("votes.disagree") %></span>
-        </span>
-        <span class="percentage"><%= votes_percentage("dislikes", votable) %></span>
-      </div>
+    <%= button_to polymorphic_path(votable, action: :vote, value: "no"),
+        class: "unlike #{voted_classes[:against]}",
+        title: t("votes.disagree"),
+        "aria-label": disagree_aria_label,
+        method: "post",
+        remote: true,
+        disabled: !current_user do %>
+      <span class="icon-unlike">
+        <span class="show-for-sr"><%= t("votes.disagree") %></span>
+      </span>
+      <span class="percentage"><%= votes_percentage("dislikes", votable) %></span>
     <% end %>
   </div>
 </div>

--- a/app/components/shared/in_favor_against_component.html.erb
+++ b/app/components/shared/in_favor_against_component.html.erb
@@ -1,5 +1,5 @@
 <div class="in-favor-against">
-  <div class="in-favor inline-block">
+  <div class="in-favor">
     <%= button_to polymorphic_path(votable, action: :vote, value: "yes"),
         class: "like #{voted_classes[:in_favor]}",
         title: t("votes.agree"),
@@ -10,13 +10,13 @@
       <span class="icon-like">
         <span class="show-for-sr"><%= t("votes.agree") %></span>
       </span>
-      <span class="percentage"><%= votes_percentage("likes", votable) %></span>
     <% end %>
+    <span class="percentage"><%= votes_percentage("likes", votable) %></span>
   </div>
 
   <span class="divider"></span>
 
-  <div class="against inline-block">
+  <div class="against">
     <%= button_to polymorphic_path(votable, action: :vote, value: "no"),
         class: "unlike #{voted_classes[:against]}",
         title: t("votes.disagree"),
@@ -27,7 +27,7 @@
       <span class="icon-unlike">
         <span class="show-for-sr"><%= t("votes.disagree") %></span>
       </span>
-      <span class="percentage"><%= votes_percentage("dislikes", votable) %></span>
     <% end %>
+    <span class="percentage"><%= votes_percentage("dislikes", votable) %></span>
   </div>
 </div>

--- a/app/components/shared/in_favor_against_component.html.erb
+++ b/app/components/shared/in_favor_against_component.html.erb
@@ -2,7 +2,11 @@
   <div class="in-favor inline-block">
     <% if current_user %>
       <%= link_to polymorphic_path(votable, action: :vote, value: "yes"),
-          class: "like #{voted_classes[:in_favor]}", title: t("votes.agree"), method: "post", remote: true do %>
+          class: "like #{voted_classes[:in_favor]}",
+          title: t("votes.agree"),
+          "aria-label": agree_aria_label,
+          method: "post",
+          remote: true do %>
         <span class="icon-like">
           <span class="show-for-sr"><%= t("votes.agree") %></span>
         </span>
@@ -22,7 +26,12 @@
 
   <div class="against inline-block">
     <% if current_user %>
-      <%= link_to polymorphic_path(votable, action: :vote, value: "no"), class: "unlike #{voted_classes[:against]}", title: t("votes.disagree"), method: "post", remote: true do %>
+      <%= link_to polymorphic_path(votable, action: :vote, value: "no"),
+          class: "unlike #{voted_classes[:against]}",
+          title: t("votes.disagree"),
+          "aria-label": disagree_aria_label,
+          method: "post",
+          remote: true do %>
         <span class="icon-unlike">
           <span class="show-for-sr"><%= t("votes.disagree") %></span>
         </span>

--- a/app/components/shared/in_favor_against_component.rb
+++ b/app/components/shared/in_favor_against_component.rb
@@ -22,4 +22,12 @@ class Shared::InFavorAgainstComponent < ApplicationComponent
         { in_favor: "", against: "" }
       end
     end
+
+    def agree_aria_label
+      t("votes.agree_label", title: votable.title)
+    end
+
+    def disagree_aria_label
+      t("votes.disagree_label", title: votable.title)
+    end
 end

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -23,6 +23,7 @@ en:
             other: "You can vote up to <span>%{count}</span> projects"
         no_balloted_group_yet: "You have not voted on this group yet, go vote!"
         remove: Remove vote
+        remove_label: "Remove your vote for %{investment}"
         voted:
           one: "You have voted <span>one</span> investment."
           other: "You have voted <span>%{count}</span> investments."
@@ -151,6 +152,7 @@ en:
       wrong_price_format: Only integer numbers
       investment:
         add: Vote
+        add_label: "Vote %{investment}"
         already_added: You have already added this investment project
         support_title: Support this project
         supports:

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -847,9 +847,11 @@ en:
       retired_help_text: Dashboard not available for retired proposals
   votes:
     agree: I agree
+    agree_label: "I agree with %{title}"
     anonymous: Too many anonymous votes to admit vote %{verify_account}.
     comment_unauthenticated: You must %{signin} or %{signup} to vote.
     disagree: I disagree
+    disagree_label: "I don't agree with %{title}"
     organizations: Organizations are not permitted to vote
     supports: Supports
     verified_only: Only verified users can vote on proposals; %{verify_account}.

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -408,6 +408,7 @@ en:
         other: "%{count} comments"
         zero: No comments
       support: Support
+      support_label: "Support %{proposal}"
       support_title: Support this proposal
       supports:
         one: 1 support

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -23,6 +23,7 @@ es:
             other: "Puedes votar hasta <span>%{count}</span> proyectos"
         no_balloted_group_yet: "Todavía no has votado proyectos de este grupo, ¡vota!"
         remove: Quitar voto
+        remove_label: "Quitar tu voto a %{investment}"
         voted:
           one: "Has votado <span>un</span> proyecto."
           other: "Has votado <span>%{count}</span> proyectos."
@@ -151,6 +152,7 @@ es:
       wrong_price_format: Solo puede incluir caracteres numéricos
       investment:
         add: Votar
+        add_label: "Votar %{investment}"
         already_added: Ya has añadido este proyecto de gasto
         support_title: Apoyar este proyecto
         supports:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -408,6 +408,7 @@ es:
         one: 1 Comentario
         other: "%{count} Comentarios"
       support: Apoyar
+      support_label: "Apoyar %{proposal}"
       support_title: Apoyar esta propuesta
       supports:
         zero: Sin apoyos

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -847,9 +847,11 @@ es:
       retired_help_text: Dashboard no disponible para propuestas retiradas
   votes:
     agree: Estoy de acuerdo
+    agree_label: "Estoy de acuerdo con %{title}"
     anonymous: Demasiados votos anónimos, para poder votar %{verify_account}.
     comment_unauthenticated: Necesitas %{signin} o %{signup} para poder votar.
     disagree: No estoy de acuerdo
+    disagree_label: "No estoy de acuerdo con %{title}"
     organizations: Las organizaciones no pueden votar.
     supports: Apoyos
     verified_only: Las propuestas sólo pueden ser votadas por usuarios verificados, %{verify_account}.

--- a/spec/components/budgets/investments/ballot_component_spec.rb
+++ b/spec/components/budgets/investments/ballot_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Budgets::Investments::BallotComponent do
-  describe "vote investment link" do
+  describe "vote investment button" do
     let(:budget) { create(:budget, :balloting) }
     let(:investment) { create(:budget_investment, :selected, title: "New Sports Center", budget: budget) }
     let(:component) do
@@ -18,7 +18,7 @@ describe Budgets::Investments::BallotComponent do
 
       render_inline component
 
-      expect(page).to have_link "Vote"
+      expect(page).to have_button "Vote", disabled: true
       expect(page).to have_content "Only verified users can vote on investments; verify your account."
     end
 
@@ -27,21 +27,21 @@ describe Budgets::Investments::BallotComponent do
 
       render_inline component
 
-      expect(page).to have_link count: 1
-      expect(page).to have_link "Vote", title: "Support this project"
-      expect(page).to have_link "Vote New Sports Center"
-      expect(page).not_to have_link "Remove vote"
+      expect(page).to have_button count: 1
+      expect(page).to have_button "Vote", title: "Support this project"
+      expect(page).to have_button "Vote New Sports Center"
+      expect(page).not_to have_button "Remove vote", disabled: :all
     end
 
-    it "is replaced with a link to remove the vote when the user has already voted" do
+    it "is replaced with a button to remove the vote when the user has already voted" do
       sign_in(create(:user, :level_two, ballot_lines: [investment]))
 
       render_inline component
 
-      expect(page).to have_link count: 1
-      expect(page).to have_link "Remove vote"
-      expect(page).to have_link "Remove your vote for New Sports Center"
-      expect(page).not_to have_link "Vote"
+      expect(page).to have_button count: 1
+      expect(page).to have_button "Remove vote"
+      expect(page).to have_button "Remove your vote for New Sports Center"
+      expect(page).not_to have_button "Vote", disabled: :all
     end
   end
 end

--- a/spec/components/budgets/investments/ballot_component_spec.rb
+++ b/spec/components/budgets/investments/ballot_component_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe Budgets::Investments::BallotComponent do
+  describe "vote investment link" do
+    let(:budget) { create(:budget, :balloting) }
+    let(:investment) { create(:budget_investment, :selected, title: "New Sports Center", budget: budget) }
+    let(:component) do
+      Budgets::Investments::BallotComponent.new(
+        investment: investment,
+        investment_ids: [],
+        ballot: Budget::Ballot.where(budget: budget, user: controller.current_user).first_or_create!,
+        assigned_heading: nil
+      )
+    end
+
+    it "is shown alongside a 'not allowed' message to unverified users" do
+      sign_in(create(:user))
+
+      render_inline component
+
+      expect(page).to have_link "Vote"
+      expect(page).to have_content "Only verified users can vote on investments; verify your account."
+    end
+
+    it "is shown to verified users" do
+      sign_in(create(:user, :level_two))
+
+      render_inline component
+
+      expect(page).to have_link count: 1
+      expect(page).to have_link "Vote", title: "Support this project"
+      expect(page).to have_link "Vote New Sports Center"
+      expect(page).not_to have_link "Remove vote"
+    end
+
+    it "is replaced with a link to remove the vote when the user has already voted" do
+      sign_in(create(:user, :level_two, ballot_lines: [investment]))
+
+      render_inline component
+
+      expect(page).to have_link count: 1
+      expect(page).to have_link "Remove vote"
+      expect(page).to have_link "Remove your vote for New Sports Center"
+      expect(page).not_to have_link "Vote"
+    end
+  end
+end

--- a/spec/components/debates/votes_component_spec.rb
+++ b/spec/components/debates/votes_component_spec.rb
@@ -25,5 +25,19 @@ describe Debates::VotesComponent do
       expect(page).to have_button "I don't agree with What about the 2030 agenda?"
       expect(page).not_to have_content "You must sign in or sign up to continue."
     end
+
+    it "does not include result percentages" do
+      create(:vote, votable: debate)
+      sign_in(create(:user))
+
+      render_inline component
+
+      expect(page).to have_button count: 2
+      expect(page).to have_button "I agree"
+      expect(page).to have_button "I disagree"
+      expect(page).not_to have_button text: "%"
+      expect(page).not_to have_button text: "100"
+      expect(page).not_to have_button text: "0"
+    end
   end
 end

--- a/spec/components/debates/votes_component_spec.rb
+++ b/spec/components/debates/votes_component_spec.rb
@@ -22,7 +22,9 @@ describe Debates::VotesComponent do
 
       expect(page).to have_link count: 2
       expect(page).to have_link "I agree", title: "I agree"
+      expect(page).to have_link "I agree with What about the 2030 agenda?"
       expect(page).to have_link "I disagree", title: "I disagree"
+      expect(page).to have_link "I don't agree with What about the 2030 agenda?"
       expect(page).not_to have_content "You must sign in or sign up to continue."
     end
   end

--- a/spec/components/debates/votes_component_spec.rb
+++ b/spec/components/debates/votes_component_spec.rb
@@ -4,15 +4,13 @@ describe Debates::VotesComponent do
   let(:debate) { create(:debate, title: "What about the 2030 agenda?") }
   let(:component) { Debates::VotesComponent.new(debate) }
 
-  describe "Agree and disagree links" do
-    it "is shown as plain text to anonymous users" do
+  describe "Agree and disagree buttons" do
+    it "is disabled to anonymous users" do
       render_inline component
 
-      expect(page).to have_content "I agree"
-      expect(page).to have_content "I disagree"
+      expect(page).to have_button "I agree", disabled: true
+      expect(page).to have_button "I disagree", disabled: true
       expect(page).to have_content "You must sign in or sign up to continue."
-      expect(page).not_to have_link "I agree"
-      expect(page).not_to have_link "I disagree"
     end
 
     it "is shown to identified users" do
@@ -20,11 +18,11 @@ describe Debates::VotesComponent do
 
       render_inline component
 
-      expect(page).to have_link count: 2
-      expect(page).to have_link "I agree", title: "I agree"
-      expect(page).to have_link "I agree with What about the 2030 agenda?"
-      expect(page).to have_link "I disagree", title: "I disagree"
-      expect(page).to have_link "I don't agree with What about the 2030 agenda?"
+      expect(page).to have_button count: 2
+      expect(page).to have_button "I agree", title: "I agree"
+      expect(page).to have_button "I agree with What about the 2030 agenda?"
+      expect(page).to have_button "I disagree", title: "I disagree"
+      expect(page).to have_button "I don't agree with What about the 2030 agenda?"
       expect(page).not_to have_content "You must sign in or sign up to continue."
     end
   end

--- a/spec/components/legislation/proposals/votes_component_spec.rb
+++ b/spec/components/legislation/proposals/votes_component_spec.rb
@@ -35,7 +35,9 @@ describe Legislation::Proposals::VotesComponent do
 
       expect(page).to have_link count: 2
       expect(page).to have_link "I agree", title: "I agree"
+      expect(page).to have_link "I agree with Require wearing masks at home"
       expect(page).to have_link "I disagree", title: "I disagree"
+      expect(page).to have_link "I don't agree with Require wearing masks at home"
       expect(page).not_to have_content "You must sign in or sign up to continue."
     end
   end

--- a/spec/components/legislation/proposals/votes_component_spec.rb
+++ b/spec/components/legislation/proposals/votes_component_spec.rb
@@ -38,5 +38,19 @@ describe Legislation::Proposals::VotesComponent do
       expect(page).to have_button "I don't agree with Require wearing masks at home"
       expect(page).not_to have_content "You must sign in or sign up to continue."
     end
+
+    it "does not include result percentages" do
+      create(:vote, votable: proposal)
+      sign_in(create(:user))
+
+      render_inline component
+
+      expect(page).to have_button count: 2
+      expect(page).to have_button "I agree"
+      expect(page).to have_button "I disagree"
+      expect(page).not_to have_button text: "%"
+      expect(page).not_to have_button text: "100"
+      expect(page).not_to have_button text: "0"
+    end
   end
 end

--- a/spec/components/legislation/proposals/votes_component_spec.rb
+++ b/spec/components/legislation/proposals/votes_component_spec.rb
@@ -4,7 +4,7 @@ describe Legislation::Proposals::VotesComponent do
   let(:proposal) { create(:legislation_proposal, title: "Require wearing masks at home") }
   let(:component) { Legislation::Proposals::VotesComponent.new(proposal) }
 
-  describe "Agree and disagree links" do
+  describe "Agree and disagree buttons" do
     it "is not shown when the proposals phase isn't open" do
       proposal.process.update!(
         proposals_phase_start_date: 2.days.ago,
@@ -14,18 +14,16 @@ describe Legislation::Proposals::VotesComponent do
       sign_in(create(:user))
       render_inline component
 
-      expect(page).not_to have_content "I agree"
-      expect(page).not_to have_content "I disagree"
+      expect(page).not_to have_button "I agree", disabled: :all
+      expect(page).not_to have_button "I disagree", disabled: :all
     end
 
-    it "is shown as plain text to anonymous users" do
+    it "is disabled to anonymous users" do
       render_inline component
 
-      expect(page).to have_content "I agree"
-      expect(page).to have_content "I disagree"
+      expect(page).to have_button "I agree", disabled: true
+      expect(page).to have_button "I disagree", disabled: true
       expect(page).to have_content "You must sign in or sign up to continue."
-      expect(page).not_to have_link "I agree"
-      expect(page).not_to have_link "I disagree"
     end
 
     it "is shown to identified users" do
@@ -33,11 +31,11 @@ describe Legislation::Proposals::VotesComponent do
 
       render_inline component
 
-      expect(page).to have_link count: 2
-      expect(page).to have_link "I agree", title: "I agree"
-      expect(page).to have_link "I agree with Require wearing masks at home"
-      expect(page).to have_link "I disagree", title: "I disagree"
-      expect(page).to have_link "I don't agree with Require wearing masks at home"
+      expect(page).to have_button count: 2
+      expect(page).to have_button "I agree", title: "I agree"
+      expect(page).to have_button "I agree with Require wearing masks at home"
+      expect(page).to have_button "I disagree", title: "I disagree"
+      expect(page).to have_button "I don't agree with Require wearing masks at home"
       expect(page).not_to have_content "You must sign in or sign up to continue."
     end
   end

--- a/spec/components/proposals/votes_component_spec.rb
+++ b/spec/components/proposals/votes_component_spec.rb
@@ -21,6 +21,7 @@ describe Proposals::VotesComponent do
 
       expect(page).to have_link count: 1
       expect(page).to have_link "Support", title: "Support this proposal"
+      expect(page).to have_link "Support Create a monthly transport ticket"
       expect(page).not_to have_content "You have already supported this proposal. Share it!"
     end
 

--- a/spec/components/proposals/votes_component_spec.rb
+++ b/spec/components/proposals/votes_component_spec.rb
@@ -4,14 +4,13 @@ describe Proposals::VotesComponent do
   let(:proposal) { create(:proposal, title: "Create a monthly transport ticket") }
   let(:component) { Proposals::VotesComponent.new(proposal) }
 
-  describe "support proposal link" do
-    it "is shown as plain text to unverified users" do
+  describe "support proposal button" do
+    it "is disabled to unverified users" do
       sign_in(create(:user))
 
       render_inline component
 
-      expect(page).to have_content "Support"
-      expect(page).not_to have_link "Support"
+      expect(page).to have_button "Support", disabled: true
     end
 
     it "is shown to verified users" do
@@ -19,9 +18,9 @@ describe Proposals::VotesComponent do
 
       render_inline component
 
-      expect(page).to have_link count: 1
-      expect(page).to have_link "Support", title: "Support this proposal"
-      expect(page).to have_link "Support Create a monthly transport ticket"
+      expect(page).to have_button count: 1
+      expect(page).to have_button "Support", title: "Support this proposal"
+      expect(page).to have_button "Support Create a monthly transport ticket"
       expect(page).not_to have_content "You have already supported this proposal. Share it!"
     end
 
@@ -31,7 +30,7 @@ describe Proposals::VotesComponent do
       render_inline component
 
       expect(page).to have_content "You have already supported this proposal. Share it!"
-      expect(page).not_to have_link "Support"
+      expect(page).not_to have_button "Support", disabled: :all
     end
   end
 

--- a/spec/support/common_actions/budgets.rb
+++ b/spec/support/common_actions/budgets.rb
@@ -1,17 +1,17 @@
 module Budgets
   def expect_message_organizations_cannot_vote
     expect(page).to have_content "Organization"
-    expect(page).to have_selector(".in-favor a", obscured: true)
+    expect(page).to have_button "Vote", disabled: true, obscured: true
   end
 
   def hover_over_ballot
     scroll_to find("div.ballot"), align: :bottom
-    find("div.ballot").hover
+    first("div.ballot p").hover
   end
 
   def add_to_ballot(investment_title)
     within(".budget-investment", text: investment_title) do
-      find(".add a").click
+      click_button "Vote"
       expect(page).to have_content "Remove"
     end
   end

--- a/spec/support/common_actions/votes.rb
+++ b/spec/support/common_actions/votes.rb
@@ -12,7 +12,7 @@ module Votes
 
   def expect_message_to_many_anonymous_votes
     expect(page).to have_content "Too many anonymous votes to admit vote"
-    expect(page).to have_selector(".in-favor a", obscured: true)
+    expect(page).to have_button "I agree", obscured: true
   end
 
   def expect_message_only_verified_can_vote_proposals

--- a/spec/system/budget_polls/voter_spec.rb
+++ b/spec/system/budget_polls/voter_spec.rb
@@ -81,11 +81,11 @@ describe "BudgetPolls", :with_frozen_time do
       login_as(user)
 
       visit budget_investment_path(budget, investment)
-      find("div.ballot").hover
+      first("div.ballot p").hover
 
       within("#budget_investment_#{investment.id}") do
         expect(page).to have_content "You have already participated offline"
-        expect(page).to have_css(".add a", obscured: true)
+        expect(page).to have_button "Vote", disabled: true, obscured: true
       end
     end
   end
@@ -96,7 +96,7 @@ describe "BudgetPolls", :with_frozen_time do
       visit budget_investment_path(budget, investment)
 
       within("#budget_investment_#{investment.id}") do
-        find(".add a").click
+        click_button "Vote"
         expect(page).to have_content "Remove"
       end
     end
@@ -106,7 +106,7 @@ describe "BudgetPolls", :with_frozen_time do
       visit budget_investment_path(budget, investment)
 
       within("#budget_investment_#{investment.id}") do
-        find(".add a").click
+        click_button "Vote"
         expect(page).to have_content "Remove"
       end
 
@@ -123,7 +123,7 @@ describe "BudgetPolls", :with_frozen_time do
       visit budget_investment_path(budget, investment)
 
       within("#budget_investment_#{investment.id}") do
-        find(".add a").click
+        click_button "Vote"
         expect(page).to have_content "Remove"
       end
 

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -147,7 +147,7 @@ describe "Ballots" do
         end
 
         within("#budget_investment_#{investment.id}") do
-          find(".remove a").click
+          click_button "Remove vote"
         end
 
         expect(page).to have_css("#total_amount", text: "€0")
@@ -283,8 +283,8 @@ describe "Ballots" do
       visit budget_investments_path(budget, heading_id: california.id)
 
       within(".budget-investment", text: "Early ShakeAlert") do
-        find(".remove a").click
-        expect(page).to have_link "Vote"
+        click_button "Remove vote"
+        expect(page).to have_button "Vote"
       end
 
       visit budget_investments_path(budget, heading_id: new_york.id)
@@ -449,7 +449,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).to have_content "You must sign in or sign up to continue."
-        expect(page).to have_selector(".in-favor a", obscured: true)
+        expect(page).to have_button "Vote", disabled: true, obscured: true
       end
     end
 
@@ -515,7 +515,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).to have_content("already voted a different heading")
-        expect(page).to have_selector(".in-favor a", obscured: true)
+        expect(page).to have_button "Vote", disabled: true, obscured: true
       end
     end
 
@@ -531,7 +531,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).to have_content("You have already assigned the available budget")
-        expect(page).to have_selector(".in-favor a", obscured: true)
+        expect(page).to have_button "Vote", disabled: true, obscured: true
       end
     end
 
@@ -546,7 +546,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).not_to have_content("You have already assigned the available budget")
-        expect(page).to have_selector(".in-favor a", obscured: false)
+        expect(page).to have_button "Vote", obscured: false
       end
 
       add_to_ballot("Build replicants")
@@ -555,7 +555,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).to have_content("You have already assigned the available budget")
-        expect(page).to have_selector(".in-favor a", obscured: true)
+        expect(page).to have_button "Vote", disabled: true, obscured: true
       end
     end
 
@@ -571,7 +571,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).to have_content("You have already assigned the available budget")
-        expect(page).to have_selector(".in-favor a", obscured: true)
+        expect(page).to have_button "Vote", disabled: true, obscured: true
       end
 
       within("#budget_investment_#{bi1.id}") do
@@ -583,7 +583,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).not_to have_content("You have already assigned the available budget")
-        expect(page).to have_selector(".in-favor a", obscured: false)
+        expect(page).to have_button "Vote", obscured: false
       end
     end
 
@@ -599,7 +599,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).to have_content("You have already assigned the available budget")
-        expect(page).to have_selector(".in-favor a", obscured: true)
+        expect(page).to have_button "Vote", disabled: true, obscured: true
       end
 
       within("#budget_investment_#{bi1.id}_sidebar") do
@@ -612,7 +612,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).not_to have_content("You have already assigned the available budget")
-        expect(page).to have_selector(".in-favor a", obscured: false)
+        expect(page).to have_button "Vote", obscured: false
       end
     end
 
@@ -623,7 +623,7 @@ describe "Ballots" do
       login_as user
       visit budget_investments_path(budget, heading_id: new_york)
 
-      expect(page).to have_css(".in-favor a")
+      expect(page).to have_button "Vote"
 
       in_browser(:admin) do
         login_as admin_user
@@ -639,7 +639,7 @@ describe "Ballots" do
       end
 
       within("#budget_investment_#{investment1.id}") do
-        find(".in-favor a").click
+        click_button "Vote"
 
         expect(page).not_to have_content "Remove"
         expect(page).not_to have_selector(".participation-not-allowed")
@@ -647,7 +647,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).to have_selector(".participation-not-allowed")
-        expect(page).to have_selector(".in-favor a", obscured: true)
+        expect(page).to have_button "Vote", disabled: true, obscured: true
       end
     end
 

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -177,7 +177,7 @@ describe "Ballots" do
         end
 
         within(".budget-investment", text: "More bridges") do
-          click_link "Remove vote"
+          click_button "Remove vote"
         end
 
         within("#sidebar") do
@@ -464,7 +464,7 @@ describe "Ballots" do
         hover_over_ballot
 
         expect(page).to have_content "Only verified users can vote on investments"
-        expect(page).to have_selector(".in-favor a", obscured: true)
+        expect(page).to have_button "Vote", disabled: true, obscured: true
       end
     end
 
@@ -575,8 +575,8 @@ describe "Ballots" do
       end
 
       within("#budget_investment_#{bi1.id}") do
-        find(".remove a").click
-        expect(page).to have_css ".add a"
+        click_button "Remove vote"
+        expect(page).to have_button "Vote"
       end
 
       within("#budget_investment_#{bi2.id}") do

--- a/spec/system/comments/budget_investments_spec.rb
+++ b/spec/system/comments/budget_investments_spec.rb
@@ -509,7 +509,7 @@ describe "Commenting Budget::Investments" do
       visit budget_investment_path(budget, investment)
 
       within("#comment_#{comment.id}_votes") do
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -527,7 +527,7 @@ describe "Commenting Budget::Investments" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -545,13 +545,13 @@ describe "Commenting Budget::Investments" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I disagree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "0"
         end
 
@@ -569,13 +569,13 @@ describe "Commenting Budget::Investments" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 

--- a/spec/system/comments/budget_investments_spec.rb
+++ b/spec/system/comments/budget_investments_spec.rb
@@ -525,7 +525,7 @@ describe "Commenting Budget::Investments" do
       visit budget_investment_path(budget, investment)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
@@ -543,13 +543,13 @@ describe "Commenting Budget::Investments" do
       visit budget_investment_path(budget, investment)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".against a").click
+        click_button "I disagree"
 
         within(".in_favor") do
           expect(page).to have_content "0"
@@ -567,13 +567,13 @@ describe "Commenting Budget::Investments" do
       visit budget_investment_path(budget, investment)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"

--- a/spec/system/comments/debates_spec.rb
+++ b/spec/system/comments/debates_spec.rb
@@ -331,7 +331,7 @@ describe "Commenting debates" do
       fill_in "Leave your comment", with: "Probably if government approves."
       click_button "Publish reply"
 
-      expect(page).not_to have_selector("form")
+      expect(page).not_to have_css ".comment-form"
 
       within ".comment" do
         expect(page).to have_content "Probably if government approves."
@@ -574,7 +574,7 @@ describe "Commenting debates" do
       visit debate_path(debate)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
@@ -592,13 +592,13 @@ describe "Commenting debates" do
       visit debate_path(debate)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".against a").click
+        click_button "I disagree"
 
         within(".in_favor") do
           expect(page).to have_content "0"
@@ -616,12 +616,12 @@ describe "Commenting debates" do
       visit debate_path(debate)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".in_favor a").click
+        click_button "I agree"
         within(".in_favor") do
           expect(page).not_to have_content "2"
           expect(page).to have_content "1"

--- a/spec/system/comments/debates_spec.rb
+++ b/spec/system/comments/debates_spec.rb
@@ -558,7 +558,7 @@ describe "Commenting debates" do
       visit debate_path(debate)
 
       within("#comment_#{comment.id}_votes") do
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -576,7 +576,7 @@ describe "Commenting debates" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -594,13 +594,13 @@ describe "Commenting debates" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I disagree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "0"
         end
 
@@ -617,12 +617,12 @@ describe "Commenting debates" do
 
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I agree"
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).not_to have_content "2"
           expect(page).to have_content "1"
         end

--- a/spec/system/comments/legislation_annotations_spec.rb
+++ b/spec/system/comments/legislation_annotations_spec.rb
@@ -541,7 +541,7 @@ describe "Commenting legislation questions" do
                                                               annotation)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
@@ -561,13 +561,13 @@ describe "Commenting legislation questions" do
                                                               annotation)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".against a").click
+        click_button "I disagree"
 
         within(".in_favor") do
           expect(page).to have_content "0"
@@ -587,12 +587,12 @@ describe "Commenting legislation questions" do
                                                               annotation)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".in_favor a").click
+        click_button "I agree"
         within(".in_favor") do
           expect(page).not_to have_content "2"
           expect(page).to have_content "1"

--- a/spec/system/comments/legislation_annotations_spec.rb
+++ b/spec/system/comments/legislation_annotations_spec.rb
@@ -523,7 +523,7 @@ describe "Commenting legislation questions" do
                                                               annotation)
 
       within("#comment_#{comment.id}_votes") do
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -543,7 +543,7 @@ describe "Commenting legislation questions" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -563,13 +563,13 @@ describe "Commenting legislation questions" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I disagree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "0"
         end
 
@@ -588,12 +588,12 @@ describe "Commenting legislation questions" do
 
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I agree"
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).not_to have_content "2"
           expect(page).to have_content "1"
         end

--- a/spec/system/comments/legislation_questions_spec.rb
+++ b/spec/system/comments/legislation_questions_spec.rb
@@ -491,7 +491,7 @@ describe "Commenting legislation questions" do
       visit legislation_process_question_path(question.process, question)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
@@ -509,13 +509,13 @@ describe "Commenting legislation questions" do
       visit legislation_process_question_path(question.process, question)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".against a").click
+        click_button "I disagree"
 
         within(".in_favor") do
           expect(page).to have_content "0"
@@ -533,12 +533,12 @@ describe "Commenting legislation questions" do
       visit legislation_process_question_path(question.process, question)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".in_favor a").click
+        click_button "I agree"
         within(".in_favor") do
           expect(page).not_to have_content "2"
           expect(page).to have_content "1"

--- a/spec/system/comments/legislation_questions_spec.rb
+++ b/spec/system/comments/legislation_questions_spec.rb
@@ -475,7 +475,7 @@ describe "Commenting legislation questions" do
       visit legislation_process_question_path(question.process, question)
 
       within("#comment_#{comment.id}_votes") do
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -493,7 +493,7 @@ describe "Commenting legislation questions" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -511,13 +511,13 @@ describe "Commenting legislation questions" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I disagree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "0"
         end
 
@@ -534,12 +534,12 @@ describe "Commenting legislation questions" do
 
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I agree"
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).not_to have_content "2"
           expect(page).to have_content "1"
         end

--- a/spec/system/comments/polls_spec.rb
+++ b/spec/system/comments/polls_spec.rb
@@ -453,7 +453,7 @@ describe "Commenting polls" do
       visit poll_path(poll)
 
       within("#comment_#{comment.id}_votes") do
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -471,7 +471,7 @@ describe "Commenting polls" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -489,13 +489,13 @@ describe "Commenting polls" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I disagree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "0"
         end
 
@@ -513,13 +513,13 @@ describe "Commenting polls" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 

--- a/spec/system/comments/polls_spec.rb
+++ b/spec/system/comments/polls_spec.rb
@@ -469,7 +469,7 @@ describe "Commenting polls" do
       visit poll_path(poll)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
@@ -487,13 +487,13 @@ describe "Commenting polls" do
       visit poll_path(poll)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".against a").click
+        click_button "I disagree"
 
         within(".in_favor") do
           expect(page).to have_content "0"
@@ -511,13 +511,13 @@ describe "Commenting polls" do
       visit poll_path(poll)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"

--- a/spec/system/comments/proposals_spec.rb
+++ b/spec/system/comments/proposals_spec.rb
@@ -457,7 +457,7 @@ describe "Commenting proposals" do
       visit proposal_path(proposal)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
@@ -475,13 +475,13 @@ describe "Commenting proposals" do
       visit proposal_path(proposal)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".against a").click
+        click_button "I disagree"
 
         within(".in_favor") do
           expect(page).to have_content "0"
@@ -499,13 +499,13 @@ describe "Commenting proposals" do
       visit proposal_path(proposal)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"

--- a/spec/system/comments/proposals_spec.rb
+++ b/spec/system/comments/proposals_spec.rb
@@ -441,7 +441,7 @@ describe "Commenting proposals" do
       visit proposal_path(proposal)
 
       within("#comment_#{comment.id}_votes") do
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -459,7 +459,7 @@ describe "Commenting proposals" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -477,13 +477,13 @@ describe "Commenting proposals" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I disagree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "0"
         end
 
@@ -501,13 +501,13 @@ describe "Commenting proposals" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 

--- a/spec/system/comments/topics_spec.rb
+++ b/spec/system/comments/topics_spec.rb
@@ -507,7 +507,7 @@ describe "Commenting topics from proposals" do
       visit community_topic_path(proposal.community, topic)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
@@ -525,13 +525,13 @@ describe "Commenting topics from proposals" do
       visit community_topic_path(proposal.community, topic)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".against a").click
+        click_button "I disagree"
 
         within(".in_favor") do
           expect(page).to have_content "0"
@@ -549,13 +549,13 @@ describe "Commenting topics from proposals" do
       visit community_topic_path(proposal.community, topic)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
@@ -1018,7 +1018,7 @@ describe "Commenting topics from budget investments" do
       visit community_topic_path(investment.community, topic)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
@@ -1036,13 +1036,13 @@ describe "Commenting topics from budget investments" do
       visit community_topic_path(investment.community, topic)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".against a").click
+        click_button "I disagree"
 
         within(".in_favor") do
           expect(page).to have_content "0"
@@ -1060,13 +1060,13 @@ describe "Commenting topics from budget investments" do
       visit community_topic_path(investment.community, topic)
 
       within("#comment_#{comment.id}_votes") do
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"
         end
 
-        find(".in_favor a").click
+        click_button "I agree"
 
         within(".in_favor") do
           expect(page).to have_content "1"

--- a/spec/system/comments/topics_spec.rb
+++ b/spec/system/comments/topics_spec.rb
@@ -491,7 +491,7 @@ describe "Commenting topics from proposals" do
       visit community_topic_path(proposal.community, topic)
 
       within("#comment_#{comment.id}_votes") do
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -509,7 +509,7 @@ describe "Commenting topics from proposals" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -527,13 +527,13 @@ describe "Commenting topics from proposals" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I disagree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "0"
         end
 
@@ -551,13 +551,13 @@ describe "Commenting topics from proposals" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -1002,7 +1002,7 @@ describe "Commenting topics from budget investments" do
       visit community_topic_path(investment.community, topic)
 
       within("#comment_#{comment.id}_votes") do
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -1020,7 +1020,7 @@ describe "Commenting topics from budget investments" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
@@ -1038,13 +1038,13 @@ describe "Commenting topics from budget investments" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I disagree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "0"
         end
 
@@ -1062,13 +1062,13 @@ describe "Commenting topics from budget investments" do
       within("#comment_#{comment.id}_votes") do
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 
         click_button "I agree"
 
-        within(".in_favor") do
+        within(".in-favor") do
           expect(page).to have_content "1"
         end
 

--- a/spec/system/management/proposals_spec.rb
+++ b/spec/system/management/proposals_spec.rb
@@ -149,7 +149,7 @@ describe "Proposals" do
       click_link "Support proposals"
 
       within(".proposals-list") do
-        click_link("Support")
+        click_button "Support"
         expect(page).to have_content "1 support"
         expect(page).to have_content "You have already supported this proposal. Share it!"
       end
@@ -164,7 +164,7 @@ describe "Proposals" do
 
       within(".proposals-list") { click_link proposal.title }
       expect(page).to have_content proposal.code
-      within("#proposal_#{proposal.id}_votes") { click_link("Support") }
+      within("#proposal_#{proposal.id}_votes") { click_button "Support" }
 
       expect(page).to have_content "1 support"
       expect(page).to have_content "You have already supported this proposal. Share it!"
@@ -241,7 +241,7 @@ describe "Proposals" do
 
       click_link "Print proposals"
       within ".proposals-list" do
-        click_link "Support"
+        click_button "Support"
       end
 
       expect(page).to have_content "To perform this action you must select a user"

--- a/spec/system/votes_spec.rb
+++ b/spec/system/votes_spec.rb
@@ -193,10 +193,10 @@ describe "Votes" do
         visit proposal_path(proposal)
 
         within(".supports") do
-          find(".in-favor a").click
-          expect(page).to have_content "1 support"
+          click_button "Support"
 
-          expect(page).not_to have_selector ".in-favor a"
+          expect(page).to have_content "1 support"
+          expect(page).not_to have_button "Support"
         end
       end
 
@@ -215,7 +215,7 @@ describe "Votes" do
         visit proposal_path(proposal)
 
         within(".supports") do
-          find(".in-favor a").click
+          click_button "Support"
 
           expect(page).to have_content "1 support"
           expect(page).to have_content "You have already supported this proposal. Share it!"
@@ -226,7 +226,7 @@ describe "Votes" do
         visit proposals_path
 
         within("#proposal_#{proposal.id}") do
-          find(".in-favor a").click
+          click_button "Support"
 
           expect(page).to have_content "1 support"
           expect(page).to have_content "You have already supported this proposal. Share it!"
@@ -238,7 +238,7 @@ describe "Votes" do
         visit proposals_path
 
         within("#proposal_#{proposal.id}") do
-          find(".in-favor a").click
+          click_button "Support"
 
           expect(page).to have_content "You have already supported this proposal. Share it!"
         end

--- a/spec/system/votes_spec.rb
+++ b/spec/system/votes_spec.rb
@@ -19,37 +19,37 @@ describe "Votes" do
       within("#debates") do
         within("#debate_#{debate1.id}_votes") do
           within(".in-favor") do
-            expect(page).to have_css("a.voted")
-            expect(page).not_to have_css("a.no-voted")
+            expect(page).to have_css("button.voted")
+            expect(page).not_to have_css("button.no-voted")
           end
 
           within(".against") do
-            expect(page).to have_css("a.no-voted")
-            expect(page).not_to have_css("a.voted")
+            expect(page).to have_css("button.no-voted")
+            expect(page).not_to have_css("button.voted")
           end
         end
 
         within("#debate_#{debate2.id}_votes") do
           within(".in-favor") do
-            expect(page).not_to have_css("a.voted")
-            expect(page).not_to have_css("a.no-voted")
+            expect(page).not_to have_css("button.voted")
+            expect(page).not_to have_css("button.no-voted")
           end
 
           within(".against") do
-            expect(page).not_to have_css("a.no-voted")
-            expect(page).not_to have_css("a.voted")
+            expect(page).not_to have_css("button.no-voted")
+            expect(page).not_to have_css("button.voted")
           end
         end
 
         within("#debate_#{debate3.id}_votes") do
           within(".in-favor") do
-            expect(page).to have_css("a.no-voted")
-            expect(page).not_to have_css("a.voted")
+            expect(page).to have_css("button.no-voted")
+            expect(page).not_to have_css("button.voted")
           end
 
           within(".against") do
-            expect(page).to have_css("a.voted")
-            expect(page).not_to have_css("a.no-voted")
+            expect(page).to have_css("button.voted")
+            expect(page).not_to have_css("button.no-voted")
           end
         end
       end
@@ -63,37 +63,37 @@ describe "Votes" do
 
         within(".in-favor") do
           expect(page).to have_content "0%"
-          expect(page).not_to have_css("a.voted")
-          expect(page).not_to have_css("a.no-voted")
+          expect(page).not_to have_css("button.voted")
+          expect(page).not_to have_css("button.no-voted")
         end
 
         within(".against") do
           expect(page).to have_content "0%"
-          expect(page).not_to have_css("a.voted")
-          expect(page).not_to have_css("a.no-voted")
+          expect(page).not_to have_css("button.voted")
+          expect(page).not_to have_css("button.no-voted")
         end
       end
 
       scenario "Update" do
         visit debate_path(create(:debate))
 
-        find(".in-favor a").click
+        click_button "I agree"
 
         within(".in-favor") do
           expect(page).to have_content "100%"
-          expect(page).to have_css("a.voted")
+          expect(page).to have_css("button.voted")
         end
 
-        find(".against a").click
+        click_button "I disagree"
 
         within(".in-favor") do
           expect(page).to have_content "0%"
-          expect(page).to have_css("a.no-voted")
+          expect(page).to have_css("button.no-voted")
         end
 
         within(".against") do
           expect(page).to have_content "100%"
-          expect(page).to have_css("a.voted")
+          expect(page).to have_css("button.voted")
         end
 
         expect(page).to have_content "1 vote"
@@ -102,9 +102,9 @@ describe "Votes" do
       scenario "Trying to vote multiple times" do
         visit debate_path(create(:debate))
 
-        find(".in-favor a").click
+        click_button "I agree"
         expect(page).to have_content "1 vote"
-        find(".in-favor a").click
+        click_button "I agree"
         expect(page).not_to have_content "2 votes"
 
         within(".in-favor") do
@@ -127,28 +127,28 @@ describe "Votes" do
 
         within(".in-favor") do
           expect(page).to have_content "50%"
-          expect(page).to have_css("a.voted")
+          expect(page).to have_css("button.voted")
         end
 
         within(".against") do
           expect(page).to have_content "50%"
-          expect(page).to have_css("a.no-voted")
+          expect(page).to have_css("button.no-voted")
         end
       end
 
       scenario "Create from debate show" do
         visit debate_path(create(:debate))
 
-        find(".in-favor a").click
+        click_button "I agree"
 
         within(".in-favor") do
           expect(page).to have_content "100%"
-          expect(page).to have_css("a.voted")
+          expect(page).to have_css("button.voted")
         end
 
         within(".against") do
           expect(page).to have_content "0%"
-          expect(page).to have_css("a.no-voted")
+          expect(page).to have_css("button.no-voted")
         end
 
         expect(page).to have_content "1 vote"
@@ -159,16 +159,16 @@ describe "Votes" do
         visit debates_path
 
         within("#debates") do
-          find(".in-favor a").click
+          click_button "I agree"
 
           within(".in-favor") do
             expect(page).to have_content "100%"
-            expect(page).to have_css("a.voted")
+            expect(page).to have_css("button.voted")
           end
 
           within(".against") do
             expect(page).to have_content "0%"
-            expect(page).to have_css("a.no-voted")
+            expect(page).to have_css("button.no-voted")
           end
 
           expect(page).to have_content "1 vote"


### PR DESCRIPTION
## References

* This pull request depends on pull request #4763 and is necessary for pull request #4764
* We started replacing links with buttons in pull request #4665

## Objectives

* Use buttons instead of links to vote on processes so it's easier for people using screen readers
* Add an ARIA label to these buttons so people using screen readers have more context about what they're about to vote
* Move the percentage of agree/disagree votes out of the buttons so the text of the buttons is more clear
* Fix alignment of the agree/disagree buttons on medium-sized screens
* Avoid keyboard focus on buttons to vote during the final voting in participatory budgets when people can't vote
* Make the styles of the buttons to vote legislation annotation comments consistent with the rest of the application

## Visual Changes

Most of the changes in this pull request aren't visual; here are some which are indeed visual.

### Before these changes

Debates index:

![On medium-sized screens, the buttons to agree and disagree are not vertically aligned](https://user-images.githubusercontent.com/35156/153469851-372a0161-9e7a-479c-bff7-3b056c7e3ded.png)

Legislation annotation comments:

![The colors of the buttons to agree and disagree with legislation annotations aren't consistent with the ones in other sections](https://user-images.githubusercontent.com/35156/153470495-f6d3f46f-4d30-4622-b586-cdca2dc887f7.png)

### After these changes

Debates index:

![On medium-sized screens, the buttons to agree and disagree are vertically aligned](https://user-images.githubusercontent.com/35156/153469865-77089721-fca7-4ccb-afae-c75e4e1e2897.png)

Legislation annotation comments:

![The colors of the buttons to agree and disagree with legislation annotations are consistent with the ones in other sections](https://user-images.githubusercontent.com/35156/153470516-8c683c17-c9fd-4188-b158-c54987b01742.png)