### PR TITLE
Fix Rails/ReversibleMigration rule offenses

### DIFF
--- a/db/migrate/20150806111435_change_debates_title_length.rb
+++ b/db/migrate/20150806111435_change_debates_title_length.rb
@@ -1,5 +1,9 @@
 class ChangeDebatesTitleLength < ActiveRecord::Migration[4.2]
-  def change
+  def up
     change_column :debates, :title, :string, limit: 80
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20151019133719_remove_user_constraints.rb
+++ b/db/migrate/20151019133719_remove_user_constraints.rb
@@ -1,5 +1,9 @@
 class RemoveUserConstraints < ActiveRecord::Migration[4.2]
-  def change
+  def up
     change_column(:users, :email, :string, null: true, unique: true)
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20151103175139_make_comments_confidence_score_default_to_0.rb
+++ b/db/migrate/20151103175139_make_comments_confidence_score_default_to_0.rb
@@ -1,5 +1,9 @@
 class MakeCommentsConfidenceScoreDefaultTo0 < ActiveRecord::Migration[4.2]
-  def change
+  def up
     change_column :comments, :confidence_score, :integer, default: 0, null: false, index: true
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20160418172919_activate_newsletter_by_default.rb
+++ b/db/migrate/20160418172919_activate_newsletter_by_default.rb
@@ -1,5 +1,9 @@
 class ActivateNewsletterByDefault < ActiveRecord::Migration[4.2]
-  def change
+  def up
     change_column :users, :newsletter, :boolean, default: true
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20161102133838_default_password_changed_at.rb
+++ b/db/migrate/20161102133838_default_password_changed_at.rb
@@ -1,5 +1,9 @@
 class DefaultPasswordChangedAt < ActiveRecord::Migration[4.2]
-  def change
+  def up
     change_column :users, :password_changed_at, :datetime, null: false, default: Time.zone.now
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20170102080432_adjust_budget_fields.rb
+++ b/db/migrate/20170102080432_adjust_budget_fields.rb
@@ -1,5 +1,9 @@
 class AdjustBudgetFields < ActiveRecord::Migration[4.2]
-  def change
+  def up
     change_column :budgets, :phase, :string, limit: 40, default: "accepting"
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20180220211105_change_newsletter_segment_recipient_to_string.rb
+++ b/db/migrate/20180220211105_change_newsletter_segment_recipient_to_string.rb
@@ -1,5 +1,9 @@
 class ChangeNewsletterSegmentRecipientToString < ActiveRecord::Migration[4.2]
-  def change
+  def up
     change_column :newsletters, :segment_recipient, :string, null: false
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20180702050717_add_short_description_to_proposal_dashboard_actions.rb
+++ b/db/migrate/20180702050717_add_short_description_to_proposal_dashboard_actions.rb
@@ -1,6 +1,10 @@
 class AddShortDescriptionToProposalDashboardActions < ActiveRecord::Migration[4.2]
-  def change
+  def up
     add_column :proposal_dashboard_actions, :short_description, :string
     change_column :proposal_dashboard_actions, :description, :text
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20200908084257_change_attachment_size_fields_to_bigint.rb
+++ b/db/migrate/20200908084257_change_attachment_size_fields_to_bigint.rb
@@ -1,7 +1,13 @@
 class ChangeAttachmentSizeFieldsToBigint < ActiveRecord::Migration[5.1]
-  def change
+  def up
     change_column :site_customization_images, :image_file_size, :bigint
     change_column :images, :attachment_file_size, :bigint
     change_column :documents, :attachment_file_size, :bigint
+  end
+
+  def down
+    change_column :site_customization_images, :image_file_size, :integer
+    change_column :images, :attachment_file_size, :integer
+    change_column :documents, :attachment_file_size, :integer
   end
 end


### PR DESCRIPTION
## References

* Continues pull request #4911

## Objectives

* Make sure that running `rubocop --fail-level convention --display-only-fail-level-offenses` reports no offenses