### PR TITLE
Fix Rubocop convention offenses

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -26,6 +26,7 @@ class Admin::TagsController < Admin::BaseController
   end
 
   private
+
     def tags
       @tags ||= Tag.category.page(params[:page])
     end

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -289,7 +289,7 @@ describe Abilities::Common do
 
     before { user.update(verified_at: Time.current) }
 
-    it { should be_able_to(:vote, Proposal)          }
+    it { should be_able_to(:vote, Proposal) }
 
     it { should     be_able_to(:new, DirectMessage)            }
     it { should     be_able_to(:create, DirectMessage)         }

--- a/spec/system/legislation/processes_spec.rb
+++ b/spec/system/legislation/processes_spec.rb
@@ -254,7 +254,7 @@ describe "Legislation" do
           expect(page).to have_content("Homepage")
         end
 
-        expect(page).to     have_content("This is the process homepage")
+        expect(page).to have_content("This is the process homepage")
       end
 
       scenario "disabled", :with_frozen_time do
@@ -280,7 +280,7 @@ describe "Legislation" do
 
         visit legislation_process_path(process)
 
-        expect(page).to     have_content("This phase is not open yet")
+        expect(page).to have_content("This phase is not open yet")
       end
 
       scenario "open without questions" do


### PR DESCRIPTION
## References

* These offenses were introduced in commit 4b42a68b6 from pull request #4763,  commit 00f0c4410 from pull request #4820 and commit e76735031 from pull request #4837

## Objectives

* Keep the code as clean and consistent as possible
* Have zero reports about offenses when running `rubocop --fail-level convention --display-only-fail-level-offenses`