### PR TITLE
Add description to Legislation questions

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -191,12 +191,10 @@
         margin-bottom: 0;
         text-transform: uppercase;
       }
-    }
 
-    h4 a {
-      @include brand-color;
-
-      &:hover {
+      a {
+        @include brand-color;
+        @include header-font-size(h4);
         text-decoration: none;
       }
     }
@@ -232,6 +230,7 @@
   }
 
   .quiz-question {
+    @include header-font-size(h2);
     margin-bottom: $line-height;
   }
 

--- a/app/models/legislation/question.rb
+++ b/app/models/legislation/question.rb
@@ -4,6 +4,7 @@ class Legislation::Question < ApplicationRecord
   include Notifiable
 
   translates :title, touch: true
+  translates :description, touch: true
   include Globalizable
 
   belongs_to :author, -> { with_hidden }, class_name: "User", inverse_of: :legislation_questions

--- a/app/views/admin/legislation/questions/_form.html.erb
+++ b/app/views/admin/legislation/questions/_form.html.erb
@@ -7,7 +7,7 @@
   <div class="row">
     <%= f.translatable_fields do |translations_form| %>
       <div class="small-12 medium-9 column end">
-        <%= translations_form.text_area :title, rows: 5 %>
+        <%= translations_form.text_field :title %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/legislation/questions/_form.html.erb
+++ b/app/views/admin/legislation/questions/_form.html.erb
@@ -9,6 +9,10 @@
       <div class="small-12 medium-9 column end">
         <%= translations_form.text_field :title %>
       </div>
+
+      <div class="small-12 medium-9 column end">
+        <%= translations_form.text_area :description, class: "html-area admin" %>
+      </div>
     <% end %>
   </div>
 

--- a/app/views/legislation/questions/show.html.erb
+++ b/app/views/legislation/questions/show.html.erb
@@ -29,6 +29,7 @@
   <div class="row">
     <div class="small-12 medium-9 column">
       <h3 class="quiz-question"><%= @question.title %></h3>
+      <%= AdminWYSIWYGSanitizer.new.sanitize(@question.description) %>
       <div class="debate-questions" id="legislation-answer-form">
         <%= render "answer_form", process: @process, question: @question, answer: @answer %>
       </div>

--- a/app/views/legislation/questions/show.html.erb
+++ b/app/views/legislation/questions/show.html.erb
@@ -5,7 +5,7 @@
     <div class="small-12 medium-9 column">
       <div class="quiz-title">
         <p class="quiz-header-title"><%= t("legislation.questions.show.title") %></p>
-        <h4><%= link_to @process.title, @process %></h4>
+        <strong><%= link_to @process.title, @process %></strong>
       </div>
     </div>
     <div class="small-12 medium-3 column">
@@ -28,7 +28,7 @@
   </div>
   <div class="row">
     <div class="small-12 medium-9 column">
-      <h3 class="quiz-question"><%= @question.title %></h3>
+      <h1 class="quiz-question"><%= @question.title %></h1>
       <%= AdminWYSIWYGSanitizer.new.sanitize(@question.description) %>
       <div class="debate-questions" id="legislation-answer-form">
         <%= render "answer_form", process: @process, question: @question, answer: @answer %>
@@ -37,7 +37,7 @@
 
     <aside class="small-12 medium-3 column">
       <div id="social-share" class="sidebar-divider"></div>
-      <h3><%= t("legislation.questions.show.share") %></h3>
+      <h2><%= t("legislation.questions.show.share") %></h2>
       <%= render "/shared/social_share", title: @question.title, url: legislation_process_question_url(@question.process, @question) %>
     </aside>
   </div>

--- a/db/migrate/20220924224924_add_description_to_legislation_question_translations.rb
+++ b/db/migrate/20220924224924_add_description_to_legislation_question_translations.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToLegislationQuestionTranslations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :legislation_question_translations, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -861,6 +861,7 @@ ActiveRecord::Schema.define(version: 2023_02_06_141152) do
     t.datetime "updated_at", null: false
     t.text "title"
     t.datetime "hidden_at"
+    t.text "description"
     t.index ["hidden_at"], name: "index_legislation_question_translations_on_hidden_at"
     t.index ["legislation_question_id"], name: "index_d34cc1e1fe6d5162210c41ce56533c5afabcdbd3"
     t.index ["locale"], name: "index_legislation_question_translations_on_locale"

--- a/spec/system/admin/legislation/questions_spec.rb
+++ b/spec/system/admin/legislation/questions_spec.rb
@@ -32,6 +32,7 @@ describe "Admin legislation questions", :admin do
       click_link "Create question"
 
       fill_in "Question", with: "Question 3"
+      fill_in_ckeditor "Description", with: "A little description about question 3"
       click_button "Create question"
 
       expect(page).to have_content "Question 3"
@@ -40,7 +41,7 @@ describe "Admin legislation questions", :admin do
 
   context "Update" do
     scenario "Valid legislation question" do
-      create(:legislation_question, title: "Question 2", process: process)
+      create(:legislation_question, title: "Question 2", description: "Description 2", process: process)
 
       visit admin_root_path
 
@@ -57,9 +58,11 @@ describe "Admin legislation questions", :admin do
       click_link "Question 2"
 
       fill_in "Question", with: "Question 2b"
+      fill_in_ckeditor "Description", with: "Description 2b"
       click_button "Save changes"
 
       expect(page).to have_content "Question 2b"
+      expect(page).to have_ckeditor "Description", with: "Description 2b"
     end
   end
 

--- a/spec/system/legislation/questions_spec.rb
+++ b/spec/system/legislation/questions_spec.rb
@@ -9,9 +9,9 @@ describe "Legislation" do
     end
 
     before do
-      create(:legislation_question, process: process, title: "Question 1")
-      create(:legislation_question, process: process, title: "Question 2")
-      create(:legislation_question, process: process, title: "Question 3")
+      create(:legislation_question, process: process, title: "Question 1", description: "Description 1")
+      create(:legislation_question, process: process, title: "Question 2", description: "Description 2")
+      create(:legislation_question, process: process, title: "Question 3", description: "Description 3")
     end
 
     scenario "shows question list" do
@@ -24,16 +24,19 @@ describe "Legislation" do
       click_link "Question 1"
 
       expect(page).to have_content("Question 1")
+      expect(page).to have_content("Description 1")
       expect(page).to have_content("NEXT QUESTION")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 2")
+      expect(page).to have_content("Description 2")
       expect(page).to have_content("NEXT QUESTION")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 3")
+      expect(page).to have_content("Description 3")
       expect(page).not_to have_content("NEXT QUESTION")
     end
 
@@ -41,6 +44,7 @@ describe "Legislation" do
       visit legislation_process_question_path(process, process.questions.first)
 
       expect(page).to have_content("Question 1")
+      expect(page).to have_content("Description 1")
       expect(page).to have_content("Open answers (0)")
     end
 
@@ -48,16 +52,19 @@ describe "Legislation" do
       visit legislation_process_question_path(process, process.questions.first)
 
       expect(page).to have_content("Question 1")
+      expect(page).to have_content("Description 1")
       expect(page).to have_content("NEXT QUESTION")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 2")
+      expect(page).to have_content("Description 2")
       expect(page).to have_content("NEXT QUESTION")
 
       click_link "Next question"
 
       expect(page).to have_content("Question 3")
+      expect(page).to have_content("Description 3")
       expect(page).not_to have_content("NEXT QUESTION")
     end
 


### PR DESCRIPTION
## References

This PR resolves #4907.

## Objectives

- Replace Legislation question title textarea to text field.
- Add description to Legislation questions.

## Visual Changes

### Legislation question admin form _(BEFORE)_
<img width="1310" alt="1_before" src="https://user-images.githubusercontent.com/631897/192490961-77c99d24-0ab4-4fc0-8409-662e1be90df1.png">

### Legislation question admin form _(AFTER)_
<img width="1296" alt="1_after" src="https://user-images.githubusercontent.com/631897/192490995-7cfd27f6-5320-42f8-bbd5-3c9d7eaaa6eb.png">

### Legislation question admin index
<img width="1408" alt="2_questions" src="https://user-images.githubusercontent.com/631897/192491019-9c16ded8-60bd-4b8c-b376-07489c08f1ea.png">

### Legislation question user's view
<img width="943" alt="3" src="https://user-images.githubusercontent.com/631897/192491080-1786ccd3-a37e-45dc-8db0-5fe1323db160.png">