### PR TITLE
Use only one server when deploying to preproduction 

### DIFF
--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -8,7 +8,6 @@ preproduction:
   deploy_to: "/home/deploy/consul"
   ssh_port: "2222"
   server1: xxx.xxx.xxx.xxx
-  server2: xxx.xxx.xxx.xxx
   user: "deploy"
 
 production:

--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -7,12 +7,12 @@ staging:
 preproduction:
   deploy_to: "/home/deploy/consul"
   ssh_port: "2222"
-  server1: xxx.xxx.xxx.xxx
+  server: xxx.xxx.xxx.xxx
   user: "deploy"
 
 production:
   deploy_to: "/home/deploy/consul"
   ssh_port: "22"
-  server1: xxx.xxx.xxx.xxx
+  server: xxx.xxx.xxx.xxx
   server2: xxx.xxx.xxx.xxx
   user: "deploy"

--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -1,18 +1,17 @@
-staging:
-  deploy_to: "/home/deploy/consul"
-  ssh_port: "21"
-  server: "staging.consul.es"
-  user: "deploy"
-
-preproduction:
-  deploy_to: "/home/deploy/consul"
-  ssh_port: "2222"
-  server: xxx.xxx.xxx.xxx
-  user: "deploy"
-
-production:
+default: &default
   deploy_to: "/home/deploy/consul"
   ssh_port: "22"
+  user: "deploy"
+
+staging:
+  <<: *default
+  server: "staging.consul.es"
+
+preproduction:
+  <<: *default
+  server: xxx.xxx.xxx.xxx
+
+production:
+  <<: *default
   server: xxx.xxx.xxx.xxx
   server2: xxx.xxx.xxx.xxx
-  user: "deploy"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,15 @@ lock "~> 3.17.1"
 
 def deploysecret(key)
   @deploy_secrets_yml ||= YAML.load_file("config/deploy-secrets.yml")[fetch(:stage).to_s]
-  @deploy_secrets_yml.fetch(key.to_s, "undefined")
+  @deploy_secrets_yml.fetch(key.to_s, "")
+end
+
+def main_deploy_server
+  if deploysecret(:server1) && !deploysecret(:server1).empty?
+    deploysecret(:server1)
+  else
+    deploysecret(:server)
+  end
 end
 
 set :rails_env, fetch(:stage)

--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,4 +1,3 @@
 set :branch, ENV["branch"] || :master
 
 server deploysecret(:server1), user: deploysecret(:user), roles: %w[web app db importer cron background]
-server deploysecret(:server2), user: deploysecret(:user), roles: %w[web app db importer]

--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,3 +1,3 @@
 set :branch, ENV["branch"] || :master
 
-server deploysecret(:server1), user: deploysecret(:user), roles: %w[web app db importer cron background]
+server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
 set :branch, ENV["branch"] || :master
 
-server deploysecret(:server1), user: deploysecret(:user), roles: %w[web app db importer cron background]
+server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]
 #server deploysecret(:server2), user: deploysecret(:user), roles: %w(web app db importer cron background)
 #server deploysecret(:server3), user: deploysecret(:user), roles: %w(web app db importer)
 #server deploysecret(:server4), user: deploysecret(:user), roles: %w(web app db importer)

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,3 +1,3 @@
 set :branch, ENV["branch"] || :master
 
-server deploysecret(:server), user: deploysecret(:user), roles: %w[web app db importer cron background]
+server main_deploy_server, user: deploysecret(:user), roles: %w[web app db importer cron background]


### PR DESCRIPTION
## Objectives

* Use the same number of servers to deploy to preproduction as we do on production
* Allow using either `server` or `server1` as deploy secrets on all environments
* Simplify the deploy secrets example file