### PR TITLE
Giving the administrator the option to hide polls

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1540,7 +1540,8 @@
     &.cant-answer::after,
     &.not-logged-in::after,
     &.already-answer::after,
-    &.unverified::after {
+    &.unverified::after,
+    &.draft-poll::after {
       font-family: "icons" !important;
       left: 34px;
       position: absolute;
@@ -1589,6 +1590,15 @@
       &::after {
         color: $color-success;
         content: "\59";
+      }
+    }
+
+    &.draft-poll {
+      border-right: 60px solid $border;
+
+      &::after {
+        color: $text-medium;
+        content: "\70";
       }
     }
   }

--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -80,7 +80,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
     end
 
     def allowed_params
-      attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :budget_id, :related_sdg_list,
+      attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :budget_id, :related_sdg_list, :published,
                     geozone_ids: [], image_attributes: image_attributes]
 
       [*attributes, *report_attributes, translation_params(Poll)]

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -13,7 +13,10 @@ class PollsController < ApplicationController
   has_orders %w[most_voted newest oldest], only: :show
 
   def index
+    administrator = current_user ? current_user.administrator? : false
+
     @polls = Kaminari.paginate_array(
+      administrator ? @polls.created_by_admin.not_budget.send(@current_filter).includes(:geozones).sort_for_list(current_user) :
       @polls.created_by_admin.not_budget.published.send(@current_filter).includes(:geozones).sort_for_list(current_user)
     ).page(params[:page])
   end

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -14,7 +14,7 @@ class PollsController < ApplicationController
 
   def index
     @polls = Kaminari.paginate_array(
-      @polls.created_by_admin.not_budget.send(@current_filter).includes(:geozones).sort_for_list(current_user)
+      @polls.created_by_admin.not_budget.published.send(@current_filter).includes(:geozones).sort_for_list(current_user)
     ).page(params[:page])
   end
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -44,4 +44,8 @@ module AdminHelper
   def namespace
     controller.class.name.split("::").first.underscore
   end
+
+  def polls_has_votes(poll)
+    ::Poll::Voter.where(poll: poll).any?
+  end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -37,6 +37,7 @@ class Poll < ApplicationRecord
 
   validates_translation :name, presence: true
   validate :date_range
+  validate :published_checkbox
   validate :only_one_active, unless: :public?
 
   accepts_nested_attributes_for :questions, reject_if: :all_blank, allow_destroy: true
@@ -143,6 +144,12 @@ class Poll < ApplicationRecord
     end
   end
 
+  def published_checkbox
+    if !published && polls_has_votes?(self)
+      errors.add(:published, I18n.t("errors.messages.invalid_published_value"))
+    end
+  end
+
   def generate_slug?
     slug.nil?
   end
@@ -193,5 +200,9 @@ class Poll < ApplicationRecord
     else
       0
     end
+  end
+
+  def polls_has_votes?(poll)
+    Poll::Voter.where(poll: poll).any?
   end
 end

--- a/app/views/admin/poll/polls/_form.html.erb
+++ b/app/views/admin/poll/polls/_form.html.erb
@@ -63,6 +63,14 @@
 
   <div class="row">
     <div class="clear">
+      <div class="margin-top small-6 medium-6 column">
+        <%= f.check_box :published %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="clear">
       <div class="small-12 medium-4 large-2 column">
         <%= f.submit t("admin.polls.#{admin_submit_action(@poll)}.submit_button"),
                      class: "button success expanded margin-top" %>

--- a/app/views/admin/poll/polls/_form.html.erb
+++ b/app/views/admin/poll/polls/_form.html.erb
@@ -22,7 +22,7 @@
       </div>
 
       <div class="small-12 column">
-        <%= translations_form.text_area :summary, rows: 4 %>
+        <%= translations_form.text_field :summary, rows: 4 %>
       </div>
 
       <div class="small-12 column">
@@ -64,7 +64,7 @@
   <div class="row">
     <div class="clear">
       <div class="margin-top small-6 medium-6 column">
-        <%= f.check_box :published %>
+        <%= f.check_box :published, :disabled => polls_has_votes(@poll) %>
       </div>
     </div>
   </div>

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -17,6 +17,10 @@
         <div class="icon-poll-answer already-answer" title="<%= t("polls.index.already_answer") %>">
           <span class="show-for-sr"><%= t("polls.index.already_answer") %></span>
         </div>
+      <% elsif current_user.administrator? && !poll.published %>
+        <div class="icon-poll-answer draft-poll" title="<%= t("polls.index.already_answer") %>">
+          <span class="show-for-sr"><%= t("polls.index.already_answer") %></span>
+        </div>
       <% end %>
     <% end %>
     <div class="row" data-equalizer data-equalize-on="medium">

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -300,6 +300,7 @@ en:
         geozone_restricted: "Restricted by geozone"
         summary: "Summary"
         description: "Description"
+        published: "Publish poll"
       active_poll/translation:
         description: "Description"
       poll/booth:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -300,7 +300,7 @@ en:
         geozone_restricted: "Restricted by geozone"
         summary: "Summary"
         description: "Description"
-        published: "Publish poll"
+        published: "Published"
       active_poll/translation:
         description: "Description"
       poll/booth:

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -150,6 +150,7 @@ en:
       allowed_file_content_types: "content type must be one of %{types}"
       user_not_found: User not found
       invalid_date_range: "Invalid date range"
+      invalid_published_value: "You cannot unpublish a poll that has votes"
   form:
     accept_terms: I agree to the %{policy} and the %{conditions}
     accept_terms_title: I agree to the Privacy Policy and the Terms and conditions of use

--- a/config/locales/en/responders.yml
+++ b/config/locales/en/responders.yml
@@ -30,6 +30,7 @@ en:
         topic: "Topic updated successfully."
         valuator_group: "Valuator group updated successfully"
         translation: "Translation updated successfully"
+        unable_to_unpublish: "You cannot unpublish a poll that has votes"
       destroy:
         budget_investment: "Investment project deleted succesfully."
         error: "Could not delete"

--- a/spec/controllers/admin/poll/polls_controller_spec.rb
+++ b/spec/controllers/admin/poll/polls_controller_spec.rb
@@ -8,4 +8,35 @@ describe Admin::Poll::PollsController, :admin do
       expect { get :index }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
   end
+
+  describe "PATCH update" do
+    it "renders to edit_admin_poll_path when trying to unpublish a poll with votes" do
+      poll = create(:poll, :published)
+      create(:poll_question, poll: poll)
+      create(:poll_voter, :from_booth, :valid_document, poll: poll)
+
+      poll.published = false
+
+      patch :update, params: {
+        id: poll.id,
+        poll: poll.attributes
+      }
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "redirect to admin_poll_path when unpublish a poll without votes" do
+      poll = create(:poll, :published)
+      create(:poll_question, poll: poll)
+
+      poll.published = false
+
+      patch :update, params: {
+        id: poll.id,
+        poll: poll.attributes
+      }
+
+      expect(response).to have_http_status(:redirect)
+    end
+  end
 end

--- a/spec/system/admin/poll/polls_spec.rb
+++ b/spec/system/admin/poll/polls_spec.rb
@@ -33,6 +33,21 @@ describe "Admin polls", :admin do
     expect(page).not_to have_content "There are no polls"
   end
 
+  scenario "Can see all polls despite it is with the published attribute set to true or not" do
+    create(:poll)
+    create(:poll, :published)
+    create(:poll)
+
+    visit admin_root_path
+
+    click_link "Polls"
+
+    expect(page).to have_content "List of polls"
+    expect(page).to have_css ".poll", count: 3
+
+    expect(page).not_to have_content "There are no polls"
+  end
+
   scenario "Index do not show polls created by users from proposals dashboard" do
     create(:poll, name: "Poll created by admin")
     create(:poll, name: "Poll from user's proposal", related_type: "Proposal")

--- a/spec/system/budget_polls/polls_spec.rb
+++ b/spec/system/budget_polls/polls_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Polls" do
   context "Public index" do
     scenario "Budget polls should not be listed" do
-      poll = create(:poll)
+      poll = create(:poll, :published)
       budget_poll = create(:poll, :for_budget)
 
       visit polls_path

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -136,6 +136,16 @@ describe "Polls" do
       expect(page).to have_selector "img[alt='1. No Poverty']"
       expect(page).to have_content "target 1.1"
     end
+
+    scenario "Shows only polls with the published attribute set to true" do
+      create(:poll, :published)
+      create(:poll, :published)
+      create(:poll)
+
+      visit polls_path
+
+      expect(page).to have_css ".poll", count: 2
+    end
   end
 
   context "Show" do

--- a/spec/system/polls/results_spec.rb
+++ b/spec/system/polls/results_spec.rb
@@ -6,7 +6,7 @@ describe "Poll Results" do
     user2 = create(:user, :level_two)
     user3 = create(:user, :level_two)
 
-    poll = create(:poll, results_enabled: true)
+    poll = create(:poll, :published, results_enabled: true)
     question1 = create(:poll_question, poll: poll)
     answer1 = create(:poll_question_answer, question: question1, title: "Yes")
     answer2 = create(:poll_question_answer, question: question1, title: "No")


### PR DESCRIPTION
## References

> Related to issue #3535

## Objectives

> Make it possible to the administrator set a poll as published or not at its creation/update. When the poll is set published it will be shown at the polls page **/polls**. If the poll is not published it will not be shown.

## Visual Changes

> Addition of a new checkbox in the create/update poll form:
![screenshot_poll_form](https://user-images.githubusercontent.com/42497300/166010282-6ed88eb9-3020-404f-9ac5-e8dac811dd9b.png)


## Notes

> Currently the "published" attribute in the poll model is not used to filter polls. I saw that it was not set to true at any moment, so it was not being used. With the new feature brought by this PR, the "published" atribute is now being used. If a poll has the "published" attribute set to true it will be exhibited and vice versa. All the already existing polls need to have it set to true in order for them to be shown, so the following SQL script needs to be executed: `update polls set published = true`
