### PR TITLE
Close comments when the allegations phase is closed

### DIFF
--- a/app/controllers/legislation/annotations_controller.rb
+++ b/app/controllers/legislation/annotations_controller.rb
@@ -6,12 +6,11 @@ class Legislation::AnnotationsController < Legislation::BaseController
 
   load_and_authorize_resource :process
   load_and_authorize_resource :draft_version, through: :process
-  load_and_authorize_resource
+  load_and_authorize_resource through: :draft_version
 
   has_orders %w[most_voted newest oldest], only: :show
 
   def index
-    @annotations = @draft_version.annotations
   end
 
   def show
@@ -61,13 +60,13 @@ class Legislation::AnnotationsController < Legislation::BaseController
   end
 
   def search
-    @annotations = @draft_version.annotations.order(Arel.sql("LENGTH(quote) DESC"))
+    @annotations = @annotations.order(Arel.sql("LENGTH(quote) DESC"))
     annotations_hash = { total: @annotations.size, rows: @annotations }
     render json: annotations_hash.to_json(methods: :weight)
   end
 
   def comments
-    @annotation = Legislation::Annotation.find(params[:annotation_id])
+    @annotation = @annotations.find(params[:annotation_id])
     @comment = @annotation.comments.new
   end
 
@@ -78,8 +77,7 @@ class Legislation::AnnotationsController < Legislation::BaseController
   end
 
   def new_comment
-    @draft_version = Legislation::DraftVersion.find(params[:draft_version_id])
-    @annotation = @draft_version.annotations.find(params[:annotation_id])
+    @annotation = @annotations.find(params[:annotation_id])
     @comment = @annotation.comments.new(body: params[:comment][:body], user: current_user)
     if @comment.save
       @comment = @annotation.comments.new

--- a/app/models/legislation/annotation.rb
+++ b/app/models/legislation/annotation.rb
@@ -55,4 +55,8 @@ class Legislation::Annotation < ApplicationRecord
   def weight
     comments_count + comments.sum(:cached_votes_total)
   end
+
+  def comments_closed?
+    !draft_version.process.allegations_phase.open?
+  end
 end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -41,6 +41,28 @@ describe CommentsController do
       end.not_to change { question.reload.comments_count }
     end
 
+    it "does not create an annotation comment if the allegations phase is closed" do
+      process = create(:legislation_process,
+                       allegations_start_date: 2.days.from_now,
+                       allegations_end_date: 1.month.from_now)
+
+      version = create(:legislation_draft_version, process: process)
+      annotation = create(:legislation_annotation, draft_version: version, text: "One annotation")
+
+      sign_in user
+
+      expect do
+        post :create, xhr: true,
+          params: {
+            comment: {
+              commentable_id: annotation.id,
+              commentable_type: "Legislation::Annotation",
+              body: "a comment"
+            }
+          }
+      end.not_to change { annotation.reload.comments_count }
+    end
+
     it "does not create a comment for unverified users when the commentable requires it" do
       sign_in unverified_user
 

--- a/spec/controllers/legislation/annotations_controller_spec.rb
+++ b/spec/controllers/legislation/annotations_controller_spec.rb
@@ -1,6 +1,27 @@
 require "rails_helper"
 
 describe Legislation::AnnotationsController do
+  describe "GET show" do
+    it "finds the annotation when it belongs to the draft version" do
+      version = create(:legislation_draft_version)
+      annotation = create(:legislation_annotation, draft_version: version)
+
+      get :show, params: { process_id: version.process, draft_version_id: version, id: annotation }
+
+      expect(response).to be_ok
+    end
+
+    it "returns a 404 when the annotation belongs to a different draft version" do
+      version = create(:legislation_draft_version)
+      annotation = create(:legislation_annotation, draft_version: version)
+      other_version = create(:legislation_draft_version, process: version.process)
+
+      expect do
+        get :show, params: { process_id: version.process, draft_version_id: other_version, id: annotation }
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
   describe "POST create" do
     let(:legal_process) do
       create(:legislation_process, allegations_start_date: Date.current - 3.days,

--- a/spec/system/comments/legislation_annotations_spec.rb
+++ b/spec/system/comments/legislation_annotations_spec.rb
@@ -254,6 +254,25 @@ describe "Commenting legislation questions" do
     expect(page).to have_content "Can't be blank"
   end
 
+  scenario "Comments are disabled when the allegations phase is closed" do
+    process = create(:legislation_process,
+                     allegations_start_date: 1.month.ago,
+                     allegations_end_date: Date.yesterday)
+
+    version = create(:legislation_draft_version, process: process)
+    annotation = create(:legislation_annotation, draft_version: version, text: "One annotation")
+
+    login_as(user)
+
+    visit legislation_process_draft_version_annotation_path(version.process, version, annotation)
+
+    within "#comments" do
+      expect(page).to have_content "Comments are closed"
+      expect(page).not_to have_content "Leave your comment"
+      expect(page).not_to have_button "Publish comment"
+    end
+  end
+
   scenario "Reply" do
     citizen = create(:user, username: "Ana")
     manuela = create(:user, username: "Manuela")


### PR DESCRIPTION
## Objectives

If a user comments a text of collaborative legislation during the allegations phase, and further comments are added to the text once the phase is over, these are added to the text. 

It should not be possible to add more comments to the text after the allegations phase is finished, so this PR hides comment form on annotations when allegations phase is closed on legislation processes. 
