### PR TITLE
Add kanban automation for new pull requests

### DIFF
--- a/.github/workflows/kanban.yml
+++ b/.github/workflows/kanban.yml
@@ -1,0 +1,25 @@
+name: Assign new pull requests
+on:
+  pull_request_target:
+    types: [opened, reopened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.KANBAN_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign new pull requests
+    steps:
+    - name: Assign new pull requests to the reviewing column
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: github.event.pull_request.draft == false
+      with:
+        project: "https://github.com/orgs/consul/projects/1"
+        column_name: "Reviewing"
+
+    - name: Assign new draft pull requests to the doing column
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: github.event.pull_request.draft == true
+      with:
+        project: "https://github.com/orgs/consul/projects/1"
+        column_name: "Doing"


### PR DESCRIPTION
## Objectives

* Automatically move new pull request to our kanban's "Reviewing" column  without having to manually select it
* Automatically move new draft pull requests to our kanban's "Doing" column 

## Notes

* This will only work on pull requests that aren't already in the project; that is, if a pull request is already in the "Doing" column, closing it and reopening it will *not* move it to the "Reviewing column"; so it looks like we won't easily be able to extend this feature in order to automatically move pull requests when they're marked as ready for review
* I don't know whether this will work on pull request opened by collaborators :relieved: