### PR TITLE
Fix mark as featured button being rendered to everyone

### DIFF
--- a/app/components/debates/mark_featured_action_component.rb
+++ b/app/components/debates/mark_featured_action_component.rb
@@ -6,7 +6,7 @@ class Debates::MarkFeaturedActionComponent < ApplicationComponent
     @debate = debate
   end
 
-  def render
+  def render?
     can? :mark_featured, debate
   end
 end

--- a/spec/components/debates/mark_featured_action_component_spec.rb
+++ b/spec/components/debates/mark_featured_action_component_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe Debates::MarkFeaturedActionComponent do
+  let(:debate) { create(:debate) }
+
+  it "is not rendered for regular users" do
+    sign_in(create(:user, :verified))
+
+    render_inline Debates::MarkFeaturedActionComponent.new(debate)
+
+    expect(page).not_to be_rendered
+  end
+
+  context "administradors", :admin do
+    it "renders a button to mark debates as featured" do
+      render_inline Debates::MarkFeaturedActionComponent.new(debate)
+
+      expect(page).to have_button "Featured"
+      expect(page).to have_button count: 1
+    end
+
+    it "renders a button to unmark featured debates" do
+      debate = create(:debate, featured_at: Time.current)
+
+      render_inline Debates::MarkFeaturedActionComponent.new(debate)
+
+      expect(page).to have_button "Unmark featured"
+      expect(page).to have_button count: 1
+    end
+  end
+end


### PR DESCRIPTION
## References

* We introduced this issue in commit f8faabf7d from pull request #5740.

## Objectives

* Make sure the "mark as featured" and "unmarked as featured" buttons are only shown to people who have permission to so.

## Notes

There weren't any security implications, because clicking on the button was returning a "you don't have permission" error unless you were an administrator.