### PR TITLE
Fix verified check when signing in with Google

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,7 +131,8 @@ class User < ApplicationRecord
   # Get the existing user by email if the provider gives us a verified email.
   def self.first_or_initialize_for_oauth(auth)
     oauth_email           = auth.info.email
-    oauth_email_confirmed = oauth_email.present? && (auth.info.verified || auth.info.verified_email)
+    oauth_verified        = auth.info.verified || auth.info.verified_email || auth.info.email_verified
+    oauth_email_confirmed = oauth_email.present? && oauth_verified
     oauth_user            = User.find_by(email: oauth_email) if oauth_email_confirmed
 
     oauth_user || User.new(

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -479,6 +479,31 @@ describe "Users" do
       end
     end
 
+    context "Google" do
+      let(:google_hash) do
+        {
+          uid: "12345",
+          info: {
+            name: "manuela",
+            email: "manuelacarmena@example.com",
+            email_verified: "1"
+          }
+        }
+      end
+
+      before { Setting["feature.google_login"] = true }
+
+      scenario "Sign in with an already registered user using a verified google account" do
+        OmniAuth.config.add_mock(:google_oauth2, google_hash)
+        create(:user, username: "manuela", email: "manuelacarmena@example.com")
+
+        visit new_user_session_path
+        click_link "Sign in with Google"
+
+        expect_to_be_signed_in
+      end
+    end
+
     context "Wordpress" do
       let(:wordpress_hash) do
         {

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -223,11 +223,10 @@ describe "Users" do
     end
 
     context "Twitter" do
-      let(:twitter_hash) { { provider: "twitter", uid: "12345", info: { name: "manuela" }} }
-      let(:twitter_hash_with_email) { { provider: "twitter", uid: "12345", info: { name: "manuela", email: "manuelacarmena@example.com" }} }
+      let(:twitter_hash) { { uid: "12345", info: { name: "manuela" }} }
+      let(:twitter_hash_with_email) { { uid: "12345", info: { name: "manuela", email: "manuelacarmena@example.com" }} }
       let(:twitter_hash_with_verified_email) do
         {
-          provider: "twitter",
           uid: "12345",
           info: {
             name: "manuela",
@@ -482,11 +481,13 @@ describe "Users" do
 
     context "Wordpress" do
       let(:wordpress_hash) do
-        { provider: "wordpress",
+        {
           uid: "12345",
           info: {
             name: "manuela",
-            email: "manuelacarmena@example.com" }}
+            email: "manuelacarmena@example.com"
+          }
+        }
       end
 
       before { Setting["feature.wordpress_login"] = true }


### PR DESCRIPTION
## References

* We've found this issue while testing pull request #4030

## Background

The Google response contains an `email_verified` field instead of a `verified_email` field, and so we weren't treating verified Google accounts as verified.

## Objectives

* Allow signing in with a Google verified email after signing up in a different way