### PR TITLE
Fix checkbox label styles

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1063,6 +1063,10 @@ form {
     line-height: $line-height;
   }
 
+  .checkbox-label {
+    display: table;
+  }
+
   fieldset legend {
     font-weight: bold;
   }

--- a/app/assets/stylesheets/mixins/forms.scss
+++ b/app/assets/stylesheets/mixins/forms.scss
@@ -170,6 +170,11 @@
     @include breakpoint(medium) {
       width: 75%;
     }
+
+    label {
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 }
 

--- a/lib/consul_form_builder.rb
+++ b/lib/consul_form_builder.rb
@@ -25,7 +25,10 @@ class ConsulFormBuilder < FoundationRailsHelper::FormBuilder
     else
       label = tag.span sanitize(label_text(attribute, options[:label])), class: "checkbox"
 
-      super(attribute, options.merge(label: label, label_options: label_options_for(options)))
+      super(attribute, options.merge(
+        label: label,
+        label_options: { class: "checkbox-label" }.merge(label_options_for(options))
+      ))
     end
   end
 

--- a/spec/lib/consul_form_builder_spec.rb
+++ b/spec/lib/consul_form_builder_spec.rb
@@ -4,7 +4,7 @@ describe ConsulFormBuilder do
   before do
     dummy_model = Class.new do
       include ActiveModel::Model
-      attr_accessor :title, :quality
+      attr_accessor :title, :quality, :published
     end
 
     stub_const("DummyModel", dummy_model)
@@ -72,6 +72,15 @@ describe ConsulFormBuilder do
 
       expect(page).to have_css ".help-text", text: "Ugly is neither good nor bad"
       expect(page).to have_css "select[aria-describedby='dummy_quality-help-text']"
+    end
+  end
+
+  describe "#check_box" do
+    it "adds a checkbox-label class to the label by default" do
+      render builder.check_box(:published)
+
+      expect(page).to have_css "label", count: 1
+      expect(page).to have_css ".checkbox-label"
     end
   end
 


### PR DESCRIPTION
## References

Reference to Pending notes: https://github.com/orgs/consul/projects/1#card-74165527

## Background

Currently we use a `display: block` style for labels containing check boxes inside them, and so the label has a width of 100%.

Since, on most browsers, clicking on a label has a similar effect as clicking on its associated input, this means that clicking on the blank space on the right of the label text will check/uncheck the checkbox. In usability tests we've seen people accidentally activating and deactivating options without noticing, due to this issue.

## Objectives

Check checkbox labels styles in the admin section in order to prevent accidental clicks.

