### PR TITLE
Fix image size on proposals list

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -394,6 +394,7 @@
   }
 }
 
+.proposals-list,
 .budget-investments-list {
 
   @include breakpoint(medium) {


### PR DESCRIPTION
## Objectives

This PR fix image size on proposals list using `display: flex` like on budget investments list.

## Visual Changes
### Before
<img width="933" alt="before_1" src="https://user-images.githubusercontent.com/631897/191121910-6a7f53b1-b18a-4ad2-9de5-08d69fc87651.png">
<img width="983" alt="before_2" src="https://user-images.githubusercontent.com/631897/191121932-1ccc3de6-f507-46e0-aae2-37e11a490087.png">

### After
<img width="930" alt="after_1" src="https://user-images.githubusercontent.com/631897/191122064-66f6c45e-c7db-486b-a685-b726634d847b.png">
<img width="934" alt="after_2" src="https://user-images.githubusercontent.com/631897/191122081-dffa163f-4a25-4f20-a4a3-f3bcdecf0793.png">
