### PR TITLE
Run test coverage just on the master branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  TEST_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && 1 || '' }}
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -23,7 +26,6 @@ jobs:
           POSTGRES_USER: consul
           POSTGRES_PASSWORD: ""
     env:
-      TEST_COVERAGE: 1
       PGUSER: consul
       POSTGRES_HOST: postgres
       RAILS_ENV: test
@@ -54,6 +56,7 @@ jobs:
           KNAPSACK_PRO_LOG_LEVEL: info
         run: bin/knapsack_pro_rspec
       - name: Coveralls Parallel
+        if: ${{ env.TEST_COVERAGE == 1 }}
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,6 +75,7 @@ jobs:
     needs: tests
     steps:
       - name: Finish coveralls
+        if: ${{ env.TEST_COVERAGE == 1 }}
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,5 @@
 ENV["RAILS_ENV"] ||= "test"
-if ENV["TEST_COVERAGE"]
+if ENV["TEST_COVERAGE"] && !ENV["TEST_COVERAGE"].empty?
   require "simplecov"
   require "simplecov-lcov"
   SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true


### PR DESCRIPTION
## References

* We're getting useless reports on pull requests regarding coveralls since merging pull request #5039
* On my repository there are actions testing that [coveralls runs on the master branch](https://github.com/javierm/consul/actions/runs/4306448854) and [it doesn't run on pull requests](https://github.com/javierm/consul/actions/runs/4306450673)

## Objectives

* Reduce the noise in the results of github actions when opening a pull request