### PR TITLE
Fix crash voting on a heading with a content block

### DIFF
--- a/app/components/budgets/investments/content_blocks_component.html.erb
+++ b/app/components/budgets/investments/content_blocks_component.html.erb
@@ -1,0 +1,5 @@
+<ul class="no-bullet categories">
+  <% content_blocks.each do |content_block| %>
+    <%= raw content_block.body %>
+  <% end %>
+</ul>

--- a/app/components/budgets/investments/content_blocks_component.rb
+++ b/app/components/budgets/investments/content_blocks_component.rb
@@ -1,0 +1,17 @@
+class Budgets::Investments::ContentBlocksComponent < ApplicationComponent
+  attr_reader :heading
+
+  def initialize(heading)
+    @heading = heading
+  end
+
+  def render?
+    heading&.allow_custom_content && content_blocks.any?
+  end
+
+  private
+
+    def content_blocks
+      heading.content_blocks.where(locale: I18n.locale)
+    end
+end

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -25,7 +25,6 @@ module Budgets
     before_action :load_categories, only: :index
     before_action :set_default_investment_filter, only: :index
     before_action :set_view, only: :index
-    before_action :load_content_blocks, only: :index
 
     skip_authorization_check only: :json_data
 
@@ -147,10 +146,6 @@ module Budgets
 
       def load_categories
         @categories = Tag.category.order(:name)
-      end
-
-      def load_content_blocks
-        @heading_content_blocks = @heading.content_blocks.where(locale: I18n.locale) if @heading
       end
 
       def tag_cloud

--- a/app/views/budgets/investments/_content_blocks.html.erb
+++ b/app/views/budgets/investments/_content_blocks.html.erb
@@ -1,7 +1,0 @@
-<% if @heading.allow_custom_content %>
-  <ul class="no-bullet categories">
-    <% @heading_content_blocks.each do |content_block| %>
-      <%= raw content_block.body %>
-    <% end %>
-  </ul>
-<% end %>

--- a/app/views/budgets/investments/_sidebar.html.erb
+++ b/app/views/budgets/investments/_sidebar.html.erb
@@ -59,9 +59,7 @@
   </div>
 <% end %>
 
-<% if @heading && !@heading.content_blocks.where(locale: I18n.locale).empty? %>
-  <%= render "budgets/investments/content_blocks" %>
-<% end %>
+<%= render Budgets::Investments::ContentBlocksComponent.new(@heading) %>
 
 <% if @map_location&.available? %>
   <%= render "budgets/investments/map" %>

--- a/spec/components/budgets/investments/content_blocks_component_spec.rb
+++ b/spec/components/budgets/investments/content_blocks_component_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe Budgets::Investments::ContentBlocksComponent do
+  it "is not rendered without a heading" do
+    render_inline Budgets::Investments::ContentBlocksComponent.new(nil)
+
+    expect(page).not_to be_rendered
+  end
+
+  it "is not rendered with a heading without custom blocks" do
+    heading = Budget::Heading.new(allow_custom_content: true)
+
+    render_inline Budgets::Investments::ContentBlocksComponent.new(heading)
+
+    expect(page).not_to be_rendered
+  end
+
+  it "is not rendered with a heading with custom blocks in other languages" do
+    heading = create(:budget_heading, allow_custom_content: true)
+    create(:heading_content_block, heading: heading, locale: :es)
+
+    render_inline Budgets::Investments::ContentBlocksComponent.new(heading)
+
+    expect(page).not_to be_rendered
+  end
+
+  it "is not rendered with a heading not allowing custom content" do
+    heading = create(:budget_heading, allow_custom_content: false)
+    create(:heading_content_block, heading: heading, locale: :en)
+
+    render_inline Budgets::Investments::ContentBlocksComponent.new(heading)
+
+    expect(page).not_to be_rendered
+  end
+
+  it "renders content blocks for the current language" do
+    heading = create(:budget_heading, allow_custom_content: true)
+    create(:heading_content_block, heading: heading, locale: :en, body: "<li>Heading block</li>")
+
+    render_inline Budgets::Investments::ContentBlocksComponent.new(heading)
+
+    page.find("ul") do |list|
+      expect(page).to have_css "li", exact_text: "Heading block"
+    end
+  end
+end

--- a/spec/system/budgets/ballots_spec.rb
+++ b/spec/system/budgets/ballots_spec.rb
@@ -160,13 +160,16 @@ describe "Ballots" do
         end
       end
 
-      scenario "the Map shoud be visible before and after" do
+      scenario "map and content block shoud be visible before and after" do
         create(:budget_investment, :selected, heading: new_york, price: 10000, title: "More bridges")
+        create(:heading_content_block, heading: new_york, body: "<li>New Block</li>")
+        new_york.update!(allow_custom_content: true)
 
         visit budget_investments_path(budget, heading_id: new_york)
 
         within("#sidebar") do
           expect(page).to have_content "OpenStreetMap"
+          expect(page).to have_content "New Block"
         end
 
         add_to_ballot("More bridges")
@@ -174,6 +177,7 @@ describe "Ballots" do
         within("#sidebar") do
           expect(page).to have_content "More bridges"
           expect(page).to have_content "OpenStreetMap"
+          expect(page).to have_content "New Block"
         end
 
         within(".budget-investment", text: "More bridges") do
@@ -183,6 +187,7 @@ describe "Ballots" do
         within("#sidebar") do
           expect(page).not_to have_content "More bridges"
           expect(page).to have_content "OpenStreetMap"
+          expect(page).to have_content "New Block"
         end
       end
     end


### PR DESCRIPTION
## References

* Closes #5035

## Objectives

* Fix crash when rendering a heading content block after voting for an investment

## Notes

* The ERB Lint error due to using `raw` was already there before this pull request.