### PR TITLE
Add and improve hint information related to phases duration

### DIFF
--- a/app/assets/stylesheets/admin/budgets/show.scss
+++ b/app/assets/stylesheets/admin/budgets/show.scss
@@ -13,4 +13,10 @@
   h4 {
     @include header-font-size(h3);
   }
+
+  .phases {
+    h3 {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -450,6 +450,10 @@ button,
 .help-text {
   line-height: rem-calc(20);
   margin-top: 0;
+
+  strong {
+    font-style: normal;
+  }
 }
 
 .menu-and-content {

--- a/app/components/admin/budget_phases/form_component.html.erb
+++ b/app/components/admin/budget_phases/form_component.html.erb
@@ -16,11 +16,11 @@
     </p>
 
     <div class="date-field">
-      <%= f.date_field :starts_at, id: "start_date" %>
+      <%= f.date_field :starts_at, id: "start_date", hint: t("admin.budget_phases.edit.dates_help_text") %>
     </div>
 
     <div class="date-field">
-      <%= f.date_field :ends_at, id: "end_date" %>
+      <%= f.date_field :ends_at, id: "end_date", hint: t("admin.budget_phases.edit.dates_help_text") %>
     </div>
   </fieldset>
 

--- a/app/components/admin/budget_phases/form_component.html.erb
+++ b/app/components/admin/budget_phases/form_component.html.erb
@@ -12,7 +12,7 @@
     </legend>
 
     <p class="help-text" id="phase_duration_description">
-      <%= t("admin.budget_phases.edit.duration_description") %>
+      <%= sanitize(t("admin.budget_phases.edit.duration_description")) %>
     </p>
 
     <div class="date-field">

--- a/app/components/admin/budgets/show_component.html.erb
+++ b/app/components/admin/budgets/show_component.html.erb
@@ -11,8 +11,9 @@
     <%= render Admin::Budgets::GroupsAndHeadingsComponent.new(budget) %>
   </section>
 
-  <section aria-labelledby="phases_header">
+  <section class="phases" aria-labelledby="phases_header">
     <h3 id="phases_header"><%= t("admin.budgets.edit.phases_caption") %></h3>
+    <span class="help-text"><%= t("admin.budgets.edit.phases_table_help_text") %></span>
     <%= render Admin::BudgetPhases::PhasesComponent.new(budget) %>
   </section>
 

--- a/app/views/admin/budget_phases/edit.html.erb
+++ b/app/views/admin/budget_phases/edit.html.erb
@@ -1,1 +1,7 @@
-<%= render Admin::BudgetsWizard::Phases::EditComponent.new(@phase) %>
+<%= back_link_to admin_budget_path(@budget) %>
+
+<h2><%= @budget.name %></h2>
+
+<h3><%= "#{t("admin.budget_phases.edit.title")} - #{@phase.name}" %></h3>
+
+<%= render "form" %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -113,6 +113,7 @@ en:
         delete: Delete budget
         phase: Phase
         phases_caption: "Phases"
+        phases_table_help_text: "The configuration of these phases is used for information purposes only. Its function is to define the phases information displayed on the public page of the participatory budget."
         duration: "Duration"
         enabled: Enabled
         actions: Actions
@@ -153,7 +154,7 @@ en:
         headings:
           multiple: "Headings are meant to divide the money of the participatory budget. Here you can add headings for this group and assign the amount of money that will be used for each heading."
           single: "Headings are meant to divide the money of the participatory budget. Since this budget will only contain one heading, this is the place where you stablish the money that will be spent in this participaroty budget."
-        phases: "Participatory budgets have different phases. Here you can enable or disable phases and also customize each individual phase."
+        phases: "Participatory budgets have different phases. Here you can enable or disable phases and also customize each individual phase. The configuration of these phases is used for information purposes only and will be displayed on the public page of the participatory budget."
       show:
         add_group: "Add group"
         add_heading: "Add heading"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -215,8 +215,8 @@ en:
         title: "Edit phase"
         description_help_text: This text will appear in the header when the phase is active
         duration: "Phase's duration"
-        duration_description: "The period of time this phase will be active."
-        enabled_help_text: This phase will be public in the budget's phases timeline, as well as active for any other purpose
+        duration_description: "These fields are used for information purposes only and <strong>do not trigger an automatic update of the active phase.</strong> In order to update it, edit the budget and select the active phase."
+        enabled_help_text: This phase will be public in the budget's phases timeline.
         image_description: "If an image is uploaded it will be displayed next to the description of this phase."
         main_call_to_action: "Main call to action (optional)"
         main_call_to_action_description: "This link will appear on main banner of this participatory budget when this phase is enabled and encourages your user to perform a specific action like creating a proposal, voting for existing ones, or learn more about the process."

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -213,6 +213,7 @@ en:
     budget_phases:
       edit:
         title: "Edit phase"
+        dates_help_text: "For information purposes only"
         description_help_text: This text will appear in the header when the phase is active
         duration: "Phase's duration"
         duration_description: "These fields are used for information purposes only and <strong>do not trigger an automatic update of the active phase.</strong> In order to update it, edit the budget and select the active phase."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -214,8 +214,8 @@ es:
       edit:
         description_help_text: Este texto aparecerá en la cabecera cuando la fase esté activa
         duration: "Duración de la fase"
-        duration_description: "El período de tiempo que esta fase estará activa."
-        enabled_help_text: Esta fase será pública en el calendario de fases del presupuesto y estará activa para otros propósitos
+        duration_description: "Estos campos se utilizan únicamente con fines informativos y <strong>no provocan una actualización automática de la fase activa.</strong> Para actualizarla, edita el presupuesto y selecciona la fase activa."
+        enabled_help_text: Esta fase será pública en el calendario de fases del presupuesto.
         image_description: "Si se proporciona una imagen se mostrará junto a la descripción de esta fase."
         main_call_to_action: "Enlace de acción principal (opcional)"
         main_call_to_action_description: "Este enlace aparecerá en la cabecera de este presupuesto participativo cuando esta fase esté activa y permite al usuario ejecutar una acción específica como crear una nueva propuesta, votar las existentes, o leer más sobre el funcionamiento de los presupuestos participativos."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -212,6 +212,7 @@ es:
         title: "Partidas de %{budget} / %{group}"
     budget_phases:
       edit:
+        dates_help_text: "Solo con fines informativos"
         description_help_text: Este texto aparecerá en la cabecera cuando la fase esté activa
         duration: "Duración de la fase"
         duration_description: "Estos campos se utilizan únicamente con fines informativos y <strong>no provocan una actualización automática de la fase activa.</strong> Para actualizarla, edita el presupuesto y selecciona la fase activa."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -113,6 +113,7 @@ es:
         delete: Eliminar presupuesto
         phase: Fase
         phases_caption: "Fases"
+        phases_table_help_text: "La configuración de estas fases se utiliza únicamente con fines informativos. Su función es definir la información de las fases que se muestra en la página pública del presupuesto participativo."
         duration: "Duración"
         enabled: Habilitada
         actions: Acciones
@@ -153,7 +154,7 @@ es:
         headings:
           multiple: "Las partidas sirven para dividir el dinero del presupuesto participativo. Aquí puedes ir añadiendo partidas para cada grupo y establecer la cantidad de dinero que se gastará en cada partida."
           single: "Las partidas sirven para dividir el dinero del presupuesto participativo. Como este presupuesto solo tendrá una partida aquí podrás establecer la cantidad de dinero que se gastará en este presupuesto participativo."
-        phases: "Los presupuestos participativos tienen distintas fases. Aquí puedes habilitar o deshabilitar fases y también personalizar cada una de las fases."
+        phases: "Los presupuestos participativos tienen distintas fases. Aquí puedes habilitar o deshabilitar fases y también personalizar cada una de las fases. La configuración de estas fases se utiliza únicamente con fines informativos y se mostrará en la página pública del presupuesto participativo."
       show:
         add_group: "Añadir grupo"
         add_heading: "Añadir partida"

--- a/spec/system/admin/budget_phases_spec.rb
+++ b/spec/system/admin/budget_phases_spec.rb
@@ -10,6 +10,7 @@ describe "Admin budget phases" do
       expect(page).to have_content "These fields are used for information purposes only and do not trigger "\
                                    "an automatic update of the active phase. In order to update it, edit "\
                                    "the budget and select the active phase."
+      expect(page).to have_content "For information purposes only"
 
       fill_in "start_date", with: Date.current + 1.day
       fill_in "end_date", with: Date.current + 12.days

--- a/spec/system/admin/budget_phases_spec.rb
+++ b/spec/system/admin/budget_phases_spec.rb
@@ -7,6 +7,10 @@ describe "Admin budget phases" do
     scenario "Update phase" do
       visit edit_admin_budget_budget_phase_path(budget, budget.current_phase)
 
+      expect(page).to have_content "These fields are used for information purposes only and do not trigger "\
+                                   "an automatic update of the active phase. In order to update it, edit "\
+                                   "the budget and select the active phase."
+
       fill_in "start_date", with: Date.current + 1.day
       fill_in "end_date", with: Date.current + 12.days
       fill_in_ckeditor "Description", with: "New description of the phase."

--- a/spec/system/admin/budget_phases_spec.rb
+++ b/spec/system/admin/budget_phases_spec.rb
@@ -37,7 +37,7 @@ describe "Admin budget phases" do
         within("tr", text: "Accepting projects") { click_link "Edit" }
       end
 
-      expect(page).to have_css "h2", exact_text: "Edit phase - Accepting projects"
+      expect(page).to have_css "h3", exact_text: "Edit phase - Accepting projects"
 
       fill_in "Name", with: "My phase custom name"
       click_button "Save changes"

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -235,6 +235,9 @@ describe "Admin budgets", :admin do
 
         visit admin_budget_path(budget)
 
+        expect(page).to have_content "The configuration of these phases is used for information purposes "\
+                                     "only. Its function is to define the phases information displayed "\
+                                     "on the public page of the participatory budget."
         expect(page).to have_table "Phases", with_cols: [
           [
             "Information",


### PR DESCRIPTION
## Objectives
Add a hint telling administrators that the dates for budget phases are informative and the phase has to be manually changed.

## Visual Changes
- Updated text on wizard phases step
![Updated text on wizard phases step](https://user-images.githubusercontent.com/16189/162932879-1d49323b-b449-4f42-b360-6dbff1a4d4d5.png)

- New text above phases table on admin budget show page
![New text above phases table on admin budget show page](https://user-images.githubusercontent.com/16189/162933239-4b2f7c7e-0eff-4dbf-9038-ae7915cc28fe.png)

- Updated hint text for Duration field and new hint texts for Dates fields
![Updated hint text for Duration field and new hint texts for Dates fields](https://user-images.githubusercontent.com/16189/162933467-b1a5e067-8b7a-4041-94a8-2d5f1894eedb.png)

- Do not render wizard component for edit phase page when we are not in the wizard
![Do not render wizard component for edit phase page when we are not in the wizard](https://user-images.githubusercontent.com/16189/162933741-cbafb5b1-0f79-4741-829e-cef791fe49b2.png)
