### PR TITLE
Remove unused CSS containing a typo

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -173,10 +173,6 @@ button,
   display: inline-block;
 }
 
-.aling-middle {
-  vertical-align: middle;
-}
-
 .sidebar-divider {
   border-top: 1px solid $border;
   margin-top: $line-height;


### PR DESCRIPTION
## References

* The code was accidentally added in commit ddc4ff329
* The right code had already been introduced in commit 0950a98dd.

## Objectives

* Remove unused code
* Remove code with a typo which can confuse developers