### PR TITLE
Remove and simplify API and votes-related code

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -37,12 +37,7 @@ class Comment < ApplicationRecord
   scope :sort_by_flags, -> { order(flags_count: :desc, updated_at: :desc) }
   scope :public_for_api, -> do
     not_valuations
-      .where(%{(comments.commentable_type = 'Debate' and comments.commentable_id in (?)) or
-            (comments.commentable_type = 'Proposal' and comments.commentable_id in (?)) or
-            (comments.commentable_type = 'Poll' and comments.commentable_id in (?))},
-          Debate.public_for_api.pluck(:id),
-          Proposal.public_for_api.pluck(:id),
-          Poll.public_for_api.pluck(:id))
+      .where(commentable: [Debate.public_for_api, Proposal.public_for_api, Poll.public_for_api])
   end
 
   scope :sort_by_most_voted, -> { order(confidence_score: :desc, created_at: :desc) }

--- a/app/models/proposal_notification.rb
+++ b/app/models/proposal_notification.rb
@@ -10,7 +10,7 @@ class ProposalNotification < ApplicationRecord
   validates :proposal, presence: true
   validate :minimum_interval
 
-  scope :public_for_api,     -> { where(proposal_id: Proposal.public_for_api.pluck(:id)) }
+  scope :public_for_api,     -> { where(proposal: Proposal.public_for_api) }
   scope :sort_by_created_at, -> { reorder(created_at: :desc) }
   scope :sort_by_moderated,  -> { reorder(moderated: :desc) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -153,7 +153,7 @@ class User < ApplicationRecord
   end
 
   def voted_in_group?(group)
-    votes.for_budget_investments(Budget::Investment.where(group: group)).exists?
+    votes.where(votable: Budget::Investment.where(group: group)).exists?
   end
 
   def headings_voted_within_group(group)
@@ -161,7 +161,7 @@ class User < ApplicationRecord
   end
 
   def voted_investments
-    Budget::Investment.where(id: votes.for_budget_investments.pluck(:votable_id))
+    Budget::Investment.where(id: votes.where(votable: Budget::Investment.all).pluck(:votable_id))
   end
 
   def administrator?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -368,15 +368,15 @@ class User < ApplicationRecord
   delegate :can?, :cannot?, to: :ability
 
   def public_proposals
-    public_activity? ? proposals : User.none
+    public_activity? ? proposals : proposals.none
   end
 
   def public_debates
-    public_activity? ? debates : User.none
+    public_activity? ? debates : debates.none
   end
 
   def public_comments
-    public_activity? ? comments : User.none
+    public_activity? ? comments : comments.none
   end
 
   # overwritting of Devise method to allow login using email OR username

--- a/config/initializers/vote_extensions.rb
+++ b/config/initializers/vote_extensions.rb
@@ -13,18 +13,6 @@ ActsAsVotable::Vote.class_eval do
           Comment.public_for_api.pluck(:id))
   end
 
-  def self.for_debates(debates)
-    where(votable_type: "Debate", votable_id: debates)
-  end
-
-  def self.for_proposals(proposals)
-    where(votable_type: "Proposal", votable_id: proposals)
-  end
-
-  def self.for_legislation_proposals(proposals)
-    where(votable_type: "Legislation::Proposal", votable_id: proposals)
-  end
-
   def self.for_budget_investments(budget_investments = Budget::Investment.all)
     where(votable_type: "Budget::Investment", votable_id: budget_investments)
   end

--- a/config/initializers/vote_extensions.rb
+++ b/config/initializers/vote_extensions.rb
@@ -13,10 +13,6 @@ ActsAsVotable::Vote.class_eval do
           Comment.public_for_api.pluck(:id))
   end
 
-  def self.for_budget_investments(budget_investments = Budget::Investment.all)
-    where(votable_type: "Budget::Investment", votable_id: budget_investments)
-  end
-
   def value
     vote_flag
   end

--- a/config/initializers/vote_extensions.rb
+++ b/config/initializers/vote_extensions.rb
@@ -5,12 +5,7 @@ ActsAsVotable::Vote.class_eval do
   belongs_to :budget_investment, foreign_key: "votable_id", class_name: "Budget::Investment"
 
   scope :public_for_api, -> do
-    where(%{(votes.votable_type = 'Debate' and votes.votable_id in (?)) or
-            (votes.votable_type = 'Proposal' and votes.votable_id in (?)) or
-            (votes.votable_type = 'Comment' and votes.votable_id in (?))},
-          Debate.public_for_api.pluck(:id),
-          Proposal.public_for_api.pluck(:id),
-          Comment.public_for_api.pluck(:id))
+    where(votable: [Debate.public_for_api, Proposal.public_for_api, Comment.public_for_api])
   end
 
   def value

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -1,32 +1,6 @@
 require "rails_helper"
 
 describe Vote do
-  describe "#for_debates" do
-    it "does not returns votes for other votables" do
-      debate = create(:debate)
-      create(:vote, votable: create(:comment))
-
-      expect(Vote.for_debates(debate).count).to eq(0)
-    end
-
-    it "returns votes only for debates in parameters" do
-      debate1 = create(:debate, voters: [create(:user)])
-      debate2 = create(:debate)
-
-      expect(Vote.for_debates(debate1).count).to eq(1)
-      expect(Vote.for_debates(debate2).count).to eq(0)
-    end
-
-    it "accepts more than 1 debate" do
-      debate1 = create(:debate, voters: [create(:user)])
-      debate2 = create(:debate)
-      debate3 = create(:debate, voters: [create(:user)])
-
-      expect(Vote.for_debates([debate1, debate2]).count).to eq(1)
-      expect(Vote.for_debates([debate1, debate3]).count).to eq(2)
-    end
-  end
-
   describe "#value" do
     it "returns vote flag" do
       vote = create(:vote, vote_flag: true)


### PR DESCRIPTION
## References

* Some methods weren't used since commit b98244afd from pull request #4763
* We did a similar simplification in commit 2e863fdc51

## Objectives

* Remove unused code
* Simplify scopes to get public votes and comments
* Fix typos in API public methods