### PR TITLE
Fix crash running machine learning with no data dir

### DIFF
--- a/app/models/machine_learning.rb
+++ b/app/models/machine_learning.rb
@@ -195,17 +195,24 @@ class MachineLearning
 
   private
 
+    def create_data_folder
+      FileUtils.mkdir_p DATA_FOLDER
+    end
+
     def export_proposals_to_json
+      create_data_folder
       filename = DATA_FOLDER.join(MachineLearning.proposals_filename)
       Proposal::Exporter.new.to_json_file(filename)
     end
 
     def export_budget_investments_to_json
+      create_data_folder
       filename = DATA_FOLDER.join(MachineLearning.investments_filename)
       Budget::Investment::Exporter.new(Array.new).to_json_file(filename)
     end
 
     def export_comments_to_json
+      create_data_folder
       filename = DATA_FOLDER.join(MachineLearning.comments_filename)
       Comment::Exporter.new.to_json_file(filename)
     end

--- a/spec/models/machine_learning_spec.rb
+++ b/spec/models/machine_learning_spec.rb
@@ -303,9 +303,6 @@ describe MachineLearning do
 
   describe "#export_proposals_to_json" do
     it "creates a JSON file with all proposals" do
-      require "fileutils"
-      FileUtils.mkdir_p Rails.root.join("public", "machine_learning", "data")
-
       first_proposal = create(:proposal)
       last_proposal = create(:proposal)
 
@@ -332,9 +329,6 @@ describe MachineLearning do
 
   describe "#export_budget_investments_to_json" do
     it "creates a JSON file with all budget investments" do
-      require "fileutils"
-      FileUtils.mkdir_p Rails.root.join("public", "machine_learning", "data")
-
       first_budget_investment = create(:budget_investment)
       last_budget_investment = create(:budget_investment)
 
@@ -359,9 +353,6 @@ describe MachineLearning do
 
   describe "#export_comments_to_json" do
     it "creates a JSON file with all comments" do
-      require "fileutils"
-      FileUtils.mkdir_p Rails.root.join("public", "machine_learning", "data")
-
       first_comment = create(:comment)
       last_comment = create(:comment)
 

--- a/spec/system/admin/machine_learning_spec.rb
+++ b/spec/system/admin/machine_learning_spec.rb
@@ -207,8 +207,7 @@ describe "Machine learning" do
   end
 
   scenario "Show output files info on settins page" do
-    require "fileutils"
-    FileUtils.mkdir_p Rails.root.join("public", "machine_learning", "data")
+    FileUtils.mkdir_p MachineLearning::DATA_FOLDER
 
     allow_any_instance_of(MachineLearning).to receive(:run) do
       MachineLearningJob.first.update!(finished_at: 2.minutes.from_now)


### PR DESCRIPTION
## References

* This bug was introduced in pull request #4585
* This crash is particularly relevant when using multitenancy #4030

## Objectives

* Fix a crash running machine learning scripts on a machine which doesn't have the `public/machine_learning/data` folder