### PR TITLE
Don't cache related actions in investments view

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -7,122 +7,118 @@
             og_image_url: (investment.image.present? ? polymorphic_path(investment.image.variant(:thumb)) : nil) %>
 <% end %>
 
-<% cache [locale_and_user_status(investment),
-          investment,
-          investment.author,
-          Flag.flagged?(current_user, investment),
-          investment.followed_by?(current_user),
-          feature?(:remove_investments_supports),
-          current_user&.voted_for?(investment)] do %>
-  <section class="budget-investment-show" id="<%= dom_id(investment) %>">
-
-    <div class="row">
+<section class="budget-investment-show" id="<%= dom_id(investment) %>">
+  <div class="row">
+    <% cache [locale_and_user_status(investment),
+              investment,
+              investment.author,
+              Flag.flagged?(current_user, investment)] do %>
       <div class="small-12 medium-9 column">
         <%= back_link_to budget_investments_path(investment.budget, heading_id: investment.heading) %>
 
         <%= render "/budgets/investments/investment_detail", investment: investment %>
       </div>
+    <% end %>
 
-      <aside class="small-12 medium-3 column">
-        <%= render "/budgets/investments/author_actions", investment: investment %>
+    <aside class="small-12 medium-3 column">
+      <%= render "/budgets/investments/author_actions", investment: investment %>
 
-        <% if investment.should_show_aside? %>
-          <% if investment.should_show_votes? %>
-            <div class="sidebar-divider"></div>
-            <h2><%= t("budgets.investments.show.supports") %></h2>
-            <div class="text-center">
-              <div id="<%= dom_id(investment) %>_votes">
-                <%= render Budgets::Investments::VotesComponent.new(investment) %>
-              </div>
+      <% if investment.should_show_aside? %>
+        <% if investment.should_show_votes? %>
+          <div class="sidebar-divider"></div>
+          <h2><%= t("budgets.investments.show.supports") %></h2>
+          <div class="text-center">
+            <div id="<%= dom_id(investment) %>_votes">
+              <%= render Budgets::Investments::VotesComponent.new(investment) %>
             </div>
-          <% elsif investment.should_show_vote_count? %>
-            <div class="sidebar-divider"></div>
-            <h2><%= t("budgets.investments.show.supports") %></h2>
-            <div class="text-center">
-              <span class="total-supports">
-                <strong>
-                  <%= t("budgets.investments.investment.supports",
-                      count: investment.total_votes) %>
-                </strong>
-              </span>
-            </div>
-          <% elsif investment.should_show_ballots? %>
-            <div class="sidebar-divider"></div>
-            <h2><%= t("budgets.investments.show.votes") %></h2>
-            <div class="text-center">
-              <div id="<%= dom_id(investment) %>_ballot">
-                <%= render "ballot",
-                  investment: investment,
-                  investment_ids: investment_ids,
-                  ballot: ballot %>
-              </div>
-            </div>
-          <% end %>
-        <% end %>
-
-        <% if investment.unfeasible? && investment.valuation_finished? %>
-          <div class="callout warning">
-            <%= sanitize(t("budgets.investments.show.project_unfeasible")) %>
           </div>
-        <% elsif investment.winner? && @budget.finished? %>
-          <div class="callout success">
-            <strong><%= t("budgets.investments.show.project_winner") %></strong>
-          </div>
-        <% elsif investment.selected? %>
-          <div class="callout success">
-            <%= sanitize(t("budgets.investments.show.project_selected")) %>
-          </div>
-        <% elsif @budget.balloting_or_later? %>
-          <div class="callout warning">
-            <%= sanitize(t("budgets.investments.show.project_not_selected")) %>
-          </div>
-        <% else %>
-          <br>
-          <div class="float-right">
-            <span class="label-budget-investment float-left">
-              <%= t("budgets.investments.show.title") %>
+        <% elsif investment.should_show_vote_count? %>
+          <div class="sidebar-divider"></div>
+          <h2><%= t("budgets.investments.show.supports") %></h2>
+          <div class="text-center">
+            <span class="total-supports">
+              <strong>
+                <%= t("budgets.investments.investment.supports",
+                    count: investment.total_votes) %>
+              </strong>
             </span>
-            <span class="icon-budget"></span>
           </div>
-        <% end %>
-        <% if investment.should_show_price? %>
+        <% elsif investment.should_show_ballots? %>
           <div class="sidebar-divider"></div>
-          <h2><%= t("budgets.investments.show.price") %></h2>
-          <div class="supports text-center">
-            <p class="investment-project-amount">
-              <%= investment.formatted_price %>
-            </p>
-          </div>
-          <% if investment.should_show_price_explanation? %>
-            <div class="text-center" data-magellan>
-              <%= link_to t("budgets.investments.show.see_price_explanation"),
-                            "#price_explanation", class: "small" %>
+          <h2><%= t("budgets.investments.show.votes") %></h2>
+          <div class="text-center">
+            <div id="<%= dom_id(investment) %>_ballot">
+              <%= render "ballot",
+                investment: investment,
+                investment_ids: investment_ids,
+                ballot: ballot %>
             </div>
-          <% end %>
+          </div>
         <% end %>
+      <% end %>
 
-        <%= render "shared/social_share",
-          share_title: t("budgets.investments.show.share"),
-          title: investment.title,
-          image_url: image_absolute_url(investment.image, :thumb),
-          url: budget_investment_url(investment.budget, investment),
-          description: t("budgets.investments.share.message",
-                          title: investment.title,
-                          handle: setting["org_name"]),
-          mobile: t("budgets.investments.share.message",
-                     title: investment.title,
-                     handle: setting["twitter_handle"]) %>
-
-        <% if current_user %>
-          <div class="sidebar-divider"></div>
-          <p class="sidebar-title"><%= t("shared.follow") %></p>
-
-          <%= render "follows/follow_button", follow: find_or_build_follow(current_user, investment) %>
+      <% if investment.unfeasible? && investment.valuation_finished? %>
+        <div class="callout warning">
+          <%= sanitize(t("budgets.investments.show.project_unfeasible")) %>
+        </div>
+      <% elsif investment.winner? && @budget.finished? %>
+        <div class="callout success">
+          <strong><%= t("budgets.investments.show.project_winner") %></strong>
+        </div>
+      <% elsif investment.selected? %>
+        <div class="callout success">
+          <%= sanitize(t("budgets.investments.show.project_selected")) %>
+        </div>
+      <% elsif @budget.balloting_or_later? %>
+        <div class="callout warning">
+          <%= sanitize(t("budgets.investments.show.project_not_selected")) %>
+        </div>
+      <% else %>
+        <br>
+        <div class="float-right">
+          <span class="label-budget-investment float-left">
+            <%= t("budgets.investments.show.title") %>
+          </span>
+          <span class="icon-budget"></span>
+        </div>
+      <% end %>
+      <% if investment.should_show_price? %>
+        <div class="sidebar-divider"></div>
+        <h2><%= t("budgets.investments.show.price") %></h2>
+        <div class="supports text-center">
+          <p class="investment-project-amount">
+            <%= investment.formatted_price %>
+          </p>
+        </div>
+        <% if investment.should_show_price_explanation? %>
+          <div class="text-center" data-magellan>
+            <%= link_to t("budgets.investments.show.see_price_explanation"),
+                          "#price_explanation", class: "small" %>
+          </div>
         <% end %>
+      <% end %>
 
-        <%= render "communities/access_button", community: investment.community %>
+      <%= render "shared/social_share",
+        share_title: t("budgets.investments.show.share"),
+        title: investment.title,
+        image_url: image_absolute_url(investment.image, :thumb),
+        url: budget_investment_url(investment.budget, investment),
+        description: t("budgets.investments.share.message",
+                        title: investment.title,
+                        handle: setting["org_name"]),
+        mobile: t("budgets.investments.share.message",
+                   title: investment.title,
+                   handle: setting["twitter_handle"]) %>
 
-       </aside>
-    </div>
-  </section>
-<% end %>
+      <% if current_user %>
+        <div class="sidebar-divider"></div>
+        <p class="sidebar-title"><%= t("shared.follow") %></p>
+
+        <%= render "follows/follow_button", follow: find_or_build_follow(current_user, investment) %>
+      <% end %>
+
+      <%= render "communities/access_button", community: investment.community %>
+
+     </aside>
+  </div>
+</section>


### PR DESCRIPTION
## References

* Closes #5075
* We solved similar issues in pull requests #3423 and #4224

## Objectives

* Fix issues with the investment cache not being expired when its budget and/or certain settings are updated
* Reduce the chance of experiencing similar issues in the future

## Notes

As mentioned above, we've experienced some caching issues with this code for years, but we're still running into other issues. In order to really cache this section, we'd need to cache:

* Whether or not the investment should show the aside and vote/support buttons (we could do it by caching its budget)
* Whether its budget is balloting or finished (we could do it by caching its budget)
* Whether the current user is following the investment
* Whether the `remove_investments_supports` feature is enabled
* Whether the `community` feature is enabled
* The value of the `org_name` setting
* The value of the `twitter_handle` setting

Chances are that this list is incomplete.

So, instead of trying to take into account every single possible factor that should make us expire the cache, we're restricting the cache so it only affects the content of the investment. This is similar to what we do in the investments index, where we cache the content of the investment but we don't cache the vote/support buttons.