### PR TITLE
Fix warnings in Ruby 2.7 and Ruby 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -164,6 +164,9 @@ Lint/BooleanSymbol:
 Lint/ConstantDefinitionInBlock:
   Enabled: true
 
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
 Lint/DuplicateBranch:
   Enabled: true
 

--- a/app/components/admin/table_actions_component.html.erb
+++ b/app/components/admin/table_actions_component.html.erb
@@ -2,10 +2,10 @@
   <%= content %>
 
   <% if actions.include?(:edit) %>
-    <%= action(:edit, edit_options.merge(text: edit_text, path: edit_path)) %>
+    <%= action(:edit, **edit_options.merge(text: edit_text, path: edit_path)) %>
   <% end %>
 
   <% if actions.include?(:destroy) %>
-    <%= action(:destroy, destroy_options.merge(text: destroy_text, path: destroy_path)) %>
+    <%= action(:destroy, **destroy_options.merge(text: destroy_text, path: destroy_path)) %>
   <% end %>
 </div>

--- a/app/components/admin/widget/cards/row_component.html.erb
+++ b/app/components/admin/widget/cards/row_component.html.erb
@@ -17,6 +17,6 @@
     <% end %>
   </td>
   <td>
-    <%= render Admin::TableActionsComponent.new(card, options) %>
+    <%= render Admin::TableActionsComponent.new(card, **options) %>
   </td>
 </tr>

--- a/app/components/admin/widget/cards/table_component.html.erb
+++ b/app/components/admin/widget/cards/table_component.html.erb
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
       <% cards.each do |card| %>
-        <%= render Admin::Widget::Cards::RowComponent.new(card, options) %>
+        <%= render Admin::Widget::Cards::RowComponent.new(card, **options) %>
       <% end %>
     </tbody>
   </table>

--- a/app/components/shared/link_list_component.rb
+++ b/app/components/shared/link_list_component.rb
@@ -17,7 +17,15 @@ class Shared::LinkListComponent < ApplicationComponent
     end
 
     def list_items
-      present_links.map do |text, url, current = false, **link_options|
+      present_links.map do |text, url, current_or_options = false, options = {}|
+        if current_or_options.is_a?(Hash)
+          current = false
+          link_options = current_or_options
+        else
+          current = current_or_options
+          link_options = options
+        end
+
         tag.li("aria-current": (true if current)) do
           if url
             link_to text, url, link_options

--- a/app/models/machine_learning.rb
+++ b/app/models/machine_learning.rb
@@ -95,14 +95,14 @@ class MachineLearning
     def data_output_files
       files = { tags: [], related_content: [], comments_summary: [] }
 
-      files[:tags] << proposals_tags_filename if File.exists?(data_folder.join(proposals_tags_filename))
-      files[:tags] << proposals_taggings_filename if File.exists?(data_folder.join(proposals_taggings_filename))
-      files[:tags] << investments_tags_filename if File.exists?(data_folder.join(investments_tags_filename))
-      files[:tags] << investments_taggings_filename if File.exists?(data_folder.join(investments_taggings_filename))
-      files[:related_content] << proposals_related_filename if File.exists?(data_folder.join(proposals_related_filename))
-      files[:related_content] << investments_related_filename if File.exists?(data_folder.join(investments_related_filename))
-      files[:comments_summary] << proposals_comments_summary_filename if File.exists?(data_folder.join(proposals_comments_summary_filename))
-      files[:comments_summary] << investments_comments_summary_filename if File.exists?(data_folder.join(investments_comments_summary_filename))
+      files[:tags] << proposals_tags_filename if File.exist?(data_folder.join(proposals_tags_filename))
+      files[:tags] << proposals_taggings_filename if File.exist?(data_folder.join(proposals_taggings_filename))
+      files[:tags] << investments_tags_filename if File.exist?(data_folder.join(investments_tags_filename))
+      files[:tags] << investments_taggings_filename if File.exist?(data_folder.join(investments_taggings_filename))
+      files[:related_content] << proposals_related_filename if File.exist?(data_folder.join(proposals_related_filename))
+      files[:related_content] << investments_related_filename if File.exist?(data_folder.join(investments_related_filename))
+      files[:comments_summary] << proposals_comments_summary_filename if File.exist?(data_folder.join(proposals_comments_summary_filename))
+      files[:comments_summary] << investments_comments_summary_filename if File.exist?(data_folder.join(investments_comments_summary_filename))
 
       files
     end
@@ -438,13 +438,13 @@ class MachineLearning
     end
 
     def last_modified_date_for(filename)
-      return nil unless File.exists? data_folder.join(filename)
+      return nil unless File.exist? data_folder.join(filename)
 
       File.mtime data_folder.join(filename)
     end
 
     def updated_file?(filename)
-      return false unless File.exists? data_folder.join(filename)
+      return false unless File.exist? data_folder.join(filename)
       return true unless previous_modified_date[filename].present?
 
       last_modified_date_for(filename) > previous_modified_date[filename]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+Warning[:deprecated] = true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -3,6 +3,8 @@
 # your test database is "scratch space" for the test suite and is wiped
 # and recreated between test runs. Don't rely on the data there!
 
+Warning[:deprecated] = true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/initializers/globalize.rb
+++ b/config/initializers/globalize.rb
@@ -1,7 +1,7 @@
 module Globalize
   module ActiveRecord
     module InstanceMethods
-      def save(*)
+      def save(...)
         # Credit for this code belongs to Jack Tomaszewski:
         # https://github.com/globalize/globalize/pull/578
         Globalize.with_locale(Globalize.locale || I18n.default_locale) do

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -36,6 +36,17 @@ def random_locales_attributes(**attribute_names_with_values)
   end
 end
 
+def add_image_to(imageable, sample_image_files)
+  # imageable should respond to #title & #author
+  imageable.image = Image.create!({
+    imageable: imageable,
+    title: imageable.title,
+    attachment: Rack::Test::UploadedFile.new(sample_image_files.sample),
+    user: imageable.author
+  })
+  imageable.save!
+end
+
 log "Creating dev seeds for tenant #{Tenant.current_schema}" unless Tenant.default?
 
 load_dev_seeds "settings"

--- a/db/dev_seeds/admin_notifications.rb
+++ b/db/dev_seeds/admin_notifications.rb
@@ -1,7 +1,7 @@
 section "Creating Admin Notifications & Templates" do
   AdminNotification.create!(
     random_locales_attributes(
-      %i[title body].index_with do |attribute|
+      **%i[title body].index_with do |attribute|
         -> { I18n.t("seeds.admin_notifications.proposal.#{attribute}") }
       end
     ).merge(
@@ -12,7 +12,7 @@ section "Creating Admin Notifications & Templates" do
 
   AdminNotification.create!(
     random_locales_attributes(
-      %i[title body].index_with do |attribute|
+      **%i[title body].index_with do |attribute|
         -> { I18n.t("seeds.admin_notifications.help.#{attribute}") }
       end
     ).merge(link: "https://crwd.in/consul", segment_recipient: "administrators")
@@ -20,7 +20,7 @@ section "Creating Admin Notifications & Templates" do
 
   AdminNotification.create!(
     random_locales_attributes(
-      %i[title body].index_with do |attribute|
+      **%i[title body].index_with do |attribute|
         -> { I18n.t("seeds.admin_notifications.map.#{attribute}") }
       end
     ).merge(segment_recipient: "administrators")
@@ -28,7 +28,7 @@ section "Creating Admin Notifications & Templates" do
 
   AdminNotification.create!(
     random_locales_attributes(
-      %i[title body].index_with do |attribute|
+      **%i[title body].index_with do |attribute|
         -> { I18n.t("seeds.admin_notifications.budget.#{attribute}") }
       end
     ).merge(segment_recipient: "administrators", sent_at: nil)

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -1,27 +1,20 @@
-INVESTMENT_IMAGE_FILES = %w[
-  brennan-ehrhardt-25066-unsplash_713x513.jpg
-  carl-nenzen-loven-381554-unsplash_713x475.jpg
-  carlos-zurita-215387-unsplash_713x475.jpg
-  hector-arguello-canals-79584-unsplash_713x475.jpg
-  olesya-grichina-218176-unsplash_713x475.jpg
-  sole-d-alessandro-340443-unsplash_713x475.jpg
-].map do |filename|
-  Rails.root.join("db",
-                  "dev_seeds",
-                  "images",
-                  "budget",
-                  "investments", filename)
-end
+def add_image_to_investment(investment)
+  image_files = %w[
+    brennan-ehrhardt-25066-unsplash_713x513.jpg
+    carl-nenzen-loven-381554-unsplash_713x475.jpg
+    carlos-zurita-215387-unsplash_713x475.jpg
+    hector-arguello-canals-79584-unsplash_713x475.jpg
+    olesya-grichina-218176-unsplash_713x475.jpg
+    sole-d-alessandro-340443-unsplash_713x475.jpg
+  ].map do |filename|
+    Rails.root.join("db",
+                    "dev_seeds",
+                    "images",
+                    "budget",
+                    "investments", filename)
+  end
 
-def add_image_to(imageable)
-  # imageable should respond to #title & #author
-  imageable.image = Image.create!({
-    imageable: imageable,
-    title: imageable.title,
-    attachment: Rack::Test::UploadedFile.new(INVESTMENT_IMAGE_FILES.sample),
-    user: imageable.author
-  })
-  imageable.save!
+  add_image_to(investment, image_files)
 end
 
 section "Creating Budgets" do
@@ -122,7 +115,7 @@ section "Creating Investments" do
       terms_of_service: "1"
     }.merge(translation_attributes))
 
-    add_image_to(investment) if Random.rand > 0.5
+    add_image_to_investment(investment) if Random.rand > 0.5
   end
 end
 
@@ -167,7 +160,7 @@ section "Winner Investments" do
       price: rand(10000..heading.price),
       terms_of_service: "1"
     )
-    add_image_to(investment) if Random.rand > 0.3
+    add_image_to_investment(investment) if Random.rand > 0.3
   end
   budget.headings.each do |heading|
     Budget::Result.new(budget, heading).calculate_winners

--- a/db/dev_seeds/proposals.rb
+++ b/db/dev_seeds/proposals.rb
@@ -1,24 +1,17 @@
-IMAGE_FILES = %w[
-  firdouss-ross-414668-unsplash_846x475.jpg
-  nathan-dumlao-496190-unsplash_713x475.jpg
-  steve-harvey-597760-unsplash_713x475.jpg
-  tim-mossholder-302931-unsplash_713x475.jpg
-].map do |filename|
-  Rails.root.join("db",
-                  "dev_seeds",
-                  "images",
-                  "proposals", filename)
-end
+def add_image_to_proposal(proposal)
+  image_files = %w[
+    firdouss-ross-414668-unsplash_846x475.jpg
+    nathan-dumlao-496190-unsplash_713x475.jpg
+    steve-harvey-597760-unsplash_713x475.jpg
+    tim-mossholder-302931-unsplash_713x475.jpg
+  ].map do |filename|
+    Rails.root.join("db",
+                    "dev_seeds",
+                    "images",
+                    "proposals", filename)
+  end
 
-def add_image_to(imageable)
-  # imageable should respond to #title & #author
-  imageable.image = Image.create!({
-    imageable: imageable,
-    title: imageable.title,
-    attachment: Rack::Test::UploadedFile.new(IMAGE_FILES.sample),
-    user: imageable.author
-  })
-  imageable.save!
+  add_image_to(proposal, image_files)
 end
 
 section "Creating Proposals" do
@@ -47,7 +40,7 @@ section "Creating Proposals" do
         proposal.save!
       end
     end
-    add_image_to proposal
+    add_image_to_proposal proposal
   end
 end
 
@@ -75,7 +68,7 @@ section "Creating Archived Proposals" do
         proposal.save!
       end
     end
-    add_image_to proposal
+    add_image_to_proposal proposal
   end
 end
 
@@ -103,7 +96,7 @@ section "Creating Successful Proposals" do
         proposal.save!
       end
     end
-    add_image_to proposal
+    add_image_to_proposal proposal
   end
 
   tags = Tag.where(kind: "category")
@@ -128,7 +121,7 @@ section "Creating Successful Proposals" do
         proposal.save!
       end
     end
-    add_image_to proposal
+    add_image_to_proposal proposal
   end
 end
 

--- a/db/dev_seeds/widgets.rb
+++ b/db/dev_seeds/widgets.rb
@@ -9,7 +9,7 @@ section "Creating header and cards for the homepage" do
 
   Widget::Card.create!(
     random_locales_attributes(
-      %i[title description link_text label].index_with do |attribute|
+      **%i[title description link_text label].index_with do |attribute|
         -> { I18n.t("seeds.cards.header.#{attribute}") }
       end
     ).merge(
@@ -21,7 +21,7 @@ section "Creating header and cards for the homepage" do
 
   Widget::Card.create!(
     random_locales_attributes(
-      %i[title description link_text label].index_with do |attribute|
+      **%i[title description link_text label].index_with do |attribute|
         -> { I18n.t("seeds.cards.debate.#{attribute}") }
       end
     ).merge(
@@ -33,7 +33,7 @@ section "Creating header and cards for the homepage" do
 
   Widget::Card.create!(
     random_locales_attributes(
-      %i[title description link_text label].index_with do |attribute|
+      **%i[title description link_text label].index_with do |attribute|
         -> { I18n.t("seeds.cards.proposal.#{attribute}") }
       end
     ).merge(
@@ -45,7 +45,7 @@ section "Creating header and cards for the homepage" do
 
   Widget::Card.create!(
     random_locales_attributes(
-      %i[title description link_text label].index_with do |attribute|
+      **%i[title description link_text label].index_with do |attribute|
         -> { I18n.t("seeds.cards.budget.#{attribute}") }
       end
     ).merge(

--- a/spec/lib/tasks/files_spec.rb
+++ b/spec/lib/tasks/files_spec.rb
@@ -18,8 +18,8 @@ describe "files tasks" do
 
       travel_to(2.days.from_now) { run_rake_task }
 
-      expect(File.exists?(image.file_path)).to be false
-      expect(File.exists?(document.file_path)).to be false
+      expect(File.exist?(image.file_path)).to be false
+      expect(File.exist?(document.file_path)).to be false
     end
 
     it "does not delete recent cached attachments" do
@@ -33,8 +33,8 @@ describe "files tasks" do
 
       travel_to(2.minutes.from_now) { run_rake_task }
 
-      expect(File.exists?(image.file_path)).to be true
-      expect(File.exists?(document.file_path)).to be true
+      expect(File.exist?(image.file_path)).to be true
+      expect(File.exist?(document.file_path)).to be true
     end
 
     it "does not delete old regular attachments" do
@@ -43,8 +43,8 @@ describe "files tasks" do
 
       travel_to(2.days.from_now) { run_rake_task }
 
-      expect(File.exists?(image.file_path)).to be true
-      expect(File.exists?(document.file_path)).to be true
+      expect(File.exist?(image.file_path)).to be true
+      expect(File.exist?(document.file_path)).to be true
     end
   end
 end

--- a/spec/shared/system/mappable.rb
+++ b/spec/shared/system/mappable.rb
@@ -1,4 +1,4 @@
-shared_examples "mappable" do |mappable_factory_name, mappable_association_name, mappable_new_path, mappable_edit_path, mappable_show_path, mappable_path_arguments, management: false|
+shared_examples "mappable" do |mappable_factory_name, mappable_association_name, mappable_new_path, mappable_edit_path, mappable_show_path, mappable_path_arguments: {}, management: false|
   let!(:user)         { create(:user, :level_two) }
   let!(:arguments)    { {} }
   let!(:mappable)     { create(mappable_factory_name.to_s.to_sym) }

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -65,7 +65,7 @@ describe "Admin collaborative legislation", :admin do
 
       base_date = Date.current
 
-      within_fieldset text: "Draft phase" do
+      within "fieldset", text: "Draft phase" do
         check "Enabled"
         fill_in "Start", with: base_date - 3.days
         fill_in "End", with: base_date - 1.day
@@ -134,7 +134,7 @@ describe "Admin collaborative legislation", :admin do
 
       base_date = Date.current - 2.days
 
-      within_fieldset text: "Draft phase" do
+      within "fieldset", text: "Draft phase" do
         check "Enabled"
         fill_in "Start", with: base_date
         fill_in "End", with: base_date + 3.days

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1130,7 +1130,7 @@ describe "Budget Investments" do
                   "new_budget_investment_path",
                   "",
                   "budget_investment_path",
-                  { budget_id: "budget_id" }
+                  mappable_path_arguments: { budget_id: "budget_id" }
 
   context "Destroy" do
     scenario "Admin cannot destroy budget investments", :admin do

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -32,7 +32,7 @@ describe "Budget Investments" do
                   "new_management_budget_investment_path",
                   "",
                   "management_budget_investment_path",
-                  { budget_id: "budget_id" },
+                  mappable_path_arguments: { budget_id: "budget_id" },
                   management: true
 
   context "Load" do

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -1296,8 +1296,7 @@ describe "Proposals" do
                   "proposal",
                   "new_proposal_path",
                   "edit_proposal_path",
-                  "proposal_path",
-                  {}
+                  "proposal_path"
 
   scenario "Erased author" do
     user = create(:user)


### PR DESCRIPTION
## References

* [Ruby 3.0 separates positional and keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

## Objectives

* Fix warnings we're getting with Ruby 2.7.x
* Make it possible to upgrade to Ruby 3.0 in the future
* Add a Rubocop rule for deprecated class methods so we detect them immediately in the future