### PR TITLE
Reduce log size in development/test environments

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,6 +64,12 @@ Rails.application.configure do
 
   config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
 
+  # Limit size of local logs
+  # TODO: replace with config.log_file_size after upgrading to Rails 7.1
+  logger = ActiveSupport::Logger.new(config.default_log_file, 1, 100.megabytes)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,6 +54,12 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
+  # Limit size of local logs
+  # TODO: replace with config.log_file_size after upgrading to Rails 7.1
+  logger = ActiveSupport::Logger.new(config.default_log_file, 1, 100.megabytes)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true


### PR DESCRIPTION
## References

* Originally part of #5105, but I'm extracting this pull request since we don't have to check possible side-effects

## Objectives

* Avoid huge log files (might be even tens of gigabytes) while developing Consul