### PR TITLE
Add development instructions regarding i18n translations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ If you'd like us to review your pull request in good spirits, please follow our 
 * Our CI will check whether the rest of the application is still working properly; check its build and make sure all tests are passing
 * Run `bundle exec pronto run` and fix any issues it reports; these issues will also be automatically reported on the pull request
 * Follow [the seven rules of a great commit message](https://chris.beams.io/posts/git-commit/)
+* Add or modify i18n translations only in the base languages, English (en) and Spanish (es); we manage all other languages through the [Crowdin integration](https://crowdin.com/project/consul).
 
 When we review your pull request and ask for changes, if you're proficient using `git rebase` edit existing commits instead of adding new ones. If you aren't proficient with `git rebase`, ignore this point.
 

--- a/CONTRIBUTING_ES.md
+++ b/CONTRIBUTING_ES.md
@@ -36,6 +36,7 @@ Si quieres que revisemos tu código con una sonrisa, por favor sigue nuestras co
 * Los tests se ejecutarán automáticamente para comprobar que el resto de la aplicación sigue funcionando; asegúrate de que los tests pasan
 * Ejecuta `bundle exec pronto run` y arregla los problemas de los que informe (si es que hay alguno)
 * Sigue [las siete reglas para un gran mensaje de commit](https://chris.beams.io/posts/git-commit/)
+* Añade o modifica las traducciones i18n sólo en los idiomas base, inglés (en) y español (es); todos los demás idiomas los gestionamos a través de la [integración de Crowdin](https://crowdin.com/project/consul).
 
 Cuando revisemos tu código y te pidamos que cambies alguna cosa, si tienes experiencia con `git rebase` edita los commits existentes en vez de añadir más. Si no tienes experiencia con `git rebase`, puedes saltarte este punto.
 


### PR DESCRIPTION
## Objectives

Explain to contributors how to deal with i18n translations.

Avoid contributors adding translations for all the existing languages. We only add/update English (en) and Spanish (es) translations. We manage all the other languages through the [Crowdin integration](https://crowdin.com/project/consul).