### PR TITLE
Bump parser from 3.1.0.3 to 3.2.2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,8 +410,9 @@ GEM
     parallel (1.22.1)
     paranoia (2.6.0)
       activerecord (>= 5.1, < 7.1)
-    parser (3.1.3.0)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
+      racc
     pg (1.4.3)
     pg_search (2.3.6)
       activerecord (>= 5.2)


### PR DESCRIPTION
## References

* We forgot to include this change in pull request #5074

## Objectives

Fix a warning we have with ruby 3.0.6.

```
warning: parser/current is loading parser/ruby30, which recognizes3.0.5-compliant syntax, but you are running 3.0.6.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```