### PR TITLE
Disable scroll wheel for zooming in favor of map zoom buttons

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -117,7 +117,7 @@
         return "<a href='/budgets/" + data.budget_id + "/investments/" + data.investment_id + "'>" + data.investment_title + "</a>";
       };
       mapCenterLatLng = new L.LatLng(mapCenterLatitude, mapCenterLongitude);
-      map = L.map(element.id).setView(mapCenterLatLng, zoom);
+      map = L.map(element.id, { scrollWheelZoom: false }).setView(mapCenterLatLng, zoom);
       App.Map.maps.push(map);
       L.tileLayer(mapTilesProvider, {
         attribution: mapAttribution


### PR DESCRIPTION
## References

Replaces:

* #4768

## Objectives

Fix the mousewheel trap when scrolling the page to the bottom when there is more content below the map.

# Manual testing

**Desktop browsers**

Verified successfully in:
* Chrome
* Firefox
* Edge
* Safari
* Opera

This update has no impact in touchable devices as they do not have mouse wheel. It seems the map behaves nicely with all the browsers mentioned above.

## Visual Changes
None
