### PR TITLE
Remove unused translations

### DIFF
--- a/config/locales/es/community.yml
+++ b/config/locales/es/community.yml
@@ -25,10 +25,6 @@ es:
       topic:
         edit: Editar tema
         destroy: Eliminar tema
-        comments:
-          zero: Sin comentarios
-          one: 1 Comentario
-          other: "%{count} Comentarios"
       author: Autor
       back: Volver a %{community} %{proposal}
     topic:


### PR DESCRIPTION
## References
Related PR: #4839 

## Objectives
In the related PR #4839, we forgot to remove the translations from the `/config/local/es/community.yml` file.