### PR TITLE
Fix Serbian locale code

### DIFF
--- a/lib/search_dictionary_selector.rb
+++ b/lib/search_dictionary_selector.rb
@@ -23,7 +23,7 @@ module SearchDictionarySelector
     pt: "portuguese",
     ro: "romanian",
     ru: "russian",
-    sv: "serbian",
+    sr: "serbian",
     sv: "swedish",
     tr: "turkish",
     yi: "yiddish"


### PR DESCRIPTION
## References

Related pull request:

* #5134

## Objectives

I accidentally duplicated the locale code within commit 3c3ff65.

We found it thanks to the following warning:
`consul/lib/search_dictionary_selector.rb:26: warning: key :sv is duplicated and overwritten on line 27`
