### PR TITLE
Use the tenant URL as a link to the tenant

### DIFF
--- a/app/components/admin/tenants/index_component.html.erb
+++ b/app/components/admin/tenants/index_component.html.erb
@@ -17,11 +17,9 @@
       <tr id="<%= dom_id(tenant) %>">
         <td><%= tenant.name %></td>
         <td><%= tenant.schema %></td>
-        <td><%= tenant.host %></td>
+        <td><%= link_to tenant.host, root_url(host: tenant.host) %></td>
         <td>
-          <%= render Admin::TableActionsComponent.new(tenant, actions: [:edit]) do |actions| %>
-            <%= actions.action(:show, text: t("admin.shared.view"), path: root_url(host: tenant.host)) %>
-          <% end %>
+          <%= render Admin::TableActionsComponent.new(tenant, actions: [:edit]) %>
         </td>
       </tr>
     <% end %>

--- a/spec/system/admin/tenants_spec.rb
+++ b/spec/system/admin/tenants_spec.rb
@@ -19,11 +19,7 @@ describe "Tenants", :admin, :seed_tenants do
 
       expect(page).to have_content "Tenant created successfully"
 
-      within("tr", text: "earth") do
-        expect(page).to have_content "earth.lvh.me"
-
-        click_link "View"
-      end
+      click_link "earth.lvh.me"
 
       expect(current_host).to eq "http://earth.lvh.me"
       expect(page).to have_current_path root_path
@@ -38,11 +34,7 @@ describe "Tenants", :admin, :seed_tenants do
       fill_in "Name", with: "Earthlings"
       click_button "Create tenant"
 
-      within("tr", text: "earth") do
-        expect(page).to have_content "earth.lvh.me"
-
-        click_link "View"
-      end
+      click_link "earth.lvh.me"
 
       expect(current_host).to eq "http://earth.lvh.me"
       expect(page).to have_current_path root_path
@@ -65,7 +57,7 @@ describe "Tenants", :admin, :seed_tenants do
 
     expect(page).to have_content "Tenant updated successfully"
 
-    within("tr", text: "the-moon") { click_link "View" }
+    click_link "the-moon.lvh.me"
 
     expect(current_host).to eq "http://the-moon.lvh.me"
     expect(page).to have_current_path root_path


### PR DESCRIPTION
## References

* Continues pull request #5007

## Objectives

* Meet user expectations regarding text representing a URL
* Reduce the size of the tenants table

## Visual Changes

### Before these changes

![The URL in the tenants table is plain text and there's a "view" link](https://user-images.githubusercontent.com/35156/207599603-f79ce34f-b992-4002-a0f3-99cc55803878.png)

### After these changes

![The URL in the tenants table is a link and there's no "view" link](https://user-images.githubusercontent.com/35156/207599306-d79477ed-34d6-4ea5-bf1a-cf02d4430781.png)
