### PR TITLE
Downgrade connection_pool to version 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "caxlsx", "~> 4.2.0"
 gem "caxlsx_rails", "~> 0.6.4"
 gem "ckeditor", "~> 4.3.0"
 gem "cocoon", "~> 1.2.15"
+gem "connection_pool", "~> 2.5" # TODO: remove after upgrading to Rails 8.0
 gem "csv", "~> 3.3.5"
 gem "daemons", "~> 1.4.1"
 gem "dalli", "~> 3.2.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crass (1.0.6)
     csv (3.3.5)
     daemons (1.4.1)
@@ -849,6 +849,7 @@ DEPENDENCIES
   caxlsx_rails (~> 0.6.4)
   ckeditor (~> 4.3.0)
   cocoon (~> 1.2.15)
+  connection_pool (~> 2.5)
   csv (~> 3.3.5)
   daemons (~> 1.4.1)
   dalli (~> 3.2.8)


### PR DESCRIPTION
## References

* We upgraded the `connection_pool` gem as part of pull request #6086.
* This issue has been solved in pull request in rails/rails#56294 but it hasn't been backported to Rails 7.2.

## Objectives

* Use a version of `connection_pool` compatible with ActiveSupport 7.2.