### PR TITLE
Bump wkhtmltopdf-binary from 0.12.6.5 to 0.12.6.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -659,7 +659,7 @@ GEM
       chronic (>= 0.6.3)
     wicked_pdf (2.6.3)
       activesupport
-    wkhtmltopdf-binary (0.12.6.5)
+    wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.6)


### PR DESCRIPTION
## References
https://github.com/zakird/wkhtmltopdf_binary_gem/commit/b9464a80f565f9cf08b5cc3dbe9746227c943fa9

## Objectives
In order to add compatibility to ubuntu 22.04 we update the wkhtmltopdf-binary gem.  The gem version 0.12.6.5 only supports up to ubuntu 20.04.

## Notes
- ~~Pending to be tested if it works in a staging environment.~~