### PR TITLE
Allow printing investments from any budget in the management interface

### DIFF
--- a/app/components/management/budgets/print_investments/table_component.html.erb
+++ b/app/components/management/budgets/print_investments/table_component.html.erb
@@ -7,13 +7,17 @@
     </tr>
   </thead>
   <tbody>
-    <tr id="<%= dom_id(budget) %>">
-      <td><%= budget.name %></td>
-      <td><%= budget.current_phase.name %></td>
-      <td align="right">
-        <%= link_to t("management.budgets.print_investments"),
-          print_management_budget_investments_path(budget) %>
-      </td>
-    </tr>
+    <% budgets.each do |budget| %>
+      <tr id="<%= dom_id(budget) %>">
+        <td><%= budget.name %></td>
+        <td><%= budget.current_phase.name %></td>
+        <td align="right">
+          <%= link_to t("management.budgets.print_investments"),
+            print_management_budget_investments_path(budget) %>
+        </td>
+      </tr>
+    <% end %>
   </tbody>
 </table>
+
+<%= paginate budgets %>

--- a/app/components/management/budgets/print_investments/table_component.html.erb
+++ b/app/components/management/budgets/print_investments/table_component.html.erb
@@ -1,0 +1,19 @@
+<table>
+  <thead>
+    <tr>
+      <th><%= t("management.budgets.table_name") %></th>
+      <th><%= t("management.budgets.table_phase") %></th>
+      <th><%= t("management.budgets.table_actions") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr id="<%= dom_id(budget) %>">
+      <td><%= budget.name %></td>
+      <td><%= budget.current_phase.name %></td>
+      <td align="right">
+        <%= link_to t("management.budgets.print_investments"),
+          print_management_budget_investments_path(budget) %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/components/management/budgets/print_investments/table_component.rb
+++ b/app/components/management/budgets/print_investments/table_component.rb
@@ -1,7 +1,8 @@
 class Management::Budgets::PrintInvestments::TableComponent < ApplicationComponent
-  attr_reader :budget
+  attr_reader :budgets
+  delegate :paginate, to: :helpers
 
-  def initialize(budget)
-    @budget = budget
+  def initialize(budgets)
+    @budgets = budgets
   end
 end

--- a/app/components/management/budgets/print_investments/table_component.rb
+++ b/app/components/management/budgets/print_investments/table_component.rb
@@ -1,0 +1,7 @@
+class Management::Budgets::PrintInvestments::TableComponent < ApplicationComponent
+  attr_reader :budget
+
+  def initialize(budget)
+    @budget = budget
+  end
+end

--- a/app/controllers/management/base_controller.rb
+++ b/app/controllers/management/base_controller.rb
@@ -49,10 +49,6 @@ class Management::BaseController < ActionController::Base
       I18n.with_locale(session[:locale], &action)
     end
 
-    def current_budget
-      Budget.current
-    end
-
     def clear_password
       session[:new_password] = nil
     end

--- a/app/controllers/management/budgets_controller.rb
+++ b/app/controllers/management/budgets_controller.rb
@@ -19,7 +19,7 @@ class Management::BudgetsController < Management::BaseController
   end
 
   def print_investments
-    @budget = current_budget
+    @budgets = Budget.published.order(created_at: :desc).page(params[:page])
   end
 
   private

--- a/app/views/management/budgets/print_investments.html.erb
+++ b/app/views/management/budgets/print_investments.html.erb
@@ -1,3 +1,9 @@
 <h2><%= t("management.budgets.print_investments") %></h2>
 
-<%= render Management::Budgets::PrintInvestments::TableComponent.new(@budget) %>
+<% if @budgets.any? %>
+  <%= render Management::Budgets::PrintInvestments::TableComponent.new(@budgets) %>
+<% else %>
+  <div class="callout primary">
+    <%= t("management.budgets.no_budgets") %>
+  </div>
+<% end %>

--- a/app/views/management/budgets/print_investments.html.erb
+++ b/app/views/management/budgets/print_investments.html.erb
@@ -1,21 +1,3 @@
 <h2><%= t("management.budgets.print_investments") %></h2>
 
-<table>
-  <thead>
-    <tr>
-      <th><%= t("management.budgets.table_name") %></th>
-      <th><%= t("management.budgets.table_phase") %></th>
-      <th><%= t("management.budgets.table_actions") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr id="<%= dom_id(@budget) %>">
-      <td><%= @budget.name %></td>
-      <td><%= @budget.current_phase.name %></td>
-      <td align="right">
-        <%= link_to t("management.budgets.print_investments"),
-          print_management_budget_investments_path(@budget) %>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<%= render Management::Budgets::PrintInvestments::TableComponent.new(@budget) %>

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -407,6 +407,51 @@ describe "Budget Investments" do
   end
 
   context "Printing" do
+    scenario "Shows all published budgets, last created first" do
+      finished_budget = create(:budget, :finished)
+      accepting_budget = create(:budget)
+      draft_budget = create(:budget, published: false)
+      login_as_manager(manager)
+
+      click_link "Print budget investments"
+
+      within "#budget_#{accepting_budget.id}" do
+        expect(page).to have_link("Print budget investments")
+      end
+      within "#budget_#{finished_budget.id}" do
+        expect(page).to have_link("Print budget investments")
+      end
+      expect(page).not_to have_content draft_budget.name
+      expect(accepting_budget.name).to appear_before(finished_budget.name)
+    end
+
+    scenario "Shows a message when there are no budgets to show" do
+      login_as_manager(manager)
+
+      click_link "Print budget investments"
+
+      expect(page).to have_content("There are no active participatory budgets.")
+    end
+
+    scenario "Show pagination when needed" do
+      allow(Budget).to receive(:default_per_page).and_return(1)
+      create(:budget, name: "Children")
+      create(:budget, name: "Sports")
+      login_as_manager(manager)
+      click_link "Print budget investments"
+
+      expect(page).to have_content("Sports")
+
+      within("ul.pagination") do
+        expect(page).to have_content("1")
+        expect(page).to have_link("2", href: print_investments_management_budgets_path(page: "2"))
+        expect(page).not_to have_content("3")
+        click_link "Next", exact: false
+      end
+
+      expect(page).to have_content("Children")
+    end
+
     scenario "Printing budget investments" do
       16.times { create(:budget_investment, heading: heading) }
 


### PR DESCRIPTION
## Objectives

Allow printing investments from any published budget in the management interface. 

The budget table shows the last budgets created first, and now includes pagination.