### PR TITLE
Show budgets map only if feature is enabled

### DIFF
--- a/app/components/budgets/budget_component.html.erb
+++ b/app/components/budgets/budget_component.html.erb
@@ -33,13 +33,7 @@
       <% end %>
 
       <%= render Budgets::SupportsInfoComponent.new(budget) %>
-
-      <% unless budget.informing? %>
-        <div class="map inline">
-          <h2><%= t("budgets.index.map") %></h2>
-          <%= render_map(nil, "budgets", false, nil, coordinates) %>
-        </div>
-      <% end %>
+      <%= render Budgets::MapComponent.new(budget) %>
     </div>
   </div>
 </div>

--- a/app/components/budgets/budget_component.rb
+++ b/app/components/budgets/budget_component.rb
@@ -1,5 +1,4 @@
 class Budgets::BudgetComponent < ApplicationComponent
-  delegate :wysiwyg, :auto_link_already_sanitized_html, to: :helpers
   attr_reader :budget
 
   def initialize(budget)

--- a/app/components/budgets/budget_component.rb
+++ b/app/components/budgets/budget_component.rb
@@ -1,22 +1,8 @@
 class Budgets::BudgetComponent < ApplicationComponent
-  delegate :wysiwyg, :auto_link_already_sanitized_html, :render_map, to: :helpers
+  delegate :wysiwyg, :auto_link_already_sanitized_html, to: :helpers
   attr_reader :budget
 
   def initialize(budget)
     @budget = budget
   end
-
-  private
-
-    def coordinates
-      return unless budget.present?
-
-      if budget.publishing_prices_or_later? && budget.investments.selected.any?
-        investments = budget.investments.selected
-      else
-        investments = budget.investments
-      end
-
-      MapLocation.where(investment_id: investments).map(&:json_data)
-    end
 end

--- a/app/components/budgets/map_component.html.erb
+++ b/app/components/budgets/map_component.html.erb
@@ -1,0 +1,4 @@
+<div class="map inline">
+  <h2><%= t("budgets.index.map") %></h2>
+  <%= render_map(nil, "budgets", false, nil, coordinates) %>
+</div>

--- a/app/components/budgets/map_component.rb
+++ b/app/components/budgets/map_component.rb
@@ -1,0 +1,26 @@
+class Budgets::MapComponent < ApplicationComponent
+  delegate :render_map, to: :helpers
+  attr_reader :budget
+
+  def initialize(budget)
+    @budget = budget
+  end
+
+  def render?
+    !budget.informing?
+  end
+
+  private
+
+    def coordinates
+      return unless budget.present?
+
+      if budget.publishing_prices_or_later? && budget.investments.selected.any?
+        investments = budget.investments.selected
+      else
+        investments = budget.investments
+      end
+
+      MapLocation.where(investment_id: investments).map(&:json_data)
+    end
+end

--- a/app/components/budgets/map_component.rb
+++ b/app/components/budgets/map_component.rb
@@ -7,7 +7,7 @@ class Budgets::MapComponent < ApplicationComponent
   end
 
   def render?
-    !budget.informing?
+    feature?(:map) && !budget.informing?
   end
 
   private

--- a/app/models/concerns/mappable.rb
+++ b/app/models/concerns/mappable.rb
@@ -4,9 +4,5 @@ module Mappable
   included do
     has_one :map_location, dependent: :destroy
     accepts_nested_attributes_for :map_location, allow_destroy: true, reject_if: :all_blank
-
-    def feature_maps?
-      Setting["feature.map"].present?
-    end
   end
 end

--- a/spec/components/budgets/map_component_spec.rb
+++ b/spec/components/budgets/map_component_spec.rb
@@ -4,7 +4,8 @@ describe Budgets::MapComponent do
   let(:budget) { build(:budget) }
 
   describe "#render?" do
-    it "is rendered after the informing phase" do
+    it "is rendered after the informing phase when the map feature is enabled" do
+      Setting["feature.map"] = true
       budget.phase = "accepting"
 
       render_inline Budgets::MapComponent.new(budget)
@@ -13,7 +14,17 @@ describe Budgets::MapComponent do
     end
 
     it "is not rendered during the informing phase" do
+      Setting["feature.map"] = true
       budget.phase = "informing"
+
+      render_inline Budgets::MapComponent.new(budget)
+
+      expect(page).not_to be_rendered
+    end
+
+    it "is not rendered when the map feature is disabled" do
+      Setting["feature.map"] = false
+      budget.phase = "accepting"
 
       render_inline Budgets::MapComponent.new(budget)
 

--- a/spec/components/budgets/map_component_spec.rb
+++ b/spec/components/budgets/map_component_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Budgets::MapComponent do
+  let(:budget) { build(:budget) }
+
+  describe "#render?" do
+    it "is rendered after the informing phase" do
+      budget.phase = "accepting"
+
+      render_inline Budgets::MapComponent.new(budget)
+
+      expect(page.first("div.map")).to have_content "located geographically"
+    end
+
+    it "is not rendered during the informing phase" do
+      budget.phase = "informing"
+
+      render_inline Budgets::MapComponent.new(budget)
+
+      expect(page).not_to be_rendered
+    end
+  end
+end

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -100,8 +100,6 @@ describe "Budgets" do
         expect(page).not_to have_link("List of all investment projects")
         expect(page).not_to have_link("List of all unfeasible investment projects")
         expect(page).not_to have_link("List of all investment projects not selected for balloting")
-
-        expect(page).not_to have_css("div.map")
       end
     end
 
@@ -114,8 +112,6 @@ describe "Budgets" do
       within("#budget_info") do
         expect(page).not_to have_link heading.name
         expect(page).to have_content "#{heading.name}\n€1,000,000"
-
-        expect(page).to have_css("div.map")
       end
     end
 
@@ -342,7 +338,7 @@ describe "Budgets" do
         }
       end
 
-      allow_any_instance_of(Budgets::BudgetComponent).to receive(:coordinates).and_return(coordinates)
+      allow_any_instance_of(Budgets::MapComponent).to receive(:coordinates).and_return(coordinates)
 
       visit budgets_path
 

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -96,10 +96,6 @@ describe "Budgets" do
       within("#budget_info") do
         expect(page).not_to have_link heading.name
         expect(page).to have_content "#{heading.name}\n€1,000,000"
-
-        expect(page).not_to have_link("List of all investment projects")
-        expect(page).not_to have_link("List of all unfeasible investment projects")
-        expect(page).not_to have_link("List of all investment projects not selected for balloting")
       end
     end
 


### PR DESCRIPTION
## Objectives

The [Participatory budgets page](https://demo.consulproject.org/budgets) shows a map with Budget investments' proposals located geographically. 🗺️ 

This PR hides the map if the setting "Proposals and budget investments geolocation" (`Setting["feature.map"]`) is disabled to avoid showing an empty map. 

