### PR TITLE
Upgrade default gems included in Ruby 3.3.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,8 +313,8 @@ GEM
     invisible_captcha (2.3.0)
       rails (>= 5.2)
     io-console (0.7.2)
-    irb (1.12.0)
-      rdoc
+    irb (1.13.1)
+      rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.12.2)
     jwt (2.10.1)
@@ -544,7 +544,7 @@ GEM
       mail
     redcarpet (3.6.1)
     regexp_parser (2.10.0)
-    reline (0.5.1)
+    reline (0.5.10)
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)


### PR DESCRIPTION
## Objectives

* Simplify development by using the version of gems included by default in Ruby
* Make sure new developers use a more modern version of IRB by default

## Notes

We've updated our [upgrading to a new version of Ruby](https://github.com/consuldemocracy/consuldemocracy/wiki/Upgrading-to-a-new-version-of-Ruby) wiki to include these changes.