### PR TITLE
Fix crash on attributes with interpolation arguments

### DIFF
--- a/lib/consul_form_builder.rb
+++ b/lib/consul_form_builder.rb
@@ -83,7 +83,7 @@ class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
 
     def help_text_id(attribute, options)
       if options[:hint].present?
-        "#{custom_label(attribute, nil, nil).match(/for="([^"]+)"/)[1]}-help-text"
+        "#{custom_label(attribute, "Example", nil).match(/for="([^"]+)"/)[1]}-help-text"
       end
     end
 end

--- a/lib/consul_form_builder.rb
+++ b/lib/consul_form_builder.rb
@@ -76,13 +76,13 @@ class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
     end
 
     def help_text(attribute, options)
-      if options[:hint]
+      if options[:hint].present?
         tag.span options[:hint], class: "help-text", id: help_text_id(attribute, options)
       end
     end
 
     def help_text_id(attribute, options)
-      if options[:hint]
+      if options[:hint].present?
         "#{custom_label(attribute, nil, nil).match(/for="([^"]+)"/)[1]}-help-text"
       end
     end

--- a/spec/lib/consul_form_builder_spec.rb
+++ b/spec/lib/consul_form_builder_spec.rb
@@ -28,6 +28,13 @@ describe ConsulFormBuilder do
       expect(page).to have_css "input[aria-describedby='dummy_title-help-text']"
     end
 
+    it "does not generate empty hints" do
+      render builder.text_field(:title, hint: "")
+
+      expect(page).not_to have_css ".help-text"
+      expect(page).not_to have_css "input[aria-describedby]"
+    end
+
     it "does not generate a hint attribute" do
       render builder.text_field(:title)
 

--- a/spec/lib/consul_form_builder_spec.rb
+++ b/spec/lib/consul_form_builder_spec.rb
@@ -40,6 +40,18 @@ describe ConsulFormBuilder do
 
       expect(page).not_to have_css "input[hint]"
     end
+
+    describe "attributes requiring interpolation parameters" do
+      before { I18n.backend.store_translations(:en, { attributes: { title: "Title %{info}" }}) }
+      after { I18n.backend.reload! }
+
+      it "generates a hint" do
+        render builder.text_field(:title, label: "Title whatever", hint: "Make it quick")
+
+        expect(page).to have_css ".help-text", text: "Make it quick"
+        expect(page).to have_css "input[aria-describedby='dummy_title-help-text']"
+      end
+    end
   end
 
   describe "#select" do


### PR DESCRIPTION
## References

* The bug was introduced in consul/consul#3745

## Objectives

* Allow generating fields with hints for attributes having interpolation arguments in their `human_attribute_name`
* Don't generate an empty hint element when there's an empty hint