### PR TITLE
Change poll button if results or stats are enabled

### DIFF
--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -12,13 +12,13 @@ module PollsHelper
     booth.name + location
   end
 
-  def link_to_poll(text, poll)
+  def link_to_poll(text, poll, options = {})
     if can?(:results, poll)
-      link_to text, results_poll_path(id: poll.slug || poll.id)
+      link_to text, results_poll_path(id: poll.slug || poll.id), options
     elsif can?(:stats, poll)
-      link_to text, stats_poll_path(id: poll.slug || poll.id)
+      link_to text, stats_poll_path(id: poll.slug || poll.id), options
     else
-      link_to text, poll_path(id: poll.slug || poll.id)
+      link_to text, poll_path(id: poll.slug || poll.id), options
     end
   end
 

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -56,12 +56,10 @@
       </div>
       <div class="small-12 medium-3 column table" data-equalizer-watch>
         <div class="table-cell align-middle">
-          <%= link_to poll_path(id: poll.slug || poll.id), class: "button hollow expanded" do %>
-            <% if poll.expired? %>
-              <%= t("polls.index.participate_button_expired") %>
-            <% else %>
-              <%= t("polls.index.participate_button") %>
-            <% end %>
+          <% if poll.expired? %>
+            <%= link_to_poll t("polls.index.participate_button_expired"), poll, class: "button hollow expanded" %>
+          <% else %>
+            <%= link_to_poll t("polls.index.participate_button"), poll, class: "button hollow expanded" %>
           <% end %>
         </div>
       </div>

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -109,20 +109,22 @@ describe "Polls" do
       expect(page).to have_content("You already have participated in this poll")
     end
 
-    scenario "Poll title link to stats if enabled" do
+    scenario "Poll title and button link to stats if enabled" do
       poll = create(:poll, :expired, name: "Poll with stats", stats_enabled: true)
 
       visit polls_path(filter: "expired")
 
       expect(page).to have_link("Poll with stats", href: stats_poll_path(poll.slug))
+      expect(page).to have_link("Poll ended", href: stats_poll_path(poll.slug))
     end
 
-    scenario "Poll title link to results if enabled" do
+    scenario "Poll title and button link to results if enabled" do
       poll = create(:poll, :expired, name: "Poll with results", stats_enabled: true, results_enabled: true)
 
       visit polls_path(filter: "expired")
 
       expect(page).to have_link("Poll with results", href: results_poll_path(poll.slug))
+      expect(page).to have_link("Poll ended", href: results_poll_path(poll.slug))
     end
 
     scenario "Shows SDG tags when feature is enabled" do


### PR DESCRIPTION
## Objectives

Change poll button if results/stats are enabled using the same logic of the title with the `link_to_poll` method.

