### PR TITLE
Fix Registration Without E-Mail

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,6 +12,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def create
     build_resource(sign_up_params)
+    resource.registering_from_web = true
+
     if resource.valid?
       super
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   include Verification
+  attribute :registering_from_web, default: false
 
   devise :database_authenticatable, :registerable, :confirmable, :recoverable, :rememberable,
          :trackable, :validatable, :omniauthable, :password_expirable, :secure_validatable,
@@ -333,7 +334,7 @@ class User < ApplicationRecord
   end
 
   def email_required?
-    !erased? && unverified?
+    !erased? && (unverified? || registering_from_web)
   end
 
   def locale

--- a/spec/system/registration_form_spec.rb
+++ b/spec/system/registration_form_spec.rb
@@ -23,6 +23,21 @@ describe "Registration form" do
     expect(page).to have_content I18n.t("devise_views.users.registrations.new.username_is_available")
   end
 
+  scenario "do not save blank user_email" do
+    Setting["feature.user.skip_verification"] = true
+    visit new_user_registration_path
+
+    fill_in "user_username",              with: "NewUser"
+    fill_in "user_password",              with: "password"
+    fill_in "user_password_confirmation", with: "password"
+
+    check "user_terms_of_service"
+
+    click_button "Register"
+
+    expect(page).to have_content "can't be blank"
+  end
+
   scenario "do not save blank redeemable codes" do
     visit new_user_registration_path(use_redeemable_code: "true")
 


### PR DESCRIPTION
## References

Related to the issue #4779 

## Objectives
Do not allow the form to be sent if the email is not filled in

## Visual Changes

When the user tries to submit the form without filling the email, it shows a message.
![image](https://user-images.githubusercontent.com/22120173/166975687-5440c1e4-0748-491b-ba34-2d29425d57e7.png)



## Notes

Some messages about deprecations:
```
!global assignments won't be able to declare new variables in future versions.
Consider adding `$alert-color: null` at the top level.
```
```
!global assignments won't be able to declare new variables in future versions.
Consider adding `$primary-color: null` at the top level.
```
```
!global assignments won't be able to declare new variables in future versions.
Consider adding `$secondary-color: null` at the top level.
```
```
!global assignments won't be able to declare new variables in future versions.
Consider adding `$success-color: null` at the top level.
```
```
!global assignments won't be able to declare new variables in future versions.
Consider adding `$warning-color: null` at the top level.
```
```
!global assignments won't be able to declare new variables in future versions.
Consider adding `$-zf-size: null` at the top level.
```
```
!global assignments won't be able to declare new variables in future versions.
Consider adding `$-zf-bp-value: null` at the top level.
```