### PR TITLE
Allow symbols in legislation annotation ranges

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module Consul
     config.active_support.use_authenticated_message_encryption = false
 
     # Keep reading existing data in the legislation_annotations ranges column
-    config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess]
+    config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess, Symbol]
 
     # Handle custom exceptions
     config.action_dispatch.rescue_responses["FeatureFlags::FeatureDisabled"] = :forbidden


### PR DESCRIPTION
## References

* Continues pull request #4883
* It seems to be safe to allow Symbols in YAML columns, as mentioned in rails/rails#45584

## Objectives

* Allow creating an annotation using symbols in the ranges hash (that is, `ranges: [{ start: "/p[1] }]` instead of `ranges: [{ "start" => "/p[1] }]`

## Notes

Using symbols isn't really supported and it might cause strange issues with code like: `@draft_version.annotations.find_by(range_start: ...)`. However, this might be an extreme case and using symbols might work
properly most of the time (if not all the time), and we've been using them in our demo for years.

So I'm not writing a test for this case because I'm not sure we shouldsupport it, but I'm still allowing symbols so we don't get exceptions in cases where everything might be working fine. Rails already adds Symbol by default to column permitted classes, so it's safe to enable it.