### PR TITLE
Remove URL setting

### DIFF
--- a/app/controllers/related_contents_controller.rb
+++ b/app/controllers/related_contents_controller.rb
@@ -18,7 +18,7 @@ class RelatedContentsController < ApplicationController
     elsif related_content.duplicate?
       flash[:error] = t("related_content.error_duplicate")
     else
-      flash[:error] = t("related_content.error", url: Setting["url"])
+      flash[:error] = t("related_content.error", url: root_url)
     end
     redirect_to polymorphic_path(related_content.parent_relationable)
   end
@@ -41,7 +41,7 @@ class RelatedContentsController < ApplicationController
     end
 
     def valid_url?
-      params[:url].start_with?(Setting["url"])
+      params[:url].start_with?(root_url)
     end
 
     def child_relationable_params

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -159,7 +159,6 @@ class Setting < ApplicationRecord
         "twitter_handle": nil,
         "twitter_hashtag": nil,
         "youtube_handle": nil,
-        "url": "http://example.com", # Public-facing URL of the app.
         # CONSUL installation's organization name
         "org_name": "CONSUL",
         "meta_title": nil,

--- a/app/views/relationable/_form.html.erb
+++ b/app/views/relationable/_form.html.erb
@@ -13,7 +13,7 @@
     <div class="input-group-field">
       <%= text_field_tag :url, "",
                         "aria-describedby": "related_content_help_text",
-                        placeholder: t("related_content.placeholder", url: setting["url"]) %>
+                        placeholder: t("related_content.placeholder", url: root_url) %>
 
       <%= hidden_field_tag :relationable_klass, relationable.class.name %>
       <%= hidden_field_tag :relationable_id, relationable.id %>

--- a/app/views/shared/_social_media_meta_tags.html.erb
+++ b/app/views/shared/_social_media_meta_tags.html.erb
@@ -8,9 +8,7 @@
 <meta name="twitter:image" content="<%= root_url + (local_assigns[:twitter_image_url] || "social_media_icon_twitter.png") %>" />
 <!-- Facebook OG -->
 <meta id="ogtitle" property="og:title" content="<%= local_assigns[:social_title] || setting["meta_title"] %>" />
-<% if setting["url"] %>
-  <meta property="article:publisher" content="<%= setting["url"] %>" />
-<% end %>
+<meta property="article:publisher" content="<%= root_url %>" />
 <% if setting["facebook_handle"] %>
   <meta property="article:author" content="https://www.facebook.com/<%= setting["facebook_handle"] %>" />
 <% end %>

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -40,8 +40,6 @@ en:
     telegram_handle_description: "If filled in it will appear in the footer"
     instagram_handle: "Instagram handle"
     instagram_handle_description: "If filled in it will appear in the footer"
-    url: "Main URL"
-    url_description: "Main URL of your website"
     org_name: "Site name"
     org_name_description: "This name will appear on mailers subject, help pages..."
     related_content_score_threshold: "Related content score threshold"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -40,8 +40,6 @@ es:
     telegram_handle_description: "Si está rellenado aparecerá en el pie de página"
     instagram_handle: "Usuario de Instagram"
     instagram_handle_description: "Si está rellenado aparecerá en el pie de página"
-    url: "URL general de la web"
-    url_description: "URL principal de tu web"
     org_name: "Nombre del sitio"
     org_name_description: "Este nombre aparecerá en el asunto de emails, páginas de ayuda..."
     related_content_score_threshold: "Umbral de puntuación de contenido relacionado"

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -9,7 +9,7 @@ SitemapGenerator::Sitemap.namer = SitemapGenerator::SimpleNamer.new(:sitemap, ex
 
 # default host
 SitemapGenerator::Sitemap.verbose = false if Rails.env.test?
-SitemapGenerator::Sitemap.default_host = Setting["url"]
+SitemapGenerator::Sitemap.default_host = root_url(ActionMailer::Base.default_url_options)
 
 # sitemap generator
 SitemapGenerator::Sitemap.create do

--- a/db/dev_seeds/admin_notifications.rb
+++ b/db/dev_seeds/admin_notifications.rb
@@ -4,7 +4,10 @@ section "Creating Admin Notifications & Templates" do
       %i[title body].index_with do |attribute|
         -> { I18n.t("seeds.admin_notifications.proposal.#{attribute}") }
       end
-    ).merge(link: "#{Setting["url"]}/proposals", segment_recipient: "administrators")
+    ).merge(
+      link: Rails.application.routes.url_helpers.proposals_url(ActionMailer::Base.default_url_options),
+      segment_recipient: "administrators"
+    )
   ).deliver
 
   AdminNotification.create!(

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -18,7 +18,6 @@ section "Creating Settings" do
     "telegram_handle": "CONSUL",
     "twitter_handle": "@consul_dev",
     "twitter_hashtag": "#consul_dev",
-    "url": "http://localhost:3000",
     "votes_for_proposal_success": "100",
     "youtube_handle": "CONSUL"
   }.each do |name, value|

--- a/spec/shared/system/relationable.rb
+++ b/spec/shared/system/relationable.rb
@@ -6,7 +6,6 @@ shared_examples "relationable" do |relationable_model_name|
 
   before do
     integration_session.host = Capybara.app_host # TODO: remove after upgrading to Rails 6.1
-    Setting["url"] = Capybara.app_host
   end
 
   scenario "related contents are listed" do
@@ -40,7 +39,7 @@ shared_examples "relationable" do |relationable_model_name|
     expect(page).to have_css ".add-related-content[aria-expanded='true']"
 
     within("#related_content") do
-      fill_in "Link to related content", with: polymorphic_url(related1)
+      fill_in "Link to related content", with: polymorphic_url(related1, port: app_port)
       click_button "Add"
     end
 
@@ -57,7 +56,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "Link to related content", with: polymorphic_url(related2)
+      fill_in "Link to related content", with: polymorphic_url(related2, port: app_port)
       click_button "Add"
     end
 
@@ -77,7 +76,7 @@ shared_examples "relationable" do |relationable_model_name|
       click_button "Add"
     end
 
-    expect(page).to have_content "Link not valid. Remember to start with #{Capybara.app_host}."
+    expect(page).to have_content "Link not valid. Remember to start with #{app_host}/."
   end
 
   scenario "returns error when relating content URL to itself" do
@@ -87,7 +86,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "Link to related content", with: polymorphic_url(relationable)
+      fill_in "Link to related content", with: polymorphic_url(relationable, port: app_port)
       click_button "Add"
     end
 
@@ -111,7 +110,7 @@ shared_examples "relationable" do |relationable_model_name|
       click_button "Add related content"
 
       within("#related_content") do
-        fill_in "Link to related content", with: "#{Capybara.app_host}/mypath/#{related.id}"
+        fill_in "Link to related content", with: "#{app_host}/mypath/#{related.id}"
         click_button "Add"
       end
 
@@ -129,7 +128,7 @@ shared_examples "relationable" do |relationable_model_name|
     click_button "Add related content"
 
     within("#related_content") do
-      fill_in "url", with: polymorphic_url(related1)
+      fill_in "url", with: polymorphic_url(related1, port: app_port)
       click_button "Add"
     end
 

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -19,7 +19,11 @@ module CommonActions
   include Verifications
 
   def app_host
-    "#{Capybara.app_host}:#{Capybara::Server.ports.values.last}"
+    "#{Capybara.app_host}:#{app_port}"
+  end
+
+  def app_port
+    Capybara::Server.ports.values.last
   end
 
   def fill_in_signup_form(email = "manuela@consul.dev", password = "judgementday")

--- a/spec/system/social_media_meta_tags_spec.rb
+++ b/spec/system/social_media_meta_tags_spec.rb
@@ -8,7 +8,6 @@ describe "Social media meta tags" do
       "Citizen participation tool for an open, transparent and democratic government."
     end
     let(:twitter_handle) { "@consul_test" }
-    let(:url) { "http://consul.dev" }
     let(:facebook_handle) { "consultest" }
     let(:org_name) { "CONSUL TEST" }
 
@@ -17,7 +16,6 @@ describe "Social media meta tags" do
       Setting["meta_title"] = meta_title
       Setting["meta_description"] = meta_description
       Setting["twitter_handle"] = twitter_handle
-      Setting["url"] = url
       Setting["facebook_handle"] = facebook_handle
       Setting["org_name"] = org_name
     end
@@ -30,7 +28,7 @@ describe "Social media meta tags" do
       expect(page).to have_meta "twitter:description", with: meta_description
       expect(page).to have_meta "twitter:image", with: "#{app_host}/social_media_icon_twitter.png"
       expect(page).to have_property "og:title", with: meta_title
-      expect(page).to have_property "article:publisher", with: url
+      expect(page).to have_property "article:publisher", with: "#{app_host}/"
       expect(page).to have_property "article:author", with: "https://www.facebook.com/#{facebook_handle}"
       expect(page).to have_property "og:url", with: "#{app_host}/"
       expect(page).to have_property "og:image", with: "#{app_host}/social_media_icon.png"


### PR DESCRIPTION
## References

* These changes will make it easier to deal with different hosts when adding multitenancy #4030

## Backgrounds

Until now, CONSUL installations had to specify their domain in two places: the `server_name` key in the `secrets.yml` file (which is done automatically by the installer) and the `url` configuration option in the administration settings.

This was redundant and, since the `url` option was only used when generating the sitemap, the dev_seeds, a `<meta>` tag and to validate related content, it was perfectly possible to leave it at the default value of `example.com` and never realize some things weren't working properly.

Furthermore, validating the related content and generating the mentioned `<meta>` tag is done in the context of a request, so we already have the domain in the request itself and don't need a configuration option.

## Objectives

* Simplify code dealing with absolute URLs in the context of a request
* Have only one setting to specify the main URL of the application 
* Make it easier to deal with different hosts when adding multitenancy

## Release Notes

We've removed the `url` configuration option in the administration settings. If you're using `Setting["url"]` in your custom code, replace it with either `root_url` (if the code is executed during a request) or with `root_url(ActionMailer::Base.default_url_options)` (if the code is executed during a rake task or a delayed job).