### PR TITLE
Include machine learning settings type

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -8,7 +8,7 @@ class Setting < ApplicationRecord
   end
 
   def type
-    if %w[feature process proposals map html homepage uploads sdg].include? prefix
+    if %w[feature process proposals map html homepage uploads sdg machine_learning].include? prefix
       prefix
     elsif %w[remote_census].include? prefix
       key.rpartition(".").first

--- a/spec/system/admin/settings_spec.rb
+++ b/spec/system/admin/settings_spec.rb
@@ -264,7 +264,6 @@ describe "Admin settings", :admin do
     scenario "On #tab-sdg-configuration" do
       Setting["feature.sdg"] = true
       Setting.create!(key: "sdg.whatever")
-      login_as(create(:administrator).user)
 
       visit admin_settings_path
       click_link "SDG configuration"
@@ -311,7 +310,6 @@ describe "Admin settings", :admin do
   describe "SDG configuration tab" do
     scenario "is enabled when the sdg feature is enabled" do
       Setting["feature.sdg"] = true
-      login_as(create(:administrator).user)
 
       visit admin_settings_path
       click_link "SDG configuration"
@@ -321,7 +319,6 @@ describe "Admin settings", :admin do
 
     scenario "is disabled when the sdg feature is disabled" do
       Setting["feature.sdg"] = false
-      login_as(create(:administrator).user)
 
       visit admin_settings_path
       click_link "SDG configuration"
@@ -333,7 +330,6 @@ describe "Admin settings", :admin do
 
     scenario "is enabled right after enabling the feature" do
       Setting["feature.sdg"] = false
-      login_as(create(:administrator).user)
 
       visit admin_settings_path
 

--- a/spec/system/admin/settings_spec.rb
+++ b/spec/system/admin/settings_spec.rb
@@ -346,4 +346,26 @@ describe "Admin settings", :admin do
       expect(page).to have_css "h2", exact_text: "SDG configuration"
     end
   end
+
+  describe "Machine learning settings" do
+    scenario "show the machine learning feature but not its settings" do
+      Setting["feature.machine_learning"] = true
+
+      visit admin_settings_path
+
+      expect(page).not_to have_content "Machine Learning"
+      expect(page).not_to have_content "Comments Summary"
+      expect(page).not_to have_content "Related Content"
+      expect(page).not_to have_content "Tags"
+      expect(page).not_to have_css ".translation_missing"
+
+      click_link "Features"
+
+      expect(page).to have_content "Machine Learning"
+      expect(page).not_to have_content "Comments Summary"
+      expect(page).not_to have_content "Related Content"
+      expect(page).not_to have_content "Tags"
+      expect(page).not_to have_css ".translation_missing"
+    end
+  end
 end


### PR DESCRIPTION
### Description

On the [Configuration settings page](https://demo.democrateam.com/admin/settings) three settings appear without description:

- **Comments Summary**: No description.
- **Related Content**: No description.
- **Tags**: No description.

These settings are related with the **AI / Machine learning** feature. They only should appear on [AI / Machine learning setting page](https://demo.democrateam.com/admin/machine_learning#settings) when the feature is enabled. 🤖 

This PR include machine learning settings type.

### Notes
Actually adding the `machine_learning` type prevents them from being added to the `configuration` list in [models/setting.rb](https://github.com/consul/consul/blob/master/app/models/setting.rb#L16), but as that type is not being used, maybe there is another way to exclude them. 🤔 

### Visual changes 
#### _Settings removed from Configuration settings list_
<img width="1405" alt="settings" src="https://user-images.githubusercontent.com/631897/166827181-bb54d833-3b7c-4dad-9a44-0c77020ccc37.png">


