### PR TITLE
Show account activation status for each user in the admin section

### DIFF
--- a/app/views/admin/users/_users.html.erb
+++ b/app/views/admin/users/_users.html.erb
@@ -15,6 +15,7 @@
           <th scope="col"><%= t("admin.users.columns.document_number") %></th>
           <th scope="col"><%= t("admin.users.columns.roles") %></th>
           <th scope="col"><%= t("admin.users.columns.verification_level") %></th>
+          <th scope="col"><%= t("admin.users.columns.activation_status") %></th>
         <% end %>
       </tr>
     </thead>
@@ -30,6 +31,7 @@
             <td><%= user.document_number %></td>
             <td><%= display_user_roles(user) %></td>
             <td><%= user.user_type %></td>
+            <td><%= user.confirmed_at? ? t("admin.users.account.active_status") : t("admin.users.account.inactive_status") %></td>
           <% end %>
         </tr>
       <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1533,6 +1533,10 @@ en:
         document_number: Document number
         roles: Roles
         verification_level: Verification level
+        activation_status: Activation Status
+      account:
+        active_status: Account activated
+        inactive_status: Account not activated
       index:
         title: User
         no_users: There are no users.

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1533,6 +1533,10 @@ es:
         document_number: Número de documento
         roles: Roles
         verification_level: Nivel de verficación
+        activation_status: Estado de la confirmación
+      account:
+        active_status: Cuenta confirmada
+        inactive_status: Cuenta no confirmada
       index:
         title: Usuarios
         no_users: No hay usuarios.

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -56,4 +56,23 @@ describe "Admin users" do
     expect(page).not_to have_content admin.name
     expect(page).not_to have_content admin.email
   end
+
+  describe "Show account activation status" do
+    scenario "when user account is confimed" do
+      visit admin_users_path
+
+      expect(page).to have_content "Activation Status"
+      expect(page).to have_content "Account activated"
+      expect(page).not_to have_content "Account not activated"
+    end
+
+    scenario "when user account is not confimed" do
+      user.update!(confirmed_at: nil)
+
+      visit admin_users_path
+
+      expect(page).to have_content "Activation Status"
+      expect(page).to have_content "Account not activated"
+    end
+  end
 end


### PR DESCRIPTION
## References

* Closes #2747

## Objectives

Show to an admin which users have activated account.

## Visual Changes
URL admin/users
![image](https://user-images.githubusercontent.com/22120173/172887409-8204e9dd-01e9-48ed-8023-272e29839bbd.png)

## Notes
Translations must be created for languages other than English.