### PR TITLE
Use fetch-depth 0 in Pronto workflow

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - run: |
-          git fetch --no-tags --prune origin +refs/heads/*:refs/remotes/origin/*
+        with:
+          fetch-depth: 0
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## References
- Continues Bump pronto from 0.11.4 to 0.11.5 #6192
- Issue 447 from https://github.com/prontolabs/pronto/ 

## Objectives
Historically we prevented Dependabot from upgrading the rugged gem because newer versions caused Pronto to fail in CI with errors such as:

```
undefined method `[]' for nil:NilClass
in rugged/repository.rb:114:in `diff`
```
As a result, when bumping Pronto we had to manually ensure that the rugged dependency was not upgraded, which required remembering to revert Dependabot's changes.

The objective of this PR is to simplify and make the Pronto workflow more reliable so that we no longer need to keep rugged pinned to version 1.6.3.

Instead of manually fetching all remote branches:
```
git fetch --no-tags --prune origin +refs/heads/*:refs/remotes/origin/*
```

the workflow now uses the built-in option provided by actions/checkout:
```
fetch-depth: 0
```

This ensures that the repository is checked out with full git history, allowing Pronto (via Rugged) to correctly resolve  the base branch and merge base when computing diffs for pull requests.

## Notes
Rugged has already been upgraded in the Pronto bump PR (#6192).