### PR TITLE
Fix cached tenant secrets when running tests

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -102,7 +102,7 @@ class Tenant < ApplicationRecord
 
       if @cached_rails_secrets != Rails.application.secrets
         @secrets = {}
-        @cached_rails_secrets = nil
+        @cached_rails_secrets = Rails.application.secrets
       end
 
       @secrets[current_schema] ||= Rails.application.secrets.merge(


### PR DESCRIPTION
## Objectives

When running multiple specs that have to overwrite the rails secrets, it can happen that the condition:
"@cached_rails_secrets != Rails.application.secrets" is not met and unexpected secrets are returned.

We have found this case while experimenting with tests related to the Tenant secrets. In one case, assigning cached rails secrets to nil resulted in a failure to detect when the 'rails.application.secrets' had changed.
