### PR TITLE
Disable the create booths button when the polls function is disabled

### DIFF
--- a/app/components/admin/budgets/actions_component.rb
+++ b/app/components/admin/budgets/actions_component.rb
@@ -23,7 +23,7 @@ class Admin::Budgets::ActionsComponent < ApplicationComponent
           html: winners_action
         },
         ballots: {
-          hint: t("admin.budgets.actions.descriptions.ballots"),
+          hint: ballots_hint,
           html: ballots_action
         },
         destroy: {
@@ -65,7 +65,17 @@ class Admin::Budgets::ActionsComponent < ApplicationComponent
                text: t("admin.budgets.actions.ballots"),
                path: create_budget_poll_path,
                method: :post,
-               confirm: t("admin.budgets.actions.confirm.ballots"))
+               confirm: t("admin.budgets.actions.confirm.ballots"),
+               disabled: !feature?("polls"))
+      end
+    end
+
+    def ballots_hint
+      if feature?("polls")
+        t("admin.budgets.actions.descriptions.ballots")
+      else
+        link = admin_settings_path(anchor: "tab-participation-processes")
+        t("admin.budgets.ballots.feature_disabled", link: link)
       end
     end
 

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -166,6 +166,8 @@ en:
         calculate: Calculate Winner Investments
         calculated: Winners being calculated, it may take a minute.
         recalculate: Recalculate Winner Investments
+      ballots:
+        feature_disabled: 'The feature <strong>Polls</strong> must be enabled to create booths. You can enable it from the <a href="%{link}">settings configuration</a> page.'
     budget_groups:
       name: "Name"
       headings_name: "Headings"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -166,6 +166,8 @@ es:
         calculate: Calcular proyectos ganadores
         calculated: Calculando ganadores, puede tardar un minuto.
         recalculate: Recalcular proyectos ganadores
+      ballots:
+        feature_disabled: 'La funcionalidad de <strong>Votaciones</strong> debe estar activada para poder crear urnas. Puedes activarla en la página de <a href="%{link}">configuración</a>.'
     budget_groups:
       name: "Nombre"
       headings_name: "Partidas"

--- a/spec/components/admin/budgets/actions_component_spec.rb
+++ b/spec/components/admin/budgets/actions_component_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe Admin::Budgets::ActionsComponent, controller: Admin::BaseController do
+  include Rails.application.routes.url_helpers
   before { sign_in(create(:administrator).user) }
 
   let(:budget) { create(:budget) }
@@ -29,6 +30,24 @@ describe Admin::Budgets::ActionsComponent, controller: Admin::BaseController do
 
       expect(page).not_to have_css "form[action*='polls']"
       expect(page).not_to have_button "Create booths"
+    end
+
+    it "is disabled when the polls feature is disabled" do
+      Setting["process.polls"] = false
+
+      render_inline component
+
+      expect(page).to have_button "Create booths", disabled: true
+      expect(page).to have_link href: admin_settings_path(anchor: "tab-participation-processes")
+    end
+
+    it "is enabled when the polls feature is enabled" do
+      Setting["process.polls"] = true
+
+      render_inline component
+
+      expect(page).to have_button "Create booths", disabled: false
+      expect(page).not_to have_link href: admin_settings_path(anchor: "tab-participation-processes")
     end
   end
 end


### PR DESCRIPTION
## References

Fixes:
- #4813

## Objectives

> What are the objectives of these changes?

Prevent the admin from trying to create booths when this is not possible, by disabling the button when the polls feature is disabled.

## Visual Changes

> Any visual changes? please attach screenshots (or gifs) showing them.

Down at the `/admin/budgets/{budget-id}` page, the 'Create booths' button looks at follows when the polls feature is disabled:

![create-booths](https://user-images.githubusercontent.com/38756142/232510617-4d92e460-3a2c-4e3c-b5c2-1558d8351ac1.PNG)
