### PR TITLE
Fix confirmation instructions texts

### DIFF
--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -9,8 +9,8 @@ en:
       updated: "Password successfully updated"
     confirmations:
       confirmed: "Your account has been confirmed."
-      send_instructions: "In a few minutes you will receive an email containing instructions on how to reset your password."
-      send_paranoid_instructions: "If your email address is in our database, in a few minutes you will receive an email containing instructions on how to reset your password."
+      send_instructions: "In a few minutes you will receive an email containing instructions on how to confirm your email address."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account has not yet been activated."

--- a/config/locales/es/devise.yml
+++ b/config/locales/es/devise.yml
@@ -9,8 +9,8 @@ es:
       updated: "Contraseña actualizada con éxito"
     confirmations:
       confirmed: "Tu cuenta ha sido confirmada. Por favor autentifícate con tu red social o tu usuario y contraseña"
-      send_instructions: "Recibirás un correo electrónico en unos minutos con instrucciones sobre cómo restablecer tu contraseña."
-      send_paranoid_instructions: "Si tu correo electrónico existe en nuestra base de datos recibirás un correo electrónico en unos minutos con instrucciones sobre cómo restablecer tu contraseña."
+      send_instructions: "Recibirás un correo electrónico en unos minutos con instrucciones sobre cómo confirmar tu cuenta."
+      send_paranoid_instructions: "Si tu correo electrónico existe en nuestra base de datos recibirás un correo electrónico en unos minutos con instrucciones sobre cómo confirmar tu cuenta."
     failure:
       already_authenticated: "Ya has iniciado sesión."
       inactive: "Tu cuenta aún no ha sido activada."

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -594,9 +594,9 @@ describe "Users" do
     fill_in "Email", with: "manuela@consul.dev"
     click_button "Re-send instructions"
 
-    expect(page).to have_content "If your email address is in our database, in a few minutes you "\
-                                 "will receive an email containing instructions on how to reset "\
-                                 "your password."
+    expect(page).to have_content "If your email address exists in our database, you will receive an "\
+                                 "email with instructions for how to confirm your email address in a "\
+                                 "few minutes."
   end
 
   scenario "Re-send confirmation instructions with unexisting email" do
@@ -607,9 +607,9 @@ describe "Users" do
     fill_in "Email", with: "fake@mail.dev"
     click_button "Re-send instructions"
 
-    expect(page).to have_content "If your email address is in our database, in a few minutes you "\
-                                 "will receive an email containing instructions on how to reset "\
-                                 "your password."
+    expect(page).to have_content "If your email address exists in our database, you will receive an "\
+                                 "email with instructions for how to confirm your email address in a "\
+                                 "few minutes."
   end
 
   scenario "Sign in, admin with password expired" do


### PR DESCRIPTION
## Objectives
The texts for the confirmation instructions referred to "reset the password".
We have updated the texts to refer to confirmation instructions.

## Visual Changes
![Display updated text](https://user-images.githubusercontent.com/16189/160545947-ee2e396b-8b36-4d6b-8d35-f3b449da6efd.png)
