### PR TITLE
Fix background image from Participatory Budgets page

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -989,6 +989,7 @@
   min-height: $line-height * 25;
   padding-bottom: $line-height;
   padding-top: $line-height * 4;
+  z-index: -5;
 
   &.with-background-image {
     background-position: center;


### PR DESCRIPTION
## References

Closes #4786

## Objectives

Allow to use a full background image in Participatory Budgeting

## Visual Changes

![image](https://user-images.githubusercontent.com/22120173/165516909-3191954f-7eb7-464c-8784-5faacdbbf068.png)

## Notes

In the issue description, it is informed about the _Foundation class_ already allowing this effect. However, in the file _/app/assets/stylesheets/layout.scss_ it is possible to notice that there is a limitation in the _body_ with the value of _$body-margin_ .This value is set in the file  app/assets/stylesheets/_consul_settings.scss , thus preventing the image from expanding to the entire background width. To fix it, tests were done and the best way found was to add the _z-index_ to the _budget-header_