### PR TITLE
Fix integration between `Errbit` and the `airbrake` gem

### DIFF
--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -13,6 +13,9 @@ Airbrake.configure do |config|
   end
 
   config.performance_stats = false
+  config.job_stats = false
+  config.query_stats = false
+  config.remote_config = false
 end
 
 Airbrake.add_filter do |notice|


### PR DESCRIPTION
## References

This is a backport from Cabildo Tenerife.

Quoting `errbit/errbit/blob/main/app/views/apps/_configuration_instructions.html.erb`

> airbrake.io supports various features that are out of scope for Errbit.

## Objectives

Fix integration between `Errbit` and the `airbrake` gem.

Thie `airbrake` gem automatically tries to poll `airbrake.io` servers for the project remote configuration when the `remote_config` is not explicitly disabled in the Airbrake initializer. So we need to disable the `remote_config` and other statistics features not supported by Errbit.