### PR TITLE
Remove Processes link on help page when legislation is disabled

### DIFF
--- a/app/views/pages/help/_menu.html.erb
+++ b/app/views/pages/help/_menu.html.erb
@@ -29,11 +29,13 @@
           class: "button hollow expanded"
         ] if feature?(:polls)
       ),
-      [
-        t("pages.help.menu.processes"),
-        "#processes",
-        class: "button hollow expanded"
-      ],
+      (
+        [
+          t("pages.help.menu.processes"),
+          "#processes",
+          class: "button hollow expanded"
+        ] if feature?(:legislation)
+      ),
       [
         t("pages.help.menu.other"),
         "#other",

--- a/spec/system/help_page_spec.rb
+++ b/spec/system/help_page_spec.rb
@@ -56,4 +56,22 @@ describe "Help page" do
 
     expect(page).not_to have_link "Sustainable Development Goals help"
   end
+
+  scenario "renders the legislation section link when the process is enabled" do
+    Setting["feature.help_page"] = true
+    Setting["process.legislation"] = true
+
+    visit page_path("help")
+
+    expect(page).to have_link "Processes", href: "#processes"
+  end
+
+  scenario "does not render the legislation section link when the process is disabled" do
+    Setting["feature.help_page"] = true
+    Setting["process.legislation"] = nil
+
+    visit page_path("help")
+
+    expect(page).not_to have_link "Processes"
+  end
 end


### PR DESCRIPTION
## Steps to reproduce

1. Go to CONSUL demo and disable legislation processes
2. Go to the help page
3. You will see the "Processes" link to the section when the section is hidden.

## Objectives

Do not show the "Processes" link when the process is disabled on the help page.

## Visual Changes
- Before
![Show processes link on help page menu](https://user-images.githubusercontent.com/16189/180010325-9a571eb3-91b0-45f4-8aad-b9be7dd8df56.png)

- After
![Do not show processes link on help page menu](https://user-images.githubusercontent.com/16189/180010345-b9643ab3-59e4-4704-ba51-8c0153e7fc8d.png)
