### PR TITLE
Disable Turbolinks for languages with different text direction

### DIFF
--- a/app/components/layout/locale_switcher_component.rb
+++ b/app/components/layout/locale_switcher_component.rb
@@ -1,5 +1,5 @@
 class Layout::LocaleSwitcherComponent < ApplicationComponent
-  delegate :name_for_locale, :link_list, :current_path_with_query_params, to: :helpers
+  delegate :name_for_locale, :link_list, :current_path_with_query_params, :rtl?, to: :helpers
 
   def render?
     locales.size > 1
@@ -29,7 +29,8 @@ class Layout::LocaleSwitcherComponent < ApplicationComponent
           name_for_locale(locale),
           current_path_with_query_params(locale: locale),
           locale == I18n.locale,
-          lang: locale
+          lang: locale,
+          data: { turbolinks: rtl?(I18n.locale) == rtl?(locale) }
         ]
       end
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,8 +6,8 @@ module ApplicationHelper
     url_for(request.query_parameters.merge(query_parameters).merge(only_path: true))
   end
 
-  def rtl?
-    %i[ar fa he].include?(I18n.locale)
+  def rtl?(locale = I18n.locale)
+    %i[ar fa he].include?(locale)
   end
 
   def markdown(text)

--- a/spec/components/layout/locale_switcher_component_spec.rb
+++ b/spec/components/layout/locale_switcher_component_spec.rb
@@ -74,4 +74,27 @@ describe Layout::LocaleSwitcherComponent do
       expect(page).to have_css "[aria-current]", exact_text: "English"
     end
   end
+
+  context "when the target language has a different text direction than the current language" do
+    let!(:default_locales) { I18n.available_locales }
+
+    before do
+      I18n.available_locales = %i[ar en]
+      I18n.reload!
+    end
+
+    after do
+      I18n.available_locales = default_locales
+      I18n.reload!
+    end
+
+    it "disables Turbolinks for language links" do
+      render_inline component
+
+      expect(page).to have_link "عربى", href: "/?locale=ar"
+      expect(page).to have_css "[href='/?locale=ar'][data-turbolinks=false]"
+      expect(page).to have_link "English", href: "/?locale=en"
+      expect(page).to have_css "[href='/?locale=en'][data-turbolinks=true]"
+    end
+  end
 end


### PR DESCRIPTION
## References

Not a long time ago, we changed the language selection interface when the application uses four languages or less. 

* Check #4573  for more information

**Steps to reproduce:**
1. Configure the application to use four languages or less. You can add the following to the `application_custom.rb` file
`config.i18n.available_locales = %w[ar en es fr] ` to set it up.

2. Visit the page in any language with a left to right text direction. English an example.
3. Click on the right to left language link at the top of the page. In the example, the Arabic language link.
4. The layout is not loaded correctly as it still uses the `application.css` file instead of the `application-rtl.scss` file.
 
The same happens when you first visit an RTL language and then click on any LTR language link.

**Problem description**
1. We have [separate stylesheets for LTR and RTL languages](https://github.com/consul/consul/blob/master/app/views/layouts/_common_head.html.erb#L6). 
2. As with all the application links the language links were using `Turbolinks` so only the page body changes across requests.
3. When changing from an LTR language to an RTL language or vice-versa we need to use a different stylesheet and change [some other layout attributes](https://github.com/consul/consul/blob/master/app/views/layouts/application.html.erb#L2).


## Objectives
Do a full page reload (disable Turbolinks) when the target language has a different text direction than the current language, so the application layout loads the correct stylesheet and replaces the lang attributes of the `<html>` element.

## Visual changes

**Arabic page before this patch**
<img width="1178" alt="Captura de Pantalla 2022-06-06 a las 17 18 09" src="https://user-images.githubusercontent.com/15726/172191260-54711c0b-c498-4f20-b48c-4f0123e8c4f2.png">


**Arabic page after this patch**

<img width="1191" alt="Captura de Pantalla 2022-06-06 a las 17 18 48" src="https://user-images.githubusercontent.com/15726/172191362-078f8747-883d-40fc-a9b3-43e2cc073f6f.png">
