### PR TITLE
Allow removing investment supports by default

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -102,7 +102,7 @@ class Setting < ApplicationRecord
         "feature.graphql_api": true,
         "feature.sdg": true,
         "feature.machine_learning": false,
-        "feature.remove_investments_supports": false,
+        "feature.remove_investments_supports": true,
         "homepage.widgets.feeds.debates": true,
         "homepage.widgets.feeds.processes": true,
         "homepage.widgets.feeds.proposals": true,

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -5,7 +5,6 @@ section "Creating Settings" do
     "facebook_handle": "CONSUL",
     "feature.featured_proposals": "true",
     "feature.map": "true",
-    "feature.remove_investments_supports": true,
     "instagram_handle": "CONSUL",
     "mailer_from_address": "noreply@consul.dev",
     "mailer_from_name": "CONSUL",


### PR DESCRIPTION
## References

* This setting was added in pull request #4730

## Background

When we added this setting in commit 9979b5399, we disabled it by default so it would be compatible with existing installations.

Since then, we've released version 1.4, which adds the settings to existing databases. That means we can now enable it by default and existing installations won't be affected.

## Objectives

* Use a default setting with the value that most people expect for this feature