### PR TITLE
Configure OmniAuth to send log to Rails logger

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,1 @@
+OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
## References

Before this change log generated by OmniAuth integration was sent to the STDOUT. Now developers will find the log within the `log/{environment}.log` directory as expected.

## Objectives

Send the Omniauth log to the Rails application logger so developers can easily find the OmniAuth output when debugging.

## Notes
We did some tests in the CONSUL testing server and seems to work fine.
