### PR TITLE
Allow adding per-environment custom settings

### DIFF
--- a/config/environments/custom/development.rb
+++ b/config/environments/custom/development.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  # Overwrite settings for the development environment or add your own
+  # custom settings for this environment.
+end

--- a/config/environments/custom/preproduction.rb
+++ b/config/environments/custom/preproduction.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  # Overwrite settings for the preproduction environment or add your own
+  # custom settings for this environment.
+end

--- a/config/environments/custom/production.rb
+++ b/config/environments/custom/production.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  # Overwrite settings for the production environment or add your own
+  # custom settings for this environment.
+end

--- a/config/environments/custom/staging.rb
+++ b/config/environments/custom/staging.rb
@@ -1,0 +1,7 @@
+Rails.application.configure do
+  # Overwrite settings for the staging environment or add your own
+  # custom settings for this environment. Note these changes will
+  # also affect the preproduction environment, so edit the
+  # `config/environments/custom/preproduction.rb` file if you don't
+  # want these changes to be applied there as well.
+end

--- a/config/environments/custom/test.rb
+++ b/config/environments/custom/test.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  # Overwrite settings for the test environment or add your own
+  # custom settings for this environment.
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,3 +71,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end
+
+require Rails.root.join("config", "environments", "custom", "development")

--- a/config/environments/preproduction.rb
+++ b/config/environments/preproduction.rb
@@ -1,1 +1,2 @@
 require Rails.root.join("config", "environments", "staging")
+require Rails.root.join("config", "environments", "custom", "preproduction")

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -122,3 +122,5 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end
+
+require Rails.root.join("config", "environments", "custom", "production")

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -121,3 +121,5 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end
+
+require Rails.root.join("config", "environments", "custom", "staging")

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,3 +61,5 @@ Rails.application.configure do
     end
   end
 end
+
+require Rails.root.join("config", "environments", "custom", "test")


### PR DESCRIPTION
## References

* We've found the need to customize environments while working on multitenancy #4030

## Background

Until now, when editing a specific environment, other CONSUL installations had to edit the original file, which made it harder to upgrade.

## Objectives

* Make it easier to know which part of the environment files come from customizations
* Make it easier to upgrade to versions of CONSUL which change the original environment files