### PR TITLE
Restart DelayedJob workers after they crash

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,6 +40,7 @@ set :puma_conf, "#{release_path}/config/puma/#{fetch(:rails_env)}.rb"
 
 set :delayed_job_workers, 2
 set :delayed_job_roles, :background
+set :delayed_job_monitor, true
 
 set :whenever_roles, -> { :app }
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -42,5 +42,5 @@ end
 every :reboot do
   command "cd #{@path} && bundle exec puma -C config/puma/#{@environment}.rb"
   # Number of workers must be kept in sync with capistrano's delayed_job_workers
-  command "cd #{@path} && RAILS_ENV=#{@environment} bin/delayed_job -n 2 restart"
+  command "cd #{@path} && RAILS_ENV=#{@environment} bin/delayed_job -m -n 2 restart"
 end


### PR DESCRIPTION
## References

* Closes consul/installer#212

## Background

We're receiving reports from Consul installations saying that, once in a while, DelayedJob processes stop.

In some cases we've solved this issue by monitoring these processes with Systemd or Monit, but implementing support for these tools in a way that works on existing installations is difficult.

On the other hand, DelayedJob provides a simple way to monitor its processes that might not be as powerful as systemd but it's much better than doing nothing and it's easy to make it work on existing installations

## Objectives

* Make it easier to maintain Consul installations running on production

## Notes

:warning: In order to stop delayed job, we now need to pass the `-n` option: `RAILS_ENV=production bin/delayed_job -n 2 stop`

We might switch to systemd in the future, particularly if we upgrade Puma (see pull request #4922).