### PR TITLE
Fix banner link on Chromium 101

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import "advanced_search";
 @import "annotator_overrides";
 @import "autocomplete_overrides";
+@import "banner";
 @import "datepicker_overrides";
 @import "layout";
 @import "participation";

--- a/app/assets/stylesheets/banner.scss
+++ b/app/assets/stylesheets/banner.scss
@@ -7,11 +7,15 @@
     content: none;
   }
 
-  a > * {
-    padding: 0 rem-calc(16);
+  a {
+    display: block;
 
-    &:empty {
-      display: none;
+    > * {
+      padding: 0 rem-calc(16);
+
+      &:empty {
+        display: none;
+      }
     }
   }
 

--- a/app/assets/stylesheets/banner.scss
+++ b/app/assets/stylesheets/banner.scss
@@ -1,0 +1,23 @@
+.banner {
+  @include full-width-background;
+
+  .debates-list &::before,
+  .proposals-list &::before,
+  .admin &::before {
+    content: none;
+  }
+
+  a > * {
+    padding: 0 rem-calc(16);
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  + .budget-header,
+  + .budgets-index > .budget-header,
+  + .jumbo {
+    margin-top: 0;
+  }
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -16,7 +16,6 @@
 // 15. Comments
 // 16. Flags
 // 17. Activity
-// 18. Banners
 // 19. Recommendations
 // 20. Documents
 // 21. Related content
@@ -2132,33 +2131,6 @@ table {
       border-left: 1px solid #ececec;
       padding-left: $line-height;
     }
-  }
-}
-
-// 18. Banners
-// -----------
-
-.banner {
-  @include full-width-background;
-
-  .debates-list &::before,
-  .proposals-list &::before,
-  .admin &::before {
-    content: none;
-  }
-
-  a > * {
-    padding: 0 rem-calc(16);
-
-    &:empty {
-      display: none;
-    }
-  }
-
-  + .budget-header,
-  + .budgets-index > .budget-header,
-  + .jumbo {
-    margin-top: 0;
   }
 }
 


### PR DESCRIPTION
## References

* The test ""Cross-Site Scripting protection banner URL" was failing after upgrading to Chrome/Chromium 101

## Objectives

* Keep the intended behavior when keeping on the blank space between lines in a banner
* Make the test suite green again

## Visual Changes

### Before these changes

Note the mouse cursor isn't shaped as a pointer:

![In a banner, the empty space between lines isn't considered a link](https://user-images.githubusercontent.com/35156/166240722-37ca088c-99f6-4fd4-8b59-613397de9605.png)

### After these changes

Note the mouse cursor is shaped as a pointer:

![In a banner, the empty space between lines is considered a link](https://user-images.githubusercontent.com/35156/166240748-24d65718-d0cf-4b66-b4bc-bf1a1b05a0ff.png)