### PR TITLE
Create an administrator in new tenant

### DIFF
--- a/app/components/admin/tenants/new_component.html.erb
+++ b/app/components/admin/tenants/new_component.html.erb
@@ -1,3 +1,7 @@
 <%= back_link_to admin_tenants_path %>
 <%= header %>
+<div class="callout primary">
+  <%= sanitize(t("admin.tenants.new.admin_information", username: current_user.username,
+                                                        email: current_user.email)) %>
+</div>
 <%= render Admin::Tenants::FormComponent.new(tenant) %>

--- a/app/components/admin/tenants/new_component.rb
+++ b/app/components/admin/tenants/new_component.rb
@@ -1,6 +1,7 @@
 class Admin::Tenants::NewComponent < ApplicationComponent
   include Header
   attr_reader :tenant
+  delegate :current_user, to: :helpers
 
   def initialize(tenant)
     @tenant = tenant

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1642,6 +1642,7 @@ en:
         enable: "Enable tenant %{tenant}"
         enabled: Enabled
       new:
+        admin_information: "When you create a tenant, your current user <strong>\"%{username}\"</strong> with the email <strong>\"%{email}\"</strong> and your password will be copied into the new tenant's database and will be automatically granted administration permissions. Note that these user accounts are stored in completely separate databases, so if you change the password of your user in one tenant, your accounts in other tenants will remain intact."
         title: New tenant
       restore:
         notice: Tenant enabled successfully

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1641,6 +1641,7 @@ es:
         enable: "Habilitar entidad %{tenant}"
         enabled: Habilitada
       new:
+        admin_information: 'Al crear una entidad se copiará tu usuario actual <strong>"%{username}"</strong> con el email <strong>"%{email}"</strong> y tu actual contraseña en la base de datos de la nueva entidad y se te otorgarán permisos de administración en la nueva entidad automáticamente. Nótese que serán cuentas de usuarios que están en bases de datos completamente independientes por lo que si cambias la contraseña de tu usuario en una entidad, las cuentas que tengas en otras entidades permanecerán intactas.'
         title: Nueva entidad
       restore:
         notice: Entidad habilitada correctamente

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
 # Default admin user (change password after first deploy to a server!)
-if Administrator.count == 0 && !Rails.env.test?
+if Administrator.count == 0 && (!Rails.env.test? || !Tenant.default?)
   admin = User.create!(username: "admin", email: "admin@consul.dev", password: "12345678",
                        password_confirmation: "12345678", confirmed_at: Time.current,
                        terms_of_service: "1")

--- a/spec/system/admin/tenants_spec.rb
+++ b/spec/system/admin/tenants_spec.rb
@@ -40,6 +40,33 @@ describe "Tenants", :admin, :seed_tenants do
       expect(page).to have_current_path root_path
       expect(page).to have_link "Sign in"
     end
+
+    scenario "Updates new tenant default user with the main tenant administrator login credentials" do
+      user = create(:user, email: "super@consul.dev", password: "secret_password")
+      create(:administrator, user: user)
+      login_as(user)
+
+      visit new_admin_tenant_path
+
+      expect(page).to have_content "When you create a tenant, your current user"
+
+      fill_in "Name", with: "Earthlings"
+      fill_in "Subdomain", with: "earth"
+      click_button "Create tenant"
+
+      expect(page).to have_content "Tenant created successfully"
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+
+      click_link "earth.lvh.me"
+
+      click_link "Sign in"
+      fill_in "Email or username", with: "super@consul.dev"
+      fill_in "Password", with: "secret_password"
+      click_button "Enter"
+
+      expect(page).to have_content "You have been signed in successfully."
+      expect(current_host).to eq "http://earth.lvh.me"
+    end
   end
 
   scenario "Update" do


### PR DESCRIPTION
## References
Related PR: #4030 

## Objectives
When an admin creates a new tenant, we automatically add him as admin of the newly created tenant. The admin that is created is already automatically confirmed as it is a copy of an existing user with the same password.

## Visual Changes
![create administrator in new tenant](https://user-images.githubusercontent.com/16189/207918293-4069f63f-2dd4-4ed5-bb30-591b6e580402.png)

## Notes
Add this behaviour to the [multitenancy documentation](https://github.com/consul/docs/pull/116).