### PR TITLE
Disable JavaScript in notification digest spec

### DIFF
--- a/spec/system/emails_spec.rb
+++ b/spec/system/emails_spec.rb
@@ -258,7 +258,7 @@ describe "Emails" do
   end
 
   context "Proposal notification digest" do
-    scenario "notifications for proposals that I'm following" do
+    scenario "notifications for proposals that I'm following", :no_js do
       Setting["org_name"] = "CONSUL"
       user = create(:user, email_digest: true)
 


### PR DESCRIPTION
## References

* This test has failed many times; for instance, in our [test run 3721, job 3](https://github.com/consul/consul/runs/6778392566)

## Background

This test has been failing many times because it checks the database after starting the process running the browser.

So we're disabling JavaScript like we do in every other test using the `create_proposal_notification` method. This way, Capybara will use the rack driver and there'll be no risk of errors that currently might take place if both the process running the browser and the process running the test access the database.

## Objectives

* Avoid failures in our test suite