### PR TITLE
Fix warnings when compiling SCSS

### DIFF
--- a/app/assets/stylesheets/_consul_settings.scss
+++ b/app/assets/stylesheets/_consul_settings.scss
@@ -6,6 +6,7 @@
 //  1. Foundation settings overrides
 //  2. CONSUL variables
 //  3. Foundation overrides depending on CONSUL variables
+//  4. Foundation fixes
 
 // 1. Foundation settings overrides
 // ---------------------------------
@@ -154,3 +155,14 @@ $tab-content-border: $border !default;
 $closebutton-color: $text !default;
 
 $tooltip-background-color: $brand !default;
+
+// 4. Foundation fixes
+// -------------------
+
+$alert-color: null !default;
+$primary-color: null !default;
+$secondary-color: null !default;
+$success-color: null !default;
+$warning-color: null !default;
+$-zf-bp-value: null !default;
+$-zf-size: null !default;


### PR DESCRIPTION
## References

* We're getting these warning since we updated the SassC dependency, which was necessary to update Sprockets (pull request #4609)
* Information about this problem can be found at issue foundation/foundation-sites#12080 (not fully solved at the time of writing; a fix was suggested in pull request foundation/foundation-sites#12420)

## Objectives

* Fix deprecation warnings when compiling SCSS files