### PR TITLE
Do not track `Apartment::TenantNotFound` exceptions through `Airbrake`

### DIFF
--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -16,7 +16,7 @@ Airbrake.configure do |config|
 end
 
 Airbrake.add_filter do |notice|
-  ignorables = %w[ActiveRecord::RecordNotFound]
+  ignorables = %w[ActiveRecord::RecordNotFound Apartment::TenantNotFound]
   notice.ignore! if ignorables.include? notice[:errors].first[:type]
 end
 


### PR DESCRIPTION
## References

* We implemented multitenancy in #4030

## Objectives

Do not track `Apartment::TenantNotFound` exceptions through `Airbrake` as we do with `ActiveRecord::NotFound` exceptions. Otherwise, we can quickly flood the third-party application in charge of tracking exceptions.