### PR TITLE
Make it easier to customize allowed parameters

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -22,14 +22,17 @@ class AccountController < ApplicationController
     end
 
     def account_params
-      attributes = if @account.organization?
-                     [:phone_number, :email_on_comment, :email_on_comment_reply, :newsletter,
-                      organization_attributes: [:name, :responsible_name]]
-                   else
-                     [:username, :public_activity, :public_interests, :email_on_comment,
-                      :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter,
-                      :official_position_badge, :recommended_debates, :recommended_proposals]
-                   end
-      params.require(:account).permit(*attributes)
+      params.require(:account).permit(allowed_params)
+    end
+
+    def allowed_params
+      if @account.organization?
+        [:phone_number, :email_on_comment, :email_on_comment_reply, :newsletter,
+         organization_attributes: [:name, :responsible_name]]
+      else
+        [:username, :public_activity, :public_interests, :email_on_comment,
+         :email_on_comment_reply, :email_on_direct_message, :email_digest, :newsletter,
+         :official_position_badge, :recommended_debates, :recommended_proposals]
+      end
     end
 end

--- a/app/controllers/admin/admin_notifications_controller.rb
+++ b/app/controllers/admin/admin_notifications_controller.rb
@@ -63,9 +63,11 @@ class Admin::AdminNotificationsController < Admin::BaseController
   private
 
     def admin_notification_params
-      attributes = [:link, :segment_recipient, translation_params(AdminNotification)]
+      params.require(:admin_notification).permit(allowed_params)
+    end
 
-      params.require(:admin_notification).permit(attributes)
+    def allowed_params
+      [:link, :segment_recipient, translation_params(AdminNotification)]
     end
 
     def resource

--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -41,6 +41,10 @@ class Admin::AdministratorsController < Admin::BaseController
   private
 
     def update_administrator_params
-      params.require(:administrator).permit(:description)
+      params.require(:administrator).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:description]
     end
 end

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -38,11 +38,13 @@ class Admin::BannersController < Admin::BaseController
   private
 
     def banner_params
-      attributes = [:target_url, :post_started_at, :post_ended_at,
-                    :background_color, :font_color,
-                    translation_params(Banner),
-                    web_section_ids: []]
-      params.require(:banner).permit(*attributes)
+      params.require(:banner).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:target_url, :post_started_at, :post_ended_at, :background_color, :font_color,
+       translation_params(Banner),
+       web_section_ids: []]
     end
 
     def banner_styles

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -91,10 +91,14 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def budget_investment_params
+      params.require(:budget_investment).permit(allowed_params)
+    end
+
+    def allowed_params
       attributes = [:external_url, :heading_id, :administrator_id, :tag_list,
                     :valuation_tag_list, :incompatible, :visible_to_valuators, :selected,
                     :milestone_tag_list, valuator_ids: [], valuator_group_ids: []]
-      params.require(:budget_investment).permit(attributes, translation_params(Budget::Investment))
+      [*attributes, translation_params(Budget::Investment)]
     end
 
     def load_budget

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -55,6 +55,10 @@ class Admin::BudgetsController < Admin::BaseController
   private
 
     def budget_params
+      params.require(:budget).permit(allowed_params)
+    end
+
+    def allowed_params
       descriptions = Budget::Phase::PHASE_KINDS.map { |p| "description_#{p}" }.map(&:to_sym)
       valid_attributes = [:phase,
                           :currency_symbol,
@@ -64,7 +68,8 @@ class Admin::BudgetsController < Admin::BaseController
                           valuator_ids: [],
                           image_attributes: image_attributes
       ] + descriptions
-      params.require(:budget).permit(*valid_attributes, *report_attributes, translation_params(Budget))
+
+      [*valid_attributes, *report_attributes, translation_params(Budget)]
     end
 
     def load_budget

--- a/app/controllers/admin/budgets_wizard/budgets_controller.rb
+++ b/app/controllers/admin/budgets_wizard/budgets_controller.rb
@@ -33,14 +33,14 @@ class Admin::BudgetsWizard::BudgetsController < Admin::BudgetsWizard::BaseContro
   private
 
     def budget_params
-      params.require(:budget).permit(*allowed_params)
+      params.require(:budget).permit(allowed_params)
     end
 
     def allowed_params
       valid_attributes = [:currency_symbol, :voting_style, :hide_money, administrator_ids: [],
                           valuator_ids: [], image_attributes: image_attributes]
 
-      valid_attributes + [translation_params(Budget)]
+      [*valid_attributes, translation_params(Budget)]
     end
 
     def groups_index

--- a/app/controllers/admin/dashboard/actions_controller.rb
+++ b/app/controllers/admin/dashboard/actions_controller.rb
@@ -54,14 +54,16 @@ class Admin::Dashboard::ActionsController < Admin::Dashboard::BaseController
     end
 
     def dashboard_action_params
-      params
-        .require(:dashboard_action)
-        .permit(
-          :title, :description, :short_description, :request_to_administrators, :day_offset,
-          :required_supports, :order, :active, :action_type, :published_proposal,
-          documents_attributes: document_attributes,
-          links_attributes: [:id, :label, :url, :_destroy]
-        )
+      params.require(:dashboard_action).permit(allowed_params)
+    end
+
+    def allowed_params
+      [
+        :title, :description, :short_description, :request_to_administrators, :day_offset,
+        :required_supports, :order, :active, :action_type, :published_proposal,
+        documents_attributes: document_attributes,
+        links_attributes: [:id, :label, :url, :_destroy]
+      ]
     end
 
     def dashboard_action

--- a/app/controllers/admin/geozones_controller.rb
+++ b/app/controllers/admin/geozones_controller.rb
@@ -43,6 +43,10 @@ class Admin::GeozonesController < Admin::BaseController
   private
 
     def geozone_params
-      params.require(:geozone).permit(:name, :external_code, :census_code, :html_map_coordinates)
+      params.require(:geozone).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:name, :external_code, :census_code, :html_map_coordinates]
     end
 end

--- a/app/controllers/admin/legislation/draft_versions_controller.rb
+++ b/app/controllers/admin/legislation/draft_versions_controller.rb
@@ -40,11 +40,11 @@ class Admin::Legislation::DraftVersionsController < Admin::Legislation::BaseCont
   private
 
     def draft_version_params
-      params.require(:legislation_draft_version).permit(
-        :status,
-        :final_version,
-        translation_params(Legislation::DraftVersion)
-      )
+      params.require(:legislation_draft_version).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:status, :final_version, translation_params(Legislation::DraftVersion)]
     end
 
     def resource

--- a/app/controllers/admin/legislation/homepages_controller.rb
+++ b/app/controllers/admin/legislation/homepages_controller.rb
@@ -24,11 +24,7 @@ class Admin::Legislation::HomepagesController < Admin::Legislation::BaseControll
     end
 
     def allowed_params
-      [
-        :homepage,
-        :homepage_enabled,
-        translation_params(::Legislation::Process)
-      ]
+      [:homepage, :homepage_enabled, translation_params(::Legislation::Process)]
     end
 
     def resource

--- a/app/controllers/admin/legislation/questions_controller.rb
+++ b/app/controllers/admin/legislation/questions_controller.rb
@@ -45,11 +45,15 @@ class Admin::Legislation::QuestionsController < Admin::Legislation::BaseControll
     end
 
     def question_params
-      params.require(:legislation_question).permit(
+      params.require(:legislation_question).permit(allowed_params)
+    end
+
+    def allowed_params
+      [
         translation_params(::Legislation::Question),
         question_options_attributes: [:id, :_destroy,
                                       translation_params(::Legislation::QuestionOption)]
-      )
+      ]
     end
 
     def resource

--- a/app/controllers/admin/local_census_records/imports_controller.rb
+++ b/app/controllers/admin/local_census_records/imports_controller.rb
@@ -16,6 +16,10 @@ class Admin::LocalCensusRecords::ImportsController < Admin::LocalCensusRecords::
     def local_census_records_import_params
       return {} unless params[:local_census_records_import].present?
 
-      params.require(:local_census_records_import).permit(:file)
+      params.require(:local_census_records_import).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:file]
     end
 end

--- a/app/controllers/admin/local_census_records_controller.rb
+++ b/app/controllers/admin/local_census_records_controller.rb
@@ -34,7 +34,10 @@ class Admin::LocalCensusRecordsController < Admin::BaseController
   private
 
     def local_census_record_params
-      attributes = [:document_type, :document_number, :date_of_birth, :postal_code]
-      params.require(:local_census_record).permit(*attributes)
+      params.require(:local_census_record).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:document_type, :document_number, :date_of_birth, :postal_code]
     end
 end

--- a/app/controllers/admin/milestone_statuses_controller.rb
+++ b/app/controllers/admin/milestone_statuses_controller.rb
@@ -42,6 +42,10 @@ class Admin::MilestoneStatusesController < Admin::BaseController
     end
 
     def status_params
-      params.require(:milestone_status).permit([:name, :description])
+      params.require(:milestone_status).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:name, :description]
     end
 end

--- a/app/controllers/admin/milestones_controller.rb
+++ b/app/controllers/admin/milestones_controller.rb
@@ -43,11 +43,15 @@ class Admin::MilestonesController < Admin::BaseController
   private
 
     def milestone_params
-      attributes = [:publication_date, :status_id,
-                    translation_params(Milestone),
-                    image_attributes: image_attributes, documents_attributes: document_attributes]
+      params.require(:milestone).permit(allowed_params)
+    end
 
-      params.require(:milestone).permit(*attributes)
+    def allowed_params
+      [
+        :publication_date, :status_id,
+        translation_params(Milestone),
+        image_attributes: image_attributes, documents_attributes: document_attributes
+      ]
     end
 
     def load_milestoneable

--- a/app/controllers/admin/newsletters_controller.rb
+++ b/app/controllers/admin/newsletters_controller.rb
@@ -60,6 +60,10 @@ class Admin::NewslettersController < Admin::BaseController
   private
 
     def newsletter_params
-      params.require(:newsletter).permit(:subject, :segment_recipient, :from, :body)
+      params.require(:newsletter).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:subject, :segment_recipient, :from, :body]
     end
 end

--- a/app/controllers/admin/officials_controller.rb
+++ b/app/controllers/admin/officials_controller.rb
@@ -26,6 +26,10 @@ class Admin::OfficialsController < Admin::BaseController
   private
 
     def user_params
-      params.require(:user).permit(:official_position, :official_level)
+      params.require(:user).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:official_position, :official_level]
     end
 end

--- a/app/controllers/admin/poll/active_polls_controller.rb
+++ b/app/controllers/admin/poll/active_polls_controller.rb
@@ -29,6 +29,10 @@ class Admin::Poll::ActivePollsController < Admin::Poll::BaseController
     end
 
     def active_poll_params
-      params.require(:active_poll).permit(translation_params(ActivePoll))
+      params.require(:active_poll).permit(allowed_params)
+    end
+
+    def allowed_params
+      [translation_params(ActivePoll)]
     end
 end

--- a/app/controllers/admin/poll/booths_controller.rb
+++ b/app/controllers/admin/poll/booths_controller.rb
@@ -39,6 +39,10 @@ class Admin::Poll::BoothsController < Admin::Poll::BaseController
   private
 
     def booth_params
-      params.require(:poll_booth).permit(:name, :location)
+      params.require(:poll_booth).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:name, :location]
     end
 end

--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -76,10 +76,14 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
     end
 
     def poll_params
+      params.require(:poll).permit(allowed_params)
+    end
+
+    def allowed_params
       attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :budget_id, :related_sdg_list,
                     geozone_ids: [], image_attributes: image_attributes]
 
-      params.require(:poll).permit(*attributes, *report_attributes, translation_params(Poll))
+      [*attributes, *report_attributes, translation_params(Poll)]
     end
 
     def search_params

--- a/app/controllers/admin/poll/questions/answers/images_controller.rb
+++ b/app/controllers/admin/poll/questions/answers/images_controller.rb
@@ -32,8 +32,11 @@ class Admin::Poll::Questions::Answers::ImagesController < Admin::Poll::BaseContr
   private
 
     def images_params
-      params.require(:poll_question_answer).permit(:answer_id,
-        images_attributes: image_attributes)
+      params.require(:poll_question_answer).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:answer_id, images_attributes: image_attributes]
     end
 
     def load_answer

--- a/app/controllers/admin/poll/questions/answers/videos_controller.rb
+++ b/app/controllers/admin/poll/questions/answers/videos_controller.rb
@@ -44,7 +44,11 @@ class Admin::Poll::Questions::Answers::VideosController < Admin::Poll::BaseContr
   private
 
     def video_params
-      params.require(:poll_question_answer_video).permit(:title, :url, :answer_id)
+      params.require(:poll_question_answer_video).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:title, :url, :answer_id]
     end
 
     def load_answer

--- a/app/controllers/admin/poll/questions/answers_controller.rb
+++ b/app/controllers/admin/poll/questions/answers_controller.rb
@@ -51,12 +51,14 @@ class Admin::Poll::Questions::AnswersController < Admin::Poll::BaseController
   private
 
     def answer_params
-      attributes = [:title, :description, :given_order, :question_id,
-        documents_attributes: document_attributes]
+      params.require(:poll_question_answer).permit(allowed_params)
+    end
 
-      params.require(:poll_question_answer).permit(
-        *attributes, translation_params(Poll::Question::Answer)
-      )
+    def allowed_params
+      attributes = [:title, :description, :given_order, :question_id,
+                    documents_attributes: document_attributes]
+
+      [*attributes, translation_params(Poll::Question::Answer)]
     end
 
     def load_answer

--- a/app/controllers/admin/poll/questions_controller.rb
+++ b/app/controllers/admin/poll/questions_controller.rb
@@ -54,8 +54,13 @@ class Admin::Poll::QuestionsController < Admin::Poll::BaseController
   private
 
     def question_params
+      params.require(:poll_question).permit(allowed_params)
+    end
+
+    def allowed_params
       attributes = [:poll_id, :question, :proposal_id]
-      params.require(:poll_question).permit(*attributes, translation_params(Poll::Question))
+
+      [*attributes, translation_params(Poll::Question)]
     end
 
     def search_params

--- a/app/controllers/admin/poll/shifts_controller.rb
+++ b/app/controllers/admin/poll/shifts_controller.rb
@@ -56,9 +56,13 @@ class Admin::Poll::ShiftsController < Admin::Poll::BaseController
     end
 
     def shift_params
-      date_attributes = [:vote_collection_date, :recount_scrutiny_date]
-      attributes = [:booth_id, :officer_id, :task, date: date_attributes]
-      shift_params = params.require(:shift).permit(*attributes)
+      shift_params = params.require(:shift).permit(allowed_params)
       shift_params.merge(date: shift_params[:date]["#{shift_params[:task]}_date".to_sym])
+    end
+
+    def allowed_params
+      date_attributes = [:vote_collection_date, :recount_scrutiny_date]
+
+      [:booth_id, :officer_id, :task, date: date_attributes]
     end
 end

--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -35,6 +35,10 @@ class Admin::ProposalsController < Admin::BaseController
     end
 
     def proposal_params
-      params.require(:proposal).permit(:selected)
+      params.require(:proposal).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:selected]
     end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -43,7 +43,11 @@ class Admin::SettingsController < Admin::BaseController
   private
 
     def settings_params
-      params.require(:setting).permit(:value)
+      params.require(:setting).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:value]
     end
 
     def content_type_params

--- a/app/controllers/admin/signature_sheets_controller.rb
+++ b/app/controllers/admin/signature_sheets_controller.rb
@@ -26,11 +26,10 @@ class Admin::SignatureSheetsController < Admin::BaseController
   private
 
     def signature_sheet_params
-      params.require(:signature_sheet).permit(
-        :signable_type,
-        :signable_id,
-        :title,
-        :required_fields_to_verify
-      )
+      params.require(:signature_sheet).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:signable_type, :signable_id, :title, :required_fields_to_verify]
     end
 end

--- a/app/controllers/admin/site_customization/content_blocks_controller.rb
+++ b/app/controllers/admin/site_customization/content_blocks_controller.rb
@@ -114,7 +114,11 @@ class Admin::SiteCustomization::ContentBlocksController < Admin::SiteCustomizati
   private
 
     def content_block_params
-      params.require(:site_customization_content_block).permit(:name, :locale, :body)
+      params.require(:site_customization_content_block).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:name, :locale, :body]
     end
 
     def is_heading_content_block?(name)

--- a/app/controllers/admin/site_customization/images_controller.rb
+++ b/app/controllers/admin/site_customization/images_controller.rb
@@ -38,6 +38,10 @@ class Admin::SiteCustomization::ImagesController < Admin::SiteCustomization::Bas
   private
 
     def image_params
-      params.require(:site_customization_image).permit(:image)
+      params.require(:site_customization_image).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:image]
     end
 end

--- a/app/controllers/admin/site_customization/pages_controller.rb
+++ b/app/controllers/admin/site_customization/pages_controller.rb
@@ -35,11 +35,13 @@ class Admin::SiteCustomization::PagesController < Admin::SiteCustomization::Base
   private
 
     def page_params
+      params.require(:site_customization_page).permit(allowed_params)
+    end
+
+    def allowed_params
       attributes = [:slug, :more_info_flag, :print_content_flag, :status]
 
-      params.require(:site_customization_page).permit(*attributes,
-        translation_params(SiteCustomization::Page)
-      )
+      [*attributes, translation_params(SiteCustomization::Page)]
     end
 
     def resource

--- a/app/controllers/admin/valuator_groups_controller.rb
+++ b/app/controllers/admin/valuator_groups_controller.rb
@@ -45,6 +45,10 @@ class Admin::ValuatorGroupsController < Admin::BaseController
   private
 
     def group_params
-      params.require(:valuator_group).permit(:name)
+      params.require(:valuator_group).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:name]
     end
 end

--- a/app/controllers/admin/valuators_controller.rb
+++ b/app/controllers/admin/valuators_controller.rb
@@ -44,7 +44,10 @@ class Admin::ValuatorsController < Admin::BaseController
 
     def valuator_params
       params[:valuator][:description] = nil if params[:valuator][:description].blank?
-      params.require(:valuator).permit(:user_id, :description, :valuator_group_id,
-                                       :can_comment, :can_edit_dossier)
+      params.require(:valuator).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:user_id, :description, :valuator_group_id, :can_comment, :can_edit_dossier]
     end
 end

--- a/app/controllers/admin/widget/feeds_controller.rb
+++ b/app/controllers/admin/widget/feeds_controller.rb
@@ -9,6 +9,10 @@ class Admin::Widget::FeedsController < Admin::BaseController
   private
 
     def feed_params
-      params.require(:widget_feed).permit(:limit)
+      params.require(:widget_feed).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:limit]
     end
 end

--- a/app/controllers/budgets/ballot/lines_controller.rb
+++ b/app/controllers/budgets/ballot/lines_controller.rb
@@ -32,7 +32,11 @@ module Budgets
       private
 
         def line_params
-          params.permit(:investment_id, :budget_id)
+          params.permit(allowed_params)
+        end
+
+        def allowed_params
+          [:investment_id, :budget_id]
         end
 
         def load_budget

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -118,12 +118,17 @@ module Budgets
       end
 
       def investment_params
+        params.require(:budget_investment).permit(allowed_params)
+      end
+
+      def allowed_params
         attributes = [:heading_id, :tag_list, :organization_name, :location,
                       :terms_of_service, :related_sdg_list,
                       image_attributes: image_attributes,
                       documents_attributes: document_attributes,
                       map_location_attributes: map_location_attributes]
-        params.require(:budget_investment).permit(attributes, translation_params(Budget::Investment))
+
+        [*attributes, translation_params(Budget::Investment)]
       end
 
       def load_ballot

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -54,8 +54,14 @@ class CommentsController < ApplicationController
   private
 
     def comment_params
-      params.require(:comment).permit(:commentable_type, :commentable_id, :parent_id,
-                                      :body, :as_moderator, :as_administrator, :valuation)
+      params.require(:comment).permit(allowed_params)
+    end
+
+    def allowed_params
+      [
+        :commentable_type, :commentable_id, :parent_id,
+        :body, :as_moderator, :as_administrator, :valuation
+      ]
     end
 
     def build_comment

--- a/app/controllers/concerns/admin/budget_groups_actions.rb
+++ b/app/controllers/concerns/admin/budget_groups_actions.rb
@@ -54,7 +54,12 @@ module Admin::BudgetGroupsActions
     end
 
     def budget_group_params
+      params.require(:budget_group).permit(allowed_params)
+    end
+
+    def allowed_params
       valid_attributes = [:max_votable_headings]
-      params.require(:budget_group).permit(*valid_attributes, translation_params(Budget::Group))
+
+      [*valid_attributes, translation_params(Budget::Group)]
     end
 end

--- a/app/controllers/concerns/admin/budget_headings_actions.rb
+++ b/app/controllers/concerns/admin/budget_headings_actions.rb
@@ -55,7 +55,12 @@ module Admin::BudgetHeadingsActions
     end
 
     def budget_heading_params
+      params.require(:budget_heading).permit(allowed_params)
+    end
+
+    def allowed_params
       valid_attributes = [:price, :population, :allow_custom_content, :latitude, :longitude, :max_ballot_lines]
-      params.require(:budget_heading).permit(*valid_attributes, translation_params(Budget::Heading))
+
+      [*valid_attributes, translation_params(Budget::Heading)]
     end
 end

--- a/app/controllers/concerns/admin/budget_phases_actions.rb
+++ b/app/controllers/concerns/admin/budget_phases_actions.rb
@@ -40,8 +40,13 @@ module Admin::BudgetPhasesActions
     end
 
     def budget_phase_params
+      params.require(:budget_phase).permit(allowed_params)
+    end
+
+    def allowed_params
       valid_attributes = [:starts_at, :ends_at, :enabled,
                           image_attributes: image_attributes]
-      params.require(:budget_phase).permit(*valid_attributes, translation_params(Budget::Phase))
+
+      [*valid_attributes, translation_params(Budget::Phase)]
     end
 end

--- a/app/controllers/concerns/admin/widget/cards_actions.rb
+++ b/app/controllers/concerns/admin/widget/cards_actions.rb
@@ -40,11 +40,15 @@ module Admin::Widget::CardsActions
   private
 
     def card_params
-      params.require(:widget_card).permit(
+      params.require(:widget_card).permit(allowed_params)
+    end
+
+    def allowed_params
+      [
         :link_url, :button_text, :button_url, :alignment, :header, :columns,
         translation_params(Widget::Card),
         image_attributes: image_attributes
-      )
+      ]
     end
 
     def header_card?

--- a/app/controllers/dashboard/polls_controller.rb
+++ b/app/controllers/dashboard/polls_controller.rb
@@ -56,10 +56,10 @@ class Dashboard::PollsController < Dashboard::BaseController
     end
 
     def poll_params
-      params.require(:poll).permit(poll_attributes)
+      params.require(:poll).permit(allowed_params)
     end
 
-    def poll_attributes
+    def allowed_params
       [:name, :starts_at, :ends_at, :description, :results_enabled,
        questions_attributes: question_attributes]
     end

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -53,8 +53,11 @@ class DebatesController < ApplicationController
   private
 
     def debate_params
-      attributes = [:tag_list, :terms_of_service, :related_sdg_list]
-      params.require(:debate).permit(attributes, translation_params(Debate))
+      params.require(:debate).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:tag_list, :terms_of_service, :related_sdg_list, translation_params(Debate)]
     end
 
     def resource_model

--- a/app/controllers/direct_messages_controller.rb
+++ b/app/controllers/direct_messages_controller.rb
@@ -27,7 +27,11 @@ class DirectMessagesController < ApplicationController
   private
 
     def direct_message_params
-      params.require(:direct_message).permit(:title, :body)
+      params.require(:direct_message).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:title, :body]
     end
 
     def parsed_params

--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -28,7 +28,13 @@ class DirectUploadsController < ApplicationController
 
     def direct_upload_params
       params.require(:direct_upload)
-            .permit(:resource, :resource_type, :resource_id, :resource_relation,
-                    :attachment, :cached_attachment, attachment_attributes: [])
+            .permit(allowed_params)
+    end
+
+    def allowed_params
+      [
+        :resource, :resource_type, :resource_id, :resource_relation,
+        :attachment, :cached_attachment, attachment_attributes: []
+      ]
     end
 end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -17,7 +17,11 @@ class FollowsController < ApplicationController
   private
 
     def follow_params
-      params.permit(:followable_type, :followable_id)
+      params.permit(allowed_params)
+    end
+
+    def allowed_params
+      [:followable_type, :followable_id]
     end
 
     def followable_translation_key(followable)

--- a/app/controllers/legislation/annotations_controller.rb
+++ b/app/controllers/legislation/annotations_controller.rb
@@ -95,7 +95,11 @@ class Legislation::AnnotationsController < Legislation::BaseController
     def annotation_params
       params
         .require(:legislation_annotation)
-        .permit(:quote, :text, ranges: [:start, :startOffset, :end, :endOffset])
+        .permit(allowed_params)
+    end
+
+    def allowed_params
+      [:quote, :text, ranges: [:start, :startOffset, :end, :endOffset]]
     end
 
     def track_event

--- a/app/controllers/legislation/answers_controller.rb
+++ b/app/controllers/legislation/answers_controller.rb
@@ -29,7 +29,11 @@ class Legislation::AnswersController < Legislation::BaseController
   private
 
     def answer_params
-      params.require(:legislation_answer).permit(:legislation_question_option_id)
+      params.require(:legislation_answer).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:legislation_question_option_id]
     end
 
     def track_event

--- a/app/controllers/legislation/proposals_controller.rb
+++ b/app/controllers/legislation/proposals_controller.rb
@@ -43,11 +43,17 @@ class Legislation::ProposalsController < Legislation::BaseController
   private
 
     def proposal_params
-      params.require(:legislation_proposal).permit(:legislation_process_id, :title,
-                    :summary, :description, :video_url, :tag_list,
-                    :terms_of_service, :geozone_id,
-                    image_attributes: image_attributes,
-                    documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id])
+      params.require(:legislation_proposal).permit(allowed_params)
+    end
+
+    def allowed_params
+      [
+        :legislation_process_id, :title,
+        :summary, :description, :video_url, :tag_list,
+        :terms_of_service, :geozone_id,
+        image_attributes: image_attributes,
+        documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id]
+      ]
     end
 
     def resource_model

--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -43,11 +43,16 @@ class Management::Budgets::InvestmentsController < Management::BaseController
   private
 
     def investment_params
+      params.require(:budget_investment).permit(allowed_params)
+    end
+
+    def allowed_params
       attributes = [:external_url, :heading_id, :tag_list, :organization_name, :location,
                     image_attributes: image_attributes,
                     documents_attributes: document_attributes,
                     map_location_attributes: map_location_attributes]
-      params.require(:budget_investment).permit(attributes, translation_params(Budget::Investment))
+
+      [*attributes, translation_params(Budget::Investment)]
     end
 
     def only_verified_users

--- a/app/controllers/management/document_verifications_controller.rb
+++ b/app/controllers/management/document_verifications_controller.rb
@@ -33,8 +33,11 @@ class Management::DocumentVerificationsController < Management::BaseController
   private
 
     def document_verification_params
-      params.require(:document_verification).permit(:document_type, :document_number,
-                                                    :date_of_birth, :postal_code)
+      params.require(:document_verification).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:document_type, :document_number, :date_of_birth, :postal_code]
     end
 
     def set_document

--- a/app/controllers/management/email_verifications_controller.rb
+++ b/app/controllers/management/email_verifications_controller.rb
@@ -16,6 +16,10 @@ class Management::EmailVerificationsController < Management::BaseController
   private
 
     def email_verification_params
-      params.require(:email_verification).permit(:document_type, :document_number, :email)
+      params.require(:email_verification).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:document_type, :document_number, :email]
     end
 end

--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -50,10 +50,15 @@ class Management::ProposalsController < Management::BaseController
     end
 
     def proposal_params
+      params.require(:proposal).permit(allowed_params)
+    end
+
+    def allowed_params
       attributes = [:video_url, :responsible_name, :tag_list,
                     :terms_of_service, :geozone_id,
                     map_location_attributes: map_location_attributes]
-      params.require(:proposal).permit(attributes, translation_params(Proposal))
+
+      [*attributes, translation_params(Proposal)]
     end
 
     def resource_model

--- a/app/controllers/management/users_controller.rb
+++ b/app/controllers/management/users_controller.rb
@@ -37,7 +37,11 @@ class Management::UsersController < Management::BaseController
   private
 
     def user_params
-      params.require(:user).permit(:document_type, :document_number, :username, :email, :date_of_birth)
+      params.require(:user).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:document_type, :document_number, :username, :email, :date_of_birth]
     end
 
     def destroy_session

--- a/app/controllers/officing/ballot_sheets_controller.rb
+++ b/app/controllers/officing/ballot_sheets_controller.rb
@@ -57,6 +57,10 @@ class Officing::BallotSheetsController < Officing::BaseController
     end
 
     def ballot_sheet_params
-      params.permit(:data, :poll_id, :officer_assignment_id)
+      params.permit(allowed_params)
+    end
+
+    def allowed_params
+      [:data, :poll_id, :officer_assignment_id]
     end
 end

--- a/app/controllers/officing/residence_controller.rb
+++ b/app/controllers/officing/residence_controller.rb
@@ -19,7 +19,10 @@ class Officing::ResidenceController < Officing::BaseController
   private
 
     def residence_params
-      params.require(:residence).permit(:document_number, :document_type, :year_of_birth,
-                                        :date_of_birth, :postal_code)
+      params.require(:residence).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:document_number, :document_type, :year_of_birth, :date_of_birth, :postal_code]
     end
 end

--- a/app/controllers/organizations/registrations_controller.rb
+++ b/app/controllers/organizations/registrations_controller.rb
@@ -29,7 +29,13 @@ class Organizations::RegistrationsController < Devise::RegistrationsController
   private
 
     def sign_up_params
-      params.require(:user).permit(:email, :password, :phone_number, :password_confirmation, :terms_of_service,
-                                   organization_attributes: [:name, :responsible_name])
+      params.require(:user).permit(allowed_params)
+    end
+
+    def allowed_params
+      [
+        :email, :password, :phone_number, :password_confirmation, :terms_of_service,
+        organization_attributes: [:name, :responsible_name]
+      ]
     end
 end

--- a/app/controllers/proposal_notifications_controller.rb
+++ b/app/controllers/proposal_notifications_controller.rb
@@ -27,6 +27,10 @@ class ProposalNotificationsController < ApplicationController
   private
 
     def proposal_notification_params
-      params.require(:proposal_notification).permit(:title, :body, :proposal_id)
+      params.require(:proposal_notification).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:title, :body, :proposal_id]
     end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -92,19 +92,26 @@ class ProposalsController < ApplicationController
   private
 
     def proposal_params
+      params.require(:proposal).permit(allowed_params)
+    end
+
+    def allowed_params
       attributes = [:video_url, :responsible_name, :tag_list, :terms_of_service,
                     :geozone_id, :related_sdg_list,
                     image_attributes: image_attributes,
                     documents_attributes: document_attributes,
                     map_location_attributes: map_location_attributes]
       translations_attributes = translation_params(Proposal, except: :retired_explanation)
-      params.require(:proposal).permit(attributes, translations_attributes)
+
+      [*attributes, translations_attributes]
     end
 
     def retired_params
-      attributes = [:retired_reason]
-      translations_attributes = translation_params(Proposal, only: :retired_explanation)
-      params.require(:proposal).permit(attributes, translations_attributes)
+      params.require(:proposal).permit(allowed_retired_params)
+    end
+
+    def allowed_retired_params
+      [:retired_reason, translation_params(Proposal, only: :retired_explanation)]
     end
 
     def resource_model

--- a/app/controllers/remote_translations_controller.rb
+++ b/app/controllers/remote_translations_controller.rb
@@ -14,7 +14,11 @@ class RemoteTranslationsController < ApplicationController
   private
 
     def remote_translations_params
-      params.permit(:remote_translations)
+      params.permit(allowed_params)
+    end
+
+    def allowed_params
+      [:remote_translations]
     end
 
     def set_remote_translations

--- a/app/controllers/sdg_management/local_targets_controller.rb
+++ b/app/controllers/sdg_management/local_targets_controller.rb
@@ -37,7 +37,12 @@ class SDGManagement::LocalTargetsController < SDGManagement::BaseController
   private
 
     def local_target_params
+      params.require(:sdg_local_target).permit(allowed_params)
+    end
+
+    def allowed_params
       translations_attributes = translation_params(::SDG::LocalTarget)
-      params.require(:sdg_local_target).permit(:code, :target_id, translations_attributes)
+
+      [:code, :target_id, translations_attributes]
     end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -47,7 +47,11 @@ class TopicsController < ApplicationController
   private
 
     def topic_params
-      params.require(:topic).permit(:title, :description)
+      params.require(:topic).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:title, :description]
     end
 
     def load_community

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -46,7 +46,11 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   protected
 
     def resource_params
-      params.require(resource_name).permit(:password, :password_confirmation, :email)
+      params.require(resource_name).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:password, :password_confirmation, :email]
     end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,9 +60,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     def sign_up_params
       params[:user].delete(:redeemable_code) if params[:user].present? && params[:user][:redeemable_code].blank?
-      params.require(:user).permit(:username, :email, :password,
-                                   :password_confirmation, :terms_of_service, :locale,
-                                   :redeemable_code)
+      params.require(:user).permit(allowed_params)
+    end
+
+    def allowed_params
+      [
+        :username, :email, :password,
+        :password_confirmation, :terms_of_service, :locale,
+        :redeemable_code
+      ]
     end
 
     def configure_permitted_parameters

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -98,9 +98,15 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     end
 
     def valuation_params
-      params.require(:budget_investment).permit(:price, :price_first_year, :price_explanation,
-                                                :feasibility, :unfeasibility_explanation,
-                                                :duration, :valuation_finished)
+      params.require(:budget_investment).permit(allowed_params)
+    end
+
+    def allowed_params
+      [
+        :price, :price_first_year, :price_explanation,
+        :feasibility, :unfeasibility_explanation,
+        :duration, :valuation_finished
+      ]
     end
 
     def restrict_access

--- a/app/controllers/verification/letter_controller.rb
+++ b/app/controllers/verification/letter_controller.rb
@@ -40,7 +40,11 @@ class Verification::LetterController < ApplicationController
   private
 
     def letter_params
-      params.require(:verification_letter).permit(:verification_code, :email, :password)
+      params.require(:verification_letter).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:verification_code, :email, :password]
     end
 
     def verify_phone!

--- a/app/controllers/verification/residence_controller.rb
+++ b/app/controllers/verification/residence_controller.rb
@@ -20,6 +20,10 @@ class Verification::ResidenceController < ApplicationController
   private
 
     def residence_params
-      params.require(:residence).permit(:document_number, :document_type, :date_of_birth, :postal_code, :terms_of_service)
+      params.require(:residence).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:document_number, :document_type, :date_of_birth, :postal_code, :terms_of_service]
     end
 end

--- a/app/controllers/verification/sms_controller.rb
+++ b/app/controllers/verification/sms_controller.rb
@@ -44,7 +44,11 @@ class Verification::SmsController < ApplicationController
   private
 
     def sms_params
-      params.require(:sms).permit(:phone, :confirmation_code)
+      params.require(:sms).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:phone, :confirmation_code]
     end
 
     def set_phone


### PR DESCRIPTION
## Background

When customizing CONSUL, one of the most common actions is adding a new field to a form.

This requires modifying the permitted/allowed parameters. However, in most cases, the method returning these parameters returned an instance of `ActionController::Parameters`, so adding more parameters to it wasn't easy.

So customizing the code required copying the method returning those parameters and adding the new ones. For example:

```
def something_params
  params.require(:something).permit(
    :one_consul_attribute,
    :another_consul_attribute,
    :my_custom_attribute
  )
end
```

This meant that, if the `something_params` method changed in CONSUL, the customization of this method had to be updated as well.

## Objectives

Make it possible to permit more parameters without copying the original method.

## Notes

Now this code can be customized without copying the original method:

```
alias_method :consul_allowed_params, :allowed_params

def allowed_params
  consul_allowed_params + [:my_custom_attribute]
end
```