### PR TITLE
Use match_array in notifications scopes tests

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -474,7 +474,7 @@ describe User do
         create(:user, newsletter: true, username: "Subscriber2")
         create(:user, newsletter: false, username: "NonSubscriber")
 
-        expect(User.newsletter.pluck(:username)).to eq ["Subscriber1", "Subscriber2"]
+        expect(User.newsletter.pluck(:username)).to match_array ["Subscriber1", "Subscriber2"]
       end
     end
 
@@ -484,7 +484,7 @@ describe User do
         create(:user, email_digest: true, username: "Digester2")
         create(:user, email_digest: false, username: "NonDigester")
 
-        expect(User.email_digest.pluck(:username)).to eq ["Digester1", "Digester2"]
+        expect(User.email_digest.pluck(:username)).to match_array ["Digester1", "Digester2"]
       end
     end
 


### PR DESCRIPTION
## References

* Continues pull request #6076

## Objectives

* Make sure test expectations don't depend on the random order of the records.

## Notes

Just to clarify, the one who made the mistake in the original pull request was me :smile:. I edited Johann's commit to add a third user, and so I added the `eq` comparison.