### PR TITLE
Revert "Use the same color for solid and hollow buttons"

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -134,8 +134,9 @@ button,
 }
 
 .button.hollow {
-  @include brand-text;
+  @include normal-selection;
   border: 1px solid;
+  color: $anchor-color;
 }
 
 .button.hollow.error {

--- a/app/assets/stylesheets/mixins/buttons.scss
+++ b/app/assets/stylesheets/mixins/buttons.scss
@@ -23,7 +23,7 @@
   @include base-button;
 }
 
-@mixin hollow-button($color: $brand) {
+@mixin hollow-button($color: $anchor-color) {
   @include button($style: hollow, $background: $color);
   @include normal-selection;
   @include base-button;


### PR DESCRIPTION
## References

* This reverts commit 5dbd69486 from pull request #5017

## Background

Back in commit 5dbd69486, I said:

> I'm choosing to use the same color for solid and hollow buttons because these elements are usually isolated and so from the UX perspective they are similar; links, on the other hand, are often in the middle of some text.

However, I made a mistake. The crucial factor is that solid buttons might have a light background if we choose the brand color to be a light one, and in this case they automatically get black text. However, hollow buttons always have a light background and so we can't use a light color for the text and border of these buttons.

## Objectives

* Avoid situations where hollow buttons have light text over light background, making the text illegible