### PR TITLE
Show verification info only if verification is enabled

### DIFF
--- a/app/assets/stylesheets/account/verify-account.scss
+++ b/app/assets/stylesheets/account/verify-account.scss
@@ -3,11 +3,11 @@
 
   .already-verified {
     @include has-fa-icon(check, solid);
-    color: $check;
+    color: $color-success;
     line-height: $line-height * 2;
 
     &::before {
-      color: $text-medium;
+      color: $check;
       font-size: 1.4em;
     }
   }

--- a/app/assets/stylesheets/account/verify-account.scss
+++ b/app/assets/stylesheets/account/verify-account.scss
@@ -4,7 +4,7 @@
   .already-verified {
     @include has-fa-icon(check, solid);
     color: $color-success;
-    line-height: $line-height * 2;
+    margin-top: $line-height;
 
     &::before {
       color: $check;

--- a/app/assets/stylesheets/account/verify-account.scss
+++ b/app/assets/stylesheets/account/verify-account.scss
@@ -2,14 +2,13 @@
   padding-right: $line-height / 2;
 
   .already-verified {
+    @include has-fa-icon(check, solid);
     color: $check;
     line-height: $line-height * 2;
 
-    .icon-check {
+    &::before {
       color: $text-medium;
-      font-size: rem-calc(24);
-      line-height: rem-calc(45);
-      vertical-align: middle;
+      font-size: 1.4em;
     }
   }
 }

--- a/app/assets/stylesheets/account/verify-account.scss
+++ b/app/assets/stylesheets/account/verify-account.scss
@@ -1,0 +1,15 @@
+.verify-account {
+  padding-right: $line-height / 2;
+
+  .already-verified {
+    color: $check;
+    line-height: $line-height * 2;
+
+    .icon-check {
+      color: $text-medium;
+      font-size: rem-calc(24);
+      line-height: rem-calc(45);
+      vertical-align: middle;
+    }
+  }
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1228,10 +1228,6 @@ form {
     margin-right: $line-height / 2;
   }
 
-  .verify-account {
-    padding-right: $line-height / 2;
-  }
-
   .final-votes-info {
     background: $warning-bg;
     border: 1px solid $warning-border;
@@ -1268,16 +1264,6 @@ form {
   line-height: rem-calc(32);
   height: rem-calc(32);
   vertical-align: top;
-}
-
-.user-permissions {
-
-  p {
-    span {
-      color: $text-medium;
-      font-size: rem-calc(12);
-    }
-  }
 }
 
 .notifications-list {
@@ -1663,21 +1649,6 @@ table {
 
   .number {
     opacity: 0.5;
-  }
-}
-
-.verify-account {
-  padding-right: $line-height / 2;
-
-  .already-verified {
-    color: $check;
-    line-height: $line-height * 2;
-
-    .icon-check {
-      font-size: rem-calc(24);
-      line-height: rem-calc(45);
-      vertical-align: middle;
-    }
   }
 }
 

--- a/app/components/account/verify_account_component.html.erb
+++ b/app/components/account/verify_account_component.html.erb
@@ -1,7 +1,6 @@
 <div class="verify-account">
   <% if account.level_three_verified? %>
     <p class="already-verified">
-      <span class="icon-check"></span>
       <%= t("account.show.verified_account") %>
     </p>
   <% else %>

--- a/app/components/account/verify_account_component.html.erb
+++ b/app/components/account/verify_account_component.html.erb
@@ -1,22 +1,18 @@
-<div class="verification-info">
-  <p>
-    <%= t("account.show.user_permission_verify") %>
-  </p>
+<div class="verify-account">
+  <% if account.level_three_verified? %>
+    <p class="already-verified">
+      <span class="icon-check"></span>
+      <%= t("account.show.verified_account") %>
+    </p>
+  <% else %>
+    <p>
+      <%= t("account.show.user_permission_verify") %>
+    </p>
 
-  <% unless account.organization? %>
-    <div>
-      <span class="verify-account">
-        <% if account.level_three_verified? %>
-          <p class="already-verified">
-            <span class="icon-check"></span>
-            <%= t("account.show.verified_account") %>
-          </p>
-        <% elsif account.level_two_verified? %>
-          <%= link_to t("account.show.finish_verification"), verification_path, class: "button success" %>
-        <% else %>
-          <%= link_to t("account.show.verify_my_account"), verification_path, class: "button success" %>
-        <% end %>
-      </span>
-    </div>
+    <% if account.level_two_verified? %>
+      <%= link_to t("account.show.finish_verification"), verification_path, class: "button success" %>
+    <% else %>
+      <%= link_to t("account.show.verify_my_account"), verification_path, class: "button success" %>
+    <% end %>
   <% end %>
 </div>

--- a/app/components/account/verify_account_component.html.erb
+++ b/app/components/account/verify_account_component.html.erb
@@ -1,0 +1,22 @@
+<div class="verification-info">
+  <p>
+    <%= t("account.show.user_permission_verify") %>
+  </p>
+
+  <% unless account.organization? %>
+    <div>
+      <span class="verify-account">
+        <% if account.level_three_verified? %>
+          <p class="already-verified">
+            <span class="icon-check"></span>
+            <%= t("account.show.verified_account") %>
+          </p>
+        <% elsif account.level_two_verified? %>
+          <%= link_to t("account.show.finish_verification"), verification_path, class: "button success" %>
+        <% else %>
+          <%= link_to t("account.show.verify_my_account"), verification_path, class: "button success" %>
+        <% end %>
+      </span>
+    </div>
+  <% end %>
+</div>

--- a/app/components/account/verify_account_component.rb
+++ b/app/components/account/verify_account_component.rb
@@ -6,6 +6,6 @@ class Account::VerifyAccountComponent < ApplicationComponent
   end
 
   def render?
-    !account.organization?
+    Setting["feature.user.skip_verification"].blank? && !account.organization?
   end
 end

--- a/app/components/account/verify_account_component.rb
+++ b/app/components/account/verify_account_component.rb
@@ -1,0 +1,7 @@
+class Account::VerifyAccountComponent < ApplicationComponent
+  attr_reader :account
+
+  def initialize(account)
+    @account = account
+  end
+end

--- a/app/components/account/verify_account_component.rb
+++ b/app/components/account/verify_account_component.rb
@@ -4,4 +4,8 @@ class Account::VerifyAccountComponent < ApplicationComponent
   def initialize(account)
     @account = account
   end
+
+  def render?
+    !account.organization?
+  end
 end

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -94,27 +94,7 @@
           <p><%= t("account.show.user_permission_info") %></p>
 
           <%= render Account::PermissionsListComponent.new(current_user) %>
-
-          <p>
-            <%= t("account.show.user_permission_verify") %>
-          </p>
-
-          <% unless @account.organization? %>
-            <div>
-              <span class="verify-account">
-                <% if current_user.level_three_verified? %>
-                  <p class="already-verified">
-                    <span class="icon-check"></span>
-                    <%= t("account.show.verified_account") %>
-                  </p>
-                <% elsif current_user.level_two_verified? %>
-                  <%= link_to t("account.show.finish_verification"), verification_path, class: "button success" %>
-                <% else %>
-                  <%= link_to t("account.show.verify_my_account"), verification_path, class: "button success" %>
-                <% end %>
-              </span>
-            </div>
-          <% end %>
+          <%= render Account::VerifyAccountComponent.new(@account) %>
         </div>
       </div>
     <% end %>

--- a/spec/components/account/verify_account_component_spec.rb
+++ b/spec/components/account/verify_account_component_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe Account::VerifyAccountComponent do
+  it "shows a link to verify account to unverified users" do
+    account = User.new
+
+    render_inline Account::VerifyAccountComponent.new(account)
+
+    expect(page).to have_content "To perform all the actions verify your account."
+    expect(page).to have_link "Verify my account"
+  end
+
+  it "shows a link to complete verification to level two verified users" do
+    account = User.new(level_two_verified_at: Time.current)
+
+    render_inline Account::VerifyAccountComponent.new(account)
+
+    expect(page).to have_content "To perform all the actions verify your account."
+    expect(page).to have_link "Complete verification"
+  end
+
+  it "shows information about a verified account to level three verified users" do
+    account = User.new(verified_at: Time.current)
+
+    render_inline Account::VerifyAccountComponent.new(account)
+
+    expect(page).to have_content "To perform all the actions verify your account."
+    expect(page).to have_content "Account verified"
+  end
+
+  it "does not show verification info to organizations" do
+    account = User.new(organization: Organization.new)
+
+    render_inline Account::VerifyAccountComponent.new(account)
+
+    expect(page).to have_content "To perform all the actions verify your account."
+    expect(page).not_to have_link "Verify my account"
+    expect(page).not_to have_link "Complete verification"
+    expect(page).not_to have_content "Account verified"
+  end
+end

--- a/spec/components/account/verify_account_component_spec.rb
+++ b/spec/components/account/verify_account_component_spec.rb
@@ -24,7 +24,7 @@ describe Account::VerifyAccountComponent do
 
     render_inline Account::VerifyAccountComponent.new(account)
 
-    expect(page).to have_content "To perform all the actions verify your account."
+    expect(page).not_to have_content "To perform all the actions verify your account."
     expect(page).to have_content "Account verified"
   end
 
@@ -33,9 +33,6 @@ describe Account::VerifyAccountComponent do
 
     render_inline Account::VerifyAccountComponent.new(account)
 
-    expect(page).to have_content "To perform all the actions verify your account."
-    expect(page).not_to have_link "Verify my account"
-    expect(page).not_to have_link "Complete verification"
-    expect(page).not_to have_content "Account verified"
+    expect(page).not_to be_rendered
   end
 end

--- a/spec/components/account/verify_account_component_spec.rb
+++ b/spec/components/account/verify_account_component_spec.rb
@@ -1,38 +1,54 @@
 require "rails_helper"
 
 describe Account::VerifyAccountComponent do
-  it "shows a link to verify account to unverified users" do
-    account = User.new
+  context "verification is enabled" do
+    before { Setting["feature.user.skip_verification"] = false }
 
-    render_inline Account::VerifyAccountComponent.new(account)
+    it "shows a link to verify account to unverified users" do
+      account = User.new
 
-    expect(page).to have_content "To perform all the actions verify your account."
-    expect(page).to have_link "Verify my account"
+      render_inline Account::VerifyAccountComponent.new(account)
+
+      expect(page).to have_content "To perform all the actions verify your account."
+      expect(page).to have_link "Verify my account"
+    end
+
+    it "shows a link to complete verification to level two verified users" do
+      account = User.new(level_two_verified_at: Time.current)
+
+      render_inline Account::VerifyAccountComponent.new(account)
+
+      expect(page).to have_content "To perform all the actions verify your account."
+      expect(page).to have_link "Complete verification"
+    end
+
+    it "shows information about a verified account to level three verified users" do
+      account = User.new(verified_at: Time.current)
+
+      render_inline Account::VerifyAccountComponent.new(account)
+
+      expect(page).not_to have_content "To perform all the actions verify your account."
+      expect(page).to have_content "Account verified"
+    end
+
+    it "does not show verification info to organizations" do
+      account = User.new(organization: Organization.new)
+
+      render_inline Account::VerifyAccountComponent.new(account)
+
+      expect(page).not_to be_rendered
+    end
   end
 
-  it "shows a link to complete verification to level two verified users" do
-    account = User.new(level_two_verified_at: Time.current)
+  context "verification is disabled" do
+    before { Setting["feature.user.skip_verification"] = true }
 
-    render_inline Account::VerifyAccountComponent.new(account)
+    it "does not show verification info to anyone" do
+      account = User.new
 
-    expect(page).to have_content "To perform all the actions verify your account."
-    expect(page).to have_link "Complete verification"
-  end
+      render_inline Account::VerifyAccountComponent.new(account)
 
-  it "shows information about a verified account to level three verified users" do
-    account = User.new(verified_at: Time.current)
-
-    render_inline Account::VerifyAccountComponent.new(account)
-
-    expect(page).not_to have_content "To perform all the actions verify your account."
-    expect(page).to have_content "Account verified"
-  end
-
-  it "does not show verification info to organizations" do
-    account = User.new(organization: Organization.new)
-
-    render_inline Account::VerifyAccountComponent.new(account)
-
-    expect(page).not_to be_rendered
+      expect(page).not_to be_rendered
+    end
   end
 end


### PR DESCRIPTION
## References

* Depends on pull request #4902

## Objectives

Now, even if the "**Skip user verification**" setting is enabled at `admin/settings#tab-feature-flags` on the "**My account**" `/account` page the text "To perform all the actions verify your account. / Account verified" is displayed which can be a bit confusing for users.

This PR hides this information if the "Skip user verification" setting is active.

## Visual Changes
### Before
<img width="445" alt="before" src="https://user-images.githubusercontent.com/631897/180289430-c9a321a5-6cfb-423c-8b5e-d08e24d95334.png">

<img width="404" alt="before2" src="https://user-images.githubusercontent.com/631897/180289437-2567f009-ab5d-4d61-9f0d-e4bde8d15e27.png">

### After
<img width="321" alt="after" src="https://user-images.githubusercontent.com/631897/180289479-919c6fdc-46b6-4c4e-8e4b-630628d1f6ce.png">


