### PR TITLE
Bump Leaflet from 1.5.1 to 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "jquery-fileupload-rails"
 gem "jquery-rails", "~> 4.5.0"
 gem "jquery-ui-rails", "~> 6.0.1"
 gem "kaminari", "~> 1.2.2"
+gem "leaflet-rails", "~> 1.9.3"
 gem "mini_magick", "~> 4.11.0"
 gem "omniauth", "~> 2.1.0"
 gem "omniauth-facebook", "~> 9.0.0"
@@ -66,7 +67,6 @@ gem "wicked_pdf", "~> 2.6.3"
 gem "wkhtmltopdf-binary", "~> 0.12.6"
 
 source "https://rails-assets.org" do
-  gem "rails-assets-leaflet"
   gem "rails-assets-markdown-it", "~> 9.0.1"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rails-assets.org/
   specs:
-    rails-assets-leaflet (1.5.1)
     rails-assets-markdown-it (9.0.1)
 
 GEM
@@ -327,6 +326,8 @@ GEM
       kramdown (~> 2.0)
     launchy (2.5.0)
       addressable (~> 2.7)
+    leaflet-rails (1.9.3)
+      rails (>= 4.2.0)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
     letter_opener_web (2.0.0)
@@ -717,6 +718,7 @@ DEPENDENCIES
   kaminari (~> 1.2.2)
   knapsack_pro (~> 3.3.1)
   launchy (~> 2.5.0)
+  leaflet-rails (~> 1.9.3)
   letter_opener_web (~> 2.0.0)
   mdl (~> 0.11.0)
   mini_magick (~> 4.11.0)
@@ -735,7 +737,6 @@ DEPENDENCIES
   pronto-scss (~> 0.11.0)
   puma (~> 4.3.12)
   rails (= 6.0.6.1)
-  rails-assets-leaflet!
   rails-assets-markdown-it (~> 9.0.1)!
   recipient_interceptor (~> 0.3.1)
   redcarpet (~> 3.5.1)

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -7,6 +7,9 @@
         App.Map.initializeMap(this);
       });
     },
+    attributionPrefix: function() {
+      return '<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">Leaflet</a>';
+    },
     destroy: function() {
       App.Map.maps.forEach(function(map) {
         map.off();
@@ -118,6 +121,7 @@
       };
       mapCenterLatLng = new L.LatLng(mapCenterLatitude, mapCenterLongitude);
       map = L.map(element.id, { scrollWheelZoom: false }).setView(mapCenterLatLng, zoom);
+      map.attributionControl.setPrefix(App.Map.attributionPrefix());
       App.Map.maps.push(map);
       L.tileLayer(mapTilesProvider, {
         attribution: mapAttribution


### PR DESCRIPTION
## References

Replaces:

* #4970 

## Objectives

Newer versions have more capabilities and also [fix lot of errors,
usability and accessibility issues](https://github.com/Leaflet/Leaflet/blob/main/CHANGELOG.md).

Note that we're using an external gem to rails-assets.org as it
not supports the rails-assets pipeline. This gems wraps the
original one and make the code work with the default rails assets
pipeline as usual.

# Manual testing

**Desktop browsers**

Verified successfully in the following desktop and mobile browsers:
* Chrome
* Firefox
* Edge
* Safari
* Opera

## Visual Changes
None
