### PR TITLE
Remove roles when block or delete users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -230,6 +230,7 @@ class User < ApplicationRecord
     Proposal.hide_all proposal_ids
     Budget::Investment.hide_all budget_investment_ids
     ProposalNotification.hide_all ProposalNotification.where(author_id: id).ids
+    remove_roles
   end
 
   def full_restore
@@ -263,10 +264,19 @@ class User < ApplicationRecord
       unconfirmed_phone: nil
     )
     identities.destroy_all
+    remove_roles
   end
 
   def erased?
     erased_at.present?
+  end
+
+  def remove_roles
+    administrator&.destroy!
+    valuator&.destroy!
+    moderator&.destroy!
+    manager&.destroy!
+    sdg_manager&.destroy!
   end
 
   def take_votes_if_erased_document(document_number, document_type)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -538,6 +538,19 @@ describe User do
 
       expect(Identity.exists?(identity.id)).not_to be
     end
+
+    it "removes all user roles" do
+      user = create(:user)
+      [:administrator, :moderator, :manager, :sdg_manager, :valuator].each do |role|
+        create(role, user: user)
+      end
+
+      expect { user.erase }.to change { Administrator.count }.by(-1)
+                           .and change { Moderator.count }.by(-1)
+                           .and change { Manager.count }.by(-1)
+                           .and change { SDG::Manager.count }.by(-1)
+                           .and change { Valuator.count }.by(-1)
+    end
   end
 
   describe "#take_votes_from" do
@@ -748,6 +761,19 @@ describe User do
 
       expect(Legislation::Proposal.all).to eq [other_proposal]
       expect(Legislation::Proposal.with_hidden).to match_array [proposal, other_proposal]
+    end
+
+    it "removes all user roles" do
+      user = create(:user)
+      [:administrator, :moderator, :manager, :sdg_manager, :valuator].each do |role|
+        create(role, user: user)
+      end
+
+      expect { user.block }.to change { Administrator.count }.by(-1)
+                           .and change { Moderator.count }.by(-1)
+                           .and change { Manager.count }.by(-1)
+                           .and change { SDG::Manager.count }.by(-1)
+                           .and change { Valuator.count }.by(-1)
     end
   end
 

--- a/spec/system/moderation/users_spec.rb
+++ b/spec/system/moderation/users_spec.rb
@@ -94,4 +94,26 @@ describe "Moderate users" do
       expect(page).to have_content "Hidden"
     end
   end
+
+  scenario "Block a user removes all their roles" do
+    admin = create(:administrator).user
+    user = create(:user, username: "Budget administrator")
+    budget = create(:budget, administrators: [create(:administrator, user: user)])
+    debate = create(:debate, author: user)
+    login_as(admin)
+    visit admin_budget_budget_investments_path(budget)
+
+    expect(page).to have_select options: ["All administrators", "Budget administrator"]
+
+    visit debate_path(debate)
+    within("#debate_#{debate.id}") do
+      accept_confirm { click_button "Block author" }
+    end
+
+    expect(page).to have_current_path(debates_path)
+
+    visit admin_budget_budget_investments_path(budget)
+
+    expect(page).to have_select options: ["All administrators"]
+  end
 end


### PR DESCRIPTION
## References

* This PR resolves https://github.com/consul/consul/issues/3988
* Depends on pull request #4823

## Objectives

With these changes, when a user is blocked or delete their account, all their roles (Administrator, Valuator, Moderator, Manager and SDG Manager) are removed.