### PR TITLE
Update image suggestions docs with required "Add image" step

### DIFF
--- a/docs/en/features/image_suggestions.md
+++ b/docs/en/features/image_suggestions.md
@@ -102,21 +102,23 @@ When creating or editing budget investments:
 
 1. **User fills in title and/or description**: The feature uses whichever of these fields is present to generate image suggestions.
 
-2. **User clicks "Suggest an image with AI"**: A button appears next to the image upload field (only when no image is currently attached).
+2. **User clicks "Add image"**: Under optional fields, this button expands both the image upload form and the AI suggestion button.
+
+3. **User clicks "Suggest an image with AI"**: A button appears next to the image upload field (only when no image is currently attached).
 
    ![Image upload form with AI suggestion button](../../img/image_suggestions/upload-form-with-button-en.png)
 
-3. **System generates suggestions**:
+4. **System generates suggestions**:
    - The LLM analyzes the title and description
    - Extracts key concepts and generates a search query
    - Searches Pexels API with the generated query
    - Returns up to 4 relevant image suggestions
 
-4. **User views suggestions**: A grid of suggested images appears below the upload button.
+5. **User views suggestions**: A grid of suggested images appears below the upload button.
 
    ![Suggested images grid](../../img/image_suggestions/suggested-images-grid-en.png)
 
-5. **User selects an image**: Clicking on a suggested image:
+6. **User selects an image**: Clicking on a suggested image:
    - Downloads the image from Pexels
    - Attaches it to the form as if it were user-uploaded
    - Replaces the upload interface with the selected image preview
@@ -190,6 +192,7 @@ For higher usage, Pexels offers paid plans. See [Pexels API pricing](https://www
 
 ### Feature button doesn't appear
 
+- Make sure you clicked **"Add image"** for the descriptive image first; the AI suggestion button only appears after that block is expanded.
 - Check that LLM provider and model are configured in **Admin > Global Settings > LLM Settings**
 - Verify that Image suggestions setting is enabled
 - Ensure Pexels API key is present in `secrets.yml`

--- a/docs/es/features/image_suggestions.md
+++ b/docs/es/features/image_suggestions.md
@@ -101,21 +101,23 @@ Al crear o editar proyectos de gasto:
 
 1. **El usuario completa título y/o descripción**: La funcionalidad usa el contenido de estos campos cuando están disponibles para generar sugerencias.
 
-2. **El usuario hace clic en "Sugerir una imagen con IA"**: Aparece un botón junto al campo de carga de imagen (solo cuando no hay imagen adjunta actualmente).
+2. **El usuario hace clic en "Añadir imagen"**: En la sección de campos opcionales, este botón despliega tanto el formulario para seleccionar una imagen como el botón de sugerencias con IA
+
+3. **El usuario hace clic en "Sugerir una imagen con IA"**: Aparece un botón junto al campo de carga de imagen (solo cuando no hay imagen adjunta actualmente).
 
    ![Formulario de carga de imagen con botón de sugerencia IA](../../img/image_suggestions/upload-form-with-button-es.png)
 
-3. **El sistema genera sugerencias**:
+4. **El sistema genera sugerencias**:
    - El LLM analiza el título y la descripción
    - Extrae conceptos clave y genera una consulta de búsqueda
    - Busca en la API de Pexels con la consulta generada
    - Devuelve hasta 4 sugerencias de imágenes relevantes
 
-4. **El usuario ve las sugerencias**: Aparece una cuadrícula de imágenes sugeridas debajo del botón de carga.
+5. **El usuario ve las sugerencias**: Aparece una cuadrícula de imágenes sugeridas debajo del botón de carga.
 
    ![Cuadrícula de imágenes sugeridas](../../img/image_suggestions/suggested-images-grid-es.png)
 
-5. **El usuario selecciona una imagen**: Al hacer clic en una imagen sugerida:
+6. **El usuario selecciona una imagen**: Al hacer clic en una imagen sugerida:
    - Descarga la imagen de Pexels
    - La adjunta al formulario como si fuera subida por el usuario
    - Reemplaza la interfaz de carga con la vista previa de la imagen seleccionada
@@ -189,6 +191,7 @@ Para mayor uso, Pexels ofrece planes de pago. Consulta [precios de la API de Pex
 
 ### El botón para solicitar imágenes no aparece
 
+- Confirma que has pulsado antes **"Añadir imagen"** en la imagen descriptiva; el botón de sugerencias con IA solo se muestra después de abrir ese bloque.
 - Verifica que el proveedor LLM y el modelo estén configurados en **Admin > Configuración Global > Configuración LLM**
 - Verifica que la configuración de Sugerencias de imágenes esté habilitada
 - Asegúrate de que la clave API de Pexels esté presente en `secrets.yml`


### PR DESCRIPTION
## References
Related PR: #6190 

## Objectives
Clarify in Spanish and English documentation that users must click **"Add image"** before the **"Suggest an image with AI"** button is available.
