### PR TITLE
Do not show money with hidden money

### DIFF
--- a/app/components/budgets/investments/ballot_component.html.erb
+++ b/app/components/budgets/investments/ballot_component.html.erb
@@ -4,9 +4,11 @@
       <span class="icon-check-circle"
             title="<%= t("budgets.investments.investment.already_added") %>">
       </span>
-      <p class="investment-project-amount">
-        <%= investment.formatted_price %>
-      </p>
+      <% if investment.should_show_price? %>
+        <p class="investment-project-amount">
+          <%= investment.formatted_price %>
+        </p>
+      <% end %>
       <% if investment.should_show_ballots? %>
         <%= button_to budget_ballot_line_path(id: investment.id,
                                               budget_id: investment.budget_id,
@@ -21,9 +23,11 @@
     </div>
   <% else %>
     <div class="add in-favor">
-      <p class="investment-project-amount">
-        <%= investment.formatted_price %>
-      </p>
+      <% if investment.should_show_price? %>
+        <p class="investment-project-amount">
+          <%= investment.formatted_price %>
+        </p>
+      <% end %>
       <% if investment.should_show_ballots? %>
         <%= button_to budget_ballot_lines_path(investment_id: investment.id,
                                                budget_id: investment.budget_id,

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -51,10 +51,12 @@
             <h2 class="margin-top">
               <%= t("budgets.investments.index.by_heading", heading: @heading.name) %>
             </h2>
-            <h3>
-              <span class="tagline"><%= t("budgets.investments.header.price") %></span>
-              <%= @budget.formatted_heading_price(@heading) %>
-            </h3>
+            <% if @budget.show_money? %>
+              <h3>
+                <span class="tagline"><%= t("budgets.investments.header.price") %></span>
+                <%= @budget.formatted_heading_price(@heading) %>
+              </h3>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/spec/components/budgets/investments/ballot_component_spec.rb
+++ b/spec/components/budgets/investments/ballot_component_spec.rb
@@ -43,4 +43,44 @@ describe Budgets::Investments::BallotComponent do
       expect(page).not_to have_button "Vote", disabled: :all
     end
   end
+
+  describe "price" do
+    let(:budget) { create(:budget, :approval, :balloting) }
+    let(:investment) { create(:budget_investment, :selected, price: 20, budget: budget) }
+    let(:component) do
+      Budgets::Investments::BallotComponent.new(
+        investment: investment,
+        investment_ids: [],
+        ballot: Budget::Ballot.where(budget: budget, user: controller.current_user).first_or_create!
+      )
+    end
+
+    it "is shown when the budget has not hidey_money active" do
+      sign_in(create(:user, :level_two))
+
+      render_inline component
+
+      expect(page).to have_content "€20"
+    end
+
+    context "when the budget has hidey_money active" do
+      before { budget.update!(hide_money: true) }
+
+      it "is not shown when the user has already voted" do
+        sign_in(create(:user, :level_two, ballot_lines: [investment]))
+
+        render_inline component
+
+        expect(page).not_to have_content "€20"
+      end
+
+      it "is not shown when the user has not already voted" do
+        sign_in(create(:user, :level_two))
+
+        render_inline component
+
+        expect(page).not_to have_content "€20"
+      end
+    end
+  end
 end

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1498,6 +1498,29 @@ describe "Budget Investments" do
       end
     end
 
+    describe "total amount" do
+      before do
+        budget.update!(voting_style: "approval")
+        heading.update!(price: 2000)
+      end
+
+      scenario "Do not show total budget amount for budget with hidden money" do
+        budget.update!(hide_money: true)
+
+        visit budget_investments_path(budget, heading_id: heading)
+
+        expect(page).not_to have_content "Total budget"
+        expect(page).not_to have_content "€2,000"
+      end
+
+      scenario "Show total budget amount for budget without hidden money" do
+        visit budget_investments_path(budget, heading_id: heading)
+
+        expect(page).to have_content "Total budget"
+        expect(page).to have_content "€2,000"
+      end
+    end
+
     scenario "Highlight voted heading" do
       budget.update!(phase: "balloting")
       user = create(:user, :level_two)


### PR DESCRIPTION
## Objectives
During the balloting phase, the amounts of money appear in the progress bar and the list of investment projects even though the option "Hide money amount for this budget" was active for that budget.
