### PR TITLE
Remove unused code from Legislation proposals

### DIFF
--- a/app/views/legislation/proposals/_proposal.html.erb
+++ b/app/views/legislation/proposals/_proposal.html.erb
@@ -64,8 +64,7 @@
       </div>
 
       <div id="<%= dom_id(proposal) %>_votes" class="small-12 medium-3 column">
-        <%= render "legislation/proposals/votes",
-                  { proposal: proposal, vote_url: vote_legislation_process_proposal_path(proposal.legislation_process_id, proposal, value: "yes") } %>
+        <%= render "legislation/proposals/votes", proposal: proposal %>
       </div>
     </div>
   </div>

--- a/app/views/legislation/proposals/_proposal.html.erb
+++ b/app/views/legislation/proposals/_proposal.html.erb
@@ -64,7 +64,7 @@
       </div>
 
       <div id="<%= dom_id(proposal) %>_votes" class="small-12 medium-3 column">
-        <%= render "legislation/proposals/votes", proposal: proposal %>
+        <%= render Legislation::Proposals::VotesComponent.new(proposal) %>
       </div>
     </div>
   </div>

--- a/app/views/legislation/proposals/_votes.html.erb
+++ b/app/views/legislation/proposals/_votes.html.erb
@@ -1,1 +1,0 @@
-<%= render Legislation::Proposals::VotesComponent.new(proposal) %>

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -105,8 +105,7 @@
         <div class="sidebar-divider"></div>
         <h2><%= t("votes.supports") %></h2>
         <div id="<%= dom_id(@proposal) %>_votes">
-          <%= render "votes",
-                    { proposal: @proposal, vote_url: vote_legislation_process_proposal_path(@proposal.legislation_process_id, @proposal, value: "yes") } %>
+          <%= render "votes", proposal: @proposal %>
         </div>
         <%= render "shared/social_share",
           share_title: t("proposals.show.share"),

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -105,7 +105,7 @@
         <div class="sidebar-divider"></div>
         <h2><%= t("votes.supports") %></h2>
         <div id="<%= dom_id(@proposal) %>_votes">
-          <%= render "votes", proposal: @proposal %>
+          <%= render Legislation::Proposals::VotesComponent.new(@proposal) %>
         </div>
         <%= render "shared/social_share",
           share_title: t("proposals.show.share"),

--- a/app/views/legislation/proposals/vote.js.erb
+++ b/app/views/legislation/proposals/vote.js.erb
@@ -1,1 +1,2 @@
-$("#<%= dom_id(@proposal) %>_votes").html("<%= j render("legislation/proposals/votes", proposal: @proposal) %>");
+$("#<%= dom_id(@proposal) %>_votes")
+  .html("<%= j render Legislation::Proposals::VotesComponent.new(@proposal) %>");


### PR DESCRIPTION
## References
Related PR:  #1906 

## Objectives
Remove unused code.

## Description
In these commits 38ba5e159b and 8805037e2fad we added the parameter "vote_url" in the call to the partial "votes" in collaborative legislation proposals.

It seems that this parameter is only used in the proposals module and not in collaborative legislation proposals.

While it is true that in the partial "votes" in these commits this parameter "vote_url" is referred to, in commit 276baedcf it seems to be removed.



