### PR TITLE
Use the latest Ubuntu image to run tests and coveralls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     services:
       postgres:
@@ -65,7 +65,7 @@ jobs:
   coveralls:
     permissions:
       contents: none
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: tests
     env:
       CI_BUILD_NUMBER: ${{ github.run_number }}


### PR DESCRIPTION
It is the Ubuntu 20.04 version at the time of writing.

## References

* actions/runner-images/issues/6002

Tests and coveralls workflows stopped working since Github Action has deprecated the Ubuntu 18.04 image.

## Objectives

Run the latest Ubuntu image, so we do not have to update the workflow each time the system we use becomes deprecated.