### PR TITLE
Make it possible to disable tenants 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -335,6 +335,7 @@ Rails/SkipsModelValidations:
   ForbiddenMethods:
     - update_attribute
   Exclude:
+    - app/models/tenant.rb
     - lib/acts_as_paranoid_aliases.rb
 
 Rails/TimeZone:

--- a/app/assets/stylesheets/admin/budget_phases/phases.scss
+++ b/app/assets/stylesheets/admin/budget_phases/phases.scss
@@ -3,9 +3,4 @@
   caption {
     @include element-invisible;
   }
-
-  [aria-pressed] {
-    @include switch;
-    margin-bottom: 0;
-  }
 }

--- a/app/assets/stylesheets/admin/toggle_switch.scss
+++ b/app/assets/stylesheets/admin/toggle_switch.scss
@@ -1,0 +1,6 @@
+.admin .toggle-switch {
+  [aria-pressed] {
+    @include switch;
+    margin-bottom: 0;
+  }
+}

--- a/app/components/admin/budget_phases/toggle_enabled_component.html.erb
+++ b/app/components/admin/budget_phases/toggle_enabled_component.html.erb
@@ -1,1 +1,1 @@
-<%= render Admin::ActionComponent.new(action, phase, options) %>
+<%= render Admin::ToggleSwitchComponent.new(action, phase, pressed: enabled?, **options) %>

--- a/app/components/admin/budget_phases/toggle_enabled_component.html.erb
+++ b/app/components/admin/budget_phases/toggle_enabled_component.html.erb
@@ -1,1 +1,1 @@
-<%= render Admin::ActionComponent.new(:toggle_enabled, phase, options) %>
+<%= render Admin::ActionComponent.new(action, phase, options) %>

--- a/app/components/admin/budget_phases/toggle_enabled_component.rb
+++ b/app/components/admin/budget_phases/toggle_enabled_component.rb
@@ -9,14 +9,7 @@ class Admin::BudgetPhases::ToggleEnabledComponent < ApplicationComponent
   private
 
     def options
-      {
-        text: text,
-        method: :patch,
-        remote: true,
-        "aria-label": t("admin.budgets.edit.enable_phase", phase: phase.name),
-        "aria-pressed": enabled?,
-        form_class: "toggle-switch"
-      }
+      { "aria-label": t("admin.budgets.edit.enable_phase", phase: phase.name) }
     end
 
     def action
@@ -24,14 +17,6 @@ class Admin::BudgetPhases::ToggleEnabledComponent < ApplicationComponent
         :disable
       else
         :enable
-      end
-    end
-
-    def text
-      if enabled?
-        t("shared.yes")
-      else
-        t("shared.no")
       end
     end
 end

--- a/app/components/admin/budget_phases/toggle_enabled_component.rb
+++ b/app/components/admin/budget_phases/toggle_enabled_component.rb
@@ -1,5 +1,6 @@
 class Admin::BudgetPhases::ToggleEnabledComponent < ApplicationComponent
   attr_reader :phase
+  delegate :enabled?, to: :phase
 
   def initialize(phase)
     @phase = phase
@@ -13,12 +14,21 @@ class Admin::BudgetPhases::ToggleEnabledComponent < ApplicationComponent
         method: :patch,
         remote: true,
         "aria-label": t("admin.budgets.edit.enable_phase", phase: phase.name),
-        "aria-pressed": phase.enabled?
+        "aria-pressed": enabled?,
+        form_class: "toggle-switch"
       }
     end
 
+    def action
+      if enabled?
+        :disable
+      else
+        :enable
+      end
+    end
+
     def text
-      if phase.enabled?
+      if enabled?
         t("shared.yes")
       else
         t("shared.no")

--- a/app/components/admin/tenants/index_component.html.erb
+++ b/app/components/admin/tenants/index_component.html.erb
@@ -8,20 +8,14 @@
       <th><%= attribute_name(:name) %></th>
       <th><%= attribute_name(:schema) %></th>
       <th><%= attribute_name(:url) %></th>
+      <th><%= t("admin.tenants.index.enabled") %></th>
       <th><%= t("admin.shared.actions") %></th>
     </tr>
   </thead>
 
   <tbody>
     <% @tenants.each do |tenant| %>
-      <tr id="<%= dom_id(tenant) %>">
-        <td><%= tenant.name %></td>
-        <td><%= tenant.schema %></td>
-        <td><%= link_to tenant.host, root_url(host: tenant.host) %></td>
-        <td>
-          <%= render Admin::TableActionsComponent.new(tenant, actions: [:edit]) %>
-        </td>
-      </tr>
+      <%= render Admin::Tenants::RowComponent.new(tenant) %>
     <% end %>
   </tbody>
 </table>

--- a/app/components/admin/tenants/row_component.html.erb
+++ b/app/components/admin/tenants/row_component.html.erb
@@ -1,0 +1,9 @@
+<tr id="<%= dom_id(tenant) %>">
+  <td><%= tenant.name %></td>
+  <td><%= tenant.schema %></td>
+  <td><%= link_to_unless tenant.hidden?, tenant.host, root_url(host: tenant.host) %></td>
+  <td><%= render Admin::Tenants::ToggleHiddenComponent.new(tenant) %></td>
+  <td>
+    <%= render Admin::TableActionsComponent.new(tenant, actions: [:edit]) %>
+  </td>
+</tr>

--- a/app/components/admin/tenants/row_component.rb
+++ b/app/components/admin/tenants/row_component.rb
@@ -1,0 +1,7 @@
+class Admin::Tenants::RowComponent < ApplicationComponent
+  attr_reader :tenant
+
+  def initialize(tenant)
+    @tenant = tenant
+  end
+end

--- a/app/components/admin/tenants/toggle_hidden_component.html.erb
+++ b/app/components/admin/tenants/toggle_hidden_component.html.erb
@@ -1,0 +1,1 @@
+<%= render Admin::ToggleSwitchComponent.new(action, tenant, pressed: enabled?, **options) %>

--- a/app/components/admin/tenants/toggle_hidden_component.rb
+++ b/app/components/admin/tenants/toggle_hidden_component.rb
@@ -1,0 +1,28 @@
+class Admin::Tenants::ToggleHiddenComponent < ApplicationComponent
+  attr_reader :tenant
+
+  def initialize(tenant)
+    @tenant = tenant
+  end
+
+  private
+
+    def action
+      if enabled?
+        :hide
+      else
+        :restore
+      end
+    end
+
+    def options
+      {
+        method: :put,
+        "aria-label": t("admin.tenants.index.enable", tenant: tenant.name)
+      }
+    end
+
+    def enabled?
+      !tenant.hidden?
+    end
+end

--- a/app/components/admin/toggle_switch_component.html.erb
+++ b/app/components/admin/toggle_switch_component.html.erb
@@ -1,0 +1,1 @@
+<%= render Admin::ActionComponent.new(action, record, **default_options.merge(options)) %>

--- a/app/components/admin/toggle_switch_component.rb
+++ b/app/components/admin/toggle_switch_component.rb
@@ -1,0 +1,31 @@
+class Admin::ToggleSwitchComponent < ApplicationComponent
+  attr_reader :action, :record, :pressed, :options
+  alias_method :pressed?, :pressed
+
+  def initialize(action, record, pressed:, **options)
+    @action = action
+    @record = record
+    @pressed = pressed
+    @options = options
+  end
+
+  private
+
+    def text
+      if pressed?
+        t("shared.yes")
+      else
+        t("shared.no")
+      end
+    end
+
+    def default_options
+      {
+        text: text,
+        method: :patch,
+        remote: true,
+        "aria-pressed": pressed?,
+        form_class: "toggle-switch"
+      }
+    end
+end

--- a/app/controllers/admin/tenants_controller.rb
+++ b/app/controllers/admin/tenants_controller.rb
@@ -27,6 +27,24 @@ class Admin::TenantsController < Admin::BaseController
     end
   end
 
+  def hide
+    @tenant.hide
+
+    respond_to do |format|
+      format.html { redirect_to admin_tenants_path, notice: t("admin.tenants.hide.notice") }
+      format.js { render template: "admin/tenants/toggle_enabled" }
+    end
+  end
+
+  def restore
+    @tenant.restore
+
+    respond_to do |format|
+      format.html { redirect_to admin_tenants_path, notice: t("admin.tenants.restore.notice") }
+      format.js { render template: "admin/tenants/toggle_enabled" }
+    end
+  end
+
   private
 
     def tenant_params

--- a/app/controllers/concerns/admin/budget_phases_actions.rb
+++ b/app/controllers/concerns/admin/budget_phases_actions.rb
@@ -6,7 +6,7 @@ module Admin::BudgetPhasesActions
     include ImageAttributes
 
     before_action :load_budget
-    before_action :load_phase, only: [:edit, :update, :toggle_enabled]
+    before_action :load_phase, only: [:edit, :update, :enable, :disable]
   end
 
   def edit
@@ -20,12 +20,21 @@ module Admin::BudgetPhasesActions
     end
   end
 
-  def toggle_enabled
-    @phase.update!(enabled: !@phase.enabled)
+  def enable
+    @phase.update!(enabled: true)
 
     respond_to do |format|
       format.html { redirect_to phases_index, notice: t("flash.actions.save_changes.notice") }
-      format.js
+      format.js { render template: "admin/budgets_wizard/phases/toggle_enabled" }
+    end
+  end
+
+  def disable
+    @phase.update!(enabled: false)
+
+    respond_to do |format|
+      format.html { redirect_to phases_index, notice: t("flash.actions.save_changes.notice") }
+      format.js { render template: "admin/budgets_wizard/phases/toggle_enabled" }
     end
   end
 

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -136,7 +136,7 @@ module Abilities
       can [:create, :read], LocalCensusRecords::Import
 
       if Rails.application.config.multitenancy && Tenant.default?
-        can [:create, :read, :update], Tenant
+        can [:create, :read, :update, :hide, :restore], Tenant
       end
     end
   end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -30,7 +30,11 @@ class Tenant < ApplicationRecord
       host_domain = allowed_domains.find { |domain| host == domain || host.ends_with?(".#{domain}") }
       schema = host_without_www.sub(/\.?#{host_domain}\Z/, "").presence
 
-      schema unless find_by_domain(schema)
+      if find_by_domain(schema)
+        raise Apartment::TenantNotFound
+      else
+        schema
+      end
     end
   end
 

--- a/app/views/admin/budget_phases/toggle_enabled.js.erb
+++ b/app/views/admin/budget_phases/toggle_enabled.js.erb
@@ -1,1 +1,0 @@
-<%= render template: "admin/budgets_wizard/phases/toggle_enabled" %>

--- a/app/views/admin/budgets_wizard/phases/toggle_enabled.js.erb
+++ b/app/views/admin/budgets_wizard/phases/toggle_enabled.js.erb
@@ -1,4 +1,5 @@
 var replacement = $("<%= j render Admin::BudgetPhases::ToggleEnabledComponent.new(@phase) %>");
-var form = $("#" + replacement.find("[type='submit']").attr("id")).closest("form");
+var form = $("#<%= dom_id(@phase) %> .toggle-switch");
 
-form.html(replacement.html()).find("[type='submit']").focus();
+form.replaceWith(replacement);
+replacement.find("[type='submit']").focus();

--- a/app/views/admin/tenants/toggle_enabled.js.erb
+++ b/app/views/admin/tenants/toggle_enabled.js.erb
@@ -1,0 +1,4 @@
+var replacement = $("<%= j render Admin::Tenants::RowComponent.new(@tenant) %>");
+var row = $("#<%= dom_id(@tenant) %>");
+
+row.html(replacement.html()).find(".toggle-switch [type='submit']").focus();

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1635,10 +1635,16 @@ en:
       form:
         use_subdomain: "Use a subdomain in the %{domain} domain to access this tenant"
         use_domain: "Use a different domain to access this tenant"
+      hide:
+        notice: Tenant disabled successfully
       index:
         create: Create tenant
+        enable: "Enable tenant %{tenant}"
+        enabled: Enabled
       new:
         title: New tenant
+      restore:
+        notice: Tenant enabled successfully
       update:
         notice: Tenant updated successfully
     homepage:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1634,10 +1634,16 @@ es:
       form:
         use_subdomain: "Utiliza un subdominio en el dominio %{domain} para acceder a esta entidad"
         use_domain: "Utiliza un dominio distinto para acceder a esta entidad"
+      hide:
+        notice: Entidad deshabilitada correctamente
       index:
         create: Crear entidad
+        enable: "Habilitar entidad %{tenant}"
+        enabled: Habilitada
       new:
         title: Nueva entidad
+      restore:
+        notice: Entidad habilitada correctamente
       update:
         notice: Entidad actualizada correctamente
     homepage:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -70,7 +70,10 @@ namespace :admin do
     end
 
     resources :budget_phases, only: [:edit, :update] do
-      member { patch :toggle_enabled }
+      member do
+        patch :enable
+        patch :disable
+      end
     end
   end
 
@@ -81,7 +84,10 @@ namespace :admin do
       end
 
       resources :phases, as: "budget_phases", only: [:index, :edit, :update] do
-        member { patch :toggle_enabled }
+        member do
+          patch :enable
+          patch :disable
+        end
       end
     end
   end

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -284,7 +284,12 @@ namespace :admin do
     delete :cancel, on: :collection
   end
 
-  resources :tenants, except: [:show, :destroy]
+  resources :tenants, except: [:show, :destroy] do
+    member do
+      put :hide
+      put :restore
+    end
+  end
 end
 
 resolve "Milestone" do |milestone|

--- a/db/migrate/20221203140136_add_hidden_at_to_tenants.rb
+++ b/db/migrate/20221203140136_add_hidden_at_to_tenants.rb
@@ -1,0 +1,5 @@
+class AddHiddenAtToTenants < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tenants, :hidden_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_20_123254) do
+ActiveRecord::Schema.define(version: 2022_12_03_140136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -1562,6 +1562,7 @@ ActiveRecord::Schema.define(version: 2022_11_20_123254) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "schema_type", default: 0, null: false
+    t.datetime "hidden_at"
     t.index ["name"], name: "index_tenants_on_name", unique: true
     t.index ["schema"], name: "index_tenants_on_schema", unique: true
   end

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -181,6 +181,8 @@ describe Abilities::Administrator do
       it { should be_able_to :create, Tenant }
       it { should be_able_to :read, Tenant }
       it { should be_able_to :update, Tenant }
+      it { should be_able_to :hide, Tenant }
+      it { should be_able_to :restore, Tenant }
       it { should_not be_able_to :destroy, Tenant }
 
       context "administrators from other tenants" do
@@ -193,6 +195,8 @@ describe Abilities::Administrator do
         it { should_not be_able_to :read, Tenant }
         it { should_not be_able_to :update, Tenant }
         it { should_not be_able_to :destroy, Tenant }
+        it { should_not be_able_to :hide, Tenant }
+        it { should_not be_able_to :restore, Tenant }
       end
     end
   end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -86,10 +86,10 @@ describe Tenant do
       expect(Tenant.resolve_host("saturn.consul.dev")).to eq "saturn"
     end
 
-    it "returns nil when a domain is accessed as a subdomain" do
+    it "raises an exception when a domain is accessed as a subdomain" do
       insert(:tenant, :domain, schema: "saturn.dev")
 
-      expect(Tenant.resolve_host("saturn.dev.consul.dev")).to be nil
+      expect { Tenant.resolve_host("saturn.dev.consul.dev") }.to raise_exception(Apartment::TenantNotFound)
     end
 
     it "returns nested subdomains when there's a subdomain-type tenant with nested subdomains" do

--- a/spec/system/admin/tenants_spec.rb
+++ b/spec/system/admin/tenants_spec.rb
@@ -63,4 +63,43 @@ describe "Tenants", :admin, :seed_tenants do
     expect(page).to have_current_path root_path
     expect(page).to have_link "Sign in"
   end
+
+  scenario "Hide and restore", :show_exceptions do
+    create(:tenant, schema: "moon", name: "Moon")
+
+    visit admin_tenants_path
+
+    within("tr", text: "moon") do
+      expect(page).to have_content "Yes"
+
+      click_button "Enable tenant Moon"
+
+      expect(page).to have_content "No"
+      expect(page).not_to have_link "moon.lvh.me"
+    end
+
+    with_subdomain("moon") do
+      visit root_path
+
+      expect(page).to have_title "Not found"
+    end
+
+    visit admin_tenants_path
+
+    within("tr", text: "moon") do
+      expect(page).to have_content "No"
+
+      click_button "Enable tenant Moon"
+
+      expect(page).to have_content "Yes"
+      expect(page).to have_link "moon.lvh.me"
+    end
+
+    with_subdomain("moon") do
+      visit root_path
+
+      expect(page).to have_link "Sign in"
+      expect(page).not_to have_title "Not found"
+    end
+  end
 end


### PR DESCRIPTION
## References

* We implemented multitenancy in #4030

## Background

We don't allow removing a tenant because it would remove all its data, which would be a dangerous operation. However, there might be cases where we don't want a tenant to be accessible, and there's currently no way to do so.

## Objectives

* Make it possible to make a tenant unaccessible

## Visual Changes

### Before these changes

![There's no way to disable a tenant](https://user-images.githubusercontent.com/35156/208126783-e7559cca-3b05-44e7-a9d6-e9aa14cc86ea.png)

### After these changes

![In the tenants index, there's a switch to enable/disable a tenant](https://user-images.githubusercontent.com/35156/208126758-676a7900-7602-4865-99d2-c0735ade2356.png)