### PR TITLE
Simplify locking current user when voting

### DIFF
--- a/app/models/poll/answer.rb
+++ b/app/models/poll/answer.rb
@@ -38,7 +38,6 @@ class Poll::Answer < ApplicationRecord
     def max_votes
       return if !question || question&.unique? || persisted?
 
-      author.reload
       author.lock!
 
       if question.answers.by_author(author).count >= question.max_votes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -339,7 +339,7 @@ class User < ApplicationRecord
   end
 
   def locale
-    self[:locale] ||= I18n.default_locale.to_s
+    self[:locale] || I18n.default_locale.to_s
   end
 
   def confirmation_required?


### PR DESCRIPTION
## References

* We introduced the lock in commit 36e452437 from pull request #5012

## Objectives

* Simplify code
* Avoid unneeded changes in the `current_user` object