### PR TITLE
Add more expectations in SDG Management search spec

### DIFF
--- a/spec/system/sdg_management/relations_spec.rb
+++ b/spec/system/sdg_management/relations_spec.rb
@@ -205,22 +205,41 @@ describe "SDG Relations" do
       end
 
       scenario "search within current tab" do
+        create(:proposal, title: "Proposal pending review")
+        create(:sdg_review, relatable: create(:proposal, title: "Proposal already reviewed"))
+
         visit sdg_management_proposals_path(filter: "pending_sdg_review")
 
+        expect(page).to have_content "Proposal pending review"
+        expect(page).not_to have_content "Proposal already reviewed"
+
+        fill_in "search", with: "non existent"
         click_button "Search"
 
+        expect(page).not_to have_content "Proposal pending review"
         expect(page).to have_css "li.is-active h2", exact_text: "Pending"
 
         visit sdg_management_proposals_path(filter: "sdg_reviewed")
 
+        expect(page).not_to have_content "Proposal pending review"
+        expect(page).to have_content "Proposal already reviewed"
+
+        fill_in "search", with: "non existent"
         click_button "Search"
 
+        expect(page).not_to have_content "Proposal already reviewed"
         expect(page).to have_css "li.is-active h2", exact_text: "Marked as reviewed"
 
         visit sdg_management_proposals_path(filter: "all")
 
+        expect(page).to have_content "Proposal pending review"
+        expect(page).to have_content "Proposal already reviewed"
+
+        fill_in "search", with: "non existent"
         click_button "Search"
 
+        expect(page).not_to have_content "Proposal pending review"
+        expect(page).not_to have_content "Proposal already reviewed"
         expect(page).to have_css "li.is-active h2", exact_text: "All"
       end
 


### PR DESCRIPTION
## Background

We've had some tests fail after this test was executed in our CI, and one possible reason could be that sometimes this test finished before all its requests had finished. This could be the case with the following code:

```
visit sdg_management_proposals_path(filter: "pending_sdg_review")

click_button "Search"

expect(page).to have_css "li.is-active h2", exact_text: "Pending"
```

Before clicking the "Search" button, the expectation is already true, so there's a chance that the expectation is evaluated as true before the request has finished. That might result in requests and session data leaking between tests.

So we're adding more expectations in order to make sure that the requests have finished before evaluating the expectations associated to them.

## References

* We had 80+ test failures in our CI during our [test run #3928, job 1](https://github.com/consul/consul/runs/7994910930); one possible cause could be leaking request between tests

## Objectives

Make sure all requests finish before the test finishes.