### PR TITLE
Allow administrators to override legislation and budget translations

### DIFF
--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -8,6 +8,7 @@ module SiteCustomizationHelper
   end
 
   def information_texts_tabs
-    [:basic, :debates, :community, :proposals, :polls, :layouts, :mailers, :management, :welcome, :machine_learning]
+    [:basic, :debates, :community, :proposals, :polls, :legislation, :layouts, :mailers, :management,
+     :welcome, :machine_learning]
   end
 end

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -8,7 +8,7 @@ module SiteCustomizationHelper
   end
 
   def information_texts_tabs
-    [:basic, :debates, :community, :proposals, :polls, :legislation, :layouts, :mailers, :management,
-     :welcome, :machine_learning]
+    [:basic, :debates, :community, :proposals, :polls, :legislation, :budgets, :layouts, :mailers,
+     :management, :welcome, :machine_learning]
   end
 end

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -763,6 +763,7 @@ en:
           proposals: "Proposals"
           polls: "Polls"
           legislation: "Collaborative legislation"
+          budgets: "Budgets"
           layouts: "Layouts"
           machine_learning: "AI / Machine Learning"
           mailers: "Emails"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -762,6 +762,7 @@ en:
           community: "Community"
           proposals: "Proposals"
           polls: "Polls"
+          legislation: "Collaborative legislation"
           layouts: "Layouts"
           machine_learning: "AI / Machine Learning"
           mailers: "Emails"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -762,6 +762,7 @@ es:
           community: "Comunidad"
           proposals: "Propuestas"
           polls: "Votaciones"
+          legislation: "Legislación colaborativa"
           layouts: "Plantillas"
           machine_learning: "IA / Machine Learning"
           mailers: "Correos"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -763,6 +763,7 @@ es:
           proposals: "Propuestas"
           polls: "Votaciones"
           legislation: "Legislación colaborativa"
+          budgets: "Presupuestos participativos"
           layouts: "Plantillas"
           machine_learning: "IA / Machine Learning"
           mailers: "Correos"

--- a/spec/system/admin/site_customization/information_texts_spec.rb
+++ b/spec/system/admin/site_customization/information_texts_spec.rb
@@ -31,6 +31,10 @@ describe "Admin custom information texts", :admin do
 
     expect(page).to have_content "Help with collaborative legislation"
 
+    within("#information-texts-tabs") { click_link "Budgets" }
+
+    expect(page).to have_content "You have not voted any investment project."
+
     click_link "Layouts"
     expect(page).to have_content "Accessibility"
 

--- a/spec/system/admin/site_customization/information_texts_spec.rb
+++ b/spec/system/admin/site_customization/information_texts_spec.rb
@@ -27,6 +27,10 @@ describe "Admin custom information texts", :admin do
 
     expect(page).to have_content "Results"
 
+    within("#information-texts-tabs") { click_link "Collaborative legislation" }
+
+    expect(page).to have_content "Help with collaborative legislation"
+
     click_link "Layouts"
     expect(page).to have_content "Accessibility"
 


### PR DESCRIPTION
## Objectives

Allow administrators to override legislation and budget translations from the admin site information text page, just like other modules.

## Visual Changes
**New tab**
<img width="1363" alt="Captura de pantalla 2023-06-22 a las 12 40 28" src="https://github.com/consul/consul/assets/15726/864238af-3d62-4366-8ba7-e856da0ea750">
 