### PR TITLE
Make sure SMTP settings use symbols as keys

### DIFF
--- a/config/environments/preproduction.rb
+++ b/config/environments/preproduction.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   # Configure your SMTP service credentials in secrets.yml
   if Rails.application.secrets.smtp_settings
     config.action_mailer.delivery_method = Rails.application.secrets.mailer_delivery_method || :smtp
-    config.action_mailer.smtp_settings = Rails.application.secrets.smtp_settings
+    config.action_mailer.smtp_settings = Rails.application.secrets.smtp_settings.symbolize_keys
   end
 
   # Disable locale fallbacks for I18n

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
   # Configure your SMTP service credentials in secrets.yml
   if Rails.application.secrets.smtp_settings
     config.action_mailer.delivery_method = Rails.application.secrets.mailer_delivery_method || :smtp
-    config.action_mailer.smtp_settings = Rails.application.secrets.smtp_settings
+    config.action_mailer.smtp_settings = Rails.application.secrets.smtp_settings.symbolize_keys
   end
 
   # Disable locale fallbacks for I18n

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   # Configure your SMTP service credentials in secrets.yml
   if Rails.application.secrets.smtp_settings
     config.action_mailer.delivery_method = Rails.application.secrets.mailer_delivery_method || :smtp
-    config.action_mailer.smtp_settings = Rails.application.secrets.smtp_settings
+    config.action_mailer.smtp_settings = Rails.application.secrets.smtp_settings.symbolize_keys
   end
 
   # Disable locale fallbacks for I18n


### PR DESCRIPTION
## References

* Continues pull request #3871

## Background

It's possible that, while editing the `secrets.yml` file, people accidentally delete the starting colon in the SMTP settings, which would result in these settings being ignored.

## Objectives

* Make sure the SMTP settings work even if the starting colon is accidentally deleted