### PR TITLE
Avoid model inheritance in skip validation test

### DIFF
--- a/spec/models/skip_validation_spec.rb
+++ b/spec/models/skip_validation_spec.rb
@@ -49,19 +49,21 @@ describe SkipValidation do
 
   describe ".skip_translation_validation" do
     before do
-      dummy_banner = Class.new(Banner) do
-        def self.translation_class
-          @translation_class ||= Class.new(Banner::Translation) { clear_validators! }
+      dummy_banner = Class.new(ApplicationRecord) do
+        def self.name
+          "DummyBanner"
         end
-        reflect_on_association(:translations).options[:class_name] = "DummyBanner::Translation"
+        self.table_name = "banners"
 
-        clear_validators!
+        translates :title, touch: true
+        translates :description, touch: true
+        include Globalizable
+
         validates_translation :title, presence: true
         validates_translation :description, presence: true
       end
 
       stub_const("DummyBanner", dummy_banner)
-      stub_const("DummyBanner::Translation", dummy_banner.translation_class)
     end
 
     it "removes the validation from the translatable attribute" do


### PR DESCRIPTION
## References

* The failing test was introduced in pull request #4790
* The test has failed several times on Github Actions, like in our [test run 3485, build 4](https://github.com/consul/consul/runs/5695139234)

## Objectives

* Make sure the skip validation tests don't fail on Github Actions

## Notes 

Afet debugging, it looks like the line `custom_banner.save!` was using the validations from the Banner class sometimes, even if the callbacks had correctly been removed in the DummyBanner class.

Se we're inheriting from ApplicationRecord instead of inheriting from Banner. Since I couldn't reproduce the issue locally after running the test hundreds of times and with the same seed and tests that were running on Github Actions, there's a chance this won't work. I've tested a few times on Github Actions and it seems to be working, but we'll have to keep an eye on it.