### PR TITLE
Allow to change the application name for deployments

### DIFF
--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -2,6 +2,7 @@ default: &default
   deploy_to: "/home/deploy/consul"
   ssh_port: "22"
   user: "deploy"
+  app_name: "consul"
 
 staging:
   <<: *default

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,9 +1,9 @@
 # config valid only for current version of Capistrano
 lock "~> 3.17.1"
 
-def deploysecret(key)
+def deploysecret(key, default: "")
   @deploy_secrets_yml ||= YAML.load_file("config/deploy-secrets.yml")[fetch(:stage).to_s]
-  @deploy_secrets_yml.fetch(key.to_s, "")
+  @deploy_secrets_yml.fetch(key.to_s, default)
 end
 
 def main_deploy_server
@@ -17,7 +17,7 @@ end
 set :rails_env, fetch(:stage)
 set :rvm1_map_bins, -> { fetch(:rvm_map_bins).to_a.concat(%w[rake gem bundle ruby]).uniq }
 
-set :application, "consul"
+set :application, deploysecret(:app_name, default: "consul")
 set :deploy_to, deploysecret(:deploy_to)
 set :ssh_options, port: deploysecret(:ssh_port)
 


### PR DESCRIPTION
# Objective
Make deployments easier when using a custom application name.

# Description
When someone installs CONSUL with the installer using a custom `app_name`, the deployment configuration file must use the same application name; otherwise, the Capistrano task to update the crontab will duplicate the crontab entries with different names causing unexpected errors.

Below is an example of the issue. The first set of crontab entries was created during installation using a custom app_name. The second set of entries are duplicated during the first deployment with a wrong application name in the config/deploy.rb file.

```
deploy@ubuntu:~$ crontab -l
# Begin Whenever generated tasks for: participacyl at: 2023-05-29 12:56:26 +0200
* * * * * /bin/bash -l -c 'date > ~/cron-test.txt'
0 5 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bundle exec rake -s sitemap:refresh --silent'
0 1 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bundle exec rake files:remove_old_cached_attachments --silent'
0 3 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bundle exec rake votes:reset_hot_score --silent'
0 0,2,4,6,8,10,12,14,16,18,20,22 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bundle exec rake -s stats:generate --silent'
@reboot /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && bundle exec puma -C config/puma/production.rb'
@reboot /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230529101753 && RAILS_ENV=production bin/delayed_job -n 2 restart'
# End Whenever generated tasks for: participacyl at: 2023-05-29 12:56:26 +0200

# Begin Whenever generated tasks for: consul at: 2023-05-31 11:53:45 +0200
* * * * * /bin/bash -l -c 'date > ~/cron-test.txt'
0 5 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && RAILS_ENV=production bundle exec rake -s sitemap:refresh --silent'
0 1 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && RAILS_ENV=production bundle exec rake files:remove_old_cached_attachments --silent'
0 3 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && RAILS_ENV=production bundle exec rake votes:reset_hot_score --silent'
0 0,2,4,6,8,10,12,14,16,18,20,22 * * * /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && RAILS_ENV=production bundle exec rake -s stats:generate --silent'
@reboot /bin/bash -l -c 'cd /home/deploy/participacyl/releases/20230530112702 && bundle exec puma -C config/puma/production.rb'
# End Whenever generated tasks for: consul at: 2023-05-31 11:53:45 +0200
```