### PR TITLE
Fix text selection in budget header

### DIFF
--- a/app/assets/stylesheets/admin/budgets_wizard/creation_timeline.scss
+++ b/app/assets/stylesheets/admin/budgets_wizard/creation_timeline.scss
@@ -13,7 +13,7 @@
     text-transform: uppercase;
 
     &::before {
-      @extend %brand-background;
+      @include brand-background;
       border-radius: 50%;
       content: "";
       height: 20px;

--- a/app/assets/stylesheets/budgets/single_heading.scss
+++ b/app/assets/stylesheets/budgets/single_heading.scss
@@ -4,7 +4,7 @@
   position: relative;
 
   &::after {
-    @extend %brand-background;
+    @include brand-background;
     bottom: 0;
     content: "";
     height: rem-calc(6);


### PR DESCRIPTION
## References

* We introduced this issue in commit fcc63cb436e from pull request #5021

## Objectives

* Correctly highlight selected texts in places where the brand color is used as background color

## Visual changes
![valid_selection](https://github.com/consul/consul/assets/16189/72787c57-0f7c-4113-ba5b-5db7b9e8eca5)

