### PR TITLE
Remove legacy annotations route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
 
   draw :account
   draw :admin
-  draw :annotation
   draw :budget
   draw :comment
   draw :community

--- a/config/routes/annotation.rb
+++ b/config/routes/annotation.rb
@@ -1,3 +1,0 @@
-resources :annotations do
-  get :search, on: :collection
-end


### PR DESCRIPTION
## References

* Continues pull request #3275

## Objectives

* Fix a `uninitialized constant AnnotationsController` crash when accessing `/annotations/search`