### PR TITLE
Don't run kanban assignment on forks

### DIFF
--- a/.github/workflows/kanban.yml
+++ b/.github/workflows/kanban.yml
@@ -1,4 +1,4 @@
-name: Assign new pull requests
+name: Kanban management
 on:
   pull_request_target:
     types: [opened, reopened]
@@ -7,9 +7,9 @@ env:
 
 jobs:
   assign_one_project:
+    name: Add new pull requests to the kanban
     if: github.repository_owner == 'consul'
     runs-on: ubuntu-latest
-    name: Assign new pull requests
     steps:
     - name: Assign new pull requests to the reviewing column
       uses: srggrs/assign-one-project-github-action@1.3.1

--- a/.github/workflows/kanban.yml
+++ b/.github/workflows/kanban.yml
@@ -7,6 +7,7 @@ env:
 
 jobs:
   assign_one_project:
+    if: github.repository_owner == 'consul'
     runs-on: ubuntu-latest
     name: Assign new pull requests
     steps:


### PR DESCRIPTION
## References

* Continues pull request #4853

## Objectives

* Make sure forks don't run a task that only makes sense for the main CONSUL repository