### PR TITLE
Add helpers for mailer footer styles

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -24,6 +24,10 @@ module MailerHelper
     "font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;"
   end
 
+  def mailer_footer_spacing
+    "margin: 0;padding: 0;line-height: 1.5em;"
+  end
+
   def css_for_mailer_heading
     mailer_font_family + "font-size: 48px;"
   end
@@ -34,6 +38,14 @@ module MailerHelper
 
   def css_for_mailer_text
     mailer_font_family + "font-size: 14px;font-weight: normal;line-height: 24px;"
+  end
+
+  def css_for_mailer_org
+    mailer_font_family + mailer_footer_spacing + "color: #797f7f; font-size: 12px;"
+  end
+
+  def css_for_mailer_footer
+    mailer_font_family + mailer_footer_spacing + "color: #222; font-size: 10px; margin-top: 12px;"
   end
 
   def css_for_mailer_button

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,7 @@
 class ApplicationMailer < ActionMailer::Base
   helper :settings
   helper :application
+  helper :mailer
   default from: proc { "#{Setting["mailer_from_name"]} <#{Setting["mailer_from_address"]}>" }
   layout "mailer"
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -2,7 +2,6 @@ class Mailer < ApplicationMailer
   after_action :prevent_delivery_to_users_without_email
 
   helper :text_with_links
-  helper :mailer
   helper :users
 
   def comment(comment)

--- a/app/views/layouts/_mailer_footer.html.erb
+++ b/app/views/layouts/_mailer_footer.html.erb
@@ -2,11 +2,13 @@
   <tbody>
     <tr>
       <td style="text-align: center; border-top: 1px solid #dadfe1; padding-top: 20px;">
-        <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif; margin: 0;padding: 0;line-height: 1.5em;color: #797f7f; font-size: 12px;">
-        <%= setting["org_name"] %></p>
+        <p style="<%= css_for_mailer_org %>">
+          <%= setting["org_name"] %>
+        </p>
 
-        <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif; margin: 0;padding: 0;line-height: 1.5em;color: #222; font-size: 10px; margin-top: 12px;">
-        <%= t("mailers.no_reply") %></p>
+        <p style="<%= css_for_mailer_footer %>">
+          <%= t("mailers.no_reply") %>
+        </p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Objectives

This PR adds helpers for mailer footer styles as done in https://github.com/consul/consul/pull/4818.

