### PR TITLE
Add notice after destroying a banner

### DIFF
--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -32,7 +32,7 @@ class Admin::BannersController < Admin::BaseController
 
   def destroy
     @banner.destroy!
-    redirect_to admin_banners_path
+    redirect_to admin_banners_path, notice: t("admin.banners.destroy.notice")
   end
 
   private

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -38,6 +38,8 @@ en:
           sdg: SDG
       create:
         notice: "Banner created successfully"
+      destroy:
+        notice: "Banner deleted successfully"
       edit:
         editing: Edit banner
         form:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -38,6 +38,8 @@ es:
           sdg: ODS
       create:
         notice: "Banner creado correctamente"
+      destroy:
+        notice: "Banner eliminado correctamente"
       edit:
         editing: Editar el banner
         form:

--- a/spec/system/admin/banners_spec.rb
+++ b/spec/system/admin/banners_spec.rb
@@ -177,6 +177,8 @@ describe "Admin banners magement", :admin do
       click_button "Delete"
     end
 
+    expect(page).to have_content "Banner deleted successfully"
+
     visit admin_root_path
     expect(page).not_to have_content "Ugly banner"
   end


### PR DESCRIPTION
## Objectives

* Improve the user experience by notifying administrators of what has just happened
* Avoid possible simultaneous requests in the spec testing this feature

## Visual Changes

### After these changes

![There's a notice saying "Banner deleted successfully" after deleting a banner](https://user-images.githubusercontent.com/35156/171686634-664a6d02-8f24-4acf-b4c0-391aa13cb36b.png)