### PR TITLE
Make it easier to customize JavaScript functions

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -114,6 +114,7 @@
 //= require_tree ./admin
 //= require_tree ./sdg
 //= require_tree ./sdg_management
+//= require_tree ./custom
 
 var initialize_modules = function() {
   "use strict";

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -92,7 +92,6 @@
 //= require documentable
 //= require imageable
 //= require tree_navigator
-//= require custom
 //= require tag_autocomplete
 //= require polls_admin
 //= require leaflet
@@ -114,6 +113,7 @@
 //= require_tree ./admin
 //= require_tree ./sdg
 //= require_tree ./sdg_management
+//= require custom
 //= require_tree ./custom
 
 var initialize_modules = function() {

--- a/config/application.rb
+++ b/config/application.rb
@@ -114,7 +114,7 @@ end
 class Rails::Engine
   initializer :prepend_custom_assets_path, group: :all do |app|
     if self.class.name == "Consul::Application"
-      %w[images fonts javascripts].each do |asset|
+      %w[images fonts].each do |asset|
         app.config.assets.paths.unshift(Rails.root.join("app", "assets", asset, "custom").to_s)
       end
     end


### PR DESCRIPTION
## Background

When there was a custom JavaScript file, we weren't loading the original one, meaning that, in order to customize it, it was necessary to copy the whole original file and then changing it.

## Objectives

* Make it possible to customize parts of the original JavaScript file wihout copying the whole file
* Make sure the custom JavaScript overwrites the original one

## Notes

Existing copies of original files will still overwrite the whole file and won't be affected.

## Release Notes

:warning: JavaScript files in the `custom/` folder are now automatically required. If you've added files to that folder that aren't present in CONSUL, like `homepage_enhancements.js`, and are requiring them with `//= require homepage_enhancements`, you need to delete the line saying `//= require homepage_enhancements`. You don't have to delete this line if the files are a copy of files already existing in CONSUL (for example, `custom/globalize.js`, which is based on CONSUL's `globalize.js`).