### PR TITLE
Remove obsolete Foundation meta generator tag from layout

### DIFF
--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -1,7 +1,6 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-<meta name="generator" content="Zurb Foundation for Sites 6" class="foundation-mq">
 <title><%= content_for?(:title) ? yield(:title) : default_title %></title>
 <% if rtl? %>
   <%= stylesheet_link_tag "vendored-rtl" %>


### PR DESCRIPTION
## References

Related PR: [#4753](https://github.com/consuldemocracy/consuldemocracy/pull/4753)

## Objectives

Remove the obsolete workaround for Foundation's invalid meta tag.

## Notes

The issue in Foundation was fixed in version 6.7.1, and the project now uses Foundation ≥ 6.8.1 via npm instead of the legacy foundation-rails gem, making this workaround unnecessary.