### PR TITLE
Respond with not found on missing tenants

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,6 +48,7 @@ module Consul
 
     # Handle custom exceptions
     config.action_dispatch.rescue_responses["FeatureFlags::FeatureDisabled"] = :forbidden
+    config.action_dispatch.rescue_responses["Apartment::TenantNotFound"] = :not_found
 
     # Store uploaded files on the local file system (see config/storage.yml for options).
     config.active_storage.service = :local

--- a/spec/system/multitenancy_spec.rb
+++ b/spec/system/multitenancy_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
 
 describe "Multitenancy", :seed_tenants do
-  before do
-    create(:tenant, schema: "mars")
-    create(:tenant, schema: "venus")
-  end
+  before { create(:tenant, schema: "mars") }
 
   scenario "Disabled features", :no_js do
+    create(:tenant, schema: "venus")
     Tenant.switch("mars") { Setting["process.debates"] = true }
     Tenant.switch("venus") { Setting["process.debates"] = nil }
 
@@ -22,6 +20,7 @@ describe "Multitenancy", :seed_tenants do
   end
 
   scenario "Content is different for differents tenants" do
+    create(:tenant, schema: "venus")
     Tenant.switch("mars") { create(:poll, name: "Human rights for Martians?") }
 
     with_subdomain("mars") do
@@ -69,6 +68,7 @@ describe "Multitenancy", :seed_tenants do
   end
 
   scenario "Creating content in one tenant doesn't affect other tenants" do
+    create(:tenant, schema: "venus")
     Tenant.switch("mars") { login_as(create(:user)) }
 
     with_subdomain("mars") do
@@ -96,6 +96,7 @@ describe "Multitenancy", :seed_tenants do
   end
 
   scenario "Users from another tenant cannot vote" do
+    create(:tenant, schema: "venus")
     Tenant.switch("mars") { create(:proposal, title: "Earth invasion") }
     Tenant.switch("venus") { login_as(create(:user)) }
 
@@ -138,6 +139,7 @@ describe "Multitenancy", :seed_tenants do
   end
 
   scenario "Users from another tenant can't sign in" do
+    create(:tenant, schema: "venus")
     Tenant.switch("mars") { create(:user, email: "marty@consul.dev", password: "20151021") }
 
     with_subdomain("mars") do

--- a/spec/system/multitenancy_spec.rb
+++ b/spec/system/multitenancy_spec.rb
@@ -173,4 +173,12 @@ describe "Multitenancy", :seed_tenants do
       expect(page).not_to have_css "html.tenant-public"
     end
   end
+
+  scenario "Shows the not found page when accessing a non-existing tenant", :show_exceptions do
+    with_subdomain("jupiter") do
+      visit root_path
+
+      expect(page).to have_title "Not found"
+    end
+  end
 end


### PR DESCRIPTION
## References

* We added mutitenancy in pull request #4030

## Background

On applications using multitenancy, we were raising a 500 internal server error whenever we access the application using a subdomain which doesn't belong to a tenant. However, the application was working properly, so showing "internal server error" was misleading.

## Objectives

* Return a "Not found" message when accessing a tenant page which doesn't exist