### PR TITLE
Add landingURL to publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -2,6 +2,7 @@ publiccodeYmlVersion: "0.4"
 
 name: Consul Democracy
 url: "https://github.com/consuldemocracy/consuldemocracy.git"
+landingURL: "https://consuldemocracy.org"
 softwareVersion: "2.4.1"
 releaseDate: "2025-11-17"
 logo: "https://github.com/consuldemocracy/consuldemocracy/blob/master/public/consul_logo.svg"


### PR DESCRIPTION
## References

(none)

## Objectives

Add landing URL so that the EU OSS Catalog can have a nice link to the project page.
