### PR TITLE
Add expectations in tests confirming account

### DIFF
--- a/spec/system/multitenancy_spec.rb
+++ b/spec/system/multitenancy_spec.rb
@@ -129,6 +129,8 @@ describe "Multitenancy", :seed_tenants do
       check "By registering you accept the terms and conditions of use"
       click_button "Register"
 
+      expect(page).to have_content "You have been sent a message containing a verification link"
+
       confirm_email
 
       expect(page).to have_content "Your account has been confirmed."

--- a/spec/system/users_auth_spec.rb
+++ b/spec/system/users_auth_spec.rb
@@ -392,6 +392,9 @@ describe "Users" do
 
         fill_in "Username", with: "manuela2"
         click_button "Register"
+
+        expect(page).to have_content "To continue, please click on the confirmation link that we have sent you via email"
+
         confirm_email
 
         expect(page).to have_content "Your account has been confirmed"


### PR DESCRIPTION
## References

* One of these tests failed during our [test run 4537, job 4](https://github.com/consul/consul/actions/runs/3553790095/jobs/5969505972) (see the [test run 4537, job 4 log](https://github.com/consul/consul/files/10103502/run_4537_job_4.txt))

## Objectives

* Reduce the number of possible reasons why the test failed once in our CI
* (Maybe) Fix the reason why the test failed once in our CI