### PR TITLE
Fix crash deleting admin with assigned budgets

### DIFF
--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -1,5 +1,7 @@
 class Administrator < ApplicationRecord
   belongs_to :user, touch: true
+  has_many :budget_administrators, dependent: :destroy
+
   delegate :name, :email, :name_and_email, to: :user
 
   validates :user_id, presence: true, uniqueness: true

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -38,4 +38,13 @@ describe Administrator do
       expect(administrator.description_or_name_and_email).to eq("Billy Wilder (test@test.com)")
     end
   end
+
+  describe "#destroy" do
+    it "removes dependent budget administrator records" do
+      administrator = create(:administrator)
+      create_list(:budget, 2, administrators: [administrator])
+
+      expect { administrator.destroy }.to change { BudgetAdministrator.count }.by(-2)
+    end
+  end
 end


### PR DESCRIPTION
## References

While reviewing other PR I found this bug.

## Objectives

Remove dependent budget administrator records when an administrator record is removed.
